### PR TITLE
[ore] Fix Windows build: replace POSIX strptime_l/timegm with ores.platform datetime

### DIFF
--- a/projects/ores.ore/src/log/ore_log_parser.cpp
+++ b/projects/ores.ore/src/log/ore_log_parser.cpp
@@ -21,7 +21,9 @@
 
 #include <array>
 #include <chrono>
+#include <cstdlib>
 #include <cstring>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include "ores.platform/time/datetime.hpp"


### PR DESCRIPTION
## Summary
- Replaces POSIX-only `strptime_l`, `freelocale`, and `timegm` in `ore_log_parser.cpp` with `ores::platform::time::datetime::parse_time_point_utc`
- `std::get_time` (used internally by `parse_time_point_utc`) operates in the classic C locale by default, so `%b` always matches English month abbreviations cross-platform
- Removes `<clocale>` and `<ctime>` includes that are no longer needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)