### PR TITLE
Fix Windows linking errors in security password tests

### DIFF
--- a/projects/ores.assets/src/CMakeLists.txt
+++ b/projects/ores.assets/src/CMakeLists.txt
@@ -44,7 +44,7 @@ target_link_libraries(${lib_target_name}
         ores.database.lib
         faker-cxx::faker-cxx
         libfort::fort
-        OpenSSL::SSL
         Boost::boost)
+# Note: OpenSSL comes transitively through ores.comms.lib (PUBLIC)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.comms/src/CMakeLists.txt
+++ b/projects/ores.comms/src/CMakeLists.txt
@@ -43,9 +43,12 @@ target_include_directories(${lib_target_name} PUBLIC
 target_link_libraries(${lib_target_name}
     PUBLIC
         ores.eventing.lib
+        OpenSSL::SSL
     PRIVATE
-        Boost::iostreams
-        OpenSSL::SSL)
+        Boost::iostreams)
+# Note: OpenSSL::SSL is PUBLIC because public headers (net/client.hpp,
+# net/server.hpp, net/connection.hpp) include <boost/asio/ssl.hpp> which
+# contains inline/template code that calls OpenSSL functions.
 # Note: reflectcpp comes transitively through ores.eventing.lib
 # -> ores.database.lib (reflectcpp is linked)
 

--- a/projects/ores.iam/src/CMakeLists.txt
+++ b/projects/ores.iam/src/CMakeLists.txt
@@ -41,8 +41,9 @@ target_link_libraries(${lib_target_name}
         ores.geo.lib
         ores.platform.lib
     PRIVATE
-        OpenSSL::Crypto
         faker-cxx::faker-cxx
         libfort::fort)
+# Note: OpenSSL::Crypto comes transitively through ores.variability.lib
+# -> ores.comms.lib -> OpenSSL::SSL (which depends on OpenSSL::Crypto)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.risk/src/CMakeLists.txt
+++ b/projects/ores.risk/src/CMakeLists.txt
@@ -41,8 +41,8 @@ target_link_libraries(${lib_target_name}
         ores.platform.lib
         faker-cxx::faker-cxx
         libfort::fort
-        OpenSSL::SSL
     PUBLIC
         ores.comms.lib)
+# Note: OpenSSL comes transitively through ores.comms.lib (PUBLIC)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.variability/src/CMakeLists.txt
+++ b/projects/ores.variability/src/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(${lib_target_name}
     PUBLIC
         ores.comms.lib
     PRIVATE
-        libfort::fort
-        OpenSSL::SSL)
+        libfort::fort)
+# Note: OpenSSL comes transitively through ores.comms.lib (PUBLIC)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)


### PR DESCRIPTION
The root cause of Windows linking errors was that ores.comms exposes Boost.Asio SSL headers publicly (net/client.hpp, net/server.hpp, net/connection.hpp include <boost/asio/ssl.hpp>), but linked OpenSSL as PRIVATE. This caused consumers to compile code that calls OpenSSL functions without having OpenSSL on their link line.

Changes:
- Make OpenSSL::SSL PUBLIC in ores.comms.lib (source of SSL headers)
- Remove redundant OpenSSL links from libraries that get it transitively:
  - ores.variability.lib (depends PUBLIC on ores.comms.lib)
  - ores.risk.lib (depends PUBLIC on ores.comms.lib)
  - ores.iam.lib (depends on ores.variability.lib -> ores.comms.lib)
  - ores.assets.lib (depends PUBLIC on ores.comms.lib)

This fixes both:
- Windows: undefined symbol ERR_reason_error_string/ERR_lib_error_string
- macOS: duplicate library warnings (OpenSSL now linked once at source)