### PR TITLE
[ore] Fix xsd::vector to use alias for non-bool to support incomplete types

### DIFF
--- a/projects/ores.ore/include/ores.ore/domain/domain.hpp
+++ b/projects/ores.ore/include/ores.ore/domain/domain.hpp
@@ -1905,7 +1905,7 @@ std::string to_string(oreTradeType);
 struct trade
 {
     xsd::string id{};
-    xsd::vector<xsd::any_element> other_elements;
+    xsd::vector<xsd::any_attribute> other_attributes;
     domain::oreTradeType TradeType{};
     xsd::optional<domain::envelope> Envelope;
     xsd::optional<domain::tradeActions> TradeActions;

--- a/projects/ores.ore/include/ores.ore/domain/domain.hpp
+++ b/projects/ores.ore/include/ores.ore/domain/domain.hpp
@@ -1905,6 +1905,7 @@ std::string to_string(oreTradeType);
 struct trade
 {
     xsd::string id{};
+    xsd::vector<xsd::any_attribute> other_attributes;
     xsd::vector<xsd::any_element> other_elements;
     domain::oreTradeType TradeType{};
     xsd::optional<domain::envelope> Envelope;

--- a/projects/ores.ore/include/ores.ore/domain/domain.hpp
+++ b/projects/ores.ore/include/ores.ore/domain/domain.hpp
@@ -1905,7 +1905,6 @@ std::string to_string(oreTradeType);
 struct trade
 {
     xsd::string id{};
-    xsd::vector<xsd::any_attribute> other_attributes;
     xsd::vector<xsd::any_element> other_elements;
     domain::oreTradeType TradeType{};
     xsd::optional<domain::envelope> Envelope;

--- a/projects/ores.ore/include/ores.ore/domain/domain_xsd.hpp
+++ b/projects/ores.ore/include/ores.ore/domain/domain_xsd.hpp
@@ -12,19 +12,10 @@ namespace xsd {
 
 typedef std::string string;
 
-// Wrapper for vector to allow specialization for bool
-// std::vector<bool> is specialized and .back() returns a proxy, not a real reference
-template <typename T>
-class vector : public std::vector<T>
-{
-public:
-    using std::vector<T>::vector;
-    using std::vector<T>::operator=;
-};
+namespace detail {
 
-// Specialization for vector<bool> using char storage to avoid proxy issues
-template <>
-class vector<bool> : public std::vector<char>
+// Custom bool vector using char storage to avoid std::vector<bool>'s proxy type.
+class bool_vector : public std::vector<char>
 {
 public:
     using std::vector<char>::vector;
@@ -33,6 +24,20 @@ public:
     bool& back() { return reinterpret_cast<bool&>(std::vector<char>::back()); }
     const bool& back() const { return reinterpret_cast<const bool&>(std::vector<char>::back()); }
 };
+
+template <typename T>
+struct vector_selector { using type = std::vector<T>; };
+
+template <>
+struct vector_selector<bool> { using type = bool_vector; };
+
+} // namespace detail
+
+// vector<T> is std::vector<T> for all non-bool types (preserving MSVC's lenient
+// handling of incomplete element types in generated headers), and the char-backed
+// bool_vector for bool (avoiding std::vector<bool>'s bit-packing proxy).
+template <typename T>
+using vector = typename detail::vector_selector<T>::type;
 
 template <typename T>
 class optional

--- a/projects/ores.ore/include/ores.ore/domain/domain_xsd.hpp
+++ b/projects/ores.ore/include/ores.ore/domain/domain_xsd.hpp
@@ -19,6 +19,7 @@ class bool_vector : public std::vector<char>
 {
 public:
     using std::vector<char>::vector;
+    using std::vector<char>::operator=;
     void push_back(bool value) { std::vector<char>::push_back(value ? 1 : 0); }
     void emplace_back() { std::vector<char>::emplace_back(0); }
     bool& back() { return reinterpret_cast<bool&>(std::vector<char>::back()); }

--- a/projects/ores.ore/src/domain/domain.cpp
+++ b/projects/ores.ore/src/domain/domain.cpp
@@ -5613,6 +5613,7 @@ xsdcpp::ChildElementInfo _trade_Children[] = {
     {nullptr}
 };
 void* _get_trade_id(domain::trade* elem) { return &elem->id; }
+void _any_trade(domain::trade* element, std::string&& name, std::string&& value) { element->other_attributes.emplace_back(xsd::any_attribute{std::move(name), std::move(value)}); }
 void _any_elem_trade(domain::trade* element, std::string&& name, std::string&& value) { element->other_elements.emplace_back(xsd::any_element{std::move(name), std::move(value)}); }
 xsdcpp::AttributeInfo _trade_Attributes[] = {
     {"id", 1ULL, (xsdcpp::get_field_t)&_get_trade_id, (xsdcpp::set_value_t)&xsdcpp::set_string, true, nullptr},
@@ -27450,6 +27451,7 @@ XSDCPP_MAYBE_UNUSED void _serialize_totalReturnSwapData(xsdcpp::XmlWriter& w, co
 XSDCPP_MAYBE_UNUSED void _serialize_trade(xsdcpp::XmlWriter& w, const char* name, const domain::trade& v) {
     w.startElement(name);
     w.writeAttribute("id", (&v)->id);
+    for (const auto& attr : (&v)->other_attributes) w.writeAttribute(attr.name.c_str(), attr.value);
     _serialize_oreTradeType(w, "TradeType", v.TradeType);
     if (v.Envelope) _serialize_envelope(w, "Envelope", *v.Envelope);
     if (v.TradeActions) _serialize_tradeActions(w, "TradeActions", *v.TradeActions);
@@ -36077,7 +36079,7 @@ XSDCPP_MAYBE_UNUSED void _serialize_counterpartyInformation(xsdcpp::XmlWriter& w
 namespace domain {
 
 const xsdcpp::ElementInfo _portfolio_Info = { xsdcpp::ElementInfo::EntryPointFlag, nullptr, _portfolio_Children, 1, nullptr, 0ULL, nullptr, nullptr, nullptr };
-const xsdcpp::ElementInfo _trade_Info = { xsdcpp::ElementInfo::EntryPointFlag|xsdcpp::ElementInfo::AnyElementFlag|xsdcpp::ElementInfo::CheckChildrenFlag, nullptr, _trade_Children, 180, _trade_Attributes, 1ULL, nullptr, nullptr, (xsdcpp::set_any_element_t)&_any_elem_trade };
+const xsdcpp::ElementInfo _trade_Info = { xsdcpp::ElementInfo::EntryPointFlag|xsdcpp::ElementInfo::AnyAttributeFlag|xsdcpp::ElementInfo::AnyElementFlag|xsdcpp::ElementInfo::CheckChildrenFlag, nullptr, _trade_Children, 180, _trade_Attributes, 1ULL, nullptr, (xsdcpp::set_any_attribute_t)&_any_trade, (xsdcpp::set_any_element_t)&_any_elem_trade };
 const xsdcpp::ElementInfo _simulation_Info = { xsdcpp::ElementInfo::EntryPointFlag, nullptr, _simulation_Children, 3, nullptr, 0ULL, nullptr, nullptr, nullptr };
 const xsdcpp::ElementInfo _crossAssetModel_Currencies_t_Info = { xsdcpp::ElementInfo::CheckChildrenFlag, nullptr, _crossAssetModel_Currencies_t_Children, 1, nullptr, 0ULL, nullptr, nullptr, nullptr };
 const xsdcpp::ElementInfo _crossAssetModel_InterestRateModels_t_Info = { 0, nullptr, _crossAssetModel_InterestRateModels_t_Children, 2, nullptr, 0ULL, nullptr, nullptr, nullptr };

--- a/projects/ores.ore/src/domain/domain.cpp
+++ b/projects/ores.ore/src/domain/domain.cpp
@@ -5613,7 +5613,7 @@ xsdcpp::ChildElementInfo _trade_Children[] = {
     {nullptr}
 };
 void* _get_trade_id(domain::trade* elem) { return &elem->id; }
-void _any_elem_trade(domain::trade* element, std::string&& name, std::string&& value) { element->other_elements.emplace_back(xsd::any_element{std::move(name), std::move(value)}); }
+void _any_trade(domain::trade* element, std::string&& name, std::string&& value) { element->other_attributes.emplace_back(xsd::any_attribute{std::move(name), std::move(value)}); }
 xsdcpp::AttributeInfo _trade_Attributes[] = {
     {"id", 1ULL, (xsdcpp::get_field_t)&_get_trade_id, (xsdcpp::set_value_t)&xsdcpp::set_string, true, nullptr},
     {nullptr}
@@ -27450,6 +27450,7 @@ XSDCPP_MAYBE_UNUSED void _serialize_totalReturnSwapData(xsdcpp::XmlWriter& w, co
 XSDCPP_MAYBE_UNUSED void _serialize_trade(xsdcpp::XmlWriter& w, const char* name, const domain::trade& v) {
     w.startElement(name);
     w.writeAttribute("id", (&v)->id);
+    for (const auto& attr : (&v)->other_attributes) w.writeAttribute(attr.name.c_str(), attr.value);
     _serialize_oreTradeType(w, "TradeType", v.TradeType);
     if (v.Envelope) _serialize_envelope(w, "Envelope", *v.Envelope);
     if (v.TradeActions) _serialize_tradeActions(w, "TradeActions", *v.TradeActions);
@@ -27630,7 +27631,6 @@ XSDCPP_MAYBE_UNUSED void _serialize_trade(xsdcpp::XmlWriter& w, const char* name
     if (v.EquityStrikeResettableOptionData) _serialize_strikeResettableOptionData2(w, "EquityStrikeResettableOptionData", *v.EquityStrikeResettableOptionData);
     if (v.FxStrikeResettableOptionData) _serialize_strikeResettableOptionData2(w, "FxStrikeResettableOptionData", *v.FxStrikeResettableOptionData);
     if (v.CommodityStrikeResettableOptionData) _serialize_strikeResettableOptionData2(w, "CommodityStrikeResettableOptionData", *v.CommodityStrikeResettableOptionData);
-    for (const auto& e : v.other_elements) { w.startElement(e.name.c_str()); w.writeText(e.value); w.endElement(e.name.c_str()); }
     w.endElement(name);
 }
 
@@ -36077,7 +36077,7 @@ XSDCPP_MAYBE_UNUSED void _serialize_counterpartyInformation(xsdcpp::XmlWriter& w
 namespace domain {
 
 const xsdcpp::ElementInfo _portfolio_Info = { xsdcpp::ElementInfo::EntryPointFlag, nullptr, _portfolio_Children, 1, nullptr, 0ULL, nullptr, nullptr, nullptr };
-const xsdcpp::ElementInfo _trade_Info = { xsdcpp::ElementInfo::EntryPointFlag|xsdcpp::ElementInfo::AnyElementFlag|xsdcpp::ElementInfo::CheckChildrenFlag, nullptr, _trade_Children, 180, _trade_Attributes, 1ULL, nullptr, nullptr, (xsdcpp::set_any_element_t)&_any_elem_trade };
+const xsdcpp::ElementInfo _trade_Info = { xsdcpp::ElementInfo::EntryPointFlag|xsdcpp::ElementInfo::AnyAttributeFlag|xsdcpp::ElementInfo::CheckChildrenFlag, nullptr, _trade_Children, 180, _trade_Attributes, 1ULL, nullptr, (xsdcpp::set_any_attribute_t)&_any_trade, nullptr };
 const xsdcpp::ElementInfo _simulation_Info = { xsdcpp::ElementInfo::EntryPointFlag, nullptr, _simulation_Children, 3, nullptr, 0ULL, nullptr, nullptr, nullptr };
 const xsdcpp::ElementInfo _crossAssetModel_Currencies_t_Info = { xsdcpp::ElementInfo::CheckChildrenFlag, nullptr, _crossAssetModel_Currencies_t_Children, 1, nullptr, 0ULL, nullptr, nullptr, nullptr };
 const xsdcpp::ElementInfo _crossAssetModel_InterestRateModels_t_Info = { 0, nullptr, _crossAssetModel_InterestRateModels_t_Children, 2, nullptr, 0ULL, nullptr, nullptr, nullptr };

--- a/projects/ores.ore/src/domain/domain.cpp
+++ b/projects/ores.ore/src/domain/domain.cpp
@@ -5613,7 +5613,6 @@ xsdcpp::ChildElementInfo _trade_Children[] = {
     {nullptr}
 };
 void* _get_trade_id(domain::trade* elem) { return &elem->id; }
-void _any_trade(domain::trade* element, std::string&& name, std::string&& value) { element->other_attributes.emplace_back(xsd::any_attribute{std::move(name), std::move(value)}); }
 void _any_elem_trade(domain::trade* element, std::string&& name, std::string&& value) { element->other_elements.emplace_back(xsd::any_element{std::move(name), std::move(value)}); }
 xsdcpp::AttributeInfo _trade_Attributes[] = {
     {"id", 1ULL, (xsdcpp::get_field_t)&_get_trade_id, (xsdcpp::set_value_t)&xsdcpp::set_string, true, nullptr},
@@ -27451,7 +27450,6 @@ XSDCPP_MAYBE_UNUSED void _serialize_totalReturnSwapData(xsdcpp::XmlWriter& w, co
 XSDCPP_MAYBE_UNUSED void _serialize_trade(xsdcpp::XmlWriter& w, const char* name, const domain::trade& v) {
     w.startElement(name);
     w.writeAttribute("id", (&v)->id);
-    for (const auto& attr : (&v)->other_attributes) w.writeAttribute(attr.name.c_str(), attr.value);
     _serialize_oreTradeType(w, "TradeType", v.TradeType);
     if (v.Envelope) _serialize_envelope(w, "Envelope", *v.Envelope);
     if (v.TradeActions) _serialize_tradeActions(w, "TradeActions", *v.TradeActions);
@@ -36079,7 +36077,7 @@ XSDCPP_MAYBE_UNUSED void _serialize_counterpartyInformation(xsdcpp::XmlWriter& w
 namespace domain {
 
 const xsdcpp::ElementInfo _portfolio_Info = { xsdcpp::ElementInfo::EntryPointFlag, nullptr, _portfolio_Children, 1, nullptr, 0ULL, nullptr, nullptr, nullptr };
-const xsdcpp::ElementInfo _trade_Info = { xsdcpp::ElementInfo::EntryPointFlag|xsdcpp::ElementInfo::AnyAttributeFlag|xsdcpp::ElementInfo::AnyElementFlag|xsdcpp::ElementInfo::CheckChildrenFlag, nullptr, _trade_Children, 180, _trade_Attributes, 1ULL, nullptr, (xsdcpp::set_any_attribute_t)&_any_trade, (xsdcpp::set_any_element_t)&_any_elem_trade };
+const xsdcpp::ElementInfo _trade_Info = { xsdcpp::ElementInfo::EntryPointFlag|xsdcpp::ElementInfo::AnyElementFlag|xsdcpp::ElementInfo::CheckChildrenFlag, nullptr, _trade_Children, 180, _trade_Attributes, 1ULL, nullptr, nullptr, (xsdcpp::set_any_element_t)&_any_elem_trade };
 const xsdcpp::ElementInfo _simulation_Info = { xsdcpp::ElementInfo::EntryPointFlag, nullptr, _simulation_Children, 3, nullptr, 0ULL, nullptr, nullptr, nullptr };
 const xsdcpp::ElementInfo _crossAssetModel_Currencies_t_Info = { xsdcpp::ElementInfo::CheckChildrenFlag, nullptr, _crossAssetModel_Currencies_t_Children, 1, nullptr, 0ULL, nullptr, nullptr, nullptr };
 const xsdcpp::ElementInfo _crossAssetModel_InterestRateModels_t_Info = { 0, nullptr, _crossAssetModel_InterestRateModels_t_Children, 2, nullptr, 0ULL, nullptr, nullptr, nullptr };


### PR DESCRIPTION
## Summary

- `xsd::vector<T>` was implemented as `class vector : public std::vector<T>`, which requires `T` to be complete at instantiation on MSVC/Clang-CL
- xsdcpp-generated `domain.hpp` forward-declares types (`lgm`, `hw`, `transitionmatrix`, `entity`) before fully defining them, and struct members like `xsd::vector<lgm>` appear between the forward declaration and definition — causing Windows Clang build failures
- Fix: replace the inheriting template with a `using`-alias via `detail::vector_selector<T>`, resolving to `std::vector<T>` for non-bool (preserving MSVC's lenient incomplete-type extension) and to `detail::bool_vector` for bool

Fixes Windows Clang failures in main from PR #683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)