### PR TITLE
[cmake] Fix MSVC debug build PDB contention with sccache

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -156,6 +156,9 @@
                 "windows-arch-x64",
                 "msvc-cl"
             ],
+            "cacheVariables": {
+                "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded"
+            },
             "vendor": {
                 "microsoft.com/VisualStudioSettings/CMake/1.0": {
                     "hostOS": [


### PR DESCRIPTION
## Summary
- Set `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` to `Embedded` for MSVC builds
- Uses `/Z7` instead of `/Zi`, embedding debug info in object files rather than a shared PDB
- Fixes C1041 errors when Ninja runs parallel compiler processes through sccache that contend for `vc140.pdb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)