### PR TITLE
Add support for data sets

### DIFF
--- a/projects/ores.qt/include/ores.qt/ClientCodingSchemeModel.hpp
+++ b/projects/ores.qt/include/ores.qt/ClientCodingSchemeModel.hpp
@@ -1,0 +1,108 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CLIENT_CODING_SCHEME_MODEL_HPP
+#define ORES_QT_CLIENT_CODING_SCHEME_MODEL_HPP
+
+#include <vector>
+#include <unordered_set>
+#include <QTimer>
+#include <QDateTime>
+#include <QFutureWatcher>
+#include <QAbstractTableModel>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.dq/domain/coding_scheme.hpp"
+
+namespace ores::qt {
+
+class ClientCodingSchemeModel final : public QAbstractTableModel {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.client_coding_scheme_model";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    enum Column {
+        Code,
+        Name,
+        AuthorityType,
+        SubjectArea,
+        Domain,
+        Description,
+        Version,
+        RecordedBy,
+        RecordedAt,
+        ColumnCount
+    };
+
+    explicit ClientCodingSchemeModel(ClientManager* clientManager,
+                                     QObject* parent = nullptr);
+    ~ClientCodingSchemeModel() override = default;
+
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+        int role = Qt::DisplayRole) const override;
+
+    void refresh();
+    const dq::domain::coding_scheme* getScheme(int row) const;
+
+signals:
+    void dataLoaded();
+    void loadError(const QString& error_message);
+
+private slots:
+    void onSchemesLoaded();
+    void onPulseTimerTimeout();
+
+private:
+    void update_recent_schemes();
+    QVariant recency_foreground_color(const std::string& code) const;
+
+    struct FetchResult {
+        bool success;
+        std::vector<dq::domain::coding_scheme> schemes;
+    };
+
+    ClientManager* clientManager_;
+    std::vector<dq::domain::coding_scheme> schemes_;
+    QFutureWatcher<FetchResult>* watcher_;
+    bool is_fetching_{false};
+
+    QTimer* pulse_timer_;
+    std::unordered_set<std::string> recent_scheme_codes_;
+    QDateTime last_reload_time_;
+    bool pulse_state_{false};
+    int pulse_count_{0};
+    static constexpr int pulse_interval_ms_ = 500;
+    static constexpr int max_pulse_cycles_ = 6;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/ClientDatasetModel.hpp
+++ b/projects/ores.qt/include/ores.qt/ClientDatasetModel.hpp
@@ -1,0 +1,113 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CLIENT_DATASET_MODEL_HPP
+#define ORES_QT_CLIENT_DATASET_MODEL_HPP
+
+#include <vector>
+#include <unordered_set>
+#include <QTimer>
+#include <QDateTime>
+#include <QFutureWatcher>
+#include <QAbstractTableModel>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.dq/domain/dataset.hpp"
+
+namespace ores::qt {
+
+class ClientDatasetModel final : public QAbstractTableModel {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.client_dataset_model";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    enum Column {
+        Name,
+        Catalog,
+        SubjectArea,
+        Domain,
+        Origin,
+        Nature,
+        Treatment,
+        SourceSystem,
+        AsOfDate,
+        Version,
+        RecordedBy,
+        RecordedAt,
+        ColumnCount
+    };
+
+    explicit ClientDatasetModel(ClientManager* clientManager,
+                                QObject* parent = nullptr);
+    ~ClientDatasetModel() override = default;
+
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+        int role = Qt::DisplayRole) const override;
+
+    void refresh();
+    const dq::domain::dataset* getDataset(int row) const;
+
+signals:
+    void dataLoaded();
+    void loadError(const QString& error_message);
+
+private slots:
+    void onDatasetsLoaded();
+    void onPulseTimerTimeout();
+
+private:
+    void update_recent_datasets();
+    QVariant recency_foreground_color(const boost::uuids::uuid& id) const;
+
+    struct FetchResult {
+        bool success;
+        std::vector<dq::domain::dataset> datasets;
+    };
+
+    ClientManager* clientManager_;
+    std::vector<dq::domain::dataset> datasets_;
+    QFutureWatcher<FetchResult>* watcher_;
+    bool is_fetching_{false};
+
+    QTimer* pulse_timer_;
+    std::unordered_set<std::string> recent_dataset_ids_;
+    QDateTime last_reload_time_;
+    bool pulse_state_{false};
+    int pulse_count_{0};
+    static constexpr int pulse_interval_ms_ = 500;
+    static constexpr int max_pulse_cycles_ = 6;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/ClientMethodologyModel.hpp
+++ b/projects/ores.qt/include/ores.qt/ClientMethodologyModel.hpp
@@ -1,0 +1,107 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CLIENT_METHODOLOGY_MODEL_HPP
+#define ORES_QT_CLIENT_METHODOLOGY_MODEL_HPP
+
+#include <vector>
+#include <unordered_set>
+#include <QTimer>
+#include <QDateTime>
+#include <QFutureWatcher>
+#include <QAbstractTableModel>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.dq/domain/methodology.hpp"
+
+namespace ores::qt {
+
+class ClientMethodologyModel final : public QAbstractTableModel {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.client_methodology_model";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    enum Column {
+        Name,
+        Description,
+        LogicReference,
+        Version,
+        RecordedBy,
+        RecordedAt,
+        ColumnCount
+    };
+
+    explicit ClientMethodologyModel(ClientManager* clientManager,
+                                    QObject* parent = nullptr);
+    ~ClientMethodologyModel() override = default;
+
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+        int role = Qt::DisplayRole) const override;
+
+    void refresh();
+    const dq::domain::methodology* getMethodology(int row) const;
+
+signals:
+    void dataLoaded();
+    void loadError(const QString& error_message);
+
+private slots:
+    void onMethodologiesLoaded();
+    void onPulseTimerTimeout();
+
+private:
+    void update_recent_methodologies();
+    QVariant recency_foreground_color(const boost::uuids::uuid& id) const;
+
+    struct FetchResult {
+        bool success;
+        std::vector<dq::domain::methodology> methodologies;
+    };
+
+    ClientManager* clientManager_;
+    std::vector<dq::domain::methodology> methodologies_;
+    QFutureWatcher<FetchResult>* watcher_;
+    bool is_fetching_{false};
+
+    QTimer* pulse_timer_;
+    std::unordered_set<std::string> recent_methodology_ids_;
+    QDateTime last_reload_time_;
+    bool pulse_state_{false};
+    int pulse_count_{0};
+    static constexpr int pulse_interval_ms_ = 500;
+    static constexpr int max_pulse_cycles_ = 6;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/CodingSchemeController.hpp
+++ b/projects/ores.qt/include/ores.qt/CodingSchemeController.hpp
@@ -1,0 +1,84 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CODING_SCHEME_CONTROLLER_HPP
+#define ORES_QT_CODING_SCHEME_CONTROLLER_HPP
+
+#include <QMdiArea>
+#include <QMainWindow>
+#include "ores.qt/EntityController.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.dq/domain/coding_scheme.hpp"
+
+namespace ores::qt {
+
+class CodingSchemeMdiWindow;
+class DetachableMdiSubWindow;
+
+class CodingSchemeController final : public EntityController {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.coding_scheme_controller";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    CodingSchemeController(
+        QMainWindow* mainWindow,
+        QMdiArea* mdiArea,
+        ClientManager* clientManager,
+        const QString& username,
+        QList<DetachableMdiSubWindow*>& allDetachableWindows,
+        QObject* parent = nullptr);
+    ~CodingSchemeController() override;
+
+    void showListWindow() override;
+    void closeAllWindows() override;
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& error);
+
+private slots:
+    void onShowDetails(const dq::domain::coding_scheme& scheme);
+    void onAddNewRequested();
+    void onShowHistory(const QString& code);
+    void onRevertVersion(const dq::domain::coding_scheme& scheme);
+    void onOpenVersion(const dq::domain::coding_scheme& scheme, int versionNumber);
+
+private:
+    void showAddWindow();
+    void showDetailWindow(const dq::domain::coding_scheme& scheme);
+    void showHistoryWindow(const QString& code);
+
+    CodingSchemeMdiWindow* listWindow_;
+    DetachableMdiSubWindow* listMdiSubWindow_;
+    QList<DetachableMdiSubWindow*>& allDetachableWindows_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/CodingSchemeDetailDialog.hpp
+++ b/projects/ores.qt/include/ores.qt/CodingSchemeDetailDialog.hpp
@@ -1,0 +1,82 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CODING_SCHEME_DETAIL_DIALOG_HPP
+#define ORES_QT_CODING_SCHEME_DETAIL_DIALOG_HPP
+
+#include <QWidget>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.dq/domain/coding_scheme.hpp"
+
+namespace Ui {
+class CodingSchemeDetailDialog;
+}
+
+namespace ores::qt {
+
+class CodingSchemeDetailDialog final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.coding_scheme_detail_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit CodingSchemeDetailDialog(QWidget* parent = nullptr);
+    ~CodingSchemeDetailDialog() override;
+
+    void setClientManager(ClientManager* cm) { clientManager_ = cm; }
+    void setUsername(const std::string& username) { username_ = username; }
+    void setCreateMode(bool create);
+    void setScheme(const dq::domain::coding_scheme& scheme);
+    void setReadOnly(bool readOnly);
+    void loadLookupData();
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& error);
+    void schemeSaved(const QString& code);
+    void schemeDeleted(const QString& code);
+
+private slots:
+    void onSaveClicked();
+    void onDeleteClicked();
+
+private:
+    void setupConnections();
+    void updateUiState();
+
+    Ui::CodingSchemeDetailDialog* ui_;
+    ClientManager* clientManager_;
+    std::string username_;
+    dq::domain::coding_scheme scheme_;
+    bool isCreateMode_;
+    bool isReadOnly_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/CodingSchemeHistoryDialog.hpp
+++ b/projects/ores.qt/include/ores.qt/CodingSchemeHistoryDialog.hpp
@@ -1,0 +1,90 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CODING_SCHEME_HISTORY_DIALOG_HPP
+#define ORES_QT_CODING_SCHEME_HISTORY_DIALOG_HPP
+
+#include <QWidget>
+#include <QToolBar>
+#include <QTableWidget>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.dq/domain/coding_scheme.hpp"
+
+namespace Ui {
+class CodingSchemeHistoryDialog;
+}
+
+namespace ores::qt {
+
+class CodingSchemeHistoryDialog final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.coding_scheme_history_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit CodingSchemeHistoryDialog(
+        const QString& code,
+        ClientManager* clientManager,
+        QWidget* parent = nullptr);
+    ~CodingSchemeHistoryDialog() override;
+
+    void loadHistory();
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void openVersionRequested(const dq::domain::coding_scheme& scheme, int versionNumber);
+    void revertVersionRequested(const dq::domain::coding_scheme& scheme);
+
+private slots:
+    void onVersionSelected();
+    void onOpenVersionClicked();
+    void onRevertClicked();
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupConnections();
+    void updateVersionList();
+    void updateChangesTable(int currentVersionIndex);
+    void updateFullDetails(int versionIndex);
+    void updateActionStates();
+
+    Ui::CodingSchemeHistoryDialog* ui_;
+    QString code_;
+    ClientManager* clientManager_;
+    std::vector<dq::domain::coding_scheme> versions_;
+
+    QToolBar* toolbar_;
+    QAction* openVersionAction_;
+    QAction* revertAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/CodingSchemeMdiWindow.hpp
+++ b/projects/ores.qt/include/ores.qt/CodingSchemeMdiWindow.hpp
@@ -1,0 +1,98 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CODING_SCHEME_MDI_WINDOW_HPP
+#define ORES_QT_CODING_SCHEME_MDI_WINDOW_HPP
+
+#include <QWidget>
+#include <QTableView>
+#include <QToolBar>
+#include <QSortFilterProxyModel>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ClientCodingSchemeModel.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.dq/domain/coding_scheme.hpp"
+
+namespace ores::qt {
+
+class CodingSchemeMdiWindow final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.coding_scheme_mdi_window";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit CodingSchemeMdiWindow(ClientManager* clientManager,
+                                   const QString& username,
+                                   QWidget* parent = nullptr);
+    ~CodingSchemeMdiWindow() override = default;
+
+    QSize sizeHint() const override { return QSize(1000, 600); }
+    void reload();
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void showSchemeDetails(const dq::domain::coding_scheme& scheme);
+    void showSchemeHistory(const QString& code);
+    void addNewRequested();
+
+private slots:
+    void onDataLoaded();
+    void onLoadError(const QString& error_message);
+    void onRowDoubleClicked(const QModelIndex& index);
+    void onAddClicked();
+    void onEditClicked();
+    void onDeleteClicked();
+    void onRefreshClicked();
+    void onSelectionChanged();
+    void onHistoryClicked();
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupConnections();
+    void updateActionStates();
+    void saveColumnVisibility();
+    void loadColumnVisibility();
+
+    ClientManager* clientManager_;
+    QString username_;
+    ClientCodingSchemeModel* model_;
+    QSortFilterProxyModel* proxyModel_;
+    QTableView* tableView_;
+    QToolBar* toolbar_;
+
+    QAction* addAction_;
+    QAction* editAction_;
+    QAction* deleteAction_;
+    QAction* refreshAction_;
+    QAction* historyAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/DatasetController.hpp
+++ b/projects/ores.qt/include/ores.qt/DatasetController.hpp
@@ -1,0 +1,85 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_DATASET_CONTROLLER_HPP
+#define ORES_QT_DATASET_CONTROLLER_HPP
+
+#include <QMdiArea>
+#include <QMainWindow>
+#include <boost/uuid/uuid.hpp>
+#include "ores.qt/EntityController.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.dq/domain/dataset.hpp"
+
+namespace ores::qt {
+
+class DatasetMdiWindow;
+class DetachableMdiSubWindow;
+
+class DatasetController final : public EntityController {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.dataset_controller";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    DatasetController(
+        QMainWindow* mainWindow,
+        QMdiArea* mdiArea,
+        ClientManager* clientManager,
+        const QString& username,
+        QList<DetachableMdiSubWindow*>& allDetachableWindows,
+        QObject* parent = nullptr);
+    ~DatasetController() override;
+
+    void showListWindow() override;
+    void closeAllWindows() override;
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& error);
+
+private slots:
+    void onShowDetails(const dq::domain::dataset& dataset);
+    void onAddNewRequested();
+    void onShowHistory(const boost::uuids::uuid& id);
+    void onRevertVersion(const dq::domain::dataset& dataset);
+    void onOpenVersion(const dq::domain::dataset& dataset, int versionNumber);
+
+private:
+    void showAddWindow();
+    void showDetailWindow(const dq::domain::dataset& dataset);
+    void showHistoryWindow(const boost::uuids::uuid& id);
+
+    DatasetMdiWindow* listWindow_;
+    DetachableMdiSubWindow* listMdiSubWindow_;
+    QList<DetachableMdiSubWindow*>& allDetachableWindows_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/DatasetDetailDialog.hpp
+++ b/projects/ores.qt/include/ores.qt/DatasetDetailDialog.hpp
@@ -1,0 +1,86 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_DATASET_DETAIL_DIALOG_HPP
+#define ORES_QT_DATASET_DETAIL_DIALOG_HPP
+
+#include <QWidget>
+#include <boost/uuid/uuid.hpp>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.dq/domain/dataset.hpp"
+
+namespace Ui {
+class DatasetDetailDialog;
+}
+
+namespace ores::qt {
+
+class DatasetDetailDialog final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.dataset_detail_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit DatasetDetailDialog(QWidget* parent = nullptr);
+    ~DatasetDetailDialog() override;
+
+    void setClientManager(ClientManager* cm) { clientManager_ = cm; }
+    void setUsername(const std::string& username) { username_ = username; }
+    void setCreateMode(bool create);
+    void setDataset(const dq::domain::dataset& dataset);
+    void setReadOnly(bool readOnly);
+    void loadLookupData();
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& error);
+    void datasetSaved(const boost::uuids::uuid& id);
+    void datasetDeleted(const boost::uuids::uuid& id);
+
+private slots:
+    void onSaveClicked();
+    void onDeleteClicked();
+
+private:
+    void setupConnections();
+    void updateUiState();
+
+    Ui::DatasetDetailDialog* ui_;
+    ClientManager* clientManager_;
+    std::string username_;
+    dq::domain::dataset dataset_;
+    bool isCreateMode_;
+    bool isReadOnly_;
+
+    // Store methodology UUID to name mapping
+    std::vector<std::pair<boost::uuids::uuid, std::string>> methodologies_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/DatasetHistoryDialog.hpp
+++ b/projects/ores.qt/include/ores.qt/DatasetHistoryDialog.hpp
@@ -1,0 +1,91 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_DATASET_HISTORY_DIALOG_HPP
+#define ORES_QT_DATASET_HISTORY_DIALOG_HPP
+
+#include <QWidget>
+#include <QToolBar>
+#include <QTableWidget>
+#include <boost/uuid/uuid.hpp>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.dq/domain/dataset.hpp"
+
+namespace Ui {
+class DatasetHistoryDialog;
+}
+
+namespace ores::qt {
+
+class DatasetHistoryDialog final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.dataset_history_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit DatasetHistoryDialog(
+        const boost::uuids::uuid& id,
+        ClientManager* clientManager,
+        QWidget* parent = nullptr);
+    ~DatasetHistoryDialog() override;
+
+    void loadHistory();
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void openVersionRequested(const dq::domain::dataset& dataset, int versionNumber);
+    void revertVersionRequested(const dq::domain::dataset& dataset);
+
+private slots:
+    void onVersionSelected();
+    void onOpenVersionClicked();
+    void onRevertClicked();
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupConnections();
+    void updateVersionList();
+    void updateChangesTable(int currentVersionIndex);
+    void updateFullDetails(int versionIndex);
+    void updateActionStates();
+
+    Ui::DatasetHistoryDialog* ui_;
+    boost::uuids::uuid id_;
+    ClientManager* clientManager_;
+    std::vector<dq::domain::dataset> versions_;
+
+    QToolBar* toolbar_;
+    QAction* openVersionAction_;
+    QAction* revertAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/DatasetMdiWindow.hpp
+++ b/projects/ores.qt/include/ores.qt/DatasetMdiWindow.hpp
@@ -1,0 +1,99 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_DATASET_MDI_WINDOW_HPP
+#define ORES_QT_DATASET_MDI_WINDOW_HPP
+
+#include <QWidget>
+#include <QTableView>
+#include <QToolBar>
+#include <QSortFilterProxyModel>
+#include <boost/uuid/uuid.hpp>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ClientDatasetModel.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.dq/domain/dataset.hpp"
+
+namespace ores::qt {
+
+class DatasetMdiWindow final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.dataset_mdi_window";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit DatasetMdiWindow(ClientManager* clientManager,
+                              const QString& username,
+                              QWidget* parent = nullptr);
+    ~DatasetMdiWindow() override = default;
+
+    QSize sizeHint() const override { return QSize(1200, 600); }
+    void reload();
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void showDatasetDetails(const dq::domain::dataset& dataset);
+    void showDatasetHistory(const boost::uuids::uuid& id);
+    void addNewRequested();
+
+private slots:
+    void onDataLoaded();
+    void onLoadError(const QString& error_message);
+    void onRowDoubleClicked(const QModelIndex& index);
+    void onAddClicked();
+    void onEditClicked();
+    void onDeleteClicked();
+    void onRefreshClicked();
+    void onSelectionChanged();
+    void onHistoryClicked();
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupConnections();
+    void updateActionStates();
+    void saveColumnVisibility();
+    void loadColumnVisibility();
+
+    ClientManager* clientManager_;
+    QString username_;
+    ClientDatasetModel* model_;
+    QSortFilterProxyModel* proxyModel_;
+    QTableView* tableView_;
+    QToolBar* toolbar_;
+
+    QAction* addAction_;
+    QAction* editAction_;
+    QAction* deleteAction_;
+    QAction* refreshAction_;
+    QAction* historyAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/MainWindow.hpp
+++ b/projects/ores.qt/include/ores.qt/MainWindow.hpp
@@ -64,6 +64,9 @@ class CodingSchemeAuthorityTypeController;
 class DataDomainController;
 class SubjectAreaController;
 class CatalogController;
+class CodingSchemeController;
+class MethodologyController;
+class DatasetController;
 class ImageCache;
 class ChangeReasonCache;
 
@@ -418,6 +421,30 @@ private:
      * and history windows.
      */
     std::unique_ptr<CatalogController> catalogController_;
+
+    /**
+     * @brief Controller managing coding scheme windows.
+     *
+     * Created after successful login, handles coding scheme list, detail,
+     * and history windows.
+     */
+    std::unique_ptr<CodingSchemeController> codingSchemeController_;
+
+    /**
+     * @brief Controller managing methodology windows.
+     *
+     * Created after successful login, handles methodology list, detail,
+     * and history windows.
+     */
+    std::unique_ptr<MethodologyController> methodologyController_;
+
+    /**
+     * @brief Controller managing dataset windows.
+     *
+     * Created after successful login, handles dataset list, detail,
+     * and history windows.
+     */
+    std::unique_ptr<DatasetController> datasetController_;
 
     /** @brief Event bus for decoupled event handling */
     std::shared_ptr<eventing::service::event_bus> eventBus_;

--- a/projects/ores.qt/include/ores.qt/MethodologyController.hpp
+++ b/projects/ores.qt/include/ores.qt/MethodologyController.hpp
@@ -1,0 +1,85 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_METHODOLOGY_CONTROLLER_HPP
+#define ORES_QT_METHODOLOGY_CONTROLLER_HPP
+
+#include <QMdiArea>
+#include <QMainWindow>
+#include <boost/uuid/uuid.hpp>
+#include "ores.qt/EntityController.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.dq/domain/methodology.hpp"
+
+namespace ores::qt {
+
+class MethodologyMdiWindow;
+class DetachableMdiSubWindow;
+
+class MethodologyController final : public EntityController {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.methodology_controller";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    MethodologyController(
+        QMainWindow* mainWindow,
+        QMdiArea* mdiArea,
+        ClientManager* clientManager,
+        const QString& username,
+        QList<DetachableMdiSubWindow*>& allDetachableWindows,
+        QObject* parent = nullptr);
+    ~MethodologyController() override;
+
+    void showListWindow() override;
+    void closeAllWindows() override;
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& error);
+
+private slots:
+    void onShowDetails(const dq::domain::methodology& methodology);
+    void onAddNewRequested();
+    void onShowHistory(const boost::uuids::uuid& id);
+    void onRevertVersion(const dq::domain::methodology& methodology);
+    void onOpenVersion(const dq::domain::methodology& methodology, int versionNumber);
+
+private:
+    void showAddWindow();
+    void showDetailWindow(const dq::domain::methodology& methodology);
+    void showHistoryWindow(const boost::uuids::uuid& id);
+
+    MethodologyMdiWindow* listWindow_;
+    DetachableMdiSubWindow* listMdiSubWindow_;
+    QList<DetachableMdiSubWindow*>& allDetachableWindows_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/MethodologyDetailDialog.hpp
+++ b/projects/ores.qt/include/ores.qt/MethodologyDetailDialog.hpp
@@ -1,0 +1,82 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_METHODOLOGY_DETAIL_DIALOG_HPP
+#define ORES_QT_METHODOLOGY_DETAIL_DIALOG_HPP
+
+#include <QWidget>
+#include <boost/uuid/uuid.hpp>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.dq/domain/methodology.hpp"
+
+namespace Ui {
+class MethodologyDetailDialog;
+}
+
+namespace ores::qt {
+
+class MethodologyDetailDialog final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.methodology_detail_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit MethodologyDetailDialog(QWidget* parent = nullptr);
+    ~MethodologyDetailDialog() override;
+
+    void setClientManager(ClientManager* cm) { clientManager_ = cm; }
+    void setUsername(const std::string& username) { username_ = username; }
+    void setCreateMode(bool create);
+    void setMethodology(const dq::domain::methodology& methodology);
+    void setReadOnly(bool readOnly);
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& error);
+    void methodologySaved(const boost::uuids::uuid& id);
+    void methodologyDeleted(const boost::uuids::uuid& id);
+
+private slots:
+    void onSaveClicked();
+    void onDeleteClicked();
+
+private:
+    void setupConnections();
+    void updateUiState();
+
+    Ui::MethodologyDetailDialog* ui_;
+    ClientManager* clientManager_;
+    std::string username_;
+    dq::domain::methodology methodology_;
+    bool isCreateMode_;
+    bool isReadOnly_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/MethodologyHistoryDialog.hpp
+++ b/projects/ores.qt/include/ores.qt/MethodologyHistoryDialog.hpp
@@ -1,0 +1,91 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_METHODOLOGY_HISTORY_DIALOG_HPP
+#define ORES_QT_METHODOLOGY_HISTORY_DIALOG_HPP
+
+#include <QWidget>
+#include <QToolBar>
+#include <QTableWidget>
+#include <boost/uuid/uuid.hpp>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.dq/domain/methodology.hpp"
+
+namespace Ui {
+class MethodologyHistoryDialog;
+}
+
+namespace ores::qt {
+
+class MethodologyHistoryDialog final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.methodology_history_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit MethodologyHistoryDialog(
+        const boost::uuids::uuid& id,
+        ClientManager* clientManager,
+        QWidget* parent = nullptr);
+    ~MethodologyHistoryDialog() override;
+
+    void loadHistory();
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void openVersionRequested(const dq::domain::methodology& methodology, int versionNumber);
+    void revertVersionRequested(const dq::domain::methodology& methodology);
+
+private slots:
+    void onVersionSelected();
+    void onOpenVersionClicked();
+    void onRevertClicked();
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupConnections();
+    void updateVersionList();
+    void updateChangesTable(int currentVersionIndex);
+    void updateFullDetails(int versionIndex);
+    void updateActionStates();
+
+    Ui::MethodologyHistoryDialog* ui_;
+    boost::uuids::uuid id_;
+    ClientManager* clientManager_;
+    std::vector<dq::domain::methodology> versions_;
+
+    QToolBar* toolbar_;
+    QAction* openVersionAction_;
+    QAction* revertAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/include/ores.qt/MethodologyMdiWindow.hpp
+++ b/projects/ores.qt/include/ores.qt/MethodologyMdiWindow.hpp
@@ -1,0 +1,99 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_METHODOLOGY_MDI_WINDOW_HPP
+#define ORES_QT_METHODOLOGY_MDI_WINDOW_HPP
+
+#include <QWidget>
+#include <QTableView>
+#include <QToolBar>
+#include <QSortFilterProxyModel>
+#include <boost/uuid/uuid.hpp>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ClientMethodologyModel.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.dq/domain/methodology.hpp"
+
+namespace ores::qt {
+
+class MethodologyMdiWindow final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.methodology_mdi_window";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit MethodologyMdiWindow(ClientManager* clientManager,
+                                  const QString& username,
+                                  QWidget* parent = nullptr);
+    ~MethodologyMdiWindow() override = default;
+
+    QSize sizeHint() const override { return QSize(900, 600); }
+    void reload();
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void showMethodologyDetails(const dq::domain::methodology& methodology);
+    void showMethodologyHistory(const boost::uuids::uuid& id);
+    void addNewRequested();
+
+private slots:
+    void onDataLoaded();
+    void onLoadError(const QString& error_message);
+    void onRowDoubleClicked(const QModelIndex& index);
+    void onAddClicked();
+    void onEditClicked();
+    void onDeleteClicked();
+    void onRefreshClicked();
+    void onSelectionChanged();
+    void onHistoryClicked();
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupConnections();
+    void updateActionStates();
+    void saveColumnVisibility();
+    void loadColumnVisibility();
+
+    ClientManager* clientManager_;
+    QString username_;
+    ClientMethodologyModel* model_;
+    QSortFilterProxyModel* proxyModel_;
+    QTableView* tableView_;
+    QToolBar* toolbar_;
+
+    QAction* addAction_;
+    QAction* editAction_;
+    QAction* deleteAction_;
+    QAction* refreshAction_;
+    QAction* historyAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt/src/ClientCodingSchemeModel.cpp
+++ b/projects/ores.qt/src/ClientCodingSchemeModel.cpp
@@ -1,0 +1,212 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/ClientCodingSchemeModel.hpp"
+
+#include <QtConcurrent>
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.dq/messaging/coding_scheme_protocol.hpp"
+#include "ores.comms/messaging/frame.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+ClientCodingSchemeModel::ClientCodingSchemeModel(
+    ClientManager* clientManager, QObject* parent)
+    : QAbstractTableModel(parent),
+      clientManager_(clientManager),
+      watcher_(new QFutureWatcher<FetchResult>(this)),
+      pulse_timer_(new QTimer(this)) {
+
+    connect(watcher_, &QFutureWatcher<FetchResult>::finished,
+            this, &ClientCodingSchemeModel::onSchemesLoaded);
+
+    pulse_timer_->setInterval(pulse_interval_ms_);
+    connect(pulse_timer_, &QTimer::timeout,
+            this, &ClientCodingSchemeModel::onPulseTimerTimeout);
+}
+
+int ClientCodingSchemeModel::rowCount(const QModelIndex& parent) const {
+    if (parent.isValid()) return 0;
+    return static_cast<int>(schemes_.size());
+}
+
+int ClientCodingSchemeModel::columnCount(const QModelIndex& parent) const {
+    if (parent.isValid()) return 0;
+    return ColumnCount;
+}
+
+QVariant ClientCodingSchemeModel::data(const QModelIndex& index, int role) const {
+    if (!index.isValid() || index.row() >= static_cast<int>(schemes_.size()))
+        return {};
+
+    const auto& scheme = schemes_[index.row()];
+
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case Code: return QString::fromStdString(scheme.code);
+        case Name: return QString::fromStdString(scheme.name);
+        case AuthorityType: return QString::fromStdString(scheme.authority_type);
+        case SubjectArea: return QString::fromStdString(scheme.subject_area_name);
+        case Domain: return QString::fromStdString(scheme.domain_name);
+        case Description: return QString::fromStdString(scheme.description);
+        case Version: return scheme.version;
+        case RecordedBy: return QString::fromStdString(scheme.recorded_by);
+        case RecordedAt: return relative_time_helper::format(scheme.recorded_at);
+        default: return {};
+        }
+    }
+
+    if (role == Qt::ForegroundRole) {
+        return recency_foreground_color(scheme.code);
+    }
+
+    return {};
+}
+
+QVariant ClientCodingSchemeModel::headerData(int section,
+    Qt::Orientation orientation, int role) const {
+    if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
+        return {};
+
+    switch (section) {
+    case Code: return tr("Code");
+    case Name: return tr("Name");
+    case AuthorityType: return tr("Authority Type");
+    case SubjectArea: return tr("Subject Area");
+    case Domain: return tr("Domain");
+    case Description: return tr("Description");
+    case Version: return tr("Version");
+    case RecordedBy: return tr("Recorded By");
+    case RecordedAt: return tr("Recorded At");
+    default: return {};
+    }
+}
+
+void ClientCodingSchemeModel::refresh() {
+    if (!clientManager_ || !clientManager_->isConnected() || is_fetching_)
+        return;
+
+    is_fetching_ = true;
+    BOOST_LOG_SEV(lg(), debug) << "Fetching coding schemes...";
+
+    auto task = [cm = clientManager_]() -> FetchResult {
+        dq::messaging::get_coding_schemes_request request;
+        auto payload = request.serialize();
+
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_coding_schemes_request,
+            0, std::move(payload));
+
+        auto response_result = cm->sendRequest(std::move(request_frame));
+        if (!response_result) {
+            return {false, {}};
+        }
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) {
+            return {false, {}};
+        }
+
+        auto response = dq::messaging::get_coding_schemes_response::deserialize(
+            *payload_result);
+        if (!response) {
+            return {false, {}};
+        }
+
+        return {true, std::move(response->schemes)};
+    };
+
+    watcher_->setFuture(QtConcurrent::run(task));
+}
+
+void ClientCodingSchemeModel::onSchemesLoaded() {
+    is_fetching_ = false;
+    auto result = watcher_->result();
+
+    if (result.success) {
+        beginResetModel();
+        auto old_schemes = std::move(schemes_);
+        schemes_ = std::move(result.schemes);
+        update_recent_schemes();
+        endResetModel();
+
+        BOOST_LOG_SEV(lg(), debug) << "Loaded " << schemes_.size()
+                                   << " coding schemes";
+        emit dataLoaded();
+    } else {
+        BOOST_LOG_SEV(lg(), error) << "Failed to load coding schemes";
+        emit loadError(tr("Failed to load coding schemes"));
+    }
+}
+
+const dq::domain::coding_scheme* ClientCodingSchemeModel::getScheme(
+    int row) const {
+    if (row < 0 || row >= static_cast<int>(schemes_.size()))
+        return nullptr;
+    return &schemes_[row];
+}
+
+void ClientCodingSchemeModel::update_recent_schemes() {
+    recent_scheme_codes_.clear();
+    QDateTime now = QDateTime::currentDateTime();
+    last_reload_time_ = now;
+
+    for (const auto& scheme : schemes_) {
+        auto recorded = QDateTime::fromSecsSinceEpoch(
+            std::chrono::duration_cast<std::chrono::seconds>(
+                scheme.recorded_at.time_since_epoch()).count());
+
+        if (recorded.secsTo(now) <= 60) {
+            recent_scheme_codes_.insert(scheme.code);
+        }
+    }
+
+    if (!recent_scheme_codes_.empty()) {
+        pulse_count_ = 0;
+        pulse_state_ = true;
+        pulse_timer_->start();
+    }
+}
+
+void ClientCodingSchemeModel::onPulseTimerTimeout() {
+    pulse_state_ = !pulse_state_;
+    pulse_count_++;
+
+    if (pulse_count_ >= max_pulse_cycles_) {
+        pulse_timer_->stop();
+        recent_scheme_codes_.clear();
+    }
+
+    emit dataChanged(index(0, 0),
+                     index(rowCount() - 1, columnCount() - 1),
+                     {Qt::ForegroundRole});
+}
+
+QVariant ClientCodingSchemeModel::recency_foreground_color(
+    const std::string& code) const {
+    if (recent_scheme_codes_.contains(code) && pulse_state_) {
+        return QColor(100, 200, 100);
+    }
+    return {};
+}
+
+}

