### PR TITLE
[qt] Fix Windows build: rename ReviewPage to AppProvisionerReviewPage

### DIFF
--- a/projects/ores.qt/include/ores.qt/AppProvisionerWizard.hpp
+++ b/projects/ores.qt/include/ores.qt/AppProvisionerWizard.hpp
@@ -105,7 +105,7 @@ private:
     PlatformsPage*      platforms_page_;
     PackageUploadPage*  package_upload_page_;
     AuditPage*          audit_page_;
-    AppProvisionerReviewPage*         review_page_;
+    AppProvisionerReviewPage*         app_provisioner_review_page_;
 };
 
 } // namespace ores::qt

--- a/projects/ores.qt/src/AppProvisionerWizard.cpp
+++ b/projects/ores.qt/src/AppProvisionerWizard.cpp
@@ -623,14 +623,14 @@ AppProvisionerWizard::AppProvisionerWizard(ClientManager* clientManager,
     package_upload_page_  = new PackageUploadPage(http_base_url_,
                                                   app_version_id_, this);
     audit_page_           = new AuditPage(changeReasonCache, this);
-    review_page_          = new AppProvisionerReviewPage(this);
+    app_provisioner_review_page_ = new AppProvisionerReviewPage(this);
 
     setPage(kAppIdentityPage,    app_identity_page_);
     setPage(kVersionDetailsPage, version_details_page_);
     setPage(kPlatformsPage,      platforms_page_);
     setPage(kPackageUploadPage,  package_upload_page_);
     setPage(kAuditPage,          audit_page_);
-    setPage(kReviewPage,         review_page_);
+    setPage(kReviewPage,         app_provisioner_review_page_);
 
     setStartId(kAppIdentityPage);
 }


### PR DESCRIPTION
## Summary

- Both `AppProvisionerWizard.cpp` and `PublishDatasetsDialog.cpp` defined a class named `ReviewPage` in `namespace ores::qt`, causing a duplicate symbol linker error on Windows (`LNK2005`/`lld-link` duplicate symbol)
- GCC/Clang silently tolerated this but MSVC/lld-link correctly rejects it
- Renamed the local page class in `AppProvisionerWizard.cpp` and its header from `ReviewPage` to `AppProvisionerReviewPage`, updating the forward declaration, `friend` declaration, and member pointer type

🤖 Generated with [Claude Code](https://claude.com/claude-code)