### PR TITLE
[qt] Add full CRUD support for change reason dialogs

### DIFF
--- a/projects/ores.comms/include/ores.comms/messaging/message_types.hpp
+++ b/projects/ores.comms/include/ores.comms/messaging/message_types.hpp
@@ -166,8 +166,13 @@ constexpr std::uint32_t PROTOCOL_MAGIC = 0x4F524553;
 // Version 21.1 adds change management messages for querying the catalog of valid
 // change reasons. New messages: get_change_reason_categories_request/response,
 // get_change_reasons_request/response, get_change_reasons_by_category_request/response.
+//
+// Version 21.2 adds CRUD and history operations for change reasons and categories.
+// New messages: save_change_reason_request/response, delete_change_reason_request/response,
+// get_change_reason_history_request/response, save_change_reason_category_request/response,
+// delete_change_reason_category_request/response, get_change_reason_category_history_request/response.
 constexpr std::uint16_t PROTOCOL_VERSION_MAJOR = 21;
-constexpr std::uint16_t PROTOCOL_VERSION_MINOR = 1;
+constexpr std::uint16_t PROTOCOL_VERSION_MINOR = 2;
 
 // Subsystem message type ranges
 constexpr std::uint16_t CORE_SUBSYSTEM_MIN = 0x0000;
@@ -296,13 +301,25 @@ enum class message_type {
     get_active_sessions_request = 0x2044,
     get_active_sessions_response = 0x2045,
 
-    // Change management messages (0x2050 - 0x205F)
+    // Change management messages (0x2050 - 0x206F)
     get_change_reason_categories_request = 0x2050,
     get_change_reason_categories_response = 0x2051,
     get_change_reasons_request = 0x2052,
     get_change_reasons_response = 0x2053,
     get_change_reasons_by_category_request = 0x2054,
     get_change_reasons_by_category_response = 0x2055,
+    save_change_reason_request = 0x2056,
+    save_change_reason_response = 0x2057,
+    delete_change_reason_request = 0x2058,
+    delete_change_reason_response = 0x2059,
+    get_change_reason_history_request = 0x205A,
+    get_change_reason_history_response = 0x205B,
+    save_change_reason_category_request = 0x205C,
+    save_change_reason_category_response = 0x205D,
+    delete_change_reason_category_request = 0x205E,
+    delete_change_reason_category_response = 0x205F,
+    get_change_reason_category_history_request = 0x2060,
+    get_change_reason_category_history_response = 0x2061,
 
     // Variability subsystem messages (0x3000 - 0x3FFF)
     get_feature_flags_request = 0x3000,  // Renamed from list_feature_flags in v21.0

--- a/projects/ores.iam/include/ores.iam/messaging/accounts_message_handler.hpp
+++ b/projects/ores.iam/include/ores.iam/messaging/accounts_message_handler.hpp
@@ -422,6 +422,63 @@ private:
         std::span<const std::byte> payload,
         const std::string& remote_address);
 
+    /**
+     * @brief Handle save_change_reason_request message.
+     *
+     * Requires authentication and change_reasons:write permission.
+     */
+    handler_result
+    handle_save_change_reason_request(std::span<const std::byte> payload,
+        const std::string& remote_address);
+
+    /**
+     * @brief Handle delete_change_reason_request message.
+     *
+     * Requires authentication and change_reasons:delete permission.
+     */
+    handler_result
+    handle_delete_change_reason_request(std::span<const std::byte> payload,
+        const std::string& remote_address);
+
+    /**
+     * @brief Handle get_change_reason_history_request message.
+     *
+     * Requires authentication. Returns all versions of a change reason.
+     */
+    handler_result
+    handle_get_change_reason_history_request(std::span<const std::byte> payload,
+        const std::string& remote_address);
+
+    /**
+     * @brief Handle save_change_reason_category_request message.
+     *
+     * Requires authentication and change_reason_categories:write permission.
+     */
+    handler_result
+    handle_save_change_reason_category_request(
+        std::span<const std::byte> payload,
+        const std::string& remote_address);
+
+    /**
+     * @brief Handle delete_change_reason_category_request message.
+     *
+     * Requires authentication and change_reason_categories:delete permission.
+     */
+    handler_result
+    handle_delete_change_reason_category_request(
+        std::span<const std::byte> payload,
+        const std::string& remote_address);
+
+    /**
+     * @brief Handle get_change_reason_category_history_request message.
+     *
+     * Requires authentication. Returns all versions of a category.
+     */
+    handler_result
+    handle_get_change_reason_category_history_request(
+        std::span<const std::byte> payload,
+        const std::string& remote_address);
+
     service::account_service service_;
     database::context ctx_;
     std::shared_ptr<variability::service::system_flags_service> system_flags_;

--- a/projects/ores.iam/include/ores.iam/messaging/change_management_protocol.hpp
+++ b/projects/ores.iam/include/ores.iam/messaging/change_management_protocol.hpp
@@ -117,6 +117,239 @@ struct get_change_reasons_by_category_response final {
 std::ostream& operator<<(std::ostream& s,
     const get_change_reasons_by_category_response& v);
 
+// ============================================================================
+// Change Reason CRUD Operations
+// ============================================================================
+
+/**
+ * @brief Request to save a change reason (create or update).
+ *
+ * Due to bitemporal storage, both create and update operations
+ * result in writing a new record. Database triggers handle temporal
+ * versioning automatically. The code field is the natural key.
+ */
+struct save_change_reason_request final {
+    domain::change_reason reason;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<save_change_reason_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const save_change_reason_request& v);
+
+/**
+ * @brief Response confirming change reason save operation.
+ */
+struct save_change_reason_response final {
+    bool success;
+    std::string message;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<save_change_reason_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const save_change_reason_response& v);
+
+/**
+ * @brief Result for a single change reason deletion.
+ */
+struct delete_change_reason_result final {
+    std::string code;
+    bool success;
+    std::string message;
+};
+
+std::ostream& operator<<(std::ostream& s, const delete_change_reason_result& v);
+
+/**
+ * @brief Request to delete one or more change reasons.
+ *
+ * Supports batch deletion by accepting a vector of codes.
+ * Each reason is processed independently - partial success is possible.
+ */
+struct delete_change_reason_request final {
+    std::vector<std::string> codes;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<delete_change_reason_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const delete_change_reason_request& v);
+
+/**
+ * @brief Response confirming change reason deletion(s).
+ *
+ * Contains one result per requested reason, indicating individual
+ * success or failure. Supports partial success in batch operations.
+ */
+struct delete_change_reason_response final {
+    std::vector<delete_change_reason_result> results;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<delete_change_reason_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const delete_change_reason_response& v);
+
+/**
+ * @brief Request to retrieve version history for a change reason.
+ */
+struct get_change_reason_history_request final {
+    std::string code;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<get_change_reason_history_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s,
+    const get_change_reason_history_request& v);
+
+/**
+ * @brief Response containing change reason version history.
+ */
+struct get_change_reason_history_response final {
+    bool success;
+    std::string message;
+    std::vector<domain::change_reason> versions;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<get_change_reason_history_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s,
+    const get_change_reason_history_response& v);
+
+// ============================================================================
+// Change Reason Category CRUD Operations
+// ============================================================================
+
+/**
+ * @brief Request to save a change reason category (create or update).
+ *
+ * Due to bitemporal storage, both create and update operations
+ * result in writing a new record. Database triggers handle temporal
+ * versioning automatically. The code field is the natural key.
+ */
+struct save_change_reason_category_request final {
+    domain::change_reason_category category;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<save_change_reason_category_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s,
+    const save_change_reason_category_request& v);
+
+/**
+ * @brief Response confirming change reason category save operation.
+ */
+struct save_change_reason_category_response final {
+    bool success;
+    std::string message;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<save_change_reason_category_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s,
+    const save_change_reason_category_response& v);
+
+/**
+ * @brief Result for a single change reason category deletion.
+ */
+struct delete_change_reason_category_result final {
+    std::string code;
+    bool success;
+    std::string message;
+};
+
+std::ostream& operator<<(std::ostream& s,
+    const delete_change_reason_category_result& v);
+
+/**
+ * @brief Request to delete one or more change reason categories.
+ *
+ * Supports batch deletion by accepting a vector of codes.
+ * Each category is processed independently - partial success is possible.
+ */
+struct delete_change_reason_category_request final {
+    std::vector<std::string> codes;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<delete_change_reason_category_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s,
+    const delete_change_reason_category_request& v);
+
+/**
+ * @brief Response confirming change reason category deletion(s).
+ *
+ * Contains one result per requested category, indicating individual
+ * success or failure. Supports partial success in batch operations.
+ */
+struct delete_change_reason_category_response final {
+    std::vector<delete_change_reason_category_result> results;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<delete_change_reason_category_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s,
+    const delete_change_reason_category_response& v);
+
+/**
+ * @brief Request to retrieve version history for a change reason category.
+ */
+struct get_change_reason_category_history_request final {
+    std::string code;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<get_change_reason_category_history_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s,
+    const get_change_reason_category_history_request& v);
+
+/**
+ * @brief Response containing change reason category version history.
+ */
+struct get_change_reason_category_history_response final {
+    bool success;
+    std::string message;
+    std::vector<domain::change_reason_category> versions;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<get_change_reason_category_history_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s,
+    const get_change_reason_category_history_response& v);
+
 }
 
 namespace ores::comms::messaging {
@@ -152,6 +385,72 @@ struct message_traits<iam::messaging::get_change_reasons_by_category_request> {
     using response_type = iam::messaging::get_change_reasons_by_category_response;
     static constexpr message_type request_message_type =
         message_type::get_change_reasons_by_category_request;
+};
+
+/**
+ * @brief Message traits specialization for save_change_reason_request.
+ */
+template<>
+struct message_traits<iam::messaging::save_change_reason_request> {
+    using request_type = iam::messaging::save_change_reason_request;
+    using response_type = iam::messaging::save_change_reason_response;
+    static constexpr message_type request_message_type =
+        message_type::save_change_reason_request;
+};
+
+/**
+ * @brief Message traits specialization for delete_change_reason_request.
+ */
+template<>
+struct message_traits<iam::messaging::delete_change_reason_request> {
+    using request_type = iam::messaging::delete_change_reason_request;
+    using response_type = iam::messaging::delete_change_reason_response;
+    static constexpr message_type request_message_type =
+        message_type::delete_change_reason_request;
+};
+
+/**
+ * @brief Message traits specialization for get_change_reason_history_request.
+ */
+template<>
+struct message_traits<iam::messaging::get_change_reason_history_request> {
+    using request_type = iam::messaging::get_change_reason_history_request;
+    using response_type = iam::messaging::get_change_reason_history_response;
+    static constexpr message_type request_message_type =
+        message_type::get_change_reason_history_request;
+};
+
+/**
+ * @brief Message traits specialization for save_change_reason_category_request.
+ */
+template<>
+struct message_traits<iam::messaging::save_change_reason_category_request> {
+    using request_type = iam::messaging::save_change_reason_category_request;
+    using response_type = iam::messaging::save_change_reason_category_response;
+    static constexpr message_type request_message_type =
+        message_type::save_change_reason_category_request;
+};
+
+/**
+ * @brief Message traits specialization for delete_change_reason_category_request.
+ */
+template<>
+struct message_traits<iam::messaging::delete_change_reason_category_request> {
+    using request_type = iam::messaging::delete_change_reason_category_request;
+    using response_type = iam::messaging::delete_change_reason_category_response;
+    static constexpr message_type request_message_type =
+        message_type::delete_change_reason_category_request;
+};
+
+/**
+ * @brief Message traits specialization for get_change_reason_category_history_request.
+ */
+template<>
+struct message_traits<iam::messaging::get_change_reason_category_history_request> {
+    using request_type = iam::messaging::get_change_reason_category_history_request;
+    using response_type = iam::messaging::get_change_reason_category_history_response;
+    static constexpr message_type request_message_type =
+        message_type::get_change_reason_category_history_request;
 };
 
 }

--- a/projects/ores.iam/include/ores.iam/repository/change_reason_category_repository.hpp
+++ b/projects/ores.iam/include/ores.iam/repository/change_reason_category_repository.hpp
@@ -85,6 +85,13 @@ public:
     std::uint32_t get_total_count();
 
     /**
+     * @brief Reads all historical versions of a change_reason_category by code.
+     * @param code The category code to look up
+     * @return Vector of all versions, ordered by version descending
+     */
+    std::vector<domain::change_reason_category> read_all(const std::string& code);
+
+    /**
      * @brief Deletes a change_reason_category by closing its temporal validity.
      */
     void remove(const std::string& code);

--- a/projects/ores.iam/include/ores.iam/repository/change_reason_repository.hpp
+++ b/projects/ores.iam/include/ores.iam/repository/change_reason_repository.hpp
@@ -91,6 +91,13 @@ public:
     std::uint32_t get_total_count();
 
     /**
+     * @brief Reads all historical versions of a change_reason by code.
+     * @param code The change reason code to look up
+     * @return Vector of all versions, ordered by version descending
+     */
+    std::vector<domain::change_reason> read_all(const std::string& code);
+
+    /**
      * @brief Deletes a change_reason by closing its temporal validity.
      */
     void remove(const std::string& code);

--- a/projects/ores.iam/include/ores.iam/service/account_service.hpp
+++ b/projects/ores.iam/include/ores.iam/service/account_service.hpp
@@ -194,11 +194,15 @@ public:
      * @param account_id The ID of the account to update
      * @param email The new email address
      * @param recorded_by The username making the change