--- a/projects/ores.qt/src/ClientDatasetModel.cpp
+++ b/projects/ores.qt/src/ClientDatasetModel.cpp
@@ -1,0 +1,222 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/ClientDatasetModel.hpp"
+
+#include <QtConcurrent>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.dq/messaging/dataset_protocol.hpp"
+#include "ores.comms/messaging/frame.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+ClientDatasetModel::ClientDatasetModel(
+    ClientManager* clientManager, QObject* parent)
+    : QAbstractTableModel(parent),
+      clientManager_(clientManager),
+      watcher_(new QFutureWatcher<FetchResult>(this)),
+      pulse_timer_(new QTimer(this)) {
+
+    connect(watcher_, &QFutureWatcher<FetchResult>::finished,
+            this, &ClientDatasetModel::onDatasetsLoaded);
+
+    pulse_timer_->setInterval(pulse_interval_ms_);
+    connect(pulse_timer_, &QTimer::timeout,
+            this, &ClientDatasetModel::onPulseTimerTimeout);
+}
+
+int ClientDatasetModel::rowCount(const QModelIndex& parent) const {
+    if (parent.isValid()) return 0;
+    return static_cast<int>(datasets_.size());
+}
+
+int ClientDatasetModel::columnCount(const QModelIndex& parent) const {
+    if (parent.isValid()) return 0;
+    return ColumnCount;
+}
+
+QVariant ClientDatasetModel::data(const QModelIndex& index, int role) const {
+    if (!index.isValid() || index.row() >= static_cast<int>(datasets_.size()))
+        return {};
+
+    const auto& dataset = datasets_[index.row()];
+
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case Name: return QString::fromStdString(dataset.name);
+        case Catalog:
+            return dataset.catalog_name
+                ? QString::fromStdString(*dataset.catalog_name)
+                : QString();
+        case SubjectArea: return QString::fromStdString(dataset.subject_area_name);
+        case Domain: return QString::fromStdString(dataset.domain_name);
+        case Origin: return QString::fromStdString(dataset.origin_code);
+        case Nature: return QString::fromStdString(dataset.nature_code);
+        case Treatment: return QString::fromStdString(dataset.treatment_code);
+        case SourceSystem: return QString::fromStdString(dataset.source_system_id);
+        case AsOfDate: return relative_time_helper::format(dataset.as_of_date);
+        case Version: return dataset.version;
+        case RecordedBy: return QString::fromStdString(dataset.recorded_by);
+        case RecordedAt: return relative_time_helper::format(dataset.recorded_at);
+        default: return {};
+        }
+    }
+
+    if (role == Qt::ForegroundRole) {
+        return recency_foreground_color(dataset.id);
+    }
+
+    return {};
+}
+
+QVariant ClientDatasetModel::headerData(int section,
+    Qt::Orientation orientation, int role) const {
+    if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
+        return {};
+
+    switch (section) {
+    case Name: return tr("Name");
+    case Catalog: return tr("Catalog");
+    case SubjectArea: return tr("Subject Area");
+    case Domain: return tr("Domain");
+    case Origin: return tr("Origin");
+    case Nature: return tr("Nature");
+    case Treatment: return tr("Treatment");
+    case SourceSystem: return tr("Source System");
+    case AsOfDate: return tr("As Of Date");
+    case Version: return tr("Version");
+    case RecordedBy: return tr("Recorded By");
+    case RecordedAt: return tr("Recorded At");
+    default: return {};
+    }
+}
+
+void ClientDatasetModel::refresh() {
+    if (!clientManager_ || !clientManager_->isConnected() || is_fetching_)
+        return;
+
+    is_fetching_ = true;
+    BOOST_LOG_SEV(lg(), debug) << "Fetching datasets...";
+
+    auto task = [cm = clientManager_]() -> FetchResult {
+        dq::messaging::get_datasets_request request;
+        auto payload = request.serialize();
+
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_datasets_request,
+            0, std::move(payload));
+
+        auto response_result = cm->sendRequest(std::move(request_frame));
+        if (!response_result) {
+            return {false, {}};
+        }
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) {
+            return {false, {}};
+        }
+
+        auto response = dq::messaging::get_datasets_response::deserialize(
+            *payload_result);
+        if (!response) {
+            return {false, {}};
+        }
+
+        return {true, std::move(response->datasets)};
+    };
+
+    watcher_->setFuture(QtConcurrent::run(task));
+}
+
+void ClientDatasetModel::onDatasetsLoaded() {
+    is_fetching_ = false;
+    auto result = watcher_->result();
+
+    if (result.success) {
+        beginResetModel();
+        auto old_datasets = std::move(datasets_);
+        datasets_ = std::move(result.datasets);
+        update_recent_datasets();
+        endResetModel();
+
+        BOOST_LOG_SEV(lg(), debug) << "Loaded " << datasets_.size()
+                                   << " datasets";
+        emit dataLoaded();
+    } else {
+        BOOST_LOG_SEV(lg(), error) << "Failed to load datasets";
+        emit loadError(tr("Failed to load datasets"));
+    }
+}
+
+const dq::domain::dataset* ClientDatasetModel::getDataset(
+    int row) const {
+    if (row < 0 || row >= static_cast<int>(datasets_.size()))
+        return nullptr;
+    return &datasets_[row];
+}
+
+void ClientDatasetModel::update_recent_datasets() {
+    recent_dataset_ids_.clear();
+    QDateTime now = QDateTime::currentDateTime();
+    last_reload_time_ = now;
+
+    for (const auto& dataset : datasets_) {
+        auto recorded = QDateTime::fromSecsSinceEpoch(
+            std::chrono::duration_cast<std::chrono::seconds>(
+                dataset.recorded_at.time_since_epoch()).count());
+
+        if (recorded.secsTo(now) <= 60) {
+            recent_dataset_ids_.insert(boost::uuids::to_string(dataset.id));
+        }
+    }
+
+    if (!recent_dataset_ids_.empty()) {
+        pulse_count_ = 0;
+        pulse_state_ = true;
+        pulse_timer_->start();
+    }
+}
+
+void ClientDatasetModel::onPulseTimerTimeout() {
+    pulse_state_ = !pulse_state_;
+    pulse_count_++;
+
+    if (pulse_count_ >= max_pulse_cycles_) {
+        pulse_timer_->stop();
+        recent_dataset_ids_.clear();
+    }
+
+    emit dataChanged(index(0, 0),
+                     index(rowCount() - 1, columnCount() - 1),
+                     {Qt::ForegroundRole});
+}
+
+QVariant ClientDatasetModel::recency_foreground_color(
+    const boost::uuids::uuid& id) const {
+    if (recent_dataset_ids_.contains(boost::uuids::to_string(id)) && pulse_state_) {
+        return QColor(100, 200, 100);
+    }
+    return {};
+}
+
+}

--- a/projects/ores.qt/src/ClientMethodologyModel.cpp
+++ b/projects/ores.qt/src/ClientMethodologyModel.cpp
@@ -1,0 +1,210 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/ClientMethodologyModel.hpp"
+
+#include <QtConcurrent>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.dq/messaging/dataset_protocol.hpp"
+#include "ores.comms/messaging/frame.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+ClientMethodologyModel::ClientMethodologyModel(
+    ClientManager* clientManager, QObject* parent)
+    : QAbstractTableModel(parent),
+      clientManager_(clientManager),
+      watcher_(new QFutureWatcher<FetchResult>(this)),
+      pulse_timer_(new QTimer(this)) {
+
+    connect(watcher_, &QFutureWatcher<FetchResult>::finished,
+            this, &ClientMethodologyModel::onMethodologiesLoaded);
+
+    pulse_timer_->setInterval(pulse_interval_ms_);
+    connect(pulse_timer_, &QTimer::timeout,
+            this, &ClientMethodologyModel::onPulseTimerTimeout);
+}
+
+int ClientMethodologyModel::rowCount(const QModelIndex& parent) const {
+    if (parent.isValid()) return 0;
+    return static_cast<int>(methodologies_.size());
+}
+
+int ClientMethodologyModel::columnCount(const QModelIndex& parent) const {
+    if (parent.isValid()) return 0;
+    return ColumnCount;
+}
+
+QVariant ClientMethodologyModel::data(const QModelIndex& index, int role) const {
+    if (!index.isValid() || index.row() >= static_cast<int>(methodologies_.size()))
+        return {};
+
+    const auto& methodology = methodologies_[index.row()];
+
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case Name: return QString::fromStdString(methodology.name);
+        case Description: return QString::fromStdString(methodology.description);
+        case LogicReference:
+            return methodology.logic_reference
+                ? QString::fromStdString(*methodology.logic_reference)
+                : QString();
+        case Version: return methodology.version;
+        case RecordedBy: return QString::fromStdString(methodology.recorded_by);
+        case RecordedAt: return relative_time_helper::format(methodology.recorded_at);
+        default: return {};
+        }
+    }
+
+    if (role == Qt::ForegroundRole) {
+        return recency_foreground_color(methodology.id);
+    }
+
+    return {};
+}
+
+QVariant ClientMethodologyModel::headerData(int section,
+    Qt::Orientation orientation, int role) const {
+    if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
+        return {};
+
+    switch (section) {
+    case Name: return tr("Name");
+    case Description: return tr("Description");
+    case LogicReference: return tr("Logic Reference");
+    case Version: return tr("Version");
+    case RecordedBy: return tr("Recorded By");
+    case RecordedAt: return tr("Recorded At");
+    default: return {};
+    }
+}
+
+void ClientMethodologyModel::refresh() {
+    if (!clientManager_ || !clientManager_->isConnected() || is_fetching_)
+        return;
+
+    is_fetching_ = true;
+    BOOST_LOG_SEV(lg(), debug) << "Fetching methodologies...";
+
+    auto task = [cm = clientManager_]() -> FetchResult {
+        dq::messaging::get_methodologies_request request;
+        auto payload = request.serialize();
+
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_methodologies_request,
+            0, std::move(payload));
+
+        auto response_result = cm->sendRequest(std::move(request_frame));
+        if (!response_result) {
+            return {false, {}};
+        }
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) {
+            return {false, {}};
+        }
+
+        auto response = dq::messaging::get_methodologies_response::deserialize(
+            *payload_result);
+        if (!response) {
+            return {false, {}};
+        }
+
+        return {true, std::move(response->methodologies)};
+    };
+
+    watcher_->setFuture(QtConcurrent::run(task));
+}
+
+void ClientMethodologyModel::onMethodologiesLoaded() {
+    is_fetching_ = false;
+    auto result = watcher_->result();
+
+    if (result.success) {
+        beginResetModel();
+        auto old_methodologies = std::move(methodologies_);
+        methodologies_ = std::move(result.methodologies);
+        update_recent_methodologies();
+        endResetModel();
+
+        BOOST_LOG_SEV(lg(), debug) << "Loaded " << methodologies_.size()
+                                   << " methodologies";
+        emit dataLoaded();
+    } else {
+        BOOST_LOG_SEV(lg(), error) << "Failed to load methodologies";
+        emit loadError(tr("Failed to load methodologies"));
+    }
+}
+
+const dq::domain::methodology* ClientMethodologyModel::getMethodology(
+    int row) const {
+    if (row < 0 || row >= static_cast<int>(methodologies_.size()))
+        return nullptr;
+    return &methodologies_[row];
+}
+
+void ClientMethodologyModel::update_recent_methodologies() {
+    recent_methodology_ids_.clear();
+    QDateTime now = QDateTime::currentDateTime();
+    last_reload_time_ = now;
+
+    for (const auto& methodology : methodologies_) {
+        auto recorded = QDateTime::fromSecsSinceEpoch(
+            std::chrono::duration_cast<std::chrono::seconds>(
+                methodology.recorded_at.time_since_epoch()).count());
+
+        if (recorded.secsTo(now) <= 60) {
+            recent_methodology_ids_.insert(boost::uuids::to_string(methodology.id));
+        }
+    }
+
+    if (!recent_methodology_ids_.empty()) {
+        pulse_count_ = 0;
+        pulse_state_ = true;
+        pulse_timer_->start();
+    }
+}
+
+void ClientMethodologyModel::onPulseTimerTimeout() {
+    pulse_state_ = !pulse_state_;
+    pulse_count_++;
+
+    if (pulse_count_ >= max_pulse_cycles_) {
+        pulse_timer_->stop();
+        recent_methodology_ids_.clear();
+    }
+
+    emit dataChanged(index(0, 0),
+                     index(rowCount() - 1, columnCount() - 1),
+                     {Qt::ForegroundRole});
+}
+
+QVariant ClientMethodologyModel::recency_foreground_color(
+    const boost::uuids::uuid& id) const {
+    if (recent_methodology_ids_.contains(boost::uuids::to_string(id)) && pulse_state_) {
+        return QColor(100, 200, 100);
+    }
+    return {};
+}
+
+}

