### PR TITLE
Fix valgrind suppression for telemetry logging

### DIFF
--- a/build/valgrind/custom.supp
+++ b/build/valgrind/custom.supp
@@ -36,7 +36,9 @@
    Memcheck:Leak
    match-leak-kinds: reachable
    fun:_Znwm
+   # boost::log::v2s_mt_posix::sources::aux::get_severity_level()
    fun:_ZN5boost3log12v2s_mt_posix7sources3aux18get_severity_levelEv
+   # boost::log::v2s_mt_posix::sources::aux::severity_level<ores::telemetry::log::boost_severity>::set_value(...)
    fun:_ZN5boost3log12v2s_mt_posix7sources3aux14severity_levelIN4ores9telemetry3log14boost_severityEE9set_valueES8_
    ...
 }
@@ -100,7 +102,9 @@
    fun:_ZN5boost6detail31get_or_make_current_thread_dataEv
    fun:_ZN5boost6detail24add_thread_exit_functionEPNS0_25thread_exit_function_baseE
    fun:_ZN5boost11this_thread14at_thread_exitIZNS_3log12v2s_mt_posix7sources3aux18get_severity_levelEvEUlvE_EEvT_
+   # boost::log::v2s_mt_posix::sources::aux::get_severity_level()
    fun:_ZN5boost3log12v2s_mt_posix7sources3aux18get_severity_levelEv
+   # boost::log::v2s_mt_posix::sources::aux::severity_level<ores::telemetry::log::boost_severity>::set_value(...)
    fun:_ZN5boost3log12v2s_mt_posix7sources3aux14severity_levelIN4ores9telemetry3log14boost_severityEE9set_valueES8_
    ...
    fun:main


### PR DESCRIPTION
After logging moved from utility to telemetry, the mangled function names in valgrind suppressions no longer match. Update references from ores::utility::log::severity_level to ores::telemetry::log::boost_severity.