### PR TITLE
[all] Fix build: migrate logging includes to ores.logging

### DIFF
--- a/projects/ores.cli/tests/add_options_tests.cpp
+++ b/projects/ores.cli/tests/add_options_tests.cpp
@@ -26,7 +26,7 @@
 #include <sstream>
 #include <variant>
 #include <catch2/catch_test_macros.hpp>
-#include "ores.telemetry/log/make_logger.hpp"
+#include "ores.logging/make_logger.hpp"
 
 namespace {
 
@@ -36,7 +36,7 @@ const std::string tags("[add_options]");
 }
 
 using namespace ores::cli::config;
-using namespace ores::telemetry::log;
+using namespace ores::logging;
 
 TEST_CASE("add_currency_options_required_fields", tags) {
     auto lg(make_logger(test_suite));

--- a/projects/ores.cli/tests/config_options_tests.cpp
+++ b/projects/ores.cli/tests/config_options_tests.cpp
@@ -25,7 +25,7 @@
 
 #include <sstream>
 #include <catch2/catch_test_macros.hpp>
-#include "ores.telemetry/log/make_logger.hpp"
+#include "ores.logging/make_logger.hpp"
 
 namespace {
 
@@ -35,7 +35,7 @@ const std::string tags("[config]");
 }
 
 using namespace ores::cli::config;
-using namespace ores::telemetry::log;
+using namespace ores::logging;
 
 TEST_CASE("import_options_construction", tags) {
     auto lg(make_logger(test_suite));

--- a/projects/ores.comms.analyser/tests/options_tests.cpp
+++ b/projects/ores.comms.analyser/tests/options_tests.cpp
@@ -20,7 +20,7 @@
 #include "ores.comms.analyser/config/options.hpp"
 
 #include <catch2/catch_test_macros.hpp>
-#include "ores.telemetry/log/make_logger.hpp"
+#include "ores.logging/make_logger.hpp"
 
 namespace {
 
@@ -30,7 +30,7 @@ const std::string tags("[options]");
 }
 
 using namespace ores::comms::analyser::config;
-using namespace ores::telemetry::log;
+using namespace ores::logging;
 
 TEST_CASE("options_default_construction", tags) {
     auto lg(make_logger(test_suite));

--- a/projects/ores.http/tests/http_request_tests.cpp
+++ b/projects/ores.http/tests/http_request_tests.cpp
@@ -20,7 +20,7 @@
 #include "ores.http/domain/http_request.hpp"
 
 #include <catch2/catch_test_macros.hpp>
-#include "ores.telemetry/log/make_logger.hpp"
+#include "ores.logging/make_logger.hpp"
 
 namespace {
 
@@ -30,7 +30,7 @@ const std::string tags("[http_request]");
 }
 
 using namespace ores::http::domain;
-using namespace ores::telemetry::log;
+using namespace ores::logging;
 
 TEST_CASE("http_request_get_header_returns_value", tags) {
     auto lg(make_logger(test_suite));

--- a/projects/ores.http/tests/http_response_tests.cpp
+++ b/projects/ores.http/tests/http_response_tests.cpp
@@ -20,7 +20,7 @@
 #include "ores.http/domain/http_response.hpp"
 
 #include <catch2/catch_test_macros.hpp>
-#include "ores.telemetry/log/make_logger.hpp"
+#include "ores.logging/make_logger.hpp"
 
 namespace {
 
@@ -30,7 +30,7 @@ const std::string tags("[http_response]");
 }
 
 using namespace ores::http::domain;
-using namespace ores::telemetry::log;
+using namespace ores::logging;
 
 TEST_CASE("http_response_json_creates_json_response", tags) {
     auto lg(make_logger(test_suite));

--- a/projects/ores.http/tests/http_server_options_tests.cpp
+++ b/projects/ores.http/tests/http_server_options_tests.cpp
@@ -21,7 +21,7 @@
 
 #include <sstream>
 #include <catch2/catch_test_macros.hpp>
-#include "ores.telemetry/log/make_logger.hpp"
+#include "ores.logging/make_logger.hpp"
 
 namespace {
 
@@ -31,7 +31,7 @@ const std::string tags("[http_server_options]");
 }
 
 using namespace ores::http::net;
-using namespace ores::telemetry::log;
+using namespace ores::logging;
 
 TEST_CASE("http_server_options_default_construction", tags) {
     auto lg(make_logger(test_suite));

--- a/projects/ores.http/tests/jwt_claims_tests.cpp
+++ b/projects/ores.http/tests/jwt_claims_tests.cpp
@@ -20,7 +20,7 @@
 #include "ores.http/domain/jwt_claims.hpp"
 
 #include <catch2/catch_test_macros.hpp>
-#include "ores.telemetry/log/make_logger.hpp"
+#include "ores.logging/make_logger.hpp"
 
 namespace {
 
@@ -30,7 +30,7 @@ const std::string tags("[jwt_claims]");
 }
 
 using namespace ores::http::domain;
-using namespace ores::telemetry::log;
+using namespace ores::logging;
 
 TEST_CASE("jwt_claims_default_construction", tags) {
     auto lg(make_logger(test_suite));

--- a/projects/ores.http/tests/route_tests.cpp
+++ b/projects/ores.http/tests/route_tests.cpp
@@ -21,7 +21,7 @@
 
 #include <regex>
 #include <catch2/catch_test_macros.hpp>
-#include "ores.telemetry/log/make_logger.hpp"
+#include "ores.logging/make_logger.hpp"
 
 namespace {
 
@@ -42,7 +42,7 @@ ores::http::domain::route make_route(const std::string& pattern,
 }
 
 using namespace ores::http::domain;
-using namespace ores::telemetry::log;
+using namespace ores::logging;
 
 TEST_CASE("route_match_simple_path", tags) {
     auto lg(make_logger(test_suite));

--- a/projects/ores.qt/include/ores.qt/FeatureFlagHistoryDialog.hpp
+++ b/projects/ores.qt/include/ores.qt/FeatureFlagHistoryDialog.hpp
@@ -29,7 +29,7 @@
 #include <QAction>
 #include "ores.qt/ClientManager.hpp"
 #include "ores.variability/domain/feature_flags.hpp"
-#include "ores.telemetry/log/make_logger.hpp"
+#include "ores.logging/make_logger.hpp"
 #include "ui_FeatureFlagHistoryDialog.h"
 
 namespace Ui {
@@ -49,7 +49,7 @@ private:
         "ores.qt.feature_flag_history_dialog";
 
     [[nodiscard]] static auto& lg() {
-        using namespace ores::telemetry::log;
+        using namespace ores::logging;
         static auto instance = make_logger(logger_name);
         return instance;
     }

--- a/projects/ores.qt/src/FeatureFlagHistoryDialog.cpp
+++ b/projects/ores.qt/src/FeatureFlagHistoryDialog.cpp
@@ -36,7 +36,7 @@ namespace ores::qt {
 
 using comms::messaging::frame;
 using comms::messaging::message_type;
-using namespace ores::telemetry::log;
+using namespace ores::logging;
 
 const QIcon& FeatureFlagHistoryDialog::getHistoryIcon() const {
     static const QIcon historyIcon(":/icons/ic_fluent_history_20_regular.svg");


### PR DESCRIPTION
## Summary

- Fix build breakage caused by stale include paths after logging refactoring
- Update `ores.telemetry/log/make_logger.hpp` to `ores.logging/make_logger.hpp`
- Update `ores::telemetry::log` namespace to `ores::logging`

Affected files:
- CLI tests (add_options_tests.cpp, config_options_tests.cpp)
- HTTP tests (http_request_tests.cpp, http_response_tests.cpp, http_server_options_tests.cpp, jwt_claims_tests.cpp, route_tests.cpp)
- Comms analyser tests (options_tests.cpp)
- Qt feature flag history dialog (header and implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)