### PR TITLE
[refdata] Add C++ domain layer for business units, portfolios, and books

### DIFF
--- a/projects/ores.comms/include/ores.comms/messaging/message_type.hpp
+++ b/projects/ores.comms/include/ores.comms/messaging/message_type.hpp
@@ -168,6 +168,33 @@ enum class message_type : std::uint16_t {
     delete_business_centre_response = 0x1066,
     get_business_centre_history_request = 0x1067,
     get_business_centre_history_response = 0x1068,
+    // Refdata subsystem - Business units
+    get_business_units_request = 0x1069,
+    get_business_units_response = 0x106A,
+    save_business_unit_request = 0x106B,
+    save_business_unit_response = 0x106C,
+    delete_business_unit_request = 0x106D,
+    delete_business_unit_response = 0x106E,
+    get_business_unit_history_request = 0x106F,
+    get_business_unit_history_response = 0x1070,
+    // Refdata subsystem - Portfolios
+    get_portfolios_request = 0x1071,
+    get_portfolios_response = 0x1072,
+    save_portfolio_request = 0x1073,
+    save_portfolio_response = 0x1074,
+    delete_portfolio_request = 0x1075,
+    delete_portfolio_response = 0x1076,
+    get_portfolio_history_request = 0x1077,
+    get_portfolio_history_response = 0x1078,
+    // Refdata subsystem - Books
+    get_books_request = 0x1079,
+    get_books_response = 0x107A,
+    save_book_request = 0x107B,
+    save_book_response = 0x107C,
+    delete_book_request = 0x107D,
+    delete_book_response = 0x107E,
+    get_book_history_request = 0x107F,
+    get_book_history_response = 0x1080,
     // IAM subsystem - Accounts
     get_accounts_request = 0x2003,
     get_accounts_response = 0x2004,
@@ -568,6 +595,30 @@ enum class message_type : std::uint16_t {
     case message_type::delete_business_centre_response: return "delete_business_centre_response";
     case message_type::get_business_centre_history_request: return "get_business_centre_history_request";
     case message_type::get_business_centre_history_response: return "get_business_centre_history_response";
+    case message_type::get_business_units_request: return "get_business_units_request";
+    case message_type::get_business_units_response: return "get_business_units_response";
+    case message_type::save_business_unit_request: return "save_business_unit_request";
+    case message_type::save_business_unit_response: return "save_business_unit_response";
+    case message_type::delete_business_unit_request: return "delete_business_unit_request";
+    case message_type::delete_business_unit_response: return "delete_business_unit_response";
+    case message_type::get_business_unit_history_request: return "get_business_unit_history_request";
+    case message_type::get_business_unit_history_response: return "get_business_unit_history_response";
+    case message_type::get_portfolios_request: return "get_portfolios_request";
+    case message_type::get_portfolios_response: return "get_portfolios_response";
+    case message_type::save_portfolio_request: return "save_portfolio_request";
+    case message_type::save_portfolio_response: return "save_portfolio_response";
+    case message_type::delete_portfolio_request: return "delete_portfolio_request";
+    case message_type::delete_portfolio_response: return "delete_portfolio_response";
+    case message_type::get_portfolio_history_request: return "get_portfolio_history_request";
+    case message_type::get_portfolio_history_response: return "get_portfolio_history_response";
+    case message_type::get_books_request: return "get_books_request";
+    case message_type::get_books_response: return "get_books_response";
+    case message_type::save_book_request: return "save_book_request";
+    case message_type::save_book_response: return "save_book_response";
+    case message_type::delete_book_request: return "delete_book_request";
+    case message_type::delete_book_response: return "delete_book_response";
+    case message_type::get_book_history_request: return "get_book_history_request";
+    case message_type::get_book_history_response: return "get_book_history_response";
     case message_type::get_accounts_request: return "get_accounts_request";
     case message_type::get_accounts_response: return "get_accounts_response";
     case message_type::login_request: return "login_request";

--- a/projects/ores.refdata/include/ores.refdata/domain/book.hpp
+++ b/projects/ores.refdata/include/ores.refdata/domain/book.hpp
@@ -1,0 +1,140 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_BOOK_HPP
+#define ORES_REFDATA_DOMAIN_BOOK_HPP
+
+#include <chrono>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Operational ledger leaf that holds trades.
+ *
+ * Operational ledger leaves. The only entity that holds trades.
+ * Serves as the basis for accounting, ownership, and regulatory
+ * capital treatment. Must belong to exactly one portfolio.
+ */
+struct book final {
+    /**
+     * @brief Version number for optimistic locking and change tracking.
+     */
+    int version = 0;
+
+    /**
+     * @brief Tenant identifier for multi-tenancy isolation.
+     */
+    std::string tenant_id;
+
+    /**
+     * @brief UUID uniquely identifying this book.
+     *
+     * Surrogate key for the book record.
+     */
+    boost::uuids::uuid id;
+
+    /**
+     * @brief Party that owns this book.
+     *
+     * References the parties table.
+     */
+    boost::uuids::uuid party_id;
+
+    /**
+     * @brief Book name, unique within party.
+     *
+     * e.g., 'FXO_EUR_VOL_01'.
+     */
+    std::string name;
+
+    /**
+     * @brief Links to exactly one portfolio.
+     *
+     * Mandatory: Every book must belong to a portfolio.
+     */
+    boost::uuids::uuid parent_portfolio_id;
+
+    /**
+     * @brief Functional/accounting currency.
+     *
+     * ISO 4217 currency code.
+     */
+    std::string ledger_ccy;
+
+    /**
+     * @brief Reference to external General Ledger.
+     *
+     * e.g., 'GL-10150-FXO'. Nullable if not integrated.
+     */
+    std::string gl_account_ref;
+
+    /**
+     * @brief Internal finance code for P&L attribution.
+     *
+     * Links to cost center in finance system.
+     */
+    std::string cost_center;
+
+    /**
+     * @brief Lifecycle status of the book.
+     *
+     * References book_statuses lookup (Active, Closed, Frozen).
+     */
+    std::string book_status;
+
+    /**
+     * @brief Basel III/IV classification.
+     *
+     * 1 = Trading Book, 0 = Banking Book.
+     */
+    int is_trading_book;
+
+    /**
+     * @brief Username of the person who last modified this book.
+     */
+    std::string modified_by;
+
+    /**
+     * @brief Username of the account that performed this action.
+     */
+    std::string performed_by;
+
+    /**
+     * @brief Code identifying the reason for the change.
+     *
+     * References change_reasons table (soft FK).
+     */
+    std::string change_reason_code;
+
+    /**
+     * @brief Free-text commentary explaining the change.
+     */
+    std::string change_commentary;
+
+    /**
+     * @brief Timestamp when this version of the record was recorded.
+     */
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/domain/book_json_io.hpp
+++ b/projects/ores.refdata/include/ores.refdata/domain/book_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_BOOK_JSON_IO_HPP
+#define ORES_REFDATA_DOMAIN_BOOK_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.refdata/domain/book.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the book to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const book& v);
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/domain/book_table.hpp
+++ b/projects/ores.refdata/include/ores.refdata/domain/book_table.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_BOOK_TABLE_HPP
+#define ORES_REFDATA_DOMAIN_BOOK_TABLE_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata/domain/book.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Converts books to the table format.
+ */
+std::string convert_to_table(const std::vector<book>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/domain/book_table_io.hpp
+++ b/projects/ores.refdata/include/ores.refdata/domain/book_table_io.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_BOOK_TABLE_IO_HPP
+#define ORES_REFDATA_DOMAIN_BOOK_TABLE_IO_HPP
+
+#include <iosfwd>
+#include <vector>
+#include "ores.refdata/domain/book.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the book objects to a stream in table format.
+ */
+std::ostream& operator<<(std::ostream& s, const std::vector<book>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/domain/business_unit.hpp
+++ b/projects/ores.refdata/include/ores.refdata/domain/business_unit.hpp
@@ -1,0 +1,120 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_BUSINESS_UNIT_HPP
+#define ORES_REFDATA_DOMAIN_BUSINESS_UNIT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Internal organizational unit within a party.
+ *
+ * Represents internal organizational units (e.g., desks, departments, branches).
+ * Supports hierarchical structure via self-referencing parent_business_unit_id.
+ * Each unit belongs to a top-level legal entity (party).
+ */
+struct business_unit final {
+    /**
+     * @brief Version number for optimistic locking and change tracking.
+     */
+    int version = 0;
+
+    /**
+     * @brief Tenant identifier for multi-tenancy isolation.
+     */
+    std::string tenant_id;
+
+    /**
+     * @brief UUID uniquely identifying this business unit.
+     *
+     * Surrogate key for the business unit record.
+     */
+    boost::uuids::uuid id;
+
+    /**
+     * @brief Top-level legal entity this unit belongs to.
+     *
+     * References the parent party record.
+     */
+    boost::uuids::uuid party_id;
+
+    /**
+     * @brief Human-readable name for the business unit.
+     *
+     * e.g., 'FX Options Desk', 'London Branch'.
+     */
+    std::string unit_name;
+
+    /**
+     * @brief Self-referencing parent unit for hierarchy.
+     *
+     * NULL indicates a top-level unit.
+     */
+    std::optional<boost::uuids::uuid> parent_business_unit_id;
+
+    /**
+     * @brief Optional internal code or alias.
+     *
+     * Short identifier for the business unit.
+     */
+    std::string unit_code;
+
+    /**
+     * @brief Business centre for the unit.
+     *
+     * References the business centres scheme. May be null for global units.
+     */
+    std::string business_centre_code;
+
+    /**
+     * @brief Username of the person who last modified this business unit.
+     */
+    std::string modified_by;
+
+    /**
+     * @brief Username of the account that performed this action.
+     */
+    std::string performed_by;
+
+    /**
+     * @brief Code identifying the reason for the change.
+     *
+     * References change_reasons table (soft FK).
+     */
+    std::string change_reason_code;
+
+    /**
+     * @brief Free-text commentary explaining the change.
+     */
+    std::string change_commentary;
+
+    /**
+     * @brief Timestamp when this version of the record was recorded.
+     */
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/domain/business_unit_json_io.hpp
+++ b/projects/ores.refdata/include/ores.refdata/domain/business_unit_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_BUSINESS_UNIT_JSON_IO_HPP
+#define ORES_REFDATA_DOMAIN_BUSINESS_UNIT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.refdata/domain/business_unit.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the business_unit to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const business_unit& v);
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/domain/business_unit_table.hpp
+++ b/projects/ores.refdata/include/ores.refdata/domain/business_unit_table.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_BUSINESS_UNIT_TABLE_HPP
+#define ORES_REFDATA_DOMAIN_BUSINESS_UNIT_TABLE_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata/domain/business_unit.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Converts business_units to the table format.
+ */
+std::string convert_to_table(const std::vector<business_unit>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/domain/business_unit_table_io.hpp
+++ b/projects/ores.refdata/include/ores.refdata/domain/business_unit_table_io.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_BUSINESS_UNIT_TABLE_IO_HPP
+#define ORES_REFDATA_DOMAIN_BUSINESS_UNIT_TABLE_IO_HPP
+
+#include <iosfwd>
+#include <vector>
+#include "ores.refdata/domain/business_unit.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the business_unit objects to a stream in table format.
+ */
+std::ostream& operator<<(std::ostream& s, const std::vector<business_unit>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/domain/portfolio.hpp
+++ b/projects/ores.refdata/include/ores.refdata/domain/portfolio.hpp
@@ -1,0 +1,127 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_PORTFOLIO_HPP
+#define ORES_REFDATA_DOMAIN_PORTFOLIO_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Logical aggregation node for risk and reporting.
+ *
+ * Represents organizational, risk, or reporting groupings.
+ * Never holds trades directly. Supports hierarchical structure
+ * via self-referencing parent_portfolio_id.
+ */
+struct portfolio final {
+    /**
+     * @brief Version number for optimistic locking and change tracking.
+     */
+    int version = 0;
+
+    /**
+     * @brief Tenant identifier for multi-tenancy isolation.
+     */
+    std::string tenant_id;
+
+    /**
+     * @brief UUID uniquely identifying this portfolio.
+     *
+     * Surrogate key for the portfolio record.
+     */
+    boost::uuids::uuid id;
+
+    /**
+     * @brief Human-readable name for the portfolio.
+     *
+     * e.g., 'Global Rates', 'APAC Credit'.
+     */
+    std::string name;
+
+    /**
+     * @brief Self-referencing FK. NULL indicates a root node.
+     *
+     * Links to the parent portfolio in the hierarchy.
+     */
+    std::optional<boost::uuids::uuid> parent_portfolio_id;
+
+    /**
+     * @brief Business unit responsible for management.
+     *
+     * References the business_units table.
+     */
+    std::optional<boost::uuids::uuid> owner_unit_id;
+
+    /**
+     * @brief Portfolio purpose classification.
+     *
+     * References purpose_types lookup (Risk, Regulatory, ClientReporting, Internal).
+     */
+    std::string purpose_type;
+
+    /**
+     * @brief Currency for P&L/risk aggregation at this node.
+     *
+     * ISO 4217 currency code.
+     */
+    std::string aggregation_ccy;
+
+    /**
+     * @brief If 1, node is purely for on-demand reporting.
+     *
+     * Not persisted in trade attribution when virtual.
+     */
+    int is_virtual;
+
+    /**
+     * @brief Username of the person who last modified this portfolio.
+     */
+    std::string modified_by;
+
+    /**
+     * @brief Username of the account that performed this action.
+     */
+    std::string performed_by;
+
+    /**
+     * @brief Code identifying the reason for the change.
+     *
+     * References change_reasons table (soft FK).
+     */
+    std::string change_reason_code;
+
+    /**
+     * @brief Free-text commentary explaining the change.
+     */
+    std::string change_commentary;
+
+    /**
+     * @brief Timestamp when this version of the record was recorded.
+     */
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/domain/portfolio_json_io.hpp
+++ b/projects/ores.refdata/include/ores.refdata/domain/portfolio_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_PORTFOLIO_JSON_IO_HPP
+#define ORES_REFDATA_DOMAIN_PORTFOLIO_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.refdata/domain/portfolio.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the portfolio to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const portfolio& v);
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/domain/portfolio_table.hpp
+++ b/projects/ores.refdata/include/ores.refdata/domain/portfolio_table.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_PORTFOLIO_TABLE_HPP
+#define ORES_REFDATA_DOMAIN_PORTFOLIO_TABLE_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata/domain/portfolio.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Converts portfolios to the table format.
+ */
+std::string convert_to_table(const std::vector<portfolio>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/domain/portfolio_table_io.hpp
+++ b/projects/ores.refdata/include/ores.refdata/domain/portfolio_table_io.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_PORTFOLIO_TABLE_IO_HPP
+#define ORES_REFDATA_DOMAIN_PORTFOLIO_TABLE_IO_HPP
+
+#include <iosfwd>
+#include <vector>
+#include "ores.refdata/domain/portfolio.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the portfolio objects to a stream in table format.
+ */
+std::ostream& operator<<(std::ostream& s, const std::vector<portfolio>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/generators/book_generator.hpp
+++ b/projects/ores.refdata/include/ores.refdata/generators/book_generator.hpp
@@ -1,0 +1,44 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_GENERATORS_BOOK_GENERATOR_HPP
+#define ORES_REFDATA_GENERATORS_BOOK_GENERATOR_HPP
+
+#include <vector>
+#include "ores.refdata/domain/book.hpp"
+#include "ores.utility/generation/generation_context.hpp"
+
+namespace ores::refdata::generators {
+
+/**
+ * @brief Generates a synthetic book.
+ */
+domain::book generate_synthetic_book(
+    utility::generation::generation_context& ctx);
+
+/**
+ * @brief Generates N synthetic books.
+ */
+std::vector<domain::book>
+generate_synthetic_books(std::size_t n,
+    utility::generation::generation_context& ctx);
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/generators/business_unit_generator.hpp
+++ b/projects/ores.refdata/include/ores.refdata/generators/business_unit_generator.hpp
@@ -1,0 +1,44 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_GENERATORS_BUSINESS_UNIT_GENERATOR_HPP
+#define ORES_REFDATA_GENERATORS_BUSINESS_UNIT_GENERATOR_HPP
+
+#include <vector>
+#include "ores.refdata/domain/business_unit.hpp"
+#include "ores.utility/generation/generation_context.hpp"
+
+namespace ores::refdata::generators {
+
+/**
+ * @brief Generates a synthetic business_unit.
+ */
+domain::business_unit generate_synthetic_business_unit(
+    utility::generation::generation_context& ctx);
+
+/**
+ * @brief Generates N synthetic business_units.
+ */
+std::vector<domain::business_unit>
+generate_synthetic_business_units(std::size_t n,
+    utility::generation::generation_context& ctx);
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/generators/portfolio_generator.hpp
+++ b/projects/ores.refdata/include/ores.refdata/generators/portfolio_generator.hpp
@@ -1,0 +1,44 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_GENERATORS_PORTFOLIO_GENERATOR_HPP
+#define ORES_REFDATA_GENERATORS_PORTFOLIO_GENERATOR_HPP
+
+#include <vector>
+#include "ores.refdata/domain/portfolio.hpp"
+#include "ores.utility/generation/generation_context.hpp"
+
+namespace ores::refdata::generators {
+
+/**
+ * @brief Generates a synthetic portfolio.
+ */
+domain::portfolio generate_synthetic_portfolio(
+    utility::generation::generation_context& ctx);
+
+/**
+ * @brief Generates N synthetic portfolios.
+ */
+std::vector<domain::portfolio>
+generate_synthetic_portfolios(std::size_t n,
+    utility::generation::generation_context& ctx);
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/messaging/book_protocol.hpp
+++ b/projects/ores.refdata/include/ores.refdata/messaging/book_protocol.hpp
@@ -1,0 +1,202 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_BOOK_PROTOCOL_HPP
+#define ORES_REFDATA_MESSAGING_BOOK_PROTOCOL_HPP
+
+#include <span>
+#include <iosfwd>
+#include <vector>
+#include <expected>
+#include <boost/uuid/uuid.hpp>
+#include "ores.comms/messaging/message_type.hpp"
+#include "ores.comms/messaging/message_traits.hpp"
+#include "ores.utility/serialization/error_code.hpp"
+#include "ores.refdata/domain/book.hpp"
+
+namespace ores::refdata::messaging {
+
+// ============================================================================
+// Book Messages
+// ============================================================================
+
+/**
+ * @brief Request to retrieve all books.
+ */
+struct get_books_request final {
+    std::vector<std::byte> serialize() const;
+    static std::expected<get_books_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const get_books_request& v);
+
+/**
+ * @brief Response containing all books.
+ */
+struct get_books_response final {
+    std::vector<domain::book> books;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<get_books_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const get_books_response& v);
+
+/**
+ * @brief Request to save a book (create or update).
+ */
+struct save_book_request final {
+    domain::book book;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<save_book_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const save_book_request& v);
+
+/**
+ * @brief Response confirming book save operation.
+ */
+struct save_book_response final {
+    bool success;
+    std::string message;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<save_book_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const save_book_response& v);
+
+/**
+ * @brief Result for a single book deletion.
+ */
+struct delete_book_result final {
+    boost::uuids::uuid id;  ///< Primary key
+    bool success;
+    std::string message;
+};
+
+std::ostream& operator<<(std::ostream& s, const delete_book_result& v);
+
+/**
+ * @brief Request to delete one or more books.
+ */
+struct delete_book_request final {
+    std::vector<boost::uuids::uuid> ids;  ///< Primary keys
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<delete_book_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const delete_book_request& v);
+
+/**
+ * @brief Response confirming book deletion(s).
+ */
+struct delete_book_response final {
+    std::vector<delete_book_result> results;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<delete_book_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const delete_book_response& v);
+
+/**
+ * @brief Request to retrieve version history for a book.
+ */
+struct get_book_history_request final {
+    boost::uuids::uuid id;  ///< Primary key
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<get_book_history_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const get_book_history_request& v);
+
+/**
+ * @brief Response containing book version history.
+ */
+struct get_book_history_response final {
+    bool success;
+    std::string message;
+    std::vector<domain::book> versions;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<get_book_history_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const get_book_history_response& v);
+
+}
+
+namespace ores::comms::messaging {
+
+// Book traits
+template<>
+struct message_traits<refdata::messaging::get_books_request> {
+    using request_type = refdata::messaging::get_books_request;
+    using response_type = refdata::messaging::get_books_response;
+    static constexpr message_type request_message_type =
+        message_type::get_books_request;
+};
+
+template<>
+struct message_traits<refdata::messaging::save_book_request> {
+    using request_type = refdata::messaging::save_book_request;
+    using response_type = refdata::messaging::save_book_response;
+    static constexpr message_type request_message_type =
+        message_type::save_book_request;
+};
+
+template<>
+struct message_traits<refdata::messaging::delete_book_request> {
+    using request_type = refdata::messaging::delete_book_request;
+    using response_type = refdata::messaging::delete_book_response;
+    static constexpr message_type request_message_type =
+        message_type::delete_book_request;
+};
+
+template<>
+struct message_traits<refdata::messaging::get_book_history_request> {
+    using request_type = refdata::messaging::get_book_history_request;
+    using response_type = refdata::messaging::get_book_history_response;
+    static constexpr message_type request_message_type =
+        message_type::get_book_history_request;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/messaging/business_unit_protocol.hpp
+++ b/projects/ores.refdata/include/ores.refdata/messaging/business_unit_protocol.hpp
@@ -1,0 +1,202 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_BUSINESS_UNIT_PROTOCOL_HPP
+#define ORES_REFDATA_MESSAGING_BUSINESS_UNIT_PROTOCOL_HPP
+
+#include <span>
+#include <iosfwd>
+#include <vector>
+#include <expected>
+#include <boost/uuid/uuid.hpp>
+#include "ores.comms/messaging/message_type.hpp"
+#include "ores.comms/messaging/message_traits.hpp"
+#include "ores.utility/serialization/error_code.hpp"
+#include "ores.refdata/domain/business_unit.hpp"
+
+namespace ores::refdata::messaging {
+
+// ============================================================================
+// Business Unit Messages
+// ============================================================================
+
+/**
+ * @brief Request to retrieve all business units.
+ */
+struct get_business_units_request final {
+    std::vector<std::byte> serialize() const;
+    static std::expected<get_business_units_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const get_business_units_request& v);
+
+/**
+ * @brief Response containing all business units.
+ */
+struct get_business_units_response final {
+    std::vector<domain::business_unit> business_units;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<get_business_units_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const get_business_units_response& v);
+
+/**
+ * @brief Request to save a business unit (create or update).
+ */
+struct save_business_unit_request final {
+    domain::business_unit business_unit;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<save_business_unit_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const save_business_unit_request& v);
+
+/**
+ * @brief Response confirming business unit save operation.
+ */
+struct save_business_unit_response final {
+    bool success;
+    std::string message;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<save_business_unit_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const save_business_unit_response& v);
+
+/**
+ * @brief Result for a single business unit deletion.
+ */
+struct delete_business_unit_result final {
+    boost::uuids::uuid id;  ///< Primary key
+    bool success;
+    std::string message;
+};
+
+std::ostream& operator<<(std::ostream& s, const delete_business_unit_result& v);
+
+/**
+ * @brief Request to delete one or more business units.
+ */
+struct delete_business_unit_request final {
+    std::vector<boost::uuids::uuid> ids;  ///< Primary keys
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<delete_business_unit_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const delete_business_unit_request& v);
+
+/**
+ * @brief Response confirming business unit deletion(s).
+ */
+struct delete_business_unit_response final {
+    std::vector<delete_business_unit_result> results;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<delete_business_unit_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const delete_business_unit_response& v);
+
+/**
+ * @brief Request to retrieve version history for a business unit.
+ */
+struct get_business_unit_history_request final {
+    boost::uuids::uuid id;  ///< Primary key
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<get_business_unit_history_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const get_business_unit_history_request& v);
+
+/**
+ * @brief Response containing business unit version history.
+ */
+struct get_business_unit_history_response final {
+    bool success;
+    std::string message;
+    std::vector<domain::business_unit> versions;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<get_business_unit_history_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const get_business_unit_history_response& v);
+
+}
+
+namespace ores::comms::messaging {
+
+// Business Unit traits
+template<>
+struct message_traits<refdata::messaging::get_business_units_request> {
+    using request_type = refdata::messaging::get_business_units_request;
+    using response_type = refdata::messaging::get_business_units_response;
+    static constexpr message_type request_message_type =
+        message_type::get_business_units_request;
+};
+
+template<>
+struct message_traits<refdata::messaging::save_business_unit_request> {
+    using request_type = refdata::messaging::save_business_unit_request;
+    using response_type = refdata::messaging::save_business_unit_response;
+    static constexpr message_type request_message_type =
+        message_type::save_business_unit_request;
+};
+
+template<>
+struct message_traits<refdata::messaging::delete_business_unit_request> {
+    using request_type = refdata::messaging::delete_business_unit_request;
+    using response_type = refdata::messaging::delete_business_unit_response;
+    static constexpr message_type request_message_type =
+        message_type::delete_business_unit_request;
+};
+
+template<>
+struct message_traits<refdata::messaging::get_business_unit_history_request> {
+    using request_type = refdata::messaging::get_business_unit_history_request;
+    using response_type = refdata::messaging::get_business_unit_history_response;
+    static constexpr message_type request_message_type =
+        message_type::get_business_unit_history_request;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/messaging/portfolio_protocol.hpp
+++ b/projects/ores.refdata/include/ores.refdata/messaging/portfolio_protocol.hpp
@@ -1,0 +1,202 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_PORTFOLIO_PROTOCOL_HPP
+#define ORES_REFDATA_MESSAGING_PORTFOLIO_PROTOCOL_HPP
+
+#include <span>
+#include <iosfwd>
+#include <vector>
+#include <expected>
+#include <boost/uuid/uuid.hpp>
+#include "ores.comms/messaging/message_type.hpp"
+#include "ores.comms/messaging/message_traits.hpp"
+#include "ores.utility/serialization/error_code.hpp"
+#include "ores.refdata/domain/portfolio.hpp"
+
+namespace ores::refdata::messaging {
+
+// ============================================================================
+// Portfolio Messages
+// ============================================================================
+
+/**
+ * @brief Request to retrieve all portfolios.
+ */
+struct get_portfolios_request final {
+    std::vector<std::byte> serialize() const;
+    static std::expected<get_portfolios_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const get_portfolios_request& v);
+
+/**
+ * @brief Response containing all portfolios.
+ */
+struct get_portfolios_response final {
+    std::vector<domain::portfolio> portfolios;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<get_portfolios_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const get_portfolios_response& v);
+
+/**
+ * @brief Request to save a portfolio (create or update).
+ */
+struct save_portfolio_request final {
+    domain::portfolio portfolio;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<save_portfolio_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const save_portfolio_request& v);
+
+/**
+ * @brief Response confirming portfolio save operation.
+ */
+struct save_portfolio_response final {
+    bool success;
+    std::string message;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<save_portfolio_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const save_portfolio_response& v);
+
+/**
+ * @brief Result for a single portfolio deletion.
+ */
+struct delete_portfolio_result final {
+    boost::uuids::uuid id;  ///< Primary key
+    bool success;
+    std::string message;
+};
+
+std::ostream& operator<<(std::ostream& s, const delete_portfolio_result& v);
+
+/**
+ * @brief Request to delete one or more portfolios.
+ */
+struct delete_portfolio_request final {
+    std::vector<boost::uuids::uuid> ids;  ///< Primary keys
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<delete_portfolio_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const delete_portfolio_request& v);
+
+/**
+ * @brief Response confirming portfolio deletion(s).
+ */
+struct delete_portfolio_response final {
+    std::vector<delete_portfolio_result> results;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<delete_portfolio_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const delete_portfolio_response& v);
+
+/**
+ * @brief Request to retrieve version history for a portfolio.
+ */
+struct get_portfolio_history_request final {
+    boost::uuids::uuid id;  ///< Primary key
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<get_portfolio_history_request,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const get_portfolio_history_request& v);
+
+/**
+ * @brief Response containing portfolio version history.
+ */
+struct get_portfolio_history_response final {
+    bool success;
+    std::string message;
+    std::vector<domain::portfolio> versions;
+
+    std::vector<std::byte> serialize() const;
+    static std::expected<get_portfolio_history_response,
+                         ores::utility::serialization::error_code>
+    deserialize(std::span<const std::byte> data);
+};
+
+std::ostream& operator<<(std::ostream& s, const get_portfolio_history_response& v);
+
+}
+
+namespace ores::comms::messaging {
+
+// Portfolio traits
+template<>
+struct message_traits<refdata::messaging::get_portfolios_request> {
+    using request_type = refdata::messaging::get_portfolios_request;
+    using response_type = refdata::messaging::get_portfolios_response;
+    static constexpr message_type request_message_type =
+        message_type::get_portfolios_request;
+};
+
+template<>
+struct message_traits<refdata::messaging::save_portfolio_request> {
+    using request_type = refdata::messaging::save_portfolio_request;
+    using response_type = refdata::messaging::save_portfolio_response;
+    static constexpr message_type request_message_type =
+        message_type::save_portfolio_request;
+};
+
+template<>
+struct message_traits<refdata::messaging::delete_portfolio_request> {
+    using request_type = refdata::messaging::delete_portfolio_request;
+    using response_type = refdata::messaging::delete_portfolio_response;
+    static constexpr message_type request_message_type =
+        message_type::delete_portfolio_request;
+};
+
+template<>
+struct message_traits<refdata::messaging::get_portfolio_history_request> {
+    using request_type = refdata::messaging::get_portfolio_history_request;
+    using response_type = refdata::messaging::get_portfolio_history_response;
+    static constexpr message_type request_message_type =
+        message_type::get_portfolio_history_request;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/repository/book_entity.hpp
+++ b/projects/ores.refdata/include/ores.refdata/repository/book_entity.hpp
@@ -1,0 +1,59 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_BOOK_ENTITY_HPP
+#define ORES_REFDATA_REPOSITORY_BOOK_ENTITY_HPP
+
+#include <string>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Represents a book in the database.
+ */
+struct book_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_refdata_books_tbl";
+
+    sqlgen::PrimaryKey<std::string> id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::string name;
+    std::string parent_portfolio_id;
+    std::string ledger_ccy;
+    std::string gl_account_ref;
+    std::string cost_center;
+    std::string book_status;
+    int is_trading_book;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S"> valid_from = "9999-12-31 23:59:59";
+    sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S"> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const book_entity& v);
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/repository/book_mapper.hpp
+++ b/projects/ores.refdata/include/ores.refdata/repository/book_mapper.hpp
@@ -1,0 +1,54 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_BOOK_MAPPER_HPP
+#define ORES_REFDATA_REPOSITORY_BOOK_MAPPER_HPP
+
+#include "ores.refdata/domain/book.hpp"
+#include "ores.refdata/repository/book_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Maps book domain entities to data storage layer and vice-versa.
+ */
+class book_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.book_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::book map(const book_entity& v);
+    static book_entity map(const domain::book& v);
+
+    static std::vector<domain::book>
+    map(const std::vector<book_entity>& v);
+    static std::vector<book_entity>
+    map(const std::vector<domain::book>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/repository/book_repository.hpp
+++ b/projects/ores.refdata/include/ores.refdata/repository/book_repository.hpp
@@ -1,0 +1,70 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_BOOK_REPOSITORY_HPP
+#define ORES_REFDATA_REPOSITORY_BOOK_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include <boost/uuid/uuid.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata/domain/book.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Reads and writes books to data storage.
+ */
+class book_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.book_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit book_repository(context ctx);
+
+    std::string sql();
+
+    void write(const domain::book& book);
+    void write(const std::vector<domain::book>& books);
+
+    std::vector<domain::book> read_latest();
+    std::vector<domain::book> read_latest(const boost::uuids::uuid& id);
+    std::vector<domain::book> read_latest_by_code(const std::string& code);
+
+    std::vector<domain::book> read_all(const boost::uuids::uuid& id);
+    void remove(const boost::uuids::uuid& id);
+
+private:
+    context ctx_;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/repository/business_unit_entity.hpp
+++ b/projects/ores.refdata/include/ores.refdata/repository/business_unit_entity.hpp
@@ -1,0 +1,57 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_BUSINESS_UNIT_ENTITY_HPP
+#define ORES_REFDATA_REPOSITORY_BUSINESS_UNIT_ENTITY_HPP
+
+#include <optional>
+#include <string>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Represents a business unit in the database.
+ */
+struct business_unit_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_refdata_business_units_tbl";
+
+    sqlgen::PrimaryKey<std::string> id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::string unit_name;
+    std::optional<std::string> parent_business_unit_id;
+    std::string unit_code;
+    std::string business_centre_code;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S"> valid_from = "9999-12-31 23:59:59";
+    sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S"> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const business_unit_entity& v);
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/repository/business_unit_mapper.hpp
+++ b/projects/ores.refdata/include/ores.refdata/repository/business_unit_mapper.hpp
@@ -1,0 +1,54 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_BUSINESS_UNIT_MAPPER_HPP
+#define ORES_REFDATA_REPOSITORY_BUSINESS_UNIT_MAPPER_HPP
+
+#include "ores.refdata/domain/business_unit.hpp"
+#include "ores.refdata/repository/business_unit_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Maps business_unit domain entities to data storage layer and vice-versa.
+ */
+class business_unit_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.business_unit_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::business_unit map(const business_unit_entity& v);
+    static business_unit_entity map(const domain::business_unit& v);
+
+    static std::vector<domain::business_unit>
+    map(const std::vector<business_unit_entity>& v);
+    static std::vector<business_unit_entity>
+    map(const std::vector<domain::business_unit>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/repository/business_unit_repository.hpp
+++ b/projects/ores.refdata/include/ores.refdata/repository/business_unit_repository.hpp
@@ -1,0 +1,70 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_BUSINESS_UNIT_REPOSITORY_HPP
+#define ORES_REFDATA_REPOSITORY_BUSINESS_UNIT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include <boost/uuid/uuid.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata/domain/business_unit.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Reads and writes business units to data storage.
+ */
+class business_unit_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.business_unit_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit business_unit_repository(context ctx);
+
+    std::string sql();
+
+    void write(const domain::business_unit& business_unit);
+    void write(const std::vector<domain::business_unit>& business_units);
+
+    std::vector<domain::business_unit> read_latest();
+    std::vector<domain::business_unit> read_latest(const boost::uuids::uuid& id);
+    std::vector<domain::business_unit> read_latest_by_code(const std::string& code);
+
+    std::vector<domain::business_unit> read_all(const boost::uuids::uuid& id);
+    void remove(const boost::uuids::uuid& id);
+
+private:
+    context ctx_;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/repository/portfolio_entity.hpp
+++ b/projects/ores.refdata/include/ores.refdata/repository/portfolio_entity.hpp
@@ -1,0 +1,58 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_PORTFOLIO_ENTITY_HPP
+#define ORES_REFDATA_REPOSITORY_PORTFOLIO_ENTITY_HPP
+
+#include <optional>
+#include <string>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Represents a portfolio in the database.
+ */
+struct portfolio_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_refdata_portfolios_tbl";
+
+    sqlgen::PrimaryKey<std::string> id;
+    std::string tenant_id;
+    int version = 0;
+    std::string name;
+    std::optional<std::string> parent_portfolio_id;
+    std::optional<std::string> owner_unit_id;
+    std::string purpose_type;
+    std::string aggregation_ccy;
+    int is_virtual;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S"> valid_from = "9999-12-31 23:59:59";
+    sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S"> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const portfolio_entity& v);
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/repository/portfolio_mapper.hpp
+++ b/projects/ores.refdata/include/ores.refdata/repository/portfolio_mapper.hpp
@@ -1,0 +1,54 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_PORTFOLIO_MAPPER_HPP
+#define ORES_REFDATA_REPOSITORY_PORTFOLIO_MAPPER_HPP
+
+#include "ores.refdata/domain/portfolio.hpp"
+#include "ores.refdata/repository/portfolio_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Maps portfolio domain entities to data storage layer and vice-versa.
+ */
+class portfolio_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.portfolio_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::portfolio map(const portfolio_entity& v);
+    static portfolio_entity map(const domain::portfolio& v);
+
+    static std::vector<domain::portfolio>
+    map(const std::vector<portfolio_entity>& v);
+    static std::vector<portfolio_entity>
+    map(const std::vector<domain::portfolio>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/repository/portfolio_repository.hpp
+++ b/projects/ores.refdata/include/ores.refdata/repository/portfolio_repository.hpp
@@ -1,0 +1,70 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_PORTFOLIO_REPOSITORY_HPP
+#define ORES_REFDATA_REPOSITORY_PORTFOLIO_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include <boost/uuid/uuid.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata/domain/portfolio.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Reads and writes portfolios to data storage.
+ */
+class portfolio_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.portfolio_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit portfolio_repository(context ctx);
+
+    std::string sql();
+
+    void write(const domain::portfolio& portfolio);
+    void write(const std::vector<domain::portfolio>& portfolios);
+
+    std::vector<domain::portfolio> read_latest();
+    std::vector<domain::portfolio> read_latest(const boost::uuids::uuid& id);
+    std::vector<domain::portfolio> read_latest_by_code(const std::string& code);
+
+    std::vector<domain::portfolio> read_all(const boost::uuids::uuid& id);
+    void remove(const boost::uuids::uuid& id);
+
+private:
+    context ctx_;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/service/book_service.hpp
+++ b/projects/ores.refdata/include/ores.refdata/service/book_service.hpp
@@ -1,0 +1,107 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_SERVICE_BOOK_SERVICE_HPP
+#define ORES_REFDATA_SERVICE_BOOK_SERVICE_HPP
+
+#include <string>
+#include <vector>
+#include <optional>
+#include <boost/uuid/uuid.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata/domain/book.hpp"
+#include "ores.refdata/repository/book_repository.hpp"
+
+namespace ores::refdata::service {
+
+/**
+ * @brief Service for managing books.
+ *
+ * This service provides functionality for:
+ * - Managing books (CRUD operations)
+ */
+class book_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.service.book_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    /**
+     * @brief Constructs a book_service with required repositories.
+     *
+     * @param ctx The database context.
+     */
+    explicit book_service(context ctx);
+
+    /**
+     * @brief Lists all books.
+     */
+    std::vector<domain::book> list_books();
+
+    /**
+     * @brief Finds a book by its ID.
+     */
+    std::optional<domain::book>
+    find_book(const boost::uuids::uuid& id);
+
+    /**
+     * @brief Finds a book by its code.
+     */
+    std::optional<domain::book>
+    find_book_by_code(const std::string& code);
+
+    /**
+     * @brief Saves a book (creates or updates).
+     *
+     * @param book The book to save
+     */
+    void save_book(const domain::book& book);
+
+    /**
+     * @brief Removes a book.
+     *
+     * @param id The ID of the book to remove
+     */
+    void remove_book(const boost::uuids::uuid& id);
+
+    /**
+     * @brief Gets the version history for a book.
+     *
+     * @param id The book ID
+     * @return Vector of all versions, newest first
+     */
+    std::vector<domain::book>
+    get_book_history(const boost::uuids::uuid& id);
+
+private:
+    repository::book_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/service/business_unit_service.hpp
+++ b/projects/ores.refdata/include/ores.refdata/service/business_unit_service.hpp
@@ -1,0 +1,107 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_SERVICE_BUSINESS_UNIT_SERVICE_HPP
+#define ORES_REFDATA_SERVICE_BUSINESS_UNIT_SERVICE_HPP
+
+#include <string>
+#include <vector>
+#include <optional>
+#include <boost/uuid/uuid.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata/domain/business_unit.hpp"
+#include "ores.refdata/repository/business_unit_repository.hpp"
+
+namespace ores::refdata::service {
+
+/**
+ * @brief Service for managing business units.
+ *
+ * This service provides functionality for:
+ * - Managing business units (CRUD operations)
+ */
+class business_unit_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.service.business_unit_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    /**
+     * @brief Constructs a business_unit_service with required repositories.
+     *
+     * @param ctx The database context.
+     */
+    explicit business_unit_service(context ctx);
+
+    /**
+     * @brief Lists all business units.
+     */
+    std::vector<domain::business_unit> list_business_units();
+
+    /**
+     * @brief Finds a business unit by its ID.
+     */
+    std::optional<domain::business_unit>
+    find_business_unit(const boost::uuids::uuid& id);
+
+    /**
+     * @brief Finds a business unit by its code.
+     */
+    std::optional<domain::business_unit>
+    find_business_unit_by_code(const std::string& code);
+
+    /**
+     * @brief Saves a business unit (creates or updates).
+     *
+     * @param business_unit The business unit to save
+     */
+    void save_business_unit(const domain::business_unit& business_unit);
+
+    /**
+     * @brief Removes a business unit.
+     *
+     * @param id The ID of the business unit to remove
+     */
+    void remove_business_unit(const boost::uuids::uuid& id);
+
+    /**
+     * @brief Gets the version history for a business unit.
+     *
+     * @param id The business unit ID
+     * @return Vector of all versions, newest first
+     */
+    std::vector<domain::business_unit>
+    get_business_unit_history(const boost::uuids::uuid& id);
+
+private:
+    repository::business_unit_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/include/ores.refdata/service/portfolio_service.hpp
+++ b/projects/ores.refdata/include/ores.refdata/service/portfolio_service.hpp
@@ -1,0 +1,107 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_SERVICE_PORTFOLIO_SERVICE_HPP
+#define ORES_REFDATA_SERVICE_PORTFOLIO_SERVICE_HPP
+
+#include <string>
+#include <vector>
+#include <optional>
+#include <boost/uuid/uuid.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata/domain/portfolio.hpp"
+#include "ores.refdata/repository/portfolio_repository.hpp"
+
+namespace ores::refdata::service {
+
+/**
+ * @brief Service for managing portfolios.
+ *
+ * This service provides functionality for:
+ * - Managing portfolios (CRUD operations)
+ */
+class portfolio_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.service.portfolio_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    /**
+     * @brief Constructs a portfolio_service with required repositories.
+     *
+     * @param ctx The database context.
+     */
+    explicit portfolio_service(context ctx);
+
+    /**
+     * @brief Lists all portfolios.
+     */
+    std::vector<domain::portfolio> list_portfolios();
+
+    /**
+     * @brief Finds a portfolio by its ID.
+     */
+    std::optional<domain::portfolio>
+    find_portfolio(const boost::uuids::uuid& id);
+
+    /**
+     * @brief Finds a portfolio by its code.
+     */
+    std::optional<domain::portfolio>
+    find_portfolio_by_code(const std::string& code);
+
+    /**
+     * @brief Saves a portfolio (creates or updates).
+     *
+     * @param portfolio The portfolio to save
+     */
+    void save_portfolio(const domain::portfolio& portfolio);
+
+    /**
+     * @brief Removes a portfolio.
+     *
+     * @param id The ID of the portfolio to remove
+     */
+    void remove_portfolio(const boost::uuids::uuid& id);
+
+    /**
+     * @brief Gets the version history for a portfolio.
+     *
+     * @param id The portfolio ID
+     * @return Vector of all versions, newest first
+     */
+    std::vector<domain::portfolio>
+    get_portfolio_history(const boost::uuids::uuid& id);
+
+private:
+    repository::portfolio_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata/src/domain/book_json_io.cpp
+++ b/projects/ores.refdata/src/domain/book_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/domain/book_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::domain {
+
+std::ostream& operator<<(std::ostream& s, const book& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata/src/domain/book_table.cpp
+++ b/projects/ores.refdata/src/domain/book_table.cpp
@@ -1,0 +1,39 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/domain/book_table.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <fort.hpp>
+
+namespace ores::refdata::domain {
+
+std::string convert_to_table(const std::vector<book>& v) {
+    fort::char_table table;
+    table.set_border_style(FT_BASIC_STYLE);
+
+    table << fort::header << "Name" << "Party" << "Currency" << "Status" << "Trading Book" << "Modified By" << "Version" << fort::endr;
+
+    for (const auto& bk : v) {
+        table << bk.name << boost::uuids::to_string(bk.party_id) << bk.ledger_ccy << bk.book_status << bk.is_trading_book << bk.modified_by << bk.version << fort::endr;
+    }
+    return table.to_string();
+}
+
+}

--- a/projects/ores.refdata/src/domain/book_table_io.cpp
+++ b/projects/ores.refdata/src/domain/book_table_io.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/domain/book_table_io.hpp"
+
+#include <ostream>
+#include "ores.refdata/domain/book_table.hpp"
+
+namespace ores::refdata::domain {
+
+namespace {
+
+void print_book_table(std::ostream& s, const std::vector<book>& v) {
+    s << std::endl << convert_to_table(v) << std::endl;
+}
+
+}
+
+std::ostream& operator<<(std::ostream& s, const std::vector<book>& v) {
+    print_book_table(s, v);
+    return s;
+}
+
+}

--- a/projects/ores.refdata/src/domain/business_unit_json_io.cpp
+++ b/projects/ores.refdata/src/domain/business_unit_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/domain/business_unit_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::domain {
+
+std::ostream& operator<<(std::ostream& s, const business_unit& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata/src/domain/business_unit_table.cpp
+++ b/projects/ores.refdata/src/domain/business_unit_table.cpp
@@ -1,0 +1,39 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/domain/business_unit_table.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <fort.hpp>
+
+namespace ores::refdata::domain {
+
+std::string convert_to_table(const std::vector<business_unit>& v) {
+    fort::char_table table;
+    table.set_border_style(FT_BASIC_STYLE);
+
+    table << fort::header << "Party" << "Unit Name" << "Code" << "Business Centre" << "Modified By" << "Version" << fort::endr;
+
+    for (const auto& bu : v) {
+        table << boost::uuids::to_string(bu.party_id) << bu.unit_name << bu.unit_code << bu.business_centre_code << bu.modified_by << bu.version << fort::endr;
+    }
+    return table.to_string();
+}
+
+}

--- a/projects/ores.refdata/src/domain/business_unit_table_io.cpp
+++ b/projects/ores.refdata/src/domain/business_unit_table_io.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/domain/business_unit_table_io.hpp"
+
+#include <ostream>
+#include "ores.refdata/domain/business_unit_table.hpp"
+
+namespace ores::refdata::domain {
+
+namespace {
+
+void print_business_unit_table(std::ostream& s, const std::vector<business_unit>& v) {
+    s << std::endl << convert_to_table(v) << std::endl;
+}
+
+}
+
+std::ostream& operator<<(std::ostream& s, const std::vector<business_unit>& v) {
+    print_business_unit_table(s, v);
+    return s;
+}
+
+}

--- a/projects/ores.refdata/src/domain/portfolio_json_io.cpp
+++ b/projects/ores.refdata/src/domain/portfolio_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/domain/portfolio_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::domain {
+
+std::ostream& operator<<(std::ostream& s, const portfolio& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata/src/domain/portfolio_table.cpp
+++ b/projects/ores.refdata/src/domain/portfolio_table.cpp
@@ -1,0 +1,39 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/domain/portfolio_table.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <fort.hpp>
+
+namespace ores::refdata::domain {
+
+std::string convert_to_table(const std::vector<portfolio>& v) {
+    fort::char_table table;
+    table.set_border_style(FT_BASIC_STYLE);
+
+    table << fort::header << "Name" << "Purpose" << "Currency" << "Virtual" << "Modified By" << "Version" << fort::endr;
+
+    for (const auto& pf : v) {
+        table << pf.name << pf.purpose_type << pf.aggregation_ccy << pf.is_virtual << pf.modified_by << pf.version << fort::endr;
+    }
+    return table.to_string();
+}
+
+}

--- a/projects/ores.refdata/src/domain/portfolio_table_io.cpp
+++ b/projects/ores.refdata/src/domain/portfolio_table_io.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/domain/portfolio_table_io.hpp"
+
+#include <ostream>
+#include "ores.refdata/domain/portfolio_table.hpp"
+
+namespace ores::refdata::domain {
+
+namespace {
+
+void print_portfolio_table(std::ostream& s, const std::vector<portfolio>& v) {
+    s << std::endl << convert_to_table(v) << std::endl;
+}
+
+}
+
+std::ostream& operator<<(std::ostream& s, const std::vector<portfolio>& v) {
+    print_portfolio_table(s, v);
+    return s;
+}
+
+}

--- a/projects/ores.refdata/src/generators/book_generator.cpp
+++ b/projects/ores.refdata/src/generators/book_generator.cpp
@@ -1,0 +1,69 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/generators/book_generator.hpp"
+
+#include <atomic>
+#include <faker-cxx/faker.h> // IWYU pragma: keep.
+#include "ores.utility/generation/generation_keys.hpp"
+
+namespace ores::refdata::generators {
+
+using ores::utility::generation::generation_keys;
+
+domain::book generate_synthetic_book(
+    utility::generation::generation_context& ctx) {
+    static std::atomic<int> counter{0};
+    const auto idx = ++counter;
+    const auto modified_by = ctx.env().get_or(
+        generation_keys::modified_by, "system");
+    const auto tenant_id = ctx.env().get_or(
+        generation_keys::tenant_id, "system");
+
+    domain::book r;
+    r.version = 1;
+    r.tenant_id = tenant_id;
+    r.id = ctx.generate_uuid();
+    r.party_id = ctx.generate_uuid();
+    r.name = std::string("BOOK_") + std::to_string(idx);
+    r.parent_portfolio_id = ctx.generate_uuid();
+    r.ledger_ccy = std::string("USD");
+    r.gl_account_ref = std::string("GL-10150-TEST");
+    r.cost_center = std::string("CC-001");
+    r.book_status = std::string("Active");
+    r.is_trading_book = 1;
+    r.modified_by = modified_by;
+    r.performed_by = modified_by;
+    r.change_reason_code = "system.new";
+    r.change_commentary = "Synthetic test data";
+    r.recorded_at = ctx.past_timepoint();
+    return r;
+}
+
+std::vector<domain::book>
+generate_synthetic_books(std::size_t n,
+    utility::generation::generation_context& ctx) {
+    std::vector<domain::book> r;
+    r.reserve(n);
+    while (r.size() < n)
+        r.push_back(generate_synthetic_book(ctx));
+    return r;
+}
+
+}

--- a/projects/ores.refdata/src/generators/business_unit_generator.cpp
+++ b/projects/ores.refdata/src/generators/business_unit_generator.cpp
@@ -1,0 +1,66 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/generators/business_unit_generator.hpp"
+
+#include <atomic>
+#include <faker-cxx/faker.h> // IWYU pragma: keep.
+#include "ores.utility/generation/generation_keys.hpp"
+
+namespace ores::refdata::generators {
+
+using ores::utility::generation::generation_keys;
+
+domain::business_unit generate_synthetic_business_unit(
+    utility::generation::generation_context& ctx) {
+    static std::atomic<int> counter{0};
+    const auto idx = ++counter;
+    const auto modified_by = ctx.env().get_or(
+        generation_keys::modified_by, "system");
+    const auto tenant_id = ctx.env().get_or(
+        generation_keys::tenant_id, "system");
+
+    domain::business_unit r;
+    r.version = 1;
+    r.tenant_id = tenant_id;
+    r.id = ctx.generate_uuid();
+    r.party_id = ctx.generate_uuid();
+    r.unit_name = faker::company::companyName() + " Desk " + std::to_string(idx);
+    r.parent_business_unit_id = std::nullopt;
+    r.unit_code = std::string("DESK") + std::to_string(idx);
+    r.business_centre_code = std::string("GBLO");
+    r.modified_by = modified_by;
+    r.performed_by = modified_by;
+    r.change_reason_code = "system.new";
+    r.change_commentary = "Synthetic test data";
+    r.recorded_at = ctx.past_timepoint();
+    return r;
+}
+
+std::vector<domain::business_unit>
+generate_synthetic_business_units(std::size_t n,
+    utility::generation::generation_context& ctx) {
+    std::vector<domain::business_unit> r;
+    r.reserve(n);
+    while (r.size() < n)
+        r.push_back(generate_synthetic_business_unit(ctx));
+    return r;
+}
+
+}

--- a/projects/ores.refdata/src/generators/portfolio_generator.cpp
+++ b/projects/ores.refdata/src/generators/portfolio_generator.cpp
@@ -1,0 +1,67 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/generators/portfolio_generator.hpp"
+
+#include <atomic>
+#include <faker-cxx/faker.h> // IWYU pragma: keep.
+#include "ores.utility/generation/generation_keys.hpp"
+
+namespace ores::refdata::generators {
+
+using ores::utility::generation::generation_keys;
+
+domain::portfolio generate_synthetic_portfolio(
+    utility::generation::generation_context& ctx) {
+    static std::atomic<int> counter{0};
+    const auto idx = ++counter;
+    const auto modified_by = ctx.env().get_or(
+        generation_keys::modified_by, "system");
+    const auto tenant_id = ctx.env().get_or(
+        generation_keys::tenant_id, "system");
+
+    domain::portfolio r;
+    r.version = 1;
+    r.tenant_id = tenant_id;
+    r.id = ctx.generate_uuid();
+    r.name = faker::company::companyName() + " Portfolio " + std::to_string(idx);
+    r.parent_portfolio_id = std::nullopt;
+    r.owner_unit_id = ctx.generate_uuid();
+    r.purpose_type = std::string("Risk");
+    r.aggregation_ccy = std::string("USD");
+    r.is_virtual = 0;
+    r.modified_by = modified_by;
+    r.performed_by = modified_by;
+    r.change_reason_code = "system.new";
+    r.change_commentary = "Synthetic test data";
+    r.recorded_at = ctx.past_timepoint();
+    return r;
+}
+
+std::vector<domain::portfolio>
+generate_synthetic_portfolios(std::size_t n,
+    utility::generation::generation_context& ctx) {
+    std::vector<domain::portfolio> r;
+    r.reserve(n);
+    while (r.size() < n)
+        r.push_back(generate_synthetic_portfolio(ctx));
+    return r;
+}
+
+}

--- a/projects/ores.refdata/src/messaging/book_protocol.cpp
+++ b/projects/ores.refdata/src/messaging/book_protocol.cpp
@@ -1,0 +1,384 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/messaging/book_protocol.hpp"
+
+#include <expected>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.platform/time/datetime.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+#include "ores.utility/serialization/reader.hpp"
+#include "ores.utility/serialization/writer.hpp"
+
+namespace ores::refdata::messaging {
+
+using ores::utility::serialization::error_code;
+using ores::utility::serialization::reader;
+using ores::utility::serialization::writer;
+
+namespace {
+
+// ============================================================================
+// Book helpers
+// ============================================================================
+
+void write_book(std::vector<std::byte>& buffer,
+    const domain::book& bk) {
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(bk.version));
+    writer::write_uuid(buffer, bk.id);
+    writer::write_uuid(buffer, bk.party_id);
+    writer::write_string(buffer, bk.name);
+    writer::write_uuid(buffer, bk.parent_portfolio_id);
+    writer::write_string(buffer, bk.ledger_ccy);
+    writer::write_string(buffer, bk.gl_account_ref);
+    writer::write_string(buffer, bk.cost_center);
+    writer::write_string(buffer, bk.book_status);
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(bk.is_trading_book));
+    writer::write_string(buffer, bk.modified_by);
+    writer::write_string(buffer, bk.performed_by);
+    writer::write_string(buffer, bk.change_reason_code);
+    writer::write_string(buffer, bk.change_commentary);
+    writer::write_string(buffer,
+        ores::platform::time::datetime::format_time_point(bk.recorded_at));
+}
+
+std::expected<domain::book, error_code>
+read_book(std::span<const std::byte>& data) {
+    domain::book bk;
+
+    auto version_result = reader::read_uint32(data);
+    if (!version_result) return std::unexpected(version_result.error());
+    bk.version = static_cast<int>(*version_result);
+
+    auto id_result = reader::read_uuid(data);
+    if (!id_result) return std::unexpected(id_result.error());
+    bk.id = *id_result;
+
+    auto party_id_result = reader::read_uuid(data);
+    if (!party_id_result) return std::unexpected(party_id_result.error());
+    bk.party_id = *party_id_result;
+
+    auto name_result = reader::read_string(data);
+    if (!name_result) return std::unexpected(name_result.error());
+    bk.name = *name_result;
+
+    auto parent_portfolio_id_result = reader::read_uuid(data);
+    if (!parent_portfolio_id_result) return std::unexpected(parent_portfolio_id_result.error());
+    bk.parent_portfolio_id = *parent_portfolio_id_result;
+
+    auto ledger_ccy_result = reader::read_string(data);
+    if (!ledger_ccy_result) return std::unexpected(ledger_ccy_result.error());
+    bk.ledger_ccy = *ledger_ccy_result;
+
+    auto gl_account_ref_result = reader::read_string(data);
+    if (!gl_account_ref_result) return std::unexpected(gl_account_ref_result.error());
+    bk.gl_account_ref = *gl_account_ref_result;
+
+    auto cost_center_result = reader::read_string(data);
+    if (!cost_center_result) return std::unexpected(cost_center_result.error());
+    bk.cost_center = *cost_center_result;
+
+    auto book_status_result = reader::read_string(data);
+    if (!book_status_result) return std::unexpected(book_status_result.error());
+    bk.book_status = *book_status_result;
+
+    auto is_trading_book_result = reader::read_uint32(data);
+    if (!is_trading_book_result) return std::unexpected(is_trading_book_result.error());
+    bk.is_trading_book = static_cast<int>(*is_trading_book_result);
+
+    auto modified_by_result = reader::read_string(data);
+    if (!modified_by_result) return std::unexpected(modified_by_result.error());
+    bk.modified_by = *modified_by_result;
+
+    auto performed_by_result = reader::read_string(data);
+    if (!performed_by_result) return std::unexpected(performed_by_result.error());
+    bk.performed_by = *performed_by_result;
+
+    auto change_reason_code_result = reader::read_string(data);
+    if (!change_reason_code_result) return std::unexpected(change_reason_code_result.error());
+    bk.change_reason_code = *change_reason_code_result;
+
+    auto change_commentary_result = reader::read_string(data);
+    if (!change_commentary_result) return std::unexpected(change_commentary_result.error());
+    bk.change_commentary = *change_commentary_result;
+
+    auto recorded_at_result = reader::read_string(data);
+    if (!recorded_at_result) return std::unexpected(recorded_at_result.error());
+    try {
+        bk.recorded_at = ores::platform::time::datetime::parse_time_point(*recorded_at_result);
+    } catch (const std::invalid_argument&) {
+        return std::unexpected(error_code::invalid_request);
+    }
+
+    return bk;
+}
+
+} // anonymous namespace
+
+// ============================================================================
+// Book Messages Implementation
+// ============================================================================
+
+std::vector<std::byte> get_books_request::serialize() const {
+    return {};
+}
+
+std::expected<get_books_request, error_code>
+get_books_request::deserialize(std::span<const std::byte> data) {
+    if (!data.empty()) {
+        return std::unexpected(error_code::payload_too_large);
+    }
+    return get_books_request{};
+}
+
+std::ostream& operator<<(std::ostream& s, const get_books_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> get_books_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(books.size()));
+    for (const auto& bk : books) {
+        write_book(buffer, bk);
+    }
+    return buffer;
+}
+
+std::expected<get_books_response, error_code>
+get_books_response::deserialize(std::span<const std::byte> data) {
+    get_books_response response;
+
+    auto count_result = reader::read_count(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    response.books.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        auto result = read_book(data);
+        if (!result) return std::unexpected(result.error());
+        response.books.push_back(std::move(*result));
+    }
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s, const get_books_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> save_book_request::serialize() const {
+    std::vector<std::byte> buffer;
+    write_book(buffer, book);
+    return buffer;
+}
+
+std::expected<save_book_request, error_code>
+save_book_request::deserialize(std::span<const std::byte> data) {
+    save_book_request request;
+
+    auto result = read_book(data);
+    if (!result) return std::unexpected(result.error());
+    request.book = std::move(*result);
+
+    return request;
+}
+
+std::ostream& operator<<(std::ostream& s, const save_book_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> save_book_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_bool(buffer, success);
+    writer::write_string(buffer, message);
+    return buffer;
+}
+
+std::expected<save_book_response, error_code>
+save_book_response::deserialize(std::span<const std::byte> data) {
+    save_book_response response;
+
+    auto success_result = reader::read_bool(data);
+    if (!success_result) return std::unexpected(success_result.error());
+    response.success = *success_result;
+
+    auto message_result = reader::read_string(data);
+    if (!message_result) return std::unexpected(message_result.error());
+    response.message = *message_result;
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s, const save_book_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::ostream& operator<<(std::ostream& s, const delete_book_result& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> delete_book_request::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(ids.size()));
+    for (const auto& id : ids) {
+        writer::write_uuid(buffer, id);
+    }
+    return buffer;
+}
+
+std::expected<delete_book_request, error_code>
+delete_book_request::deserialize(std::span<const std::byte> data) {
+    delete_book_request request;
+
+    auto count_result = reader::read_count(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    request.ids.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        auto id_result = reader::read_uuid(data);
+        if (!id_result) return std::unexpected(id_result.error());
+        request.ids.push_back(*id_result);
+    }
+
+    return request;
+}
+
+std::ostream& operator<<(std::ostream& s, const delete_book_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> delete_book_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(results.size()));
+    for (const auto& r : results) {
+        writer::write_uuid(buffer, r.id);
+        writer::write_bool(buffer, r.success);
+        writer::write_string(buffer, r.message);
+    }
+    return buffer;
+}
+
+std::expected<delete_book_response, error_code>
+delete_book_response::deserialize(std::span<const std::byte> data) {
+    delete_book_response response;
+
+    auto count_result = reader::read_count(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    response.results.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        delete_book_result r;
+
+        auto id_result = reader::read_uuid(data);
+        if (!id_result) return std::unexpected(id_result.error());
+        r.id = *id_result;
+
+        auto success_result = reader::read_bool(data);
+        if (!success_result) return std::unexpected(success_result.error());
+        r.success = *success_result;
+
+        auto message_result = reader::read_string(data);
+        if (!message_result) return std::unexpected(message_result.error());
+        r.message = *message_result;
+
+        response.results.push_back(std::move(r));
+    }
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s, const delete_book_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> get_book_history_request::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_uuid(buffer, id);
+    return buffer;
+}
+
+std::expected<get_book_history_request, error_code>
+get_book_history_request::deserialize(std::span<const std::byte> data) {
+    get_book_history_request request;
+
+    auto id_result = reader::read_uuid(data);
+    if (!id_result) return std::unexpected(id_result.error());
+    request.id = *id_result;
+
+    return request;
+}
+
+std::ostream& operator<<(std::ostream& s, const get_book_history_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> get_book_history_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_bool(buffer, success);
+    writer::write_string(buffer, message);
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(versions.size()));
+    for (const auto& v : versions) {
+        write_book(buffer, v);
+    }
+    return buffer;
+}
+
+std::expected<get_book_history_response, error_code>
+get_book_history_response::deserialize(std::span<const std::byte> data) {
+    get_book_history_response response;
+
+    auto success_result = reader::read_bool(data);
+    if (!success_result) return std::unexpected(success_result.error());
+    response.success = *success_result;
+
+    auto message_result = reader::read_string(data);
+    if (!message_result) return std::unexpected(message_result.error());
+    response.message = *message_result;
+
+    auto count_result = reader::read_count(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    response.versions.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        auto result = read_book(data);
+        if (!result) return std::unexpected(result.error());
+        response.versions.push_back(std::move(*result));
+    }
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s, const get_book_history_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata/src/messaging/business_unit_protocol.cpp
+++ b/projects/ores.refdata/src/messaging/business_unit_protocol.cpp
@@ -1,0 +1,376 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/messaging/business_unit_protocol.hpp"
+
+#include <expected>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.platform/time/datetime.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+#include "ores.utility/serialization/reader.hpp"
+#include "ores.utility/serialization/writer.hpp"
+
+namespace ores::refdata::messaging {
+
+using ores::utility::serialization::error_code;
+using ores::utility::serialization::reader;
+using ores::utility::serialization::writer;
+
+namespace {
+
+// ============================================================================
+// Business Unit helpers
+// ============================================================================
+
+void write_business_unit(std::vector<std::byte>& buffer,
+    const domain::business_unit& bu) {
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(bu.version));
+    writer::write_uuid(buffer, bu.id);
+    writer::write_uuid(buffer, bu.party_id);
+    writer::write_string(buffer, bu.unit_name);
+    writer::write_bool(buffer, bu.parent_business_unit_id.has_value());
+    if (bu.parent_business_unit_id.has_value()) {
+        writer::write_uuid(buffer, *bu.parent_business_unit_id);
+    }
+    writer::write_string(buffer, bu.unit_code);
+    writer::write_string(buffer, bu.business_centre_code);
+    writer::write_string(buffer, bu.modified_by);
+    writer::write_string(buffer, bu.performed_by);
+    writer::write_string(buffer, bu.change_reason_code);
+    writer::write_string(buffer, bu.change_commentary);
+    writer::write_string(buffer,
+        ores::platform::time::datetime::format_time_point(bu.recorded_at));
+}
+
+std::expected<domain::business_unit, error_code>
+read_business_unit(std::span<const std::byte>& data) {
+    domain::business_unit bu;
+
+    auto version_result = reader::read_uint32(data);
+    if (!version_result) return std::unexpected(version_result.error());
+    bu.version = static_cast<int>(*version_result);
+
+    auto id_result = reader::read_uuid(data);
+    if (!id_result) return std::unexpected(id_result.error());
+    bu.id = *id_result;
+
+    auto party_id_result = reader::read_uuid(data);
+    if (!party_id_result) return std::unexpected(party_id_result.error());
+    bu.party_id = *party_id_result;
+
+    auto unit_name_result = reader::read_string(data);
+    if (!unit_name_result) return std::unexpected(unit_name_result.error());
+    bu.unit_name = *unit_name_result;
+
+    auto parent_business_unit_id_present_result = reader::read_bool(data);
+    if (!parent_business_unit_id_present_result) return std::unexpected(parent_business_unit_id_present_result.error());
+    if (*parent_business_unit_id_present_result) {
+        auto parent_business_unit_id_result = reader::read_uuid(data);
+        if (!parent_business_unit_id_result) return std::unexpected(parent_business_unit_id_result.error());
+        bu.parent_business_unit_id = *parent_business_unit_id_result;
+    }
+
+    auto unit_code_result = reader::read_string(data);
+    if (!unit_code_result) return std::unexpected(unit_code_result.error());
+    bu.unit_code = *unit_code_result;
+
+    auto business_centre_code_result = reader::read_string(data);
+    if (!business_centre_code_result) return std::unexpected(business_centre_code_result.error());
+    bu.business_centre_code = *business_centre_code_result;
+
+    auto modified_by_result = reader::read_string(data);
+    if (!modified_by_result) return std::unexpected(modified_by_result.error());
+    bu.modified_by = *modified_by_result;
+
+    auto performed_by_result = reader::read_string(data);
+    if (!performed_by_result) return std::unexpected(performed_by_result.error());
+    bu.performed_by = *performed_by_result;
+
+    auto change_reason_code_result = reader::read_string(data);
+    if (!change_reason_code_result) return std::unexpected(change_reason_code_result.error());
+    bu.change_reason_code = *change_reason_code_result;
+
+    auto change_commentary_result = reader::read_string(data);
+    if (!change_commentary_result) return std::unexpected(change_commentary_result.error());
+    bu.change_commentary = *change_commentary_result;
+
+    auto recorded_at_result = reader::read_string(data);
+    if (!recorded_at_result) return std::unexpected(recorded_at_result.error());
+    try {
+        bu.recorded_at = ores::platform::time::datetime::parse_time_point(*recorded_at_result);
+    } catch (const std::invalid_argument&) {
+        return std::unexpected(error_code::invalid_request);
+    }
+
+    return bu;
+}
+
+} // anonymous namespace
+
+// ============================================================================
+// Business Unit Messages Implementation
+// ============================================================================
+
+std::vector<std::byte> get_business_units_request::serialize() const {
+    return {};
+}
+
+std::expected<get_business_units_request, error_code>
+get_business_units_request::deserialize(std::span<const std::byte> data) {
+    if (!data.empty()) {
+        return std::unexpected(error_code::payload_too_large);
+    }
+    return get_business_units_request{};
+}
+
+std::ostream& operator<<(std::ostream& s, const get_business_units_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> get_business_units_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(business_units.size()));
+    for (const auto& bu : business_units) {
+        write_business_unit(buffer, bu);
+    }
+    return buffer;
+}
+
+std::expected<get_business_units_response, error_code>
+get_business_units_response::deserialize(std::span<const std::byte> data) {
+    get_business_units_response response;
+
+    auto count_result = reader::read_count(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    response.business_units.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        auto result = read_business_unit(data);
+        if (!result) return std::unexpected(result.error());
+        response.business_units.push_back(std::move(*result));
+    }
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s, const get_business_units_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> save_business_unit_request::serialize() const {
+    std::vector<std::byte> buffer;
+    write_business_unit(buffer, business_unit);
+    return buffer;
+}
+
+std::expected<save_business_unit_request, error_code>
+save_business_unit_request::deserialize(std::span<const std::byte> data) {
+    save_business_unit_request request;
+
+    auto result = read_business_unit(data);
+    if (!result) return std::unexpected(result.error());
+    request.business_unit = std::move(*result);
+
+    return request;
+}
+
+std::ostream& operator<<(std::ostream& s, const save_business_unit_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> save_business_unit_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_bool(buffer, success);
+    writer::write_string(buffer, message);
+    return buffer;
+}
+
+std::expected<save_business_unit_response, error_code>
+save_business_unit_response::deserialize(std::span<const std::byte> data) {
+    save_business_unit_response response;
+
+    auto success_result = reader::read_bool(data);
+    if (!success_result) return std::unexpected(success_result.error());
+    response.success = *success_result;
+
+    auto message_result = reader::read_string(data);
+    if (!message_result) return std::unexpected(message_result.error());
+    response.message = *message_result;
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s, const save_business_unit_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::ostream& operator<<(std::ostream& s, const delete_business_unit_result& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> delete_business_unit_request::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(ids.size()));
+    for (const auto& id : ids) {
+        writer::write_uuid(buffer, id);
+    }
+    return buffer;
+}
+
+std::expected<delete_business_unit_request, error_code>
+delete_business_unit_request::deserialize(std::span<const std::byte> data) {
+    delete_business_unit_request request;
+
+    auto count_result = reader::read_count(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    request.ids.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        auto id_result = reader::read_uuid(data);
+        if (!id_result) return std::unexpected(id_result.error());
+        request.ids.push_back(*id_result);
+    }
+
+    return request;
+}
+
+std::ostream& operator<<(std::ostream& s, const delete_business_unit_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> delete_business_unit_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(results.size()));
+    for (const auto& r : results) {
+        writer::write_uuid(buffer, r.id);
+        writer::write_bool(buffer, r.success);
+        writer::write_string(buffer, r.message);
+    }
+    return buffer;
+}
+
+std::expected<delete_business_unit_response, error_code>
+delete_business_unit_response::deserialize(std::span<const std::byte> data) {
+    delete_business_unit_response response;
+
+    auto count_result = reader::read_count(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    response.results.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        delete_business_unit_result r;
+
+        auto id_result = reader::read_uuid(data);
+        if (!id_result) return std::unexpected(id_result.error());
+        r.id = *id_result;
+
+        auto success_result = reader::read_bool(data);
+        if (!success_result) return std::unexpected(success_result.error());
+        r.success = *success_result;
+
+        auto message_result = reader::read_string(data);
+        if (!message_result) return std::unexpected(message_result.error());
+        r.message = *message_result;
+
+        response.results.push_back(std::move(r));
+    }
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s, const delete_business_unit_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> get_business_unit_history_request::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_uuid(buffer, id);
+    return buffer;
+}
+
+std::expected<get_business_unit_history_request, error_code>
+get_business_unit_history_request::deserialize(std::span<const std::byte> data) {
+    get_business_unit_history_request request;
+
+    auto id_result = reader::read_uuid(data);
+    if (!id_result) return std::unexpected(id_result.error());
+    request.id = *id_result;
+
+    return request;
+}
+
+std::ostream& operator<<(std::ostream& s, const get_business_unit_history_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> get_business_unit_history_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_bool(buffer, success);
+    writer::write_string(buffer, message);
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(versions.size()));
+    for (const auto& v : versions) {
+        write_business_unit(buffer, v);
+    }
+    return buffer;
+}
+
+std::expected<get_business_unit_history_response, error_code>
+get_business_unit_history_response::deserialize(std::span<const std::byte> data) {
+    get_business_unit_history_response response;
+
+    auto success_result = reader::read_bool(data);
+    if (!success_result) return std::unexpected(success_result.error());
+    response.success = *success_result;
+
+    auto message_result = reader::read_string(data);
+    if (!message_result) return std::unexpected(message_result.error());
+    response.message = *message_result;
+
+    auto count_result = reader::read_count(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    response.versions.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        auto result = read_business_unit(data);
+        if (!result) return std::unexpected(result.error());
+        response.versions.push_back(std::move(*result));
+    }
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s, const get_business_unit_history_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata/src/messaging/portfolio_protocol.cpp
+++ b/projects/ores.refdata/src/messaging/portfolio_protocol.cpp
@@ -1,0 +1,388 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/messaging/portfolio_protocol.hpp"
+
+#include <expected>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.platform/time/datetime.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+#include "ores.utility/serialization/reader.hpp"
+#include "ores.utility/serialization/writer.hpp"
+
+namespace ores::refdata::messaging {
+
+using ores::utility::serialization::error_code;
+using ores::utility::serialization::reader;
+using ores::utility::serialization::writer;
+
+namespace {
+
+// ============================================================================
+// Portfolio helpers
+// ============================================================================
+
+void write_portfolio(std::vector<std::byte>& buffer,
+    const domain::portfolio& pf) {
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(pf.version));
+    writer::write_uuid(buffer, pf.id);
+    writer::write_string(buffer, pf.name);
+    writer::write_bool(buffer, pf.parent_portfolio_id.has_value());
+    if (pf.parent_portfolio_id.has_value()) {
+        writer::write_uuid(buffer, *pf.parent_portfolio_id);
+    }
+    writer::write_bool(buffer, pf.owner_unit_id.has_value());
+    if (pf.owner_unit_id.has_value()) {
+        writer::write_uuid(buffer, *pf.owner_unit_id);
+    }
+    writer::write_string(buffer, pf.purpose_type);
+    writer::write_string(buffer, pf.aggregation_ccy);
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(pf.is_virtual));
+    writer::write_string(buffer, pf.modified_by);
+    writer::write_string(buffer, pf.performed_by);
+    writer::write_string(buffer, pf.change_reason_code);
+    writer::write_string(buffer, pf.change_commentary);
+    writer::write_string(buffer,
+        ores::platform::time::datetime::format_time_point(pf.recorded_at));
+}
+
+std::expected<domain::portfolio, error_code>
+read_portfolio(std::span<const std::byte>& data) {
+    domain::portfolio pf;
+
+    auto version_result = reader::read_uint32(data);
+    if (!version_result) return std::unexpected(version_result.error());
+    pf.version = static_cast<int>(*version_result);
+
+    auto id_result = reader::read_uuid(data);
+    if (!id_result) return std::unexpected(id_result.error());
+    pf.id = *id_result;
+
+    auto name_result = reader::read_string(data);
+    if (!name_result) return std::unexpected(name_result.error());
+    pf.name = *name_result;
+
+    auto parent_portfolio_id_present_result = reader::read_bool(data);
+    if (!parent_portfolio_id_present_result) return std::unexpected(parent_portfolio_id_present_result.error());
+    if (*parent_portfolio_id_present_result) {
+        auto parent_portfolio_id_result = reader::read_uuid(data);
+        if (!parent_portfolio_id_result) return std::unexpected(parent_portfolio_id_result.error());
+        pf.parent_portfolio_id = *parent_portfolio_id_result;
+    }
+
+    auto owner_unit_id_present_result = reader::read_bool(data);
+    if (!owner_unit_id_present_result) return std::unexpected(owner_unit_id_present_result.error());
+    if (*owner_unit_id_present_result) {
+        auto owner_unit_id_result = reader::read_uuid(data);
+        if (!owner_unit_id_result) return std::unexpected(owner_unit_id_result.error());
+        pf.owner_unit_id = *owner_unit_id_result;
+    }
+
+    auto purpose_type_result = reader::read_string(data);
+    if (!purpose_type_result) return std::unexpected(purpose_type_result.error());
+    pf.purpose_type = *purpose_type_result;
+
+    auto aggregation_ccy_result = reader::read_string(data);
+    if (!aggregation_ccy_result) return std::unexpected(aggregation_ccy_result.error());
+    pf.aggregation_ccy = *aggregation_ccy_result;
+
+    auto is_virtual_result = reader::read_uint32(data);
+    if (!is_virtual_result) return std::unexpected(is_virtual_result.error());
+    pf.is_virtual = static_cast<int>(*is_virtual_result);
+
+    auto modified_by_result = reader::read_string(data);
+    if (!modified_by_result) return std::unexpected(modified_by_result.error());
+    pf.modified_by = *modified_by_result;
+
+    auto performed_by_result = reader::read_string(data);
+    if (!performed_by_result) return std::unexpected(performed_by_result.error());
+    pf.performed_by = *performed_by_result;
+
+    auto change_reason_code_result = reader::read_string(data);
+    if (!change_reason_code_result) return std::unexpected(change_reason_code_result.error());
+    pf.change_reason_code = *change_reason_code_result;
+
+    auto change_commentary_result = reader::read_string(data);
+    if (!change_commentary_result) return std::unexpected(change_commentary_result.error());
+    pf.change_commentary = *change_commentary_result;
+
+    auto recorded_at_result = reader::read_string(data);
+    if (!recorded_at_result) return std::unexpected(recorded_at_result.error());
+    try {
+        pf.recorded_at = ores::platform::time::datetime::parse_time_point(*recorded_at_result);
+    } catch (const std::invalid_argument&) {
+        return std::unexpected(error_code::invalid_request);
+    }
+
+    return pf;
+}
+
+} // anonymous namespace
+
+// ============================================================================
+// Portfolio Messages Implementation
+// ============================================================================
+
+std::vector<std::byte> get_portfolios_request::serialize() const {
+    return {};
+}
+
+std::expected<get_portfolios_request, error_code>
+get_portfolios_request::deserialize(std::span<const std::byte> data) {
+    if (!data.empty()) {
+        return std::unexpected(error_code::payload_too_large);
+    }
+    return get_portfolios_request{};
+}
+
+std::ostream& operator<<(std::ostream& s, const get_portfolios_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> get_portfolios_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(portfolios.size()));
+    for (const auto& pf : portfolios) {
+        write_portfolio(buffer, pf);
+    }
+    return buffer;
+}
+
+std::expected<get_portfolios_response, error_code>
+get_portfolios_response::deserialize(std::span<const std::byte> data) {
+    get_portfolios_response response;
+
+    auto count_result = reader::read_count(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    response.portfolios.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        auto result = read_portfolio(data);
+        if (!result) return std::unexpected(result.error());
+        response.portfolios.push_back(std::move(*result));
+    }
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s, const get_portfolios_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> save_portfolio_request::serialize() const {
+    std::vector<std::byte> buffer;
+    write_portfolio(buffer, portfolio);
+    return buffer;
+}
+
+std::expected<save_portfolio_request, error_code>
+save_portfolio_request::deserialize(std::span<const std::byte> data) {
+    save_portfolio_request request;
+
+    auto result = read_portfolio(data);
+    if (!result) return std::unexpected(result.error());
+    request.portfolio = std::move(*result);
+
+    return request;
+}
+
+std::ostream& operator<<(std::ostream& s, const save_portfolio_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> save_portfolio_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_bool(buffer, success);
+    writer::write_string(buffer, message);
+    return buffer;
+}
+
+std::expected<save_portfolio_response, error_code>
+save_portfolio_response::deserialize(std::span<const std::byte> data) {
+    save_portfolio_response response;
+
+    auto success_result = reader::read_bool(data);
+    if (!success_result) return std::unexpected(success_result.error());
+    response.success = *success_result;
+
+    auto message_result = reader::read_string(data);
+    if (!message_result) return std::unexpected(message_result.error());
+    response.message = *message_result;
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s, const save_portfolio_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::ostream& operator<<(std::ostream& s, const delete_portfolio_result& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> delete_portfolio_request::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(ids.size()));
+    for (const auto& id : ids) {
+        writer::write_uuid(buffer, id);
+    }
+    return buffer;
+}
+
+std::expected<delete_portfolio_request, error_code>
+delete_portfolio_request::deserialize(std::span<const std::byte> data) {
+    delete_portfolio_request request;
+
+    auto count_result = reader::read_count(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    request.ids.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        auto id_result = reader::read_uuid(data);
+        if (!id_result) return std::unexpected(id_result.error());
+        request.ids.push_back(*id_result);
+    }
+
+    return request;
+}
+
+std::ostream& operator<<(std::ostream& s, const delete_portfolio_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> delete_portfolio_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(results.size()));
+    for (const auto& r : results) {
+        writer::write_uuid(buffer, r.id);
+        writer::write_bool(buffer, r.success);
+        writer::write_string(buffer, r.message);
+    }
+    return buffer;
+}
+
+std::expected<delete_portfolio_response, error_code>
+delete_portfolio_response::deserialize(std::span<const std::byte> data) {
+    delete_portfolio_response response;
+
+    auto count_result = reader::read_count(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    response.results.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        delete_portfolio_result r;
+
+        auto id_result = reader::read_uuid(data);
+        if (!id_result) return std::unexpected(id_result.error());
+        r.id = *id_result;
+
+        auto success_result = reader::read_bool(data);
+        if (!success_result) return std::unexpected(success_result.error());
+        r.success = *success_result;
+
+        auto message_result = reader::read_string(data);
+        if (!message_result) return std::unexpected(message_result.error());
+        r.message = *message_result;
+
+        response.results.push_back(std::move(r));
+    }
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s, const delete_portfolio_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> get_portfolio_history_request::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_uuid(buffer, id);
+    return buffer;
+}
+
+std::expected<get_portfolio_history_request, error_code>
+get_portfolio_history_request::deserialize(std::span<const std::byte> data) {
+    get_portfolio_history_request request;
+
+    auto id_result = reader::read_uuid(data);
+    if (!id_result) return std::unexpected(id_result.error());
+    request.id = *id_result;
+
+    return request;
+}
+
+std::ostream& operator<<(std::ostream& s, const get_portfolio_history_request& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+std::vector<std::byte> get_portfolio_history_response::serialize() const {
+    std::vector<std::byte> buffer;
+    writer::write_bool(buffer, success);
+    writer::write_string(buffer, message);
+    writer::write_uint32(buffer, static_cast<std::uint32_t>(versions.size()));
+    for (const auto& v : versions) {
+        write_portfolio(buffer, v);
+    }
+    return buffer;
+}
+
+std::expected<get_portfolio_history_response, error_code>
+get_portfolio_history_response::deserialize(std::span<const std::byte> data) {
+    get_portfolio_history_response response;
+
+    auto success_result = reader::read_bool(data);
+    if (!success_result) return std::unexpected(success_result.error());
+    response.success = *success_result;
+
+    auto message_result = reader::read_string(data);
+    if (!message_result) return std::unexpected(message_result.error());
+    response.message = *message_result;
+
+    auto count_result = reader::read_count(data);
+    if (!count_result) return std::unexpected(count_result.error());
+    auto count = *count_result;
+
+    response.versions.reserve(count);
+    for (std::uint32_t i = 0; i < count; ++i) {
+        auto result = read_portfolio(data);
+        if (!result) return std::unexpected(result.error());
+        response.versions.push_back(std::move(*result));
+    }
+
+    return response;
+}
+
+std::ostream& operator<<(std::ostream& s, const get_portfolio_history_response& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata/src/repository/book_entity.cpp
+++ b/projects/ores.refdata/src/repository/book_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/repository/book_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::refdata::repository {
+
+std::ostream& operator<<(std::ostream& s, const book_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata/src/repository/book_mapper.cpp
+++ b/projects/ores.refdata/src/repository/book_mapper.cpp
@@ -1,0 +1,101 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/repository/book_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.refdata/domain/book_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::book
+book_mapper::map(const book_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::book r;
+    r.version = v.version;
+    r.tenant_id = v.tenant_id;
+    r.id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.name = v.name;
+    r.parent_portfolio_id = boost::lexical_cast<boost::uuids::uuid>(v.parent_portfolio_id);
+    r.ledger_ccy = v.ledger_ccy;
+    r.gl_account_ref = v.gl_account_ref;
+    r.cost_center = v.cost_center;
+    r.book_status = v.book_status;
+    r.is_trading_book = v.is_trading_book;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+book_entity
+book_mapper::map(const domain::book& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    book_entity r;
+    r.id = boost::uuids::to_string(v.id);
+    r.tenant_id = v.tenant_id;
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.name = v.name;
+    r.parent_portfolio_id = boost::uuids::to_string(v.parent_portfolio_id);
+    r.ledger_ccy = v.ledger_ccy;
+    r.gl_account_ref = v.gl_account_ref;
+    r.cost_center = v.cost_center;
+    r.book_status = v.book_status;
+    r.is_trading_book = v.is_trading_book;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::book>
+book_mapper::map(const std::vector<book_entity>& v) {
+    return map_vector<book_entity, domain::book>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<book_entity>
+book_mapper::map(const std::vector<domain::book>& v) {
+    return map_vector<domain::book, book_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.refdata/src/repository/book_repository.cpp
+++ b/projects/ores.refdata/src/repository/book_repository.cpp
@@ -1,0 +1,126 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/repository/book_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.refdata/domain/book_json_io.hpp" // IWYU pragma: keep.
+#include "ores.refdata/repository/book_entity.hpp"
+#include "ores.refdata/repository/book_mapper.hpp"
+
+namespace ores::refdata::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string book_repository::sql() {
+    return generate_create_table_sql<book_entity>(lg());
+}
+
+book_repository::book_repository(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+void book_repository::write(const domain::book& book) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing book to database: "
+                               << book.id;
+    execute_write_query(ctx_, book_mapper::map(book),
+        lg(), "writing book to database");
+}
+
+void book_repository::write(
+    const std::vector<domain::book>& books) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing books to database. Count: "
+                               << books.size();
+    execute_write_query(ctx_, book_mapper::map(books),
+        lg(), "writing books to database");
+}
+
+std::vector<domain::book>
+book_repository::read_latest() {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::read<std::vector<book_entity>> |
+        where("valid_to"_c == max.value()) |
+        order_by("name"_c);
+
+    return execute_read_query<book_entity, domain::book>(
+        ctx_, query,
+        [](const auto& entities) { return book_mapper::map(entities); },
+        lg(), "Reading latest books");
+}
+
+std::vector<domain::book>
+book_repository::read_latest(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest book. Id: " << id;
+
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto id_str = boost::uuids::to_string(id);
+    const auto query = sqlgen::read<std::vector<book_entity>> |
+        where("id"_c == id_str && "valid_to"_c == max.value());
+
+    return execute_read_query<book_entity, domain::book>(
+        ctx_, query,
+        [](const auto& entities) { return book_mapper::map(entities); },
+        lg(), "Reading latest book by id.");
+}
+
+std::vector<domain::book>
+book_repository::read_latest_by_code(const std::string& code) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest book. Code: " << code;
+
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::read<std::vector<book_entity>> |
+        where("name"_c == code && "valid_to"_c == max.value());
+
+    return execute_read_query<book_entity, domain::book>(
+        ctx_, query,
+        [](const auto& entities) { return book_mapper::map(entities); },
+        lg(), "Reading latest book by code.");
+}
+
+std::vector<domain::book>
+book_repository::read_all(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all book versions. Id: " << id;
+
+    const auto id_str = boost::uuids::to_string(id);
+    const auto query = sqlgen::read<std::vector<book_entity>> |
+        where("id"_c == id_str) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<book_entity, domain::book>(
+        ctx_, query,
+        [](const auto& entities) { return book_mapper::map(entities); },
+        lg(), "Reading all book versions by id.");
+}
+
+void book_repository::remove(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing book from database: " << id;
+
+    const auto id_str = boost::uuids::to_string(id);
+    const auto query = sqlgen::delete_from<book_entity> |
+        where("id"_c == id_str);
+
+    execute_delete_query(ctx_, query, lg(), "removing book from database");
+}
+
+}

--- a/projects/ores.refdata/src/repository/business_unit_entity.cpp
+++ b/projects/ores.refdata/src/repository/business_unit_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/repository/business_unit_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::refdata::repository {
+
+std::ostream& operator<<(std::ostream& s, const business_unit_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata/src/repository/business_unit_mapper.cpp
+++ b/projects/ores.refdata/src/repository/business_unit_mapper.cpp
@@ -1,0 +1,97 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/repository/business_unit_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.refdata/domain/business_unit_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::business_unit
+business_unit_mapper::map(const business_unit_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::business_unit r;
+    r.version = v.version;
+    r.tenant_id = v.tenant_id;
+    r.id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.unit_name = v.unit_name;
+    if (v.parent_business_unit_id.has_value() && !v.parent_business_unit_id->empty())
+        r.parent_business_unit_id = boost::lexical_cast<boost::uuids::uuid>(*v.parent_business_unit_id);
+    r.unit_code = v.unit_code;
+    r.business_centre_code = v.business_centre_code;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+business_unit_entity
+business_unit_mapper::map(const domain::business_unit& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    business_unit_entity r;
+    r.id = boost::uuids::to_string(v.id);
+    r.tenant_id = v.tenant_id;
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.unit_name = v.unit_name;
+    if (v.parent_business_unit_id)
+        r.parent_business_unit_id = boost::uuids::to_string(*v.parent_business_unit_id);
+    r.unit_code = v.unit_code;
+    r.business_centre_code = v.business_centre_code;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::business_unit>
+business_unit_mapper::map(const std::vector<business_unit_entity>& v) {
+    return map_vector<business_unit_entity, domain::business_unit>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<business_unit_entity>
+business_unit_mapper::map(const std::vector<domain::business_unit>& v) {
+    return map_vector<domain::business_unit, business_unit_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.refdata/src/repository/business_unit_repository.cpp
+++ b/projects/ores.refdata/src/repository/business_unit_repository.cpp
@@ -1,0 +1,126 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/repository/business_unit_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.refdata/domain/business_unit_json_io.hpp" // IWYU pragma: keep.
+#include "ores.refdata/repository/business_unit_entity.hpp"
+#include "ores.refdata/repository/business_unit_mapper.hpp"
+
+namespace ores::refdata::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string business_unit_repository::sql() {
+    return generate_create_table_sql<business_unit_entity>(lg());
+}
+
+business_unit_repository::business_unit_repository(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+void business_unit_repository::write(const domain::business_unit& business_unit) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing business unit to database: "
+                               << business_unit.id;
+    execute_write_query(ctx_, business_unit_mapper::map(business_unit),
+        lg(), "writing business unit to database");
+}
+
+void business_unit_repository::write(
+    const std::vector<domain::business_unit>& business_units) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing business units to database. Count: "
+                               << business_units.size();
+    execute_write_query(ctx_, business_unit_mapper::map(business_units),
+        lg(), "writing business units to database");
+}
+
+std::vector<domain::business_unit>
+business_unit_repository::read_latest() {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::read<std::vector<business_unit_entity>> |
+        where("valid_to"_c == max.value()) |
+        order_by("unit_name"_c);
+
+    return execute_read_query<business_unit_entity, domain::business_unit>(
+        ctx_, query,
+        [](const auto& entities) { return business_unit_mapper::map(entities); },
+        lg(), "Reading latest business units");
+}
+
+std::vector<domain::business_unit>
+business_unit_repository::read_latest(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest business unit. Id: " << id;
+
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto id_str = boost::uuids::to_string(id);
+    const auto query = sqlgen::read<std::vector<business_unit_entity>> |
+        where("id"_c == id_str && "valid_to"_c == max.value());
+
+    return execute_read_query<business_unit_entity, domain::business_unit>(
+        ctx_, query,
+        [](const auto& entities) { return business_unit_mapper::map(entities); },
+        lg(), "Reading latest business unit by id.");
+}
+
+std::vector<domain::business_unit>
+business_unit_repository::read_latest_by_code(const std::string& code) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest business unit. Code: " << code;
+
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::read<std::vector<business_unit_entity>> |
+        where("unit_code"_c == code && "valid_to"_c == max.value());
+
+    return execute_read_query<business_unit_entity, domain::business_unit>(
+        ctx_, query,
+        [](const auto& entities) { return business_unit_mapper::map(entities); },
+        lg(), "Reading latest business unit by code.");
+}
+
+std::vector<domain::business_unit>
+business_unit_repository::read_all(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all business unit versions. Id: " << id;
+
+    const auto id_str = boost::uuids::to_string(id);
+    const auto query = sqlgen::read<std::vector<business_unit_entity>> |
+        where("id"_c == id_str) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<business_unit_entity, domain::business_unit>(
+        ctx_, query,
+        [](const auto& entities) { return business_unit_mapper::map(entities); },
+        lg(), "Reading all business unit versions by id.");
+}
+
+void business_unit_repository::remove(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing business unit from database: " << id;
+
+    const auto id_str = boost::uuids::to_string(id);
+    const auto query = sqlgen::delete_from<business_unit_entity> |
+        where("id"_c == id_str);
+
+    execute_delete_query(ctx_, query, lg(), "removing business unit from database");
+}
+
+}

--- a/projects/ores.refdata/src/repository/portfolio_entity.cpp
+++ b/projects/ores.refdata/src/repository/portfolio_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/repository/portfolio_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::refdata::repository {
+
+std::ostream& operator<<(std::ostream& s, const portfolio_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata/src/repository/portfolio_mapper.cpp
+++ b/projects/ores.refdata/src/repository/portfolio_mapper.cpp
@@ -1,0 +1,101 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/repository/portfolio_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.refdata/domain/portfolio_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::portfolio
+portfolio_mapper::map(const portfolio_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::portfolio r;
+    r.version = v.version;
+    r.tenant_id = v.tenant_id;
+    r.id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
+    r.name = v.name;
+    if (v.parent_portfolio_id.has_value() && !v.parent_portfolio_id->empty())
+        r.parent_portfolio_id = boost::lexical_cast<boost::uuids::uuid>(*v.parent_portfolio_id);
+    if (v.owner_unit_id.has_value() && !v.owner_unit_id->empty())
+        r.owner_unit_id = boost::lexical_cast<boost::uuids::uuid>(*v.owner_unit_id);
+    r.purpose_type = v.purpose_type;
+    r.aggregation_ccy = v.aggregation_ccy;
+    r.is_virtual = v.is_virtual;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+portfolio_entity
+portfolio_mapper::map(const domain::portfolio& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    portfolio_entity r;
+    r.id = boost::uuids::to_string(v.id);
+    r.tenant_id = v.tenant_id;
+    r.version = v.version;
+    r.name = v.name;
+    if (v.parent_portfolio_id)
+        r.parent_portfolio_id = boost::uuids::to_string(*v.parent_portfolio_id);
+    if (v.owner_unit_id)
+        r.owner_unit_id = boost::uuids::to_string(*v.owner_unit_id);
+    r.purpose_type = v.purpose_type;
+    r.aggregation_ccy = v.aggregation_ccy;
+    r.is_virtual = v.is_virtual;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::portfolio>
+portfolio_mapper::map(const std::vector<portfolio_entity>& v) {
+    return map_vector<portfolio_entity, domain::portfolio>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<portfolio_entity>
+portfolio_mapper::map(const std::vector<domain::portfolio>& v) {
+    return map_vector<domain::portfolio, portfolio_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.refdata/src/repository/portfolio_repository.cpp
+++ b/projects/ores.refdata/src/repository/portfolio_repository.cpp
@@ -1,0 +1,126 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/repository/portfolio_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.refdata/domain/portfolio_json_io.hpp" // IWYU pragma: keep.
+#include "ores.refdata/repository/portfolio_entity.hpp"
+#include "ores.refdata/repository/portfolio_mapper.hpp"
+
+namespace ores::refdata::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string portfolio_repository::sql() {
+    return generate_create_table_sql<portfolio_entity>(lg());
+}
+
+portfolio_repository::portfolio_repository(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+void portfolio_repository::write(const domain::portfolio& portfolio) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing portfolio to database: "
+                               << portfolio.id;
+    execute_write_query(ctx_, portfolio_mapper::map(portfolio),
+        lg(), "writing portfolio to database");
+}
+
+void portfolio_repository::write(
+    const std::vector<domain::portfolio>& portfolios) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing portfolios to database. Count: "
+                               << portfolios.size();
+    execute_write_query(ctx_, portfolio_mapper::map(portfolios),
+        lg(), "writing portfolios to database");
+}
+
+std::vector<domain::portfolio>
+portfolio_repository::read_latest() {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::read<std::vector<portfolio_entity>> |
+        where("valid_to"_c == max.value()) |
+        order_by("name"_c);
+
+    return execute_read_query<portfolio_entity, domain::portfolio>(
+        ctx_, query,
+        [](const auto& entities) { return portfolio_mapper::map(entities); },
+        lg(), "Reading latest portfolios");
+}
+
+std::vector<domain::portfolio>
+portfolio_repository::read_latest(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest portfolio. Id: " << id;
+
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto id_str = boost::uuids::to_string(id);
+    const auto query = sqlgen::read<std::vector<portfolio_entity>> |
+        where("id"_c == id_str && "valid_to"_c == max.value());
+
+    return execute_read_query<portfolio_entity, domain::portfolio>(
+        ctx_, query,
+        [](const auto& entities) { return portfolio_mapper::map(entities); },
+        lg(), "Reading latest portfolio by id.");
+}
+
+std::vector<domain::portfolio>
+portfolio_repository::read_latest_by_code(const std::string& code) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest portfolio. Code: " << code;
+
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto query = sqlgen::read<std::vector<portfolio_entity>> |
+        where("name"_c == code && "valid_to"_c == max.value());
+
+    return execute_read_query<portfolio_entity, domain::portfolio>(
+        ctx_, query,
+        [](const auto& entities) { return portfolio_mapper::map(entities); },
+        lg(), "Reading latest portfolio by code.");
+}
+
+std::vector<domain::portfolio>
+portfolio_repository::read_all(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all portfolio versions. Id: " << id;
+
+    const auto id_str = boost::uuids::to_string(id);
+    const auto query = sqlgen::read<std::vector<portfolio_entity>> |
+        where("id"_c == id_str) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<portfolio_entity, domain::portfolio>(
+        ctx_, query,
+        [](const auto& entities) { return portfolio_mapper::map(entities); },
+        lg(), "Reading all portfolio versions by id.");
+}
+
+void portfolio_repository::remove(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing portfolio from database: " << id;
+
+    const auto id_str = boost::uuids::to_string(id);
+    const auto query = sqlgen::delete_from<portfolio_entity> |
+        where("id"_c == id_str);
+
+    execute_delete_query(ctx_, query, lg(), "removing portfolio from database");
+}
+
+}

--- a/projects/ores.refdata/src/service/book_service.cpp
+++ b/projects/ores.refdata/src/service/book_service.cpp
@@ -1,0 +1,78 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/service/book_service.hpp"
+
+#include <stdexcept>
+#include <boost/uuid/uuid_io.hpp>
+
+namespace ores::refdata::service {
+
+using namespace ores::logging;
+
+book_service::book_service(context ctx)
+    : repo_(ctx) {}
+
+std::vector<domain::book> book_service::list_books() {
+    BOOST_LOG_SEV(lg(), debug) << "Listing all books";
+    return repo_.read_latest();
+}
+
+std::optional<domain::book>
+book_service::find_book(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Finding book: " << id;
+    auto results = repo_.read_latest(id);
+    if (results.empty()) {
+        return std::nullopt;
+    }
+    return results.front();
+}
+
+std::optional<domain::book>
+book_service::find_book_by_code(const std::string& code) {
+    BOOST_LOG_SEV(lg(), debug) << "Finding book by code: " << code;
+    auto results = repo_.read_latest_by_code(code);
+    if (results.empty()) {
+        return std::nullopt;
+    }
+    return results.front();
+}
+
+void book_service::save_book(const domain::book& book) {
+    if (book.id.is_nil()) {
+        throw std::invalid_argument("Book ID cannot be nil.");
+    }
+    BOOST_LOG_SEV(lg(), debug) << "Saving book: " << book.id;
+    repo_.write(book);
+    BOOST_LOG_SEV(lg(), info) << "Saved book: " << book.id;
+}
+
+void book_service::remove_book(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing book: " << id;
+    repo_.remove(id);
+    BOOST_LOG_SEV(lg(), info) << "Removed book: " << id;
+}
+
+std::vector<domain::book>
+book_service::get_book_history(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting history for book: " << id;
+    return repo_.read_all(id);
+}
+
+}

--- a/projects/ores.refdata/src/service/business_unit_service.cpp
+++ b/projects/ores.refdata/src/service/business_unit_service.cpp
@@ -1,0 +1,78 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/service/business_unit_service.hpp"
+
+#include <stdexcept>
+#include <boost/uuid/uuid_io.hpp>
+
+namespace ores::refdata::service {
+
+using namespace ores::logging;
+
+business_unit_service::business_unit_service(context ctx)
+    : repo_(ctx) {}
+
+std::vector<domain::business_unit> business_unit_service::list_business_units() {
+    BOOST_LOG_SEV(lg(), debug) << "Listing all business units";
+    return repo_.read_latest();
+}
+
+std::optional<domain::business_unit>
+business_unit_service::find_business_unit(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Finding business unit: " << id;
+    auto results = repo_.read_latest(id);
+    if (results.empty()) {
+        return std::nullopt;
+    }
+    return results.front();
+}
+
+std::optional<domain::business_unit>
+business_unit_service::find_business_unit_by_code(const std::string& code) {
+    BOOST_LOG_SEV(lg(), debug) << "Finding business unit by code: " << code;
+    auto results = repo_.read_latest_by_code(code);
+    if (results.empty()) {
+        return std::nullopt;
+    }
+    return results.front();
+}
+
+void business_unit_service::save_business_unit(const domain::business_unit& business_unit) {
+    if (business_unit.id.is_nil()) {
+        throw std::invalid_argument("Business Unit ID cannot be nil.");
+    }
+    BOOST_LOG_SEV(lg(), debug) << "Saving business unit: " << business_unit.id;
+    repo_.write(business_unit);
+    BOOST_LOG_SEV(lg(), info) << "Saved business unit: " << business_unit.id;
+}
+
+void business_unit_service::remove_business_unit(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing business unit: " << id;
+    repo_.remove(id);
+    BOOST_LOG_SEV(lg(), info) << "Removed business unit: " << id;
+}
+
+std::vector<domain::business_unit>
+business_unit_service::get_business_unit_history(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting history for business unit: " << id;
+    return repo_.read_all(id);
+}
+
+}

--- a/projects/ores.refdata/src/service/portfolio_service.cpp
+++ b/projects/ores.refdata/src/service/portfolio_service.cpp
@@ -1,0 +1,78 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata/service/portfolio_service.hpp"
+
+#include <stdexcept>
+#include <boost/uuid/uuid_io.hpp>
+
+namespace ores::refdata::service {
+
+using namespace ores::logging;
+
+portfolio_service::portfolio_service(context ctx)
+    : repo_(ctx) {}
+
+std::vector<domain::portfolio> portfolio_service::list_portfolios() {
+    BOOST_LOG_SEV(lg(), debug) << "Listing all portfolios";
+    return repo_.read_latest();
+}
+
+std::optional<domain::portfolio>
+portfolio_service::find_portfolio(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Finding portfolio: " << id;
+    auto results = repo_.read_latest(id);
+    if (results.empty()) {
+        return std::nullopt;
+    }
+    return results.front();
+}
+
+std::optional<domain::portfolio>
+portfolio_service::find_portfolio_by_code(const std::string& code) {
+    BOOST_LOG_SEV(lg(), debug) << "Finding portfolio by code: " << code;
+    auto results = repo_.read_latest_by_code(code);
+    if (results.empty()) {
+        return std::nullopt;
+    }
+    return results.front();
+}
+
+void portfolio_service::save_portfolio(const domain::portfolio& portfolio) {
+    if (portfolio.id.is_nil()) {
+        throw std::invalid_argument("Portfolio ID cannot be nil.");
+    }
+    BOOST_LOG_SEV(lg(), debug) << "Saving portfolio: " << portfolio.id;
+    repo_.write(portfolio);
+    BOOST_LOG_SEV(lg(), info) << "Saved portfolio: " << portfolio.id;
+}
+
+void portfolio_service::remove_portfolio(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing portfolio: " << id;
+    repo_.remove(id);
+    BOOST_LOG_SEV(lg(), info) << "Removed portfolio: " << id;
+}
+
+std::vector<domain::portfolio>
+portfolio_service::get_portfolio_history(const boost::uuids::uuid& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting history for portfolio: " << id;
+    return repo_.read_all(id);
+}
+
+}


### PR DESCRIPTION
## Summary
- Add complete C++ domain layer for three Organisation subject area entities: `business_unit`, `portfolio`, and `book`
- Each entity includes domain class, JSON I/O, table I/O, generator, repository (entity/mapper/repository), service, and binary protocol (58 files, ~5000 lines)
- Register 24 new message types in `message_type.hpp` (0x1069-0x1080) for CRUD and history operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)