--- a/projects/ores.qt/src/CodingSchemeController.cpp
+++ b/projects/ores.qt/src/CodingSchemeController.cpp
@@ -1,0 +1,447 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/CodingSchemeController.hpp"
+
+#include <QMdiSubWindow>
+#include <QMessageBox>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/CodingSchemeMdiWindow.hpp"
+#include "ores.qt/CodingSchemeDetailDialog.hpp"
+#include "ores.qt/CodingSchemeHistoryDialog.hpp"
+#include "ores.qt/DetachableMdiSubWindow.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+CodingSchemeController::CodingSchemeController(
+    QMainWindow* mainWindow,
+    QMdiArea* mdiArea,
+    ClientManager* clientManager,
+    const QString& username,
+    QList<DetachableMdiSubWindow*>& allDetachableWindows,
+    QObject* parent)
+    : EntityController(mainWindow, mdiArea, clientManager, username, parent),
+      listWindow_(nullptr),
+      listMdiSubWindow_(nullptr),
+      allDetachableWindows_(allDetachableWindows) {
+
+    BOOST_LOG_SEV(lg(), debug) << "CodingSchemeController created";
+}
+
+CodingSchemeController::~CodingSchemeController() {
+    BOOST_LOG_SEV(lg(), debug) << "CodingSchemeController destroyed";
+}
+
+void CodingSchemeController::showListWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "showListWindow called";
+
+    const QString key = build_window_key("list", "coding_schemes");
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing list window";
+        return;
+    }
+
+    listWindow_ = new CodingSchemeMdiWindow(clientManager_, username_);
+
+    connect(listWindow_, &CodingSchemeMdiWindow::statusChanged,
+            this, &CodingSchemeController::statusMessage);
+    connect(listWindow_, &CodingSchemeMdiWindow::errorOccurred,
+            this, &CodingSchemeController::errorMessage);
+    connect(listWindow_, &CodingSchemeMdiWindow::showSchemeDetails,
+            this, &CodingSchemeController::onShowDetails);
+    connect(listWindow_, &CodingSchemeMdiWindow::addNewRequested,
+            this, &CodingSchemeController::onAddNewRequested);
+    connect(listWindow_, &CodingSchemeMdiWindow::showSchemeHistory,
+            this, &CodingSchemeController::onShowHistory);
+
+    const QColor iconColor(220, 220, 220);
+    listMdiSubWindow_ = new DetachableMdiSubWindow(mainWindow_);
+    listMdiSubWindow_->setWidget(listWindow_);
+    listMdiSubWindow_->setWindowTitle("Coding Schemes");
+    listMdiSubWindow_->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_code_20_regular.svg", iconColor));
+    listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
+    listMdiSubWindow_->resize(listWindow_->sizeHint());
+
+    mdiArea_->addSubWindow(listMdiSubWindow_);
+    listMdiSubWindow_->show();
+
+    track_window(key, listMdiSubWindow_);
+    allDetachableWindows_.append(listMdiSubWindow_);
+
+    connect(listMdiSubWindow_, &QObject::destroyed, this, [this, key]() {
+        untrack_window(key);
+        allDetachableWindows_.removeOne(listMdiSubWindow_);
+        listWindow_ = nullptr;
+        listMdiSubWindow_ = nullptr;
+    });
+
+    BOOST_LOG_SEV(lg(), debug) << "Coding scheme list window created";
+}
+
+void CodingSchemeController::closeAllWindows() {
+    BOOST_LOG_SEV(lg(), debug) << "closeAllWindows called";
+
+    QList<QString> keys = managed_windows_.keys();
+    for (const QString& key : keys) {
+        if (auto* window = managed_windows_.value(key)) {
+            window->close();
+        }
+    }
+    managed_windows_.clear();
+
+    listWindow_ = nullptr;
+    listMdiSubWindow_ = nullptr;
+}
+
+void CodingSchemeController::onShowDetails(const dq::domain::coding_scheme& scheme) {
+    BOOST_LOG_SEV(lg(), debug) << "Show details for: " << scheme.code;
+    showDetailWindow(scheme);
+}
+
+void CodingSchemeController::onAddNewRequested() {
+    BOOST_LOG_SEV(lg(), info) << "Add new coding scheme requested";
+    showAddWindow();
+}
+
+void CodingSchemeController::onShowHistory(const QString& code) {
+    BOOST_LOG_SEV(lg(), debug) << "Show history requested for: " << code.toStdString();
+    showHistoryWindow(code);
+}
+
+void CodingSchemeController::showAddWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "Creating add window for new coding scheme";
+
+    const QColor iconColor(220, 220, 220);
+
+    auto* detailDialog = new CodingSchemeDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(true);
+    detailDialog->loadLookupData();
+
+    connect(detailDialog, &CodingSchemeDetailDialog::statusMessage,
+            this, &CodingSchemeController::statusMessage);
+    connect(detailDialog, &CodingSchemeDetailDialog::errorMessage,
+            this, &CodingSchemeController::errorMessage);
+    connect(detailDialog, &CodingSchemeDetailDialog::schemeSaved,
+            this, [this](const QString& code) {
+        BOOST_LOG_SEV(lg(), info) << "Coding scheme saved: " << code.toStdString();
+        if (listWindow_) {
+            listWindow_->reload();
+        }
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle("New Coding Scheme");
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_code_20_regular.svg", iconColor));
+
+    allDetachableWindows_.append(detailWindow);
+    QPointer<CodingSchemeController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, detailWindow]() {
+        if (self)
+            self->allDetachableWindows_.removeAll(detailWindow);
+    });
+
+    mdiArea_->addSubWindow(detailWindow);
+    detailWindow->setWindowFlags(detailWindow->windowFlags()
+        & ~Qt::WindowMaximizeButtonHint);
+    detailWindow->adjustSize();
+
+    if (listMdiSubWindow_ && listMdiSubWindow_->isDetached()) {
+        detailWindow->show();
+        detailWindow->detach();
+        QPoint parentPos = listMdiSubWindow_->pos();
+        detailWindow->move(parentPos.x() + 30, parentPos.y() + 30);
+    } else {
+        detailWindow->show();
+    }
+}
+
+void CodingSchemeController::showDetailWindow(const dq::domain::coding_scheme& scheme) {
+    const QString identifier = QString::fromStdString(scheme.code);
+    const QString key = build_window_key("details", identifier);
+
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing detail window";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Creating detail window for: " << scheme.code;
+
+    const QColor iconColor(220, 220, 220);
+
+    auto* detailDialog = new CodingSchemeDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(false);
+    detailDialog->loadLookupData();
+    detailDialog->setScheme(scheme);
+
+    connect(detailDialog, &CodingSchemeDetailDialog::statusMessage,
+            this, &CodingSchemeController::statusMessage);
+    connect(detailDialog, &CodingSchemeDetailDialog::errorMessage,
+            this, &CodingSchemeController::errorMessage);
+    connect(detailDialog, &CodingSchemeDetailDialog::schemeSaved,
+            this, [this](const QString& code) {
+        BOOST_LOG_SEV(lg(), info) << "Coding scheme saved: " << code.toStdString();
+        if (listWindow_) {
+            listWindow_->reload();
+        }
+    });
+    connect(detailDialog, &CodingSchemeDetailDialog::schemeDeleted,
+            this, [this, key](const QString& code) {
+        BOOST_LOG_SEV(lg(), info) << "Coding scheme deleted: " << code.toStdString();
+        if (listWindow_) {
+            listWindow_->reload();
+        }
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Coding Scheme: %1").arg(identifier));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_code_20_regular.svg", iconColor));
+
+    track_window(key, detailWindow);
+    allDetachableWindows_.append(detailWindow);
+
+    QPointer<CodingSchemeController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, detailWindow, key]() {
+        if (self) {
+            self->untrack_window(key);
+            self->allDetachableWindows_.removeAll(detailWindow);
+        }
+    });
+
+    mdiArea_->addSubWindow(detailWindow);
+    detailWindow->setWindowFlags(detailWindow->windowFlags()
+        & ~Qt::WindowMaximizeButtonHint);
+    detailWindow->adjustSize();
+
+    if (listMdiSubWindow_ && listMdiSubWindow_->isDetached()) {
+        detailWindow->show();
+        detailWindow->detach();
+        QPoint parentPos = listMdiSubWindow_->pos();
+        detailWindow->move(parentPos.x() + 30, parentPos.y() + 30);
+    } else {
+        detailWindow->show();
+    }
+}
+
+void CodingSchemeController::showHistoryWindow(const QString& code) {
+    BOOST_LOG_SEV(lg(), info) << "Opening history window for coding scheme: "
+                              << code.toStdString();
+
+    const QString windowKey = build_window_key("history", code);
+
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing history window for: "
+                                  << code.toStdString();
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Creating new history window for: "
+                              << code.toStdString();
+    const QColor iconColor(220, 220, 220);
+
+    auto* historyDialog = new CodingSchemeHistoryDialog(code, clientManager_, mainWindow_);
+
+    connect(historyDialog, &CodingSchemeHistoryDialog::statusChanged,
+            this, [this](const QString& message) {
+        emit statusMessage(message);
+    });
+    connect(historyDialog, &CodingSchemeHistoryDialog::errorOccurred,
+            this, [this](const QString& message) {
+        emit errorMessage(message);
+    });
+    connect(historyDialog, &CodingSchemeHistoryDialog::revertVersionRequested,
+            this, &CodingSchemeController::onRevertVersion);
+    connect(historyDialog, &CodingSchemeHistoryDialog::openVersionRequested,
+            this, &CodingSchemeController::onOpenVersion);
+
+    historyDialog->loadHistory();
+
+    auto* historyWindow = new DetachableMdiSubWindow(mainWindow_);
+    historyWindow->setAttribute(Qt::WA_DeleteOnClose);
+    historyWindow->setWidget(historyDialog);
+    historyWindow->setWindowTitle(QString("Coding Scheme History: %1").arg(code));
+    historyWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_history_20_regular.svg", iconColor));
+
+    track_window(windowKey, historyWindow);
+
+    allDetachableWindows_.append(historyWindow);
+    QPointer<CodingSchemeController> self = this;
+    QPointer<DetachableMdiSubWindow> windowPtr = historyWindow;
+    connect(historyWindow, &QObject::destroyed, this,
+            [self, windowPtr, windowKey]() {
+        if (self) {
+            self->allDetachableWindows_.removeAll(windowPtr.data());
+            self->untrack_window(windowKey);
+        }
+    });
+
+    mdiArea_->addSubWindow(historyWindow);
+    historyWindow->adjustSize();
+
+    if (listMdiSubWindow_ && listMdiSubWindow_->isDetached()) {
+        historyWindow->show();
+        historyWindow->detach();
+        QPoint parentPos = listMdiSubWindow_->pos();
+        historyWindow->move(parentPos.x() + 30, parentPos.y() + 30);
+    } else {
+        historyWindow->show();
+    }
+}
+
+void CodingSchemeController::onOpenVersion(
+    const dq::domain::coding_scheme& scheme, int versionNumber) {
+    BOOST_LOG_SEV(lg(), info) << "Opening historical version " << versionNumber
+                              << " for coding scheme: " << scheme.code;
+
+    const QString code = QString::fromStdString(scheme.code);
+    const QString windowKey = build_window_key("version", QString("%1_v%2")
+        .arg(code).arg(versionNumber));
+
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing version window";
+        return;
+    }
+
+    const QColor iconColor(220, 220, 220);
+
+    auto* detailDialog = new CodingSchemeDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->loadLookupData();
+    detailDialog->setScheme(scheme);
+    detailDialog->setReadOnly(true);
+
+    connect(detailDialog, &CodingSchemeDetailDialog::statusMessage,
+            this, [this](const QString& message) {
+        emit statusMessage(message);
+    });
+    connect(detailDialog, &CodingSchemeDetailDialog::errorMessage,
+            this, [this](const QString& message) {
+        emit errorMessage(message);
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Coding Scheme: %1 (Version %2)")
+        .arg(code).arg(versionNumber));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_history_20_regular.svg", iconColor));
+
+    track_window(windowKey, detailWindow);
+    allDetachableWindows_.append(detailWindow);
+
+    QPointer<CodingSchemeController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, detailWindow, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+            self->allDetachableWindows_.removeAll(detailWindow);
+        }
+    });
+
+    mdiArea_->addSubWindow(detailWindow);
+    detailWindow->setWindowFlags(detailWindow->windowFlags()
+        & ~Qt::WindowMaximizeButtonHint);
+    detailWindow->adjustSize();
+
+    if (listMdiSubWindow_ && listMdiSubWindow_->isDetached()) {
+        detailWindow->show();
+        detailWindow->detach();
+        QPoint parentPos = listMdiSubWindow_->pos();
+        detailWindow->move(parentPos.x() + 60, parentPos.y() + 60);
+    } else {
+        detailWindow->show();
+    }
+}
+
+void CodingSchemeController::onRevertVersion(
+    const dq::domain::coding_scheme& scheme) {
+    BOOST_LOG_SEV(lg(), info) << "Reverting coding scheme to version: "
+                              << scheme.version;
+
+    auto* detailDialog = new CodingSchemeDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->loadLookupData();
+    detailDialog->setScheme(scheme);
+    detailDialog->setCreateMode(false);
+
+    connect(detailDialog, &CodingSchemeDetailDialog::statusMessage,
+            this, &CodingSchemeController::statusMessage);
+    connect(detailDialog, &CodingSchemeDetailDialog::errorMessage,
+            this, &CodingSchemeController::errorMessage);
+    connect(detailDialog, &CodingSchemeDetailDialog::schemeSaved,
+            this, [this](const QString& code) {
+        BOOST_LOG_SEV(lg(), info) << "Coding scheme reverted: " << code.toStdString();
+        emit statusMessage(QString("Coding scheme '%1' reverted successfully").arg(code));
+        if (listWindow_) {
+            listWindow_->reload();
+        }
+    });
+
+    const QColor iconColor(220, 220, 220);
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Revert Coding Scheme: %1")
+        .arg(QString::fromStdString(scheme.code)));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_arrow_rotate_counterclockwise_20_regular.svg", iconColor));
+
+    allDetachableWindows_.append(detailWindow);
+    QPointer<CodingSchemeController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, detailWindow]() {
+        if (self) {
+            self->allDetachableWindows_.removeAll(detailWindow);
+        }
+    });
+
+    mdiArea_->addSubWindow(detailWindow);
+    detailWindow->setWindowFlags(detailWindow->windowFlags()
+        & ~Qt::WindowMaximizeButtonHint);
+    detailWindow->adjustSize();
+
+    if (listMdiSubWindow_ && listMdiSubWindow_->isDetached()) {
+        detailWindow->show();
+        detailWindow->detach();
+        QPoint parentPos = listMdiSubWindow_->pos();
+        detailWindow->move(parentPos.x() + 30, parentPos.y() + 30);
+    } else {
+        detailWindow->show();
+    }
+}
+
+}

--- a/projects/ores.qt/src/CodingSchemeDetailDialog.cpp
+++ b/projects/ores.qt/src/CodingSchemeDetailDialog.cpp
@@ -1,0 +1,371 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/CodingSchemeDetailDialog.hpp"
+
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_CodingSchemeDetailDialog.h"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.dq/messaging/coding_scheme_protocol.hpp"
+#include "ores.dq/messaging/data_organization_protocol.hpp"
+#include "ores.comms/messaging/frame.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+CodingSchemeDetailDialog::CodingSchemeDetailDialog(QWidget* parent)
+    : QWidget(parent),
+      ui_(new Ui::CodingSchemeDetailDialog),
+      clientManager_(nullptr),
+      isCreateMode_(true),
+      isReadOnly_(false) {
+
+    ui_->setupUi(this);
+    setupConnections();
+}
+
+CodingSchemeDetailDialog::~CodingSchemeDetailDialog() {
+    delete ui_;
+}
+
+void CodingSchemeDetailDialog::setupConnections() {
+    connect(ui_->saveButton, &QPushButton::clicked,
+            this, &CodingSchemeDetailDialog::onSaveClicked);
+    connect(ui_->deleteButton, &QPushButton::clicked,
+            this, &CodingSchemeDetailDialog::onDeleteClicked);
+}
+
+void CodingSchemeDetailDialog::loadLookupData() {
+    if (!clientManager_ || !clientManager_->isConnected()) return;
+
+    QPointer<CodingSchemeDetailDialog> self = this;
+
+    // Load authority types
+    auto authTask = [self]() -> std::vector<std::string> {
+        if (!self || !self->clientManager_) return {};
+
+        dq::messaging::get_coding_scheme_authority_types_request request;
+        auto payload = request.serialize();
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_coding_scheme_authority_types_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {};
+
+        auto response = dq::messaging::get_coding_scheme_authority_types_response::deserialize(*payload_result);
+        if (!response) return {};
+
+        std::vector<std::string> codes;
+        for (const auto& at : response->authority_types) {
+            codes.push_back(at.code);
+        }
+        return codes;
+    };
+
+    auto* authWatcher = new QFutureWatcher<std::vector<std::string>>(this);
+    connect(authWatcher, &QFutureWatcher<std::vector<std::string>>::finished,
+            this, [self, authWatcher]() {
+        auto codes = authWatcher->result();
+        authWatcher->deleteLater();
+        if (!self) return;
+
+        self->ui_->authorityTypeCombo->clear();
+        for (const auto& code : codes) {
+            self->ui_->authorityTypeCombo->addItem(QString::fromStdString(code));
+        }
+    });
+    authWatcher->setFuture(QtConcurrent::run(authTask));
+
+    // Load subject areas
+    auto saTask = [self]() -> std::vector<std::string> {
+        if (!self || !self->clientManager_) return {};
+
+        dq::messaging::get_subject_areas_request request;
+        auto payload = request.serialize();
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_subject_areas_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {};
+
+        auto response = dq::messaging::get_subject_areas_response::deserialize(*payload_result);
+        if (!response) return {};
+
+        std::vector<std::string> names;
+        for (const auto& sa : response->subject_areas) {
+            names.push_back(sa.name);
+        }
+        return names;
+    };
+
+    auto* saWatcher = new QFutureWatcher<std::vector<std::string>>(this);
+    connect(saWatcher, &QFutureWatcher<std::vector<std::string>>::finished,
+            this, [self, saWatcher]() {
+        auto names = saWatcher->result();
+        saWatcher->deleteLater();
+        if (!self) return;
+
+        self->ui_->subjectAreaCombo->clear();
+        for (const auto& name : names) {
+            self->ui_->subjectAreaCombo->addItem(QString::fromStdString(name));
+        }
+    });
+    saWatcher->setFuture(QtConcurrent::run(saTask));
+
+    // Load data domains
+    auto ddTask = [self]() -> std::vector<std::string> {
+        if (!self || !self->clientManager_) return {};
+
+        dq::messaging::get_data_domains_request request;
+        auto payload = request.serialize();
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_data_domains_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {};
+
+        auto response = dq::messaging::get_data_domains_response::deserialize(*payload_result);
+        if (!response) return {};
+
+        std::vector<std::string> names;
+        for (const auto& dd : response->domains) {
+            names.push_back(dd.name);
+        }
+        return names;
+    };
+
+    auto* ddWatcher = new QFutureWatcher<std::vector<std::string>>(this);
+    connect(ddWatcher, &QFutureWatcher<std::vector<std::string>>::finished,
+            this, [self, ddWatcher]() {
+        auto names = ddWatcher->result();
+        ddWatcher->deleteLater();
+        if (!self) return;
+
+        self->ui_->domainCombo->clear();
+        for (const auto& name : names) {
+            self->ui_->domainCombo->addItem(QString::fromStdString(name));
+        }
+    });
+    ddWatcher->setFuture(QtConcurrent::run(ddTask));
+}
+
+void CodingSchemeDetailDialog::setCreateMode(bool create) {
+    isCreateMode_ = create;
+    updateUiState();
+}
+
+void CodingSchemeDetailDialog::setScheme(
+    const dq::domain::coding_scheme& scheme) {
+    scheme_ = scheme;
+
+    ui_->codeEdit->setText(QString::fromStdString(scheme.code));
+    ui_->nameEdit->setText(QString::fromStdString(scheme.name));
+    ui_->descriptionEdit->setPlainText(QString::fromStdString(scheme.description));
+    ui_->commentaryEdit->setPlainText(QString::fromStdString(scheme.change_commentary));
+
+    if (scheme.uri) {
+        ui_->uriEdit->setText(QString::fromStdString(*scheme.uri));
+    }
+
+    int authIdx = ui_->authorityTypeCombo->findText(QString::fromStdString(scheme.authority_type));
+    if (authIdx >= 0) ui_->authorityTypeCombo->setCurrentIndex(authIdx);
+
+    int saIdx = ui_->subjectAreaCombo->findText(QString::fromStdString(scheme.subject_area_name));
+    if (saIdx >= 0) ui_->subjectAreaCombo->setCurrentIndex(saIdx);
+
+    int ddIdx = ui_->domainCombo->findText(QString::fromStdString(scheme.domain_name));
+    if (ddIdx >= 0) ui_->domainCombo->setCurrentIndex(ddIdx);
+
+    updateUiState();
+}
+
+void CodingSchemeDetailDialog::setReadOnly(bool readOnly) {
+    isReadOnly_ = readOnly;
+    updateUiState();
+}
+
+void CodingSchemeDetailDialog::updateUiState() {
+    ui_->codeEdit->setReadOnly(!isCreateMode_ || isReadOnly_);
+    ui_->nameEdit->setReadOnly(isReadOnly_);
+    ui_->descriptionEdit->setReadOnly(isReadOnly_);
+    ui_->commentaryEdit->setReadOnly(isReadOnly_);
+    ui_->uriEdit->setReadOnly(isReadOnly_);
+    ui_->authorityTypeCombo->setEnabled(!isReadOnly_);
+    ui_->subjectAreaCombo->setEnabled(!isReadOnly_);
+    ui_->domainCombo->setEnabled(!isReadOnly_);
+
+    ui_->saveButton->setVisible(!isReadOnly_);
+    ui_->deleteButton->setVisible(!isCreateMode_ && !isReadOnly_);
+}
+
+void CodingSchemeDetailDialog::onSaveClicked() {
+    QString code = ui_->codeEdit->text().trimmed();
+    QString name = ui_->nameEdit->text().trimmed();
+    QString description = ui_->descriptionEdit->toPlainText().trimmed();
+    QString commentary = ui_->commentaryEdit->toPlainText().trimmed();
+    QString uri = ui_->uriEdit->text().trimmed();
+    QString authorityType = ui_->authorityTypeCombo->currentText();
+    QString subjectArea = ui_->subjectAreaCombo->currentText();
+    QString domain = ui_->domainCombo->currentText();
+
+    if (code.isEmpty()) {
+        MessageBoxHelper::warning(this, tr("Validation Error"),
+                                  tr("Code is required."));
+        return;
+    }
+
+    if (name.isEmpty()) {
+        MessageBoxHelper::warning(this, tr("Validation Error"),
+                                  tr("Name is required."));
+        return;
+    }
+
+    dq::domain::coding_scheme scheme;
+    scheme.code = code.toStdString();
+    scheme.name = name.toStdString();
+    scheme.description = description.toStdString();
+    scheme.change_commentary = commentary.toStdString();
+    scheme.authority_type = authorityType.toStdString();
+    scheme.subject_area_name = subjectArea.toStdString();
+    scheme.domain_name = domain.toStdString();
+    scheme.recorded_by = username_;
+    scheme.version = isCreateMode_ ? 0 : scheme_.version;
+
+    if (!uri.isEmpty()) {
+        scheme.uri = uri.toStdString();
+    }
+
+    QPointer<CodingSchemeDetailDialog> self = this;
+
+    struct SaveResult { bool success; std::string message; };
+
+    auto task = [self, scheme]() -> SaveResult {
+        if (!self || !self->clientManager_) return {false, "Dialog closed"};
+
+        dq::messaging::save_coding_scheme_request request;
+        request.scheme = scheme;
+        auto payload = request.serialize();
+
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::save_coding_scheme_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {false, "Failed to communicate with server"};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {false, "Failed to decompress response"};
+
+        auto response = dq::messaging::save_coding_scheme_response::deserialize(*payload_result);
+        if (!response) return {false, "Invalid server response"};
+
+        return {response->success, response->message};
+    };
+
+    auto* watcher = new QFutureWatcher<SaveResult>(this);
+    connect(watcher, &QFutureWatcher<SaveResult>::finished, this, [self, watcher, code]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (!self) return;
+
+        if (result.success) {
+            emit self->statusMessage(tr("Coding scheme saved successfully"));
+            emit self->schemeSaved(code);
+            if (auto* parentWidget = self->parentWidget()) {
+                parentWidget->close();
+            }
+        } else {
+            emit self->errorMessage(QString::fromStdString(result.message));
+        }
+    });
+
+    emit statusMessage(tr("Saving..."));
+    watcher->setFuture(QtConcurrent::run(task));
+}
+
+void CodingSchemeDetailDialog::onDeleteClicked() {
+    auto reply = MessageBoxHelper::question(this, tr("Confirm Delete"),
+        tr("Delete coding scheme '%1'?").arg(ui_->codeEdit->text()),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) return;
+
+    QPointer<CodingSchemeDetailDialog> self = this;
+    QString code = ui_->codeEdit->text();
+
+    auto task = [self, code]() -> bool {
+        if (!self || !self->clientManager_) return false;
+
+        dq::messaging::delete_coding_scheme_request request;
+        request.codes = {code.toStdString()};
+        auto payload = request.serialize();
+
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::delete_coding_scheme_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return false;
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return false;
+
+        auto response = dq::messaging::delete_coding_scheme_response::deserialize(*payload_result);
+        return response && !response->results.empty() && response->results[0].success;
+    };
+
+    auto* watcher = new QFutureWatcher<bool>(this);
+    connect(watcher, &QFutureWatcher<bool>::finished, this, [self, watcher, code]() {
+        bool success = watcher->result();
+        watcher->deleteLater();
+
+        if (!self) return;
+
+        if (success) {
+            emit self->statusMessage(tr("Coding scheme deleted successfully"));
+            emit self->schemeDeleted(code);
+            if (auto* parentWidget = self->parentWidget()) {
+                parentWidget->close();
+            }
+        } else {
+            emit self->errorMessage(tr("Failed to delete coding scheme"));
+        }
+    });
+
+    emit statusMessage(tr("Deleting..."));
+    watcher->setFuture(QtConcurrent::run(task));
+}
+
+}

