### PR TITLE
Fix C++ build errors in ores.assets project

### DIFF
--- a/projects/ores.risk/src/CMakeLists.txt
+++ b/projects/ores.risk/src/CMakeLists.txt
@@ -41,6 +41,8 @@ target_link_libraries(${lib_target_name}
         ores.platform.lib
         faker-cxx::faker-cxx
         libfort::fort
+        OpenSSL::SSL
+        OpenSSL::Crypto
     PUBLIC
         ores.comms.lib)
 


### PR DESCRIPTION
The ores.risk library uses ores.comms which depends on Boost.Asio with SSL support. On Windows, the OpenSSL symbols (ERR_reason_error_string, ERR_lib_error_string) need to be explicitly linked to resolve the ssl_category::message function references.

This follows the same pattern applied to ores.variability and ores.comms.