### PR TITLE
Fix compiler warnings in executable linking

### DIFF
--- a/projects/ores.qt/src/CMakeLists.txt
+++ b/projects/ores.qt/src/CMakeLists.txt
@@ -38,12 +38,12 @@ target_link_libraries(${exe_binary_name} PRIVATE
     ores.eventing.lib
     ores.telemetry.lib
     ores.utility.lib
-    Boost::process
     Qt6::Core
     Qt6::Gui
     Qt6::Widgets
     Qt6::Concurrent
     Qt6::Svg)
+# Note: Boost::process comes transitively through ores.telemetry.lib (PUBLIC)
 
 set_target_properties(${exe_binary_name} PROPERTIES
     AUTORCC_RESOURCE_DIRS "${ORES_QT_DIR}/resources;${ORES_QT_DIR}/resources/icons"

--- a/projects/ores.wt/src/CMakeLists.txt
+++ b/projects/ores.wt/src/CMakeLists.txt
@@ -70,8 +70,6 @@ target_link_libraries(${exe_target_name}
     PRIVATE
         ${lib_target_name}
         ores.platform.lib
-        Wt::Wt
-        Wt::HTTP
         ${CMAKE_THREAD_LIBS_INIT})
 # Note: Wt::Wt and Wt::HTTP come transitively through ${lib_target_name} (PUBLIC)
 


### PR DESCRIPTION
Remove explicit linking to libraries that already come transitively:
- ores.qt: Remove Boost::process (comes via ores.telemetry.lib)
- ores.wt: Remove Wt::Wt and Wt::HTTP (come via ores.wt.lib)