--- a/projects/ores.qt/src/CodingSchemeHistoryDialog.cpp
+++ b/projects/ores.qt/src/CodingSchemeHistoryDialog.cpp
@@ -1,0 +1,263 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/CodingSchemeHistoryDialog.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_CodingSchemeHistoryDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.dq/messaging/coding_scheme_protocol.hpp"
+#include "ores.comms/messaging/frame.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+CodingSchemeHistoryDialog::CodingSchemeHistoryDialog(
+    const QString& code, ClientManager* clientManager, QWidget* parent)
+    : QWidget(parent),
+      ui_(new Ui::CodingSchemeHistoryDialog),
+      code_(code),
+      clientManager_(clientManager),
+      toolbar_(nullptr),
+      openVersionAction_(nullptr),
+      revertAction_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupToolbar();
+    setupConnections();
+}
+
+CodingSchemeHistoryDialog::~CodingSchemeHistoryDialog() {
+    delete ui_;
+}
+
+void CodingSchemeHistoryDialog::setupUi() {
+    ui_->titleLabel->setText(QString("History for: %1").arg(code_));
+    ui_->versionListWidget->setColumnCount(4);
+    ui_->versionListWidget->setHorizontalHeaderLabels({"Version", "Recorded At", "Recorded By", "Commentary"});
+    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
+    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+    ui_->changesTableWidget->setColumnCount(3);
+    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
+    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+}
+
+void CodingSchemeHistoryDialog::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    const auto& iconColor = color_constants::icon_color;
+
+    openVersionAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_open_20_regular.svg", iconColor), tr("Open"));
+    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
+    openVersionAction_->setEnabled(false);
+
+    revertAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_arrow_rotate_counterclockwise_20_regular.svg", iconColor),
+        tr("Revert"));
+    revertAction_->setToolTip(tr("Revert to this version"));
+    revertAction_->setEnabled(false);
+
+    if (auto* layout = qobject_cast<QVBoxLayout*>(this->layout())) {
+        layout->insertWidget(0, toolbar_);
+    }
+}
+
+void CodingSchemeHistoryDialog::setupConnections() {
+    connect(ui_->versionListWidget, &QTableWidget::itemSelectionChanged, this, &CodingSchemeHistoryDialog::onVersionSelected);
+    connect(openVersionAction_, &QAction::triggered, this, &CodingSchemeHistoryDialog::onOpenVersionClicked);
+    connect(revertAction_, &QAction::triggered, this, &CodingSchemeHistoryDialog::onRevertClicked);
+}
+
+void CodingSchemeHistoryDialog::loadHistory() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        emit errorOccurred("Not connected to server");
+        return;
+    }
+
+    emit statusChanged(tr("Loading history..."));
+
+    QPointer<CodingSchemeHistoryDialog> self = this;
+    struct HistoryResult { bool success; std::string message; std::vector<dq::domain::coding_scheme> versions; };
+
+    auto task = [self, code = code_.toStdString()]() -> HistoryResult {
+        if (!self || !self->clientManager_) return {false, "Dialog closed", {}};
+
+        dq::messaging::get_coding_scheme_history_request request;
+        request.code = code;
+        auto payload = request.serialize();
+
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_coding_scheme_history_request, 0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {false, "Failed to communicate with server", {}};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {false, "Failed to decompress response", {}};
+
+        auto response = dq::messaging::get_coding_scheme_history_response::deserialize(*payload_result);
+        if (!response) return {false, "Invalid server response", {}};
+
+        return {response->success, response->message, std::move(response->versions)};
+    };
+
+    auto* watcher = new QFutureWatcher<HistoryResult>(self);
+    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            self->versions_ = std::move(result.versions);
+            self->updateVersionList();
+            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        } else {
+            emit self->errorOccurred(QString::fromStdString(result.message));
+        }
+    });
+
+    watcher->setFuture(QtConcurrent::run(task));
+}
+
+void CodingSchemeHistoryDialog::updateVersionList() {
+    ui_->versionListWidget->setRowCount(0);
+
+    for (const auto& version : versions_) {
+        int row = ui_->versionListWidget->rowCount();
+        ui_->versionListWidget->insertRow(row);
+
+        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
+        versionItem->setTextAlignment(Qt::AlignCenter);
+        ui_->versionListWidget->setItem(row, 0, versionItem);
+        ui_->versionListWidget->setItem(row, 1, new QTableWidgetItem(relative_time_helper::format(version.recorded_at)));
+        ui_->versionListWidget->setItem(row, 2, new QTableWidgetItem(QString::fromStdString(version.recorded_by)));
+        ui_->versionListWidget->setItem(row, 3, new QTableWidgetItem(QString::fromStdString(version.change_commentary)));
+    }
+
+    if (!versions_.empty()) ui_->versionListWidget->selectRow(0);
+}
+
+void CodingSchemeHistoryDialog::onVersionSelected() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) { updateActionStates(); return; }
+
+    int row = selected.first()->row();
+    updateChangesTable(row);
+    updateFullDetails(row);
+    updateActionStates();
+}
+
+void CodingSchemeHistoryDialog::updateChangesTable(int currentVersionIndex) {
+    ui_->changesTableWidget->setRowCount(0);
+
+    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) return;
+
+    int previousVersionIndex = currentVersionIndex + 1;
+    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+        return;
+    }
+
+    const auto& current = versions_[currentVersionIndex];
+    const auto& previous = versions_[previousVersionIndex];
+
+    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
+        int row = ui_->changesTableWidget->rowCount();
+        ui_->changesTableWidget->insertRow(row);
+        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
+        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
+        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
+    };
+
+    if (current.name != previous.name) addChange("Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
+    if (current.authority_type != previous.authority_type) addChange("Authority Type", QString::fromStdString(previous.authority_type), QString::fromStdString(current.authority_type));
+    if (current.subject_area_name != previous.subject_area_name) addChange("Subject Area", QString::fromStdString(previous.subject_area_name), QString::fromStdString(current.subject_area_name));
+    if (current.domain_name != previous.domain_name) addChange("Domain", QString::fromStdString(previous.domain_name), QString::fromStdString(current.domain_name));
+    if (current.uri != previous.uri) addChange("URI", QString::fromStdString(previous.uri.value_or("")), QString::fromStdString(current.uri.value_or("")));
+    if (current.description != previous.description) addChange("Description", QString::fromStdString(previous.description), QString::fromStdString(current.description));
+
+    if (ui_->changesTableWidget->rowCount() == 0) {
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+    }
+}
+
+void CodingSchemeHistoryDialog::updateFullDetails(int versionIndex) {
+    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) return;
+
+    const auto& version = versions_[versionIndex];
+    ui_->codeValue->setText(QString::fromStdString(version.code));
+    ui_->nameValue->setText(QString::fromStdString(version.name));
+    ui_->authorityTypeValue->setText(QString::fromStdString(version.authority_type));
+    ui_->subjectAreaValue->setText(QString::fromStdString(version.subject_area_name));
+    ui_->domainValue->setText(QString::fromStdString(version.domain_name));
+    ui_->uriValue->setText(QString::fromStdString(version.uri.value_or("")));
+    ui_->descriptionValue->setText(QString::fromStdString(version.description));
+    ui_->versionNumberValue->setText(QString::number(version.version));
+    ui_->recordedByValue->setText(QString::fromStdString(version.recorded_by));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+}
+
+void CodingSchemeHistoryDialog::updateActionStates() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    bool hasSelection = !selected.isEmpty();
+    bool isNotLatest = hasSelection && selected.first()->row() > 0;
+
+    openVersionAction_->setEnabled(hasSelection);
+    revertAction_->setEnabled(isNotLatest);
+}
+
+void CodingSchemeHistoryDialog::onOpenVersionClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit openVersionRequested(versions_[row], versions_[row].version);
+}
+
+void CodingSchemeHistoryDialog::onRevertClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit revertVersionRequested(versions_[row]);
+}
+
+}

--- a/projects/ores.qt/src/CodingSchemeMdiWindow.cpp
+++ b/projects/ores.qt/src/CodingSchemeMdiWindow.cpp
@@ -1,0 +1,280 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/CodingSchemeMdiWindow.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QSettings>
+#include <QMessageBox>
+#include <QtConcurrent>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.dq/messaging/coding_scheme_protocol.hpp"
+#include "ores.comms/messaging/frame.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+CodingSchemeMdiWindow::CodingSchemeMdiWindow(
+    ClientManager* clientManager, const QString& username, QWidget* parent)
+    : QWidget(parent),
+      clientManager_(clientManager),
+      username_(username),
+      model_(new ClientCodingSchemeModel(clientManager, this)),
+      proxyModel_(new QSortFilterProxyModel(this)),
+      tableView_(new QTableView(this)),
+      toolbar_(nullptr) {
+
+    proxyModel_->setSourceModel(model_);
+    proxyModel_->setSortCaseSensitivity(Qt::CaseInsensitive);
+
+    setupUi();
+    setupToolbar();
+    setupConnections();
+    loadColumnVisibility();
+
+    model_->refresh();
+}
+
+void CodingSchemeMdiWindow::setupUi() {
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    tableView_->setModel(proxyModel_);
+    tableView_->setSortingEnabled(true);
+    tableView_->setSelectionBehavior(QAbstractItemView::SelectRows);
+    tableView_->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    tableView_->setAlternatingRowColors(true);
+    tableView_->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    tableView_->horizontalHeader()->setStretchLastSection(true);
+    tableView_->verticalHeader()->setVisible(false);
+    tableView_->sortByColumn(ClientCodingSchemeModel::Code, Qt::AscendingOrder);
+
+    layout->addWidget(tableView_);
+}
+
+void CodingSchemeMdiWindow::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    const auto& iconColor = color_constants::icon_color;
+
+    addAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_add_20_regular.svg", iconColor),
+        tr("Add"));
+    addAction_->setToolTip(tr("Add new coding scheme"));
+
+    editAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_edit_20_regular.svg", iconColor),
+        tr("Edit"));
+    editAction_->setToolTip(tr("Edit selected coding scheme"));
+    editAction_->setEnabled(false);
+
+    deleteAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_delete_20_regular.svg", iconColor),
+        tr("Delete"));
+    deleteAction_->setToolTip(tr("Delete selected coding scheme(s)"));
+    deleteAction_->setEnabled(false);
+
+    toolbar_->addSeparator();
+
+    historyAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_history_20_regular.svg", iconColor),
+        tr("History"));
+    historyAction_->setToolTip(tr("View version history"));
+    historyAction_->setEnabled(false);
+
+    toolbar_->addSeparator();
+
+    refreshAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_arrow_sync_20_regular.svg", iconColor),
+        tr("Refresh"));
+    refreshAction_->setToolTip(tr("Refresh coding schemes"));
+
+    if (auto* layout = qobject_cast<QVBoxLayout*>(this->layout())) {
+        layout->insertWidget(0, toolbar_);
+    }
+}
+
+void CodingSchemeMdiWindow::setupConnections() {
+    connect(model_, &ClientCodingSchemeModel::dataLoaded,
+            this, &CodingSchemeMdiWindow::onDataLoaded);
+    connect(model_, &ClientCodingSchemeModel::loadError,
+            this, &CodingSchemeMdiWindow::onLoadError);
+    connect(tableView_, &QTableView::doubleClicked,
+            this, &CodingSchemeMdiWindow::onRowDoubleClicked);
+    connect(tableView_->selectionModel(), &QItemSelectionModel::selectionChanged,
+            this, &CodingSchemeMdiWindow::onSelectionChanged);
+
+    connect(addAction_, &QAction::triggered, this, &CodingSchemeMdiWindow::onAddClicked);
+    connect(editAction_, &QAction::triggered, this, &CodingSchemeMdiWindow::onEditClicked);
+    connect(deleteAction_, &QAction::triggered, this, &CodingSchemeMdiWindow::onDeleteClicked);
+    connect(refreshAction_, &QAction::triggered, this, &CodingSchemeMdiWindow::onRefreshClicked);
+    connect(historyAction_, &QAction::triggered, this, &CodingSchemeMdiWindow::onHistoryClicked);
+}
+
+void CodingSchemeMdiWindow::onDataLoaded() {
+    emit statusChanged(tr("Loaded %1 coding schemes").arg(model_->rowCount()));
+    updateActionStates();
+}
+
+void CodingSchemeMdiWindow::onLoadError(const QString& error_message) {
+    emit errorOccurred(error_message);
+}
+
+void CodingSchemeMdiWindow::onRowDoubleClicked(const QModelIndex& index) {
+    auto sourceIndex = proxyModel_->mapToSource(index);
+    if (auto* scheme = model_->getScheme(sourceIndex.row())) {
+        emit showSchemeDetails(*scheme);
+    }
+}
+
+void CodingSchemeMdiWindow::onAddClicked() {
+    emit addNewRequested();
+}
+
+void CodingSchemeMdiWindow::onEditClicked() {
+    auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) return;
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* scheme = model_->getScheme(sourceIndex.row())) {
+        emit showSchemeDetails(*scheme);
+    }
+}
+
+void CodingSchemeMdiWindow::onDeleteClicked() {
+    auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) return;
+
+    std::vector<std::string> codes;
+    for (const auto& index : selected) {
+        auto sourceIndex = proxyModel_->mapToSource(index);
+        if (auto* scheme = model_->getScheme(sourceIndex.row())) {
+            codes.push_back(scheme->code);
+        }
+    }
+
+    QString message = codes.size() == 1
+        ? tr("Delete coding scheme '%1'?").arg(QString::fromStdString(codes[0]))
+        : tr("Delete %1 coding schemes?").arg(codes.size());
+
+    auto reply = MessageBoxHelper::question(this, tr("Confirm Delete"), message,
+                                            QMessageBox::Yes | QMessageBox::No);
+    if (reply != QMessageBox::Yes) return;
+
+    QPointer<CodingSchemeMdiWindow> self = this;
+    auto task = [self, codes = std::move(codes)]() -> bool {
+        if (!self || !self->clientManager_) return false;
+
+        dq::messaging::delete_coding_scheme_request request;
+        request.codes = codes;
+        auto payload = request.serialize();
+
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::delete_coding_scheme_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return false;
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return false;
+
+        auto response = dq::messaging::delete_coding_scheme_response::deserialize(*payload_result);
+        return response && !response->results.empty() && response->results[0].success;
+    };
+
+    auto* watcher = new QFutureWatcher<bool>(this);
+    connect(watcher, &QFutureWatcher<bool>::finished, this, [self, watcher]() {
+        bool success = watcher->result();
+        watcher->deleteLater();
+
+        if (self) {
+            if (success) {
+                emit self->statusChanged(tr("Coding scheme(s) deleted successfully"));
+                self->reload();
+            } else {
+                emit self->errorOccurred(tr("Failed to delete coding scheme(s)"));
+            }
+        }
+    });
+
+    watcher->setFuture(QtConcurrent::run(task));
+}
+
+void CodingSchemeMdiWindow::onRefreshClicked() {
+    emit statusChanged(tr("Refreshing..."));
+    model_->refresh();
+}
+
+void CodingSchemeMdiWindow::onSelectionChanged() {
+    updateActionStates();
+}
+
+void CodingSchemeMdiWindow::onHistoryClicked() {
+    auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) return;
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* scheme = model_->getScheme(sourceIndex.row())) {
+        emit showSchemeHistory(QString::fromStdString(scheme->code));
+    }
+}
+
+void CodingSchemeMdiWindow::updateActionStates() {
+    auto selected = tableView_->selectionModel()->selectedRows();
+    bool hasSelection = !selected.isEmpty();
+    bool singleSelection = selected.size() == 1;
+
+    editAction_->setEnabled(singleSelection);
+    deleteAction_->setEnabled(hasSelection);
+    historyAction_->setEnabled(singleSelection);
+}
+
+void CodingSchemeMdiWindow::reload() {
+    model_->refresh();
+}
+
+void CodingSchemeMdiWindow::saveColumnVisibility() {
+    QSettings settings;
+    settings.beginGroup("CodingSchemeMdiWindow");
+    for (int i = 0; i < model_->columnCount(); ++i) {
+        settings.setValue(QString("column_%1_visible").arg(i),
+                          !tableView_->isColumnHidden(i));
+    }
+    settings.endGroup();
+}
+
+void CodingSchemeMdiWindow::loadColumnVisibility() {
+    QSettings settings;
+    settings.beginGroup("CodingSchemeMdiWindow");
+    for (int i = 0; i < model_->columnCount(); ++i) {
+        bool visible = settings.value(QString("column_%1_visible").arg(i), true).toBool();
+        tableView_->setColumnHidden(i, !visible);
+    }
+    settings.endGroup();
+}
+
+}

--- a/projects/ores.qt/src/DatasetController.cpp
+++ b/projects/ores.qt/src/DatasetController.cpp
@@ -1,0 +1,447 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/DatasetController.hpp"
+
+#include <QMdiSubWindow>
+#include <QMessageBox>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/DatasetMdiWindow.hpp"
+#include "ores.qt/DatasetDetailDialog.hpp"
+#include "ores.qt/DatasetHistoryDialog.hpp"
+#include "ores.qt/DetachableMdiSubWindow.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+DatasetController::DatasetController(
+    QMainWindow* mainWindow,
+    QMdiArea* mdiArea,
+    ClientManager* clientManager,
+    const QString& username,
+    QList<DetachableMdiSubWindow*>& allDetachableWindows,
+    QObject* parent)
+    : EntityController(mainWindow, mdiArea, clientManager, username, parent),
+      listWindow_(nullptr),
+      listMdiSubWindow_(nullptr),
+      allDetachableWindows_(allDetachableWindows) {
+
+    BOOST_LOG_SEV(lg(), debug) << "DatasetController created";
+}
+
+DatasetController::~DatasetController() {
+    BOOST_LOG_SEV(lg(), debug) << "DatasetController destroyed";
+}
+
+void DatasetController::showListWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "showListWindow called";
+
+    const QString key = build_window_key("list", "datasets");
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing list window";
+        return;
+    }
+
+    listWindow_ = new DatasetMdiWindow(clientManager_, username_);
+
+    connect(listWindow_, &DatasetMdiWindow::statusChanged,
+            this, &DatasetController::statusMessage);
+    connect(listWindow_, &DatasetMdiWindow::errorOccurred,
+            this, &DatasetController::errorMessage);
+    connect(listWindow_, &DatasetMdiWindow::showDatasetDetails,
+            this, &DatasetController::onShowDetails);
+    connect(listWindow_, &DatasetMdiWindow::addNewRequested,
+            this, &DatasetController::onAddNewRequested);
+    connect(listWindow_, &DatasetMdiWindow::showDatasetHistory,
+            this, &DatasetController::onShowHistory);
+
+    const QColor iconColor(220, 220, 220);
+    listMdiSubWindow_ = new DetachableMdiSubWindow(mainWindow_);
+    listMdiSubWindow_->setWidget(listWindow_);
+    listMdiSubWindow_->setWindowTitle("Datasets");
+    listMdiSubWindow_->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_database_20_regular.svg", iconColor));
+    listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
+    listMdiSubWindow_->resize(listWindow_->sizeHint());
+
+    mdiArea_->addSubWindow(listMdiSubWindow_);
+    listMdiSubWindow_->show();
+
+    track_window(key, listMdiSubWindow_);
+    allDetachableWindows_.append(listMdiSubWindow_);
+
+    connect(listMdiSubWindow_, &QObject::destroyed, this, [this, key]() {
+        untrack_window(key);
+        allDetachableWindows_.removeOne(listMdiSubWindow_);
+        listWindow_ = nullptr;
+        listMdiSubWindow_ = nullptr;
+    });
+
+    BOOST_LOG_SEV(lg(), debug) << "Dataset list window created";
+}
+
+void DatasetController::closeAllWindows() {
+    BOOST_LOG_SEV(lg(), debug) << "closeAllWindows called";
+
+    QList<QString> keys = managed_windows_.keys();
+    for (const QString& key : keys) {
+        if (auto* window = managed_windows_.value(key)) {
+            window->close();
+        }
+    }
+    managed_windows_.clear();
+
+    listWindow_ = nullptr;
+    listMdiSubWindow_ = nullptr;
+}
+
+void DatasetController::onShowDetails(const dq::domain::dataset& dataset) {
+    BOOST_LOG_SEV(lg(), debug) << "Show details for: " << dataset.id;
+    showDetailWindow(dataset);
+}
+
+void DatasetController::onAddNewRequested() {
+    BOOST_LOG_SEV(lg(), info) << "Add new dataset requested";
+    showAddWindow();
+}
+
+void DatasetController::onShowHistory(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Show history requested for: " << id;
+    showHistoryWindow(id);
+}
+
+void DatasetController::showAddWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "Creating add window for new dataset";
+
+    const QColor iconColor(220, 220, 220);
+
+    auto* detailDialog = new DatasetDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(true);
+    detailDialog->loadLookupData();
+
+    connect(detailDialog, &DatasetDetailDialog::statusMessage,
+            this, &DatasetController::statusMessage);
+    connect(detailDialog, &DatasetDetailDialog::errorMessage,
+            this, &DatasetController::errorMessage);
+    connect(detailDialog, &DatasetDetailDialog::datasetSaved,
+            this, [this](const boost::uuids::uuid& id) {
+        BOOST_LOG_SEV(lg(), info) << "Dataset saved: " << id;
+        if (listWindow_) {
+            listWindow_->reload();
+        }
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle("New Dataset");
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_database_20_regular.svg", iconColor));
+
+    allDetachableWindows_.append(detailWindow);
+    QPointer<DatasetController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, detailWindow]() {
+        if (self)
+            self->allDetachableWindows_.removeAll(detailWindow);
+    });
+
+    mdiArea_->addSubWindow(detailWindow);
+    detailWindow->setWindowFlags(detailWindow->windowFlags()
+        & ~Qt::WindowMaximizeButtonHint);
+    detailWindow->adjustSize();
+
+    if (listMdiSubWindow_ && listMdiSubWindow_->isDetached()) {
+        detailWindow->show();
+        detailWindow->detach();
+        QPoint parentPos = listMdiSubWindow_->pos();
+        detailWindow->move(parentPos.x() + 30, parentPos.y() + 30);
+    } else {
+        detailWindow->show();
+    }
+}
+
+void DatasetController::showDetailWindow(const dq::domain::dataset& dataset) {
+    const QString identifier = QString::fromStdString(boost::uuids::to_string(dataset.id));
+    const QString key = build_window_key("details", identifier);
+
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing detail window";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Creating detail window for: " << dataset.id;
+
+    const QColor iconColor(220, 220, 220);
+
+    auto* detailDialog = new DatasetDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(false);
+    detailDialog->loadLookupData();
+    detailDialog->setDataset(dataset);
+
+    connect(detailDialog, &DatasetDetailDialog::statusMessage,
+            this, &DatasetController::statusMessage);
+    connect(detailDialog, &DatasetDetailDialog::errorMessage,
+            this, &DatasetController::errorMessage);
+    connect(detailDialog, &DatasetDetailDialog::datasetSaved,
+            this, [this](const boost::uuids::uuid& id) {
+        BOOST_LOG_SEV(lg(), info) << "Dataset saved: " << id;
+        if (listWindow_) {
+            listWindow_->reload();
+        }
+    });
+    connect(detailDialog, &DatasetDetailDialog::datasetDeleted,
+            this, [this, key](const boost::uuids::uuid& id) {
+        BOOST_LOG_SEV(lg(), info) << "Dataset deleted: " << id;
+        if (listWindow_) {
+            listWindow_->reload();
+        }
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Dataset: %1").arg(
+        QString::fromStdString(dataset.name)));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_database_20_regular.svg", iconColor));
+
+    track_window(key, detailWindow);
+    allDetachableWindows_.append(detailWindow);
+
+    QPointer<DatasetController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, detailWindow, key]() {
+        if (self) {
+            self->untrack_window(key);
+            self->allDetachableWindows_.removeAll(detailWindow);
+        }
+    });
+
+    mdiArea_->addSubWindow(detailWindow);
+    detailWindow->setWindowFlags(detailWindow->windowFlags()
+        & ~Qt::WindowMaximizeButtonHint);
+    detailWindow->adjustSize();
+
+    if (listMdiSubWindow_ && listMdiSubWindow_->isDetached()) {
+        detailWindow->show();
+        detailWindow->detach();
+        QPoint parentPos = listMdiSubWindow_->pos();
+        detailWindow->move(parentPos.x() + 30, parentPos.y() + 30);
+    } else {
+        detailWindow->show();
+    }
+}
+
+void DatasetController::showHistoryWindow(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), info) << "Opening history window for dataset: " << id;
+
+    const QString idStr = QString::fromStdString(boost::uuids::to_string(id));
+    const QString windowKey = build_window_key("history", idStr);
+
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing history window for: " << id;
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Creating new history window for: " << id;
+    const QColor iconColor(220, 220, 220);
+
+    auto* historyDialog = new DatasetHistoryDialog(id, clientManager_, mainWindow_);
+
+    connect(historyDialog, &DatasetHistoryDialog::statusChanged,
+            this, [this](const QString& message) {
+        emit statusMessage(message);
+    });
+    connect(historyDialog, &DatasetHistoryDialog::errorOccurred,
+            this, [this](const QString& message) {
+        emit errorMessage(message);
+    });
+    connect(historyDialog, &DatasetHistoryDialog::revertVersionRequested,
+            this, &DatasetController::onRevertVersion);
+    connect(historyDialog, &DatasetHistoryDialog::openVersionRequested,
+            this, &DatasetController::onOpenVersion);
+
+    historyDialog->loadHistory();
+
+    auto* historyWindow = new DetachableMdiSubWindow(mainWindow_);
+    historyWindow->setAttribute(Qt::WA_DeleteOnClose);
+    historyWindow->setWidget(historyDialog);
+    historyWindow->setWindowTitle(QString("Dataset History: %1").arg(idStr));
+    historyWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_history_20_regular.svg", iconColor));
+
+    track_window(windowKey, historyWindow);
+
+    allDetachableWindows_.append(historyWindow);
+    QPointer<DatasetController> self = this;
+    QPointer<DetachableMdiSubWindow> windowPtr = historyWindow;
+    connect(historyWindow, &QObject::destroyed, this,
+            [self, windowPtr, windowKey]() {
+        if (self) {
+            self->allDetachableWindows_.removeAll(windowPtr.data());
+            self->untrack_window(windowKey);
+        }
+    });
+
+    mdiArea_->addSubWindow(historyWindow);
+    historyWindow->adjustSize();
+
+    if (listMdiSubWindow_ && listMdiSubWindow_->isDetached()) {
+        historyWindow->show();
+        historyWindow->detach();
+        QPoint parentPos = listMdiSubWindow_->pos();
+        historyWindow->move(parentPos.x() + 30, parentPos.y() + 30);
+    } else {
+        historyWindow->show();
+    }
+}
+
+void DatasetController::onOpenVersion(
+    const dq::domain::dataset& dataset, int versionNumber) {
+    BOOST_LOG_SEV(lg(), info) << "Opening historical version " << versionNumber
+                              << " for dataset: " << dataset.id;
+
+    const QString idStr = QString::fromStdString(boost::uuids::to_string(dataset.id));
+    const QString windowKey = build_window_key("version", QString("%1_v%2")
+        .arg(idStr).arg(versionNumber));
+
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing version window";
+        return;
+    }
+
+    const QColor iconColor(220, 220, 220);
+
+    auto* detailDialog = new DatasetDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->loadLookupData();
+    detailDialog->setDataset(dataset);
+    detailDialog->setReadOnly(true);
+
+    connect(detailDialog, &DatasetDetailDialog::statusMessage,
+            this, [this](const QString& message) {
+        emit statusMessage(message);
+    });
+    connect(detailDialog, &DatasetDetailDialog::errorMessage,
+            this, [this](const QString& message) {
+        emit errorMessage(message);
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Dataset: %1 (Version %2)")
+        .arg(QString::fromStdString(dataset.name)).arg(versionNumber));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_history_20_regular.svg", iconColor));
+
+    track_window(windowKey, detailWindow);
+    allDetachableWindows_.append(detailWindow);
+
+    QPointer<DatasetController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, detailWindow, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+            self->allDetachableWindows_.removeAll(detailWindow);
+        }
+    });
+
+    mdiArea_->addSubWindow(detailWindow);
+    detailWindow->setWindowFlags(detailWindow->windowFlags()
+        & ~Qt::WindowMaximizeButtonHint);
+    detailWindow->adjustSize();
+
+    if (listMdiSubWindow_ && listMdiSubWindow_->isDetached()) {
+        detailWindow->show();
+        detailWindow->detach();
+        QPoint parentPos = listMdiSubWindow_->pos();
+        detailWindow->move(parentPos.x() + 60, parentPos.y() + 60);
+    } else {
+        detailWindow->show();
+    }
+}
+
+void DatasetController::onRevertVersion(
+    const dq::domain::dataset& dataset) {
+    BOOST_LOG_SEV(lg(), info) << "Reverting dataset to version: "
+                              << dataset.version;
+
+    auto* detailDialog = new DatasetDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->loadLookupData();
+    detailDialog->setDataset(dataset);
+    detailDialog->setCreateMode(false);
+
+    connect(detailDialog, &DatasetDetailDialog::statusMessage,
+            this, &DatasetController::statusMessage);
+    connect(detailDialog, &DatasetDetailDialog::errorMessage,
+            this, &DatasetController::errorMessage);
+    connect(detailDialog, &DatasetDetailDialog::datasetSaved,
+            this, [this](const boost::uuids::uuid& id) {
+        BOOST_LOG_SEV(lg(), info) << "Dataset reverted: " << id;
+        emit statusMessage(QString("Dataset reverted successfully"));
+        if (listWindow_) {
+            listWindow_->reload();
+        }
+    });
+
+    const QColor iconColor(220, 220, 220);
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Revert Dataset: %1")
+        .arg(QString::fromStdString(dataset.name)));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_arrow_rotate_counterclockwise_20_regular.svg", iconColor));
+
+    allDetachableWindows_.append(detailWindow);
+    QPointer<DatasetController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, detailWindow]() {
+        if (self) {
+            self->allDetachableWindows_.removeAll(detailWindow);
+        }
+    });
+
+    mdiArea_->addSubWindow(detailWindow);
+    detailWindow->setWindowFlags(detailWindow->windowFlags()
+        & ~Qt::WindowMaximizeButtonHint);
+    detailWindow->adjustSize();
+
+    if (listMdiSubWindow_ && listMdiSubWindow_->isDetached()) {
+        detailWindow->show();
+        detailWindow->detach();
+        QPoint parentPos = listMdiSubWindow_->pos();
+        detailWindow->move(parentPos.x() + 30, parentPos.y() + 30);
+    } else {
+        detailWindow->show();
+    }
+}
+
+}

