### PR TITLE
[ci] Use init-environment.sh uniformly across all workflows

### DIFF
--- a/.github/workflows/canary-linux.yml
+++ b/.github/workflows/canary-linux.yml
@@ -68,28 +68,12 @@ jobs:
           modules: 'qtcharts'
           cache: true
 
-      - name: Generate DB Passwords
-        id: db_passwords
+      - name: Generate postgres password
+        id: pg_password
         run: |
-          echo "ddl_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "cli_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "wt_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "comms_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "http_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "test_ddl_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "test_dml_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "ro_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "admin_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "iam_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "refdata_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "dq_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "variability_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "assets_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "synthetic_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "scheduler_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "reporting_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "telemetry_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "trading_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
+          PG_PASS="$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')"
+          echo "admin_password=${PG_PASS}" >> $GITHUB_OUTPUT
+          echo "PGPASSWORD=${PG_PASS}" >> $GITHUB_ENV
 
       - name: Install PostgreSQL extensions
         run: |
@@ -99,7 +83,7 @@ jobs:
         uses: ikalnytskyi/action-setup-postgres@v8
         with:
           username: postgres
-          password: ${{ steps.db_passwords.outputs.admin_password }}
+          password: ${{ steps.pg_password.outputs.admin_password }}
           database: oresdb
           port: 5432
           postgres-version: "18"
@@ -111,27 +95,16 @@ jobs:
           echo "shared_preload_libraries = 'pg_cron,timescaledb'" >> "$PGDATA/postgresql.conf"
           pg_ctl restart --pgdata="$PGDATA" --wait
 
-      - name: Setup Database
+      - name: Init environment
         env:
-          PGPASSWORD: ${{ steps.db_passwords.outputs.admin_password }}
-          ORES_DB_DDL_PASSWORD: ${{ steps.db_passwords.outputs.ddl_password }}
-          ORES_DB_CLI_PASSWORD: ${{ steps.db_passwords.outputs.cli_password }}
-          ORES_DB_WT_PASSWORD: ${{ steps.db_passwords.outputs.wt_password }}
-          ORES_DB_COMMS_PASSWORD: ${{ steps.db_passwords.outputs.comms_password }}
-          ORES_DB_HTTP_PASSWORD: ${{ steps.db_passwords.outputs.http_password }}
-          ORES_DB_TEST_DDL_PASSWORD: ${{ steps.db_passwords.outputs.test_ddl_password }}
-          ORES_DB_TEST_PASSWORD: ${{ steps.db_passwords.outputs.test_dml_password }}
-          ORES_DB_READONLY_PASSWORD: ${{ steps.db_passwords.outputs.ro_password }}
-          ORES_IAM_SERVICE_DB_PASSWORD: ${{ steps.db_passwords.outputs.iam_service_password }}
-          ORES_REFDATA_SERVICE_DB_PASSWORD: ${{ steps.db_passwords.outputs.refdata_service_password }}
-          ORES_DQ_SERVICE_DB_PASSWORD: ${{ steps.db_passwords.outputs.dq_service_password }}
-          ORES_VARIABILITY_SERVICE_DB_PASSWORD: ${{ steps.db_passwords.outputs.variability_service_password }}
-          ORES_ASSETS_SERVICE_DB_PASSWORD: ${{ steps.db_passwords.outputs.assets_service_password }}
-          ORES_SYNTHETIC_SERVICE_DB_PASSWORD: ${{ steps.db_passwords.outputs.synthetic_service_password }}
-          ORES_SCHEDULER_SERVICE_DB_PASSWORD: ${{ steps.db_passwords.outputs.scheduler_service_password }}
-          ORES_REPORTING_SERVICE_DB_PASSWORD: ${{ steps.db_passwords.outputs.reporting_service_password }}
-          ORES_TELEMETRY_SERVICE_DB_PASSWORD: ${{ steps.db_passwords.outputs.telemetry_service_password }}
-          ORES_TRADING_SERVICE_DB_PASSWORD: ${{ steps.db_passwords.outputs.trading_service_password }}
+          ORES_DATABASE_NAME: ores_ci
+          PGPASSWORD: ${{ steps.pg_password.outputs.admin_password }}
+        run: |
+          ./build/scripts/init-environment.sh -y
+          grep -v '^[[:space:]]*#' .env | grep -v '^[[:space:]]*$' \
+            | grep -v 'ORES_IAM_SERVICE_JWT_PRIVATE_KEY' >> $GITHUB_ENV
+
+      - name: Setup Database
         run: |
           ./projects/ores.sql/recreate_database.sh -y -D ores_ci
 