+     * @param change_reason_code The change reason code for audit trail
+     * @param change_commentary Free-text commentary explaining the change
      * @return true if the account was updated successfully, false otherwise
      * @throws std::invalid_argument If account does not exist
      */
     bool update_account(const boost::uuids::uuid& account_id,
-        const std::string& email, const std::string& recorded_by);
+        const std::string& email, const std::string& recorded_by,
+        const std::string& change_reason_code,
+        const std::string& change_commentary);
 
     /**
      * @brief Retrieves all historical versions of an account by username.

--- a/projects/ores.iam/include/ores.iam/service/change_management_service.hpp
+++ b/projects/ores.iam/include/ores.iam/service/change_management_service.hpp
@@ -90,17 +90,13 @@ public:
     /**
      * @brief Creates a new change reason category.
      *
-     * @param code The category code (e.g., "static_data", "trade")
-     * @param description Human-readable description
-     * @param recorded_by Username of the person creating the category
-     * @param change_commentary Commentary explaining the creation
+     * @param category The category to create
      * @return The created category
+     * @throws std::invalid_argument if code is empty
+     * @throws std::runtime_error if category already exists
      */
     domain::change_reason_category create_category(
-        const std::string& code,
-        const std::string& description,
-        const std::string& recorded_by,
-        const std::string& change_commentary);
+        const domain::change_reason_category& category);
 
     /**
      * @brief Updates an existing change reason category.
@@ -115,6 +111,15 @@ public:
      * @param code The code of the category to remove
      */
     void remove_category(const std::string& code);
+
+    /**
+     * @brief Gets the version history for a category.
+     *
+     * @param code The category code
+     * @return Vector of all versions, newest first
+     */
+    std::vector<domain::change_reason_category>
+    get_category_history(const std::string& code);
 
     // ========================================================================
     // Reason Management
@@ -169,6 +174,14 @@ public:
      * @param code The code of the reason to remove
      */
     void remove_reason(const std::string& code);
+
+    /**
+     * @brief Gets the version history for a reason.
+     *
+     * @param code The reason code
+     * @return Vector of all versions, newest first
+     */
+    std::vector<domain::change_reason> get_reason_history(const std::string& code);
 
     // ========================================================================
     // Validation

--- a/projects/ores.iam/src/messaging/change_management_protocol.cpp
+++ b/projects/ores.iam/src/messaging/change_management_protocol.cpp
@@ -390,4 +390,572 @@ std::ostream& operator<<(std::ostream& s,
     return s;
 }
 
+// ============================================================================
+// Change Reason CRUD Operations
+// ============================================================================
+
+namespace {
+
+// Helper to serialize a change_reason
+void write_change_reason(std::vector<std::byte>& buffer,
+    const domain::change_reason& r) {
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(r.version));
+    writer::write_string(buffer, r.code);
+    writer::write_string(buffer, r.description);
+    writer::write_string(buffer, r.category_code);
+    writer::write_bool(buffer, r.applies_to_amend);
+    writer::write_bool(buffer, r.applies_to_delete);
+    writer::write_bool(buffer, r.requires_commentary);
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(r.display_order));
+    writer::write_string(buffer, r.recorded_by);
+    writer::write_string(buffer, r.change_commentary);
+    writer::write_string(buffer,
+        ores::platform::time::datetime::format_time_point(r.recorded_at));
+}
+
+// Helper to deserialize a change_reason
+std::expected<domain::change_reason, error_code>
+read_change_reason(std::span<const std::byte>& data) {
+    domain::change_reason r;
+
+    auto version_result = reader::read_uint32(data);
+    if (!version_result) return std::unexpected(version_result.error());
+    r.version = static_cast<int>(*version_result);
+
+    auto code_result = reader::read_string(data);
+    if (!code_result) return std::unexpected(code_result.error());
+    r.code = *code_result;
+
+    auto description_result = reader::read_string(data);
+    if (!description_result) return std::unexpected(description_result.error());
+    r.description = *description_result;
+
+    auto category_code_result = reader::read_string(data);
+    if (!category_code_result) return std::unexpected(category_code_result.error());
+    r.category_code = *category_code_result;
+
+    auto applies_to_amend_result = reader::read_bool(data);
+    if (!applies_to_amend_result) return std::unexpected(applies_to_amend_result.error());
+    r.applies_to_amend = *applies_to_amend_result;
+
+    auto applies_to_delete_result = reader::read_bool(data);
+    if (!applies_to_delete_result) return std::unexpected(applies_to_delete_result.error());
+    r.applies_to_delete = *applies_to_delete_result;
+
+    auto requires_commentary_result = reader::read_bool(data);
+    if (!requires_commentary_result) return std::unexpected(requires_commentary_result.error());
+    r.requires_commentary = *requires_commentary_result;
+
+    auto display_order_result = reader::read_uint32(data);
+    if (!display_order_result) return std::unexpected(display_order_result.error());
+    r.display_order = static_cast<int>(*display_order_result);
+
+    auto recorded_by_result = reader::read_string(data);
+    if (!recorded_by_result) return std::unexpected(recorded_by_result.error());
+    r.recorded_by = *recorded_by_result;
+
+    auto change_commentary_result = reader::read_string(data);
+    if (!change_commentary_result) return std::unexpected(change_commentary_result.error());
+    r.change_commentary = *change_commentary_result;
+
+    auto recorded_at_result = reader::read_string(data);
+    if (!recorded_at_result) return std::unexpected(recorded_at_result.error());
+    try {
+        r.recorded_at = ores::platform::time::datetime::parse_time_point(
+            *recorded_at_result);
+    } catch (const std::invalid_argument&) {
+        return std::unexpected(error_code::invalid_request);
+    }
+
+    return r;
+}
+
+// Helper to serialize a change_reason_category
+void write_change_reason_category(std::vector<std::byte>& buffer,
+    const domain::change_reason_category& c) {
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(c.version));
+    writer::write_string(buffer, c.code);
+    writer::write_string(buffer, c.description);
+    writer::write_string(buffer, c.recorded_by);
+    writer::write_string(buffer, c.change_commentary);
+    writer::write_string(buffer,
+        ores::platform::time::datetime::format_time_point(c.recorded_at));
+}
+
+// Helper to deserialize a change_reason_category
+std::expected<domain::change_reason_category, error_code>
+read_change_reason_category(std::span<const std::byte>& data) {
+    domain::change_reason_category c;
+
+    auto version_result = reader::read_uint32(data);
+    if (!version_result) return std::unexpected(version_result.error());
+    c.version = static_cast<int>(*version_result);
+
+    auto code_result = reader::read_string(data);
+    if (!code_result) return std::unexpected(code_result.error());
+    c.code = *code_result;
+
+    auto description_result = reader::read_string(data);
+    if (!description_result) return std::unexpected(description_result.error());
+    c.description = *description_result;
+
+    auto recorded_by_result = reader::read_string(data);
+    if (!recorded_by_result) return std::unexpected(recorded_by_result.error());
+    c.recorded_by = *recorded_by_result;
+
+    auto change_commentary_result = reader::read_string(data);
+    if (!change_commentary_result) return std::unexpected(change_commentary_result.error());
+    c.change_commentary = *change_commentary_result;
+
+    auto recorded_at_result = reader::read_string(data);
+    if (!recorded_at_result) return std::unexpected(recorded_at_result.error());
+    try {
+        c.recorded_at = ores::platform::time::datetime::parse_time_point(
+            *recorded_at_result);
+    } catch (const std::invalid_argument&) {
+        return std::unexpected(error_code::invalid_request);
+    }
+
+    return c;
+}
+
+} // anonymous namespace
+
+// save_change_reason_request
+
+std::vector<std::byte> save_change_reason_request::serialize() const {
+    std::vector<std::byte> buffer;
+    write_change_reason(buffer, reason);
+    return buffer;
+}
+
+std::expected<save_change_reason_request, error_code>
+save_change_reason_request::deserialize(std::span<const std::byte> data) {
+    save_change_reason_request request;
+
+    auto reason_result = read_change_reason(data);
+    if (!reason_result) return std::unexpected(reason_result.error());
+    request.reason = std::move(*reason_result);
+
+    return request;
+}
+
+std::ostream& operator<<(std::ostream& s, const save_change_reason_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+// save_change_reason_response
+
+std::vector<std::byte> save_change_reason_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_bool(buffer, success);
+    writer::write_string(buffer, message);
+    return buffer;
+}
+
+std::expected<save_change_reason_response, error_code>
+save_change_reason_response::deserialize(std::span<const std::byte> data) {
+    save_change_reason_response response;
+
+    auto success_result = reader::read_bool(data);
+    if (!success_result) return std::unexpected(success_result.error());
+    response.success = *success_result;
+
+    auto message_result = reader::read_string(data);
+    if (!message_result) return std::unexpected(message_result.error());
+    response.message = *message_result;
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s, const save_change_reason_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+// delete_change_reason_result
+
+std::ostream& operator<<(std::ostream& s, const delete_change_reason_result& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+// delete_change_reason_request
+
+std::vector<std::byte> delete_change_reason_request::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(codes.size()));
+    for (const auto& code : codes) {
+        writer::write_string(buffer, code);
+    }
+    return buffer;
+}
+
+std::expected<delete_change_reason_request, error_code>
+delete_change_reason_request::deserialize(std::span<const std::byte> data) {
+    delete_change_reason_request request;
+
+    auto count_result = reader::read_uint32(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    request.codes.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        auto code_result = reader::read_string(data);
+        if (!code_result) return std::unexpected(code_result.error());
+        request.codes.push_back(*code_result);
+    }
+
+    return request;
+}
+
+std::ostream& operator<<(std::ostream& s, const delete_change_reason_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+// delete_change_reason_response
+
+std::vector<std::byte> delete_change_reason_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(results.size()));
+    for (const auto& r : results) {
+        writer::write_string(buffer, r.code);
+        writer::write_bool(buffer, r.success);
+        writer::write_string(buffer, r.message);
+    }
+    return buffer;
+}
+
+std::expected<delete_change_reason_response, error_code>
+delete_change_reason_response::deserialize(std::span<const std::byte> data) {
+    delete_change_reason_response response;
+
+    auto count_result = reader::read_uint32(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    response.results.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        delete_change_reason_result r;
+
+        auto code_result = reader::read_string(data);
+        if (!code_result) return std::unexpected(code_result.error());
+        r.code = *code_result;
+
+        auto success_result = reader::read_bool(data);
+        if (!success_result) return std::unexpected(success_result.error());
+        r.success = *success_result;
+
+        auto message_result = reader::read_string(data);
+        if (!message_result) return std::unexpected(message_result.error());
+        r.message = *message_result;
+
+        response.results.push_back(std::move(r));
+    }
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s, const delete_change_reason_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+// get_change_reason_history_request
+
+std::vector<std::byte> get_change_reason_history_request::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_string(buffer, code);
+    return buffer;
+}
+
+std::expected<get_change_reason_history_request, error_code>
+get_change_reason_history_request::deserialize(std::span<const std::byte> data) {
+    get_change_reason_history_request request;
+
+    auto code_result = reader::read_string(data);
+    if (!code_result) return std::unexpected(code_result.error());
+    request.code = *code_result;
+
+    return request;
+}
+
+std::ostream& operator<<(std::ostream& s,
+    const get_change_reason_history_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+// get_change_reason_history_response
+
+std::vector<std::byte> get_change_reason_history_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_bool(buffer, success);
+    writer::write_string(buffer, message);
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(versions.size()));
+    for (const auto& v : versions) {
+        write_change_reason(buffer, v);
+    }
+    return buffer;
+}
+
+std::expected<get_change_reason_history_response, error_code>
+get_change_reason_history_response::deserialize(std::span<const std::byte> data) {
+    get_change_reason_history_response response;
+
+    auto success_result = reader::read_bool(data);
+    if (!success_result) return std::unexpected(success_result.error());
+    response.success = *success_result;
+
+    auto message_result = reader::read_string(data);
+    if (!message_result) return std::unexpected(message_result.error());
+    response.message = *message_result;
+
+    auto count_result = reader::read_uint32(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    response.versions.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        auto reason_result = read_change_reason(data);
+        if (!reason_result) return std::unexpected(reason_result.error());
+        response.versions.push_back(std::move(*reason_result));
+    }
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s,
+    const get_change_reason_history_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+// ============================================================================
+// Change Reason Category CRUD Operations
+// ============================================================================
+
+// save_change_reason_category_request
+
+std::vector<std::byte> save_change_reason_category_request::serialize() const {
+    std::vector<std::byte> buffer;
+    write_change_reason_category(buffer, category);
+    return buffer;
+}
+
+std::expected<save_change_reason_category_request, error_code>
+save_change_reason_category_request::deserialize(std::span<const std::byte> data) {
+    save_change_reason_category_request request;
+
+    auto category_result = read_change_reason_category(data);
+    if (!category_result) return std::unexpected(category_result.error());
+    request.category = std::move(*category_result);
+
+    return request;
+}
+
+std::ostream& operator<<(std::ostream& s,
+    const save_change_reason_category_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+// save_change_reason_category_response
+
+std::vector<std::byte> save_change_reason_category_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_bool(buffer, success);
+    writer::write_string(buffer, message);
+    return buffer;
+}
+
+std::expected<save_change_reason_category_response, error_code>
+save_change_reason_category_response::deserialize(std::span<const std::byte> data) {
+    save_change_reason_category_response response;
+
+    auto success_result = reader::read_bool(data);
+    if (!success_result) return std::unexpected(success_result.error());
+    response.success = *success_result;
+
+    auto message_result = reader::read_string(data);
+    if (!message_result) return std::unexpected(message_result.error());
+    response.message = *message_result;
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s,
+    const save_change_reason_category_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+// delete_change_reason_category_result
+
+std::ostream& operator<<(std::ostream& s,
+    const delete_change_reason_category_result& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+// delete_change_reason_category_request
+
+std::vector<std::byte> delete_change_reason_category_request::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(codes.size()));
+    for (const auto& code : codes) {
+        writer::write_string(buffer, code);
+    }
+    return buffer;
+}
+
+std::expected<delete_change_reason_category_request, error_code>
+delete_change_reason_category_request::deserialize(std::span<const std::byte> data) {
+    delete_change_reason_category_request request;
+
+    auto count_result = reader::read_uint32(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    request.codes.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        auto code_result = reader::read_string(data);
+        if (!code_result) return std::unexpected(code_result.error());
+        request.codes.push_back(*code_result);
+    }
+
+    return request;
+}
+
+std::ostream& operator<<(std::ostream& s,
+    const delete_change_reason_category_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+// delete_change_reason_category_response
+
+std::vector<std::byte> delete_change_reason_category_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(results.size()));
+    for (const auto& r : results) {
+        writer::write_string(buffer, r.code);
+        writer::write_bool(buffer, r.success);
+        writer::write_string(buffer, r.message);
+    }
+    return buffer;
+}
+
+std::expected<delete_change_reason_category_response, error_code>
+delete_change_reason_category_response::deserialize(std::span<const std::byte> data) {
+    delete_change_reason_category_response response;
+
+    auto count_result = reader::read_uint32(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    response.results.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        delete_change_reason_category_result r;
+
+        auto code_result = reader::read_string(data);
+        if (!code_result) return std::unexpected(code_result.error());
+        r.code = *code_result;
+
+        auto success_result = reader::read_bool(data);
+        if (!success_result) return std::unexpected(success_result.error());
+        r.success = *success_result;
+
+        auto message_result = reader::read_string(data);
+        if (!message_result) return std::unexpected(message_result.error());
+        r.message = *message_result;
+
+        response.results.push_back(std::move(r));
+    }
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s,
+    const delete_change_reason_category_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+// get_change_reason_category_history_request
+
+std::vector<std::byte>
+get_change_reason_category_history_request::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_string(buffer, code);
+    return buffer;
+}
+
+std::expected<get_change_reason_category_history_request, error_code>
+get_change_reason_category_history_request::deserialize(
+    std::span<const std::byte> data) {
+    get_change_reason_category_history_request request;
+
+    auto code_result = reader::read_string(data);
+    if (!code_result) return std::unexpected(code_result.error());
+    request.code = *code_result;
+
+    return request;
+}
+
+std::ostream& operator<<(std::ostream& s,
+    const get_change_reason_category_history_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+// get_change_reason_category_history_response
+
+std::vector<std::byte>
+get_change_reason_category_history_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_bool(buffer, success);
+    writer::write_string(buffer, message);
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(versions.size()));
+    for (const auto& v : versions) {
+        write_change_reason_category(buffer, v);
+    }
+    return buffer;
+}
+
+std::expected<get_change_reason_category_history_response, error_code>
+get_change_reason_category_history_response::deserialize(
+    std::span<const std::byte> data) {
+    get_change_reason_category_history_response response;
+
+    auto success_result = reader::read_bool(data);
+    if (!success_result) return std::unexpected(success_result.error());
+    response.success = *success_result;
+
+    auto message_result = reader::read_string(data);
+    if (!message_result) return std::unexpected(message_result.error());
+    response.message = *message_result;
+
+    auto count_result = reader::read_uint32(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    response.versions.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        auto category_result = read_change_reason_category(data);
+        if (!category_result) return std::unexpected(category_result.error());
+        response.versions.push_back(std::move(*category_result));
+    }
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s,
+    const get_change_reason_category_history_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
 }

