### PR TITLE
[ore] Fix Windows build: use ores.platform timegm_safe in ore log parser tests

### DIFF
--- a/projects/ores.ore/tests/log_ore_log_parser_tests.cpp
+++ b/projects/ores.ore/tests/log_ore_log_parser_tests.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "ores.ore/log/ore_log_parser.hpp"
+#include "ores.platform/time/time_utils.hpp"
 
 #include <chrono>
 #include <ctime>
@@ -41,7 +42,7 @@ std::chrono::system_clock::time_point make_utc(
     tm.tm_min   = min;
     tm.tm_sec   = sec;
     tm.tm_isdst = 0;
-    const std::time_t t = timegm(&tm);
+    const std::time_t t = ores::platform::time::time_utils::timegm_safe(&tm);
     return std::chrono::system_clock::from_time_t(t)
         + std::chrono::microseconds(microseconds);
 }


### PR DESCRIPTION
## Summary

- `timegm` is a POSIX-only function not available on Windows, causing a build failure in `log_ore_log_parser_tests.cpp`
- Replaced `timegm(&tm)` with `ores::platform::time::time_utils::timegm_safe(&tm)`, the existing cross-platform wrapper (uses `_mkgmtime` on Windows)
- Added the missing `#include "ores.platform/time/time_utils.hpp"`

Fixes: `use of undeclared identifier 'timegm'` on all Windows clang builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)