### PR TITLE
Fix Python test parsing on macOS

### DIFF
--- a/.github/workflows/canary-linux.yml
+++ b/.github/workflows/canary-linux.yml
@@ -91,5 +91,5 @@ jobs:
 
       - name: Parse test results
         run: |
-           pip install defusedxml
+           python3 -m pip install defusedxml
            python3 ./build/scripts/parse_catch2_results.py "./build/output/linux-gcc-debug/publish/bin/test-results-*.xml"

--- a/.github/workflows/continuous-linux.yml
+++ b/.github/workflows/continuous-linux.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Parse test results
         run: |
-           pip install defusedxml
+           python3 -m pip install defusedxml
            python3 ./build/scripts/parse_catch2_results.py "./build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}/publish/bin/test-results-*.xml"
 
       - name: Upload a Build Artifact

--- a/.github/workflows/continuous-macos.yml
+++ b/.github/workflows/continuous-macos.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Parse test results
         run: |
-           pip install defusedxml
+           python3 -m pip install defusedxml
            python3 ./build/scripts/parse_catch2_results.py "./build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}/publish/bin/test-results-*.xml"
 
       - name: Upload a Build Artifact

--- a/.github/workflows/continuous-windows.yml
+++ b/.github/workflows/continuous-windows.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Parse test results
         run: |
-           pip install defusedxml
+           python -m pip install defusedxml
            python ./build/scripts/parse_catch2_results.py "./build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}/publish/bin/test-results-*.xml"
 
       - name: Upload artifact

--- a/.github/workflows/nightly-linux.yml
+++ b/.github/workflows/nightly-linux.yml
@@ -130,5 +130,5 @@ jobs:
 
       - name: Parse test results
         run: |
-           pip install defusedxml
+           python3 -m pip install defusedxml
            python3 ./build/scripts/parse_catch2_results.py "./build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}/publish/bin/test-results-*.xml"


### PR DESCRIPTION
Use python3 -m pip instead of pip to ensure the defusedxml package is installed for the same Python interpreter used to run the script. On macOS, pip and python3 can point to different Python installations.