--- a/projects/ores.iam/src/repository/change_reason_category_repository.cpp
+++ b/projects/ores.iam/src/repository/change_reason_category_repository.cpp
@@ -133,6 +133,23 @@ std::uint32_t change_reason_category_repository::get_total_count() {
     return count;
 }
 
+std::vector<domain::change_reason_category>
+change_reason_category_repository::read_all(const std::string& code) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all change_reason_category versions. Code: "
+                               << code;
+
+    const auto query = sqlgen::read<std::vector<change_reason_category_entity>> |
+        where("code"_c == code) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<change_reason_category_entity,
+                              domain::change_reason_category>(ctx_, query,
+        [](const auto& entities) {
+            return change_reason_category_mapper::map(entities);
+        },
+        lg(), "Reading all change_reason_category versions by code.");
+}
+
 void change_reason_category_repository::remove(const std::string& code) {
     BOOST_LOG_SEV(lg(), debug) << "Removing change_reason_category from database: "
                                << code;

--- a/projects/ores.iam/src/repository/change_reason_repository.cpp
+++ b/projects/ores.iam/src/repository/change_reason_repository.cpp
@@ -140,6 +140,21 @@ std::uint32_t change_reason_repository::get_total_count() {
     return count;
 }
 
+std::vector<domain::change_reason>
+change_reason_repository::read_all(const std::string& code) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all change_reason versions. Code: "
+                               << code;
+
+    const auto query = sqlgen::read<std::vector<change_reason_entity>> |
+        where("code"_c == code) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<change_reason_entity, domain::change_reason>(
+        ctx_, query,
+        [](const auto& entities) { return change_reason_mapper::map(entities); },
+        lg(), "Reading all change_reason versions by code.");
+}
+
 void change_reason_repository::remove(const std::string& code) {
     BOOST_LOG_SEV(lg(), debug) << "Removing change_reason from database: " << code;
 

--- a/projects/ores.iam/src/service/change_management_service.cpp
+++ b/projects/ores.iam/src/service/change_management_service.cpp
@@ -67,34 +67,29 @@ change_management_service::find_category(const std::string& code) {
 }
 
 domain::change_reason_category change_management_service::create_category(
-    const std::string& code,
-    const std::string& description,
-    const std::string& recorded_by,
-    const std::string& change_commentary) {
-    BOOST_LOG_SEV(lg(), info) << "Creating change reason category: " << code;
+    const domain::change_reason_category& category) {
+    BOOST_LOG_SEV(lg(), info) << "Creating change reason category: "
+                              << category.code;
 
-    if (code.empty()) {
+    if (category.code.empty()) {
         throw std::invalid_argument("Category code cannot be empty.");
     }
 
     // Check if category already exists
-    auto existing = find_category(code);
+    auto existing = find_category(category.code);
     if (existing) {
-        throw std::runtime_error("Category with code '" + code +
+        throw std::runtime_error("Category with code '" + category.code +
             "' already exists.");
     }
 
-    domain::change_reason_category category;
-    category.version = 0;
-    category.code = code;
-    category.description = description;
-    category.recorded_by = recorded_by;
-    category.change_commentary = change_commentary;
+    domain::change_reason_category new_category = category;
+    new_category.version = 0;
 
-    category_repo_.write(category);
+    category_repo_.write(new_category);
 
-    BOOST_LOG_SEV(lg(), info) << "Created change reason category: " << code;
-    return category;
+    BOOST_LOG_SEV(lg(), info) << "Created change reason category: "
+                              << category.code;
+    return new_category;
 }
 
 void change_management_service::update_category(
@@ -128,6 +123,12 @@ void change_management_service::remove_category(const std::string& code) {
     category_repo_.remove(code);
 
     BOOST_LOG_SEV(lg(), info) << "Removed change reason category: " << code;
+}
+
+std::vector<domain::change_reason_category>
+change_management_service::get_category_history(const std::string& code) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting category history for: " << code;
+    return category_repo_.read_all(code);
 }
 
 // ============================================================================
@@ -235,6 +236,12 @@ void change_management_service::remove_reason(const std::string& code) {
     reason_repo_.remove(code);
 
     BOOST_LOG_SEV(lg(), info) << "Removed change reason: " << code;
+}
+
+std::vector<domain::change_reason>
+change_management_service::get_reason_history(const std::string& code) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting reason history for: " << code;
+    return reason_repo_.read_all(code);
 }
 
 // ============================================================================

--- a/projects/ores.qt/include/ores.qt/ChangeReasonCategoryController.hpp
+++ b/projects/ores.qt/include/ores.qt/ChangeReasonCategoryController.hpp
@@ -65,11 +65,14 @@ public:
 
 private slots:
     void onShowDetails(const iam::domain::change_reason_category& category);
+    void onAddNewRequested();
+    void onShowHistory(const QString& code);
     void onNotificationReceived(const QString& eventType, const QDateTime& timestamp,
                                 const QStringList& entityIds);
 
 private:
     void showDetailWindow(const iam::domain::change_reason_category& category);
+    void showAddWindow();
 
 private:
     ChangeReasonCategoryMdiWindow* listWindow_;

--- a/projects/ores.qt/include/ores.qt/ChangeReasonCategoryDetailDialog.hpp
+++ b/projects/ores.qt/include/ores.qt/ChangeReasonCategoryDetailDialog.hpp
@@ -1,0 +1,126 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CHANGE_REASON_CATEGORY_DETAIL_DIALOG_HPP
+#define ORES_QT_CHANGE_REASON_CATEGORY_DETAIL_DIALOG_HPP
+
+#include <vector>
+#include <QWidget>
+#include <QAction>
+#include <QToolBar>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.iam/domain/change_reason_category.hpp"
+
+namespace Ui {
+class ChangeReasonCategoryDetailDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Dialog widget for creating and editing change reason categories.
+ *
+ * This widget provides a form for entering change reason category details,
+ * with save and delete capabilities.
+ */
+class ChangeReasonCategoryDetailDialog : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.change_reason_category_detail_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit ChangeReasonCategoryDetailDialog(QWidget* parent = nullptr);
+    ~ChangeReasonCategoryDetailDialog() override;
+
+    void setClientManager(ClientManager* clientManager);
+    void setUsername(const std::string& username);
+
+    void setCategory(const iam::domain::change_reason_category& category);
+    iam::domain::change_reason_category getCategory() const;
+    void setCreateMode(bool createMode);
+    void setReadOnly(bool readOnly, int versionNumber = 0);
+    void setHistory(const std::vector<iam::domain::change_reason_category>& history,
+                    int versionNumber);
+    void clearDialog();
+    void save();
+
+    QString categoryCode() const;
+    bool isDirty() const { return isDirty_; }
+    bool isReadOnly() const { return isReadOnly_; }
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& message);
+    void isDirtyChanged(bool dirty);
+    void categorySaved(const QString& code);
+    void categoryDeleted(const QString& code);
+
+private slots:
+    void onSaveClicked();
+    void onDeleteClicked();
+    void onFieldChanged();
+
+    // Version navigation slots
+    void onFirstVersionClicked();
+    void onPrevVersionClicked();
+    void onNextVersionClicked();
+    void onLastVersionClicked();
+
+private:
+    void updateSaveButtonState();
+    void closeParentWindow();
+    void displayCurrentVersion();
+    void updateVersionNavButtonStates();
+    void showVersionNavActions(bool visible);
+
+private:
+    Ui::ChangeReasonCategoryDetailDialog* ui_;
+    QToolBar* toolBar_;
+    QAction* saveAction_;
+    QAction* deleteAction_;
+    QAction* revertAction_;
+
+    iam::domain::change_reason_category currentCategory_;
+    bool isDirty_;
+    bool isAddMode_;
+    bool isReadOnly_;
+    std::string modifiedByUsername_;
+    ClientManager* clientManager_;
+
+    // Version navigation members
+    std::vector<iam::domain::change_reason_category> history_;
+    int currentHistoryIndex_;
+    QAction* firstVersionAction_;
+    QAction* prevVersionAction_;
+    QAction* nextVersionAction_;
+    QAction* lastVersionAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/ChangeReasonCategoryMdiWindow.hpp
+++ b/projects/ores.qt/include/ores.qt/ChangeReasonCategoryMdiWindow.hpp
@@ -70,6 +70,15 @@ signals:
     void statusChanged(const QString& message);
     void errorOccurred(const QString& error_message);
     void showCategoryDetails(const iam::domain::change_reason_category& category);
+    void addNewRequested();
+    void categoryDeleted(const QString& code);
+    void showCategoryHistory(const QString& code);
+
+public slots:
+    void addNew();
+    void editSelected();
+    void deleteSelected();
+    void viewHistorySelected();
 
 private slots:
     void onDataLoaded();
@@ -83,6 +92,7 @@ private:
     void setupTable();
     void setupConnections();
     void startPulseAnimation();
+    void updateActionStates();
 
     ClientManager* clientManager_;
     QString username_;
@@ -94,7 +104,10 @@ private:
 
     // Toolbar actions
     QAction* reloadAction_;
-    QAction* viewDetailsAction_;
+    QAction* addAction_;
+    QAction* editAction_;
+    QAction* deleteAction_;
+    QAction* historyAction_;
 
     // Stale indicator
     QIcon normalReloadIcon_;

--- a/projects/ores.qt/include/ores.qt/ChangeReasonController.hpp
+++ b/projects/ores.qt/include/ores.qt/ChangeReasonController.hpp
@@ -65,11 +65,14 @@ public:
 
 private slots:
     void onShowDetails(const iam::domain::change_reason& reason);
+    void onAddNewRequested();
+    void onShowHistory(const QString& code);
     void onNotificationReceived(const QString& eventType, const QDateTime& timestamp,
                                 const QStringList& entityIds);
 
 private:
     void showDetailWindow(const iam::domain::change_reason& reason);
+    void showAddWindow();
 
 private:
     ChangeReasonMdiWindow* listWindow_;

--- a/projects/ores.qt/include/ores.qt/ChangeReasonDetailDialog.hpp
+++ b/projects/ores.qt/include/ores.qt/ChangeReasonDetailDialog.hpp
@@ -1,0 +1,131 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CHANGE_REASON_DETAIL_DIALOG_HPP
+#define ORES_QT_CHANGE_REASON_DETAIL_DIALOG_HPP
+
+#include <vector>
+#include <QWidget>
+#include <QAction>
+#include <QToolBar>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.iam/domain/change_reason.hpp"
+#include "ores.iam/domain/change_reason_category.hpp"
+
+namespace Ui {
+class ChangeReasonDetailDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Dialog widget for creating and editing change reasons.
+ *
+ * This widget provides a form for entering change reason details,
+ * with save and delete capabilities.
+ */
+class ChangeReasonDetailDialog : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.change_reason_detail_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit ChangeReasonDetailDialog(QWidget* parent = nullptr);
+    ~ChangeReasonDetailDialog() override;
+
+    void setClientManager(ClientManager* clientManager);
+    void setUsername(const std::string& username);
+
+    void setChangeReason(const iam::domain::change_reason& reason);
+    iam::domain::change_reason getChangeReason() const;
+    void setCreateMode(bool createMode);
+    void setReadOnly(bool readOnly, int versionNumber = 0);
+    void setHistory(const std::vector<iam::domain::change_reason>& history,
+                    int versionNumber);
+    void clearDialog();
+    void save();
+
+    void setCategories(const std::vector<iam::domain::change_reason_category>& categories);
+
+    QString changeReasonCode() const;
+    bool isDirty() const { return isDirty_; }
+    bool isReadOnly() const { return isReadOnly_; }
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& message);
+    void isDirtyChanged(bool dirty);
+    void changeReasonSaved(const QString& code);
+    void changeReasonDeleted(const QString& code);
+
+private slots:
+    void onSaveClicked();
+    void onDeleteClicked();
+    void onFieldChanged();
+
+    // Version navigation slots
+    void onFirstVersionClicked();
+    void onPrevVersionClicked();
+    void onNextVersionClicked();
+    void onLastVersionClicked();
+
+private:
+    void updateSaveButtonState();
+    void closeParentWindow();
+    void displayCurrentVersion();
+    void updateVersionNavButtonStates();
+    void showVersionNavActions(bool visible);
+    void populateCategoryComboBox();
+
+private:
+    Ui::ChangeReasonDetailDialog* ui_;
+    QToolBar* toolBar_;
+    QAction* saveAction_;
+    QAction* deleteAction_;
+    QAction* revertAction_;
+
+    iam::domain::change_reason currentReason_;
+    std::vector<iam::domain::change_reason_category> categories_;
+    bool isDirty_;
+    bool isAddMode_;
+    bool isReadOnly_;
+    std::string modifiedByUsername_;
+    ClientManager* clientManager_;
+
+    // Version navigation members
+    std::vector<iam::domain::change_reason> history_;
+    int currentHistoryIndex_;
+    QAction* firstVersionAction_;
+    QAction* prevVersionAction_;
+    QAction* nextVersionAction_;
+    QAction* lastVersionAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/ChangeReasonItemDelegate.hpp
+++ b/projects/ores.qt/include/ores.qt/ChangeReasonItemDelegate.hpp
@@ -1,0 +1,67 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CHANGE_REASON_ITEM_DELEGATE_HPP
+#define ORES_QT_CHANGE_REASON_ITEM_DELEGATE_HPP
+
+#include <QStyledItemDelegate>
+#include <QFont>
+
+namespace ores::qt {
+
+/**
+ * @brief Custom delegate for rendering change reason table cells.
+ *
+ * This delegate provides custom rendering for the change reasons table,
+ * including badge-style rendering for the boolean columns (AppliesToAmend,
+ * AppliesToDelete, RequiresCommentary).
+ */
+class ChangeReasonItemDelegate : public QStyledItemDelegate {
+    Q_OBJECT
+
+public:
+    explicit ChangeReasonItemDelegate(QObject* parent = nullptr);
+
+    void paint(QPainter* painter, const QStyleOptionViewItem& option,
+               const QModelIndex& index) const override;
+
+    QSize sizeHint(const QStyleOptionViewItem& option,
+                   const QModelIndex& index) const override;
+
+private:
+    /**
+     * @brief Draw a pill-shaped badge with text.
+     *
+     * @param painter The painter to use.
+     * @param rect The bounding rectangle for the badge.
+     * @param text The text to display in the badge.
+     * @param backgroundColor The badge background color.
+     * @param textColor The badge text color.
+     */
+    void drawBadge(QPainter* painter, const QRect& rect,
+                   const QString& text, const QColor& backgroundColor,
+                   const QColor& textColor) const;
+
+    QFont monospaceFont_;
+    QFont badgeFont_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/ChangeReasonMdiWindow.hpp
+++ b/projects/ores.qt/include/ores.qt/ChangeReasonMdiWindow.hpp
@@ -70,6 +70,15 @@ signals:
     void statusChanged(const QString& message);
     void errorOccurred(const QString& error_message);
     void showReasonDetails(const iam::domain::change_reason& reason);
+    void addNewRequested();
+    void reasonDeleted(const QString& code);
+    void showReasonHistory(const QString& code);
+
+public slots:
+    void addNew();
+    void editSelected();
+    void deleteSelected();
+    void viewHistorySelected();
 
 private slots:
     void onDataLoaded();
@@ -83,6 +92,7 @@ private:
     void setupTable();
     void setupConnections();
     void startPulseAnimation();
+    void updateActionStates();
 
     ClientManager* clientManager_;
     QString username_;
@@ -94,7 +104,10 @@ private:
 
     // Toolbar actions
     QAction* reloadAction_;
-    QAction* viewDetailsAction_;
+    QAction* addAction_;
+    QAction* editAction_;
+    QAction* deleteAction_;
+    QAction* historyAction_;
 
     // Stale indicator
     QIcon normalReloadIcon_;

--- a/projects/ores.qt/include/ores.qt/ClientChangeReasonModel.hpp
+++ b/projects/ores.qt/include/ores.qt/ClientChangeReasonModel.hpp
@@ -57,7 +57,6 @@ public:
      */
     enum Column {
         Code,
-        Description,
         CategoryCode,
         AppliesToAmend,
         AppliesToDelete,

--- a/projects/ores.qt/src/ChangeReasonCategoryDetailDialog.cpp
+++ b/projects/ores.qt/src/ChangeReasonCategoryDetailDialog.cpp
@@ -1,0 +1,518 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/ChangeReasonCategoryDetailDialog.hpp"
+
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include <QVBoxLayout>
+#include <QToolBar>
+#include <QIcon>
+#include <QMdiSubWindow>
+#include <QMetaObject>
+#include "ui_ChangeReasonCategoryDetailDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.iam/messaging/change_management_protocol.hpp"
+#include "ores.comms/messaging/frame.hpp"
+
+namespace ores::qt {
+
+using comms::messaging::frame;
+using comms::messaging::message_type;
+using namespace ores::logging;
+using FutureResult = std::pair<bool, std::string>;
+
+ChangeReasonCategoryDetailDialog::ChangeReasonCategoryDetailDialog(QWidget* parent)
+    : QWidget(parent), ui_(new Ui::ChangeReasonCategoryDetailDialog), isDirty_(false),
+      isAddMode_(false), isReadOnly_(false), clientManager_(nullptr),
+      currentHistoryIndex_(0),
+      firstVersionAction_(nullptr), prevVersionAction_(nullptr),
+      nextVersionAction_(nullptr), lastVersionAction_(nullptr) {
+
+    ui_->setupUi(this);
+
+    // Create toolbar
+    toolBar_ = new QToolBar(this);
+    toolBar_->setMovable(false);
+    toolBar_->setFloatable(false);
+
+    const QColor iconColor(220, 220, 220);
+
+    // Create Save action
+    saveAction_ = new QAction("Save", this);
+    saveAction_->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_save_20_regular.svg", iconColor));
+    saveAction_->setToolTip("Save changes");
+    connect(saveAction_, &QAction::triggered, this,
+        &ChangeReasonCategoryDetailDialog::onSaveClicked);
+    toolBar_->addAction(saveAction_);
+
+    // Create Delete action
+    deleteAction_ = new QAction("Delete", this);
+    deleteAction_->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_delete_20_regular.svg", iconColor));
+    deleteAction_->setToolTip("Delete category");
+    connect(deleteAction_, &QAction::triggered, this,
+        &ChangeReasonCategoryDetailDialog::onDeleteClicked);
+    toolBar_->addAction(deleteAction_);
+
+    toolBar_->addSeparator();
+
+    // Create Revert action (initially hidden)
+    revertAction_ = new QAction("Revert", this);
+    revertAction_->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_arrow_rotate_counterclockwise_20_regular.svg", iconColor));
+    revertAction_->setToolTip("Revert category to this historical version");
+    toolBar_->addAction(revertAction_);
+    revertAction_->setVisible(false);
+
+    // Version navigation actions (initially hidden)
+    toolBar_->addSeparator();
+
+    firstVersionAction_ = new QAction("First", this);
+    firstVersionAction_->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_arrow_previous_20_regular.svg", iconColor));
+    firstVersionAction_->setToolTip(tr("First version"));
+    connect(firstVersionAction_, &QAction::triggered, this,
+        &ChangeReasonCategoryDetailDialog::onFirstVersionClicked);
+    toolBar_->addAction(firstVersionAction_);
+    firstVersionAction_->setVisible(false);
+
+    prevVersionAction_ = new QAction("Previous", this);
+    prevVersionAction_->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_arrow_left_20_regular.svg", iconColor));
+    prevVersionAction_->setToolTip(tr("Previous version"));
+    connect(prevVersionAction_, &QAction::triggered, this,
+        &ChangeReasonCategoryDetailDialog::onPrevVersionClicked);
+    toolBar_->addAction(prevVersionAction_);
+    prevVersionAction_->setVisible(false);
+
+    nextVersionAction_ = new QAction("Next", this);
+    nextVersionAction_->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_arrow_right_20_regular.svg", iconColor));
+    nextVersionAction_->setToolTip(tr("Next version"));
+    connect(nextVersionAction_, &QAction::triggered, this,
+        &ChangeReasonCategoryDetailDialog::onNextVersionClicked);
+    toolBar_->addAction(nextVersionAction_);
+    nextVersionAction_->setVisible(false);
+
+    lastVersionAction_ = new QAction("Last", this);
+    lastVersionAction_->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_arrow_next_20_regular.svg", iconColor));
+    lastVersionAction_->setToolTip(tr("Last version"));
+    connect(lastVersionAction_, &QAction::triggered, this,
+        &ChangeReasonCategoryDetailDialog::onLastVersionClicked);
+    toolBar_->addAction(lastVersionAction_);
+    lastVersionAction_->setVisible(false);
+
+    // Add toolbar to the dialog's layout
+    auto* mainLayout = qobject_cast<QVBoxLayout*>(layout());
+    if (mainLayout)
+        mainLayout->insertWidget(0, toolBar_);
+
+    // Connect signals for editable fields to detect changes
+    connect(ui_->codeEdit, &QLineEdit::textChanged, this,
+        &ChangeReasonCategoryDetailDialog::onFieldChanged);
+    connect(ui_->descriptionEdit, &QTextEdit::textChanged, this,
+        &ChangeReasonCategoryDetailDialog::onFieldChanged);
+
+    // Initially disable save button
+    updateSaveButtonState();
+}
+
+ChangeReasonCategoryDetailDialog::~ChangeReasonCategoryDetailDialog() {
+    delete ui_;
+}
+
+void ChangeReasonCategoryDetailDialog::setClientManager(ClientManager* clientManager) {
+    clientManager_ = clientManager;
+}
+
+void ChangeReasonCategoryDetailDialog::setUsername(const std::string& username) {
+    modifiedByUsername_ = username;
+}
+
+void ChangeReasonCategoryDetailDialog::setCategory(
+    const iam::domain::change_reason_category& category) {
+    currentCategory_ = category;
+
+    ui_->codeEdit->setText(QString::fromStdString(category.code));
+    ui_->descriptionEdit->setPlainText(QString::fromStdString(category.description));
+
+    ui_->versionEdit->setText(QString::number(category.version));
+    ui_->recordedByEdit->setText(QString::fromStdString(category.recorded_by));
+    ui_->recordedAtEdit->setText(relative_time_helper::format(category.recorded_at));
+
+    isDirty_ = false;
+    emit isDirtyChanged(false);
+    updateSaveButtonState();
+}
+
+iam::domain::change_reason_category ChangeReasonCategoryDetailDialog::getCategory() const {
+    iam::domain::change_reason_category category = currentCategory_;
+    category.code = ui_->codeEdit->text().trimmed().toStdString();
+    category.description = ui_->descriptionEdit->toPlainText().trimmed().toStdString();
+    category.recorded_by = modifiedByUsername_;
+    return category;
+}
+
+void ChangeReasonCategoryDetailDialog::setCreateMode(bool createMode) {
+    isAddMode_ = createMode;
+
+    // Code is only editable in create mode
+    ui_->codeEdit->setReadOnly(!createMode);
+
+    // Hide metadata section in create mode
+    ui_->metadataGroup->setVisible(!createMode);
+
+    // Hide delete button in create mode
+    deleteAction_->setVisible(!createMode);
+
+    if (createMode) {
+        clearDialog();
+    }
+
+    updateSaveButtonState();
+}
+
+void ChangeReasonCategoryDetailDialog::setReadOnly(bool readOnly, int versionNumber) {
+    isReadOnly_ = readOnly;
+
+    ui_->codeEdit->setReadOnly(true);
+    ui_->descriptionEdit->setReadOnly(readOnly);
+
+    saveAction_->setVisible(!readOnly);
+    deleteAction_->setVisible(!readOnly);
+    revertAction_->setVisible(readOnly);
+
+    if (readOnly && versionNumber > 0) {
+        setWindowTitle(tr("Category Details - Version %1").arg(versionNumber));
+    }
+}
+
+void ChangeReasonCategoryDetailDialog::setHistory(
+    const std::vector<iam::domain::change_reason_category>& history, int versionNumber) {
+    history_ = history;
+
+    // Find the index of the requested version
+    currentHistoryIndex_ = 0;
+    for (size_t i = 0; i < history_.size(); ++i) {
+        if (history_[i].version == versionNumber) {
+            currentHistoryIndex_ = static_cast<int>(i);
+            break;
+        }
+    }
+
+    showVersionNavActions(history_.size() > 1);
+    displayCurrentVersion();
+    updateVersionNavButtonStates();
+}
+
+void ChangeReasonCategoryDetailDialog::clearDialog() {
+    currentCategory_ = iam::domain::change_reason_category{};
+
+    ui_->codeEdit->clear();
+    ui_->descriptionEdit->clear();
+
+    ui_->versionEdit->clear();
+    ui_->recordedByEdit->clear();
+    ui_->recordedAtEdit->clear();
+
+    isDirty_ = false;
+    emit isDirtyChanged(false);
+    updateSaveButtonState();
+}
+
+void ChangeReasonCategoryDetailDialog::save() {
+    onSaveClicked();
+}
+
+QString ChangeReasonCategoryDetailDialog::categoryCode() const {
+    return ui_->codeEdit->text();
+}
+
+void ChangeReasonCategoryDetailDialog::onFieldChanged() {
+    if (!isDirty_) {
+        isDirty_ = true;
+        emit isDirtyChanged(true);
+    }
+    updateSaveButtonState();
+}
+
+void ChangeReasonCategoryDetailDialog::updateSaveButtonState() {
+    bool canSave = isDirty_ && !ui_->codeEdit->text().trimmed().isEmpty();
+    saveAction_->setEnabled(canSave && !isReadOnly_);
+}
+
+void ChangeReasonCategoryDetailDialog::closeParentWindow() {
+    if (auto* subWindow = qobject_cast<QMdiSubWindow*>(parentWidget())) {
+        subWindow->close();
+    }
+}
+
+void ChangeReasonCategoryDetailDialog::displayCurrentVersion() {
+    if (currentHistoryIndex_ >= 0 &&
+        currentHistoryIndex_ < static_cast<int>(history_.size())) {
+        const auto& version = history_[currentHistoryIndex_];
+        setCategory(version);
+        setWindowTitle(tr("Category Details - Version %1 of %2")
+            .arg(version.version)
+            .arg(history_.front().version));
+    }
+}
+
+void ChangeReasonCategoryDetailDialog::updateVersionNavButtonStates() {
+    bool hasHistory = history_.size() > 1;
+    bool atFirst = currentHistoryIndex_ >= static_cast<int>(history_.size()) - 1;
+    bool atLast = currentHistoryIndex_ <= 0;
+
+    firstVersionAction_->setEnabled(hasHistory && !atFirst);
+    prevVersionAction_->setEnabled(hasHistory && !atFirst);
+    nextVersionAction_->setEnabled(hasHistory && !atLast);
+    lastVersionAction_->setEnabled(hasHistory && !atLast);
+}
+
+void ChangeReasonCategoryDetailDialog::showVersionNavActions(bool visible) {
+    firstVersionAction_->setVisible(visible);
+    prevVersionAction_->setVisible(visible);
+    nextVersionAction_->setVisible(visible);
+    lastVersionAction_->setVisible(visible);
+}
+
+void ChangeReasonCategoryDetailDialog::onFirstVersionClicked() {
+    if (!history_.empty()) {
+        currentHistoryIndex_ = static_cast<int>(history_.size()) - 1;
+        displayCurrentVersion();
+        updateVersionNavButtonStates();
+    }
+}
+
+void ChangeReasonCategoryDetailDialog::onPrevVersionClicked() {
+    if (currentHistoryIndex_ < static_cast<int>(history_.size()) - 1) {
+        currentHistoryIndex_++;
+        displayCurrentVersion();
+        updateVersionNavButtonStates();
+    }
+}
+
+void ChangeReasonCategoryDetailDialog::onNextVersionClicked() {
+    if (currentHistoryIndex_ > 0) {
+        currentHistoryIndex_--;
+        displayCurrentVersion();
+        updateVersionNavButtonStates();
+    }
+}
+
+void ChangeReasonCategoryDetailDialog::onLastVersionClicked() {
+    if (!history_.empty()) {
+        currentHistoryIndex_ = 0;
+        displayCurrentVersion();
+        updateVersionNavButtonStates();
+    }
+}
+
+void ChangeReasonCategoryDetailDialog::onSaveClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Save clicked but client not connected.";
+        emit errorMessage("Not connected to server. Please login.");
+        return;
+    }
+
+    // Validate code
+    if (ui_->codeEdit->text().trimmed().isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Validation failed: code is empty";
+        MessageBoxHelper::warning(this, "Validation Error",
+            "Category code is required.");
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Save clicked for category: "
+                               << currentCategory_.code;
+
+    QPointer<ChangeReasonCategoryDetailDialog> self = this;
+    const iam::domain::change_reason_category categoryToSave = getCategory();
+
+    QFuture<FutureResult> future =
+        QtConcurrent::run([self, categoryToSave]() -> FutureResult {
+            if (!self) return {false, ""};
+
+            BOOST_LOG_SEV(lg(), debug) << "Sending save category request for: "
+                                       << categoryToSave.code;
+
+            iam::messaging::save_change_reason_category_request request;
+            request.category = categoryToSave;
+
+            auto payload = request.serialize();
+            frame request_frame(message_type::save_change_reason_category_request,
+                0, std::move(payload));
+
+            auto response_result =
+                self->clientManager_->sendRequest(std::move(request_frame));
+
+            if (!response_result) {
+                return {false, "Failed to communicate with server"};
+            }
+
+            auto payload_result = response_result->decompressed_payload();
+            if (!payload_result) {
+                return {false, "Failed to decompress server response"};
+            }
+
+            auto response = iam::messaging::save_change_reason_category_response::
+                deserialize(*payload_result);
+
+            if (!response) {
+                return {false, "Invalid server response"};
+            }
+
+            return {response->success, response->message};
+        });
+
+    auto* watcher = new QFutureWatcher<FutureResult>(self);
+    connect(watcher, &QFutureWatcher<FutureResult>::finished, self,
+        [self, watcher, categoryToSave]() {
+        if (!self) return;
+
+        auto [success, message] = watcher->result();
+        watcher->deleteLater();
+
+        if (success) {
+            BOOST_LOG_SEV(lg(), debug) << "Category saved successfully";
+
+            emit self->statusMessage(QString("Successfully saved category: %1")
+                .arg(QString::fromStdString(categoryToSave.code)));
+
+            self->isDirty_ = false;
+            emit self->isDirtyChanged(false);
+            self->updateSaveButtonState();
+
+            emit self->categorySaved(QString::fromStdString(categoryToSave.code));
+            self->closeParentWindow();
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Category save failed: " << message;
+            emit self->errorMessage(QString("Failed to save category: %1")
+                .arg(QString::fromStdString(message)));
+            MessageBoxHelper::critical(self, "Save Failed",
+                QString::fromStdString(message));
+        }
+    });
+
+    watcher->setFuture(future);
+}
+
+void ChangeReasonCategoryDetailDialog::onDeleteClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Delete clicked but client not connected.";
+        emit errorMessage("Not connected to server. Please login.");
+        return;
+    }
+
+    if (isAddMode_) {
+        BOOST_LOG_SEV(lg(), warn) << "Delete clicked in add mode.";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Delete request for category: "
+                               << currentCategory_.code;
+
+    auto reply = MessageBoxHelper::question(this, "Delete Category",
+        QString("Are you sure you want to delete category '%1'?")
+            .arg(QString::fromStdString(currentCategory_.code)),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        BOOST_LOG_SEV(lg(), debug) << "Delete cancelled by user";
+        return;
+    }
+
+    QPointer<ChangeReasonCategoryDetailDialog> self = this;
+    const std::string code = currentCategory_.code;
+
+    QFuture<FutureResult> future =
+        QtConcurrent::run([self, code]() -> FutureResult {
+            if (!self) return {false, ""};
+
+            BOOST_LOG_SEV(lg(), debug) << "Sending delete category request for: "
+                                       << code;
+
+            iam::messaging::delete_change_reason_category_request request;
+            request.codes = {code};
+
+            auto payload = request.serialize();
+            frame request_frame(message_type::delete_change_reason_category_request,
+                0, std::move(payload));
+
+            auto response_result =
+                self->clientManager_->sendRequest(std::move(request_frame));
+
+            if (!response_result) {
+                return {false, "Failed to communicate with server"};
+            }
+
+            auto payload_result = response_result->decompressed_payload();
+            if (!payload_result) {
+                return {false, "Failed to decompress server response"};
+            }
+
+            auto response = iam::messaging::delete_change_reason_category_response::
+                deserialize(*payload_result);
+
+            if (!response) {
+                return {false, "Invalid server response"};
+            }
+
+            // Check if all deletions succeeded
+            if (response->results.empty()) {
+                return {false, "No results in response"};
+            }
+            const auto& result = response->results.front();
+            return {result.success, result.message};
+        });
+
+    auto* watcher = new QFutureWatcher<FutureResult>(self);
+    connect(watcher, &QFutureWatcher<FutureResult>::finished, self,
+        [self, watcher, code]() {
+        if (!self) return;
+
+        auto [success, message] = watcher->result();
+        watcher->deleteLater();
+
+        if (success) {
+            BOOST_LOG_SEV(lg(), debug) << "Category deleted successfully";
+
+            emit self->statusMessage(QString("Successfully deleted category: %1")
+                .arg(QString::fromStdString(code)));
+
+            emit self->categoryDeleted(QString::fromStdString(code));
+            self->closeParentWindow();
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Category delete failed: " << message;
+            emit self->errorMessage(QString("Failed to delete category: %1")
+                .arg(QString::fromStdString(message)));
+            MessageBoxHelper::critical(self, "Delete Failed",
+                QString::fromStdString(message));
+        }
+    });
+
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt/src/ChangeReasonDetailDialog.cpp
+++ b/projects/ores.qt/src/ChangeReasonDetailDialog.cpp
@@ -1,0 +1,582 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/ChangeReasonDetailDialog.hpp"
+
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include <QVBoxLayout>
+#include <QToolBar>
+#include <QIcon>
+#include <QComboBox>
+#include <QMdiSubWindow>
+#include <QMetaObject>
+#include "ui_ChangeReasonDetailDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.iam/messaging/change_management_protocol.hpp"
+#include "ores.comms/messaging/frame.hpp"
+
+namespace ores::qt {
+
+using comms::messaging::frame;
+using comms::messaging::message_type;
+using namespace ores::logging;
+using FutureResult = std::pair<bool, std::string>;
+
+ChangeReasonDetailDialog::ChangeReasonDetailDialog(QWidget* parent)
+    : QWidget(parent), ui_(new Ui::ChangeReasonDetailDialog), isDirty_(false),
+      isAddMode_(false), isReadOnly_(false), clientManager_(nullptr),
+      currentHistoryIndex_(0),
+      firstVersionAction_(nullptr), prevVersionAction_(nullptr),
+      nextVersionAction_(nullptr), lastVersionAction_(nullptr) {
+
+    ui_->setupUi(this);
+
+    // Create toolbar
+    toolBar_ = new QToolBar(this);
+    toolBar_->setMovable(false);
+    toolBar_->setFloatable(false);
+
+    const QColor iconColor(220, 220, 220);
+
+    // Create Save action
+    saveAction_ = new QAction("Save", this);
+    saveAction_->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_save_20_regular.svg", iconColor));
+    saveAction_->setToolTip("Save changes");
+    connect(saveAction_, &QAction::triggered, this,
+        &ChangeReasonDetailDialog::onSaveClicked);
+    toolBar_->addAction(saveAction_);
+
+    // Create Delete action
+    deleteAction_ = new QAction("Delete", this);
+    deleteAction_->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_delete_20_regular.svg", iconColor));
+    deleteAction_->setToolTip("Delete change reason");
+    connect(deleteAction_, &QAction::triggered, this,
+        &ChangeReasonDetailDialog::onDeleteClicked);
+    toolBar_->addAction(deleteAction_);
+
+    toolBar_->addSeparator();
+
+    // Create Revert action (initially hidden)
+    revertAction_ = new QAction("Revert", this);
+    revertAction_->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_arrow_rotate_counterclockwise_20_regular.svg", iconColor));
+    revertAction_->setToolTip("Revert change reason to this historical version");
+    toolBar_->addAction(revertAction_);
+    revertAction_->setVisible(false);
+
+    // Version navigation actions (initially hidden)
+    toolBar_->addSeparator();
+
+    firstVersionAction_ = new QAction("First", this);
+    firstVersionAction_->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_arrow_previous_20_regular.svg", iconColor));
+    firstVersionAction_->setToolTip(tr("First version"));
+    connect(firstVersionAction_, &QAction::triggered, this,
+        &ChangeReasonDetailDialog::onFirstVersionClicked);
+    toolBar_->addAction(firstVersionAction_);
+    firstVersionAction_->setVisible(false);
+
+    prevVersionAction_ = new QAction("Previous", this);
+    prevVersionAction_->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_arrow_left_20_regular.svg", iconColor));
+    prevVersionAction_->setToolTip(tr("Previous version"));
+    connect(prevVersionAction_, &QAction::triggered, this,
+        &ChangeReasonDetailDialog::onPrevVersionClicked);
+    toolBar_->addAction(prevVersionAction_);
+    prevVersionAction_->setVisible(false);
+
+    nextVersionAction_ = new QAction("Next", this);
+    nextVersionAction_->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_arrow_right_20_regular.svg", iconColor));
+    nextVersionAction_->setToolTip(tr("Next version"));
+    connect(nextVersionAction_, &QAction::triggered, this,
+        &ChangeReasonDetailDialog::onNextVersionClicked);
+    toolBar_->addAction(nextVersionAction_);
+    nextVersionAction_->setVisible(false);
+
+    lastVersionAction_ = new QAction("Last", this);
+    lastVersionAction_->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_arrow_next_20_regular.svg", iconColor));
+    lastVersionAction_->setToolTip(tr("Last version"));
+    connect(lastVersionAction_, &QAction::triggered, this,
+        &ChangeReasonDetailDialog::onLastVersionClicked);
+    toolBar_->addAction(lastVersionAction_);
+    lastVersionAction_->setVisible(false);
+
+    // Add toolbar to the dialog's layout
+    auto* mainLayout = qobject_cast<QVBoxLayout*>(layout());
+    if (mainLayout)
+        mainLayout->insertWidget(0, toolBar_);
+
+    // Connect signals for editable fields to detect changes
+    connect(ui_->codeEdit, &QLineEdit::textChanged, this,
+        &ChangeReasonDetailDialog::onFieldChanged);
+    connect(ui_->descriptionEdit, &QLineEdit::textChanged, this,
+        &ChangeReasonDetailDialog::onFieldChanged);
+    connect(ui_->categoryCodeComboBox, &QComboBox::currentIndexChanged, this,
+        &ChangeReasonDetailDialog::onFieldChanged);
+    connect(ui_->displayOrderSpinBox, &QSpinBox::valueChanged, this,
+        &ChangeReasonDetailDialog::onFieldChanged);
+    connect(ui_->appliesToAmendCheckBox, &QCheckBox::checkStateChanged, this,
+        &ChangeReasonDetailDialog::onFieldChanged);
+    connect(ui_->appliesToDeleteCheckBox, &QCheckBox::checkStateChanged, this,
+        &ChangeReasonDetailDialog::onFieldChanged);
+    connect(ui_->requiresCommentaryCheckBox, &QCheckBox::checkStateChanged, this,
+        &ChangeReasonDetailDialog::onFieldChanged);
+
+    // Initially disable save button
+    updateSaveButtonState();
+}
+
+ChangeReasonDetailDialog::~ChangeReasonDetailDialog() {
+    delete ui_;
+}
+
+void ChangeReasonDetailDialog::setClientManager(ClientManager* clientManager) {
+    clientManager_ = clientManager;
+}
+
+void ChangeReasonDetailDialog::setUsername(const std::string& username) {
+    modifiedByUsername_ = username;
+}
+
+void ChangeReasonDetailDialog::setCategories(
+    const std::vector<iam::domain::change_reason_category>& categories) {
+    categories_ = categories;
+    populateCategoryComboBox();
+}
+
+void ChangeReasonDetailDialog::populateCategoryComboBox() {
+    ui_->categoryCodeComboBox->clear();
+    for (const auto& category : categories_) {
+        ui_->categoryCodeComboBox->addItem(
+            QString::fromStdString(category.code),
+            QString::fromStdString(category.code));
+    }
+}
+
+void ChangeReasonDetailDialog::setChangeReason(
+    const iam::domain::change_reason& reason) {
+    currentReason_ = reason;
+
+    ui_->codeEdit->setText(QString::fromStdString(reason.code));
+    ui_->descriptionEdit->setText(QString::fromStdString(reason.description));
+
+    // Set category in combo box
+    int index = ui_->categoryCodeComboBox->findData(
+        QString::fromStdString(reason.category_code));
+    if (index >= 0) {
+        ui_->categoryCodeComboBox->setCurrentIndex(index);
+    }
+
+    ui_->displayOrderSpinBox->setValue(reason.display_order);
+    ui_->appliesToAmendCheckBox->setChecked(reason.applies_to_amend);
+    ui_->appliesToDeleteCheckBox->setChecked(reason.applies_to_delete);
+    ui_->requiresCommentaryCheckBox->setChecked(reason.requires_commentary);
+
+    ui_->versionEdit->setText(QString::number(reason.version));
+    ui_->recordedByEdit->setText(QString::fromStdString(reason.recorded_by));
+    ui_->recordedAtEdit->setText(relative_time_helper::format(reason.recorded_at));
+
+    isDirty_ = false;
+    emit isDirtyChanged(false);
+    updateSaveButtonState();
+}
+
+iam::domain::change_reason ChangeReasonDetailDialog::getChangeReason() const {
+    iam::domain::change_reason reason = currentReason_;
+    reason.code = ui_->codeEdit->text().trimmed().toStdString();
+    reason.description = ui_->descriptionEdit->text().trimmed().toStdString();
+    reason.category_code = ui_->categoryCodeComboBox->currentData().toString().toStdString();
+    reason.display_order = ui_->displayOrderSpinBox->value();
+    reason.applies_to_amend = ui_->appliesToAmendCheckBox->isChecked();
+    reason.applies_to_delete = ui_->appliesToDeleteCheckBox->isChecked();
+    reason.requires_commentary = ui_->requiresCommentaryCheckBox->isChecked();
+    reason.recorded_by = modifiedByUsername_;
+    return reason;
+}
+
+void ChangeReasonDetailDialog::setCreateMode(bool createMode) {
+    isAddMode_ = createMode;
+
+    // Code is only editable in create mode
+    ui_->codeEdit->setReadOnly(!createMode);
+
+    // Hide metadata section in create mode
+    ui_->metadataGroup->setVisible(!createMode);
+
+    // Hide delete button in create mode
+    deleteAction_->setVisible(!createMode);
+
+    if (createMode) {
+        clearDialog();
+    }
+
+    updateSaveButtonState();
+}
+
+void ChangeReasonDetailDialog::setReadOnly(bool readOnly, int versionNumber) {
+    isReadOnly_ = readOnly;
+
+    ui_->codeEdit->setReadOnly(true);
+    ui_->descriptionEdit->setReadOnly(readOnly);
+    ui_->categoryCodeComboBox->setEnabled(!readOnly);
+    ui_->displayOrderSpinBox->setReadOnly(readOnly);
+    ui_->appliesToAmendCheckBox->setEnabled(!readOnly);
+    ui_->appliesToDeleteCheckBox->setEnabled(!readOnly);
+    ui_->requiresCommentaryCheckBox->setEnabled(!readOnly);
+
+    saveAction_->setVisible(!readOnly);
+    deleteAction_->setVisible(!readOnly);
+    revertAction_->setVisible(readOnly);
+
+    if (readOnly && versionNumber > 0) {
+        setWindowTitle(tr("Change Reason Details - Version %1").arg(versionNumber));
+    }
+}
+
+void ChangeReasonDetailDialog::setHistory(
+    const std::vector<iam::domain::change_reason>& history, int versionNumber) {
+    history_ = history;
+
+    // Find the index of the requested version
+    currentHistoryIndex_ = 0;
+    for (size_t i = 0; i < history_.size(); ++i) {
+        if (history_[i].version == versionNumber) {
+            currentHistoryIndex_ = static_cast<int>(i);
+            break;
+        }
+    }
+
+    showVersionNavActions(history_.size() > 1);
+    displayCurrentVersion();
+    updateVersionNavButtonStates();
+}
+
+void ChangeReasonDetailDialog::clearDialog() {
+    currentReason_ = iam::domain::change_reason{};
+
+    ui_->codeEdit->clear();
+    ui_->descriptionEdit->clear();
+    if (ui_->categoryCodeComboBox->count() > 0) {
+        ui_->categoryCodeComboBox->setCurrentIndex(0);
+    }
+    ui_->displayOrderSpinBox->setValue(0);
+    ui_->appliesToAmendCheckBox->setChecked(false);
+    ui_->appliesToDeleteCheckBox->setChecked(false);
+    ui_->requiresCommentaryCheckBox->setChecked(false);
+
+    ui_->versionEdit->clear();
+    ui_->recordedByEdit->clear();
+    ui_->recordedAtEdit->clear();
+
+    isDirty_ = false;
+    emit isDirtyChanged(false);
+    updateSaveButtonState();
+}
+
+void ChangeReasonDetailDialog::save() {
+    onSaveClicked();
+}
+
+QString ChangeReasonDetailDialog::changeReasonCode() const {
+    return ui_->codeEdit->text();
+}
+
+void ChangeReasonDetailDialog::onFieldChanged() {
+    if (!isDirty_) {
+        isDirty_ = true;
+        emit isDirtyChanged(true);
+    }
+    updateSaveButtonState();
+}
+
+void ChangeReasonDetailDialog::updateSaveButtonState() {
+    bool canSave = isDirty_ && !ui_->codeEdit->text().trimmed().isEmpty() &&
+                   ui_->categoryCodeComboBox->currentIndex() >= 0;
+    saveAction_->setEnabled(canSave && !isReadOnly_);
+}
+
+void ChangeReasonDetailDialog::closeParentWindow() {
+    if (auto* subWindow = qobject_cast<QMdiSubWindow*>(parentWidget())) {
+        subWindow->close();
+    }
+}
+
+void ChangeReasonDetailDialog::displayCurrentVersion() {
+    if (currentHistoryIndex_ >= 0 &&
+        currentHistoryIndex_ < static_cast<int>(history_.size())) {
+        const auto& version = history_[currentHistoryIndex_];
+        setChangeReason(version);
+        setWindowTitle(tr("Change Reason Details - Version %1 of %2")
+            .arg(version.version)
+            .arg(history_.front().version));
+    }
+}
+
+void ChangeReasonDetailDialog::updateVersionNavButtonStates() {
+    bool hasHistory = history_.size() > 1;
+    bool atFirst = currentHistoryIndex_ >= static_cast<int>(history_.size()) - 1;
+    bool atLast = currentHistoryIndex_ <= 0;
+
+    firstVersionAction_->setEnabled(hasHistory && !atFirst);
+    prevVersionAction_->setEnabled(hasHistory && !atFirst);
+    nextVersionAction_->setEnabled(hasHistory && !atLast);
+    lastVersionAction_->setEnabled(hasHistory && !atLast);
+}
+
+void ChangeReasonDetailDialog::showVersionNavActions(bool visible) {
+    firstVersionAction_->setVisible(visible);
+    prevVersionAction_->setVisible(visible);
+    nextVersionAction_->setVisible(visible);
+    lastVersionAction_->setVisible(visible);
+}
+
+void ChangeReasonDetailDialog::onFirstVersionClicked() {
+    if (!history_.empty()) {
+        currentHistoryIndex_ = static_cast<int>(history_.size()) - 1;
+        displayCurrentVersion();
+        updateVersionNavButtonStates();
+    }
+}
+
+void ChangeReasonDetailDialog::onPrevVersionClicked() {
+    if (currentHistoryIndex_ < static_cast<int>(history_.size()) - 1) {
+        currentHistoryIndex_++;
+        displayCurrentVersion();
+        updateVersionNavButtonStates();
+    }
+}
+
+void ChangeReasonDetailDialog::onNextVersionClicked() {
+    if (currentHistoryIndex_ > 0) {
+        currentHistoryIndex_--;
+        displayCurrentVersion();
+        updateVersionNavButtonStates();
+    }
+}
+
+void ChangeReasonDetailDialog::onLastVersionClicked() {
+    if (!history_.empty()) {
+        currentHistoryIndex_ = 0;
+        displayCurrentVersion();
+        updateVersionNavButtonStates();
+    }
+}
+
+void ChangeReasonDetailDialog::onSaveClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Save clicked but client not connected.";
+        emit errorMessage("Not connected to server. Please login.");
+        return;
+    }
+
+    // Validate code
+    if (ui_->codeEdit->text().trimmed().isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Validation failed: code is empty";
+        MessageBoxHelper::warning(this, "Validation Error",
+            "Change reason code is required.");
+        return;
+    }
+
+    // Validate category
+    if (ui_->categoryCodeComboBox->currentIndex() < 0) {
+        BOOST_LOG_SEV(lg(), warn) << "Validation failed: category not selected";
+        MessageBoxHelper::warning(this, "Validation Error",
+            "Category is required.");
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Save clicked for change reason: "
+                               << currentReason_.code;
+
+    QPointer<ChangeReasonDetailDialog> self = this;
+    const iam::domain::change_reason reasonToSave = getChangeReason();
+
+    QFuture<FutureResult> future =
+        QtConcurrent::run([self, reasonToSave]() -> FutureResult {
+            if (!self) return {false, ""};
+
+            BOOST_LOG_SEV(lg(), debug) << "Sending save change reason request for: "
+                                       << reasonToSave.code;
+
+            iam::messaging::save_change_reason_request request;
+            request.reason = reasonToSave;
+
+            auto payload = request.serialize();
+            frame request_frame(message_type::save_change_reason_request,
+                0, std::move(payload));
+
+            auto response_result =
+                self->clientManager_->sendRequest(std::move(request_frame));
+
+            if (!response_result) {
+                return {false, "Failed to communicate with server"};
+            }
+
+            auto payload_result = response_result->decompressed_payload();
+            if (!payload_result) {
+                return {false, "Failed to decompress server response"};
+            }
+
+            auto response = iam::messaging::save_change_reason_response::
+                deserialize(*payload_result);
+
+            if (!response) {
+                return {false, "Invalid server response"};
+            }
+
+            return {response->success, response->message};
+        });
+
+    auto* watcher = new QFutureWatcher<FutureResult>(self);
+    connect(watcher, &QFutureWatcher<FutureResult>::finished, self,
+        [self, watcher, reasonToSave]() {
+        if (!self) return;
+
+        auto [success, message] = watcher->result();
+        watcher->deleteLater();
+
+        if (success) {
+            BOOST_LOG_SEV(lg(), debug) << "Change reason saved successfully";
+
+            emit self->statusMessage(QString("Successfully saved change reason: %1")
+                .arg(QString::fromStdString(reasonToSave.code)));
+
+            self->isDirty_ = false;
+            emit self->isDirtyChanged(false);
+            self->updateSaveButtonState();
+
+            emit self->changeReasonSaved(QString::fromStdString(reasonToSave.code));
+            self->closeParentWindow();
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Change reason save failed: " << message;
+            emit self->errorMessage(QString("Failed to save change reason: %1")
+                .arg(QString::fromStdString(message)));
+            MessageBoxHelper::critical(self, "Save Failed",
+                QString::fromStdString(message));
+        }
+    });
+
+    watcher->setFuture(future);
+}
+
+void ChangeReasonDetailDialog::onDeleteClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Delete clicked but client not connected.";
+        emit errorMessage("Not connected to server. Please login.");
+        return;
+    }
+
+    if (isAddMode_) {
+        BOOST_LOG_SEV(lg(), warn) << "Delete clicked in add mode.";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Delete request for change reason: "
+                               << currentReason_.code;
+
+    auto reply = MessageBoxHelper::question(this, "Delete Change Reason",
+        QString("Are you sure you want to delete change reason '%1'?")
+            .arg(QString::fromStdString(currentReason_.code)),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        BOOST_LOG_SEV(lg(), debug) << "Delete cancelled by user";
+        return;
+    }
+
+    QPointer<ChangeReasonDetailDialog> self = this;
+    const std::string code = currentReason_.code;
+
+    QFuture<FutureResult> future =
+        QtConcurrent::run([self, code]() -> FutureResult {
+            if (!self) return {false, ""};
+
+            BOOST_LOG_SEV(lg(), debug) << "Sending delete change reason request for: "
+                                       << code;
+
+            iam::messaging::delete_change_reason_request request;
+            request.codes = {code};
+
+            auto payload = request.serialize();
+            frame request_frame(message_type::delete_change_reason_request,
+                0, std::move(payload));
+
+            auto response_result =
+                self->clientManager_->sendRequest(std::move(request_frame));
+
+            if (!response_result) {
+                return {false, "Failed to communicate with server"};
+            }
+
+            auto payload_result = response_result->decompressed_payload();
+            if (!payload_result) {
+                return {false, "Failed to decompress server response"};
+            }
+
+            auto response = iam::messaging::delete_change_reason_response::
+                deserialize(*payload_result);
+
+            if (!response) {
+                return {false, "Invalid server response"};
+            }
+
+            // Check if all deletions succeeded
+            if (response->results.empty()) {
+                return {false, "No results in response"};
+            }
+            const auto& result = response->results.front();
+            return {result.success, result.message};
+        });
+
+    auto* watcher = new QFutureWatcher<FutureResult>(self);
+    connect(watcher, &QFutureWatcher<FutureResult>::finished, self,
+        [self, watcher, code]() {
+        if (!self) return;
+
+        auto [success, message] = watcher->result();
+        watcher->deleteLater();
+
+        if (success) {
+            BOOST_LOG_SEV(lg(), debug) << "Change reason deleted successfully";
+
+            emit self->statusMessage(QString("Successfully deleted change reason: %1")
+                .arg(QString::fromStdString(code)));
+
+            emit self->changeReasonDeleted(QString::fromStdString(code));
+            self->closeParentWindow();
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Change reason delete failed: " << message;
+            emit self->errorMessage(QString("Failed to delete change reason: %1")
+                .arg(QString::fromStdString(message)));
+            MessageBoxHelper::critical(self, "Delete Failed",
+                QString::fromStdString(message));
+        }
+    });
+
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt/src/ChangeReasonItemDelegate.cpp
+++ b/projects/ores.qt/src/ChangeReasonItemDelegate.cpp
@@ -1,0 +1,168 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/ChangeReasonItemDelegate.hpp"
+#include "ores.qt/ClientChangeReasonModel.hpp"
+
+#include <QPainter>
+#include <QApplication>
+#include <QStyleOptionViewItem>
+
+namespace ores::qt {
+
+namespace {
+
+// Badge colors for boolean columns
+const QColor yes_badge_bg(34, 197, 94);        // Green (#22c55e)
+const QColor yes_badge_text(255, 255, 255);    // White
+const QColor no_badge_bg(107, 114, 128);       // Gray (#6b7280)
+const QColor no_badge_text(255, 255, 255);     // White
+
+}
+
+ChangeReasonItemDelegate::ChangeReasonItemDelegate(QObject* parent)
+    : QStyledItemDelegate(parent) {
+    monospaceFont_ = QFont("Fira Code");
+    monospaceFont_.setPointSize(10);
+
+    badgeFont_ = QFont();
+    badgeFont_.setPointSize(7);
+    badgeFont_.setBold(true);
+}
+
+void ChangeReasonItemDelegate::paint(QPainter* painter,
+    const QStyleOptionViewItem& option, const QModelIndex& index) const {
+    QStyleOptionViewItem opt = option;
+    initStyleOption(&opt, index);
+
+    // Handle badge columns (AppliesToAmend, AppliesToDelete, RequiresCommentary)
+    if (index.column() == ClientChangeReasonModel::AppliesToAmend ||
+        index.column() == ClientChangeReasonModel::AppliesToDelete ||
+        index.column() == ClientChangeReasonModel::RequiresCommentary) {
+
+        // Draw the background (for selection highlighting)
+        QStyle* style = QApplication::style();
+        style->drawPrimitive(QStyle::PE_PanelItemViewItem, &opt, painter);
+
+        // Get the display text to determine badge type
+        QString text = index.data(Qt::DisplayRole).toString();
+        QColor bgColor, textColor;
+        QString badgeText;
+
+        if (text == tr("Yes")) {
+            bgColor = yes_badge_bg;
+            textColor = yes_badge_text;
+            badgeText = tr("Yes");
+        } else {
+            bgColor = no_badge_bg;
+            textColor = no_badge_text;
+            badgeText = tr("No");
+        }
+
+        // Draw the badge
+        drawBadge(painter, opt.rect, badgeText, bgColor, textColor);
+        return;
+    }
+
+    // Check if model provides a custom foreground color (e.g., recency coloring)
+    QVariant fgData = index.data(Qt::ForegroundRole);
+    if (fgData.isValid()) {
+        opt.palette.setColor(QPalette::Text, fgData.value<QColor>());
+        opt.palette.setColor(QPalette::HighlightedText, fgData.value<QColor>());
+    }
+
+    // Apply formatting based on column
+    switch (index.column()) {
+        case ClientChangeReasonModel::Code:
+            opt.displayAlignment = Qt::AlignLeft | Qt::AlignVCenter;
+            break;
+        case ClientChangeReasonModel::CategoryCode:
+            opt.displayAlignment = Qt::AlignLeft | Qt::AlignVCenter;
+            break;
+        case ClientChangeReasonModel::DisplayOrder:
+            opt.font = monospaceFont_;
+            opt.displayAlignment = Qt::AlignCenter;
+            break;
+        case ClientChangeReasonModel::Version:
+            opt.font = monospaceFont_;
+            opt.displayAlignment = Qt::AlignCenter;
+            break;
+        case ClientChangeReasonModel::RecordedBy:
+            opt.displayAlignment = Qt::AlignLeft | Qt::AlignVCenter;
+            break;
+        case ClientChangeReasonModel::RecordedAt:
+            opt.displayAlignment = Qt::AlignLeft | Qt::AlignVCenter;
+            break;
+        default:
+            break;
+    }
+
+    // Draw the item using the modified options
+    QApplication::style()->drawControl(QStyle::CE_ItemViewItem, &opt, painter);
+}
+
+QSize ChangeReasonItemDelegate::sizeHint(const QStyleOptionViewItem& option,
+                                          const QModelIndex& index) const {
+    QSize size = QStyledItemDelegate::sizeHint(option, index);
+
+    // Ensure minimum height and width for badge columns
+    if (index.column() == ClientChangeReasonModel::AppliesToAmend ||
+        index.column() == ClientChangeReasonModel::AppliesToDelete ||
+        index.column() == ClientChangeReasonModel::RequiresCommentary) {
+        size.setHeight(qMax(size.height(), 24));
+        size.setWidth(qMax(size.width(), 50));
+    }
+
+    return size;
+}
+
+void ChangeReasonItemDelegate::drawBadge(QPainter* painter, const QRect& rect,
+                                          const QString& text,
+                                          const QColor& backgroundColor,
+                                          const QColor& textColor) const {
+    painter->save();
+    painter->setRenderHint(QPainter::Antialiasing, true);
+
+    // Calculate badge dimensions (compact size)
+    QFontMetrics fm(badgeFont_);
+    int textWidth = fm.horizontalAdvance(text);
+    int padding = 5;
+    int badgeWidth = textWidth + padding * 2;
+    int badgeHeight = fm.height() + 2;
+
+    // Center the badge in the cell
+    int x = rect.center().x() - badgeWidth / 2;
+    int y = rect.center().y() - badgeHeight / 2;
+    QRect badgeRect(x, y, badgeWidth, badgeHeight);
+
+    // Draw pill-shaped background (rounded rectangle)
+    int radius = badgeHeight / 2;
+    painter->setBrush(backgroundColor);
+    painter->setPen(Qt::NoPen);
+    painter->drawRoundedRect(badgeRect, radius, radius);
+
+    // Draw text
+    painter->setFont(badgeFont_);
+    painter->setPen(textColor);
+    painter->drawText(badgeRect, Qt::AlignCenter, text);
+
+    painter->restore();
+}
+
+}

--- a/projects/ores.qt/src/ChangeReasonMdiWindow.cpp
+++ b/projects/ores.qt/src/ChangeReasonMdiWindow.cpp
@@ -21,7 +21,15 @@
 
 #include <QVBoxLayout>
 #include <QHeaderView>
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ores.qt/ChangeReasonItemDelegate.hpp"
 #include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.iam/messaging/change_management_protocol.hpp"
+#include "ores.comms/messaging/frame.hpp"
 
 namespace ores::qt {
 
@@ -39,7 +47,10 @@ ChangeReasonMdiWindow::ChangeReasonMdiWindow(
       model_(nullptr),
       proxyModel_(nullptr),
       reloadAction_(nullptr),
-      viewDetailsAction_(nullptr),
+      addAction_(nullptr),
+      editAction_(nullptr),
+      deleteAction_(nullptr),
+      historyAction_(nullptr),
       pulseTimer_(new QTimer(this)) {
 
     setupUi();
@@ -71,8 +82,8 @@ void ChangeReasonMdiWindow::setupToolbar() {
     toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
     toolbar_->setIconSize(QSize(20, 20));
 
-    const QColor iconColor(220, 220, 220);
-    const QColor staleColor(255, 165, 0);  // Orange for stale
+    const auto& iconColor = color_constants::icon_color;
+    const auto& staleColor = color_constants::stale_indicator;
 
     normalReloadIcon_ = IconUtils::createRecoloredIcon(
         ":/icons/ic_fluent_arrow_clockwise_16_regular.svg", iconColor);
@@ -86,21 +97,40 @@ void ChangeReasonMdiWindow::setupToolbar() {
 
     toolbar_->addSeparator();
 
-    viewDetailsAction_ = toolbar_->addAction(
+    addAction_ = toolbar_->addAction(
         IconUtils::createRecoloredIcon(
-            ":/icons/ic_fluent_info_20_regular.svg", iconColor),
-        tr("View Details"));
-    viewDetailsAction_->setToolTip(tr("View reason details"));
-    viewDetailsAction_->setEnabled(false);
-    connect(viewDetailsAction_, &QAction::triggered, this, [this]() {
-        auto selected = tableView_->selectionModel()->selectedRows();
-        if (selected.isEmpty())
-            return;
-        auto sourceIndex = proxyModel_->mapToSource(selected.first());
-        if (auto* reason = model_->getReason(sourceIndex.row())) {
-            emit showReasonDetails(*reason);
-        }
-    });
+            ":/icons/ic_fluent_add_20_regular.svg", iconColor),
+        tr("Add"));
+    addAction_->setToolTip(tr("Add new change reason"));
+    connect(addAction_, &QAction::triggered, this,
+            &ChangeReasonMdiWindow::addNew);
+
+    editAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            ":/icons/ic_fluent_edit_20_regular.svg", iconColor),
+        tr("Edit"));
+    editAction_->setToolTip(tr("Edit selected change reason"));
+    editAction_->setEnabled(false);
+    connect(editAction_, &QAction::triggered, this,
+            &ChangeReasonMdiWindow::editSelected);
+
+    deleteAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            ":/icons/ic_fluent_delete_20_regular.svg", iconColor),
+        tr("Delete"));
+    deleteAction_->setToolTip(tr("Delete selected change reason"));
+    deleteAction_->setEnabled(false);
+    connect(deleteAction_, &QAction::triggered, this,
+            &ChangeReasonMdiWindow::deleteSelected);
+
+    historyAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            ":/icons/ic_fluent_history_20_regular.svg", iconColor),
+        tr("History"));
+    historyAction_->setToolTip(tr("View change reason history"));
+    historyAction_->setEnabled(false);
+    connect(historyAction_, &QAction::triggered, this,
+            &ChangeReasonMdiWindow::viewHistorySelected);
 
     // Pulse timer for stale indicator
     pulseTimer_->setInterval(pulse_interval_ms_);
@@ -130,16 +160,18 @@ void ChangeReasonMdiWindow::setupTable() {
     tableView_->horizontalHeader()->setStretchLastSection(true);
     tableView_->verticalHeader()->setVisible(false);
 
+    // Set custom delegate for badge rendering
+    tableView_->setItemDelegate(new ChangeReasonItemDelegate(this));
+
     // Set column widths
-    tableView_->setColumnWidth(ClientChangeReasonModel::Code, 150);
-    tableView_->setColumnWidth(ClientChangeReasonModel::Description, 200);
-    tableView_->setColumnWidth(ClientChangeReasonModel::CategoryCode, 100);
-    tableView_->setColumnWidth(ClientChangeReasonModel::AppliesToAmend, 60);
-    tableView_->setColumnWidth(ClientChangeReasonModel::AppliesToDelete, 60);
-    tableView_->setColumnWidth(ClientChangeReasonModel::RequiresCommentary, 80);
-    tableView_->setColumnWidth(ClientChangeReasonModel::DisplayOrder, 60);
-    tableView_->setColumnWidth(ClientChangeReasonModel::Version, 60);
-    tableView_->setColumnWidth(ClientChangeReasonModel::RecordedBy, 100);
+    tableView_->setColumnWidth(ClientChangeReasonModel::Code, 200);
+    tableView_->setColumnWidth(ClientChangeReasonModel::CategoryCode, 120);
+    tableView_->setColumnWidth(ClientChangeReasonModel::AppliesToAmend, 100);
+    tableView_->setColumnWidth(ClientChangeReasonModel::AppliesToDelete, 100);
+    tableView_->setColumnWidth(ClientChangeReasonModel::RequiresCommentary, 120);
+    tableView_->setColumnWidth(ClientChangeReasonModel::DisplayOrder, 80);
+    tableView_->setColumnWidth(ClientChangeReasonModel::Version, 80);
+    tableView_->setColumnWidth(ClientChangeReasonModel::RecordedBy, 120);
 }
 
 void ChangeReasonMdiWindow::setupConnections() {
@@ -171,8 +203,7 @@ void ChangeReasonMdiWindow::onLoadError(const QString& error_message) {
 }
 
 void ChangeReasonMdiWindow::onSelectionChanged() {
-    bool hasSelection = tableView_->selectionModel()->hasSelection();
-    viewDetailsAction_->setEnabled(hasSelection);
+    updateActionStates();
 }
 
 void ChangeReasonMdiWindow::onDoubleClicked(const QModelIndex& index) {
@@ -183,6 +214,203 @@ void ChangeReasonMdiWindow::onDoubleClicked(const QModelIndex& index) {
     if (auto* reason = model_->getReason(sourceIndex.row())) {
         emit showReasonDetails(*reason);
     }
+}
+
+void ChangeReasonMdiWindow::updateActionStates() {
+    const bool hasSelection = tableView_->selectionModel()->hasSelection();
+    editAction_->setEnabled(hasSelection);
+    deleteAction_->setEnabled(hasSelection);
+    historyAction_->setEnabled(hasSelection);
+}
+
+void ChangeReasonMdiWindow::addNew() {
+    BOOST_LOG_SEV(lg(), debug) << "Add new change reason requested";
+    emit addNewRequested();
+}
+
+void ChangeReasonMdiWindow::editSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Edit requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* reason = model_->getReason(sourceIndex.row())) {
+        emit showReasonDetails(*reason);
+    }
+}
+
+void ChangeReasonMdiWindow::viewHistorySelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "View history requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* reason = model_->getReason(sourceIndex.row())) {
+        BOOST_LOG_SEV(lg(), debug) << "Emitting showReasonHistory for code: "
+                                   << reason->code;
+        emit showReasonHistory(QString::fromStdString(reason->code));
+    }
+}
+
+void ChangeReasonMdiWindow::deleteSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Delete requested but no row selected";
+        return;
+    }
+
+    if (!clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete change reason while disconnected.");
+        return;
+    }
+
+    std::vector<std::string> codes;
+    for (const auto& index : selected) {
+        auto sourceIndex = proxyModel_->mapToSource(index);
+        if (auto* reason = model_->getReason(sourceIndex.row())) {
+            codes.push_back(reason->code);
+        }
+    }
+
+    if (codes.empty()) {
+        BOOST_LOG_SEV(lg(), warn) << "No valid change reasons to delete";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Delete requested for " << codes.size()
+                               << " change reasons";
+
+    QString confirmMessage;
+    if (codes.size() == 1) {
+        confirmMessage = QString("Are you sure you want to delete change reason '%1'?")
+            .arg(QString::fromStdString(codes.front()));
+    } else {
+        confirmMessage = QString("Are you sure you want to delete %1 change reasons?")
+            .arg(codes.size());
+    }
+
+    auto reply = MessageBoxHelper::question(this, "Delete Change Reason",
+        confirmMessage, QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        BOOST_LOG_SEV(lg(), debug) << "Delete cancelled by user";
+        return;
+    }
+
+    QPointer<ChangeReasonMdiWindow> self = this;
+    using DeleteResult = std::vector<std::pair<std::string, std::pair<bool, std::string>>>;
+
+    auto task = [self, codes]() -> DeleteResult {
+        DeleteResult results;
+        if (!self) return {};
+
+        BOOST_LOG_SEV(lg(), debug) << "Making batch delete request for "
+                                   << codes.size() << " change reasons";
+
+        iam::messaging::delete_change_reason_request request;
+        request.codes = codes;
+        auto payload = request.serialize();
+
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::delete_change_reason_request,
+            0, std::move(payload)
+        );
+
+        auto response_result = self->clientManager_->sendRequest(
+            std::move(request_frame));
+
+        if (!response_result) {
+            BOOST_LOG_SEV(lg(), error) << "Failed to send batch delete request";
+            for (const auto& code : codes) {
+                results.push_back({code, {false, "Failed to communicate with server"}});
+            }
+            return results;
+        }
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) {
+            BOOST_LOG_SEV(lg(), error) << "Failed to decompress batch response";
+            for (const auto& code : codes) {
+                results.push_back({code, {false, "Failed to decompress server response"}});
+            }
+            return results;
+        }
+
+        auto response = iam::messaging::delete_change_reason_response::
+            deserialize(*payload_result);
+
+        if (!response) {
+            BOOST_LOG_SEV(lg(), error) << "Failed to deserialize batch response";
+            for (const auto& code : codes) {
+                results.push_back({code, {false, "Invalid server response"}});
+            }
+            return results;
+        }
+
+        for (const auto& result : response->results) {
+            results.push_back({result.code, {result.success, result.message}});
+        }
+
+        return results;
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, watcher]() {
+        auto results = watcher->result();
+        watcher->deleteLater();
+
+        int success_count = 0;
+        int failure_count = 0;
+        QString first_error;
+
+        for (const auto& [code, result] : results) {
+            auto [success, message] = result;
+
+            if (success) {
+                BOOST_LOG_SEV(lg(), debug) << "Change reason deleted: " << code;
+                success_count++;
+                emit self->reasonDeleted(QString::fromStdString(code));
+            } else {
+                BOOST_LOG_SEV(lg(), error) << "Change reason deletion failed: "
+                                           << code << " - " << message;
+                failure_count++;
+                if (first_error.isEmpty()) {
+                    first_error = QString::fromStdString(message);
+                }
+            }
+        }
+
+        self->model_->refresh();
+
+        if (failure_count == 0) {
+            QString msg = success_count == 1
+                ? "Successfully deleted 1 change reason"
+                : QString("Successfully deleted %1 change reasons").arg(success_count);
+            emit self->statusChanged(msg);
+        } else if (success_count == 0) {
+            QString msg = QString("Failed to delete %1 %2: %3")
+                .arg(failure_count)
+                .arg(failure_count == 1 ? "change reason" : "change reasons")
+                .arg(first_error);
+            emit self->errorOccurred(msg);
+            MessageBoxHelper::critical(self, "Delete Failed", msg);
+        } else {
+            QString msg = QString("Deleted %1, failed to delete %2")
+                .arg(success_count)
+                .arg(failure_count);
+            emit self->statusChanged(msg);
+            MessageBoxHelper::warning(self, "Partial Success", msg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
 }
 
 void ChangeReasonMdiWindow::markAsStale() {

--- a/projects/ores.qt/src/ClientChangeReasonCategoryModel.cpp
+++ b/projects/ores.qt/src/ClientChangeReasonCategoryModel.cpp
@@ -23,7 +23,7 @@
 #include <QBrush>
 #include "ores.iam/messaging/change_management_protocol.hpp"
 #include "ores.comms/messaging/frame.hpp"
-#include "ores.platform/time/datetime.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
 
 namespace ores::qt {
 
@@ -79,11 +79,8 @@ QVariant ClientChangeReasonCategoryModel::data(
             return category.version;
         case RecordedBy:
             return QString::fromStdString(category.recorded_by);
-        case RecordedAt: {
-            auto formatted = platform::time::datetime::format_time_point(
-                category.recorded_at);
-            return QString::fromStdString(formatted);
-        }
+        case RecordedAt:
+            return relative_time_helper::format(category.recorded_at);
         default:
             return {};
         }

--- a/projects/ores.qt/src/ClientChangeReasonModel.cpp
+++ b/projects/ores.qt/src/ClientChangeReasonModel.cpp
@@ -23,7 +23,7 @@
 #include <QBrush>
 #include "ores.iam/messaging/change_management_protocol.hpp"
 #include "ores.comms/messaging/frame.hpp"
-#include "ores.platform/time/datetime.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
 
 namespace ores::qt {
 
@@ -73,8 +73,6 @@ QVariant ClientChangeReasonModel::data(
         switch (index.column()) {
         case Code:
             return QString::fromStdString(reason.code);
-        case Description:
-            return QString::fromStdString(reason.description);
         case CategoryCode:
             return QString::fromStdString(reason.category_code);
         case AppliesToAmend:
@@ -89,11 +87,8 @@ QVariant ClientChangeReasonModel::data(
             return reason.version;
         case RecordedBy:
             return QString::fromStdString(reason.recorded_by);
-        case RecordedAt: {
-            auto formatted = platform::time::datetime::format_time_point(
-                reason.recorded_at);
-            return QString::fromStdString(formatted);
-        }
+        case RecordedAt:
+            return relative_time_helper::format(reason.recorded_at);
         default:
             return {};
         }
@@ -114,8 +109,6 @@ QVariant ClientChangeReasonModel::headerData(
     switch (section) {
     case Code:
         return tr("Code");
-    case Description:
-        return tr("Description");
     case CategoryCode:
         return tr("Category");
     case AppliesToAmend:

--- a/projects/ores.qt/ui/ChangeReasonCategoryDetailDialog.ui
+++ b/projects/ores.qt/ui/ChangeReasonCategoryDetailDialog.ui
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ChangeReasonCategoryDetailDialog</class>
+ <widget class="QWidget" name="ChangeReasonCategoryDetailDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>450</width>
+    <height>350</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>400</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Change Reason Category Details</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="basicInfoGroup">
+     <property name="title">
+      <string>Basic Information</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelCode">
+        <property name="text">
+         <string>Code:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="codeEdit">
+        <property name="placeholderText">
+         <string>Enter category code (e.g., data_quality)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelDescription">
+        <property name="text">
+         <string>Description:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QTextEdit" name="descriptionEdit">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>80</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>120</height>
+         </size>
+        </property>
+        <property name="placeholderText">
+         <string>Enter a description of this category</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="metadataGroup">
+     <property name="title">
+      <string>Metadata (Read-only)</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelVersion">
+        <property name="text">
+         <string>Version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="versionEdit">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelRecordedBy">
+        <property name="text">
+         <string>Recorded By:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="recordedByEdit">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelRecordedAt">
+        <property name="text">
+         <string>Recorded At:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="recordedAtEdit">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt/ui/ChangeReasonDetailDialog.ui
+++ b/projects/ores.qt/ui/ChangeReasonDetailDialog.ui
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ChangeReasonDetailDialog</class>
+ <widget class="QWidget" name="ChangeReasonDetailDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>500</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>450</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Change Reason Details</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="basicInfoGroup">
+     <property name="title">
+      <string>Basic Information</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelCode">
+        <property name="text">
+         <string>Code:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="codeEdit">
+        <property name="placeholderText">
+         <string>Enter reason code (e.g., data_correction)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelDescription">
+        <property name="text">
+         <string>Description:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="descriptionEdit">
+        <property name="placeholderText">
+         <string>Enter description</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelCategoryCode">
+        <property name="text">
+         <string>Category:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="categoryCodeComboBox"/>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="labelDisplayOrder">
+        <property name="text">
+         <string>Display Order:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QSpinBox" name="displayOrderSpinBox">
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>999</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="applicabilityGroup">
+     <property name="title">
+      <string>Applicability</string>
+     </property>
+     <layout class="QVBoxLayout" name="applicabilityLayout">
+      <item>
+       <widget class="QCheckBox" name="appliesToAmendCheckBox">
+        <property name="text">
+         <string>Applies to Amend operations</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="appliesToDeleteCheckBox">
+        <property name="text">
+         <string>Applies to Delete operations</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="requiresCommentaryCheckBox">
+        <property name="text">
+         <string>Requires commentary when selected</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="metadataGroup">
+     <property name="title">
+      <string>Metadata (Read-only)</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelVersion">
+        <property name="text">
+         <string>Version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="versionEdit">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelRecordedBy">
+        <property name="text">
+         <string>Recorded By:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="recordedByEdit">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelRecordedAt">
+        <property name="text">
+         <string>Recorded At:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="recordedAtEdit">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
## Summary

- Add complete Create, Read, Update, Delete functionality for change reasons and change reason categories
- Server-side protocol messages and handlers for save/delete/history operations
- New detail dialogs with full form editing capabilities
- Toolbar actions (Add, Edit, Delete, History) in list windows
- Boolean badge rendering for change reason flags
- Human-readable timestamps using RelativeTimeHelper

## Changes

**Server-side (ores.iam):**
- Add save/delete protocol messages for change reasons and categories
- Add history retrieval protocol messages
- Implement message handlers in accounts_message_handler
- Add repository methods for history queries

**Qt client (ores.qt):**
- Create ChangeReasonDetailDialog and ChangeReasonCategoryDetailDialog
- Create ChangeReasonItemDelegate for boolean badge rendering (Yes/No pills)
- Add toolbar actions to ChangeReasonMdiWindow and ChangeReasonCategoryMdiWindow
- Update controllers to use proper detail dialogs
- Remove Description column, adjust column widths
- Use RelativeTimeHelper for timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)