### PR TITLE
[sql] Fix TOCTOU race in party codename generation trigger

### DIFF
--- a/projects/ores.sql/create/refdata/refdata_parties_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_parties_create.sql
@@ -175,7 +175,7 @@ begin
         -- Auto-generate codename using existing whimsical name infrastructure.
         if NEW.codename = '' or NEW.codename is null then
             -- Serialize concurrent codename generation to prevent TOCTOU race.
-            perform pg_advisory_xact_lock(hashtext('ores_codename_gen'));
+            perform pg_advisory_xact_lock(hashtext('ores_refdata_parties'), hashtext('codename_gen'));
             loop
                 NEW.codename := ores_utility_generate_whimsical_name_fn();
                 exit when not exists (


### PR DESCRIPTION
## Summary

- Two concurrent transactions could both pass the `not exists` uniqueness check before either committed, causing `duplicate key value violates unique constraint "ores_refdata_parties_codename_uniq_idx"` in parallel CI test runs
- Adds `pg_advisory_xact_lock(hashtext('ores_codename_gen'))` before the generation loop in the BEFORE INSERT trigger to serialize concurrent codename generation
- Fixes intermittent CI failures seen in runs [22694488593](https://github.com/OreStudio/OreStudio/actions/runs/22694488593) and [22694488444](https://github.com/OreStudio/OreStudio/actions/runs/22694488444)

🤖 Generated with [Claude Code](https://claude.com/claude-code)