### PR TITLE
[cli] Fix Windows build: use datetime utility for timestamp formatting

### DIFF
--- a/projects/ores.cli/src/app/application.cpp
+++ b/projects/ores.cli/src/app/application.cpp
@@ -38,6 +38,7 @@
 #include "ores.utility/streaming/std_vector.hpp"
 #include "ores.utility/repository/context_factory.hpp"
 #include "ores.utility/database/database_options.hpp"
+#include "ores.utility/datetime/datetime.hpp"
 #include "ores.risk/orexml/importer.hpp"
 #include "ores.risk/orexml/exporter.hpp"
 #include "ores.risk/csv/exporter.hpp"
@@ -366,12 +367,8 @@ add_currency(const config::add_options& cfg) const {
 
     // Set timestamps to current time
     const auto now = std::chrono::system_clock::now();
-    const auto time_t_now = std::chrono::system_clock::to_time_t(now);
-    std::tm tm_now;
-    localtime_r(&time_t_now, &tm_now);
-    std::ostringstream oss;
-    oss << std::put_time(&tm_now, "%Y-%m-%d %H:%M:%S");
-    const auto timestamp = oss.str();
+    const auto timestamp = utility::datetime::datetime::format_time_point(
+        now, "%Y-%m-%d %H:%M:%S");
     currency.valid_from = timestamp;
     currency.valid_to = timestamp;
 


### PR DESCRIPTION
Replaced direct usage of localtime_r (POSIX-only) with the cross-platform utility::datetime::datetime::format_time_point() function.

The datetime utility already handles the platform differences:
- Windows: uses localtime_s()
- POSIX: uses localtime_r()

Fixes compilation error on Windows:
  error C3861: 'localtime_r': identifier not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)