### PR TITLE
[risk] Use X-prefix for fictional currency ISO codes

### DIFF
--- a/projects/ores.risk/src/generators/currency_generator.cpp
+++ b/projects/ores.risk/src/generators/currency_generator.cpp
@@ -199,301 +199,301 @@ generate_fictional_currencies(std::size_t n) {
     all.reserve(50);
 
     all.push_back({
-        .iso_code = "ALD", .name = "Aerilonian Dollar", .numeric_code = "10001",
+        .iso_code = "XAE", .name = "Aerilonian Dollar", .numeric_code = "10001",
         .symbol = "A$", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "ARA", .name = "Arcturian Arct", .numeric_code = "10002",
+        .iso_code = "XAR", .name = "Arcturian Arct", .numeric_code = "10002",
         .symbol = "Ar", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "BAF", .name = "Balthorian Florin", .numeric_code = "10003",
+        .iso_code = "XBL", .name = "Balthorian Florin", .numeric_code = "10003",
         .symbol = "Bf", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "BEB", .name = "Bellorian Bell", .numeric_code = "10004",
+        .iso_code = "XBE", .name = "Bellorian Bell", .numeric_code = "10004",
         .symbol = "Bb", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "CAC", .name = "Calandrian Crown", .numeric_code = "10005",
+        .iso_code = "XCA", .name = "Calandrian Crown", .numeric_code = "10005",
         .symbol = "Cc", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "CDC", .name = "Caledonian Caled", .numeric_code = "10006",
+        .iso_code = "XCL", .name = "Caledonian Caled", .numeric_code = "10006",
         .symbol = "Cd", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "DAD", .name = "Daelorian Dinar", .numeric_code = "10007",
+        .iso_code = "XDA", .name = "Daelorian Dinar", .numeric_code = "10007",
         .symbol = "Dd", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "DED", .name = "Delvadian Delv", .numeric_code = "10008",
+        .iso_code = "XDL", .name = "Delvadian Delv", .numeric_code = "10008",
         .symbol = "De", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "ERE", .name = "Eriadoran Euro", .numeric_code = "10009",
+        .iso_code = "XER", .name = "Eriadoran Euro", .numeric_code = "10009",
         .symbol = "Er", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "ESE", .name = "Esterian Est", .numeric_code = "10010",
+        .iso_code = "XES", .name = "Esterian Est", .numeric_code = "10010",
         .symbol = "Es", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "FEF", .name = "Felorian Franc", .numeric_code = "10011",
+        .iso_code = "XFE", .name = "Felorian Franc", .numeric_code = "10011",
         .symbol = "Ff", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "FNF", .name = "Fendarian Fen", .numeric_code = "10012",
+        .iso_code = "XFN", .name = "Fendarian Fen", .numeric_code = "10012",
         .symbol = "Fn", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "GAG", .name = "Galdorian Galleon", .numeric_code = "10013",
+        .iso_code = "XGA", .name = "Galdorian Galleon", .numeric_code = "10013",
         .symbol = "Gg", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "GRG", .name = "Grendorian Grend", .numeric_code = "10014",
+        .iso_code = "XGR", .name = "Grendorian Grend", .numeric_code = "10014",
         .symbol = "Gr", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "HEF", .name = "Helvetian Franc", .numeric_code = "10015",
+        .iso_code = "XHE", .name = "Helvetian Franc", .numeric_code = "10015",
         .symbol = "Hf", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "HYH", .name = "Hydronian Hyd", .numeric_code = "10016",
+        .iso_code = "XHY", .name = "Hydronian Hyd", .numeric_code = "10016",
         .symbol = "Hy", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "IRD", .name = "Iridian Dollar", .numeric_code = "10017",
+        .iso_code = "XIR", .name = "Iridian Dollar", .numeric_code = "10017",
         .symbol = "I$", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "ITI", .name = "Ithacan Ith", .numeric_code = "10018",
+        .iso_code = "XIT", .name = "Ithacan Ith", .numeric_code = "10018",
         .symbol = "It", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "JEJ", .name = "Jethronian Jet", .numeric_code = "10019",
+        .iso_code = "XJE", .name = "Jethronian Jet", .numeric_code = "10019",
         .symbol = "Je", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "JOK", .name = "Jorvikian Krona", .numeric_code = "10020",
+        .iso_code = "XJO", .name = "Jorvikian Krona", .numeric_code = "10020",
         .symbol = "Jk", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "KAK", .name = "Kaelorian Krown", .numeric_code = "10021",
+        .iso_code = "XKA", .name = "Kaelorian Krown", .numeric_code = "10021",
         .symbol = "Kk", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "KRK", .name = "Krynnish Krynn", .numeric_code = "10022",
+        .iso_code = "XKR", .name = "Krynnish Krynn", .numeric_code = "10022",
         .symbol = "Kr", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "LUL", .name = "Luminian Lum", .numeric_code = "10023",
+        .iso_code = "XLU", .name = "Luminian Lum", .numeric_code = "10023",
         .symbol = "Lu", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "LYL", .name = "Lysandrian Lira", .numeric_code = "10024",
+        .iso_code = "XLY", .name = "Lysandrian Lira", .numeric_code = "10024",
         .symbol = "Ly", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "MAM", .name = "Maldorian Mal", .numeric_code = "10025",
+        .iso_code = "XMA", .name = "Maldorian Mal", .numeric_code = "10025",
         .symbol = "Mm", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "MRP", .name = "Mariposan Peso", .numeric_code = "10026",
+        .iso_code = "XMR", .name = "Mariposan Peso", .numeric_code = "10026",
         .symbol = "Mp", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "NEN", .name = "Nektonian Nek", .numeric_code = "10027",
+        .iso_code = "XNE", .name = "Nektonian Nek", .numeric_code = "10027",
         .symbol = "Ne", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "NTN", .name = "Netharian Naira", .numeric_code = "10028",
+        .iso_code = "XNT", .name = "Netharian Naira", .numeric_code = "10028",
         .symbol = "Nt", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "ORB", .name = "Orinocan Bolivar", .numeric_code = "10029",
+        .iso_code = "XOR", .name = "Orinocan Bolivar", .numeric_code = "10029",
         .symbol = "Ob", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "OLO", .name = "Orlanthian Orl", .numeric_code = "10030",
+        .iso_code = "XOL", .name = "Orlanthian Orl", .numeric_code = "10030",
         .symbol = "Ol", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "PAP", .name = "Paldorian Peso", .numeric_code = "10031",
+        .iso_code = "XPL", .name = "Paldorian Peso", .numeric_code = "10031",
         .symbol = "Pp", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "PYP", .name = "Pyrrhian Pyr", .numeric_code = "10032",
+        .iso_code = "XPY", .name = "Pyrrhian Pyr", .numeric_code = "10032",
         .symbol = "Py", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "QUQ", .name = "Quentarian Quen", .numeric_code = "10033",
+        .iso_code = "XQU", .name = "Quentarian Quen", .numeric_code = "10033",
         .symbol = "Qu", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "QNQ", .name = "Quinarian Quetzal", .numeric_code = "10034",
+        .iso_code = "XQN", .name = "Quinarian Quetzal", .numeric_code = "10034",
         .symbol = "Qn", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "RER", .name = "Rendellian Rend", .numeric_code = "10035",
+        .iso_code = "XRE", .name = "Rendellian Rend", .numeric_code = "10035",
         .symbol = "Re", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "RIR", .name = "Rivenian Ruble", .numeric_code = "10036",
+        .iso_code = "XRI", .name = "Rivenian Ruble", .numeric_code = "10036",
         .symbol = "Ri", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "SES", .name = "Serendian Shilling", .numeric_code = "10037",
+        .iso_code = "XSE", .name = "Serendian Shilling", .numeric_code = "10037",
         .symbol = "Ss", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "SIS", .name = "Sildorian Sild", .numeric_code = "10038",
+        .iso_code = "XSI", .name = "Sildorian Sild", .numeric_code = "10038",
         .symbol = "Si", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "TAT", .name = "Tandorian Taka", .numeric_code = "10039",
+        .iso_code = "XTA", .name = "Tandorian Taka", .numeric_code = "10039",
         .symbol = "Ta", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "TET", .name = "Tenebrian Ten", .numeric_code = "10040",
+        .iso_code = "XTE", .name = "Tenebrian Ten", .numeric_code = "10040",
         .symbol = "Te", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "ULU", .name = "Uldorian Uld", .numeric_code = "10041",
+        .iso_code = "XUL", .name = "Uldorian Uld", .numeric_code = "10041",
         .symbol = "Ul", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "UTU", .name = "Utopian Unit", .numeric_code = "10042",
+        .iso_code = "XUT", .name = "Utopian Unit", .numeric_code = "10042",
         .symbol = "Ut", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "VAV", .name = "Valorian Valt", .numeric_code = "10042",
+        .iso_code = "XVA", .name = "Valorian Valt", .numeric_code = "10043",
         .symbol = "Vv", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "VLV", .name = "Valtarian Val", .numeric_code = "10043",
+        .iso_code = "XVL", .name = "Valtarian Val", .numeric_code = "10044",
         .symbol = "Vl", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "WIW", .name = "Wintervalean Won", .numeric_code = "10044",
+        .iso_code = "XWI", .name = "Wintervalean Won", .numeric_code = "10045",
         .symbol = "Ww", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "WYW", .name = "Wysterian Wys", .numeric_code = "10045",
+        .iso_code = "XWY", .name = "Wysterian Wys", .numeric_code = "10046",
         .symbol = "Wy", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "XAX", .name = "Xandrian Xan", .numeric_code = "10046",
+        .iso_code = "XAN", .name = "Xandrian Xan", .numeric_code = "10047",
         .symbol = "Xa", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "XEX", .name = "Xenorian Xen", .numeric_code = "10047",
+        .iso_code = "XEN", .name = "Xenorian Xen", .numeric_code = "10048",
         .symbol = "Xe", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "YSY", .name = "Yslandian Yen", .numeric_code = "10048",
+        .iso_code = "XYS", .name = "Yslandian Yen", .numeric_code = "10049",
         .symbol = "Ys", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now
     });
     all.push_back({
-        .iso_code = "ZEZ", .name = "Zephyrian Zephyr", .numeric_code = "10049",
+        .iso_code = "XZE", .name = "Zephyrian Zephyr", .numeric_code = "10050",
         .symbol = "Ze", .fractions_per_unit = 100, .rounding_type = "Closest",
         .rounding_precision = 2, .format = "%3% %1$.2f", .currency_type = "Fiat",
         .recorded_by = user, .recorded_at = now

--- a/projects/ores.risk/tests/generators_currency_generator_tests.cpp
+++ b/projects/ores.risk/tests/generators_currency_generator_tests.cpp
@@ -132,6 +132,18 @@ TEST_CASE("generate_fictional_currencies_has_unique_iso_codes", tags) {
     CHECK(codes.size() == 50);
 }
 
+TEST_CASE("generate_fictional_currencies_has_unique_numeric_codes", tags) {
+    auto lg(make_logger(test_suite));
+
+    auto currencies = generate_fictional_currencies();
+
+    std::set<std::string> codes;
+    for (const auto& c : currencies)
+        codes.insert(c.numeric_code);
+
+    CHECK(codes.size() == 50);
+}
+
 TEST_CASE("generate_fictional_currencies_has_expected_first_currency", tags) {
     auto lg(make_logger(test_suite));
 
@@ -139,7 +151,7 @@ TEST_CASE("generate_fictional_currencies_has_expected_first_currency", tags) {
     BOOST_LOG_SEV(lg, debug) << "First fictional currency: " << currencies;
 
     REQUIRE(currencies.size() == 1);
-    CHECK(currencies[0].iso_code == "ALD");
+    CHECK(currencies[0].iso_code == "XAE");
     CHECK(currencies[0].name == "Aerilonian Dollar");
     CHECK(!currencies[0].recorded_by.empty());
     CHECK(currencies[0].recorded_at != std::chrono::system_clock::time_point{});
@@ -154,9 +166,9 @@ TEST_CASE("generate_fictional_currencies_contains_known_currencies", tags) {
     for (const auto& c : currencies)
         codes.insert(c.iso_code);
 
-    CHECK(codes.count("ALD") == 1);  // Aerilonian Dollar
-    CHECK(codes.count("ZEZ") == 1);  // Zephyrian Zephyr
-    CHECK(codes.count("ERE") == 1);  // Eriadoran Euro
-    CHECK(codes.count("KRK") == 1);  // Krynnish Krynn
+    CHECK(codes.count("XAE") == 1);  // Aerilonian Dollar
+    CHECK(codes.count("XZE") == 1);  // Zephyrian Zephyr
+    CHECK(codes.count("XER") == 1);  // Eriadoran Euro
+    CHECK(codes.count("XKR") == 1);  // Krynnish Krynn
 }
 


### PR DESCRIPTION
## Summary
- Use the X-prefix convention (reserved for non-ISO currencies) for all fictional currencies to avoid potential clashes with real ISO 4217 currency codes
- Fixes duplicate numeric_code bug (VAV was using same code as UTU)
- Updates tests to check for new X-prefixed codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)