--- a/projects/ores.qt/src/DatasetDetailDialog.cpp
+++ b/projects/ores.qt/src/DatasetDetailDialog.cpp
@@ -1,0 +1,634 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/DatasetDetailDialog.hpp"
+
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/string_generator.hpp>
+#include "ui_DatasetDetailDialog.h"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.dq/messaging/dataset_protocol.hpp"
+#include "ores.dq/messaging/data_organization_protocol.hpp"
+#include "ores.dq/messaging/dimension_protocol.hpp"
+#include "ores.dq/messaging/coding_scheme_protocol.hpp"
+#include "ores.comms/messaging/frame.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+DatasetDetailDialog::DatasetDetailDialog(QWidget* parent)
+    : QWidget(parent),
+      ui_(new Ui::DatasetDetailDialog),
+      clientManager_(nullptr),
+      isCreateMode_(true),
+      isReadOnly_(false) {
+
+    ui_->setupUi(this);
+    ui_->asOfDateEdit->setDate(QDate::currentDate());
+    setupConnections();
+}
+
+DatasetDetailDialog::~DatasetDetailDialog() {
+    delete ui_;
+}
+
+void DatasetDetailDialog::setupConnections() {
+    connect(ui_->saveButton, &QPushButton::clicked,
+            this, &DatasetDetailDialog::onSaveClicked);
+    connect(ui_->deleteButton, &QPushButton::clicked,
+            this, &DatasetDetailDialog::onDeleteClicked);
+}
+
+void DatasetDetailDialog::loadLookupData() {
+    if (!clientManager_ || !clientManager_->isConnected()) return;
+
+    QPointer<DatasetDetailDialog> self = this;
+
+    // Load catalogs
+    auto catalogTask = [self]() -> std::vector<std::string> {
+        if (!self || !self->clientManager_) return {};
+
+        dq::messaging::get_catalogs_request request;
+        auto payload = request.serialize();
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_catalogs_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {};
+
+        auto response = dq::messaging::get_catalogs_response::deserialize(*payload_result);
+        if (!response) return {};
+
+        std::vector<std::string> names;
+        names.push_back(""); // Empty option
+        for (const auto& c : response->catalogs) {
+            names.push_back(c.name);
+        }
+        return names;
+    };
+
+    auto* catalogWatcher = new QFutureWatcher<std::vector<std::string>>(this);
+    connect(catalogWatcher, &QFutureWatcher<std::vector<std::string>>::finished,
+            this, [self, catalogWatcher]() {
+        auto names = catalogWatcher->result();
+        catalogWatcher->deleteLater();
+        if (!self) return;
+
+        self->ui_->catalogCombo->clear();
+        for (const auto& name : names) {
+            self->ui_->catalogCombo->addItem(QString::fromStdString(name));
+        }
+    });
+    catalogWatcher->setFuture(QtConcurrent::run(catalogTask));
+
+    // Load subject areas
+    auto saTask = [self]() -> std::vector<std::string> {
+        if (!self || !self->clientManager_) return {};
+
+        dq::messaging::get_subject_areas_request request;
+        auto payload = request.serialize();
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_subject_areas_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {};
+
+        auto response = dq::messaging::get_subject_areas_response::deserialize(*payload_result);
+        if (!response) return {};
+
+        std::vector<std::string> names;
+        for (const auto& sa : response->subject_areas) {
+            names.push_back(sa.name);
+        }
+        return names;
+    };
+
+    auto* saWatcher = new QFutureWatcher<std::vector<std::string>>(this);
+    connect(saWatcher, &QFutureWatcher<std::vector<std::string>>::finished,
+            this, [self, saWatcher]() {
+        auto names = saWatcher->result();
+        saWatcher->deleteLater();
+        if (!self) return;
+
+        self->ui_->subjectAreaCombo->clear();
+        for (const auto& name : names) {
+            self->ui_->subjectAreaCombo->addItem(QString::fromStdString(name));
+        }
+    });
+    saWatcher->setFuture(QtConcurrent::run(saTask));
+
+    // Load data domains
+    auto ddTask = [self]() -> std::vector<std::string> {
+        if (!self || !self->clientManager_) return {};
+
+        dq::messaging::get_data_domains_request request;
+        auto payload = request.serialize();
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_data_domains_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {};
+
+        auto response = dq::messaging::get_data_domains_response::deserialize(*payload_result);
+        if (!response) return {};
+
+        std::vector<std::string> names;
+        for (const auto& dd : response->domains) {
+            names.push_back(dd.name);
+        }
+        return names;
+    };
+
+    auto* ddWatcher = new QFutureWatcher<std::vector<std::string>>(this);
+    connect(ddWatcher, &QFutureWatcher<std::vector<std::string>>::finished,
+            this, [self, ddWatcher]() {
+        auto names = ddWatcher->result();
+        ddWatcher->deleteLater();
+        if (!self) return;
+
+        self->ui_->domainCombo->clear();
+        for (const auto& name : names) {
+            self->ui_->domainCombo->addItem(QString::fromStdString(name));
+        }
+    });
+    ddWatcher->setFuture(QtConcurrent::run(ddTask));
+
+    // Load origin dimensions
+    auto originTask = [self]() -> std::vector<std::string> {
+        if (!self || !self->clientManager_) return {};
+
+        dq::messaging::get_origin_dimensions_request request;
+        auto payload = request.serialize();
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_origin_dimensions_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {};
+
+        auto response = dq::messaging::get_origin_dimensions_response::deserialize(*payload_result);
+        if (!response) return {};
+
+        std::vector<std::string> codes;
+        for (const auto& od : response->dimensions) {
+            codes.push_back(od.code);
+        }
+        return codes;
+    };
+
+    auto* originWatcher = new QFutureWatcher<std::vector<std::string>>(this);
+    connect(originWatcher, &QFutureWatcher<std::vector<std::string>>::finished,
+            this, [self, originWatcher]() {
+        auto codes = originWatcher->result();
+        originWatcher->deleteLater();
+        if (!self) return;
+
+        self->ui_->originCombo->clear();
+        for (const auto& code : codes) {
+            self->ui_->originCombo->addItem(QString::fromStdString(code));
+        }
+    });
+    originWatcher->setFuture(QtConcurrent::run(originTask));
+
+    // Load nature dimensions
+    auto natureTask = [self]() -> std::vector<std::string> {
+        if (!self || !self->clientManager_) return {};
+
+        dq::messaging::get_nature_dimensions_request request;
+        auto payload = request.serialize();
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_nature_dimensions_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {};
+
+        auto response = dq::messaging::get_nature_dimensions_response::deserialize(*payload_result);
+        if (!response) return {};
+
+        std::vector<std::string> codes;
+        for (const auto& nd : response->dimensions) {
+            codes.push_back(nd.code);
+        }
+        return codes;
+    };
+
+    auto* natureWatcher = new QFutureWatcher<std::vector<std::string>>(this);
+    connect(natureWatcher, &QFutureWatcher<std::vector<std::string>>::finished,
+            this, [self, natureWatcher]() {
+        auto codes = natureWatcher->result();
+        natureWatcher->deleteLater();
+        if (!self) return;
+
+        self->ui_->natureCombo->clear();
+        for (const auto& code : codes) {
+            self->ui_->natureCombo->addItem(QString::fromStdString(code));
+        }
+    });
+    natureWatcher->setFuture(QtConcurrent::run(natureTask));
+
+    // Load treatment dimensions
+    auto treatmentTask = [self]() -> std::vector<std::string> {
+        if (!self || !self->clientManager_) return {};
+
+        dq::messaging::get_treatment_dimensions_request request;
+        auto payload = request.serialize();
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_treatment_dimensions_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {};
+
+        auto response = dq::messaging::get_treatment_dimensions_response::deserialize(*payload_result);
+        if (!response) return {};
+
+        std::vector<std::string> codes;
+        for (const auto& td : response->dimensions) {
+            codes.push_back(td.code);
+        }
+        return codes;
+    };
+
+    auto* treatmentWatcher = new QFutureWatcher<std::vector<std::string>>(this);
+    connect(treatmentWatcher, &QFutureWatcher<std::vector<std::string>>::finished,
+            this, [self, treatmentWatcher]() {
+        auto codes = treatmentWatcher->result();
+        treatmentWatcher->deleteLater();
+        if (!self) return;
+
+        self->ui_->treatmentCombo->clear();
+        for (const auto& code : codes) {
+            self->ui_->treatmentCombo->addItem(QString::fromStdString(code));
+        }
+    });
+    treatmentWatcher->setFuture(QtConcurrent::run(treatmentTask));
+
+    // Load coding schemes
+    auto csTask = [self]() -> std::vector<std::string> {
+        if (!self || !self->clientManager_) return {};
+
+        dq::messaging::get_coding_schemes_request request;
+        auto payload = request.serialize();
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_coding_schemes_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {};
+
+        auto response = dq::messaging::get_coding_schemes_response::deserialize(*payload_result);
+        if (!response) return {};
+
+        std::vector<std::string> codes;
+        codes.push_back(""); // Empty option
+        for (const auto& cs : response->schemes) {
+            codes.push_back(cs.code);
+        }
+        return codes;
+    };
+
+    auto* csWatcher = new QFutureWatcher<std::vector<std::string>>(this);
+    connect(csWatcher, &QFutureWatcher<std::vector<std::string>>::finished,
+            this, [self, csWatcher]() {
+        auto codes = csWatcher->result();
+        csWatcher->deleteLater();
+        if (!self) return;
+
+        self->ui_->codingSchemeCombo->clear();
+        for (const auto& code : codes) {
+            self->ui_->codingSchemeCombo->addItem(QString::fromStdString(code));
+        }
+    });
+    csWatcher->setFuture(QtConcurrent::run(csTask));
+
+    // Load methodologies
+    auto methTask = [self]() -> std::vector<std::pair<boost::uuids::uuid, std::string>> {
+        if (!self || !self->clientManager_) return {};
+
+        dq::messaging::get_methodologies_request request;
+        auto payload = request.serialize();
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_methodologies_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {};
+
+        auto response = dq::messaging::get_methodologies_response::deserialize(*payload_result);
+        if (!response) return {};
+
+        std::vector<std::pair<boost::uuids::uuid, std::string>> methodologies;
+        for (const auto& m : response->methodologies) {
+            methodologies.push_back({m.id, m.name});
+        }
+        return methodologies;
+    };
+
+    auto* methWatcher = new QFutureWatcher<std::vector<std::pair<boost::uuids::uuid, std::string>>>(this);
+    connect(methWatcher, &QFutureWatcher<std::vector<std::pair<boost::uuids::uuid, std::string>>>::finished,
+            this, [self, methWatcher]() {
+        auto meths = methWatcher->result();
+        methWatcher->deleteLater();
+        if (!self) return;
+
+        self->methodologies_ = meths;
+        self->ui_->methodologyCombo->clear();
+        self->ui_->methodologyCombo->addItem(""); // Empty option
+        for (const auto& [id, name] : meths) {
+            self->ui_->methodologyCombo->addItem(QString::fromStdString(name));
+        }
+    });
+    methWatcher->setFuture(QtConcurrent::run(methTask));
+}
+
+void DatasetDetailDialog::setCreateMode(bool create) {
+    isCreateMode_ = create;
+    updateUiState();
+}
+
+void DatasetDetailDialog::setDataset(const dq::domain::dataset& dataset) {
+    dataset_ = dataset;
+
+    ui_->nameEdit->setText(QString::fromStdString(dataset.name));
+    ui_->descriptionEdit->setPlainText(QString::fromStdString(dataset.description));
+    ui_->commentaryEdit->setPlainText(QString::fromStdString(dataset.change_commentary));
+    ui_->sourceSystemEdit->setText(QString::fromStdString(dataset.source_system_id));
+    ui_->businessContextEdit->setPlainText(QString::fromStdString(dataset.business_context));
+    ui_->lineageDepthSpin->setValue(dataset.lineage_depth);
+
+    if (dataset.catalog_name) {
+        int idx = ui_->catalogCombo->findText(QString::fromStdString(*dataset.catalog_name));
+        if (idx >= 0) ui_->catalogCombo->setCurrentIndex(idx);
+    }
+
+    int saIdx = ui_->subjectAreaCombo->findText(QString::fromStdString(dataset.subject_area_name));
+    if (saIdx >= 0) ui_->subjectAreaCombo->setCurrentIndex(saIdx);
+
+    int ddIdx = ui_->domainCombo->findText(QString::fromStdString(dataset.domain_name));
+    if (ddIdx >= 0) ui_->domainCombo->setCurrentIndex(ddIdx);
+
+    int originIdx = ui_->originCombo->findText(QString::fromStdString(dataset.origin_code));
+    if (originIdx >= 0) ui_->originCombo->setCurrentIndex(originIdx);
+
+    int natureIdx = ui_->natureCombo->findText(QString::fromStdString(dataset.nature_code));
+    if (natureIdx >= 0) ui_->natureCombo->setCurrentIndex(natureIdx);
+
+    int treatmentIdx = ui_->treatmentCombo->findText(QString::fromStdString(dataset.treatment_code));
+    if (treatmentIdx >= 0) ui_->treatmentCombo->setCurrentIndex(treatmentIdx);
+
+    if (dataset.coding_scheme_code) {
+        int csIdx = ui_->codingSchemeCombo->findText(QString::fromStdString(*dataset.coding_scheme_code));
+        if (csIdx >= 0) ui_->codingSchemeCombo->setCurrentIndex(csIdx);
+    }
+
+    if (dataset.methodology_id) {
+        for (size_t i = 0; i < methodologies_.size(); ++i) {
+            if (methodologies_[i].first == *dataset.methodology_id) {
+                ui_->methodologyCombo->setCurrentIndex(static_cast<int>(i + 1)); // +1 for empty option
+                break;
+            }
+        }
+    }
+
+    if (dataset.license_info) {
+        ui_->licenseEdit->setText(QString::fromStdString(*dataset.license_info));
+    }
+
+    auto asOfDate = std::chrono::duration_cast<std::chrono::seconds>(
+        dataset.as_of_date.time_since_epoch()).count();
+    ui_->asOfDateEdit->setDate(QDateTime::fromSecsSinceEpoch(asOfDate).date());
+
+    updateUiState();
+}
+
+void DatasetDetailDialog::setReadOnly(bool readOnly) {
+    isReadOnly_ = readOnly;
+    updateUiState();
+}
+
+void DatasetDetailDialog::updateUiState() {
+    ui_->nameEdit->setReadOnly(isReadOnly_);
+    ui_->descriptionEdit->setReadOnly(isReadOnly_);
+    ui_->commentaryEdit->setReadOnly(isReadOnly_);
+    ui_->sourceSystemEdit->setReadOnly(isReadOnly_);
+    ui_->businessContextEdit->setReadOnly(isReadOnly_);
+    ui_->licenseEdit->setReadOnly(isReadOnly_);
+    ui_->lineageDepthSpin->setEnabled(!isReadOnly_);
+    ui_->asOfDateEdit->setEnabled(!isReadOnly_);
+    ui_->catalogCombo->setEnabled(!isReadOnly_);
+    ui_->subjectAreaCombo->setEnabled(!isReadOnly_);
+    ui_->domainCombo->setEnabled(!isReadOnly_);
+    ui_->originCombo->setEnabled(!isReadOnly_);
+    ui_->natureCombo->setEnabled(!isReadOnly_);
+    ui_->treatmentCombo->setEnabled(!isReadOnly_);
+    ui_->codingSchemeCombo->setEnabled(!isReadOnly_);
+    ui_->methodologyCombo->setEnabled(!isReadOnly_);
+
+    ui_->saveButton->setVisible(!isReadOnly_);
+    ui_->deleteButton->setVisible(!isCreateMode_ && !isReadOnly_);
+}
+
+void DatasetDetailDialog::onSaveClicked() {
+    QString name = ui_->nameEdit->text().trimmed();
+
+    if (name.isEmpty()) {
+        MessageBoxHelper::warning(this, tr("Validation Error"),
+                                  tr("Name is required."));
+        return;
+    }
+
+    dq::domain::dataset dataset;
+    dataset.id = isCreateMode_ ? boost::uuids::random_generator()() : dataset_.id;
+    dataset.name = name.toStdString();
+    dataset.description = ui_->descriptionEdit->toPlainText().trimmed().toStdString();
+    dataset.change_commentary = ui_->commentaryEdit->toPlainText().trimmed().toStdString();
+    dataset.source_system_id = ui_->sourceSystemEdit->text().trimmed().toStdString();
+    dataset.business_context = ui_->businessContextEdit->toPlainText().trimmed().toStdString();
+    dataset.lineage_depth = ui_->lineageDepthSpin->value();
+    dataset.recorded_by = username_;
+    dataset.version = isCreateMode_ ? 0 : dataset_.version;
+
+    QString catalogName = ui_->catalogCombo->currentText();
+    if (!catalogName.isEmpty()) {
+        dataset.catalog_name = catalogName.toStdString();
+    }
+
+    dataset.subject_area_name = ui_->subjectAreaCombo->currentText().toStdString();
+    dataset.domain_name = ui_->domainCombo->currentText().toStdString();
+    dataset.origin_code = ui_->originCombo->currentText().toStdString();
+    dataset.nature_code = ui_->natureCombo->currentText().toStdString();
+    dataset.treatment_code = ui_->treatmentCombo->currentText().toStdString();
+
+    QString codingScheme = ui_->codingSchemeCombo->currentText();
+    if (!codingScheme.isEmpty()) {
+        dataset.coding_scheme_code = codingScheme.toStdString();
+    }
+
+    int methIdx = ui_->methodologyCombo->currentIndex();
+    if (methIdx > 0 && methIdx <= static_cast<int>(methodologies_.size())) {
+        dataset.methodology_id = methodologies_[methIdx - 1].first;
+    }
+
+    QString license = ui_->licenseEdit->text().trimmed();
+    if (!license.isEmpty()) {
+        dataset.license_info = license.toStdString();
+    }
+
+    QDate asOfDate = ui_->asOfDateEdit->date();
+    dataset.as_of_date = std::chrono::system_clock::from_time_t(
+        QDateTime(asOfDate, QTime(0, 0)).toSecsSinceEpoch());
+    dataset.ingestion_timestamp = std::chrono::system_clock::now();
+
+    QPointer<DatasetDetailDialog> self = this;
+    boost::uuids::uuid datasetId = dataset.id;
+
+    struct SaveResult { bool success; std::string message; };
+
+    auto task = [self, dataset]() -> SaveResult {
+        if (!self || !self->clientManager_) return {false, "Dialog closed"};
+
+        dq::messaging::save_dataset_request request;
+        request.dataset = dataset;
+        auto payload = request.serialize();
+
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::save_dataset_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {false, "Failed to communicate with server"};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {false, "Failed to decompress response"};
+
+        auto response = dq::messaging::save_dataset_response::deserialize(*payload_result);
+        if (!response) return {false, "Invalid server response"};
+
+        return {response->success, response->message};
+    };
+
+    auto* watcher = new QFutureWatcher<SaveResult>(this);
+    connect(watcher, &QFutureWatcher<SaveResult>::finished, this, [self, watcher, datasetId]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (!self) return;
+
+        if (result.success) {
+            emit self->statusMessage(tr("Dataset saved successfully"));
+            emit self->datasetSaved(datasetId);
+            if (auto* parentWidget = self->parentWidget()) {
+                parentWidget->close();
+            }
+        } else {
+            emit self->errorMessage(QString::fromStdString(result.message));
+        }
+    });
+
+    emit statusMessage(tr("Saving..."));
+    watcher->setFuture(QtConcurrent::run(task));
+}
+
+void DatasetDetailDialog::onDeleteClicked() {
+    auto reply = MessageBoxHelper::question(this, tr("Confirm Delete"),
+        tr("Delete dataset '%1'?").arg(ui_->nameEdit->text()),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) return;
+
+    QPointer<DatasetDetailDialog> self = this;
+    boost::uuids::uuid datasetId = dataset_.id;
+
+    auto task = [self, datasetId]() -> bool {
+        if (!self || !self->clientManager_) return false;
+
+        dq::messaging::delete_dataset_request request;
+        request.ids = {datasetId};
+        auto payload = request.serialize();
+
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::delete_dataset_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return false;
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return false;
+
+        auto response = dq::messaging::delete_dataset_response::deserialize(*payload_result);
+        return response && !response->results.empty() && response->results[0].success;
+    };
+
+    auto* watcher = new QFutureWatcher<bool>(this);
+    connect(watcher, &QFutureWatcher<bool>::finished, this, [self, watcher, datasetId]() {
+        bool success = watcher->result();
+        watcher->deleteLater();
+
+        if (!self) return;
+
+        if (success) {
+            emit self->statusMessage(tr("Dataset deleted successfully"));
+            emit self->datasetDeleted(datasetId);
+            if (auto* parentWidget = self->parentWidget()) {
+                parentWidget->close();
+            }
+        } else {
+            emit self->errorMessage(tr("Failed to delete dataset"));
+        }
+    });
+
+    emit statusMessage(tr("Deleting..."));
+    watcher->setFuture(QtConcurrent::run(task));
+}
+
+}

