### PR TITLE
[infra] Set CMAKE_BUILD_PARALLEL_LEVEL and CTEST_PARALLEL_LEVEL in CI

### DIFF
--- a/.github/workflows/canary-linux.yml
+++ b/.github/workflows/canary-linux.yml
@@ -123,6 +123,8 @@ jobs:
 
       - name: Run CTest workflow
         run: |
+          export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
+          export CTEST_PARALLEL_LEVEL=$(nproc)
           export PATH=${PATH}:/usr/sbin
           export ZIC=1
           export ORES_BUILD_PROVIDER="github"

--- a/.github/workflows/continuous-linux.yml
+++ b/.github/workflows/continuous-linux.yml
@@ -158,6 +158,8 @@ jobs:
 
       - name: Run CTest workflow
         run: |
+          export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
+          export CTEST_PARALLEL_LEVEL=$(nproc)
           export PATH=${PATH}:/usr/sbin
           export ZIC=1
           export ORES_BUILD_PROVIDER="github"

--- a/.github/workflows/continuous-macos.yml
+++ b/.github/workflows/continuous-macos.yml
@@ -123,6 +123,8 @@ jobs:
       - name: Run CTest workflow
         run: |
           brew install autoconf automake libtool autoconf-archive
+          export CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.logicalcpu)
+          export CTEST_PARALLEL_LEVEL=$(sysctl -n hw.logicalcpu)
           export VCPKG_DISABLE_SYSTEM_PACKAGE_CHECK=1
           export ORES_BUILD_PROVIDER="github"
           export ORES_BUILD_COMMIT="${GITHUB_SHA}"

--- a/.github/workflows/nightly-linux.yml
+++ b/.github/workflows/nightly-linux.yml
@@ -171,6 +171,8 @@ jobs:
 
       - name: Run CTest workflow
         run: |
+          export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
+          export CTEST_PARALLEL_LEVEL=$(nproc)
           export PATH=${PATH}:/usr/sbin
           export ORES_BUILD_PROVIDER="github"
           export ORES_BUILD_COMMIT="${GITHUB_SHA}"


### PR DESCRIPTION
## Summary

- Eliminates the CMake configure-time warnings about `CMAKE_BUILD_PARALLEL_LEVEL` and `CTEST_PARALLEL_LEVEL` not being set in CI
- Uses `$(nproc)` on Linux and `$(sysctl -n hw.logicalcpu)` on macOS to match the actual runner core count, enabling parallel builds and test execution

Affected: `canary-linux.yml`, `continuous-linux.yml`, `nightly-linux.yml`, `continuous-macos.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)