### PR TITLE
[ci] Fix website broken ID link and Windows NATS install

### DIFF
--- a/.github/workflows/continuous-windows.yml
+++ b/.github/workflows/continuous-windows.yml
@@ -75,7 +75,13 @@ jobs:
         run: choco install nsis
 
       - name: Install NATS Server
-        run: choco install nats-server
+        run: |
+          $version = "v2.10.24"
+          $url = "https://github.com/nats-io/nats-server/releases/download/$version/nats-server-$version-windows-amd64.zip"
+          Invoke-WebRequest -Uri $url -OutFile nats-server.zip
+          Expand-Archive -Path nats-server.zip -DestinationPath "$env:ProgramFiles\nats-server" -Force
+          $dir = Get-ChildItem "$env:ProgramFiles\nats-server" -Directory | Select-Object -First 1
+          echo "$($dir.FullName)" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1.13.0

--- a/projects/modeling/system_model.org
+++ b/projects/modeling/system_model.org
@@ -55,9 +55,9 @@ The system is organised into four architectural layers:
 
 ** Infrastructure Layer
 
-- [[id:361A6093-D24C-9BC4-0543-6540461EDBB6][ores.comms]]: Binary protocol over SSL/TLS for client-server messaging.
-  Publishes connection lifecycle events (connected, disconnected, reconnecting,
-  reconnected) to event bus.
+- ores.nats: NATS-based messaging for all inter-service and client-server
+  communication. Provides request/reply, pub/sub, and JetStream (durable
+  persistent messaging). Replaced the old ores.comms binary protocol stack.
 - [[id:7F58FF13-5A85-49C4-09BB-EED86B874ABB][ores.testing]]: Catch2 integration with database isolation and logging
   listeners.
 - [[id:DDBC94C4-F350-478B-9E4C-643DEEA803B0][ores.eventing]]: Event-driven architecture with in-process publish/subscribe


### PR DESCRIPTION
## Summary

- **Website**: `system_model.org` had a dangling `[[id:361A6093...]]` link to `ores.comms.org` which was deleted in the Phase 2+3 NATS migration. Replaced with a plain-text description of `ores.nats`.
- **Windows**: `choco install nats-server` fails because the package doesn't exist in the Chocolatey community registry. Replaced with a direct download of the binary from the GitHub releases page (v2.10.24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)