### PR TITLE
Add notification when retry logic gives up

### DIFF
--- a/projects/ores.comms/src/net/client.cpp
+++ b/projects/ores.comms/src/net/client.cpp
@@ -409,8 +409,8 @@ boost::asio::awaitable<void> client::run_reconnect_loop() {
         const bool is_final_attempt = (attempt + 1 == max_attempts);
         try {
             if (is_final_attempt) {
-                BOOST_LOG_SEV(lg(), warn) << "Final reconnection attempt ("
-                                          << max_attempts << " of " << max_attempts << ")";
+                BOOST_LOG_SEV(lg(), warn) << "Final reconnection attempt " << (attempt + 1)
+                                          << " of " << max_attempts;
             } else {
                 BOOST_LOG_SEV(lg(), info) << "Reconnection attempt " << (attempt + 1)
                                           << " of " << max_attempts;


### PR DESCRIPTION
…exhausted

The reconnection loop now logs a warning when starting the final attempt and provides a more descriptive error message when giving up, including the total number of attempts and a clear statement that auto-reconnect will not retry.