### PR TITLE
[qt] Fix dangling pointer crashes in window management

### DIFF
--- a/projects/ores.qt/src/MainWindow.cpp
+++ b/projects/ores.qt/src/MainWindow.cpp
@@ -208,6 +208,7 @@ MainWindow::MainWindow(QWidget* parent) :
 
         // Track window destruction
         connect(eventViewerWindow_, &QObject::destroyed, this, [this]() {
+            allDetachableWindows_.removeOne(eventViewerWindow_);
             eventViewerWindow_ = nullptr;
         });
 
@@ -243,6 +244,7 @@ MainWindow::MainWindow(QWidget* parent) :
 
         // Track window destruction
         connect(telemetryViewerWindow_, &QObject::destroyed, this, [this]() {
+            allDetachableWindows_.removeOne(telemetryViewerWindow_);
             telemetryViewerWindow_ = nullptr;
         });
 
@@ -1239,6 +1241,8 @@ void MainWindow::onWindowMenuAboutToShow() {
     } else {
         for (int i = 0; i < allDetachableWindows_.size(); ++i) {
             auto* detachableWindow = allDetachableWindows_[i];
+            if (!detachableWindow)
+                continue;
             QString windowTitle = detachableWindow->windowTitle();
             if (windowTitle.isEmpty()) {
                 windowTitle = QString("Window %1").arg(i + 1);


### PR DESCRIPTION
## Summary
- Fixed two SIGSEGV crashes caused by dangling pointers in `allDetachableWindows_`
- `eventViewerWindow_` and `telemetryViewerWindow_` were added to the list but their `destroyed` handlers didn't remove them
- Added defensive null check in `onWindowMenuAboutToShow()` menu building loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)