### PR TITLE
Fix OSX build warnings in CMake

### DIFF
--- a/projects/ores.accounts/src/CMakeLists.txt
+++ b/projects/ores.accounts/src/CMakeLists.txt
@@ -39,13 +39,7 @@ target_link_libraries(${lib_target_name}
         ores.variability.lib
         ores.eventing.lib
     PRIVATE
-        ores.comms.lib
-        ores.utility.lib
-        ores.database.lib
-        sqlgen::sqlgen
-        reflectcpp::reflectcpp
         faker-cxx::faker-cxx
-        libfort::fort
-        Boost::boost)
+        libfort::fort)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.cli/src/CMakeLists.txt
+++ b/projects/ores.cli/src/CMakeLists.txt
@@ -42,16 +42,12 @@ target_link_libraries(${lib_target_name}
     PUBLIC
         ores.database.lib
         ores.utility.lib
-        Boost::boost
     PRIVATE
         ores.accounts.lib
         ores.risk.lib
         ores.comms.lib
         magic_enum::magic_enum
-        sqlgen::sqlgen
-        reflectcpp::reflectcpp
-        cli::cli
-        Boost::program_options)
+        cli::cli)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)
 

--- a/projects/ores.comms/src/CMakeLists.txt
+++ b/projects/ores.comms/src/CMakeLists.txt
@@ -40,9 +40,6 @@ target_link_libraries(${lib_target_name}
     PRIVATE
         reflectcpp::reflectcpp
         OpenSSL::Crypto
-        OpenSSL::SSL
-        Boost::boost
-        Boost::iostreams
-        ores.utility.lib)
+        Boost::iostreams)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.database/src/CMakeLists.txt
+++ b/projects/ores.database/src/CMakeLists.txt
@@ -36,11 +36,9 @@ target_include_directories(${lib_target_name} PUBLIC
 
 target_link_libraries(${lib_target_name}
     PUBLIC
-        Boost::log
         sqlgen::sqlgen
     PRIVATE
         ores.utility.lib
-        reflectcpp::reflectcpp
-        Boost::boost)
+        reflectcpp::reflectcpp)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.eventing/src/CMakeLists.txt
+++ b/projects/ores.eventing/src/CMakeLists.txt
@@ -38,10 +38,8 @@ target_link_libraries(${lib_target_name}
     PUBLIC
         ores.database.lib
         ores.utility.lib
-        sqlgen::sqlgen
     PRIVATE
         faker-cxx::faker-cxx
-        libfort::fort
-        Boost::boost)
+        libfort::fort)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.risk/src/CMakeLists.txt
+++ b/projects/ores.risk/src/CMakeLists.txt
@@ -36,17 +36,11 @@ target_include_directories(${lib_target_name} PUBLIC
 
 target_link_libraries(${lib_target_name}
     PRIVATE
-        sqlgen::sqlgen
         pugixml::pugixml
-        Boost::boost
-        ores.utility.lib
-        ores.database.lib
         ores.variability.lib
         faker-cxx::faker-cxx
         libfort::fort
-   PUBLIC
-        reflectcpp::reflectcpp
-        ores.comms.lib
-    )
+    PUBLIC
+        ores.comms.lib)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.service/src/CMakeLists.txt
+++ b/projects/ores.service/src/CMakeLists.txt
@@ -43,10 +43,7 @@ target_link_libraries(${lib_target_name}
         ores.variability.lib
         ores.eventing.lib
         ores.comms.lib
-        ores.utility.lib
-        reflectcpp::reflectcpp
-        Boost::boost
-        Boost::program_options)
+        ores.utility.lib)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)
 

--- a/projects/ores.shell/src/CMakeLists.txt
+++ b/projects/ores.shell/src/CMakeLists.txt
@@ -41,14 +41,12 @@ find_package(cli CONFIG REQUIRED)
 target_link_libraries(${lib_target_name}
     PUBLIC
         ores.utility.lib
-        Boost::boost
     PRIVATE
         ores.accounts.lib
         ores.variability.lib
         ores.risk.lib
         ores.comms.lib
-        cli::cli
-        Boost::program_options)
+        cli::cli)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)
 

--- a/projects/ores.testing/src/CMakeLists.txt
+++ b/projects/ores.testing/src/CMakeLists.txt
@@ -38,12 +38,7 @@ target_link_libraries(${lib_target_name}
     PUBLIC
         ores.utility.lib
         ores.database.lib
-        Boost::log
     PRIVATE
-        Boost::boost
-        Boost::exception
-        sqlgen::sqlgen
-        Catch2::Catch2
-    )
+        Catch2::Catch2)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.utility/src/CMakeLists.txt
+++ b/projects/ores.utility/src/CMakeLists.txt
@@ -44,11 +44,9 @@ target_link_libraries(${lib_target_name}
         OpenSSL::SSL
         Boost::log
         Boost::program_options
+        Boost::exception
     PRIVATE
         faker-cxx::faker-cxx
-        reflectcpp::reflectcpp
-        Boost::boost
-        Boost::exception
-    )
+        reflectcpp::reflectcpp)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.variability/src/CMakeLists.txt
+++ b/projects/ores.variability/src/CMakeLists.txt
@@ -38,11 +38,6 @@ target_link_libraries(${lib_target_name}
     PUBLIC
         ores.comms.lib
     PRIVATE
-        ores.utility.lib
-        ores.database.lib
-        sqlgen::sqlgen
-        reflectcpp::reflectcpp
-        libfort::fort
-        Boost::boost)
+        libfort::fort)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)


### PR DESCRIPTION
Remove redundant Boost::boost umbrella package and transitive dependencies that were causing "ignoring duplicate libraries" warnings from the macOS linker. Libraries are now only linked directly where needed, relying on CMake's PUBLIC/PRIVATE transitive dependency propagation.