@@ -152,35 +125,6 @@ jobs:
           doNotCache: false
 
       - name: Run CTest workflow
-        env:
-          ORES_CLI_DB_USER: ores_cli_user
-          ORES_CLI_DB_DATABASE: ores_ci
-          ORES_COMMS_SHELL_DB_USER: ores_comms_user
-          ORES_COMMS_SHELL_DB_DATABASE: ores_ci
-          ORES_HTTP_SERVER_DB_USER: ores_http_user
-          ORES_HTTP_SERVER_DB_DATABASE: ores_ci
-          ORES_IAM_SERVICE_DB_USER: ores_iam_service
-          ORES_IAM_SERVICE_DB_DATABASE: ores_ci
-          ORES_REFDATA_SERVICE_DB_USER: ores_refdata_service
-          ORES_REFDATA_SERVICE_DB_DATABASE: ores_ci
-          ORES_DQ_SERVICE_DB_USER: ores_dq_service
-          ORES_DQ_SERVICE_DB_DATABASE: ores_ci
-          ORES_VARIABILITY_SERVICE_DB_USER: ores_variability_service
-          ORES_VARIABILITY_SERVICE_DB_DATABASE: ores_ci
-          ORES_ASSETS_SERVICE_DB_USER: ores_assets_service
-          ORES_ASSETS_SERVICE_DB_DATABASE: ores_ci
-          ORES_SYNTHETIC_SERVICE_DB_USER: ores_synthetic_service
-          ORES_SYNTHETIC_SERVICE_DB_DATABASE: ores_ci
-          ORES_SCHEDULER_SERVICE_DB_USER: ores_scheduler_service
-          ORES_SCHEDULER_SERVICE_DB_DATABASE: ores_ci
-          ORES_REPORTING_SERVICE_DB_USER: ores_reporting_service
-          ORES_REPORTING_SERVICE_DB_DATABASE: ores_ci
-          ORES_TELEMETRY_SERVICE_DB_USER: ores_telemetry_service
-          ORES_TELEMETRY_SERVICE_DB_DATABASE: ores_ci
-          ORES_TRADING_SERVICE_DB_USER: ores_trading_service
-          ORES_TRADING_SERVICE_DB_DATABASE: ores_ci
-          ORES_WT_DB_USER: ores_wt_user
-          ORES_WT_DB_DATABASE: ores_ci
         run: |
           export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
           export CTEST_PARALLEL_LEVEL=$(nproc)
@@ -190,9 +134,6 @@ jobs:
           export ORES_BUILD_COMMIT="${GITHUB_SHA}"
           export ORES_BUILD_NUMBER="${GITHUB_RUN_NUMBER}"
           export ORES_BUILD_TIMESTAMP=`date "+%Y/%m/%d %H:%M:%S"`
-          export ORES_TEST_DB_DATABASE=ores_ci
-          export ORES_TEST_DB_DDL_PASSWORD=${{ steps.db_passwords.outputs.test_ddl_password }}
-          export ORES_TEST_DB_PASSWORD=${{ steps.db_passwords.outputs.test_dml_password }}
           export preset=linux-gcc-debug-ninja
           export cmake_args="build_group=Canary,preset=${preset},code_coverage=1"
           ctest -VV --preset ${preset} --script "CTest.cmake,${cmake_args}"

--- a/.github/workflows/continuous-macos.yml
+++ b/.github/workflows/continuous-macos.yml
@@ -67,34 +67,18 @@ jobs:
           modules: 'qtcharts'
           cache: true
 
-      - name: Generate DB Passwords
-        id: db_passwords
+      - name: Generate postgres password
+        id: pg_password
         run: |
-          echo "ddl_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "cli_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "wt_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "comms_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "http_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "test_ddl_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "test_dml_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "ro_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "admin_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "iam_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "refdata_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "dq_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "variability_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "assets_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "synthetic_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "scheduler_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "reporting_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "telemetry_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
-          echo "trading_service_password=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')" >> $GITHUB_OUTPUT
+          PG_PASS="$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')"
+          echo "admin_password=${PG_PASS}" >> $GITHUB_OUTPUT
+          echo "PGPASSWORD=${PG_PASS}" >> $GITHUB_ENV
 
       - name: Setup postgres
         uses: ikalnytskyi/action-setup-postgres@v8
         with:
           username: postgres
-          password: ${{ steps.db_passwords.outputs.admin_password }}
+          password: ${{ steps.pg_password.outputs.admin_password }}
           database: oresdb
           port: 5432
           postgres-version: "18"
