### PR TITLE
[ore] Add /bigobj flag for MSVC builds

### DIFF
--- a/projects/ores.ore/src/CMakeLists.txt
+++ b/projects/ores.ore/src/CMakeLists.txt
@@ -32,7 +32,7 @@ set_target_properties(${lib_target_name}
     PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 
 if(MSVC)
-    target_compile_options(${lib_target_name} PRIVATE /bigobj)
+    target_compile_options(${lib_target_name} PUBLIC /bigobj)
 endif()
 
 target_include_directories(${lib_target_name} PUBLIC


### PR DESCRIPTION
## Summary
- Fix Windows MSVC build failure (C1128 error) when compiling `domain_xsd.hpp`
- Add `/bigobj` compiler option to `ores.ore` target for MSVC builds
- This increases the section limit for large object files generated from heavy template usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)