--- a/projects/ores.qt/src/DatasetHistoryDialog.cpp
+++ b/projects/ores.qt/src/DatasetHistoryDialog.cpp
@@ -1,0 +1,263 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/DatasetHistoryDialog.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include <boost/uuid/uuid_io.hpp>
+#include "ui_DatasetHistoryDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.dq/messaging/dataset_protocol.hpp"
+#include "ores.comms/messaging/frame.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+DatasetHistoryDialog::DatasetHistoryDialog(
+    const boost::uuids::uuid& id, ClientManager* clientManager, QWidget* parent)
+    : QWidget(parent),
+      ui_(new Ui::DatasetHistoryDialog),
+      id_(id),
+      clientManager_(clientManager),
+      toolbar_(nullptr),
+      openVersionAction_(nullptr),
+      revertAction_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupToolbar();
+    setupConnections();
+}
+
+DatasetHistoryDialog::~DatasetHistoryDialog() {
+    delete ui_;
+}
+
+void DatasetHistoryDialog::setupUi() {
+    ui_->titleLabel->setText(QString("Dataset History"));
+    ui_->versionListWidget->setColumnCount(4);
+    ui_->versionListWidget->setHorizontalHeaderLabels({"Version", "Recorded At", "Recorded By", "Commentary"});
+    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
+    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+    ui_->changesTableWidget->setColumnCount(3);
+    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
+    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+}
+
+void DatasetHistoryDialog::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    const auto& iconColor = color_constants::icon_color;
+
+    openVersionAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_open_20_regular.svg", iconColor), tr("Open"));
+    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
+    openVersionAction_->setEnabled(false);
+
+    revertAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_arrow_rotate_counterclockwise_20_regular.svg", iconColor),
+        tr("Revert"));
+    revertAction_->setToolTip(tr("Revert to this version"));
+    revertAction_->setEnabled(false);
+
+    if (auto* layout = qobject_cast<QVBoxLayout*>(this->layout())) {
+        layout->insertWidget(0, toolbar_);
+    }
+}
+
+void DatasetHistoryDialog::setupConnections() {
+    connect(ui_->versionListWidget, &QTableWidget::itemSelectionChanged, this, &DatasetHistoryDialog::onVersionSelected);
+    connect(openVersionAction_, &QAction::triggered, this, &DatasetHistoryDialog::onOpenVersionClicked);
+    connect(revertAction_, &QAction::triggered, this, &DatasetHistoryDialog::onRevertClicked);
+}
+
+void DatasetHistoryDialog::loadHistory() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        emit errorOccurred("Not connected to server");
+        return;
+    }
+
+    emit statusChanged(tr("Loading history..."));
+
+    QPointer<DatasetHistoryDialog> self = this;
+    struct HistoryResult { bool success; std::string message; std::vector<dq::domain::dataset> versions; };
+
+    auto task = [self, id = id_]() -> HistoryResult {
+        if (!self || !self->clientManager_) return {false, "Dialog closed", {}};
+
+        dq::messaging::get_dataset_history_request request;
+        request.id = id;
+        auto payload = request.serialize();
+
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_dataset_history_request, 0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {false, "Failed to communicate with server", {}};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {false, "Failed to decompress response", {}};
+
+        auto response = dq::messaging::get_dataset_history_response::deserialize(*payload_result);
+        if (!response) return {false, "Invalid server response", {}};
+
+        return {response->success, response->message, std::move(response->versions)};
+    };
+
+    auto* watcher = new QFutureWatcher<HistoryResult>(self);
+    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            self->versions_ = std::move(result.versions);
+            self->updateVersionList();
+            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        } else {
+            emit self->errorOccurred(QString::fromStdString(result.message));
+        }
+    });
+
+    watcher->setFuture(QtConcurrent::run(task));
+}
+
+void DatasetHistoryDialog::updateVersionList() {
+    ui_->versionListWidget->setRowCount(0);
+
+    for (const auto& version : versions_) {
+        int row = ui_->versionListWidget->rowCount();
+        ui_->versionListWidget->insertRow(row);
+
+        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
+        versionItem->setTextAlignment(Qt::AlignCenter);
+        ui_->versionListWidget->setItem(row, 0, versionItem);
+        ui_->versionListWidget->setItem(row, 1, new QTableWidgetItem(relative_time_helper::format(version.recorded_at)));
+        ui_->versionListWidget->setItem(row, 2, new QTableWidgetItem(QString::fromStdString(version.recorded_by)));
+        ui_->versionListWidget->setItem(row, 3, new QTableWidgetItem(QString::fromStdString(version.change_commentary)));
+    }
+
+    if (!versions_.empty()) ui_->versionListWidget->selectRow(0);
+}
+
+void DatasetHistoryDialog::onVersionSelected() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) { updateActionStates(); return; }
+
+    int row = selected.first()->row();
+    updateChangesTable(row);
+    updateFullDetails(row);
+    updateActionStates();
+}
+
+void DatasetHistoryDialog::updateChangesTable(int currentVersionIndex) {
+    ui_->changesTableWidget->setRowCount(0);
+
+    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) return;
+
+    int previousVersionIndex = currentVersionIndex + 1;
+    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+        return;
+    }
+
+    const auto& current = versions_[currentVersionIndex];
+    const auto& previous = versions_[previousVersionIndex];
+
+    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
+        int row = ui_->changesTableWidget->rowCount();
+        ui_->changesTableWidget->insertRow(row);
+        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
+        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
+        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
+    };
+
+    if (current.name != previous.name) addChange("Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
+    if (current.catalog_name != previous.catalog_name) addChange("Catalog", QString::fromStdString(previous.catalog_name.value_or("")), QString::fromStdString(current.catalog_name.value_or("")));
+    if (current.subject_area_name != previous.subject_area_name) addChange("Subject Area", QString::fromStdString(previous.subject_area_name), QString::fromStdString(current.subject_area_name));
+    if (current.domain_name != previous.domain_name) addChange("Domain", QString::fromStdString(previous.domain_name), QString::fromStdString(current.domain_name));
+    if (current.source_system_id != previous.source_system_id) addChange("Source System", QString::fromStdString(previous.source_system_id), QString::fromStdString(current.source_system_id));
+    if (current.description != previous.description) addChange("Description", QString::fromStdString(previous.description), QString::fromStdString(current.description));
+
+    if (ui_->changesTableWidget->rowCount() == 0) {
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+    }
+}
+
+void DatasetHistoryDialog::updateFullDetails(int versionIndex) {
+    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) return;
+
+    const auto& version = versions_[versionIndex];
+    ui_->nameValue->setText(QString::fromStdString(version.name));
+    ui_->catalogValue->setText(QString::fromStdString(version.catalog_name.value_or("")));
+    ui_->subjectAreaValue->setText(QString::fromStdString(version.subject_area_name));
+    ui_->domainValue->setText(QString::fromStdString(version.domain_name));
+    ui_->sourceSystemValue->setText(QString::fromStdString(version.source_system_id));
+    ui_->descriptionValue->setText(QString::fromStdString(version.description));
+    ui_->versionNumberValue->setText(QString::number(version.version));
+    ui_->recordedByValue->setText(QString::fromStdString(version.recorded_by));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+}
+
+void DatasetHistoryDialog::updateActionStates() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    bool hasSelection = !selected.isEmpty();
+    bool isNotLatest = hasSelection && selected.first()->row() > 0;
+
+    openVersionAction_->setEnabled(hasSelection);
+    revertAction_->setEnabled(isNotLatest);
+}
+
+void DatasetHistoryDialog::onOpenVersionClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit openVersionRequested(versions_[row], versions_[row].version);
+}
+
+void DatasetHistoryDialog::onRevertClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit revertVersionRequested(versions_[row]);
+}
+
+}

--- a/projects/ores.qt/src/DatasetMdiWindow.cpp
+++ b/projects/ores.qt/src/DatasetMdiWindow.cpp
@@ -1,0 +1,281 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/DatasetMdiWindow.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QSettings>
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.dq/messaging/dataset_protocol.hpp"
+#include "ores.comms/messaging/frame.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+DatasetMdiWindow::DatasetMdiWindow(
+    ClientManager* clientManager, const QString& username, QWidget* parent)
+    : QWidget(parent),
+      clientManager_(clientManager),
+      username_(username),
+      model_(new ClientDatasetModel(clientManager, this)),
+      proxyModel_(new QSortFilterProxyModel(this)),
+      tableView_(new QTableView(this)),
+      toolbar_(nullptr) {
+
+    proxyModel_->setSourceModel(model_);
+    proxyModel_->setSortCaseSensitivity(Qt::CaseInsensitive);
+
+    setupUi();
+    setupToolbar();
+    setupConnections();
+    loadColumnVisibility();
+
+    model_->refresh();
+}
+
+void DatasetMdiWindow::setupUi() {
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    tableView_->setModel(proxyModel_);
+    tableView_->setSortingEnabled(true);
+    tableView_->setSelectionBehavior(QAbstractItemView::SelectRows);
+    tableView_->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    tableView_->setAlternatingRowColors(true);
+    tableView_->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    tableView_->horizontalHeader()->setStretchLastSection(true);
+    tableView_->verticalHeader()->setVisible(false);
+    tableView_->sortByColumn(ClientDatasetModel::Name, Qt::AscendingOrder);
+
+    layout->addWidget(tableView_);
+}
+
+void DatasetMdiWindow::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    const auto& iconColor = color_constants::icon_color;
+
+    addAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_add_20_regular.svg", iconColor),
+        tr("Add"));
+    addAction_->setToolTip(tr("Add new dataset"));
+
+    editAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_edit_20_regular.svg", iconColor),
+        tr("Edit"));
+    editAction_->setToolTip(tr("Edit selected dataset"));
+    editAction_->setEnabled(false);
+
+    deleteAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_delete_20_regular.svg", iconColor),
+        tr("Delete"));
+    deleteAction_->setToolTip(tr("Delete selected dataset(s)"));
+    deleteAction_->setEnabled(false);
+
+    toolbar_->addSeparator();
+
+    historyAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_history_20_regular.svg", iconColor),
+        tr("History"));
+    historyAction_->setToolTip(tr("View version history"));
+    historyAction_->setEnabled(false);
+
+    toolbar_->addSeparator();
+
+    refreshAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_arrow_sync_20_regular.svg", iconColor),
+        tr("Refresh"));
+    refreshAction_->setToolTip(tr("Refresh datasets"));
+
+    if (auto* layout = qobject_cast<QVBoxLayout*>(this->layout())) {
+        layout->insertWidget(0, toolbar_);
+    }
+}
+
+void DatasetMdiWindow::setupConnections() {
+    connect(model_, &ClientDatasetModel::dataLoaded,
+            this, &DatasetMdiWindow::onDataLoaded);
+    connect(model_, &ClientDatasetModel::loadError,
+            this, &DatasetMdiWindow::onLoadError);
+    connect(tableView_, &QTableView::doubleClicked,
+            this, &DatasetMdiWindow::onRowDoubleClicked);
+    connect(tableView_->selectionModel(), &QItemSelectionModel::selectionChanged,
+            this, &DatasetMdiWindow::onSelectionChanged);
+
+    connect(addAction_, &QAction::triggered, this, &DatasetMdiWindow::onAddClicked);
+    connect(editAction_, &QAction::triggered, this, &DatasetMdiWindow::onEditClicked);
+    connect(deleteAction_, &QAction::triggered, this, &DatasetMdiWindow::onDeleteClicked);
+    connect(refreshAction_, &QAction::triggered, this, &DatasetMdiWindow::onRefreshClicked);
+    connect(historyAction_, &QAction::triggered, this, &DatasetMdiWindow::onHistoryClicked);
+}
+
+void DatasetMdiWindow::onDataLoaded() {
+    emit statusChanged(tr("Loaded %1 datasets").arg(model_->rowCount()));
+    updateActionStates();
+}
+
+void DatasetMdiWindow::onLoadError(const QString& error_message) {
+    emit errorOccurred(error_message);
+}
+
+void DatasetMdiWindow::onRowDoubleClicked(const QModelIndex& index) {
+    auto sourceIndex = proxyModel_->mapToSource(index);
+    if (auto* dataset = model_->getDataset(sourceIndex.row())) {
+        emit showDatasetDetails(*dataset);
+    }
+}
+
+void DatasetMdiWindow::onAddClicked() {
+    emit addNewRequested();
+}
+
+void DatasetMdiWindow::onEditClicked() {
+    auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) return;
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* dataset = model_->getDataset(sourceIndex.row())) {
+        emit showDatasetDetails(*dataset);
+    }
+}
+
+void DatasetMdiWindow::onDeleteClicked() {
+    auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) return;
+
+    std::vector<boost::uuids::uuid> ids;
+    for (const auto& index : selected) {
+        auto sourceIndex = proxyModel_->mapToSource(index);
+        if (auto* dataset = model_->getDataset(sourceIndex.row())) {
+            ids.push_back(dataset->id);
+        }
+    }
+
+    QString message = ids.size() == 1
+        ? tr("Delete selected dataset?")
+        : tr("Delete %1 datasets?").arg(ids.size());
+
+    auto reply = MessageBoxHelper::question(this, tr("Confirm Delete"), message,
+                                            QMessageBox::Yes | QMessageBox::No);
+    if (reply != QMessageBox::Yes) return;
+
+    QPointer<DatasetMdiWindow> self = this;
+    auto task = [self, ids = std::move(ids)]() -> bool {
+        if (!self || !self->clientManager_) return false;
+
+        dq::messaging::delete_dataset_request request;
+        request.ids = ids;
+        auto payload = request.serialize();
+
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::delete_dataset_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return false;
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return false;
+
+        auto response = dq::messaging::delete_dataset_response::deserialize(*payload_result);
+        return response && !response->results.empty() && response->results[0].success;
+    };
+
+    auto* watcher = new QFutureWatcher<bool>(this);
+    connect(watcher, &QFutureWatcher<bool>::finished, this, [self, watcher]() {
+        bool success = watcher->result();
+        watcher->deleteLater();
+
+        if (self) {
+            if (success) {
+                emit self->statusChanged(tr("Dataset(s) deleted successfully"));
+                self->reload();
+            } else {
+                emit self->errorOccurred(tr("Failed to delete dataset(s)"));
+            }
+        }
+    });
+
+    watcher->setFuture(QtConcurrent::run(task));
+}
+
+void DatasetMdiWindow::onRefreshClicked() {
+    emit statusChanged(tr("Refreshing..."));
+    model_->refresh();
+}
+
+void DatasetMdiWindow::onSelectionChanged() {
+    updateActionStates();
+}
+
+void DatasetMdiWindow::onHistoryClicked() {
+    auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) return;
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* dataset = model_->getDataset(sourceIndex.row())) {
+        emit showDatasetHistory(dataset->id);
+    }
+}
+
+void DatasetMdiWindow::updateActionStates() {
+    auto selected = tableView_->selectionModel()->selectedRows();
+    bool hasSelection = !selected.isEmpty();
+    bool singleSelection = selected.size() == 1;
+
+    editAction_->setEnabled(singleSelection);
+    deleteAction_->setEnabled(hasSelection);
+    historyAction_->setEnabled(singleSelection);
+}
+
+void DatasetMdiWindow::reload() {
+    model_->refresh();
+}
+
+void DatasetMdiWindow::saveColumnVisibility() {
+    QSettings settings;
+    settings.beginGroup("DatasetMdiWindow");
+    for (int i = 0; i < model_->columnCount(); ++i) {
+        settings.setValue(QString("column_%1_visible").arg(i),
+                          !tableView_->isColumnHidden(i));
+    }
+    settings.endGroup();
+}
+
+void DatasetMdiWindow::loadColumnVisibility() {
+    QSettings settings;
+    settings.beginGroup("DatasetMdiWindow");
+    for (int i = 0; i < model_->columnCount(); ++i) {
+        bool visible = settings.value(QString("column_%1_visible").arg(i), true).toBool();
+        tableView_->setColumnHidden(i, !visible);
+    }
+    settings.endGroup();
+}
+
+}

--- a/projects/ores.qt/src/MainWindow.cpp
+++ b/projects/ores.qt/src/MainWindow.cpp
@@ -58,6 +58,9 @@
 #include "ores.qt/DataDomainController.hpp"
 #include "ores.qt/SubjectAreaController.hpp"
 #include "ores.qt/CatalogController.hpp"
+#include "ores.qt/CodingSchemeController.hpp"
+#include "ores.qt/MethodologyController.hpp"
+#include "ores.qt/DatasetController.hpp"
 #include "ores.qt/ChangeReasonCache.hpp"
 #include "ores.qt/DetachableMdiSubWindow.hpp"
 #include "ores.qt/IconUtils.hpp"
@@ -152,6 +155,12 @@ MainWindow::MainWindow(QWidget* parent) :
         ":/icons/ic_fluent_tag_20_regular.svg", iconColor));
     ui_->ActionDataDomains->setIcon(IconUtils::createRecoloredIcon(
         ":/icons/ic_fluent_folder_20_regular.svg", iconColor));
+    ui_->ActionCodingSchemes->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_code_20_regular.svg", iconColor));
+    ui_->ActionMethodologies->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_book_20_regular.svg", iconColor));
+    ui_->ActionDatasets->setIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_database_20_regular.svg", iconColor));
     ui_->ActionMyAccount->setIcon(IconUtils::createRecoloredIcon(
         ":/icons/ic_fluent_person_20_regular.svg", iconColor));
     ui_->ActionMySessions->setIcon(IconUtils::createRecoloredIcon(
@@ -431,6 +440,24 @@ MainWindow::MainWindow(QWidget* parent) :
             catalogController_->showListWindow();
     });
 
+    // Connect Coding Schemes action to controller
+    connect(ui_->ActionCodingSchemes, &QAction::triggered, this, [this]() {
+        if (codingSchemeController_)
+            codingSchemeController_->showListWindow();
+    });
+
+    // Connect Methodologies action to controller
+    connect(ui_->ActionMethodologies, &QAction::triggered, this, [this]() {
+        if (methodologyController_)
+            methodologyController_->showListWindow();
+    });
+
+    // Connect Datasets action to controller
+    connect(ui_->ActionDatasets, &QAction::triggered, this, [this]() {
+        if (datasetController_)
+            datasetController_->showListWindow();
+    });
+
     // Initially disable data-related actions until logged in
     updateMenuState();
 
@@ -635,6 +662,9 @@ void MainWindow::updateMenuState() {
     ui_->ActionDataDomains->setEnabled(isConnected);
     ui_->ActionSubjectAreas->setEnabled(isConnected);
     ui_->ActionCatalogs->setEnabled(isConnected);
+    ui_->ActionCodingSchemes->setEnabled(isConnected);
+    ui_->ActionMethodologies->setEnabled(isConnected);
+    ui_->ActionDatasets->setEnabled(isConnected);
 
     // My Account and My Sessions menu items are enabled when connected
     ui_->ActionMyAccount->setEnabled(isConnected);
@@ -869,6 +899,51 @@ void MainWindow::createControllers() {
         ui_->statusbar->showMessage(message);
     });
     connect(catalogController_.get(), &CatalogController::errorMessage,
+            this, [this](const QString& message) {
+        ui_->statusbar->showMessage(message);
+    });
+
+    // Create coding scheme controller
+    codingSchemeController_ = std::make_unique<CodingSchemeController>(
+        this, mdiArea_, clientManager_, QString::fromStdString(username_),
+        allDetachableWindows_, this);
+
+    // Connect coding scheme controller signals to status bar
+    connect(codingSchemeController_.get(), &CodingSchemeController::statusMessage,
+            this, [this](const QString& message) {
+        ui_->statusbar->showMessage(message);
+    });
+    connect(codingSchemeController_.get(), &CodingSchemeController::errorMessage,
+            this, [this](const QString& message) {
+        ui_->statusbar->showMessage(message);
+    });
+
+    // Create methodology controller
+    methodologyController_ = std::make_unique<MethodologyController>(
+        this, mdiArea_, clientManager_, QString::fromStdString(username_),
+        allDetachableWindows_, this);
+
+    // Connect methodology controller signals to status bar
+    connect(methodologyController_.get(), &MethodologyController::statusMessage,
+            this, [this](const QString& message) {
+        ui_->statusbar->showMessage(message);
+    });
+    connect(methodologyController_.get(), &MethodologyController::errorMessage,
+            this, [this](const QString& message) {
+        ui_->statusbar->showMessage(message);
+    });
+
+    // Create dataset controller
+    datasetController_ = std::make_unique<DatasetController>(
+        this, mdiArea_, clientManager_, QString::fromStdString(username_),
+        allDetachableWindows_, this);
+
+    // Connect dataset controller signals to status bar
+    connect(datasetController_.get(), &DatasetController::statusMessage,
+            this, [this](const QString& message) {
+        ui_->statusbar->showMessage(message);
+    });
+    connect(datasetController_.get(), &DatasetController::errorMessage,
             this, [this](const QString& message) {
         ui_->statusbar->showMessage(message);
     });
@@ -1526,6 +1601,15 @@ void MainWindow::onLoginSuccess(const QString& username) {
     }
     if (catalogController_) {
         catalogController_->setUsername(username);
+    }
+    if (codingSchemeController_) {
+        codingSchemeController_->setUsername(username);
+    }
+    if (methodologyController_) {
+        methodologyController_->setUsername(username);
+    }
+    if (datasetController_) {
+        datasetController_->setUsername(username);
     }
 
     updateWindowTitle();

