### PR TITLE
[accounts] Fix Windows build: use cross-platform datetime utility

### DIFF
--- a/projects/ores.accounts/src/domain/login_info_table.cpp
+++ b/projects/ores.accounts/src/domain/login_info_table.cpp
@@ -21,8 +21,7 @@
 
 #include <fort.hpp>
 #include <boost/uuid/uuid_io.hpp>
-#include <iomanip>
-#include <sstream>
+#include "ores.utility/datetime/datetime.hpp"
 
 namespace ores::accounts::domain {
 
@@ -37,10 +36,10 @@ std::string convert_to_table(const std::vector<login_info>& v) {
         std::string locked_status = li.locked ? "Y" : "N";
         std::string online_status = li.online ? "Y" : "N";
 
-        // Format the timestamp
-        auto time = std::chrono::system_clock::to_time_t(li.last_login);
-        std::stringstream ss;
-        ss << std::put_time(std::localtime(&time), "%Y-%m-%d %H:%M:%S");
+        // Format the timestamp using cross-platform utility
+        using utility::datetime::datetime;
+        auto timestamp_str = datetime::format_time_point(li.last_login,
+            "%Y-%m-%d %H:%M:%S");
 
         table << boost::uuids::to_string(li.account_id)
               << li.last_ip.to_string()
@@ -48,7 +47,7 @@ std::string convert_to_table(const std::vector<login_info>& v) {
               << li.failed_logins
               << locked_status
               << online_status
-              << ss.str()
+              << timestamp_str
               << fort::endr;
     }
     return table.to_string();


### PR DESCRIPTION
## Summary

Fixes Windows compatibility issue in login_info_table by replacing unsafe `std::localtime()` with the cross-platform `utility::datetime::format_time_point()` utility.

## Problem

The code was using `std::localtime()` which:
- Is not thread-safe
- Causes build/runtime issues on Windows
- Uses a non-reentrant function that can lead to undefined behavior

## Solution

Replaced with `utility::datetime::format_time_point()` which:
- Uses `localtime_s()` on Windows (thread-safe)
- Uses `localtime_r()` on Unix/Linux (POSIX thread-safe)
- Provides consistent cross-platform behavior

## Changes

- Updated `login_info_table.cpp` to use `datetime::format_time_point()`
- Removed manual time formatting code
- Removed unnecessary includes (`<iomanip>`, `<sstream>`)
- Added include for `ores.utility/datetime/datetime.hpp`

## Testing

✅ All login_info table tests pass (7 assertions in 2 test cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>