### PR TITLE
Fix OSX build warnings for Qt MOC and UIC

### DIFF
--- a/projects/ores.assets/src/CMakeLists.txt
+++ b/projects/ores.assets/src/CMakeLists.txt
@@ -40,8 +40,6 @@ target_link_libraries(${lib_target_name}
     PRIVATE
         ores.utility.lib
         ores.database.lib
-        sqlgen::sqlgen
-        reflectcpp::reflectcpp
         faker-cxx::faker-cxx
         libfort::fort
         Boost::boost)

--- a/projects/ores.database/src/CMakeLists.txt
+++ b/projects/ores.database/src/CMakeLists.txt
@@ -38,7 +38,6 @@ target_link_libraries(${lib_target_name}
     PUBLIC
         sqlgen::sqlgen
     PRIVATE
-        ores.utility.lib
-        reflectcpp::reflectcpp)
+        ores.utility.lib)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.utility/src/CMakeLists.txt
+++ b/projects/ores.utility/src/CMakeLists.txt
@@ -45,8 +45,8 @@ target_link_libraries(${lib_target_name}
         Boost::log
         Boost::program_options
         Boost::exception
+        reflectcpp::reflectcpp
     PRIVATE
-        faker-cxx::faker-cxx
-        reflectcpp::reflectcpp)
+        faker-cxx::faker-cxx)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)


### PR DESCRIPTION
Consolidate reflectcpp and sqlgen linkage to eliminate duplicate library warnings during linking on OSX. The ld linker was warning about duplicate libraries being included in the link command.

- Move reflectcpp to PUBLIC in ores.utility (base dependency for all)
- Remove redundant reflectcpp linkage from ores.database and ores.assets
- Remove sqlgen from ores.assets (already PUBLIC via ores.database)