--- a/projects/ores.qt/src/MethodologyController.cpp
+++ b/projects/ores.qt/src/MethodologyController.cpp
@@ -1,0 +1,443 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/MethodologyController.hpp"
+
+#include <QMdiSubWindow>
+#include <QMessageBox>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MethodologyMdiWindow.hpp"
+#include "ores.qt/MethodologyDetailDialog.hpp"
+#include "ores.qt/MethodologyHistoryDialog.hpp"
+#include "ores.qt/DetachableMdiSubWindow.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+MethodologyController::MethodologyController(
+    QMainWindow* mainWindow,
+    QMdiArea* mdiArea,
+    ClientManager* clientManager,
+    const QString& username,
+    QList<DetachableMdiSubWindow*>& allDetachableWindows,
+    QObject* parent)
+    : EntityController(mainWindow, mdiArea, clientManager, username, parent),
+      listWindow_(nullptr),
+      listMdiSubWindow_(nullptr),
+      allDetachableWindows_(allDetachableWindows) {
+
+    BOOST_LOG_SEV(lg(), debug) << "MethodologyController created";
+}
+
+MethodologyController::~MethodologyController() {
+    BOOST_LOG_SEV(lg(), debug) << "MethodologyController destroyed";
+}
+
+void MethodologyController::showListWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "showListWindow called";
+
+    const QString key = build_window_key("list", "methodologies");
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing list window";
+        return;
+    }
+
+    listWindow_ = new MethodologyMdiWindow(clientManager_, username_);
+
+    connect(listWindow_, &MethodologyMdiWindow::statusChanged,
+            this, &MethodologyController::statusMessage);
+    connect(listWindow_, &MethodologyMdiWindow::errorOccurred,
+            this, &MethodologyController::errorMessage);
+    connect(listWindow_, &MethodologyMdiWindow::showMethodologyDetails,
+            this, &MethodologyController::onShowDetails);
+    connect(listWindow_, &MethodologyMdiWindow::addNewRequested,
+            this, &MethodologyController::onAddNewRequested);
+    connect(listWindow_, &MethodologyMdiWindow::showMethodologyHistory,
+            this, &MethodologyController::onShowHistory);
+
+    const QColor iconColor(220, 220, 220);
+    listMdiSubWindow_ = new DetachableMdiSubWindow(mainWindow_);
+    listMdiSubWindow_->setWidget(listWindow_);
+    listMdiSubWindow_->setWindowTitle("Methodologies");
+    listMdiSubWindow_->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_book_20_regular.svg", iconColor));
+    listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
+    listMdiSubWindow_->resize(listWindow_->sizeHint());
+
+    mdiArea_->addSubWindow(listMdiSubWindow_);
+    listMdiSubWindow_->show();
+
+    track_window(key, listMdiSubWindow_);
+    allDetachableWindows_.append(listMdiSubWindow_);
+
+    connect(listMdiSubWindow_, &QObject::destroyed, this, [this, key]() {
+        untrack_window(key);
+        allDetachableWindows_.removeOne(listMdiSubWindow_);
+        listWindow_ = nullptr;
+        listMdiSubWindow_ = nullptr;
+    });
+
+    BOOST_LOG_SEV(lg(), debug) << "Methodology list window created";
+}
+
+void MethodologyController::closeAllWindows() {
+    BOOST_LOG_SEV(lg(), debug) << "closeAllWindows called";
+
+    QList<QString> keys = managed_windows_.keys();
+    for (const QString& key : keys) {
+        if (auto* window = managed_windows_.value(key)) {
+            window->close();
+        }
+    }
+    managed_windows_.clear();
+
+    listWindow_ = nullptr;
+    listMdiSubWindow_ = nullptr;
+}
+
+void MethodologyController::onShowDetails(const dq::domain::methodology& methodology) {
+    BOOST_LOG_SEV(lg(), debug) << "Show details for: " << methodology.id;
+    showDetailWindow(methodology);
+}
+
+void MethodologyController::onAddNewRequested() {
+    BOOST_LOG_SEV(lg(), info) << "Add new methodology requested";
+    showAddWindow();
+}
+
+void MethodologyController::onShowHistory(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Show history requested for: " << id;
+    showHistoryWindow(id);
+}
+
+void MethodologyController::showAddWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "Creating add window for new methodology";
+
+    const QColor iconColor(220, 220, 220);
+
+    auto* detailDialog = new MethodologyDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(true);
+
+    connect(detailDialog, &MethodologyDetailDialog::statusMessage,
+            this, &MethodologyController::statusMessage);
+    connect(detailDialog, &MethodologyDetailDialog::errorMessage,
+            this, &MethodologyController::errorMessage);
+    connect(detailDialog, &MethodologyDetailDialog::methodologySaved,
+            this, [this](const boost::uuids::uuid& id) {
+        BOOST_LOG_SEV(lg(), info) << "Methodology saved: " << id;
+        if (listWindow_) {
+            listWindow_->reload();
+        }
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle("New Methodology");
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_book_20_regular.svg", iconColor));
+
+    allDetachableWindows_.append(detailWindow);
+    QPointer<MethodologyController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, detailWindow]() {
+        if (self)
+            self->allDetachableWindows_.removeAll(detailWindow);
+    });
+
+    mdiArea_->addSubWindow(detailWindow);
+    detailWindow->setWindowFlags(detailWindow->windowFlags()
+        & ~Qt::WindowMaximizeButtonHint);
+    detailWindow->adjustSize();
+
+    if (listMdiSubWindow_ && listMdiSubWindow_->isDetached()) {
+        detailWindow->show();
+        detailWindow->detach();
+        QPoint parentPos = listMdiSubWindow_->pos();
+        detailWindow->move(parentPos.x() + 30, parentPos.y() + 30);
+    } else {
+        detailWindow->show();
+    }
+}
+
+void MethodologyController::showDetailWindow(const dq::domain::methodology& methodology) {
+    const QString identifier = QString::fromStdString(boost::uuids::to_string(methodology.id));
+    const QString key = build_window_key("details", identifier);
+
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing detail window";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Creating detail window for: " << methodology.id;
+
+    const QColor iconColor(220, 220, 220);
+
+    auto* detailDialog = new MethodologyDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(false);
+    detailDialog->setMethodology(methodology);
+
+    connect(detailDialog, &MethodologyDetailDialog::statusMessage,
+            this, &MethodologyController::statusMessage);
+    connect(detailDialog, &MethodologyDetailDialog::errorMessage,
+            this, &MethodologyController::errorMessage);
+    connect(detailDialog, &MethodologyDetailDialog::methodologySaved,
+            this, [this](const boost::uuids::uuid& id) {
+        BOOST_LOG_SEV(lg(), info) << "Methodology saved: " << id;
+        if (listWindow_) {
+            listWindow_->reload();
+        }
+    });
+    connect(detailDialog, &MethodologyDetailDialog::methodologyDeleted,
+            this, [this, key](const boost::uuids::uuid& id) {
+        BOOST_LOG_SEV(lg(), info) << "Methodology deleted: " << id;
+        if (listWindow_) {
+            listWindow_->reload();
+        }
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Methodology: %1").arg(
+        QString::fromStdString(methodology.name)));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_book_20_regular.svg", iconColor));
+
+    track_window(key, detailWindow);
+    allDetachableWindows_.append(detailWindow);
+
+    QPointer<MethodologyController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, detailWindow, key]() {
+        if (self) {
+            self->untrack_window(key);
+            self->allDetachableWindows_.removeAll(detailWindow);
+        }
+    });
+
+    mdiArea_->addSubWindow(detailWindow);
+    detailWindow->setWindowFlags(detailWindow->windowFlags()
+        & ~Qt::WindowMaximizeButtonHint);
+    detailWindow->adjustSize();
+
+    if (listMdiSubWindow_ && listMdiSubWindow_->isDetached()) {
+        detailWindow->show();
+        detailWindow->detach();
+        QPoint parentPos = listMdiSubWindow_->pos();
+        detailWindow->move(parentPos.x() + 30, parentPos.y() + 30);
+    } else {
+        detailWindow->show();
+    }
+}
+
+void MethodologyController::showHistoryWindow(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), info) << "Opening history window for methodology: " << id;
+
+    const QString idStr = QString::fromStdString(boost::uuids::to_string(id));
+    const QString windowKey = build_window_key("history", idStr);
+
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing history window for: " << id;
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Creating new history window for: " << id;
+    const QColor iconColor(220, 220, 220);
+
+    auto* historyDialog = new MethodologyHistoryDialog(id, clientManager_, mainWindow_);
+
+    connect(historyDialog, &MethodologyHistoryDialog::statusChanged,
+            this, [this](const QString& message) {
+        emit statusMessage(message);
+    });
+    connect(historyDialog, &MethodologyHistoryDialog::errorOccurred,
+            this, [this](const QString& message) {
+        emit errorMessage(message);
+    });
+    connect(historyDialog, &MethodologyHistoryDialog::revertVersionRequested,
+            this, &MethodologyController::onRevertVersion);
+    connect(historyDialog, &MethodologyHistoryDialog::openVersionRequested,
+            this, &MethodologyController::onOpenVersion);
+
+    historyDialog->loadHistory();
+
+    auto* historyWindow = new DetachableMdiSubWindow(mainWindow_);
+    historyWindow->setAttribute(Qt::WA_DeleteOnClose);
+    historyWindow->setWidget(historyDialog);
+    historyWindow->setWindowTitle(QString("Methodology History: %1").arg(idStr));
+    historyWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_history_20_regular.svg", iconColor));
+
+    track_window(windowKey, historyWindow);
+
+    allDetachableWindows_.append(historyWindow);
+    QPointer<MethodologyController> self = this;
+    QPointer<DetachableMdiSubWindow> windowPtr = historyWindow;
+    connect(historyWindow, &QObject::destroyed, this,
+            [self, windowPtr, windowKey]() {
+        if (self) {
+            self->allDetachableWindows_.removeAll(windowPtr.data());
+            self->untrack_window(windowKey);
+        }
+    });
+
+    mdiArea_->addSubWindow(historyWindow);
+    historyWindow->adjustSize();
+
+    if (listMdiSubWindow_ && listMdiSubWindow_->isDetached()) {
+        historyWindow->show();
+        historyWindow->detach();
+        QPoint parentPos = listMdiSubWindow_->pos();
+        historyWindow->move(parentPos.x() + 30, parentPos.y() + 30);
+    } else {
+        historyWindow->show();
+    }
+}
+
+void MethodologyController::onOpenVersion(
+    const dq::domain::methodology& methodology, int versionNumber) {
+    BOOST_LOG_SEV(lg(), info) << "Opening historical version " << versionNumber
+                              << " for methodology: " << methodology.id;
+
+    const QString idStr = QString::fromStdString(boost::uuids::to_string(methodology.id));
+    const QString windowKey = build_window_key("version", QString("%1_v%2")
+        .arg(idStr).arg(versionNumber));
+
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing version window";
+        return;
+    }
+
+    const QColor iconColor(220, 220, 220);
+
+    auto* detailDialog = new MethodologyDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setMethodology(methodology);
+    detailDialog->setReadOnly(true);
+
+    connect(detailDialog, &MethodologyDetailDialog::statusMessage,
+            this, [this](const QString& message) {
+        emit statusMessage(message);
+    });
+    connect(detailDialog, &MethodologyDetailDialog::errorMessage,
+            this, [this](const QString& message) {
+        emit errorMessage(message);
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Methodology: %1 (Version %2)")
+        .arg(QString::fromStdString(methodology.name)).arg(versionNumber));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_history_20_regular.svg", iconColor));
+
+    track_window(windowKey, detailWindow);
+    allDetachableWindows_.append(detailWindow);
+
+    QPointer<MethodologyController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, detailWindow, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+            self->allDetachableWindows_.removeAll(detailWindow);
+        }
+    });
+
+    mdiArea_->addSubWindow(detailWindow);
+    detailWindow->setWindowFlags(detailWindow->windowFlags()
+        & ~Qt::WindowMaximizeButtonHint);
+    detailWindow->adjustSize();
+
+    if (listMdiSubWindow_ && listMdiSubWindow_->isDetached()) {
+        detailWindow->show();
+        detailWindow->detach();
+        QPoint parentPos = listMdiSubWindow_->pos();
+        detailWindow->move(parentPos.x() + 60, parentPos.y() + 60);
+    } else {
+        detailWindow->show();
+    }
+}
+
+void MethodologyController::onRevertVersion(
+    const dq::domain::methodology& methodology) {
+    BOOST_LOG_SEV(lg(), info) << "Reverting methodology to version: "
+                              << methodology.version;
+
+    auto* detailDialog = new MethodologyDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setMethodology(methodology);
+    detailDialog->setCreateMode(false);
+
+    connect(detailDialog, &MethodologyDetailDialog::statusMessage,
+            this, &MethodologyController::statusMessage);
+    connect(detailDialog, &MethodologyDetailDialog::errorMessage,
+            this, &MethodologyController::errorMessage);
+    connect(detailDialog, &MethodologyDetailDialog::methodologySaved,
+            this, [this](const boost::uuids::uuid& id) {
+        BOOST_LOG_SEV(lg(), info) << "Methodology reverted: " << id;
+        emit statusMessage(QString("Methodology reverted successfully"));
+        if (listWindow_) {
+            listWindow_->reload();
+        }
+    });
+
+    const QColor iconColor(220, 220, 220);
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Revert Methodology: %1")
+        .arg(QString::fromStdString(methodology.name)));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        ":/icons/ic_fluent_arrow_rotate_counterclockwise_20_regular.svg", iconColor));
+
+    allDetachableWindows_.append(detailWindow);
+    QPointer<MethodologyController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, detailWindow]() {
+        if (self) {
+            self->allDetachableWindows_.removeAll(detailWindow);
+        }
+    });
+
+    mdiArea_->addSubWindow(detailWindow);
+    detailWindow->setWindowFlags(detailWindow->windowFlags()
+        & ~Qt::WindowMaximizeButtonHint);
+    detailWindow->adjustSize();
+
+    if (listMdiSubWindow_ && listMdiSubWindow_->isDetached()) {
+        detailWindow->show();
+        detailWindow->detach();
+        QPoint parentPos = listMdiSubWindow_->pos();
+        detailWindow->move(parentPos.x() + 30, parentPos.y() + 30);
+    } else {
+        detailWindow->show();
+    }
+}
+
+}

--- a/projects/ores.qt/src/MethodologyDetailDialog.cpp
+++ b/projects/ores.qt/src/MethodologyDetailDialog.cpp
@@ -1,0 +1,230 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/MethodologyDetailDialog.hpp"
+
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include "ui_MethodologyDetailDialog.h"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.dq/messaging/dataset_protocol.hpp"
+#include "ores.comms/messaging/frame.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+MethodologyDetailDialog::MethodologyDetailDialog(QWidget* parent)
+    : QWidget(parent),
+      ui_(new Ui::MethodologyDetailDialog),
+      clientManager_(nullptr),
+      isCreateMode_(true),
+      isReadOnly_(false) {
+
+    ui_->setupUi(this);
+    setupConnections();
+}
+
+MethodologyDetailDialog::~MethodologyDetailDialog() {
+    delete ui_;
+}
+
+void MethodologyDetailDialog::setupConnections() {
+    connect(ui_->saveButton, &QPushButton::clicked,
+            this, &MethodologyDetailDialog::onSaveClicked);
+    connect(ui_->deleteButton, &QPushButton::clicked,
+            this, &MethodologyDetailDialog::onDeleteClicked);
+}
+
+void MethodologyDetailDialog::setCreateMode(bool create) {
+    isCreateMode_ = create;
+    updateUiState();
+}
+
+void MethodologyDetailDialog::setMethodology(
+    const dq::domain::methodology& methodology) {
+    methodology_ = methodology;
+
+    ui_->nameEdit->setText(QString::fromStdString(methodology.name));
+    ui_->descriptionEdit->setPlainText(QString::fromStdString(methodology.description));
+    ui_->commentaryEdit->setPlainText(QString::fromStdString(methodology.change_commentary));
+
+    if (methodology.logic_reference) {
+        ui_->logicReferenceEdit->setText(QString::fromStdString(*methodology.logic_reference));
+    }
+
+    if (methodology.implementation_details) {
+        ui_->implementationEdit->setPlainText(QString::fromStdString(*methodology.implementation_details));
+    }
+
+    updateUiState();
+}
+
+void MethodologyDetailDialog::setReadOnly(bool readOnly) {
+    isReadOnly_ = readOnly;
+    updateUiState();
+}
+
+void MethodologyDetailDialog::updateUiState() {
+    ui_->nameEdit->setReadOnly(isReadOnly_);
+    ui_->descriptionEdit->setReadOnly(isReadOnly_);
+    ui_->commentaryEdit->setReadOnly(isReadOnly_);
+    ui_->logicReferenceEdit->setReadOnly(isReadOnly_);
+    ui_->implementationEdit->setReadOnly(isReadOnly_);
+
+    ui_->saveButton->setVisible(!isReadOnly_);
+    ui_->deleteButton->setVisible(!isCreateMode_ && !isReadOnly_);
+}
+
+void MethodologyDetailDialog::onSaveClicked() {
+    QString name = ui_->nameEdit->text().trimmed();
+    QString description = ui_->descriptionEdit->toPlainText().trimmed();
+    QString commentary = ui_->commentaryEdit->toPlainText().trimmed();
+    QString logicRef = ui_->logicReferenceEdit->text().trimmed();
+    QString implementation = ui_->implementationEdit->toPlainText().trimmed();
+
+    if (name.isEmpty()) {
+        MessageBoxHelper::warning(this, tr("Validation Error"),
+                                  tr("Name is required."));
+        return;
+    }
+
+    dq::domain::methodology methodology;
+    methodology.id = isCreateMode_ ? boost::uuids::random_generator()() : methodology_.id;
+    methodology.name = name.toStdString();
+    methodology.description = description.toStdString();
+    methodology.change_commentary = commentary.toStdString();
+    methodology.recorded_by = username_;
+    methodology.version = isCreateMode_ ? 0 : methodology_.version;
+
+    if (!logicRef.isEmpty()) {
+        methodology.logic_reference = logicRef.toStdString();
+    }
+
+    if (!implementation.isEmpty()) {
+        methodology.implementation_details = implementation.toStdString();
+    }
+
+    QPointer<MethodologyDetailDialog> self = this;
+    boost::uuids::uuid methodologyId = methodology.id;
+
+    struct SaveResult { bool success; std::string message; };
+
+    auto task = [self, methodology]() -> SaveResult {
+        if (!self || !self->clientManager_) return {false, "Dialog closed"};
+
+        dq::messaging::save_methodology_request request;
+        request.methodology = methodology;
+        auto payload = request.serialize();
+
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::save_methodology_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {false, "Failed to communicate with server"};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {false, "Failed to decompress response"};
+
+        auto response = dq::messaging::save_methodology_response::deserialize(*payload_result);
+        if (!response) return {false, "Invalid server response"};
+
+        return {response->success, response->message};
+    };
+
+    auto* watcher = new QFutureWatcher<SaveResult>(this);
+    connect(watcher, &QFutureWatcher<SaveResult>::finished, this, [self, watcher, methodologyId]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (!self) return;
+
+        if (result.success) {
+            emit self->statusMessage(tr("Methodology saved successfully"));
+            emit self->methodologySaved(methodologyId);
+            if (auto* parentWidget = self->parentWidget()) {
+                parentWidget->close();
+            }
+        } else {
+            emit self->errorMessage(QString::fromStdString(result.message));
+        }
+    });
+
+    emit statusMessage(tr("Saving..."));
+    watcher->setFuture(QtConcurrent::run(task));
+}
+
+void MethodologyDetailDialog::onDeleteClicked() {
+    auto reply = MessageBoxHelper::question(this, tr("Confirm Delete"),
+        tr("Delete methodology '%1'?").arg(ui_->nameEdit->text()),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) return;
+
+    QPointer<MethodologyDetailDialog> self = this;
+    boost::uuids::uuid methodologyId = methodology_.id;
+
+    auto task = [self, methodologyId]() -> bool {
+        if (!self || !self->clientManager_) return false;
+
+        dq::messaging::delete_methodology_request request;
+        request.ids = {methodologyId};
+        auto payload = request.serialize();
+
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::delete_methodology_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return false;
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return false;
+
+        auto response = dq::messaging::delete_methodology_response::deserialize(*payload_result);
+        return response && !response->results.empty() && response->results[0].success;
+    };
+
+    auto* watcher = new QFutureWatcher<bool>(this);
+    connect(watcher, &QFutureWatcher<bool>::finished, this, [self, watcher, methodologyId]() {
+        bool success = watcher->result();
+        watcher->deleteLater();
+
+        if (!self) return;
+
+        if (success) {
+            emit self->statusMessage(tr("Methodology deleted successfully"));
+            emit self->methodologyDeleted(methodologyId);
+            if (auto* parentWidget = self->parentWidget()) {
+                parentWidget->close();
+            }
+        } else {
+            emit self->errorMessage(tr("Failed to delete methodology"));
+        }
+    });
+
+    emit statusMessage(tr("Deleting..."));
+    watcher->setFuture(QtConcurrent::run(task));
+}
+
+}

--- a/projects/ores.qt/src/MethodologyHistoryDialog.cpp
+++ b/projects/ores.qt/src/MethodologyHistoryDialog.cpp
@@ -1,0 +1,259 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/MethodologyHistoryDialog.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include <boost/uuid/uuid_io.hpp>
+#include "ui_MethodologyHistoryDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.dq/messaging/dataset_protocol.hpp"
+#include "ores.comms/messaging/frame.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+MethodologyHistoryDialog::MethodologyHistoryDialog(
+    const boost::uuids::uuid& id, ClientManager* clientManager, QWidget* parent)
+    : QWidget(parent),
+      ui_(new Ui::MethodologyHistoryDialog),
+      id_(id),
+      clientManager_(clientManager),
+      toolbar_(nullptr),
+      openVersionAction_(nullptr),
+      revertAction_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupToolbar();
+    setupConnections();
+}
+
+MethodologyHistoryDialog::~MethodologyHistoryDialog() {
+    delete ui_;
+}
+
+void MethodologyHistoryDialog::setupUi() {
+    ui_->titleLabel->setText(QString("Methodology History"));
+    ui_->versionListWidget->setColumnCount(4);
+    ui_->versionListWidget->setHorizontalHeaderLabels({"Version", "Recorded At", "Recorded By", "Commentary"});
+    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
+    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+    ui_->changesTableWidget->setColumnCount(3);
+    ui_->changesTableWidget->setHorizontalHeaderLabels({"Field", "Old Value", "New Value"});
+    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+}
+
+void MethodologyHistoryDialog::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    const auto& iconColor = color_constants::icon_color;
+
+    openVersionAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_open_20_regular.svg", iconColor), tr("Open"));
+    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
+    openVersionAction_->setEnabled(false);
+
+    revertAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_arrow_rotate_counterclockwise_20_regular.svg", iconColor),
+        tr("Revert"));
+    revertAction_->setToolTip(tr("Revert to this version"));
+    revertAction_->setEnabled(false);
+
+    if (auto* layout = qobject_cast<QVBoxLayout*>(this->layout())) {
+        layout->insertWidget(0, toolbar_);
+    }
+}
+
+void MethodologyHistoryDialog::setupConnections() {
+    connect(ui_->versionListWidget, &QTableWidget::itemSelectionChanged, this, &MethodologyHistoryDialog::onVersionSelected);
+    connect(openVersionAction_, &QAction::triggered, this, &MethodologyHistoryDialog::onOpenVersionClicked);
+    connect(revertAction_, &QAction::triggered, this, &MethodologyHistoryDialog::onRevertClicked);
+}
+
+void MethodologyHistoryDialog::loadHistory() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        emit errorOccurred("Not connected to server");
+        return;
+    }
+
+    emit statusChanged(tr("Loading history..."));
+
+    QPointer<MethodologyHistoryDialog> self = this;
+    struct HistoryResult { bool success; std::string message; std::vector<dq::domain::methodology> versions; };
+
+    auto task = [self, id = id_]() -> HistoryResult {
+        if (!self || !self->clientManager_) return {false, "Dialog closed", {}};
+
+        dq::messaging::get_methodology_history_request request;
+        request.id = id;
+        auto payload = request.serialize();
+
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::get_methodology_history_request, 0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return {false, "Failed to communicate with server", {}};
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return {false, "Failed to decompress response", {}};
+
+        auto response = dq::messaging::get_methodology_history_response::deserialize(*payload_result);
+        if (!response) return {false, "Invalid server response", {}};
+
+        return {response->success, response->message, std::move(response->versions)};
+    };
+
+    auto* watcher = new QFutureWatcher<HistoryResult>(self);
+    connect(watcher, &QFutureWatcher<HistoryResult>::finished, self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            self->versions_ = std::move(result.versions);
+            self->updateVersionList();
+            emit self->statusChanged(QString("Loaded %1 versions").arg(self->versions_.size()));
+        } else {
+            emit self->errorOccurred(QString::fromStdString(result.message));
+        }
+    });
+
+    watcher->setFuture(QtConcurrent::run(task));
+}
+
+void MethodologyHistoryDialog::updateVersionList() {
+    ui_->versionListWidget->setRowCount(0);
+
+    for (const auto& version : versions_) {
+        int row = ui_->versionListWidget->rowCount();
+        ui_->versionListWidget->insertRow(row);
+
+        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
+        versionItem->setTextAlignment(Qt::AlignCenter);
+        ui_->versionListWidget->setItem(row, 0, versionItem);
+        ui_->versionListWidget->setItem(row, 1, new QTableWidgetItem(relative_time_helper::format(version.recorded_at)));
+        ui_->versionListWidget->setItem(row, 2, new QTableWidgetItem(QString::fromStdString(version.recorded_by)));
+        ui_->versionListWidget->setItem(row, 3, new QTableWidgetItem(QString::fromStdString(version.change_commentary)));
+    }
+
+    if (!versions_.empty()) ui_->versionListWidget->selectRow(0);
+}
+
+void MethodologyHistoryDialog::onVersionSelected() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) { updateActionStates(); return; }
+
+    int row = selected.first()->row();
+    updateChangesTable(row);
+    updateFullDetails(row);
+    updateActionStates();
+}
+
+void MethodologyHistoryDialog::updateChangesTable(int currentVersionIndex) {
+    ui_->changesTableWidget->setRowCount(0);
+
+    if (currentVersionIndex < 0 || static_cast<size_t>(currentVersionIndex) >= versions_.size()) return;
+
+    int previousVersionIndex = currentVersionIndex + 1;
+    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(Initial version)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+        return;
+    }
+
+    const auto& current = versions_[currentVersionIndex];
+    const auto& previous = versions_[previousVersionIndex];
+
+    auto addChange = [this](const QString& field, const QString& oldVal, const QString& newVal) {
+        int row = ui_->changesTableWidget->rowCount();
+        ui_->changesTableWidget->insertRow(row);
+        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
+        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
+        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
+    };
+
+    if (current.name != previous.name) addChange("Name", QString::fromStdString(previous.name), QString::fromStdString(current.name));
+    if (current.description != previous.description) addChange("Description", QString::fromStdString(previous.description), QString::fromStdString(current.description));
+    if (current.logic_reference != previous.logic_reference) addChange("Logic Reference", QString::fromStdString(previous.logic_reference.value_or("")), QString::fromStdString(current.logic_reference.value_or("")));
+    if (current.implementation_details != previous.implementation_details) addChange("Implementation", QString::fromStdString(previous.implementation_details.value_or("")), QString::fromStdString(current.implementation_details.value_or("")));
+
+    if (ui_->changesTableWidget->rowCount() == 0) {
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0, new QTableWidgetItem("(No field changes)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+    }
+}
+
+void MethodologyHistoryDialog::updateFullDetails(int versionIndex) {
+    if (versionIndex < 0 || static_cast<size_t>(versionIndex) >= versions_.size()) return;
+
+    const auto& version = versions_[versionIndex];
+    ui_->nameValue->setText(QString::fromStdString(version.name));
+    ui_->descriptionValue->setText(QString::fromStdString(version.description));
+    ui_->logicReferenceValue->setText(QString::fromStdString(version.logic_reference.value_or("")));
+    ui_->implementationValue->setText(QString::fromStdString(version.implementation_details.value_or("")));
+    ui_->versionNumberValue->setText(QString::number(version.version));
+    ui_->recordedByValue->setText(QString::fromStdString(version.recorded_by));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(QString::fromStdString(version.change_commentary));
+}
+
+void MethodologyHistoryDialog::updateActionStates() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    bool hasSelection = !selected.isEmpty();
+    bool isNotLatest = hasSelection && selected.first()->row() > 0;
+
+    openVersionAction_->setEnabled(hasSelection);
+    revertAction_->setEnabled(isNotLatest);
+}
+
+void MethodologyHistoryDialog::onOpenVersionClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit openVersionRequested(versions_[row], versions_[row].version);
+}
+
+void MethodologyHistoryDialog::onRevertClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit revertVersionRequested(versions_[row]);
+}
+
+}

