### PR TITLE
[telemetry] Rename export facet to exporting

### DIFF
--- a/doc/skills/component-creator/skill.org
+++ b/doc/skills/component-creator/skill.org
@@ -133,7 +133,7 @@ specific content type. The following are the set of well-known facets:
 | =service=    | Contains standalone types with domain operations that do not fit into a domain type.                                |
 | =app=        | If the component provides an executable, it will need standard application infrastructure such as hosting, etc.     |
 | =config=     | Contains top-level configuration, if required. If it is an executable component the command-line parser lives here. |
-| =net=        | Low-level networking. Only used in =ores.comms=.                                                                    |
+| =net=        | Network-related utilities such as client/server infrastructure or network interface information.                    |
 | =orexml=     | If the component supports exporting to and from ORE (Open Source Risk Engine) the code lives here.                  |
 | =csv=        | If the component supports exporting and possibly importing from CSV, the code lives here.                           |
 

--- a/projects/ores.shell/include/ores.shell/config/options.hpp
+++ b/projects/ores.shell/include/ores.shell/config/options.hpp
@@ -25,7 +25,7 @@
 #include "ores.shell/config/login_options.hpp"
 #include "ores.comms/net/client_options.hpp"
 #include "ores.telemetry/log/logging_options.hpp"
-#include "ores.telemetry/export/telemetry_options.hpp"
+#include "ores.telemetry/exporting/telemetry_options.hpp"
 
 namespace ores::shell::config {
 
@@ -51,7 +51,7 @@ struct options final {
     /**
      * @brief Configuration options for telemetry export, if any.
      */
-    std::optional<telemetry::exp::telemetry_options> telemetry;
+    std::optional<telemetry::exporting::telemetry_options> telemetry;
 };
 
 std::ostream& operator<<(std::ostream& s, const options& v);

--- a/projects/ores.shell/src/app/host.cpp
+++ b/projects/ores.shell/src/app/host.cpp
@@ -25,7 +25,7 @@
 #include "ores.telemetry/log/lifecycle_manager.hpp"
 #include "ores.telemetry/domain/resource.hpp"
 #include "ores.telemetry/domain/telemetry_context.hpp"
-#include "ores.telemetry/export/hybrid_log_exporter.hpp"
+#include "ores.telemetry/exporting/hybrid_log_exporter.hpp"
 #include "ores.utility/streaming/std_vector.hpp" // IWYU pragma: keep.
 #include "ores.shell/app/application.hpp"
 #include "ores.shell/config/parser.hpp"
@@ -63,7 +63,7 @@ int host::execute(const std::vector<std::string>& args,
     /*
      * Set up telemetry export if enabled.
      */
-    std::shared_ptr<telemetry::exp::hybrid_log_exporter> exporter;
+    std::shared_ptr<telemetry::exporting::hybrid_log_exporter> exporter;
     std::optional<telemetry::domain::telemetry_context> telemetry_ctx;
     if (cfg.telemetry) {
         const auto& tcfg(*cfg.telemetry);
@@ -97,8 +97,8 @@ int host::execute(const std::vector<std::string>& args,
          * This requires refactoring client_session to be created earlier and
          * shared between the application and the exporter.
          */
-        telemetry::exp::send_records_callback send_callback = nullptr;
-        exporter = std::make_shared<telemetry::exp::hybrid_log_exporter>(
+        telemetry::exporting::send_records_callback send_callback = nullptr;
+        exporter = std::make_shared<telemetry::exporting::hybrid_log_exporter>(
             path, tcfg, std::move(send_callback));
 
         /*

--- a/projects/ores.shell/src/config/parser.cpp
+++ b/projects/ores.shell/src/config/parser.cpp
@@ -26,7 +26,7 @@
 #include "ores.shell/config/parser_exception.hpp"
 #include "ores.utility/version/version.hpp"
 #include "ores.telemetry/log/logging_configuration.hpp"
-#include "ores.telemetry/export/telemetry_configuration.hpp"
+#include "ores.telemetry/exporting/telemetry_configuration.hpp"
 #include "ores.utility/program_options/environment_mapper_factory.hpp"
 
 namespace {
@@ -59,7 +59,7 @@ using ores::shell::config::parser_exception;
  */
 options_description make_options_description() {
     using ores::telemetry::log::logging_configuration;
-    using ores::telemetry::exp::telemetry_configuration;
+    using ores::telemetry::exporting::telemetry_configuration;
 
     options_description god("General");
     god.add_options()
@@ -187,7 +187,7 @@ read_login_configuration(const variables_map& vm) {
 std::optional<options>
 parse_arguments(const std::vector<std::string>& arguments, std::ostream& info) {
     using ores::telemetry::log::logging_configuration;
-    using ores::telemetry::exp::telemetry_configuration;
+    using ores::telemetry::exporting::telemetry_configuration;
     using ores::utility::program_options::environment_mapper_factory;
 
     const auto od(make_options_description());

--- a/projects/ores.telemetry/include/ores.telemetry/exporting/file_log_exporter.hpp
+++ b/projects/ores.telemetry/include/ores.telemetry/exporting/file_log_exporter.hpp
@@ -17,15 +17,15 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_TELEMETRY_EXPORT_FILE_LOG_EXPORTER_HPP
-#define ORES_TELEMETRY_EXPORT_FILE_LOG_EXPORTER_HPP
+#ifndef ORES_TELEMETRY_EXPORTING_FILE_LOG_EXPORTER_HPP
+#define ORES_TELEMETRY_EXPORTING_FILE_LOG_EXPORTER_HPP
 
 #include <mutex>
 #include <fstream>
 #include <filesystem>
-#include "ores.telemetry/export/log_exporter.hpp"
+#include "ores.telemetry/exporting/log_exporter.hpp"
 
-namespace ores::telemetry::exp {
+namespace ores::telemetry::exporting {
 
 /**
  * @brief Exports log records to a JSON Lines file.

--- a/projects/ores.telemetry/include/ores.telemetry/exporting/hybrid_log_exporter.hpp
+++ b/projects/ores.telemetry/include/ores.telemetry/exporting/hybrid_log_exporter.hpp
@@ -17,8 +17,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_TELEMETRY_EXPORT_HYBRID_LOG_EXPORTER_HPP
-#define ORES_TELEMETRY_EXPORT_HYBRID_LOG_EXPORTER_HPP
+#ifndef ORES_TELEMETRY_EXPORTING_HYBRID_LOG_EXPORTER_HPP
+#define ORES_TELEMETRY_EXPORTING_HYBRID_LOG_EXPORTER_HPP
 
 #include <atomic>
 #include <chrono>
@@ -31,11 +31,11 @@
 #include <mutex>
 #include <thread>
 #include <vector>
-#include "ores.telemetry/export/log_exporter.hpp"
-#include "ores.telemetry/export/telemetry_options.hpp"
-#include "ores.telemetry/export/upload_position_tracker.hpp"
+#include "ores.telemetry/exporting/log_exporter.hpp"
+#include "ores.telemetry/exporting/telemetry_options.hpp"
+#include "ores.telemetry/exporting/upload_position_tracker.hpp"
 
-namespace ores::telemetry::exp {
+namespace ores::telemetry::exporting {
 
 /**
  * @brief Callback type for sending batched records to the server.

--- a/projects/ores.telemetry/include/ores.telemetry/exporting/log_exporter.hpp
+++ b/projects/ores.telemetry/include/ores.telemetry/exporting/log_exporter.hpp
@@ -17,12 +17,12 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_TELEMETRY_EXPORT_LOG_EXPORTER_HPP
-#define ORES_TELEMETRY_EXPORT_LOG_EXPORTER_HPP
+#ifndef ORES_TELEMETRY_EXPORTING_LOG_EXPORTER_HPP
+#define ORES_TELEMETRY_EXPORTING_LOG_EXPORTER_HPP
 
 #include "ores.telemetry/domain/log_record.hpp"
 
-namespace ores::telemetry::exp {
+namespace ores::telemetry::exporting {
 
 /**
  * @brief Interface for exporting telemetry log records.

--- a/projects/ores.telemetry/include/ores.telemetry/exporting/ores.telemetry.exporting.hpp
+++ b/projects/ores.telemetry/include/ores.telemetry/exporting/ores.telemetry.exporting.hpp
@@ -9,24 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with
  * this program; if not, write to the Free Software Foundation, Inc., 51
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#include "ores.telemetry/export/telemetry_options.hpp"
+#ifndef ORES_TELEMETRY_EXPORTING_HPP
+#define ORES_TELEMETRY_EXPORTING_HPP
 
-#include <rfl.hpp>
-#include <rfl/json.hpp>
+/**
+ * @brief Log export functionality for telemetry.
+ *
+ * Contains log exporters including file-based and hybrid exporters for
+ * persisting log records. Includes configuration types for export settings.
+ */
+namespace ores::telemetry::exporting {}
 
-namespace ores::telemetry::exp {
-
-std::ostream& operator<<(std::ostream& s, const telemetry_options& v) {
-    rfl::json::write(v, s);
-    return s;
-}
-
-}
+#endif

--- a/projects/ores.telemetry/include/ores.telemetry/exporting/telemetry_configuration.hpp
+++ b/projects/ores.telemetry/include/ores.telemetry/exporting/telemetry_configuration.hpp
@@ -17,15 +17,15 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_TELEMETRY_EXPORT_TELEMETRY_CONFIGURATION_HPP
-#define ORES_TELEMETRY_EXPORT_TELEMETRY_CONFIGURATION_HPP
+#ifndef ORES_TELEMETRY_EXPORTING_TELEMETRY_CONFIGURATION_HPP
+#define ORES_TELEMETRY_EXPORTING_TELEMETRY_CONFIGURATION_HPP
 
 #include <string>
 #include <optional>
 #include <boost/program_options.hpp>
-#include "ores.telemetry/export/telemetry_options.hpp"
+#include "ores.telemetry/exporting/telemetry_options.hpp"
 
-namespace ores::telemetry::exp {
+namespace ores::telemetry::exporting {
 
 /**
  * @brief Centralized manager for telemetry export configuration parsing.

--- a/projects/ores.telemetry/include/ores.telemetry/exporting/telemetry_options.hpp
+++ b/projects/ores.telemetry/include/ores.telemetry/exporting/telemetry_options.hpp
@@ -17,8 +17,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_TELEMETRY_EXPORT_TELEMETRY_OPTIONS_HPP
-#define ORES_TELEMETRY_EXPORT_TELEMETRY_OPTIONS_HPP
+#ifndef ORES_TELEMETRY_EXPORTING_TELEMETRY_OPTIONS_HPP
+#define ORES_TELEMETRY_EXPORTING_TELEMETRY_OPTIONS_HPP
 
 #include <chrono>
 #include <cstdint>
@@ -26,7 +26,7 @@
 #include <string>
 #include <filesystem>
 
-namespace ores::telemetry::exp {
+namespace ores::telemetry::exporting {
 
 /**
  * @brief Options related to telemetry export.

--- a/projects/ores.telemetry/include/ores.telemetry/exporting/upload_position_tracker.hpp
+++ b/projects/ores.telemetry/include/ores.telemetry/exporting/upload_position_tracker.hpp
@@ -17,14 +17,14 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_TELEMETRY_EXPORT_UPLOAD_POSITION_TRACKER_HPP
-#define ORES_TELEMETRY_EXPORT_UPLOAD_POSITION_TRACKER_HPP
+#ifndef ORES_TELEMETRY_EXPORTING_UPLOAD_POSITION_TRACKER_HPP
+#define ORES_TELEMETRY_EXPORTING_UPLOAD_POSITION_TRACKER_HPP
 
 #include <cstdint>
 #include <filesystem>
 #include <mutex>
 
-namespace ores::telemetry::exp {
+namespace ores::telemetry::exporting {
 
 /**
  * @brief Tracks the upload position for telemetry log files.

--- a/projects/ores.telemetry/modeling/ores.telemetry.org
+++ b/projects/ores.telemetry/modeling/ores.telemetry.org
@@ -32,7 +32,7 @@ The component is organized into four namespaces:
 | =domain=     | Core types: trace_id, span_id, log_record, resource |
 | =generators= | ID generators for traces and spans                 |
 | =log=        | Boost.Log integration and lifecycle management     |
-| =exp=        | Exporters for log records                          |
+| =exporting=  | Exporters for log records                          |
 
 * Logging Infrastructure
 
@@ -96,7 +96,7 @@ To enable log export, add a telemetry sink to the lifecycle manager:
 
 #+begin_src cpp
 #include "ores.telemetry/log/lifecycle_manager.hpp"
-#include "ores.telemetry/export/file_log_exporter.hpp"
+#include "ores.telemetry/exporting/file_log_exporter.hpp"
 #include "ores.telemetry/domain/resource.hpp"
 
 int main() {
@@ -113,7 +113,7 @@ int main() {
         "ores-service", "1.0.0");
 
     // Create file exporter for JSON Lines output
-    auto exporter = std::make_shared<telemetry::exp::file_log_exporter>(
+    auto exporter = std::make_shared<telemetry::exporting::file_log_exporter>(
         "/var/log/ores/telemetry.jsonl");
 
     // Add telemetry sink - all logs now also exported
@@ -184,9 +184,9 @@ void handle_request(const telemetry::domain::telemetry_context& ctx) {
 You can implement custom exporters by implementing the =log_exporter= interface:
 
 #+begin_src cpp
-#include "ores.telemetry/export/log_exporter.hpp"
+#include "ores.telemetry/exporting/log_exporter.hpp"
 
-class my_exporter : public telemetry::exp::log_exporter {
+class my_exporter : public telemetry::exporting::log_exporter {
 public:
     void export_record(telemetry::domain::log_record record) override {
         // Send to your log aggregation system

--- a/projects/ores.telemetry/src/exporting/file_log_exporter.cpp
+++ b/projects/ores.telemetry/src/exporting/file_log_exporter.cpp
@@ -17,14 +17,14 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#include "ores.telemetry/export/file_log_exporter.hpp"
+#include "ores.telemetry/exporting/file_log_exporter.hpp"
 
 #include <format>
 #include <chrono>
 #include <stdexcept>
 #include "ores.platform/time/time_utils.hpp"
 
-namespace ores::telemetry::exp {
+namespace ores::telemetry::exporting {
 
 namespace {
 

--- a/projects/ores.telemetry/src/exporting/hybrid_log_exporter.cpp
+++ b/projects/ores.telemetry/src/exporting/hybrid_log_exporter.cpp
@@ -17,7 +17,7 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#include "ores.telemetry/export/hybrid_log_exporter.hpp"
+#include "ores.telemetry/exporting/hybrid_log_exporter.hpp"
 
 #include <fstream>
 #include <format>
@@ -25,7 +25,7 @@
 #include <stdexcept>
 #include "ores.platform/time/time_utils.hpp"
 
-namespace ores::telemetry::exp {
+namespace ores::telemetry::exporting {
 
 namespace {
 

--- a/projects/ores.telemetry/src/exporting/telemetry_configuration.cpp
+++ b/projects/ores.telemetry/src/exporting/telemetry_configuration.cpp
@@ -17,9 +17,9 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#include "ores.telemetry/export/telemetry_configuration.hpp"
+#include "ores.telemetry/exporting/telemetry_configuration.hpp"
 
-namespace ores::telemetry::exp {
+namespace ores::telemetry::exporting {
 
 namespace {
 

--- a/projects/ores.telemetry/src/exporting/telemetry_options.cpp
+++ b/projects/ores.telemetry/src/exporting/telemetry_options.cpp
@@ -9,22 +9,24 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
  *
  * You should have received a copy of the GNU General Public License along with
  * this program; if not, write to the Free Software Foundation, Inc., 51
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_TELEMETRY_EXPORT_HPP
-#define ORES_TELEMETRY_EXPORT_HPP
+#include "ores.telemetry/exporting/telemetry_options.hpp"
 
-/**
- * @brief Log export functionality for telemetry.
- *
- * Contains log exporters including file-based and hybrid exporters for
- * persisting log records. Includes configuration types for export settings.
- */
-namespace ores::telemetry::exp {}
+#include <rfl.hpp>
+#include <rfl/json.hpp>
 
-#endif
+namespace ores::telemetry::exporting {
+
+std::ostream& operator<<(std::ostream& s, const telemetry_options& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.telemetry/src/exporting/upload_position_tracker.cpp
+++ b/projects/ores.telemetry/src/exporting/upload_position_tracker.cpp
@@ -17,18 +17,18 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#include "ores.telemetry/export/upload_position_tracker.hpp"
+#include "ores.telemetry/exporting/upload_position_tracker.hpp"
 
 #include <fstream>
 #include "ores.telemetry/log/make_logger.hpp"
 
-namespace ores::telemetry::exp {
+namespace ores::telemetry::exporting {
 
 namespace {
 
 auto& lg() {
     using namespace ores::telemetry::log;
-    static auto instance = make_logger("ores.telemetry.export.upload_position_tracker");
+    static auto instance = make_logger("ores.telemetry.exporting.upload_position_tracker");
     return instance;
 }
 


### PR DESCRIPTION
## Summary

- Rename the `export` folder and namespace to `exporting` in ores.telemetry to align folder and namespace names
- The previous `exp` namespace was necessary to avoid the C++ `export` keyword, but created a mismatch between folder and namespace
- Add `net` as a standard facet in the component-creator skill

## Changes

- **ores.telemetry**: Rename `export/` → `exporting/` (both include and src)
- **ores.telemetry**: Update namespace from `ores::telemetry::exp` to `ores::telemetry::exporting`
- **ores.telemetry**: Update all header guards, include paths, and namespace declarations
- **ores.shell**: Update consumers (parser.cpp, options.hpp, host.cpp)
- **ores.telemetry**: Update modeling documentation
- **component-creator skill**: Add `net` to standard facets

🤖 Generated with [Claude Code](https://claude.com/claude-code)