@@ -113,29 +97,18 @@ jobs:
           sudo cp sql/*.sql "${extdir}/"
           echo "pgmq ${version} installed to ${extdir}"
 
+      - name: Init environment
+        env:
+          ORES_DATABASE_NAME: ores_ci
+          PGPASSWORD: ${{ steps.pg_password.outputs.admin_password }}
+        run: |
+          ./build/scripts/init-environment.sh -y
+          grep -v '^[[:space:]]*#' .env | grep -v '^[[:space:]]*$' \
+            | grep -v 'ORES_IAM_SERVICE_JWT_PRIVATE_KEY' >> $GITHUB_ENV
+
       - name: Setup Database
         run: |
-          ./projects/ores.sql/recreate_database.sh -y \
-            -p '${{ steps.db_passwords.outputs.admin_password }}' \
-            -d '${{ steps.db_passwords.outputs.ddl_password }}' \
-            -c '${{ steps.db_passwords.outputs.cli_password }}' \
-            -w '${{ steps.db_passwords.outputs.wt_password }}' \
-            -m '${{ steps.db_passwords.outputs.comms_password }}' \
-            -h '${{ steps.db_passwords.outputs.http_password }}' \
-            -t '${{ steps.db_passwords.outputs.test_ddl_password }}' \
-            -T '${{ steps.db_passwords.outputs.test_dml_password }}' \
-            -r '${{ steps.db_passwords.outputs.ro_password }}' \
-            --iam-service-password '${{ steps.db_passwords.outputs.iam_service_password }}' \
-            --refdata-service-password '${{ steps.db_passwords.outputs.refdata_service_password }}' \
-            --dq-service-password '${{ steps.db_passwords.outputs.dq_service_password }}' \
-            --variability-service-password '${{ steps.db_passwords.outputs.variability_service_password }}' \
-            --assets-service-password '${{ steps.db_passwords.outputs.assets_service_password }}' \
-            --synthetic-service-password '${{ steps.db_passwords.outputs.synthetic_service_password }}' \
-            --scheduler-service-password '${{ steps.db_passwords.outputs.scheduler_service_password }}' \
-            --reporting-service-password '${{ steps.db_passwords.outputs.reporting_service_password }}' \
-            --telemetry-service-password '${{ steps.db_passwords.outputs.telemetry_service_password }}' \
-            --trading-service-password '${{ steps.db_passwords.outputs.trading_service_password }}' \
-            -D ores_ci
+          ./projects/ores.sql/recreate_database.sh -y -D ores_ci
 
       - name: get-cmake
         uses: lukka/get-cmake@v4.2.3
@@ -163,9 +136,6 @@ jobs:
           export ORES_BUILD_COMMIT="${GITHUB_SHA}"
           export ORES_BUILD_NUMBER="${GITHUB_RUN_NUMBER}"
           export ORES_BUILD_TIMESTAMP=`date "+%Y/%m/%d %H:%M:%S"`
-          export ORES_TEST_DB_DATABASE=ores_ci
-          export ORES_TEST_DB_DDL_PASSWORD=${{ steps.db_passwords.outputs.test_ddl_password }}
-          export ORES_TEST_DB_PASSWORD=${{ steps.db_passwords.outputs.test_dml_password }}
           export preset=${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja
           export cmake_args="build_group=Continuous,preset=${preset}"
           ctest -VV --preset ${preset} --script "CTest.cmake,${cmake_args}"

--- a/.github/workflows/continuous-windows.yml
+++ b/.github/workflows/continuous-windows.yml
@@ -129,6 +129,7 @@ jobs:
         shell: bash
         env:
           ORES_DATABASE_NAME: ores_ci
+          PGPASSWORD: ${{ steps.pg_password.outputs.admin_password }}
         run: |
           ./build/scripts/init-environment.sh -y
           grep -v '^[[:space:]]*#' .env | grep -v '^[[:space:]]*$' \


### PR DESCRIPTION
## Summary

- All CI workflows now use `init-environment.sh` to generate credentials and source `.env` into `GITHUB_ENV`, matching the local development workflow
- Eliminates static per-service credential lists that drift as new services are added
- **canary-linux**: replace 20-line `Generate DB Passwords` + static env blocks on `Setup Database` and `Run CTest` with `Generate postgres password` + `Init environment` + simple `Setup Database`
- **continuous-macos**: same refactoring; also fixes `Setup Database` which was still using removed CLI flags (`-p`/`-d`/`-c`/...) — this was breaking main CI
- **continuous-windows**: add `PGPASSWORD` to `Init environment` `env:` block; `action-setup-postgres` clears it from `GITHUB_ENV` on Windows — this was breaking main CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)