### PR TITLE
[scheduler] Link libfort::fort on Windows

### DIFF
--- a/projects/ores.scheduler/src/CMakeLists.txt
+++ b/projects/ores.scheduler/src/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${lib_target_name}
         ores.logging.lib
         ores.platform.lib
         croncpp::croncpp
-        faker-cxx::faker-cxx)
+        faker-cxx::faker-cxx
+        libfort::fort)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)


### PR DESCRIPTION
## Summary

- `ores.scheduler` uses `fort.hpp` for ASCII table rendering in `job_definition_table.cpp` but was missing `libfort::fort` from `target_link_libraries`
- This caused undefined symbol linker errors (`ft_create_table`, `ft_to_string`, `FT_BASIC_STYLE`, etc.) when building the `ores.scheduler.dll` on Windows
- All other components that use fort (`ores.trading`, `ores.dq`, `ores.fpml`, `ores.assets`, `ores.variability`, `ores.eventing`, `ores.refdata`, `ores.iam`, `ores.connections`) already link `libfort::fort` explicitly

Fixes https://github.com/OreStudio/OreStudio/actions/runs/22480641395

🤖 Generated with [Claude Code](https://claude.com/claude-code)