--- a/projects/ores.qt/src/MethodologyMdiWindow.cpp
+++ b/projects/ores.qt/src/MethodologyMdiWindow.cpp
@@ -1,0 +1,281 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/MethodologyMdiWindow.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QSettings>
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.dq/messaging/dataset_protocol.hpp"
+#include "ores.comms/messaging/frame.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+MethodologyMdiWindow::MethodologyMdiWindow(
+    ClientManager* clientManager, const QString& username, QWidget* parent)
+    : QWidget(parent),
+      clientManager_(clientManager),
+      username_(username),
+      model_(new ClientMethodologyModel(clientManager, this)),
+      proxyModel_(new QSortFilterProxyModel(this)),
+      tableView_(new QTableView(this)),
+      toolbar_(nullptr) {
+
+    proxyModel_->setSourceModel(model_);
+    proxyModel_->setSortCaseSensitivity(Qt::CaseInsensitive);
+
+    setupUi();
+    setupToolbar();
+    setupConnections();
+    loadColumnVisibility();
+
+    model_->refresh();
+}
+
+void MethodologyMdiWindow::setupUi() {
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    tableView_->setModel(proxyModel_);
+    tableView_->setSortingEnabled(true);
+    tableView_->setSelectionBehavior(QAbstractItemView::SelectRows);
+    tableView_->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    tableView_->setAlternatingRowColors(true);
+    tableView_->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    tableView_->horizontalHeader()->setStretchLastSection(true);
+    tableView_->verticalHeader()->setVisible(false);
+    tableView_->sortByColumn(ClientMethodologyModel::Name, Qt::AscendingOrder);
+
+    layout->addWidget(tableView_);
+}
+
+void MethodologyMdiWindow::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    const auto& iconColor = color_constants::icon_color;
+
+    addAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_add_20_regular.svg", iconColor),
+        tr("Add"));
+    addAction_->setToolTip(tr("Add new methodology"));
+
+    editAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_edit_20_regular.svg", iconColor),
+        tr("Edit"));
+    editAction_->setToolTip(tr("Edit selected methodology"));
+    editAction_->setEnabled(false);
+
+    deleteAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_delete_20_regular.svg", iconColor),
+        tr("Delete"));
+    deleteAction_->setToolTip(tr("Delete selected methodology(s)"));
+    deleteAction_->setEnabled(false);
+
+    toolbar_->addSeparator();
+
+    historyAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_history_20_regular.svg", iconColor),
+        tr("History"));
+    historyAction_->setToolTip(tr("View version history"));
+    historyAction_->setEnabled(false);
+
+    toolbar_->addSeparator();
+
+    refreshAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(":/icons/ic_fluent_arrow_sync_20_regular.svg", iconColor),
+        tr("Refresh"));
+    refreshAction_->setToolTip(tr("Refresh methodologies"));
+
+    if (auto* layout = qobject_cast<QVBoxLayout*>(this->layout())) {
+        layout->insertWidget(0, toolbar_);
+    }
+}
+
+void MethodologyMdiWindow::setupConnections() {
+    connect(model_, &ClientMethodologyModel::dataLoaded,
+            this, &MethodologyMdiWindow::onDataLoaded);
+    connect(model_, &ClientMethodologyModel::loadError,
+            this, &MethodologyMdiWindow::onLoadError);
+    connect(tableView_, &QTableView::doubleClicked,
+            this, &MethodologyMdiWindow::onRowDoubleClicked);
+    connect(tableView_->selectionModel(), &QItemSelectionModel::selectionChanged,
+            this, &MethodologyMdiWindow::onSelectionChanged);
+
+    connect(addAction_, &QAction::triggered, this, &MethodologyMdiWindow::onAddClicked);
+    connect(editAction_, &QAction::triggered, this, &MethodologyMdiWindow::onEditClicked);
+    connect(deleteAction_, &QAction::triggered, this, &MethodologyMdiWindow::onDeleteClicked);
+    connect(refreshAction_, &QAction::triggered, this, &MethodologyMdiWindow::onRefreshClicked);
+    connect(historyAction_, &QAction::triggered, this, &MethodologyMdiWindow::onHistoryClicked);
+}
+
+void MethodologyMdiWindow::onDataLoaded() {
+    emit statusChanged(tr("Loaded %1 methodologies").arg(model_->rowCount()));
+    updateActionStates();
+}
+
+void MethodologyMdiWindow::onLoadError(const QString& error_message) {
+    emit errorOccurred(error_message);
+}
+
+void MethodologyMdiWindow::onRowDoubleClicked(const QModelIndex& index) {
+    auto sourceIndex = proxyModel_->mapToSource(index);
+    if (auto* methodology = model_->getMethodology(sourceIndex.row())) {
+        emit showMethodologyDetails(*methodology);
+    }
+}
+
+void MethodologyMdiWindow::onAddClicked() {
+    emit addNewRequested();
+}
+
+void MethodologyMdiWindow::onEditClicked() {
+    auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) return;
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* methodology = model_->getMethodology(sourceIndex.row())) {
+        emit showMethodologyDetails(*methodology);
+    }
+}
+
+void MethodologyMdiWindow::onDeleteClicked() {
+    auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) return;
+
+    std::vector<boost::uuids::uuid> ids;
+    for (const auto& index : selected) {
+        auto sourceIndex = proxyModel_->mapToSource(index);
+        if (auto* methodology = model_->getMethodology(sourceIndex.row())) {
+            ids.push_back(methodology->id);
+        }
+    }
+
+    QString message = ids.size() == 1
+        ? tr("Delete selected methodology?")
+        : tr("Delete %1 methodologies?").arg(ids.size());
+
+    auto reply = MessageBoxHelper::question(this, tr("Confirm Delete"), message,
+                                            QMessageBox::Yes | QMessageBox::No);
+    if (reply != QMessageBox::Yes) return;
+
+    QPointer<MethodologyMdiWindow> self = this;
+    auto task = [self, ids = std::move(ids)]() -> bool {
+        if (!self || !self->clientManager_) return false;
+
+        dq::messaging::delete_methodology_request request;
+        request.ids = ids;
+        auto payload = request.serialize();
+
+        comms::messaging::frame request_frame(
+            comms::messaging::message_type::delete_methodology_request,
+            0, std::move(payload));
+
+        auto response_result = self->clientManager_->sendRequest(std::move(request_frame));
+        if (!response_result) return false;
+
+        auto payload_result = response_result->decompressed_payload();
+        if (!payload_result) return false;
+
+        auto response = dq::messaging::delete_methodology_response::deserialize(*payload_result);
+        return response && !response->results.empty() && response->results[0].success;
+    };
+
+    auto* watcher = new QFutureWatcher<bool>(this);
+    connect(watcher, &QFutureWatcher<bool>::finished, this, [self, watcher]() {
+        bool success = watcher->result();
+        watcher->deleteLater();
+
+        if (self) {
+            if (success) {
+                emit self->statusChanged(tr("Methodology(s) deleted successfully"));
+                self->reload();
+            } else {
+                emit self->errorOccurred(tr("Failed to delete methodology(s)"));
+            }
+        }
+    });
+
+    watcher->setFuture(QtConcurrent::run(task));
+}
+
+void MethodologyMdiWindow::onRefreshClicked() {
+    emit statusChanged(tr("Refreshing..."));
+    model_->refresh();
+}
+
+void MethodologyMdiWindow::onSelectionChanged() {
+    updateActionStates();
+}
+
+void MethodologyMdiWindow::onHistoryClicked() {
+    auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) return;
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* methodology = model_->getMethodology(sourceIndex.row())) {
+        emit showMethodologyHistory(methodology->id);
+    }
+}
+
+void MethodologyMdiWindow::updateActionStates() {
+    auto selected = tableView_->selectionModel()->selectedRows();
+    bool hasSelection = !selected.isEmpty();
+    bool singleSelection = selected.size() == 1;
+
+    editAction_->setEnabled(singleSelection);
+    deleteAction_->setEnabled(hasSelection);
+    historyAction_->setEnabled(singleSelection);
+}
+
+void MethodologyMdiWindow::reload() {
+    model_->refresh();
+}
+
+void MethodologyMdiWindow::saveColumnVisibility() {
+    QSettings settings;
+    settings.beginGroup("MethodologyMdiWindow");
+    for (int i = 0; i < model_->columnCount(); ++i) {
+        settings.setValue(QString("column_%1_visible").arg(i),
+                          !tableView_->isColumnHidden(i));
+    }
+    settings.endGroup();
+}
+
+void MethodologyMdiWindow::loadColumnVisibility() {
+    QSettings settings;
+    settings.beginGroup("MethodologyMdiWindow");
+    for (int i = 0; i < model_->columnCount(); ++i) {
+        bool visible = settings.value(QString("column_%1_visible").arg(i), true).toBool();
+        tableView_->setColumnHidden(i, !visible);
+    }
+    settings.endGroup();
+}
+
+}

--- a/projects/ores.qt/ui/CodingSchemeDetailDialog.ui
+++ b/projects/ores.qt/ui/CodingSchemeDetailDialog.ui
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CodingSchemeDetailDialog</class>
+ <widget class="QWidget" name="CodingSchemeDetailDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>500</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Coding Scheme</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Coding Scheme Details</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="codeLabel">
+       <property name="text">
+        <string>Code:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="codeEdit">
+       <property name="maxLength">
+        <number>100</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="nameLabel">
+       <property name="text">
+        <string>Name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="nameEdit">
+       <property name="maxLength">
+        <number>255</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="authorityTypeLabel">
+       <property name="text">
+        <string>Authority Type:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="authorityTypeCombo"/>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="subjectAreaLabel">
+       <property name="text">
+        <string>Subject Area:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QComboBox" name="subjectAreaCombo"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="domainLabel">
+       <property name="text">
+        <string>Domain:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QComboBox" name="domainCombo"/>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="uriLabel">
+       <property name="text">
+        <string>URI:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QLineEdit" name="uriEdit">
+       <property name="maxLength">
+        <number>500</number>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="descriptionLabel">
+       <property name="text">
+        <string>Description:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QPlainTextEdit" name="descriptionEdit">
+       <property name="maximumHeight">
+        <number>80</number>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="commentaryLabel">
+       <property name="text">
+        <string>Change Commentary:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QPlainTextEdit" name="commentaryEdit">
+       <property name="maximumHeight">
+        <number>80</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="deleteButton">
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveButton">
+       <property name="text">
+        <string>Save</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt/ui/CodingSchemeHistoryDialog.ui
+++ b/projects/ores.qt/ui/CodingSchemeHistoryDialog.ui
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CodingSchemeHistoryDialog</class>
+ <widget class="QWidget" name="CodingSchemeHistoryDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>900</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Coding Scheme History</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Coding Scheme History</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QTableWidget" name="versionListWidget">
+      <property name="minimumHeight">
+       <number>150</number>
+      </property>
+      <property name="maximumHeight">
+       <number>250</number>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="editTriggers">
+       <set>QAbstractItemView::NoEditTriggers</set>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+     </widget>
+     <widget class="QWidget" name="detailWidget">
+      <layout class="QVBoxLayout" name="detailLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTabWidget" name="tabWidget">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="changesTab">
+          <attribute name="title">
+           <string>Changes</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="changesTabLayout">
+           <item>
+            <widget class="QTableWidget" name="changesTableWidget">
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="alternatingRowColors">
+              <bool>true</bool>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::SingleSelection</enum>
+             </property>
+             <property name="selectionBehavior">
+              <enum>QAbstractItemView::SelectRows</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="fullDetailsTab">
+          <attribute name="title">
+           <string>Full Details</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="fullDetailsTabLayout">
+           <item>
+            <widget class="QScrollArea" name="scrollArea">
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents">
+              <layout class="QFormLayout" name="formLayout">
+               <item row="0" column="0">
+                <widget class="QLabel" name="codeLabel">
+                 <property name="text">
+                  <string>Code:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="codeValue"/>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="nameLabel">
+                 <property name="text">
+                  <string>Name:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="nameValue"/>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="authorityTypeLabel">
+                 <property name="text">
+                  <string>Authority Type:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLabel" name="authorityTypeValue"/>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="subjectAreaLabel">
+                 <property name="text">
+                  <string>Subject Area:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="subjectAreaValue"/>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="domainLabel">
+                 <property name="text">
+                  <string>Domain:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLabel" name="domainValue"/>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="uriLabel">
+                 <property name="text">
+                  <string>URI:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QLabel" name="uriValue">
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="descriptionLabel">
+                 <property name="text">
+                  <string>Description:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QLabel" name="descriptionValue">
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="versionNumberLabel">
+                 <property name="text">
+                  <string>Version:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QLabel" name="versionNumberValue"/>
+               </item>
+               <item row="8" column="0">
+                <widget class="QLabel" name="recordedByLabel">
+                 <property name="text">
+                  <string>Recorded By:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QLabel" name="recordedByValue"/>
+               </item>
+               <item row="9" column="0">
+                <widget class="QLabel" name="recordedAtLabel">
+                 <property name="text">
+                  <string>Recorded At:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QLabel" name="recordedAtValue"/>
+               </item>
+               <item row="10" column="0">
+                <widget class="QLabel" name="changeCommentaryLabel">
+                 <property name="text">
+                  <string>Change Commentary:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="1">
+                <widget class="QLabel" name="changeCommentaryValue">
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt/ui/DatasetDetailDialog.ui
+++ b/projects/ores.qt/ui/DatasetDetailDialog.ui
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DatasetDetailDialog</class>
+ <widget class="QWidget" name="DatasetDetailDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>700</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dataset</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Dataset Details</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <layout class="QFormLayout" name="formLayout">
+       <item row="0" column="0">
+        <widget class="QLabel" name="nameLabel">
+         <property name="text">
+          <string>Name:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="nameEdit">
+         <property name="maxLength">
+          <number>255</number>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="catalogLabel">
+         <property name="text">
+          <string>Catalog:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="catalogCombo"/>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="subjectAreaLabel">
+         <property name="text">
+          <string>Subject Area:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="subjectAreaCombo"/>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="domainLabel">
+         <property name="text">
+          <string>Domain:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QComboBox" name="domainCombo"/>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="originLabel">
+         <property name="text">
+          <string>Origin:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QComboBox" name="originCombo"/>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="natureLabel">
+         <property name="text">
+          <string>Nature:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QComboBox" name="natureCombo"/>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="treatmentLabel">
+         <property name="text">
+          <string>Treatment:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QComboBox" name="treatmentCombo"/>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="codingSchemeLabel">
+         <property name="text">
+          <string>Coding Scheme:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <widget class="QComboBox" name="codingSchemeCombo"/>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="methodologyLabel">
+         <property name="text">
+          <string>Methodology:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="QComboBox" name="methodologyCombo"/>
+       </item>
+       <item row="9" column="0">
+        <widget class="QLabel" name="sourceSystemLabel">
+         <property name="text">
+          <string>Source System:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="QLineEdit" name="sourceSystemEdit">
+         <property name="maxLength">
+          <number>255</number>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0">
+        <widget class="QLabel" name="asOfDateLabel">
+         <property name="text">
+          <string>As Of Date:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1">
+        <widget class="QDateEdit" name="asOfDateEdit">
+         <property name="calendarPopup">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
+        <widget class="QLabel" name="lineageDepthLabel">
+         <property name="text">
+          <string>Lineage Depth:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1">
+        <widget class="QSpinBox" name="lineageDepthSpin">
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>100</number>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="0">
+        <widget class="QLabel" name="descriptionLabel">
+         <property name="text">
+          <string>Description:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="1">
+        <widget class="QPlainTextEdit" name="descriptionEdit">
+         <property name="maximumHeight">
+          <number>60</number>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="0">
+        <widget class="QLabel" name="businessContextLabel">
+         <property name="text">
+          <string>Business Context:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="1">
+        <widget class="QPlainTextEdit" name="businessContextEdit">
+         <property name="maximumHeight">
+          <number>60</number>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="0">
+        <widget class="QLabel" name="licenseLabel">
+         <property name="text">
+          <string>License Info:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="1">
+        <widget class="QLineEdit" name="licenseEdit">
+         <property name="maxLength">
+          <number>255</number>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="0">
+        <widget class="QLabel" name="commentaryLabel">
+         <property name="text">
+          <string>Change Commentary:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="1">
+        <widget class="QPlainTextEdit" name="commentaryEdit">
+         <property name="maximumHeight">
+          <number>60</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="deleteButton">
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveButton">
+       <property name="text">
+        <string>Save</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt/ui/DatasetHistoryDialog.ui
+++ b/projects/ores.qt/ui/DatasetHistoryDialog.ui
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DatasetHistoryDialog</class>
+ <widget class="QWidget" name="DatasetHistoryDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>900</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dataset History</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Dataset History</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QTableWidget" name="versionListWidget">
+      <property name="minimumHeight">
+       <number>150</number>
+      </property>
+      <property name="maximumHeight">
+       <number>250</number>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="editTriggers">
+       <set>QAbstractItemView::NoEditTriggers</set>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+     </widget>
+     <widget class="QWidget" name="detailWidget">
+      <layout class="QVBoxLayout" name="detailLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTabWidget" name="tabWidget">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="changesTab">
+          <attribute name="title">
+           <string>Changes</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="changesTabLayout">
+           <item>
+            <widget class="QTableWidget" name="changesTableWidget">
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="alternatingRowColors">
+              <bool>true</bool>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::SingleSelection</enum>
+             </property>
+             <property name="selectionBehavior">
+              <enum>QAbstractItemView::SelectRows</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="fullDetailsTab">
+          <attribute name="title">
+           <string>Full Details</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="fullDetailsTabLayout">
+           <item>
+            <widget class="QScrollArea" name="scrollArea">
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents">
+              <layout class="QFormLayout" name="formLayout">
+               <item row="0" column="0">
+                <widget class="QLabel" name="nameLabel">
+                 <property name="text">
+                  <string>Name:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="nameValue"/>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="catalogLabel">
+                 <property name="text">
+                  <string>Catalog:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="catalogValue"/>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="subjectAreaLabel">
+                 <property name="text">
+                  <string>Subject Area:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLabel" name="subjectAreaValue"/>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="domainLabel">
+                 <property name="text">
+                  <string>Domain:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="domainValue"/>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="sourceSystemLabel">
+                 <property name="text">
+                  <string>Source System:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLabel" name="sourceSystemValue"/>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="descriptionLabel">
+                 <property name="text">
+                  <string>Description:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QLabel" name="descriptionValue">
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="versionNumberLabel">
+                 <property name="text">
+                  <string>Version:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QLabel" name="versionNumberValue"/>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="recordedByLabel">
+                 <property name="text">
+                  <string>Recorded By:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QLabel" name="recordedByValue"/>
+               </item>
+               <item row="8" column="0">
+                <widget class="QLabel" name="recordedAtLabel">
+                 <property name="text">
+                  <string>Recorded At:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QLabel" name="recordedAtValue"/>
+               </item>
+               <item row="9" column="0">
+                <widget class="QLabel" name="changeCommentaryLabel">
+                 <property name="text">
+                  <string>Change Commentary:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QLabel" name="changeCommentaryValue">
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt/ui/MainWindow.ui
+++ b/projects/ores.qt/ui/MainWindow.ui
@@ -70,9 +70,13 @@
     <addaction name="ActionTreatmentDimensions"/>
     <addaction name="separator"/>
     <addaction name="ActionCodingSchemeAuthorityTypes"/>
+    <addaction name="ActionCodingSchemes"/>
+    <addaction name="ActionMethodologies"/>
+    <addaction name="separator"/>
     <addaction name="ActionDataDomains"/>
     <addaction name="ActionSubjectAreas"/>
     <addaction name="ActionCatalogs"/>
+    <addaction name="ActionDatasets"/>
    </widget>
    <widget class="QMenu" name="menuWindow">
     <property name="title">
@@ -447,6 +451,42 @@
    </property>
    <property name="toolTip">
     <string>Manage catalogs for organizing datasets</string>
+   </property>
+  </action>
+  <action name="ActionCodingSchemes">
+   <property name="icon">
+    <iconset>
+     <normaloff>:/icons/ic_fluent_code_20_regular.svg</normaloff>:/icons/ic_fluent_code_20_regular.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Codin&amp;g Schemes</string>
+   </property>
+   <property name="toolTip">
+    <string>Manage coding schemes (LEI, ISIN, etc.)</string>
+   </property>
+  </action>
+  <action name="ActionMethodologies">
+   <property name="icon">
+    <iconset>
+     <normaloff>:/icons/ic_fluent_book_20_regular.svg</normaloff>:/icons/ic_fluent_book_20_regular.svg</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Methodologies</string>
+   </property>
+   <property name="toolTip">
+    <string>Manage data processing methodologies</string>
+   </property>
+  </action>
+  <action name="ActionDatasets">
+   <property name="icon">
+    <iconset>
+     <normaloff>:/icons/ic_fluent_database_20_regular.svg</normaloff>:/icons/ic_fluent_database_20_regular.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Da&amp;tasets</string>
+   </property>
+   <property name="toolTip">
+    <string>Manage datasets with data quality metadata</string>
    </property>
   </action>
  </widget>

--- a/projects/ores.qt/ui/MethodologyDetailDialog.ui
+++ b/projects/ores.qt/ui/MethodologyDetailDialog.ui
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MethodologyDetailDialog</class>
+ <widget class="QWidget" name="MethodologyDetailDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>450</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Methodology</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Methodology Details</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="nameLabel">
+       <property name="text">
+        <string>Name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="nameEdit">
+       <property name="maxLength">
+        <number>255</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="descriptionLabel">
+       <property name="text">
+        <string>Description:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QPlainTextEdit" name="descriptionEdit">
+       <property name="maximumHeight">
+        <number>80</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="logicReferenceLabel">
+       <property name="text">
+        <string>Logic Reference:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="logicReferenceEdit">
+       <property name="maxLength">
+        <number>500</number>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="implementationLabel">
+       <property name="text">
+        <string>Implementation:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QPlainTextEdit" name="implementationEdit">
+       <property name="maximumHeight">
+        <number>80</number>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="commentaryLabel">
+       <property name="text">
+        <string>Change Commentary:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QPlainTextEdit" name="commentaryEdit">
+       <property name="maximumHeight">
+        <number>80</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="deleteButton">
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveButton">
+       <property name="text">
+        <string>Save</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt/ui/MethodologyHistoryDialog.ui
+++ b/projects/ores.qt/ui/MethodologyHistoryDialog.ui
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MethodologyHistoryDialog</class>
+ <widget class="QWidget" name="MethodologyHistoryDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>900</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Methodology History</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Methodology History</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QTableWidget" name="versionListWidget">
+      <property name="minimumHeight">
+       <number>150</number>
+      </property>
+      <property name="maximumHeight">
+       <number>250</number>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="editTriggers">
+       <set>QAbstractItemView::NoEditTriggers</set>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+     </widget>
+     <widget class="QWidget" name="detailWidget">
+      <layout class="QVBoxLayout" name="detailLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTabWidget" name="tabWidget">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="changesTab">
+          <attribute name="title">
+           <string>Changes</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="changesTabLayout">
+           <item>
+            <widget class="QTableWidget" name="changesTableWidget">
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="alternatingRowColors">
+              <bool>true</bool>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::SingleSelection</enum>
+             </property>
+             <property name="selectionBehavior">
+              <enum>QAbstractItemView::SelectRows</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="fullDetailsTab">
+          <attribute name="title">
+           <string>Full Details</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="fullDetailsTabLayout">
+           <item>
+            <widget class="QScrollArea" name="scrollArea">
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents">
+              <layout class="QFormLayout" name="formLayout">
+               <item row="0" column="0">
+                <widget class="QLabel" name="nameLabel">
+                 <property name="text">
+                  <string>Name:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="nameValue"/>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="descriptionLabel">
+                 <property name="text">
+                  <string>Description:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="descriptionValue">
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="logicReferenceLabel">
+                 <property name="text">
+                  <string>Logic Reference:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLabel" name="logicReferenceValue">
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="implementationLabel">
+                 <property name="text">
+                  <string>Implementation:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="implementationValue">
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="versionNumberLabel">
+                 <property name="text">
+                  <string>Version:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLabel" name="versionNumberValue"/>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="recordedByLabel">
+                 <property name="text">
+                  <string>Recorded By:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QLabel" name="recordedByValue"/>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="recordedAtLabel">
+                 <property name="text">
+                  <string>Recorded At:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QLabel" name="recordedAtValue"/>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="changeCommentaryLabel">
+                 <property name="text">
+                  <string>Change Commentary:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QLabel" name="changeCommentaryValue">
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This commit adds full Qt UI support for three new DQ entities:

CodingScheme:
- ClientCodingSchemeModel for async data fetching via QAbstractTableModel
- CodingSchemeMdiWindow for list display with toolbar actions
- CodingSchemeDetailDialog for create/edit with lookup combos
- CodingSchemeHistoryDialog for version history with diff view
- CodingSchemeController for window management and signal routing

Methodology:
- ClientMethodologyModel for async data fetching
- MethodologyMdiWindow for list display
- MethodologyDetailDialog for create/edit
- MethodologyHistoryDialog for version history
- MethodologyController for window management

Dataset:
- ClientDatasetModel for async data fetching
- DatasetMdiWindow for list display
- DatasetDetailDialog with many lookup combos for foreign keys
- DatasetHistoryDialog for version history
- DatasetController for window management

MainWindow integration:
- Added menu actions in Data Quality menu
- Created controllers with signal/slot connections
- Enabled actions based on connection state
- Username propagation on login