### PR TITLE
Fix C++ compiler warnings in HTTP module

### DIFF
--- a/projects/ores.http.server/src/CMakeLists.txt
+++ b/projects/ores.http.server/src/CMakeLists.txt
@@ -46,8 +46,8 @@ target_link_libraries(${lib_target_name}
         ores.telemetry.lib
         ores.utility.lib
         ores.database.lib
-        ores.comms.lib
-        reflectcpp::reflectcpp)
+        ores.comms.lib)
+# Note: reflectcpp comes transitively through ores.utility.lib -> ores.platform.lib (PUBLIC)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)
 

--- a/projects/ores.http/src/CMakeLists.txt
+++ b/projects/ores.http/src/CMakeLists.txt
@@ -47,7 +47,7 @@ target_link_libraries(${lib_target_name}
     PRIVATE
         jwt-cpp::jwt-cpp
         OpenSSL::SSL
-        OpenSSL::Crypto
-        reflectcpp::reflectcpp)
+        OpenSSL::Crypto)
+# Note: reflectcpp comes transitively through ores.utility.lib -> ores.platform.lib (PUBLIC)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.http/tests/CMakeLists.txt
+++ b/projects/ores.http/tests/CMakeLists.txt
@@ -32,11 +32,11 @@ set_target_properties(${tests_target_name}
 target_link_libraries(${tests_target_name}
     PRIVATE
         ${lib_target_name}
-        ores.utility.lib
         ores.testing.lib
         Catch2::Catch2
         faker-cxx::faker-cxx
         ${CMAKE_THREAD_LIBS_INIT})
+# Note: ores.utility.lib comes transitively through ${lib_target_name} (PUBLIC)
 
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM

--- a/projects/ores.wt/src/CMakeLists.txt
+++ b/projects/ores.wt/src/CMakeLists.txt
@@ -69,8 +69,7 @@ target_include_directories(${exe_target_name}
 target_link_libraries(${exe_target_name}
     PRIVATE
         ${lib_target_name}
-        Wt::Wt
-        Wt::HTTP
         ${CMAKE_THREAD_LIBS_INIT})
+# Note: Wt::Wt and Wt::HTTP come transitively through ${lib_target_name} (PUBLIC)
 
 install(TARGETS ${exe_target_name} RUNTIME DESTINATION bin)

--- a/projects/ores.wt/tests/CMakeLists.txt
+++ b/projects/ores.wt/tests/CMakeLists.txt
@@ -32,11 +32,11 @@ set_target_properties(${tests_target_name}
 target_link_libraries(${tests_target_name}
     PRIVATE
         ${lib_target_name}
-        ores.utility.lib
         ores.testing.lib
         Catch2::Catch2
         faker-cxx::faker-cxx
         ${CMAKE_THREAD_LIBS_INIT})
+# Note: ores.utility.lib comes transitively through ${lib_target_name} (PUBLIC)
 
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM


### PR DESCRIPTION
Remove redundant library dependencies that are already provided transitively through other targets:
- reflectcpp from ores.http and ores.http.server (comes via ores.utility.lib -> ores.platform.lib)
- Wt::Wt and Wt::HTTP from ores.wt executable (comes via ores.wt.lib)
- ores.utility.lib from test targets (comes via lib targets)