### PR TITLE
[trading,sql,ore] Add typed FX instrument domain model, tables, and repository layer

### DIFF
--- a/projects/ores.ore/include/ores.ore/domain/fx_instrument_mapper.hpp
+++ b/projects/ores.ore/include/ores.ore/domain/fx_instrument_mapper.hpp
@@ -20,45 +20,59 @@
 #ifndef ORES_ORE_DOMAIN_FX_INSTRUMENT_MAPPER_HPP
 #define ORES_ORE_DOMAIN_FX_INSTRUMENT_MAPPER_HPP
 
+#include <variant>
 #include "ores.logging/make_logger.hpp"
 #include "ores.ore/domain/domain.hpp"
-#include "ores.trading.api/domain/fx_instrument.hpp"
+#include "ores.trading.api/domain/fx_forward_instrument.hpp"
+#include "ores.trading.api/domain/fx_vanilla_option_instrument.hpp"
+#include "ores.trading.api/domain/fx_barrier_option_instrument.hpp"
+#include "ores.trading.api/domain/fx_digital_option_instrument.hpp"
+#include "ores.trading.api/domain/fx_asian_forward_instrument.hpp"
+#include "ores.trading.api/domain/fx_accumulator_instrument.hpp"
+#include "ores.trading.api/domain/fx_variance_swap_instrument.hpp"
 
 namespace ores::ore::domain {
+
+/**
+ * @brief Variant holding one of the seven per-type FX instrument domain objects.
+ */
+using fx_instrument_variant = std::variant<
+    ores::trading::domain::fx_forward_instrument,
+    ores::trading::domain::fx_vanilla_option_instrument,
+    ores::trading::domain::fx_barrier_option_instrument,
+    ores::trading::domain::fx_digital_option_instrument,
+    ores::trading::domain::fx_asian_forward_instrument,
+    ores::trading::domain::fx_accumulator_instrument,
+    ores::trading::domain::fx_variance_swap_instrument
+>;
 
 /**
  * @brief Result of a forward mapping from ORE XSD to the ORES FX domain type.
  */
 struct fx_mapping_result {
-    ores::trading::domain::fx_instrument instrument;
+    fx_instrument_variant instrument;
 };
 
 /**
  * @brief Maps ORE XSD FX trade types to ORES domain types and back.
  *
  * Handles:
- *   - FxForward              (FxForwardData)
- *   - FxSwap                 (FxSwapData) — near leg mapped; far amounts noted as gap
- *   - FxOption               (FxOptionData) — vanilla European/American only
- *   - FxBarrierOption        (FxBarrierOptionData)
- *   - FxDigitalOption        (FxDigitalOptionData)
- *   - FxDigitalBarrierOption (FxDigitalBarrierOptionData)
- *   - FxTouchOption          (FxTouchOptionData) — also covers FxDoubleTouchOption
- *   - FxVarianceSwap         (FxVarianceSwapData)
- *   - FxAverageForward       (FxAverageForwardData)
- *   - FxAccumulator          (FxAccumulatorData)
- *   - FxTaRF                 (FxTaRFData)
- *   - FxGenericBarrierOption (FxGenericBarrierOptionData)
- *   - FxDoubleBarrierOption  (FxDoubleBarrierOptionData — same struct as FxBarrierOptionData)
- *   - FxEuropeanBarrierOption (FxEuropeanBarrierOptionData — same struct)
- *   - FxKIKOBarrierOption    (FxKIKOBarrierOptionData)
- *
- * Forward mapping (ORE XSD → ORES domain) captures economic fields stored
- * in the ORES relational model. Fields not yet modelled are silently dropped;
- * the coverage gap is reported by ore_coverage_check.py (Thing 2).
- *
- * Reverse mapping (ORES domain → ORE XSD) reconstructs ORE types from ORES
- * domain for the fields captured by the forward mapping.
+ *   - FxForward              → fx_forward_instrument
+ *   - FxSwap                 → fx_forward_instrument (near leg; far leg is a gap)
+ *   - FxOption               → fx_vanilla_option_instrument
+ *   - FxBarrierOption        → fx_barrier_option_instrument
+ *   - FxDoubleBarrierOption  → fx_barrier_option_instrument
+ *   - FxEuropeanBarrierOption → fx_barrier_option_instrument
+ *   - FxKIKOBarrierOption    → fx_barrier_option_instrument
+ *   - FxGenericBarrierOption → fx_barrier_option_instrument
+ *   - FxDigitalOption        → fx_digital_option_instrument
+ *   - FxDigitalBarrierOption → fx_digital_option_instrument
+ *   - FxTouchOption          → fx_digital_option_instrument
+ *   - FxDoubleTouchOption    → fx_digital_option_instrument
+ *   - FxAverageForward       → fx_asian_forward_instrument
+ *   - FxTaRF                 → fx_asian_forward_instrument
+ *   - FxAccumulator          → fx_accumulator_instrument
+ *   - FxVarianceSwap         → fx_variance_swap_instrument
  */
 class fx_instrument_mapper {
 private:
@@ -72,43 +86,15 @@ private:
     }
 
 public:
-    /**
-     * @brief Forward-maps a FxForward trade to ORES domain types.
-     */
+    // Forward mappings (ORE XSD → typed domain object)
     static fx_mapping_result forward_fx_forward(const trade& t);
-
-    /**
-     * @brief Forward-maps a FxSwap trade to ORES domain types.
-     *
-     * Maps the near leg. Far leg amounts are a known coverage gap.
-     */
     static fx_mapping_result forward_fx_swap(const trade& t);
-
-    /**
-     * @brief Forward-maps a FxOption trade to ORES domain types.
-     */
     static fx_mapping_result forward_fx_option(const trade& t);
-
-    /**
-     * @brief Reverse-maps ORES domain types back to a FxForward ORE XSD trade.
-     */
-    static trade reverse_fx_forward(
-        const ores::trading::domain::fx_instrument& instr);
-
-    /**
-     * @brief Reverse-maps ORES domain types back to a FxSwap ORE XSD trade.
-     */
-    static trade reverse_fx_swap(
-        const ores::trading::domain::fx_instrument& instr);
-
-    /**
-     * @brief Reverse-maps ORES domain types back to a FxOption ORE XSD trade.
-     */
-    static trade reverse_fx_option(
-        const ores::trading::domain::fx_instrument& instr);
-
-    // Phase 6 — forward
     static fx_mapping_result forward_fx_barrier_option(const trade& t);
+    static fx_mapping_result forward_fx_double_barrier_option(const trade& t);
+    static fx_mapping_result forward_fx_european_barrier_option(const trade& t);
+    static fx_mapping_result forward_fx_kiko_barrier_option(const trade& t);
+    static fx_mapping_result forward_fx_generic_barrier_option(const trade& t);
     static fx_mapping_result forward_fx_digital_option(const trade& t);
     static fx_mapping_result forward_fx_digital_barrier_option(const trade& t);
     static fx_mapping_result forward_fx_touch_option(const trade& t);
@@ -116,40 +102,38 @@ public:
     static fx_mapping_result forward_fx_average_forward(const trade& t);
     static fx_mapping_result forward_fx_accumulator(const trade& t);
     static fx_mapping_result forward_fx_tarf(const trade& t);
-    static fx_mapping_result forward_fx_generic_barrier_option(const trade& t);
 
-    // Phase 6 — reverse
+    // Reverse mappings (typed domain object → ORE XSD)
+    static trade reverse_fx_forward(
+        const ores::trading::domain::fx_forward_instrument& instr);
+    static trade reverse_fx_swap(
+        const ores::trading::domain::fx_forward_instrument& instr);
+    static trade reverse_fx_option(
+        const ores::trading::domain::fx_vanilla_option_instrument& instr);
     static trade reverse_fx_barrier_option(
-        const ores::trading::domain::fx_instrument& instr);
-    static trade reverse_fx_digital_option(
-        const ores::trading::domain::fx_instrument& instr);
-    static trade reverse_fx_digital_barrier_option(
-        const ores::trading::domain::fx_instrument& instr);
-    static trade reverse_fx_touch_option(
-        const ores::trading::domain::fx_instrument& instr);
-    static trade reverse_fx_variance_swap(
-        const ores::trading::domain::fx_instrument& instr);
-    static trade reverse_fx_average_forward(
-        const ores::trading::domain::fx_instrument& instr);
-    static trade reverse_fx_accumulator(
-        const ores::trading::domain::fx_instrument& instr);
-    static trade reverse_fx_tarf(
-        const ores::trading::domain::fx_instrument& instr);
-    static trade reverse_fx_generic_barrier_option(
-        const ores::trading::domain::fx_instrument& instr);
-
-    // Phase 10 — forward
-    static fx_mapping_result forward_fx_double_barrier_option(const trade& t);
-    static fx_mapping_result forward_fx_european_barrier_option(const trade& t);
-    static fx_mapping_result forward_fx_kiko_barrier_option(const trade& t);
-
-    // Phase 10 — reverse
+        const ores::trading::domain::fx_barrier_option_instrument& instr);
     static trade reverse_fx_double_barrier_option(
-        const ores::trading::domain::fx_instrument& instr);
+        const ores::trading::domain::fx_barrier_option_instrument& instr);
     static trade reverse_fx_european_barrier_option(
-        const ores::trading::domain::fx_instrument& instr);
+        const ores::trading::domain::fx_barrier_option_instrument& instr);
     static trade reverse_fx_kiko_barrier_option(
-        const ores::trading::domain::fx_instrument& instr);
+        const ores::trading::domain::fx_barrier_option_instrument& instr);
+    static trade reverse_fx_generic_barrier_option(
+        const ores::trading::domain::fx_barrier_option_instrument& instr);
+    static trade reverse_fx_digital_option(
+        const ores::trading::domain::fx_digital_option_instrument& instr);
+    static trade reverse_fx_digital_barrier_option(
+        const ores::trading::domain::fx_digital_option_instrument& instr);
+    static trade reverse_fx_touch_option(
+        const ores::trading::domain::fx_digital_option_instrument& instr);
+    static trade reverse_fx_variance_swap(
+        const ores::trading::domain::fx_variance_swap_instrument& instr);
+    static trade reverse_fx_average_forward(
+        const ores::trading::domain::fx_asian_forward_instrument& instr);
+    static trade reverse_fx_accumulator(
+        const ores::trading::domain::fx_accumulator_instrument& instr);
+    static trade reverse_fx_tarf(
+        const ores::trading::domain::fx_asian_forward_instrument& instr);
 
 private:
     static barrierData make_barrier(const std::string& type, double level);

--- a/projects/ores.ore/src/domain/fx_instrument_mapper.cpp
+++ b/projects/ores.ore/src/domain/fx_instrument_mapper.cpp
@@ -25,7 +25,13 @@
 namespace ores::ore::domain {
 
 using namespace ores::logging;
-using ores::trading::domain::fx_instrument;
+using ores::trading::domain::fx_forward_instrument;
+using ores::trading::domain::fx_vanilla_option_instrument;
+using ores::trading::domain::fx_barrier_option_instrument;
+using ores::trading::domain::fx_digital_option_instrument;
+using ores::trading::domain::fx_asian_forward_instrument;
+using ores::trading::domain::fx_accumulator_instrument;
+using ores::trading::domain::fx_variance_swap_instrument;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -33,19 +39,19 @@ using ores::trading::domain::fx_instrument;
 
 namespace {
 
-fx_instrument make_base(const std::string& trade_type_code) {
-    fx_instrument r;
-    r.trade_type_code = trade_type_code;
-    r.modified_by = "ores";
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
-    return r;
+constexpr const char* k_modified_by     = "ores";
+constexpr const char* k_performed_by    = "ores";
+constexpr const char* k_change_reason   = "system.external_data_import";
+constexpr const char* k_change_comment  = "Imported from ORE XML";
+
+void set_audit(auto& r) {
+    r.modified_by       = k_modified_by;
+    r.performed_by      = k_performed_by;
+    r.change_reason_code = k_change_reason;
+    r.change_commentary  = k_change_comment;
 }
 
 currencyCode parse_currency_code(const std::string& s) {
-    // Reuse the same exhaustive map as swap_instrument_mapper.
-    // Defined here to avoid a shared-header dependency.
     static const std::map<std::string, currencyCode> map = {
         {"AED", currencyCode::AED}, {"AFN", currencyCode::AFN},
         {"ALL", currencyCode::ALL}, {"AMD", currencyCode::AMD},
@@ -152,179 +158,6 @@ currencyCode parse_currency_code(const std::string& s) {
     return it->second;
 }
 
-} // namespace
-
-// ---------------------------------------------------------------------------
-// Forward: FxForward
-// ---------------------------------------------------------------------------
-
-fx_mapping_result fx_instrument_mapper::forward_fx_forward(const trade& t) {
-    BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxForward: "
-                               << std::string(t.id);
-    fx_mapping_result result;
-    result.instrument = make_base("FxForward");
-
-    if (!t.FxForwardData) return result;
-    const auto& fwd = *t.FxForwardData;
-
-    result.instrument.value_date    = std::string(fwd.ValueDate);
-    result.instrument.bought_currency = to_string(fwd.BoughtCurrency);
-    result.instrument.bought_amount   = static_cast<double>(fwd.BoughtAmount);
-    result.instrument.sold_currency   = to_string(fwd.SoldCurrency);
-    result.instrument.sold_amount     = static_cast<double>(fwd.SoldAmount);
-    if (fwd.Settlement)
-        result.instrument.settlement = to_string(*fwd.Settlement);
-
-    return result;
-}
-
-// ---------------------------------------------------------------------------
-// Forward: FxSwap
-// ---------------------------------------------------------------------------
-
-fx_mapping_result fx_instrument_mapper::forward_fx_swap(const trade& t) {
-    BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxSwap: "
-                               << std::string(t.id);
-    fx_mapping_result result;
-    result.instrument = make_base("FxSwap");
-
-    if (!t.FxSwapData) return result;
-    const auto& sw = *t.FxSwapData;
-
-    // Map near leg; far leg amounts are a known coverage gap.
-    result.instrument.value_date      = std::string(sw.NearDate);
-    result.instrument.bought_currency = to_string(sw.NearBoughtCurrency);
-    result.instrument.bought_amount   = static_cast<double>(sw.NearBoughtAmount);
-    result.instrument.sold_currency   = to_string(sw.NearSoldCurrency);
-    result.instrument.sold_amount     = static_cast<double>(sw.NearSoldAmount);
-    if (sw.Settlement)
-        result.instrument.settlement  = to_string(*sw.Settlement);
-
-    return result;
-}
-
-// ---------------------------------------------------------------------------
-// Forward: FxOption
-// ---------------------------------------------------------------------------
-
-fx_mapping_result fx_instrument_mapper::forward_fx_option(const trade& t) {
-    BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxOption: "
-                               << std::string(t.id);
-    fx_mapping_result result;
-    result.instrument = make_base("FxOption");
-
-    if (!t.FxOptionData) return result;
-    const auto& opt = *t.FxOptionData;
-
-    result.instrument.bought_currency = to_string(opt.BoughtCurrency);
-    result.instrument.bought_amount   = static_cast<double>(opt.BoughtAmount);
-    result.instrument.sold_currency   = to_string(opt.SoldCurrency);
-    if (opt.SoldAmount)
-        result.instrument.sold_amount = static_cast<double>(*opt.SoldAmount);
-
-    const auto& od = opt.OptionData;
-    if (od.OptionType)
-        result.instrument.option_type = std::string(*od.OptionType);
-    if (od.Settlement)
-        result.instrument.settlement  = to_string(*od.Settlement);
-
-    // Expiry date from first ExerciseDate
-    if (od.exerciseDatesGroup && od.exerciseDatesGroup->ExerciseDates &&
-            !od.exerciseDatesGroup->ExerciseDates->ExerciseDate.empty())
-        result.instrument.expiry_date =
-            std::string(od.exerciseDatesGroup->ExerciseDates->ExerciseDate.front());
-
-    return result;
-}
-
-// ---------------------------------------------------------------------------
-// Reverse: FxForward
-// ---------------------------------------------------------------------------
-
-trade fx_instrument_mapper::reverse_fx_forward(const fx_instrument& instr) {
-    BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxForward";
-
-    trade t;
-    t.TradeType = oreTradeType::FxForward;
-
-    fxForwardData fwd;
-    static_cast<std::string&>(fwd.ValueDate)  = instr.value_date.value_or("");
-    fwd.BoughtCurrency = parse_currency_code(instr.bought_currency);
-    static_cast<float&>(fwd.BoughtAmount)     = static_cast<float>(instr.bought_amount);
-    fwd.SoldCurrency   = parse_currency_code(instr.sold_currency);
-    static_cast<float&>(fwd.SoldAmount)       = static_cast<float>(instr.sold_amount);
-
-    t.FxForwardData = std::move(fwd);
-    return t;
-}
-
-// ---------------------------------------------------------------------------
-// Reverse: FxSwap
-// ---------------------------------------------------------------------------
-
-trade fx_instrument_mapper::reverse_fx_swap(const fx_instrument& instr) {
-    BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxSwap";
-
-    trade t;
-    t.TradeType = oreTradeType::FxSwap;
-
-    fxSwapData sw;
-    static_cast<std::string&>(sw.NearDate)     = instr.value_date.value_or("");
-    sw.NearBoughtCurrency = parse_currency_code(instr.bought_currency);
-    static_cast<float&>(sw.NearBoughtAmount)   = static_cast<float>(instr.bought_amount);
-    sw.NearSoldCurrency   = parse_currency_code(instr.sold_currency);
-    static_cast<float&>(sw.NearSoldAmount)     = static_cast<float>(instr.sold_amount);
-    // Far leg: not captured in forward mapping — round-trip as empty date/zero amounts.
-    static_cast<std::string&>(sw.FarDate)      = "";
-    static_cast<float&>(sw.FarBoughtAmount)    = 0.0f;
-    static_cast<float&>(sw.FarSoldAmount)      = 0.0f;
-
-    t.FxSwapData = std::move(sw);
-    return t;
-}
-
-// ---------------------------------------------------------------------------
-// Reverse: FxOption
-// ---------------------------------------------------------------------------
-
-trade fx_instrument_mapper::reverse_fx_option(const fx_instrument& instr) {
-    BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxOption";
-
-    trade t;
-    t.TradeType = oreTradeType::FxOption;
-
-    fxOptionData opt;
-    opt.BoughtCurrency = parse_currency_code(instr.bought_currency);
-    static_cast<float&>(opt.BoughtAmount) = static_cast<float>(instr.bought_amount);
-    opt.SoldCurrency   = parse_currency_code(instr.sold_currency);
-    if (instr.sold_amount != 0.0)
-        opt.SoldAmount = static_cast<float>(instr.sold_amount);
-
-    if (!instr.option_type.empty()) {
-        optionData_OptionType_t ot;
-        static_cast<std::string&>(ot) = instr.option_type;
-        opt.OptionData.OptionType = std::move(ot);
-    }
-    if (!instr.expiry_date.empty()) {
-        _ExerciseDates_t ed;
-        domain::date d;
-        static_cast<std::string&>(d) = instr.expiry_date;
-        ed.ExerciseDate.push_back(d);
-        exerciseDatesGroup_group_t edg;
-        edg.ExerciseDates = std::move(ed);
-        opt.OptionData.exerciseDatesGroup = std::move(edg);
-    }
-
-    t.FxOptionData = std::move(opt);
-    return t;
-}
-
-// ---------------------------------------------------------------------------
-// Phase 6 helpers
-// ---------------------------------------------------------------------------
-
-namespace {
-
 std::string option_type_from_vec(const xsd::vector<optionData>& v) {
     if (v.empty()) return {};
     if (v.front().OptionType) return std::string(*v.front().OptionType);
@@ -347,18 +180,28 @@ std::string expiry_date_from_single(const optionData& od) {
     return std::string(od.exerciseDatesGroup->ExerciseDates->ExerciseDate.front());
 }
 
-optionData make_fx_option_entry(const fx_instrument& instr) {
+std::string exercise_style_from_vec(const xsd::vector<optionData>& v) {
+    if (v.empty()) return "European";
+    // If ExerciseDates is present it implies European; American exercise uses
+    // ExerciseSchedule. We default to European as that is far more common.
+    return "European";
+}
+
+// Build an OptionData element from option_type + expiry_date strings.
+optionData make_option_entry(const std::string& option_type,
+                              const std::string& expiry_date,
+                              const std::string& long_short = "Long") {
     optionData od;
-    static_cast<std::string&>(od.LongShort) = "Long";
-    if (!instr.option_type.empty()) {
+    static_cast<std::string&>(od.LongShort) = long_short;
+    if (!option_type.empty()) {
         optionData_OptionType_t ot;
-        static_cast<std::string&>(ot) = instr.option_type;
+        static_cast<std::string&>(ot) = option_type;
         od.OptionType = std::move(ot);
     }
-    if (!instr.expiry_date.empty()) {
+    if (!expiry_date.empty()) {
         _ExerciseDates_t ed;
         date dt;
-        static_cast<std::string&>(dt) = instr.expiry_date;
+        static_cast<std::string&>(dt) = expiry_date;
         ed.ExerciseDate.push_back(dt);
         exerciseDatesGroup_group_t edg;
         edg.ExerciseDates = std::move(ed);
@@ -405,287 +248,556 @@ barrierData fx_instrument_mapper::make_barrier(const std::string& type,
     return b;
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// Forward: FxForward
+// ===========================================================================
+
+fx_mapping_result fx_instrument_mapper::forward_fx_forward(const trade& t) {
+    BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxForward: "
+                               << std::string(t.id);
+    fx_forward_instrument r;
+    r.trade_type_code = "FxForward";
+    set_audit(r);
+    if (!t.FxForwardData) return {r};
+    const auto& fwd = *t.FxForwardData;
+
+    r.value_date      = std::string(fwd.ValueDate);
+    r.bought_currency = to_string(fwd.BoughtCurrency);
+    r.bought_amount   = static_cast<double>(fwd.BoughtAmount);
+    r.sold_currency   = to_string(fwd.SoldCurrency);
+    r.sold_amount     = static_cast<double>(fwd.SoldAmount);
+    if (fwd.Settlement)
+        r.settlement  = to_string(*fwd.Settlement);
+
+    return {r};
+}
+
+// ===========================================================================
+// Forward: FxSwap
+// ===========================================================================
+
+fx_mapping_result fx_instrument_mapper::forward_fx_swap(const trade& t) {
+    BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxSwap: "
+                               << std::string(t.id);
+    fx_forward_instrument r;
+    r.trade_type_code = "FxSwap";
+    set_audit(r);
+    if (!t.FxSwapData) return {r};
+    const auto& sw = *t.FxSwapData;
+
+    // Near leg only; far leg is a documented coverage gap.
+    r.value_date      = std::string(sw.NearDate);
+    r.bought_currency = to_string(sw.NearBoughtCurrency);
+    r.bought_amount   = static_cast<double>(sw.NearBoughtAmount);
+    r.sold_currency   = to_string(sw.NearSoldCurrency);
+    r.sold_amount     = static_cast<double>(sw.NearSoldAmount);
+    if (sw.Settlement)
+        r.settlement  = to_string(*sw.Settlement);
+
+    return {r};
+}
+
+// ===========================================================================
+// Forward: FxOption
+// ===========================================================================
+
+fx_mapping_result fx_instrument_mapper::forward_fx_option(const trade& t) {
+    BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxOption: "
+                               << std::string(t.id);
+    fx_vanilla_option_instrument r;
+    r.trade_type_code = "FxOption";
+    set_audit(r);
+    if (!t.FxOptionData) return {r};
+    const auto& opt = *t.FxOptionData;
+
+    r.bought_currency = to_string(opt.BoughtCurrency);
+    r.bought_amount   = static_cast<double>(opt.BoughtAmount);
+    r.sold_currency   = to_string(opt.SoldCurrency);
+    if (opt.SoldAmount)
+        r.sold_amount = static_cast<double>(*opt.SoldAmount);
+
+    const auto& od = opt.OptionData;
+    if (od.OptionType)
+        r.option_type   = std::string(*od.OptionType);
+    if (od.Settlement)
+        r.settlement    = to_string(*od.Settlement);
+    r.exercise_style    = "European"; // default; American not detected here
+    r.expiry_date       = expiry_date_from_vec(
+        xsd::vector<optionData>{od});
+
+    return {r};
+}
+
+// ===========================================================================
 // Forward: FxBarrierOption
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 fx_mapping_result fx_instrument_mapper::forward_fx_barrier_option(
         const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxBarrierOption: "
                                << std::string(t.id);
-    fx_mapping_result result;
-    result.instrument = make_base("FxBarrierOption");
-    if (!t.FxBarrierOptionData) return result;
+    fx_barrier_option_instrument r;
+    r.trade_type_code = "FxBarrierOption";
+    set_audit(r);
+    if (!t.FxBarrierOptionData) return {r};
     const auto& d = *t.FxBarrierOptionData;
 
-    result.instrument.bought_currency = to_string(d.BoughtCurrency);
-    result.instrument.bought_amount   = static_cast<double>(d.BoughtAmount);
-    result.instrument.sold_currency   = to_string(d.SoldCurrency);
-    result.instrument.sold_amount     = static_cast<double>(d.SoldAmount);
-    result.instrument.option_type     = option_type_from_vec(d.OptionData);
-    result.instrument.expiry_date     = expiry_date_from_vec(d.OptionData);
+    r.bought_currency = to_string(d.BoughtCurrency);
+    r.bought_amount   = static_cast<double>(d.BoughtAmount);
+    r.sold_currency   = to_string(d.SoldCurrency);
+    r.sold_amount     = static_cast<double>(d.SoldAmount);
+    r.option_type     = option_type_from_vec(d.OptionData);
+    r.expiry_date     = expiry_date_from_vec(d.OptionData);
 
     if (!d.BarrierData.empty()) {
-        result.instrument.barrier_type = to_string(d.BarrierData.front().Type);
+        r.barrier_type = to_string(d.BarrierData.front().Type);
         if (!d.BarrierData.front().Levels.Level.empty())
-            result.instrument.lower_barrier =
-                static_cast<double>(d.BarrierData.front().Levels.Level.front());
+            r.lower_barrier = static_cast<double>(
+                d.BarrierData.front().Levels.Level.front());
         if (d.BarrierData.size() > 1 &&
                 !d.BarrierData[1].Levels.Level.empty())
-            result.instrument.upper_barrier =
-                static_cast<double>(d.BarrierData[1].Levels.Level.front());
+            r.upper_barrier = static_cast<double>(
+                d.BarrierData[1].Levels.Level.front());
     }
-    return result;
+    return {r};
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// Forward: FxDoubleBarrierOption
+// ===========================================================================
+
+fx_mapping_result fx_instrument_mapper::forward_fx_double_barrier_option(
+        const trade& t) {
+    BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxDoubleBarrierOption: "
+                               << std::string(t.id);
+    fx_barrier_option_instrument r;
+    r.trade_type_code = "FxDoubleBarrierOption";
+    set_audit(r);
+    if (!t.FxDoubleBarrierOptionData) return {r};
+    const auto& d = *t.FxDoubleBarrierOptionData;
+
+    r.bought_currency = to_string(d.BoughtCurrency);
+    r.bought_amount   = static_cast<double>(d.BoughtAmount);
+    r.sold_currency   = to_string(d.SoldCurrency);
+    r.sold_amount     = static_cast<double>(d.SoldAmount);
+    r.option_type     = option_type_from_vec(d.OptionData);
+    r.expiry_date     = expiry_date_from_vec(d.OptionData);
+
+    if (!d.BarrierData.empty()) {
+        r.barrier_type = to_string(d.BarrierData.front().Type);
+        if (!d.BarrierData.front().Levels.Level.empty())
+            r.lower_barrier = static_cast<double>(
+                d.BarrierData.front().Levels.Level.front());
+        if (d.BarrierData.size() > 1 &&
+                !d.BarrierData[1].Levels.Level.empty())
+            r.upper_barrier = static_cast<double>(
+                d.BarrierData[1].Levels.Level.front());
+    }
+    return {r};
+}
+
+// ===========================================================================
+// Forward: FxEuropeanBarrierOption
+// ===========================================================================
+
+fx_mapping_result fx_instrument_mapper::forward_fx_european_barrier_option(
+        const trade& t) {
+    BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxEuropeanBarrierOption: "
+                               << std::string(t.id);
+    fx_barrier_option_instrument r;
+    r.trade_type_code = "FxEuropeanBarrierOption";
+    set_audit(r);
+    if (!t.FxEuropeanBarrierOptionData) return {r};
+    const auto& d = *t.FxEuropeanBarrierOptionData;
+
+    r.bought_currency = to_string(d.BoughtCurrency);
+    r.bought_amount   = static_cast<double>(d.BoughtAmount);
+    r.sold_currency   = to_string(d.SoldCurrency);
+    r.sold_amount     = static_cast<double>(d.SoldAmount);
+    r.option_type     = option_type_from_vec(d.OptionData);
+    r.expiry_date     = expiry_date_from_vec(d.OptionData);
+
+    if (!d.BarrierData.empty()) {
+        r.barrier_type = to_string(d.BarrierData.front().Type);
+        if (!d.BarrierData.front().Levels.Level.empty())
+            r.lower_barrier = static_cast<double>(
+                d.BarrierData.front().Levels.Level.front());
+        if (d.BarrierData.size() > 1 &&
+                !d.BarrierData[1].Levels.Level.empty())
+            r.upper_barrier = static_cast<double>(
+                d.BarrierData[1].Levels.Level.front());
+    }
+    return {r};
+}
+
+// ===========================================================================
+// Forward: FxKIKOBarrierOption
+// ===========================================================================
+
+fx_mapping_result fx_instrument_mapper::forward_fx_kiko_barrier_option(
+        const trade& t) {
+    BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxKIKOBarrierOption: "
+                               << std::string(t.id);
+    fx_barrier_option_instrument r;
+    r.trade_type_code = "FxKIKOBarrierOption";
+    set_audit(r);
+    if (!t.FxKIKOBarrierOptionData) return {r};
+    const auto& d = *t.FxKIKOBarrierOptionData;
+
+    r.bought_currency = to_string(d.BoughtCurrency);
+    r.bought_amount   = static_cast<double>(d.BoughtAmount);
+    r.sold_currency   = to_string(d.SoldCurrency);
+    r.sold_amount     = static_cast<double>(d.SoldAmount);
+    if (d.OptionData.OptionType)
+        r.option_type = std::string(*d.OptionData.OptionType);
+    r.expiry_date     = expiry_date_from_single(d.OptionData);
+
+    if (!d.Barriers.BarrierData.empty()) {
+        r.barrier_type = to_string(d.Barriers.BarrierData.front().Type);
+        if (!d.Barriers.BarrierData.front().Levels.Level.empty())
+            r.lower_barrier = static_cast<double>(
+                d.Barriers.BarrierData.front().Levels.Level.front());
+        if (d.Barriers.BarrierData.size() > 1 &&
+                !d.Barriers.BarrierData[1].Levels.Level.empty())
+            r.upper_barrier = static_cast<double>(
+                d.Barriers.BarrierData[1].Levels.Level.front());
+    }
+    return {r};
+}
+
+// ===========================================================================
+// Forward: FxGenericBarrierOption
+// ===========================================================================
+
+fx_mapping_result fx_instrument_mapper::forward_fx_generic_barrier_option(
+        const trade& t) {
+    BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxGenericBarrierOption: "
+                               << std::string(t.id);
+    fx_barrier_option_instrument r;
+    r.trade_type_code = "FxGenericBarrierOption";
+    set_audit(r);
+    if (!t.FxGenericBarrierOptionData) return {r};
+    const auto& d = *t.FxGenericBarrierOptionData;
+
+    if (d.underlyingTypes.Name)
+        r.underlying_code = std::string(*d.underlyingTypes.Name);
+    else if (d.underlyingTypes.Underlying)
+        r.underlying_code = std::string(d.underlyingTypes.Underlying->Name);
+
+    r.bought_currency = to_string(d.PayCurrency);
+    if (d.OptionData.OptionType)
+        r.option_type   = std::string(*d.OptionData.OptionType);
+    r.expiry_date       = expiry_date_from_single(d.OptionData);
+
+    if (!d.Barriers.BarrierData.empty()) {
+        r.barrier_type = to_string(d.Barriers.BarrierData.front().Type);
+        if (!d.Barriers.BarrierData.front().Levels.Level.empty())
+            r.lower_barrier = static_cast<double>(
+                d.Barriers.BarrierData.front().Levels.Level.front());
+        if (d.Barriers.BarrierData.size() > 1 &&
+                !d.Barriers.BarrierData[1].Levels.Level.empty())
+            r.upper_barrier = static_cast<double>(
+                d.Barriers.BarrierData[1].Levels.Level.front());
+    }
+    return {r};
+}
+
+// ===========================================================================
 // Forward: FxDigitalOption
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 fx_mapping_result fx_instrument_mapper::forward_fx_digital_option(
         const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxDigitalOption: "
                                << std::string(t.id);
-    fx_mapping_result result;
-    result.instrument = make_base("FxDigitalOption");
-    if (!t.FxDigitalOptionData) return result;
+    fx_digital_option_instrument r;
+    r.trade_type_code = "FxDigitalOption";
+    r.long_short      = "Long";
+    set_audit(r);
+    if (!t.FxDigitalOptionData) return {r};
     const auto& d = *t.FxDigitalOptionData;
 
-    result.instrument.bought_currency = to_string(d.ForeignCurrency);
-    result.instrument.sold_currency   = to_string(d.DomesticCurrency);
-    result.instrument.strike_price    = static_cast<double>(d.Strike);
-    result.instrument.notional        = static_cast<double>(d.PayoffAmount);
-    result.instrument.option_type     = option_type_from_vec(d.OptionData);
-    result.instrument.expiry_date     = expiry_date_from_vec(d.OptionData);
-    return result;
+    r.foreign_currency = to_string(d.ForeignCurrency);
+    r.domestic_currency = to_string(d.DomesticCurrency);
+    r.payoff_currency  = to_string(d.ForeignCurrency); // defaults to foreign
+    r.strike           = static_cast<double>(d.Strike);
+    r.payoff_amount    = static_cast<double>(d.PayoffAmount);
+    r.option_type      = option_type_from_vec(d.OptionData);
+    r.expiry_date      = expiry_date_from_vec(d.OptionData);
+    return {r};
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Forward: FxDigitalBarrierOption
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 fx_mapping_result fx_instrument_mapper::forward_fx_digital_barrier_option(
         const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxDigitalBarrierOption: "
                                << std::string(t.id);
-    fx_mapping_result result;
-    result.instrument = make_base("FxDigitalBarrierOption");
-    if (!t.FxDigitalBarrierOptionData) return result;
+    fx_digital_option_instrument r;
+    r.trade_type_code = "FxDigitalBarrierOption";
+    r.long_short      = "Long";
+    set_audit(r);
+    if (!t.FxDigitalBarrierOptionData) return {r};
     const auto& d = *t.FxDigitalBarrierOptionData;
 
-    result.instrument.bought_currency = to_string(d.ForeignCurrency);
-    result.instrument.sold_currency   = to_string(d.DomesticCurrency);
-    result.instrument.strike_price    = static_cast<double>(d.Strike);
-    result.instrument.notional        = static_cast<double>(d.PayoffAmount);
-    result.instrument.option_type     = option_type_from_vec(d.OptionData);
-    result.instrument.expiry_date     = expiry_date_from_vec(d.OptionData);
+    r.foreign_currency  = to_string(d.ForeignCurrency);
+    r.domestic_currency = to_string(d.DomesticCurrency);
+    r.payoff_currency   = to_string(d.ForeignCurrency);
+    r.strike            = static_cast<double>(d.Strike);
+    r.payoff_amount     = static_cast<double>(d.PayoffAmount);
+    r.option_type       = option_type_from_vec(d.OptionData);
+    r.expiry_date       = expiry_date_from_vec(d.OptionData);
 
     if (!d.BarrierData.empty()) {
-        result.instrument.barrier_type = to_string(d.BarrierData.front().Type);
+        r.barrier_type = to_string(d.BarrierData.front().Type);
         if (!d.BarrierData.front().Levels.Level.empty())
-            result.instrument.lower_barrier =
-                static_cast<double>(d.BarrierData.front().Levels.Level.front());
+            r.lower_barrier = static_cast<double>(
+                d.BarrierData.front().Levels.Level.front());
     }
-    return result;
+    return {r};
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Forward: FxTouchOption / FxDoubleTouchOption
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 fx_mapping_result fx_instrument_mapper::forward_fx_touch_option(
         const trade& t) {
     const std::string type_str = to_string(t.TradeType);
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping " << type_str << ": "
                                << std::string(t.id);
-    fx_mapping_result result;
-    result.instrument = make_base(type_str);
+    fx_digital_option_instrument r;
+    r.trade_type_code = type_str;
+    r.long_short      = "Long";
+    set_audit(r);
 
     const fxTouchOptionData* dp = nullptr;
-    if (t.FxTouchOptionData) dp = &(*t.FxTouchOptionData);
+    if (t.FxTouchOptionData)       dp = &(*t.FxTouchOptionData);
     else if (t.FxDoubleTouchOptionData) dp = &(*t.FxDoubleTouchOptionData);
-    if (!dp) return result;
+    if (!dp) return {r};
     const auto& d = *dp;
 
-    result.instrument.bought_currency = to_string(d.ForeignCurrency);
-    result.instrument.sold_currency   = to_string(d.DomesticCurrency);
-    result.instrument.notional        = static_cast<double>(d.PayoffAmount);
-    result.instrument.option_type     = option_type_from_vec(d.OptionData);
-    result.instrument.expiry_date     = expiry_date_from_vec(d.OptionData);
+    r.foreign_currency  = to_string(d.ForeignCurrency);
+    r.domestic_currency = to_string(d.DomesticCurrency);
+    r.payoff_currency   = to_string(d.PayoffCurrency);
+    r.payoff_amount     = static_cast<double>(d.PayoffAmount);
+    r.expiry_date       = expiry_date_from_vec(d.OptionData);
 
     if (!d.BarrierData.empty()) {
-        result.instrument.barrier_type = to_string(d.BarrierData.front().Type);
+        r.barrier_type = to_string(d.BarrierData.front().Type);
         if (!d.BarrierData.front().Levels.Level.empty())
-            result.instrument.lower_barrier =
-                static_cast<double>(d.BarrierData.front().Levels.Level.front());
+            r.lower_barrier = static_cast<double>(
+                d.BarrierData.front().Levels.Level.front());
         if (d.BarrierData.size() > 1 &&
                 !d.BarrierData[1].Levels.Level.empty())
-            result.instrument.upper_barrier =
-                static_cast<double>(d.BarrierData[1].Levels.Level.front());
+            r.upper_barrier = static_cast<double>(
+                d.BarrierData[1].Levels.Level.front());
     }
-    return result;
+    return {r};
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Forward: FxVarianceSwap
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 fx_mapping_result fx_instrument_mapper::forward_fx_variance_swap(
         const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxVarianceSwap: "
                                << std::string(t.id);
-    fx_mapping_result result;
-    result.instrument = make_base("FxVarianceSwap");
-    if (!t.FxVarianceSwapData) return result;
+    fx_variance_swap_instrument r;
+    r.trade_type_code = "FxVarianceSwap";
+    r.long_short      = "Long";
+    set_audit(r);
+    if (!t.FxVarianceSwapData) return {r};
     const auto& d = *t.FxVarianceSwapData;
 
     if (d.underlyingTypes.Name)
-        result.instrument.underlying_code = std::string(*d.underlyingTypes.Name);
+        r.underlying_code = std::string(*d.underlyingTypes.Name);
     else if (d.underlyingTypes.Underlying)
-        result.instrument.underlying_code =
-            std::string(d.underlyingTypes.Underlying->Name);
+        r.underlying_code = std::string(d.underlyingTypes.Underlying->Name);
 
-    result.instrument.start_date      = std::string(d.StartDate);
-    result.instrument.expiry_date     = std::string(d.EndDate);
-    result.instrument.variance_strike = static_cast<double>(d.Strike);
-    result.instrument.notional        = static_cast<double>(d.Notional);
-    result.instrument.bought_currency = to_string(d.Currency);
-    return result;
+    r.start_date = std::string(d.StartDate);
+    r.end_date   = std::string(d.EndDate);
+    r.strike     = static_cast<double>(d.Strike);
+    r.notional   = static_cast<double>(d.Notional);
+    r.currency   = to_string(d.Currency);
+    r.moment_type = "Variance"; // default; MomentType element not always present
+    return {r};
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Forward: FxAverageForward
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 fx_mapping_result fx_instrument_mapper::forward_fx_average_forward(
         const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxAverageForward: "
                                << std::string(t.id);
-    fx_mapping_result result;
-    result.instrument = make_base("FxAverageForward");
-    if (!t.FxAverageForwardData) return result;
+    fx_asian_forward_instrument r;
+    r.trade_type_code = "FxAverageForward";
+    set_audit(r);
+    if (!t.FxAverageForwardData) return {r};
     const auto& d = *t.FxAverageForwardData;
 
-    result.instrument.value_date      = std::string(d.PaymentDate);
-    result.instrument.bought_currency = to_string(d.ReferenceCurrency);
-    result.instrument.bought_amount   = static_cast<double>(d.ReferenceNotional);
-    result.instrument.sold_currency   = to_string(d.SettlementCurrency);
-    result.instrument.sold_amount     = static_cast<double>(d.SettlementNotional);
-    result.instrument.underlying_code = std::string(d.FXIndex);
-    return result;
+    r.payment_date        = std::string(d.PaymentDate);
+    r.reference_currency  = to_string(d.ReferenceCurrency);
+    r.reference_notional  = static_cast<double>(d.ReferenceNotional);
+    r.settlement_currency = to_string(d.SettlementCurrency);
+    r.settlement_notional = static_cast<double>(d.SettlementNotional);
+    r.fx_index            = std::string(d.FXIndex);
+    r.long_short          = "Long";
+    return {r};
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Forward: FxAccumulator
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 fx_mapping_result fx_instrument_mapper::forward_fx_accumulator(
         const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxAccumulator: "
                                << std::string(t.id);
-    fx_mapping_result result;
-    result.instrument = make_base("FxAccumulator");
-    if (!t.FxAccumulatorData) return result;
+    fx_accumulator_instrument r;
+    r.trade_type_code = "FxAccumulator";
+    r.long_short      = "Long";
+    set_audit(r);
+    if (!t.FxAccumulatorData) return {r};
     const auto& d = *t.FxAccumulatorData;
 
-    result.instrument.bought_currency    = to_string(d.Currency);
-    result.instrument.underlying_code    = std::string(d.Underlying.Name);
-    result.instrument.accumulation_amount = static_cast<double>(d.FixingAmount);
+    r.currency          = to_string(d.Currency);
+    r.underlying_code   = std::string(d.Underlying.Name);
+    r.fixing_amount     = static_cast<double>(d.FixingAmount);
     if (d.Strike)
-        result.instrument.strike_price = static_cast<double>(*d.Strike);
+        r.strike        = static_cast<double>(*d.Strike);
     if (d.StartDate)
-        result.instrument.start_date = std::string(*d.StartDate);
-    result.instrument.expiry_date = expiry_date_from_single(d.OptionData);
+        r.start_date    = std::string(*d.StartDate);
 
     if (d.Barriers) {
         for (const auto& bd : d.Barriers->BarrierData) {
             const auto btype = to_string(bd.Type);
             if ((btype == "DownAndOut" || btype == "UpAndOut") &&
                     !bd.Levels.Level.empty()) {
-                result.instrument.knock_out_barrier =
+                r.knock_out_barrier =
                     static_cast<double>(bd.Levels.Level.front());
                 break;
             }
         }
     }
-    return result;
+    return {r};
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Forward: FxTaRF
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 fx_mapping_result fx_instrument_mapper::forward_fx_tarf(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxTaRF: "
                                << std::string(t.id);
-    fx_mapping_result result;
-    result.instrument = make_base("FxTaRF");
-    if (!t.FxTaRFData) return result;
+    fx_asian_forward_instrument r;
+    r.trade_type_code = "FxTaRF";
+    set_audit(r);
+    if (!t.FxTaRFData) return {r};
     const auto& d = *t.FxTaRFData;
 
-    result.instrument.bought_currency    = to_string(d.Currency);
-    result.instrument.underlying_code    = std::string(d.Underlying.Name);
-    result.instrument.accumulation_amount = static_cast<double>(d.FixingAmount);
+    r.currency     = to_string(d.Currency);
+    r.fx_index     = std::string(d.Underlying.Name);
+    r.fixing_amount = static_cast<double>(d.FixingAmount);
     if (d.Strike)
-        result.instrument.strike_price = static_cast<double>(*d.Strike);
-    result.instrument.expiry_date = expiry_date_from_single(d.OptionData);
+        r.strike   = static_cast<double>(*d.Strike);
 
+    // Target amount (profit cap) if present
     for (const auto& bd : d.Barriers.BarrierData) {
         const auto btype = to_string(bd.Type);
-        if ((btype == "KnockOut" || btype == "FixingCap") &&
+        if ((btype == "CumulatedProfitCap" || btype == "FixingCap") &&
                 !bd.Levels.Level.empty()) {
-            result.instrument.knock_out_barrier =
-                static_cast<double>(bd.Levels.Level.front());
+            r.target_amount = static_cast<double>(bd.Levels.Level.front());
             break;
         }
     }
-    return result;
+    return {r};
 }
 
-// ---------------------------------------------------------------------------
-// Forward: FxGenericBarrierOption
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// Reverse: FxForward
+// ===========================================================================
 
-fx_mapping_result fx_instrument_mapper::forward_fx_generic_barrier_option(
-        const trade& t) {
-    BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxGenericBarrierOption: "
-                               << std::string(t.id);
-    fx_mapping_result result;
-    result.instrument = make_base("FxGenericBarrierOption");
-    if (!t.FxGenericBarrierOptionData) return result;
-    const auto& d = *t.FxGenericBarrierOptionData;
+trade fx_instrument_mapper::reverse_fx_forward(
+        const fx_forward_instrument& instr) {
+    BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxForward";
+    trade t;
+    t.TradeType = oreTradeType::FxForward;
 
-    if (d.underlyingTypes.Name)
-        result.instrument.underlying_code = std::string(*d.underlyingTypes.Name);
-    else if (d.underlyingTypes.Underlying)
-        result.instrument.underlying_code =
-            std::string(d.underlyingTypes.Underlying->Name);
+    fxForwardData fwd;
+    static_cast<std::string&>(fwd.ValueDate)  = instr.value_date;
+    fwd.BoughtCurrency = parse_currency_code(instr.bought_currency);
+    static_cast<float&>(fwd.BoughtAmount)     = static_cast<float>(instr.bought_amount);
+    fwd.SoldCurrency   = parse_currency_code(instr.sold_currency);
+    static_cast<float&>(fwd.SoldAmount)       = static_cast<float>(instr.sold_amount);
 
-    result.instrument.bought_currency = to_string(d.PayCurrency);
-    if (d.OptionData.OptionType)
-        result.instrument.option_type = std::string(*d.OptionData.OptionType);
-    result.instrument.expiry_date = expiry_date_from_single(d.OptionData);
+    t.FxForwardData = std::move(fwd);
+    return t;
+}
 
-    if (d.Strike)
-        result.instrument.strike_price = static_cast<double>(*d.Strike);
-    if (d.Amount)
-        result.instrument.notional = static_cast<double>(*d.Amount);
+// ===========================================================================
+// Reverse: FxSwap
+// ===========================================================================
 
-    if (!d.Barriers.BarrierData.empty()) {
-        result.instrument.barrier_type = to_string(d.Barriers.BarrierData.front().Type);
-        if (!d.Barriers.BarrierData.front().Levels.Level.empty())
-            result.instrument.lower_barrier =
-                static_cast<double>(d.Barriers.BarrierData.front().Levels.Level.front());
+trade fx_instrument_mapper::reverse_fx_swap(
+        const fx_forward_instrument& instr) {
+    BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxSwap";
+    trade t;
+    t.TradeType = oreTradeType::FxSwap;
+
+    fxSwapData sw;
+    static_cast<std::string&>(sw.NearDate)     = instr.value_date;
+    sw.NearBoughtCurrency = parse_currency_code(instr.bought_currency);
+    static_cast<float&>(sw.NearBoughtAmount)   = static_cast<float>(instr.bought_amount);
+    sw.NearSoldCurrency   = parse_currency_code(instr.sold_currency);
+    static_cast<float&>(sw.NearSoldAmount)     = static_cast<float>(instr.sold_amount);
+    // Far leg: not captured in forward mapping — round-trip as empty date/zero amounts.
+    static_cast<std::string&>(sw.FarDate)      = "";
+    static_cast<float&>(sw.FarBoughtAmount)    = 0.0f;
+    static_cast<float&>(sw.FarSoldAmount)      = 0.0f;
+
+    t.FxSwapData = std::move(sw);
+    return t;
+}
+
+// ===========================================================================
+// Reverse: FxOption
+// ===========================================================================
+
+trade fx_instrument_mapper::reverse_fx_option(
+        const fx_vanilla_option_instrument& instr) {
+    BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxOption";
+    trade t;
+    t.TradeType = oreTradeType::FxOption;
+
+    fxOptionData opt;
+    opt.BoughtCurrency = parse_currency_code(instr.bought_currency);
+    static_cast<float&>(opt.BoughtAmount) = static_cast<float>(instr.bought_amount);
+    opt.SoldCurrency   = parse_currency_code(instr.sold_currency);
+    if (instr.sold_amount != 0.0)
+        opt.SoldAmount = static_cast<float>(instr.sold_amount);
+
+    opt.OptionData = make_option_entry(instr.option_type, instr.expiry_date);
+    if (!instr.settlement.empty()) {
+        // OptionData in fxOptionData carries settlement directly
+        // (this cast is the same pattern as the old mapper)
     }
-    return result;
+
+    t.FxOptionData = std::move(opt);
+    return t;
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Reverse: FxBarrierOption
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 trade fx_instrument_mapper::reverse_fx_barrier_option(
-        const fx_instrument& instr) {
+        const fx_barrier_option_instrument& instr) {
     BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxBarrierOption";
     trade t;
     t.TradeType = oreTradeType::FxBarrierOption;
@@ -695,68 +807,168 @@ trade fx_instrument_mapper::reverse_fx_barrier_option(
     d.BoughtAmount   = static_cast<float>(instr.bought_amount);
     d.SoldCurrency   = parse_currency_code(instr.sold_currency);
     d.SoldAmount     = static_cast<float>(instr.sold_amount);
-    d.OptionData.push_back(make_fx_option_entry(instr));
+    d.OptionData.push_back(make_option_entry(instr.option_type, instr.expiry_date));
 
     if (!instr.barrier_type.empty() && instr.lower_barrier != 0.0)
         d.BarrierData.push_back(make_barrier(instr.barrier_type, instr.lower_barrier));
-    if (instr.upper_barrier != 0.0)
-        d.BarrierData.push_back(make_barrier(instr.barrier_type, instr.upper_barrier));
+    if (instr.upper_barrier.has_value())
+        d.BarrierData.push_back(make_barrier(instr.barrier_type, *instr.upper_barrier));
 
     t.FxBarrierOptionData = std::move(d);
     return t;
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// Reverse: FxDoubleBarrierOption
+// ===========================================================================
+
+trade fx_instrument_mapper::reverse_fx_double_barrier_option(
+        const fx_barrier_option_instrument& instr) {
+    BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxDoubleBarrierOption";
+    trade t;
+    t.TradeType = oreTradeType::FxDoubleBarrierOption;
+    fxBarrierOptionData d;
+    d.BoughtCurrency = parse_currency_code(instr.bought_currency);
+    d.BoughtAmount   = static_cast<float>(instr.bought_amount);
+    d.SoldCurrency   = parse_currency_code(instr.sold_currency);
+    d.SoldAmount     = static_cast<float>(instr.sold_amount);
+    d.OptionData.push_back(make_option_entry(instr.option_type, instr.expiry_date));
+    if (!instr.barrier_type.empty() && instr.lower_barrier != 0.0)
+        d.BarrierData.push_back(make_barrier(instr.barrier_type, instr.lower_barrier));
+    if (instr.upper_barrier.has_value())
+        d.BarrierData.push_back(make_barrier(instr.barrier_type, *instr.upper_barrier));
+    t.FxDoubleBarrierOptionData = std::move(d);
+    return t;
+}
+
+// ===========================================================================
+// Reverse: FxEuropeanBarrierOption
+// ===========================================================================
+
+trade fx_instrument_mapper::reverse_fx_european_barrier_option(
+        const fx_barrier_option_instrument& instr) {
+    BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxEuropeanBarrierOption";
+    trade t;
+    t.TradeType = oreTradeType::FxEuropeanBarrierOption;
+    fxBarrierOptionData d;
+    d.BoughtCurrency = parse_currency_code(instr.bought_currency);
+    d.BoughtAmount   = static_cast<float>(instr.bought_amount);
+    d.SoldCurrency   = parse_currency_code(instr.sold_currency);
+    d.SoldAmount     = static_cast<float>(instr.sold_amount);
+    d.OptionData.push_back(make_option_entry(instr.option_type, instr.expiry_date));
+    if (!instr.barrier_type.empty() && instr.lower_barrier != 0.0)
+        d.BarrierData.push_back(make_barrier(instr.barrier_type, instr.lower_barrier));
+    if (instr.upper_barrier.has_value())
+        d.BarrierData.push_back(make_barrier(instr.barrier_type, *instr.upper_barrier));
+    t.FxEuropeanBarrierOptionData = std::move(d);
+    return t;
+}
+
+// ===========================================================================
+// Reverse: FxKIKOBarrierOption
+// ===========================================================================
+
+trade fx_instrument_mapper::reverse_fx_kiko_barrier_option(
+        const fx_barrier_option_instrument& instr) {
+    BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxKIKOBarrierOption";
+    trade t;
+    t.TradeType = oreTradeType::FxKIKOBarrierOption;
+    fxKIKOBarrierOptionData d;
+    d.BoughtCurrency = parse_currency_code(instr.bought_currency);
+    d.BoughtAmount   = static_cast<float>(instr.bought_amount);
+    d.SoldCurrency   = parse_currency_code(instr.sold_currency);
+    d.SoldAmount     = static_cast<float>(instr.sold_amount);
+    d.OptionData     = make_option_entry(instr.option_type, instr.expiry_date);
+    if (!instr.barrier_type.empty() && instr.lower_barrier != 0.0)
+        d.Barriers.BarrierData.push_back(
+            make_barrier(instr.barrier_type, instr.lower_barrier));
+    if (instr.upper_barrier.has_value())
+        d.Barriers.BarrierData.push_back(
+            make_barrier(instr.barrier_type, *instr.upper_barrier));
+    t.FxKIKOBarrierOptionData = std::move(d);
+    return t;
+}
+
+// ===========================================================================
+// Reverse: FxGenericBarrierOption
+// ===========================================================================
+
+trade fx_instrument_mapper::reverse_fx_generic_barrier_option(
+        const fx_barrier_option_instrument& instr) {
+    BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxGenericBarrierOption";
+    trade t;
+    t.TradeType = oreTradeType::FxGenericBarrierOption;
+
+    genericBarrierOptionData d;
+    if (!instr.bought_currency.empty())
+        d.PayCurrency = parse_currency_code(instr.bought_currency);
+    d.underlyingTypes = make_underlying_type_name(instr.underlying_code);
+    d.OptionData = make_option_entry(instr.option_type, instr.expiry_date);
+
+    if (!instr.barrier_type.empty() && instr.lower_barrier != 0.0)
+        d.Barriers.BarrierData.push_back(
+            make_barrier(instr.barrier_type, instr.lower_barrier));
+    if (instr.upper_barrier.has_value())
+        d.Barriers.BarrierData.push_back(
+            make_barrier(instr.barrier_type, *instr.upper_barrier));
+
+    t.FxGenericBarrierOptionData = std::move(d);
+    return t;
+}
+
+// ===========================================================================
 // Reverse: FxDigitalOption
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 trade fx_instrument_mapper::reverse_fx_digital_option(
-        const fx_instrument& instr) {
+        const fx_digital_option_instrument& instr) {
     BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxDigitalOption";
     trade t;
     t.TradeType = oreTradeType::FxDigitalOption;
 
     fxDigitalOptionData d;
-    d.ForeignCurrency = parse_currency_code(instr.bought_currency);
-    d.DomesticCurrency = parse_currency_code(instr.sold_currency);
-    d.Strike      = static_cast<float>(instr.strike_price);
-    d.PayoffAmount = static_cast<float>(instr.notional);
-    d.OptionData.push_back(make_fx_option_entry(instr));
+    d.ForeignCurrency  = parse_currency_code(instr.foreign_currency);
+    d.DomesticCurrency = parse_currency_code(instr.domestic_currency);
+    d.Strike           = static_cast<float>(instr.strike.value_or(0.0));
+    d.PayoffAmount     = static_cast<float>(instr.payoff_amount);
+    d.OptionData.push_back(make_option_entry(instr.option_type, instr.expiry_date,
+                                              instr.long_short));
 
     t.FxDigitalOptionData = std::move(d);
     return t;
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Reverse: FxDigitalBarrierOption
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 trade fx_instrument_mapper::reverse_fx_digital_barrier_option(
-        const fx_instrument& instr) {
+        const fx_digital_option_instrument& instr) {
     BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxDigitalBarrierOption";
     trade t;
     t.TradeType = oreTradeType::FxDigitalBarrierOption;
 
     fxDigitalBarrierOptionData d;
-    d.ForeignCurrency  = parse_currency_code(instr.bought_currency);
-    d.DomesticCurrency = parse_currency_code(instr.sold_currency);
-    d.Strike      = static_cast<float>(instr.strike_price);
-    d.PayoffAmount = static_cast<float>(instr.notional);
-    d.OptionData.push_back(make_fx_option_entry(instr));
+    d.ForeignCurrency  = parse_currency_code(instr.foreign_currency);
+    d.DomesticCurrency = parse_currency_code(instr.domestic_currency);
+    d.Strike           = static_cast<float>(instr.strike.value_or(0.0));
+    d.PayoffAmount     = static_cast<float>(instr.payoff_amount);
+    d.OptionData.push_back(make_option_entry(instr.option_type, instr.expiry_date,
+                                              instr.long_short));
 
-    if (!instr.barrier_type.empty() && instr.lower_barrier != 0.0)
-        d.BarrierData.push_back(make_barrier(instr.barrier_type, instr.lower_barrier));
+    if (!instr.barrier_type.empty() && instr.lower_barrier.has_value())
+        d.BarrierData.push_back(make_barrier(instr.barrier_type, *instr.lower_barrier));
 
     t.FxDigitalBarrierOptionData = std::move(d);
     return t;
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Reverse: FxTouchOption / FxDoubleTouchOption
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 trade fx_instrument_mapper::reverse_fx_touch_option(
-        const fx_instrument& instr) {
+        const fx_digital_option_instrument& instr) {
     BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping " << instr.trade_type_code;
     trade t;
     t.TradeType = (instr.trade_type_code == "FxDoubleTouchOption")
@@ -764,19 +976,19 @@ trade fx_instrument_mapper::reverse_fx_touch_option(
                       : oreTradeType::FxTouchOption;
 
     fxTouchOptionData d;
-    if (!instr.bought_currency.empty())
-        d.ForeignCurrency = parse_currency_code(instr.bought_currency);
-    if (!instr.sold_currency.empty())
-        d.DomesticCurrency = parse_currency_code(instr.sold_currency);
-    if (!instr.bought_currency.empty())
-        d.PayoffCurrency = parse_currency_code(instr.bought_currency);
-    d.PayoffAmount = static_cast<float>(instr.notional);
-    d.OptionData.push_back(make_fx_option_entry(instr));
+    if (!instr.foreign_currency.empty())
+        d.ForeignCurrency = parse_currency_code(instr.foreign_currency);
+    if (!instr.domestic_currency.empty())
+        d.DomesticCurrency = parse_currency_code(instr.domestic_currency);
+    if (!instr.payoff_currency.empty())
+        d.PayoffCurrency = parse_currency_code(instr.payoff_currency);
+    d.PayoffAmount = static_cast<float>(instr.payoff_amount);
+    d.OptionData.push_back(make_option_entry("", instr.expiry_date, instr.long_short));
 
-    if (!instr.barrier_type.empty() && instr.lower_barrier != 0.0)
-        d.BarrierData.push_back(make_barrier(instr.barrier_type, instr.lower_barrier));
-    if (instr.upper_barrier != 0.0)
-        d.BarrierData.push_back(make_barrier(instr.barrier_type, instr.upper_barrier));
+    if (!instr.barrier_type.empty() && instr.lower_barrier.has_value())
+        d.BarrierData.push_back(make_barrier(instr.barrier_type, *instr.lower_barrier));
+    if (instr.upper_barrier.has_value())
+        d.BarrierData.push_back(make_barrier(instr.barrier_type, *instr.upper_barrier));
 
     if (instr.trade_type_code == "FxDoubleTouchOption")
         t.FxDoubleTouchOptionData = std::move(d);
@@ -785,24 +997,24 @@ trade fx_instrument_mapper::reverse_fx_touch_option(
     return t;
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Reverse: FxVarianceSwap
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 trade fx_instrument_mapper::reverse_fx_variance_swap(
-        const fx_instrument& instr) {
+        const fx_variance_swap_instrument& instr) {
     BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxVarianceSwap";
     trade t;
     t.TradeType = oreTradeType::FxVarianceSwap;
 
     varianceSwapData d;
     static_cast<std::string&>(d.StartDate) = instr.start_date;
-    static_cast<std::string&>(d.EndDate)   = instr.expiry_date;
-    if (!instr.bought_currency.empty())
-        d.Currency = parse_currency_code(instr.bought_currency);
+    static_cast<std::string&>(d.EndDate)   = instr.end_date;
+    if (!instr.currency.empty())
+        d.Currency = parse_currency_code(instr.currency);
     d.underlyingTypes = make_underlying_type_name(instr.underlying_code);
-    static_cast<std::string&>(d.LongShort) = "Long";
-    d.Strike   = static_cast<float>(instr.variance_strike);
+    static_cast<std::string&>(d.LongShort) = instr.long_short;
+    d.Strike   = static_cast<float>(instr.strike);
     d.Notional = static_cast<float>(instr.notional);
     static_cast<std::string&>(d.Calendar) = "TARGET";
 
@@ -810,23 +1022,25 @@ trade fx_instrument_mapper::reverse_fx_variance_swap(
     return t;
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Reverse: FxAverageForward
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 trade fx_instrument_mapper::reverse_fx_average_forward(
-        const fx_instrument& instr) {
+        const fx_asian_forward_instrument& instr) {
     BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxAverageForward";
     trade t;
     t.TradeType = oreTradeType::FxAverageForward;
 
     fxAverageForwardData d;
-    static_cast<std::string&>(d.PaymentDate) = instr.value_date.value_or("");
-    d.ReferenceCurrency  = parse_currency_code(instr.bought_currency);
-    d.ReferenceNotional  = static_cast<float>(instr.bought_amount);
-    d.SettlementCurrency = parse_currency_code(instr.sold_currency);
-    d.SettlementNotional = static_cast<float>(instr.sold_amount);
-    static_cast<std::string&>(d.FXIndex) = instr.underlying_code;
+    static_cast<std::string&>(d.PaymentDate) = instr.payment_date;
+    if (!instr.reference_currency.empty())
+        d.ReferenceCurrency  = parse_currency_code(instr.reference_currency);
+    d.ReferenceNotional  = static_cast<float>(instr.reference_notional.value_or(0.0));
+    if (!instr.settlement_currency.empty())
+        d.SettlementCurrency = parse_currency_code(instr.settlement_currency);
+    d.SettlementNotional = static_cast<float>(instr.settlement_notional.value_or(0.0));
+    static_cast<std::string&>(d.FXIndex) = instr.fx_index;
     d.FixedPayer = bool_::false_;
     // Minimal observation schedule
     scheduleData_Rules_t rule;
@@ -837,24 +1051,25 @@ trade fx_instrument_mapper::reverse_fx_average_forward(
     return t;
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Reverse: FxAccumulator
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 trade fx_instrument_mapper::reverse_fx_accumulator(
-        const fx_instrument& instr) {
+        const fx_accumulator_instrument& instr) {
     BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxAccumulator";
     trade t;
     t.TradeType = oreTradeType::FxAccumulator;
 
     accumulatorData d;
-    d.Currency = parse_currency_code(instr.bought_currency);
-    d.FixingAmount = static_cast<float>(instr.accumulation_amount);
-    if (instr.strike_price != 0.0)
-        d.Strike = static_cast<float>(instr.strike_price);
+    if (!instr.currency.empty())
+        d.Currency = parse_currency_code(instr.currency);
+    d.FixingAmount = static_cast<float>(instr.fixing_amount);
+    if (instr.strike != 0.0)
+        d.Strike = static_cast<float>(instr.strike);
     static_cast<std::string&>(d.Underlying.Name) = instr.underlying_code;
     static_cast<std::string&>(d.Underlying.Type) = "FX";
-    static_cast<std::string&>(d.OptionData.LongShort) = "Long";
+    static_cast<std::string&>(d.OptionData.LongShort) = instr.long_short;
     if (!instr.start_date.empty()) {
         date sd;
         static_cast<std::string&>(sd) = instr.start_date;
@@ -867,25 +1082,34 @@ trade fx_instrument_mapper::reverse_fx_accumulator(
     static_cast<std::string&>(rule.Tenor) = "1D";
     d.ObservationDates.Rules.push_back(std::move(rule));
 
+    if (instr.knock_out_barrier.has_value())
+        d.Barriers = [&]() {
+            barriers_t b;
+            b.BarrierData.push_back(make_barrier("UpAndOut", *instr.knock_out_barrier));
+            return b;
+        }();
+
     t.FxAccumulatorData = std::move(d);
     return t;
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Reverse: FxTaRF
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
-trade fx_instrument_mapper::reverse_fx_tarf(const fx_instrument& instr) {
+trade fx_instrument_mapper::reverse_fx_tarf(
+        const fx_asian_forward_instrument& instr) {
     BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxTaRF";
     trade t;
     t.TradeType = oreTradeType::FxTaRF;
 
     tarfData2 d;
-    d.Currency = parse_currency_code(instr.bought_currency);
-    d.FixingAmount = static_cast<float>(instr.accumulation_amount);
-    if (instr.strike_price != 0.0)
-        d.Strike = static_cast<float>(instr.strike_price);
-    static_cast<std::string&>(d.Underlying.Name) = instr.underlying_code;
+    if (!instr.currency.empty())
+        d.Currency = parse_currency_code(instr.currency);
+    d.FixingAmount = static_cast<float>(instr.fixing_amount.value_or(0.0));
+    if (instr.strike.has_value())
+        d.Strike = static_cast<float>(*instr.strike);
+    static_cast<std::string&>(d.Underlying.Name) = instr.fx_index;
     static_cast<std::string&>(d.Underlying.Type) = "FX";
     static_cast<std::string&>(d.OptionData.LongShort) = "Long";
     // Minimal schedule
@@ -893,214 +1117,14 @@ trade fx_instrument_mapper::reverse_fx_tarf(const fx_instrument& instr) {
     static_cast<std::string&>(rule.Tenor) = "1Y";
     d.ScheduleData.Rules.push_back(std::move(rule));
 
+    if (instr.target_amount.has_value()) {
+        barrierData bd;
+        bd.Type = barrierType::CumulatedProfitCap;
+        bd.Levels.Level.push_back(static_cast<float>(*instr.target_amount));
+        d.Barriers.BarrierData.push_back(std::move(bd));
+    }
+
     t.FxTaRFData = std::move(d);
-    return t;
-}
-
-// ---------------------------------------------------------------------------
-// Reverse: FxGenericBarrierOption
-// ---------------------------------------------------------------------------
-
-trade fx_instrument_mapper::reverse_fx_generic_barrier_option(
-        const fx_instrument& instr) {
-    BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxGenericBarrierOption";
-    trade t;
-    t.TradeType = oreTradeType::FxGenericBarrierOption;
-
-    genericBarrierOptionData d;
-    if (!instr.bought_currency.empty())
-        d.PayCurrency = parse_currency_code(instr.bought_currency);
-    d.underlyingTypes = make_underlying_type_name(instr.underlying_code);
-
-    // Single OptionData
-    static_cast<std::string&>(d.OptionData.LongShort) = "Long";
-    if (!instr.option_type.empty()) {
-        optionData_OptionType_t ot;
-        static_cast<std::string&>(ot) = instr.option_type;
-        d.OptionData.OptionType = std::move(ot);
-    }
-    if (!instr.expiry_date.empty()) {
-        _ExerciseDates_t ed;
-        date dt;
-        static_cast<std::string&>(dt) = instr.expiry_date;
-        ed.ExerciseDate.push_back(dt);
-        exerciseDatesGroup_group_t edg;
-        edg.ExerciseDates = std::move(ed);
-        d.OptionData.exerciseDatesGroup = std::move(edg);
-    }
-    if (instr.strike_price != 0.0)
-        d.Strike = static_cast<float>(instr.strike_price);
-    if (instr.notional != 0.0)
-        d.Amount = static_cast<float>(instr.notional);
-    if (!instr.barrier_type.empty() && instr.lower_barrier != 0.0)
-        d.Barriers.BarrierData.push_back(
-            make_barrier(instr.barrier_type, instr.lower_barrier));
-
-    t.FxGenericBarrierOptionData = std::move(d);
-    return t;
-}
-
-// ---------------------------------------------------------------------------
-// Forward: FxDoubleBarrierOption (same data struct as FxBarrierOption)
-// ---------------------------------------------------------------------------
-
-fx_mapping_result fx_instrument_mapper::forward_fx_double_barrier_option(
-        const trade& t) {
-    BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxDoubleBarrierOption: "
-                               << std::string(t.id);
-    fx_mapping_result result;
-    result.instrument = make_base("FxDoubleBarrierOption");
-    if (!t.FxDoubleBarrierOptionData) return result;
-    const auto& d = *t.FxDoubleBarrierOptionData;
-    result.instrument.bought_currency = to_string(d.BoughtCurrency);
-    result.instrument.bought_amount   = static_cast<double>(d.BoughtAmount);
-    result.instrument.sold_currency   = to_string(d.SoldCurrency);
-    result.instrument.sold_amount     = static_cast<double>(d.SoldAmount);
-    result.instrument.option_type     = option_type_from_vec(d.OptionData);
-    result.instrument.expiry_date     = expiry_date_from_vec(d.OptionData);
-    if (!d.BarrierData.empty()) {
-        result.instrument.barrier_type = to_string(d.BarrierData.front().Type);
-        if (!d.BarrierData.front().Levels.Level.empty())
-            result.instrument.lower_barrier =
-                static_cast<double>(d.BarrierData.front().Levels.Level.front());
-        if (d.BarrierData.size() > 1 && !d.BarrierData[1].Levels.Level.empty())
-            result.instrument.upper_barrier =
-                static_cast<double>(d.BarrierData[1].Levels.Level.front());
-    }
-    return result;
-}
-
-// ---------------------------------------------------------------------------
-// Forward: FxEuropeanBarrierOption (same data struct as FxBarrierOption)
-// ---------------------------------------------------------------------------
-
-fx_mapping_result fx_instrument_mapper::forward_fx_european_barrier_option(
-        const trade& t) {
-    BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxEuropeanBarrierOption: "
-                               << std::string(t.id);
-    fx_mapping_result result;
-    result.instrument = make_base("FxEuropeanBarrierOption");
-    if (!t.FxEuropeanBarrierOptionData) return result;
-    const auto& d = *t.FxEuropeanBarrierOptionData;
-    result.instrument.bought_currency = to_string(d.BoughtCurrency);
-    result.instrument.bought_amount   = static_cast<double>(d.BoughtAmount);
-    result.instrument.sold_currency   = to_string(d.SoldCurrency);
-    result.instrument.sold_amount     = static_cast<double>(d.SoldAmount);
-    result.instrument.option_type     = option_type_from_vec(d.OptionData);
-    result.instrument.expiry_date     = expiry_date_from_vec(d.OptionData);
-    if (!d.BarrierData.empty()) {
-        result.instrument.barrier_type = to_string(d.BarrierData.front().Type);
-        if (!d.BarrierData.front().Levels.Level.empty())
-            result.instrument.lower_barrier =
-                static_cast<double>(d.BarrierData.front().Levels.Level.front());
-        if (d.BarrierData.size() > 1 && !d.BarrierData[1].Levels.Level.empty())
-            result.instrument.upper_barrier =
-                static_cast<double>(d.BarrierData[1].Levels.Level.front());
-    }
-    return result;
-}
-
-// ---------------------------------------------------------------------------
-// Forward: FxKIKOBarrierOption (distinct struct: single OptionData, Barriers)
-// ---------------------------------------------------------------------------
-
-fx_mapping_result fx_instrument_mapper::forward_fx_kiko_barrier_option(
-        const trade& t) {
-    BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxKIKOBarrierOption: "
-                               << std::string(t.id);
-    fx_mapping_result result;
-    result.instrument = make_base("FxKIKOBarrierOption");
-    if (!t.FxKIKOBarrierOptionData) return result;
-    const auto& d = *t.FxKIKOBarrierOptionData;
-    result.instrument.bought_currency = to_string(d.BoughtCurrency);
-    result.instrument.bought_amount   = static_cast<double>(d.BoughtAmount);
-    result.instrument.sold_currency   = to_string(d.SoldCurrency);
-    result.instrument.sold_amount     = static_cast<double>(d.SoldAmount);
-    if (d.OptionData.OptionType)
-        result.instrument.option_type = std::string(*d.OptionData.OptionType);
-    result.instrument.expiry_date = expiry_date_from_single(d.OptionData);
-    if (!d.Barriers.BarrierData.empty()) {
-        result.instrument.barrier_type =
-            to_string(d.Barriers.BarrierData.front().Type);
-        if (!d.Barriers.BarrierData.front().Levels.Level.empty())
-            result.instrument.lower_barrier = static_cast<double>(
-                d.Barriers.BarrierData.front().Levels.Level.front());
-        if (d.Barriers.BarrierData.size() > 1 &&
-                !d.Barriers.BarrierData[1].Levels.Level.empty())
-            result.instrument.upper_barrier = static_cast<double>(
-                d.Barriers.BarrierData[1].Levels.Level.front());
-    }
-    return result;
-}
-
-// ---------------------------------------------------------------------------
-// Reverse: FxDoubleBarrierOption
-// ---------------------------------------------------------------------------
-
-trade fx_instrument_mapper::reverse_fx_double_barrier_option(
-        const fx_instrument& instr) {
-    BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxDoubleBarrierOption";
-    trade t;
-    t.TradeType = oreTradeType::FxDoubleBarrierOption;
-    fxBarrierOptionData d;
-    d.BoughtCurrency = parse_currency_code(instr.bought_currency);
-    d.BoughtAmount   = static_cast<float>(instr.bought_amount);
-    d.SoldCurrency   = parse_currency_code(instr.sold_currency);
-    d.SoldAmount     = static_cast<float>(instr.sold_amount);
-    d.OptionData.push_back(make_fx_option_entry(instr));
-    if (!instr.barrier_type.empty() && instr.lower_barrier != 0.0)
-        d.BarrierData.push_back(make_barrier(instr.barrier_type, instr.lower_barrier));
-    if (instr.upper_barrier != 0.0)
-        d.BarrierData.push_back(make_barrier(instr.barrier_type, instr.upper_barrier));
-    t.FxDoubleBarrierOptionData = std::move(d);
-    return t;
-}
-
-// ---------------------------------------------------------------------------
-// Reverse: FxEuropeanBarrierOption
-// ---------------------------------------------------------------------------
-
-trade fx_instrument_mapper::reverse_fx_european_barrier_option(
-        const fx_instrument& instr) {
-    BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxEuropeanBarrierOption";
-    trade t;
-    t.TradeType = oreTradeType::FxEuropeanBarrierOption;
-    fxBarrierOptionData d;
-    d.BoughtCurrency = parse_currency_code(instr.bought_currency);
-    d.BoughtAmount   = static_cast<float>(instr.bought_amount);
-    d.SoldCurrency   = parse_currency_code(instr.sold_currency);
-    d.SoldAmount     = static_cast<float>(instr.sold_amount);
-    d.OptionData.push_back(make_fx_option_entry(instr));
-    if (!instr.barrier_type.empty() && instr.lower_barrier != 0.0)
-        d.BarrierData.push_back(make_barrier(instr.barrier_type, instr.lower_barrier));
-    if (instr.upper_barrier != 0.0)
-        d.BarrierData.push_back(make_barrier(instr.barrier_type, instr.upper_barrier));
-    t.FxEuropeanBarrierOptionData = std::move(d);
-    return t;
-}
-
-// ---------------------------------------------------------------------------
-// Reverse: FxKIKOBarrierOption
-// ---------------------------------------------------------------------------
-
-trade fx_instrument_mapper::reverse_fx_kiko_barrier_option(
-        const fx_instrument& instr) {
-    BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping FxKIKOBarrierOption";
-    trade t;
-    t.TradeType = oreTradeType::FxKIKOBarrierOption;
-    fxKIKOBarrierOptionData d;
-    d.BoughtCurrency = parse_currency_code(instr.bought_currency);
-    d.BoughtAmount   = static_cast<float>(instr.bought_amount);
-    d.SoldCurrency   = parse_currency_code(instr.sold_currency);
-    d.SoldAmount     = static_cast<float>(instr.sold_amount);
-    d.OptionData = make_fx_option_entry(instr);
-    if (!instr.barrier_type.empty() && instr.lower_barrier != 0.0)
-        d.Barriers.BarrierData.push_back(
-            make_barrier(instr.barrier_type, instr.lower_barrier));
-    if (instr.upper_barrier != 0.0)
-        d.Barriers.BarrierData.push_back(
-            make_barrier(instr.barrier_type, instr.upper_barrier));
-    t.FxKIKOBarrierOptionData = std::move(d);
     return t;
 }
 

--- a/projects/ores.ore/src/domain/fx_instrument_mapper.cpp
+++ b/projects/ores.ore/src/domain/fx_instrument_mapper.cpp
@@ -784,8 +784,13 @@ trade fx_instrument_mapper::reverse_fx_option(
 
     opt.OptionData = make_option_entry(instr.option_type, instr.expiry_date);
     if (!instr.settlement.empty()) {
-        // OptionData in fxOptionData carries settlement directly
-        // (this cast is the same pattern as the old mapper)
+        if (instr.settlement == "Physical")
+            opt.OptionData.Settlement = settlementType::Physical;
+        else if (instr.settlement == "Cash")
+            opt.OptionData.Settlement = settlementType::Cash;
+        else
+            throw std::invalid_argument(
+                "Unrecognised settlement type: " + instr.settlement);
     }
 
     t.FxOptionData = std::move(opt);

--- a/projects/ores.ore/src/domain/fx_instrument_mapper.cpp
+++ b/projects/ores.ore/src/domain/fx_instrument_mapper.cpp
@@ -1084,7 +1084,7 @@ trade fx_instrument_mapper::reverse_fx_accumulator(
 
     if (instr.knock_out_barrier.has_value())
         d.Barriers = [&]() {
-            barriers_t b;
+            accumulatorData_Barriers_t b;
             b.BarrierData.push_back(make_barrier("UpAndOut", *instr.knock_out_barrier));
             return b;
         }();

--- a/projects/ores.ore/src/domain/fx_instrument_mapper.cpp
+++ b/projects/ores.ore/src/domain/fx_instrument_mapper.cpp
@@ -187,13 +187,25 @@ std::string exercise_style_from_vec(const xsd::vector<optionData>& v) {
     return "European";
 }
 
+void validate_long_short(const std::string& v) {
+    if (v != "Long" && v != "Short")
+        throw std::invalid_argument("Unrecognised LongShort value: '" + v + "'");
+}
+
+void validate_option_type(const std::string& v) {
+    if (v != "Call" && v != "Put")
+        throw std::invalid_argument("Unrecognised OptionType value: '" + v + "'");
+}
+
 // Build an OptionData element from option_type + expiry_date strings.
 optionData make_option_entry(const std::string& option_type,
                               const std::string& expiry_date,
                               const std::string& long_short = "Long") {
+    validate_long_short(long_short);
     optionData od;
     static_cast<std::string&>(od.LongShort) = long_short;
     if (!option_type.empty()) {
+        validate_option_type(option_type);
         optionData_OptionType_t ot;
         static_cast<std::string&>(ot) = option_type;
         od.OptionType = std::move(ot);
@@ -1018,6 +1030,7 @@ trade fx_instrument_mapper::reverse_fx_variance_swap(
     if (!instr.currency.empty())
         d.Currency = parse_currency_code(instr.currency);
     d.underlyingTypes = make_underlying_type_name(instr.underlying_code);
+    validate_long_short(instr.long_short);
     static_cast<std::string&>(d.LongShort) = instr.long_short;
     d.Strike   = static_cast<float>(instr.strike);
     d.Notional = static_cast<float>(instr.notional);
@@ -1074,6 +1087,7 @@ trade fx_instrument_mapper::reverse_fx_accumulator(
         d.Strike = static_cast<float>(instr.strike);
     static_cast<std::string&>(d.Underlying.Name) = instr.underlying_code;
     static_cast<std::string&>(d.Underlying.Type) = "FX";
+    validate_long_short(instr.long_short);
     static_cast<std::string&>(d.OptionData.LongShort) = instr.long_short;
     if (!instr.start_date.empty()) {
         date sd;

--- a/projects/ores.ore/src/xml/exporter.cpp
+++ b/projects/ores.ore/src/xml/exporter.cpp
@@ -47,6 +47,153 @@ using trading::domain::scripted_instrument;
 
 namespace {
 
+// Adapters: convert legacy flat fx_instrument (from old messaging protocol)
+// to the typed per-product structs that reverse_* methods expect.
+
+trading::domain::fx_forward_instrument
+to_forward(const fx_instrument& r) {
+    trading::domain::fx_forward_instrument fwd;
+    fwd.instrument_id = r.id;
+    fwd.party_id = r.party_id;
+    fwd.trade_id = r.trade_id;
+    fwd.trade_type_code = r.trade_type_code;
+    fwd.bought_currency = r.bought_currency;
+    fwd.bought_amount = r.bought_amount;
+    fwd.sold_currency = r.sold_currency;
+    fwd.sold_amount = r.sold_amount;
+    fwd.value_date = r.value_date.value_or("");
+    fwd.settlement = r.settlement;
+    return fwd;
+}
+
+trading::domain::fx_vanilla_option_instrument
+to_vanilla_option(const fx_instrument& r) {
+    trading::domain::fx_vanilla_option_instrument opt;
+    opt.instrument_id = r.id;
+    opt.party_id = r.party_id;
+    opt.trade_id = r.trade_id;
+    opt.trade_type_code = r.trade_type_code;
+    opt.bought_currency = r.bought_currency;
+    opt.bought_amount = r.bought_amount;
+    opt.sold_currency = r.sold_currency;
+    opt.sold_amount = r.sold_amount;
+    opt.option_type = r.option_type;
+    opt.expiry_date = r.expiry_date;
+    opt.exercise_style = "European";
+    opt.settlement = r.settlement;
+    return opt;
+}
+
+trading::domain::fx_barrier_option_instrument
+to_barrier_option(const fx_instrument& r) {
+    trading::domain::fx_barrier_option_instrument bo;
+    bo.instrument_id = r.id;
+    bo.party_id = r.party_id;
+    bo.trade_id = r.trade_id;
+    bo.trade_type_code = r.trade_type_code;
+    bo.bought_currency = r.bought_currency;
+    bo.bought_amount = r.bought_amount;
+    bo.sold_currency = r.sold_currency;
+    bo.sold_amount = r.sold_amount;
+    bo.option_type = r.option_type;
+    bo.expiry_date = r.expiry_date;
+    bo.barrier_type = r.barrier_type;
+    bo.lower_barrier = r.lower_barrier;
+    if (r.upper_barrier != 0.0)
+        bo.upper_barrier = r.upper_barrier;
+    bo.underlying_code = r.underlying_code;
+    return bo;
+}
+
+trading::domain::fx_digital_option_instrument
+to_digital_option(const fx_instrument& r) {
+    trading::domain::fx_digital_option_instrument dig;
+    dig.instrument_id = r.id;
+    dig.party_id = r.party_id;
+    dig.trade_id = r.trade_id;
+    dig.trade_type_code = r.trade_type_code;
+    dig.foreign_currency = r.bought_currency;
+    dig.domestic_currency = r.sold_currency;
+    dig.payoff_currency = r.sold_currency;
+    dig.payoff_amount = r.notional;
+    dig.option_type = r.option_type;
+    dig.expiry_date = r.expiry_date;
+    if (r.strike_price != 0.0)
+        dig.strike = r.strike_price;
+    dig.barrier_type = r.barrier_type;
+    if (r.lower_barrier != 0.0)
+        dig.lower_barrier = r.lower_barrier;
+    if (r.upper_barrier != 0.0)
+        dig.upper_barrier = r.upper_barrier;
+    return dig;
+}
+
+trading::domain::fx_variance_swap_instrument
+to_variance_swap(const fx_instrument& r) {
+    trading::domain::fx_variance_swap_instrument vs;
+    vs.instrument_id = r.id;
+    vs.party_id = r.party_id;
+    vs.trade_id = r.trade_id;
+    vs.trade_type_code = r.trade_type_code;
+    vs.start_date = r.start_date;
+    vs.end_date = r.expiry_date;
+    vs.currency = r.bought_currency;
+    vs.underlying_code = r.underlying_code;
+    vs.long_short = "Long";
+    vs.strike = r.variance_strike;
+    vs.notional = r.notional;
+    vs.moment_type = "Variance";
+    return vs;
+}
+
+trading::domain::fx_asian_forward_instrument
+to_asian_forward(const fx_instrument& r) {
+    trading::domain::fx_asian_forward_instrument af;
+    af.instrument_id = r.id;
+    af.party_id = r.party_id;
+    af.trade_id = r.trade_id;
+    af.trade_type_code = r.trade_type_code;
+    af.fx_index = r.underlying_code;
+    af.reference_currency = r.bought_currency;
+    af.settlement_currency = r.sold_currency;
+    af.payment_date = r.expiry_date;
+    af.long_short = "Long";
+    return af;
+}
+
+trading::domain::fx_asian_forward_instrument
+to_tarf(const fx_instrument& r) {
+    trading::domain::fx_asian_forward_instrument af;
+    af.instrument_id = r.id;
+    af.party_id = r.party_id;
+    af.trade_id = r.trade_id;
+    af.trade_type_code = r.trade_type_code;
+    af.fx_index = r.underlying_code;
+    af.currency = r.bought_currency;
+    if (r.accumulation_amount != 0.0)
+        af.fixing_amount = r.accumulation_amount;
+    if (r.strike_price != 0.0)
+        af.strike = r.strike_price;
+    return af;
+}
+
+trading::domain::fx_accumulator_instrument
+to_accumulator(const fx_instrument& r) {
+    trading::domain::fx_accumulator_instrument acc;
+    acc.instrument_id = r.id;
+    acc.party_id = r.party_id;
+    acc.trade_id = r.trade_id;
+    acc.trade_type_code = r.trade_type_code;
+    acc.currency = r.bought_currency;
+    acc.fixing_amount = r.accumulation_amount;
+    acc.strike = r.strike_price;
+    acc.underlying_code = r.underlying_code;
+    acc.start_date = r.start_date;
+    if (r.knock_out_barrier != 0.0)
+        acc.knock_out_barrier = r.knock_out_barrier;
+    return acc;
+}
+
 void fill_envelope(domain::trade& t, const trading::domain::trade& src) {
     static_cast<std::string&>(t.id) = src.external_id;
     if (!src.netting_set_id.empty()) {
@@ -125,35 +272,49 @@ std::string exporter::export_portfolio(
                 }
             } else if constexpr (std::is_same_v<T, fx_instrument>) {
                 if (tt == "FxForward")
-                    xsd_t = fx_instrument_mapper::reverse_fx_forward(r);
+                    xsd_t = fx_instrument_mapper::reverse_fx_forward(
+                        to_forward(r));
                 else if (tt == "FxSwap")
-                    xsd_t = fx_instrument_mapper::reverse_fx_swap(r);
+                    xsd_t = fx_instrument_mapper::reverse_fx_swap(
+                        to_forward(r));
                 else if (tt == "FxOption")
-                    xsd_t = fx_instrument_mapper::reverse_fx_option(r);
+                    xsd_t = fx_instrument_mapper::reverse_fx_option(
+                        to_vanilla_option(r));
                 else if (tt == "FxBarrierOption")
-                    xsd_t = fx_instrument_mapper::reverse_fx_barrier_option(r);
+                    xsd_t = fx_instrument_mapper::reverse_fx_barrier_option(
+                        to_barrier_option(r));
                 else if (tt == "FxDigitalOption")
-                    xsd_t = fx_instrument_mapper::reverse_fx_digital_option(r);
+                    xsd_t = fx_instrument_mapper::reverse_fx_digital_option(
+                        to_digital_option(r));
                 else if (tt == "FxDigitalBarrierOption")
-                    xsd_t = fx_instrument_mapper::reverse_fx_digital_barrier_option(r);
+                    xsd_t = fx_instrument_mapper::reverse_fx_digital_barrier_option(
+                        to_digital_option(r));
                 else if (tt == "FxTouchOption" || tt == "FxDoubleTouchOption")
-                    xsd_t = fx_instrument_mapper::reverse_fx_touch_option(r);
+                    xsd_t = fx_instrument_mapper::reverse_fx_touch_option(
+                        to_digital_option(r));
                 else if (tt == "FxVarianceSwap")
-                    xsd_t = fx_instrument_mapper::reverse_fx_variance_swap(r);
+                    xsd_t = fx_instrument_mapper::reverse_fx_variance_swap(
+                        to_variance_swap(r));
                 else if (tt == "FxAverageForward")
-                    xsd_t = fx_instrument_mapper::reverse_fx_average_forward(r);
+                    xsd_t = fx_instrument_mapper::reverse_fx_average_forward(
+                        to_asian_forward(r));
                 else if (tt == "FxAccumulator")
-                    xsd_t = fx_instrument_mapper::reverse_fx_accumulator(r);
+                    xsd_t = fx_instrument_mapper::reverse_fx_accumulator(
+                        to_accumulator(r));
                 else if (tt == "FxTaRF")
-                    xsd_t = fx_instrument_mapper::reverse_fx_tarf(r);
+                    xsd_t = fx_instrument_mapper::reverse_fx_tarf(to_tarf(r));
                 else if (tt == "FxGenericBarrierOption")
-                    xsd_t = fx_instrument_mapper::reverse_fx_generic_barrier_option(r);
+                    xsd_t = fx_instrument_mapper::reverse_fx_generic_barrier_option(
+                        to_barrier_option(r));
                 else if (tt == "FxDoubleBarrierOption")
-                    xsd_t = fx_instrument_mapper::reverse_fx_double_barrier_option(r);
+                    xsd_t = fx_instrument_mapper::reverse_fx_double_barrier_option(
+                        to_barrier_option(r));
                 else if (tt == "FxEuropeanBarrierOption")
-                    xsd_t = fx_instrument_mapper::reverse_fx_european_barrier_option(r);
+                    xsd_t = fx_instrument_mapper::reverse_fx_european_barrier_option(
+                        to_barrier_option(r));
                 else if (tt == "FxKIKOBarrierOption")
-                    xsd_t = fx_instrument_mapper::reverse_fx_kiko_barrier_option(r);
+                    xsd_t = fx_instrument_mapper::reverse_fx_kiko_barrier_option(
+                        to_barrier_option(r));
                 else {
                     BOOST_LOG_SEV(lg(), debug)
                         << "No reverse mapper for FX type: " << tt;

--- a/projects/ores.ore/src/xml/exporter.cpp
+++ b/projects/ores.ore/src/xml/exporter.cpp
@@ -47,8 +47,8 @@ using trading::domain::scripted_instrument;
 
 namespace {
 
-// Adapters: convert legacy flat fx_instrument (from old messaging protocol)
-// to the typed per-product structs that reverse_* methods expect.
+// Adapters: convert typed per-product FX domain structs to the flat
+// fx_instrument (legacy messaging type) that the export path reads from DB.
 
 trading::domain::fx_forward_instrument
 to_forward(const fx_instrument& r) {
@@ -114,7 +114,7 @@ to_digital_option(const fx_instrument& r) {
     dig.trade_type_code = r.trade_type_code;
     dig.foreign_currency = r.bought_currency;
     dig.domestic_currency = r.sold_currency;
-    dig.payoff_currency = r.sold_currency;
+    dig.payoff_currency = r.bought_currency;
     dig.payoff_amount = r.notional;
     dig.option_type = r.option_type;
     dig.expiry_date = r.expiry_date;

--- a/projects/ores.ore/src/xml/importer.cpp
+++ b/projects/ores.ore/src/xml/importer.cpp
@@ -187,8 +187,10 @@ importer::import_portfolio_with_context(const std::filesystem::path& path) {
                             leg.instrument_id = instr_id;
                     } else if constexpr (std::is_same_v<T, domain::fx_mapping_result>) {
                         item.trade.product_type = product_type::fx;
-                        result.instrument.id = instr_id;
-                        result.instrument.trade_id = item.trade.id;
+                        std::visit([&](auto& instr) {
+                            instr.instrument_id = instr_id;
+                            instr.trade_id = item.trade.id;
+                        }, result.instrument);
                     } else if constexpr (std::is_same_v<T, domain::bond_mapping_result>) {
                         item.trade.product_type = product_type::bond;
                         result.instrument.id = instr_id;

--- a/projects/ores.ore/tests/xml_exporter_tests.cpp
+++ b/projects/ores.ore/tests/xml_exporter_tests.cpp
@@ -54,7 +54,88 @@ ores::trading::messaging::instrument_export_result to_export_result(
         else if constexpr (std::is_same_v<T, swap_mapping_result>)
             return swap_export_result{v.instrument, v.legs};
         else if constexpr (std::is_same_v<T, fx_mapping_result>)
-            return v.instrument;
+            return std::visit([](const auto& instr)
+                -> ores::trading::domain::fx_instrument {
+                using InstrT = std::decay_t<decltype(instr)>;
+                using ores::trading::domain::fx_forward_instrument;
+                using ores::trading::domain::fx_vanilla_option_instrument;
+                using ores::trading::domain::fx_barrier_option_instrument;
+                using ores::trading::domain::fx_digital_option_instrument;
+                using ores::trading::domain::fx_asian_forward_instrument;
+                using ores::trading::domain::fx_accumulator_instrument;
+                using ores::trading::domain::fx_variance_swap_instrument;
+                ores::trading::domain::fx_instrument fx;
+                fx.id = instr.instrument_id;
+                fx.party_id = instr.party_id;
+                fx.trade_id = instr.trade_id;
+                fx.trade_type_code = instr.trade_type_code;
+                fx.modified_by = instr.modified_by;
+                fx.performed_by = instr.performed_by;
+                fx.change_reason_code = instr.change_reason_code;
+                fx.change_commentary = instr.change_commentary;
+                fx.description = instr.description;
+                if constexpr (std::is_same_v<InstrT, fx_forward_instrument>) {
+                    fx.bought_currency = instr.bought_currency;
+                    fx.bought_amount = instr.bought_amount;
+                    fx.sold_currency = instr.sold_currency;
+                    fx.sold_amount = instr.sold_amount;
+                    fx.value_date = instr.value_date;
+                    fx.settlement = instr.settlement;
+                } else if constexpr (std::is_same_v<InstrT, fx_vanilla_option_instrument>) {
+                    fx.bought_currency = instr.bought_currency;
+                    fx.bought_amount = instr.bought_amount;
+                    fx.sold_currency = instr.sold_currency;
+                    fx.sold_amount = instr.sold_amount;
+                    fx.option_type = instr.option_type;
+                    fx.expiry_date = instr.expiry_date;
+                    fx.settlement = instr.settlement;
+                } else if constexpr (std::is_same_v<InstrT, fx_barrier_option_instrument>) {
+                    fx.bought_currency = instr.bought_currency;
+                    fx.bought_amount = instr.bought_amount;
+                    fx.sold_currency = instr.sold_currency;
+                    fx.sold_amount = instr.sold_amount;
+                    fx.option_type = instr.option_type;
+                    fx.expiry_date = instr.expiry_date;
+                    fx.barrier_type = instr.barrier_type;
+                    fx.lower_barrier = instr.lower_barrier;
+                    fx.upper_barrier = instr.upper_barrier.value_or(0.0);
+                    fx.underlying_code = instr.underlying_code;
+                } else if constexpr (std::is_same_v<InstrT, fx_digital_option_instrument>) {
+                    fx.bought_currency = instr.foreign_currency;
+                    fx.sold_currency = instr.domestic_currency;
+                    fx.option_type = instr.option_type;
+                    fx.expiry_date = instr.expiry_date;
+                    fx.strike_price = instr.strike.value_or(0.0);
+                    fx.notional = instr.payoff_amount;
+                    fx.barrier_type = instr.barrier_type;
+                    fx.lower_barrier = instr.lower_barrier.value_or(0.0);
+                    fx.upper_barrier = instr.upper_barrier.value_or(0.0);
+                } else if constexpr (std::is_same_v<InstrT, fx_asian_forward_instrument>) {
+                    fx.bought_currency = instr.reference_currency;
+                    fx.sold_currency = instr.settlement_currency;
+                    fx.underlying_code = instr.fx_index;
+                    fx.expiry_date = instr.payment_date;
+                    if (instr.fixing_amount) fx.accumulation_amount = *instr.fixing_amount;
+                    if (instr.strike) fx.strike_price = *instr.strike;
+                    fx.bought_amount = instr.reference_notional.value_or(0.0);
+                    fx.sold_amount = instr.settlement_notional.value_or(0.0);
+                } else if constexpr (std::is_same_v<InstrT, fx_accumulator_instrument>) {
+                    fx.bought_currency = instr.currency;
+                    fx.accumulation_amount = instr.fixing_amount;
+                    fx.strike_price = instr.strike;
+                    fx.underlying_code = instr.underlying_code;
+                    fx.start_date = instr.start_date;
+                    fx.knock_out_barrier = instr.knock_out_barrier.value_or(0.0);
+                } else if constexpr (std::is_same_v<InstrT, fx_variance_swap_instrument>) {
+                    fx.bought_currency = instr.currency;
+                    fx.underlying_code = instr.underlying_code;
+                    fx.start_date = instr.start_date;
+                    fx.expiry_date = instr.end_date;
+                    fx.variance_strike = instr.strike;
+                    fx.notional = instr.notional;
+                }
+                return fx;
+            }, v.instrument);
         else if constexpr (std::is_same_v<T, bond_mapping_result>)
             return v.instrument;
         else if constexpr (std::is_same_v<T, credit_mapping_result>)

--- a/projects/ores.ore/tests/xml_fx_exotic_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/tests/xml_fx_exotic_mapper_roundtrip_tests.cpp
@@ -32,10 +32,11 @@
  *
  * For each example file:
  *   1. Parse ORE XML into ores.ore domain types.
- *   2. Forward-map to fx_instrument via trade_mapper.
- *   3. Assert key economic fields are populated.
- *   4. Reverse-map back to ORE XSD trade.
- *   5. Assert the round-tripped XSD type is structurally populated.
+ *   2. Forward-map to the typed fx_instrument_variant via trade_mapper.
+ *   3. Extract the concrete typed struct from the variant.
+ *   4. Assert key economic fields are populated.
+ *   5. Reverse-map back to ORE XSD trade.
+ *   6. Assert the round-tripped XSD type is structurally populated.
  */
 
 namespace {
@@ -46,6 +47,11 @@ const std::string tags("[ore][xml][mapper][roundtrip][fx][exotic]");
 using ores::ore::domain::portfolio;
 using ores::ore::domain::fx_instrument_mapper;
 using ores::ore::domain::fx_mapping_result;
+using ores::trading::domain::fx_barrier_option_instrument;
+using ores::trading::domain::fx_digital_option_instrument;
+using ores::trading::domain::fx_variance_swap_instrument;
+using ores::trading::domain::fx_asian_forward_instrument;
+using ores::trading::domain::fx_accumulator_instrument;
 using namespace ores::logging;
 
 std::filesystem::path example_path(const std::string& filename) {
@@ -70,91 +76,97 @@ fx_mapping_result load_and_map(const std::string& filename) {
 TEST_CASE("fx_exotic_mapper_roundtrip_barrier_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("FX_Barrier_Option.xml");
+    const auto& instr = std::get<fx_barrier_option_instrument>(r.instrument);
 
-    CHECK(r.instrument.trade_type_code == "FxBarrierOption");
-    CHECK(!r.instrument.bought_currency.empty());
-    CHECK(!r.instrument.sold_currency.empty());
-    CHECK(r.instrument.bought_amount > 0.0);
-    CHECK(!r.instrument.barrier_type.empty());
-    CHECK(r.instrument.lower_barrier > 0.0);
+    CHECK(instr.trade_type_code == "FxBarrierOption");
+    CHECK(!instr.bought_currency.empty());
+    CHECK(!instr.sold_currency.empty());
+    CHECK(instr.bought_amount > 0.0);
+    CHECK(!instr.barrier_type.empty());
+    CHECK(instr.lower_barrier > 0.0);
 
-    const auto rt = fx_instrument_mapper::reverse_fx_barrier_option(
-        r.instrument);
+    const auto rt = fx_instrument_mapper::reverse_fx_barrier_option(instr);
     const bool has_data = rt.FxBarrierOptionData.operator bool();
     REQUIRE(has_data);
 
     BOOST_LOG_SEV(lg, info) << "FxBarrierOption roundtrip passed. Barrier: "
-                            << r.instrument.barrier_type;
+                            << instr.barrier_type;
 }
 
 TEST_CASE("fx_exotic_mapper_roundtrip_digital_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("FX_Digital_Option.xml");
+    const auto& instr = std::get<fx_digital_option_instrument>(r.instrument);
 
-    CHECK(r.instrument.trade_type_code == "FxDigitalOption");
-    CHECK(!r.instrument.bought_currency.empty());
-    CHECK(!r.instrument.sold_currency.empty());
-    CHECK(r.instrument.strike_price > 0.0);
-    CHECK(r.instrument.notional > 0.0);
-    CHECK(!r.instrument.option_type.empty());
+    CHECK(instr.trade_type_code == "FxDigitalOption");
+    CHECK(!instr.foreign_currency.empty());
+    CHECK(!instr.domestic_currency.empty());
+    REQUIRE(instr.strike.has_value());
+    CHECK(*instr.strike > 0.0);
+    CHECK(instr.payoff_amount > 0.0);
+    CHECK(!instr.option_type.empty());
 
-    const auto rt = fx_instrument_mapper::reverse_fx_digital_option(
-        r.instrument);
+    const auto rt = fx_instrument_mapper::reverse_fx_digital_option(instr);
     const bool has_data = rt.FxDigitalOptionData.operator bool();
     REQUIRE(has_data);
 
     BOOST_LOG_SEV(lg, info) << "FxDigitalOption roundtrip passed. Strike: "
-                            << r.instrument.strike_price;
+                            << *instr.strike;
 }
 
 TEST_CASE("fx_exotic_mapper_roundtrip_digital_barrier_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("FX_Digital_Barrier_Option.xml");
+    const auto& instr = std::get<fx_digital_option_instrument>(r.instrument);
 
-    CHECK(r.instrument.trade_type_code == "FxDigitalBarrierOption");
-    CHECK(!r.instrument.bought_currency.empty());
-    CHECK(!r.instrument.sold_currency.empty());
-    CHECK(r.instrument.strike_price > 0.0);
-    CHECK(!r.instrument.barrier_type.empty());
-    CHECK(r.instrument.lower_barrier > 0.0);
+    CHECK(instr.trade_type_code == "FxDigitalBarrierOption");
+    CHECK(!instr.foreign_currency.empty());
+    CHECK(!instr.domestic_currency.empty());
+    REQUIRE(instr.strike.has_value());
+    CHECK(*instr.strike > 0.0);
+    CHECK(!instr.barrier_type.empty());
+    REQUIRE(instr.lower_barrier.has_value());
+    CHECK(*instr.lower_barrier > 0.0);
 
-    const auto rt = fx_instrument_mapper::reverse_fx_digital_barrier_option(
-        r.instrument);
+    const auto rt = fx_instrument_mapper::reverse_fx_digital_barrier_option(instr);
     const bool has_data = rt.FxDigitalBarrierOptionData.operator bool();
     REQUIRE(has_data);
 
     BOOST_LOG_SEV(lg, info) << "FxDigitalBarrierOption roundtrip passed. Barrier: "
-                            << r.instrument.barrier_type;
+                            << instr.barrier_type;
 }
 
 TEST_CASE("fx_exotic_mapper_roundtrip_touch_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("FX_OneTouch_option.xml");
+    const auto& instr = std::get<fx_digital_option_instrument>(r.instrument);
 
-    CHECK(r.instrument.trade_type_code == "FxTouchOption");
-    CHECK(!r.instrument.bought_currency.empty());
-    CHECK(r.instrument.notional > 0.0);
-    CHECK(!r.instrument.barrier_type.empty());
-    CHECK(r.instrument.lower_barrier > 0.0);
+    CHECK(instr.trade_type_code == "FxTouchOption");
+    CHECK(!instr.foreign_currency.empty());
+    CHECK(instr.payoff_amount > 0.0);
+    CHECK(!instr.barrier_type.empty());
+    REQUIRE(instr.lower_barrier.has_value());
+    CHECK(*instr.lower_barrier > 0.0);
 
-    const auto rt = fx_instrument_mapper::reverse_fx_touch_option(r.instrument);
+    const auto rt = fx_instrument_mapper::reverse_fx_touch_option(instr);
     const bool has_data = rt.FxTouchOptionData.operator bool();
     REQUIRE(has_data);
 
     BOOST_LOG_SEV(lg, info) << "FxTouchOption roundtrip passed. Barrier: "
-                            << r.instrument.lower_barrier;
+                            << *instr.lower_barrier;
 }
 
 TEST_CASE("fx_exotic_mapper_roundtrip_double_touch_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("FX_DoubleTouch_Option.xml");
+    const auto& instr = std::get<fx_digital_option_instrument>(r.instrument);
 
-    CHECK(r.instrument.trade_type_code == "FxDoubleTouchOption");
-    CHECK(!r.instrument.bought_currency.empty());
-    CHECK(r.instrument.notional > 0.0);
-    CHECK(!r.instrument.barrier_type.empty());
+    CHECK(instr.trade_type_code == "FxDoubleTouchOption");
+    CHECK(!instr.foreign_currency.empty());
+    CHECK(instr.payoff_amount > 0.0);
+    CHECK(!instr.barrier_type.empty());
 
-    const auto rt = fx_instrument_mapper::reverse_fx_touch_option(r.instrument);
+    const auto rt = fx_instrument_mapper::reverse_fx_touch_option(instr);
     const bool has_data = rt.FxDoubleTouchOptionData.operator bool();
     REQUIRE(has_data);
 
@@ -164,88 +176,92 @@ TEST_CASE("fx_exotic_mapper_roundtrip_double_touch_option", tags) {
 TEST_CASE("fx_exotic_mapper_roundtrip_variance_swap", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("FX_Variance_Swap.xml");
+    const auto& instr = std::get<fx_variance_swap_instrument>(r.instrument);
 
-    CHECK(r.instrument.trade_type_code == "FxVarianceSwap");
-    CHECK(!r.instrument.underlying_code.empty());
-    CHECK(r.instrument.variance_strike > 0.0);
-    CHECK(r.instrument.notional > 0.0);
-    CHECK(!r.instrument.start_date.empty());
-    CHECK(!r.instrument.expiry_date.empty());
+    CHECK(instr.trade_type_code == "FxVarianceSwap");
+    CHECK(!instr.underlying_code.empty());
+    CHECK(instr.strike > 0.0);
+    CHECK(instr.notional > 0.0);
+    CHECK(!instr.start_date.empty());
+    CHECK(!instr.end_date.empty());
 
-    const auto rt = fx_instrument_mapper::reverse_fx_variance_swap(r.instrument);
+    const auto rt = fx_instrument_mapper::reverse_fx_variance_swap(instr);
     const bool has_data = rt.FxVarianceSwapData.operator bool();
     REQUIRE(has_data);
 
     BOOST_LOG_SEV(lg, info) << "FxVarianceSwap roundtrip passed. Strike: "
-                            << r.instrument.variance_strike;
+                            << instr.strike;
 }
 
 TEST_CASE("fx_exotic_mapper_roundtrip_average_forward", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("FX_Average_Forward.xml");
+    const auto& instr = std::get<fx_asian_forward_instrument>(r.instrument);
 
-    CHECK(r.instrument.trade_type_code == "FxAverageForward");
-    CHECK(r.instrument.value_date.has_value());
-    CHECK(!r.instrument.bought_currency.empty());
-    CHECK(!r.instrument.sold_currency.empty());
-    CHECK(!r.instrument.underlying_code.empty());
+    CHECK(instr.trade_type_code == "FxAverageForward");
+    CHECK(!instr.payment_date.empty());
+    CHECK(!instr.reference_currency.empty());
+    CHECK(!instr.settlement_currency.empty());
+    CHECK(!instr.fx_index.empty());
 
-    const auto rt = fx_instrument_mapper::reverse_fx_average_forward(
-        r.instrument);
+    const auto rt = fx_instrument_mapper::reverse_fx_average_forward(instr);
     const bool has_data = rt.FxAverageForwardData.operator bool();
     REQUIRE(has_data);
 
     BOOST_LOG_SEV(lg, info) << "FxAverageForward roundtrip passed. FX index: "
-                            << r.instrument.underlying_code;
+                            << instr.fx_index;
 }
 
 TEST_CASE("fx_exotic_mapper_roundtrip_accumulator", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Exotic_FxAccumulator.xml");
+    const auto& instr = std::get<fx_accumulator_instrument>(r.instrument);
 
-    CHECK(r.instrument.trade_type_code == "FxAccumulator");
-    CHECK(!r.instrument.underlying_code.empty());
-    CHECK(!r.instrument.bought_currency.empty());
-    CHECK(r.instrument.accumulation_amount > 0.0);
+    CHECK(instr.trade_type_code == "FxAccumulator");
+    CHECK(!instr.underlying_code.empty());
+    CHECK(!instr.currency.empty());
+    CHECK(instr.fixing_amount > 0.0);
 
-    const auto rt = fx_instrument_mapper::reverse_fx_accumulator(r.instrument);
+    const auto rt = fx_instrument_mapper::reverse_fx_accumulator(instr);
     const bool has_data = rt.FxAccumulatorData.operator bool();
     REQUIRE(has_data);
 
     BOOST_LOG_SEV(lg, info) << "FxAccumulator roundtrip passed. Amount: "
-                            << r.instrument.accumulation_amount;
+                            << instr.fixing_amount;
 }
 
 TEST_CASE("fx_exotic_mapper_roundtrip_tarf", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Exotic_FxTaRF.xml");
+    const auto& instr = std::get<fx_asian_forward_instrument>(r.instrument);
 
-    CHECK(r.instrument.trade_type_code == "FxTaRF");
-    CHECK(!r.instrument.underlying_code.empty());
-    CHECK(!r.instrument.bought_currency.empty());
-    CHECK(r.instrument.accumulation_amount > 0.0);
+    CHECK(instr.trade_type_code == "FxTaRF");
+    CHECK(!instr.fx_index.empty());
+    CHECK(!instr.currency.empty());
+    REQUIRE(instr.fixing_amount.has_value());
+    CHECK(*instr.fixing_amount > 0.0);
 
-    const auto rt = fx_instrument_mapper::reverse_fx_tarf(r.instrument);
+    const auto rt = fx_instrument_mapper::reverse_fx_tarf(instr);
     const bool has_data = rt.FxTaRFData.operator bool();
     REQUIRE(has_data);
 
     BOOST_LOG_SEV(lg, info) << "FxTaRF roundtrip passed. Amount: "
-                            << r.instrument.accumulation_amount;
+                            << *instr.fixing_amount;
 }
 
 TEST_CASE("fx_exotic_mapper_roundtrip_generic_barrier_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Exotic_FxGenericBarrierOption.xml");
+    const auto& instr = std::get<fx_barrier_option_instrument>(r.instrument);
 
-    CHECK(r.instrument.trade_type_code == "FxGenericBarrierOption");
-    CHECK(!r.instrument.underlying_code.empty());
-    CHECK(!r.instrument.bought_currency.empty());
+    CHECK(instr.trade_type_code == "FxGenericBarrierOption");
+    CHECK(!instr.underlying_code.empty());
+    CHECK(!instr.bought_currency.empty());
 
-    const auto rt = fx_instrument_mapper::reverse_fx_generic_barrier_option(
-        r.instrument);
+    const auto rt = fx_instrument_mapper::reverse_fx_generic_barrier_option(instr);
     const bool has_data = rt.FxGenericBarrierOptionData.operator bool();
     REQUIRE(has_data);
 
     BOOST_LOG_SEV(lg, info) << "FxGenericBarrierOption roundtrip passed. Underlying: "
-                            << r.instrument.underlying_code;
+                            << instr.underlying_code;
 }

--- a/projects/ores.ore/tests/xml_fx_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/tests/xml_fx_mapper_roundtrip_tests.cpp
@@ -34,7 +34,7 @@ using Catch::Approx;
  *
  * For each example trade:
  *   1. Parse ORE XML using ores.ore XSD types.
- *   2. Forward-map to ORES domain types.
+ *   2. Forward-map to ORES typed domain object (via fx_instrument_variant).
  *   3. Verify key fields were captured correctly.
  *   4. Reverse-map back to ORE XSD types.
  *   5. Verify the reconstructed ORE type has the fields we mapped.
@@ -47,6 +47,8 @@ const std::string tags("[ore][xml][mapper][roundtrip][fx]");
 
 using ores::ore::domain::portfolio;
 using ores::ore::domain::fx_instrument_mapper;
+using ores::trading::domain::fx_forward_instrument;
+using ores::trading::domain::fx_vanilla_option_instrument;
 using namespace ores::logging;
 
 std::filesystem::path example_path(const std::string& filename) {
@@ -75,11 +77,11 @@ TEST_CASE("mapper_roundtrip_fx_forward_forward", tags) {
     const auto t = load_first_trade("FX_Forward.xml");
 
     const auto result = fx_instrument_mapper::forward_fx_forward(t);
-    const auto& instr = result.instrument;
+    const auto& instr = std::get<fx_forward_instrument>(result.instrument);
 
     CHECK(instr.trade_type_code == "FxForward");
-    REQUIRE(instr.value_date.has_value());
-    CHECK(*instr.value_date == "2033-02-20");
+    CHECK(!instr.value_date.empty());
+    CHECK(instr.value_date == "2033-02-20");
     CHECK(instr.bought_currency == "EUR");
     CHECK(instr.bought_amount == Approx(1000000.0).epsilon(0.001));
     CHECK(instr.sold_currency == "USD");
@@ -92,9 +94,9 @@ TEST_CASE("mapper_roundtrip_fx_forward_reverse", tags) {
     auto lg(make_logger(test_suite));
     const auto t = load_first_trade("FX_Forward.xml");
     const auto result = fx_instrument_mapper::forward_fx_forward(t);
+    const auto& instr = std::get<fx_forward_instrument>(result.instrument);
 
-    const auto reconstructed =
-        fx_instrument_mapper::reverse_fx_forward(result.instrument);
+    const auto reconstructed = fx_instrument_mapper::reverse_fx_forward(instr);
 
     REQUIRE(reconstructed.FxForwardData.operator bool());
     const auto& fwd = *reconstructed.FxForwardData;
@@ -115,11 +117,11 @@ TEST_CASE("mapper_roundtrip_fx_swap_forward", tags) {
     const auto t = load_first_trade("FX_Swap.xml");
 
     const auto result = fx_instrument_mapper::forward_fx_swap(t);
-    const auto& instr = result.instrument;
+    const auto& instr = std::get<fx_forward_instrument>(result.instrument);
 
     CHECK(instr.trade_type_code == "FxSwap");
-    REQUIRE(instr.value_date.has_value());
-    CHECK(*instr.value_date == "2025-08-23");
+    CHECK(!instr.value_date.empty());
+    CHECK(instr.value_date == "2025-08-23");
     CHECK(instr.bought_currency == "EUR");
     CHECK(instr.bought_amount == Approx(1000000.0).epsilon(0.001));
     CHECK(instr.sold_currency == "USD");
@@ -132,9 +134,9 @@ TEST_CASE("mapper_roundtrip_fx_swap_reverse", tags) {
     auto lg(make_logger(test_suite));
     const auto t = load_first_trade("FX_Swap.xml");
     const auto result = fx_instrument_mapper::forward_fx_swap(t);
+    const auto& instr = std::get<fx_forward_instrument>(result.instrument);
 
-    const auto reconstructed =
-        fx_instrument_mapper::reverse_fx_swap(result.instrument);
+    const auto reconstructed = fx_instrument_mapper::reverse_fx_swap(instr);
 
     REQUIRE(reconstructed.FxSwapData.operator bool());
     const auto& sw = *reconstructed.FxSwapData;
@@ -153,7 +155,7 @@ TEST_CASE("mapper_roundtrip_fx_option_forward", tags) {
     const auto t = load_first_trade("FX_Option_European.xml");
 
     const auto result = fx_instrument_mapper::forward_fx_option(t);
-    const auto& instr = result.instrument;
+    const auto& instr = std::get<fx_vanilla_option_instrument>(result.instrument);
 
     CHECK(instr.trade_type_code == "FxOption");
     CHECK(instr.bought_currency == "EUR");
@@ -169,9 +171,9 @@ TEST_CASE("mapper_roundtrip_fx_option_reverse", tags) {
     auto lg(make_logger(test_suite));
     const auto t = load_first_trade("FX_Option_European.xml");
     const auto result = fx_instrument_mapper::forward_fx_option(t);
+    const auto& instr = std::get<fx_vanilla_option_instrument>(result.instrument);
 
-    const auto reconstructed =
-        fx_instrument_mapper::reverse_fx_option(result.instrument);
+    const auto reconstructed = fx_instrument_mapper::reverse_fx_option(instr);
 
     REQUIRE(reconstructed.FxOptionData.operator bool());
     const auto& opt = *reconstructed.FxOptionData;

--- a/projects/ores.ore/tests/xml_remaining_phases_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/tests/xml_remaining_phases_mapper_roundtrip_tests.cpp
@@ -52,6 +52,7 @@ const std::string tags(
 using ores::ore::domain::portfolio;
 using ores::ore::domain::fx_instrument_mapper;
 using ores::ore::domain::fx_mapping_result;
+using ores::trading::domain::fx_barrier_option_instrument;
 using ores::ore::domain::equity_instrument_mapper;
 using ores::ore::domain::equity_mapping_result;
 using ores::ore::domain::scripted_instrument_mapper;
@@ -137,11 +138,12 @@ bond_mapping_result load_and_map_bond(const std::string& filename,
 TEST_CASE("fx_double_barrier_option_forward", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_fx("FX_DoubleBarrierOption.xml");
+    const auto& instr = std::get<fx_barrier_option_instrument>(r.instrument);
 
-    CHECK(r.instrument.trade_type_code == "FxDoubleBarrierOption");
-    CHECK(!r.instrument.bought_currency.empty());
-    CHECK(!r.instrument.sold_currency.empty());
-    CHECK(!r.instrument.option_type.empty());
+    CHECK(instr.trade_type_code == "FxDoubleBarrierOption");
+    CHECK(!instr.bought_currency.empty());
+    CHECK(!instr.sold_currency.empty());
+    CHECK(!instr.option_type.empty());
 
     BOOST_LOG_SEV(lg, info) << "FxDoubleBarrierOption forward test passed";
 }
@@ -149,9 +151,9 @@ TEST_CASE("fx_double_barrier_option_forward", tags) {
 TEST_CASE("fx_double_barrier_option_reverse", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_fx("FX_DoubleBarrierOption.xml");
+    const auto& instr = std::get<fx_barrier_option_instrument>(r.instrument);
 
-    const auto rt = fx_instrument_mapper::reverse_fx_double_barrier_option(
-        r.instrument);
+    const auto rt = fx_instrument_mapper::reverse_fx_double_barrier_option(instr);
     REQUIRE(rt.FxDoubleBarrierOptionData.operator bool());
 
     BOOST_LOG_SEV(lg, info) << "FxDoubleBarrierOption reverse test passed";
@@ -164,10 +166,11 @@ TEST_CASE("fx_double_barrier_option_reverse", tags) {
 TEST_CASE("fx_european_barrier_option_forward", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_fx("FX_FxEuropeanBarrierOption.xml");
+    const auto& instr = std::get<fx_barrier_option_instrument>(r.instrument);
 
-    CHECK(r.instrument.trade_type_code == "FxEuropeanBarrierOption");
-    CHECK(!r.instrument.bought_currency.empty());
-    CHECK(!r.instrument.sold_currency.empty());
+    CHECK(instr.trade_type_code == "FxEuropeanBarrierOption");
+    CHECK(!instr.bought_currency.empty());
+    CHECK(!instr.sold_currency.empty());
 
     BOOST_LOG_SEV(lg, info) << "FxEuropeanBarrierOption forward test passed";
 }
@@ -175,9 +178,9 @@ TEST_CASE("fx_european_barrier_option_forward", tags) {
 TEST_CASE("fx_european_barrier_option_reverse", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_fx("FX_FxEuropeanBarrierOption.xml");
+    const auto& instr = std::get<fx_barrier_option_instrument>(r.instrument);
 
-    const auto rt = fx_instrument_mapper::reverse_fx_european_barrier_option(
-        r.instrument);
+    const auto rt = fx_instrument_mapper::reverse_fx_european_barrier_option(instr);
     REQUIRE(rt.FxEuropeanBarrierOptionData.operator bool());
 
     BOOST_LOG_SEV(lg, info) << "FxEuropeanBarrierOption reverse test passed";
@@ -190,9 +193,10 @@ TEST_CASE("fx_european_barrier_option_reverse", tags) {
 TEST_CASE("fx_kiko_barrier_option_forward", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_fx("FX_KIKO_Barrier_Option.xml");
+    const auto& instr = std::get<fx_barrier_option_instrument>(r.instrument);
 
-    CHECK(r.instrument.trade_type_code == "FxKIKOBarrierOption");
-    CHECK(!r.instrument.option_type.empty());
+    CHECK(instr.trade_type_code == "FxKIKOBarrierOption");
+    CHECK(!instr.option_type.empty());
 
     BOOST_LOG_SEV(lg, info) << "FxKIKOBarrierOption forward test passed";
 }
@@ -200,9 +204,9 @@ TEST_CASE("fx_kiko_barrier_option_forward", tags) {
 TEST_CASE("fx_kiko_barrier_option_reverse", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_fx("FX_KIKO_Barrier_Option.xml");
+    const auto& instr = std::get<fx_barrier_option_instrument>(r.instrument);
 
-    const auto rt = fx_instrument_mapper::reverse_fx_kiko_barrier_option(
-        r.instrument);
+    const auto rt = fx_instrument_mapper::reverse_fx_kiko_barrier_option(instr);
     REQUIRE(rt.FxKIKOBarrierOptionData.operator bool());
 
     BOOST_LOG_SEV(lg, info) << "FxKIKOBarrierOption reverse test passed";

--- a/projects/ores.ore/tests/xml_trade_import_tests.cpp
+++ b/projects/ores.ore/tests/xml_trade_import_tests.cpp
@@ -48,6 +48,7 @@ using ores::ore::xml::trade_import_item;
 using ores::ore::domain::instrument_mapping_result;
 using ores::ore::domain::swap_mapping_result;
 using ores::ore::domain::fx_mapping_result;
+using ores::trading::domain::fx_forward_instrument;
 using ores::ore::domain::bond_mapping_result;
 using ores::trading::domain::trade;
 using namespace ores::logging;
@@ -296,16 +297,17 @@ TEST_CASE("import_portfolio_with_context_fx_forward_has_instrument", tags) {
     REQUIRE(std::holds_alternative<fx_mapping_result>(item.instrument));
 
     const auto& r = std::get<fx_mapping_result>(item.instrument);
-    CHECK(r.instrument.id != item.trade.id);
-    CHECK(r.instrument.trade_id == item.trade.id);
-    CHECK(item.trade.instrument_id == r.instrument.id);
+    const auto& instr = std::get<fx_forward_instrument>(r.instrument);
+    CHECK(instr.instrument_id != item.trade.id);
+    CHECK(instr.trade_id == item.trade.id);
+    CHECK(item.trade.instrument_id == instr.instrument_id);
     CHECK(item.trade.product_type == ores::trading::domain::product_type::fx);
-    CHECK(!r.instrument.bought_currency.empty());
-    CHECK(!r.instrument.sold_currency.empty());
+    CHECK(!instr.bought_currency.empty());
+    CHECK(!instr.sold_currency.empty());
 
     BOOST_LOG_SEV(lg, info) << "FX instrument mapped: "
-                            << r.instrument.bought_currency << "/"
-                            << r.instrument.sold_currency;
+                            << instr.bought_currency << "/"
+                            << instr.sold_currency;
 }
 
 TEST_CASE("import_portfolio_with_context_bond_has_instrument", tags) {

--- a/projects/ores.qt.compute/src/OreImporter.cpp
+++ b/projects/ores.qt.compute/src/OreImporter.cpp
@@ -459,11 +459,66 @@ ore_import_result OreImporter::execute(
                             }
                         }, r.instrument);
                     } else if constexpr (std::is_same_v<T, fx_mapping_result>) {
-                        save_fx_instrument_request req;
-                        req.data = r.instrument;
-                        const auto resp = cm_->process_authenticated_request(std::move(req));
-                        if (!resp || !resp->success) record_error(resp);
-                        else ++res.instruments;
+                        std::visit([&](const auto& instr) {
+                            using InstrT = std::decay_t<decltype(instr)>;
+                            using ores::trading::domain::fx_forward_instrument;
+                            using ores::trading::domain::fx_vanilla_option_instrument;
+                            using ores::trading::domain::fx_barrier_option_instrument;
+                            using ores::trading::domain::fx_digital_option_instrument;
+                            using ores::trading::domain::fx_asian_forward_instrument;
+                            using ores::trading::domain::fx_accumulator_instrument;
+                            using ores::trading::domain::fx_variance_swap_instrument;
+                            if constexpr (std::is_same_v<InstrT, fx_forward_instrument>) {
+                                save_fx_forward_instrument_request req;
+                                req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            } else if constexpr (std::is_same_v<InstrT, fx_vanilla_option_instrument>) {
+                                save_fx_vanilla_option_instrument_request req;
+                                req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            } else if constexpr (std::is_same_v<InstrT, fx_barrier_option_instrument>) {
+                                save_fx_barrier_option_instrument_request req;
+                                req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            } else if constexpr (std::is_same_v<InstrT, fx_digital_option_instrument>) {
+                                save_fx_digital_option_instrument_request req;
+                                req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            } else if constexpr (std::is_same_v<InstrT, fx_asian_forward_instrument>) {
+                                save_fx_asian_forward_instrument_request req;
+                                req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            } else if constexpr (std::is_same_v<InstrT, fx_accumulator_instrument>) {
+                                save_fx_accumulator_instrument_request req;
+                                req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            } else if constexpr (std::is_same_v<InstrT, fx_variance_swap_instrument>) {
+                                save_fx_variance_swap_instrument_request req;
+                                req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            }
+                        }, r.instrument);
                     } else if constexpr (std::is_same_v<T, bond_mapping_result>) {
                         save_bond_instrument_request req;
                         req.data = r.instrument;

--- a/projects/ores.qt.trading/src/ImportTradeDialog.cpp
+++ b/projects/ores.qt.trading/src/ImportTradeDialog.cpp
@@ -617,6 +617,11 @@ void ImportTradeDialog::onImportClicked() {
                     }, r.instrument);
                     for (auto& leg : r.legs)
                         leg.instrument_id = instr_id;
+                } else if constexpr (std::is_same_v<T, ore::domain::fx_mapping_result>) {
+                    std::visit([&](auto& instr) {
+                        instr.instrument_id = instr_id;
+                        instr.trade_id = tti.trade.id;
+                    }, r.instrument);
                 } else {
                     r.instrument.id = instr_id;
                     r.instrument.trade_id = tti.trade.id;
@@ -832,9 +837,45 @@ void ImportTradeDialog::onImportClicked() {
                                     }
                                 }, r.instrument);
                             } else if constexpr (std::is_same_v<T, ore::domain::fx_mapping_result>) {
-                                save_fx_instrument_request req;
-                                req.data = r.instrument;
-                                (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                std::visit([&](const auto& instr) {
+                                    using InstrT = std::decay_t<decltype(instr)>;
+                                    using ores::trading::domain::fx_forward_instrument;
+                                    using ores::trading::domain::fx_vanilla_option_instrument;
+                                    using ores::trading::domain::fx_barrier_option_instrument;
+                                    using ores::trading::domain::fx_digital_option_instrument;
+                                    using ores::trading::domain::fx_asian_forward_instrument;
+                                    using ores::trading::domain::fx_accumulator_instrument;
+                                    using ores::trading::domain::fx_variance_swap_instrument;
+                                    if constexpr (std::is_same_v<InstrT, fx_forward_instrument>) {
+                                        save_fx_forward_instrument_request req;
+                                        req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    } else if constexpr (std::is_same_v<InstrT, fx_vanilla_option_instrument>) {
+                                        save_fx_vanilla_option_instrument_request req;
+                                        req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    } else if constexpr (std::is_same_v<InstrT, fx_barrier_option_instrument>) {
+                                        save_fx_barrier_option_instrument_request req;
+                                        req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    } else if constexpr (std::is_same_v<InstrT, fx_digital_option_instrument>) {
+                                        save_fx_digital_option_instrument_request req;
+                                        req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    } else if constexpr (std::is_same_v<InstrT, fx_asian_forward_instrument>) {
+                                        save_fx_asian_forward_instrument_request req;
+                                        req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    } else if constexpr (std::is_same_v<InstrT, fx_accumulator_instrument>) {
+                                        save_fx_accumulator_instrument_request req;
+                                        req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    } else if constexpr (std::is_same_v<InstrT, fx_variance_swap_instrument>) {
+                                        save_fx_variance_swap_instrument_request req;
+                                        req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    }
+                                }, r.instrument);
                             } else if constexpr (std::is_same_v<T, ore::domain::bond_mapping_result>) {
                                 save_bond_instrument_request req;
                                 req.data = r.instrument;

--- a/projects/ores.sql/create/trading/trading_create.sql
+++ b/projects/ores.sql/create/trading/trading_create.sql
@@ -96,6 +96,28 @@
 \ir ./trading_fx_instruments_create.sql
 \ir ./trading_fx_instruments_notify_trigger_create.sql
 
+-- Per-type FX instrument tables (Phase 2)
+\ir ./trading_fx_forward_instruments_create.sql
+\ir ./trading_fx_forward_instruments_notify_trigger_create.sql
+
+\ir ./trading_fx_vanilla_option_instruments_create.sql
+\ir ./trading_fx_vanilla_option_instruments_notify_trigger_create.sql
+
+\ir ./trading_fx_barrier_option_instruments_create.sql
+\ir ./trading_fx_barrier_option_instruments_notify_trigger_create.sql
+
+\ir ./trading_fx_digital_option_instruments_create.sql
+\ir ./trading_fx_digital_option_instruments_notify_trigger_create.sql
+
+\ir ./trading_fx_asian_forward_instruments_create.sql
+\ir ./trading_fx_asian_forward_instruments_notify_trigger_create.sql
+
+\ir ./trading_fx_accumulator_instruments_create.sql
+\ir ./trading_fx_accumulator_instruments_notify_trigger_create.sql
+
+\ir ./trading_fx_variance_swap_instruments_create.sql
+\ir ./trading_fx_variance_swap_instruments_notify_trigger_create.sql
+
 -- Bond instruments (depends on reference data above)
 \ir ./trading_bond_instruments_create.sql
 \ir ./trading_bond_instruments_notify_trigger_create.sql

--- a/projects/ores.sql/create/trading/trading_fx_accumulator_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_accumulator_instruments_create.sql
@@ -1,0 +1,146 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- FX Accumulator Instruments Table
+--
+-- Routes ORE product type: FxAccumulator.
+-- knock_out_barrier captures the primary UpAndOut barrier level.
+-- Multiple barriers and complex schedules are a Phase 2 coverage gap.
+-- =============================================================================
+
+create table if not exists "ores_trading_fx_accumulator_instruments_tbl" (
+    "instrument_id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "trade_id" uuid null,
+    "trade_type_code" text not null,
+    "currency" text not null,
+    "fixing_amount" numeric(28, 10) not null,
+    "strike" numeric(28, 10) not null,
+    "underlying_code" text not null,
+    "long_short" text not null,
+    "start_date" date not null,
+    "knock_out_barrier" numeric(28, 10) null,
+    "description" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, instrument_id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        instrument_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
+    check ("fixing_amount" > 0),
+    check ("strike" > 0),
+    check ("currency" <> ''),
+    check ("underlying_code" <> ''),
+    check ("long_short" in ('Long', 'Short')),
+    check ("trade_type_code" = 'FxAccumulator')
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_trading_fx_accumulator_instruments_version_uniq_idx
+on "ores_trading_fx_accumulator_instruments_tbl" (tenant_id, instrument_id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Current record uniqueness
+create unique index if not exists ores_trading_fx_accumulator_instruments_id_uniq_idx
+on "ores_trading_fx_accumulator_instruments_tbl" (tenant_id, instrument_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tenant index
+create index if not exists ores_trading_fx_accumulator_instruments_tenant_idx
+on "ores_trading_fx_accumulator_instruments_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Party index for RLS
+create index if not exists ores_trading_fx_accumulator_instruments_party_idx
+on "ores_trading_fx_accumulator_instruments_tbl" (tenant_id, party_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Soft FK back to trade
+create unique index if not exists ores_trading_fx_accumulator_instruments_trade_id_idx
+on "ores_trading_fx_accumulator_instruments_tbl" (tenant_id, trade_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and trade_id is not null;
+
+create or replace function ores_trading_fx_accumulator_instruments_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+    NEW.party_id := current_setting('app.current_party_id')::uuid;
+    NEW.trade_type_code := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type_code);
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    select version into current_version
+    from "ores_trading_fx_accumulator_instruments_tbl"
+    where tenant_id = NEW.tenant_id
+      and instrument_id = NEW.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_trading_fx_accumulator_instruments_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and instrument_id = NEW.instrument_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return NEW;
+end;
+$$ language plpgsql security definer;
+
+create or replace trigger ores_trading_fx_accumulator_instruments_insert_trg
+before insert on "ores_trading_fx_accumulator_instruments_tbl"
+for each row execute function ores_trading_fx_accumulator_instruments_insert_fn();
+
+create or replace rule ores_trading_fx_accumulator_instruments_delete_rule as
+on delete to "ores_trading_fx_accumulator_instruments_tbl" do instead
+    update "ores_trading_fx_accumulator_instruments_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and instrument_id = OLD.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_fx_accumulator_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_accumulator_instruments_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+create or replace function ores_trading_fx_accumulator_instruments_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.trading.fx_accumulator_instrument';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.instrument_id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.instrument_id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_trading_fx_accumulator_instruments', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_trading_fx_accumulator_instruments_notify_trg
+after insert or update or delete on ores_trading_fx_accumulator_instruments_tbl
+for each row execute function ores_trading_fx_accumulator_instruments_notify_fn();

--- a/projects/ores.sql/create/trading/trading_fx_asian_forward_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_asian_forward_instruments_create.sql
@@ -1,0 +1,148 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- FX Asian Forward Instruments Table
+--
+-- Routes ORE product types: FxAverageForward, FxTaRF.
+-- Complex schedules and range bounds are not modelled in Phase 2.
+-- fx_index captures Underlying.Name for the fixing source.
+-- =============================================================================
+
+create table if not exists "ores_trading_fx_asian_forward_instruments_tbl" (
+    "instrument_id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "trade_id" uuid null,
+    "trade_type_code" text not null,
+    "fx_index" text not null,
+    -- FxAverageForward-specific
+    "reference_currency" text null,
+    "reference_notional" numeric(28, 10) null,
+    "settlement_currency" text null,
+    "settlement_notional" numeric(28, 10) null,
+    "payment_date" date null,
+    "long_short" text null,
+    -- FxTaRF-specific
+    "currency" text null,
+    "fixing_amount" numeric(28, 10) null,
+    "target_amount" numeric(28, 10) null,
+    "strike" numeric(28, 10) null,
+    "description" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, instrument_id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        instrument_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
+    check ("fx_index" <> ''),
+    check ("trade_type_code" in ('FxAverageForward', 'FxTaRF'))
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_trading_fx_asian_forward_instruments_version_uniq_idx
+on "ores_trading_fx_asian_forward_instruments_tbl" (tenant_id, instrument_id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Current record uniqueness
+create unique index if not exists ores_trading_fx_asian_forward_instruments_id_uniq_idx
+on "ores_trading_fx_asian_forward_instruments_tbl" (tenant_id, instrument_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tenant index
+create index if not exists ores_trading_fx_asian_forward_instruments_tenant_idx
+on "ores_trading_fx_asian_forward_instruments_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Party index for RLS
+create index if not exists ores_trading_fx_asian_forward_instruments_party_idx
+on "ores_trading_fx_asian_forward_instruments_tbl" (tenant_id, party_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Soft FK back to trade
+create unique index if not exists ores_trading_fx_asian_forward_instruments_trade_id_idx
+on "ores_trading_fx_asian_forward_instruments_tbl" (tenant_id, trade_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and trade_id is not null;
+
+create or replace function ores_trading_fx_asian_forward_instruments_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+    NEW.party_id := current_setting('app.current_party_id')::uuid;
+    NEW.trade_type_code := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type_code);
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    select version into current_version
+    from "ores_trading_fx_asian_forward_instruments_tbl"
+    where tenant_id = NEW.tenant_id
+      and instrument_id = NEW.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_trading_fx_asian_forward_instruments_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and instrument_id = NEW.instrument_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return NEW;
+end;
+$$ language plpgsql security definer;
+
+create or replace trigger ores_trading_fx_asian_forward_instruments_insert_trg
+before insert on "ores_trading_fx_asian_forward_instruments_tbl"
+for each row execute function ores_trading_fx_asian_forward_instruments_insert_fn();
+
+create or replace rule ores_trading_fx_asian_forward_instruments_delete_rule as
+on delete to "ores_trading_fx_asian_forward_instruments_tbl" do instead
+    update "ores_trading_fx_asian_forward_instruments_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and instrument_id = OLD.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_fx_asian_forward_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_asian_forward_instruments_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+create or replace function ores_trading_fx_asian_forward_instruments_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.trading.fx_asian_forward_instrument';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.instrument_id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.instrument_id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_trading_fx_asian_forward_instruments', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_trading_fx_asian_forward_instruments_notify_trg
+after insert or update or delete on ores_trading_fx_asian_forward_instruments_tbl
+for each row execute function ores_trading_fx_asian_forward_instruments_notify_fn();

--- a/projects/ores.sql/create/trading/trading_fx_barrier_option_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_barrier_option_instruments_create.sql
@@ -1,0 +1,155 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- FX Barrier Option Instruments Table
+--
+-- Routes ORE product types: FxBarrierOption, FxDoubleBarrierOption,
+-- FxEuropeanBarrierOption, FxKIKOBarrierOption, FxGenericBarrierOption.
+-- lower_barrier holds the primary (or KO-side) barrier level.
+-- upper_barrier holds the second level for double-barrier and KIKO products.
+-- =============================================================================
+
+create table if not exists "ores_trading_fx_barrier_option_instruments_tbl" (
+    "instrument_id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "trade_id" uuid null,
+    "trade_type_code" text not null,
+    "bought_currency" text not null,
+    "bought_amount" numeric(28, 10) not null,
+    "sold_currency" text not null,
+    "sold_amount" numeric(28, 10) not null,
+    "option_type" text null,
+    "expiry_date" date not null,
+    "settlement" text null,
+    "barrier_type" text not null,
+    "lower_barrier" numeric(28, 10) not null,
+    "upper_barrier" numeric(28, 10) null,
+    "underlying_code" text null,
+    "description" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, instrument_id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        instrument_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
+    check ("bought_amount" > 0),
+    check ("sold_amount" > 0),
+    check ("bought_currency" <> ''),
+    check ("sold_currency" <> ''),
+    check ("barrier_type" <> ''),
+    check ("lower_barrier" > 0),
+    check ("trade_type_code" in (
+        'FxBarrierOption', 'FxDoubleBarrierOption',
+        'FxEuropeanBarrierOption', 'FxKIKOBarrierOption', 'FxGenericBarrierOption'
+    ))
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_trading_fx_barrier_option_instruments_version_uniq_idx
+on "ores_trading_fx_barrier_option_instruments_tbl" (tenant_id, instrument_id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Current record uniqueness
+create unique index if not exists ores_trading_fx_barrier_option_instruments_id_uniq_idx
+on "ores_trading_fx_barrier_option_instruments_tbl" (tenant_id, instrument_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tenant index
+create index if not exists ores_trading_fx_barrier_option_instruments_tenant_idx
+on "ores_trading_fx_barrier_option_instruments_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Party index for RLS
+create index if not exists ores_trading_fx_barrier_option_instruments_party_idx
+on "ores_trading_fx_barrier_option_instruments_tbl" (tenant_id, party_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Soft FK back to trade
+create unique index if not exists ores_trading_fx_barrier_option_instruments_trade_id_idx
+on "ores_trading_fx_barrier_option_instruments_tbl" (tenant_id, trade_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and trade_id is not null;
+
+create or replace function ores_trading_fx_barrier_option_instruments_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+    NEW.party_id := current_setting('app.current_party_id')::uuid;
+    NEW.trade_type_code := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type_code);
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    select version into current_version
+    from "ores_trading_fx_barrier_option_instruments_tbl"
+    where tenant_id = NEW.tenant_id
+      and instrument_id = NEW.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_trading_fx_barrier_option_instruments_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and instrument_id = NEW.instrument_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return NEW;
+end;
+$$ language plpgsql security definer;
+
+create or replace trigger ores_trading_fx_barrier_option_instruments_insert_trg
+before insert on "ores_trading_fx_barrier_option_instruments_tbl"
+for each row execute function ores_trading_fx_barrier_option_instruments_insert_fn();
+
+create or replace rule ores_trading_fx_barrier_option_instruments_delete_rule as
+on delete to "ores_trading_fx_barrier_option_instruments_tbl" do instead
+    update "ores_trading_fx_barrier_option_instruments_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and instrument_id = OLD.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_fx_barrier_option_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_barrier_option_instruments_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+create or replace function ores_trading_fx_barrier_option_instruments_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.trading.fx_barrier_option_instrument';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.instrument_id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.instrument_id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_trading_fx_barrier_option_instruments', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_trading_fx_barrier_option_instruments_notify_trg
+after insert or update or delete on ores_trading_fx_barrier_option_instruments_tbl
+for each row execute function ores_trading_fx_barrier_option_instruments_notify_fn();

--- a/projects/ores.sql/create/trading/trading_fx_digital_option_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_digital_option_instruments_create.sql
@@ -1,0 +1,153 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- FX Digital Option Instruments Table
+--
+-- Routes ORE product types: FxDigitalOption, FxDigitalBarrierOption,
+-- FxTouchOption (OneTouch/NoTouch), FxDoubleTouchOption.
+-- Uses ForeignCurrency/DomesticCurrency naming to match ORE XML semantics.
+-- lower_barrier / upper_barrier capture single or double barrier levels.
+-- =============================================================================
+
+create table if not exists "ores_trading_fx_digital_option_instruments_tbl" (
+    "instrument_id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "trade_id" uuid null,
+    "trade_type_code" text not null,
+    "foreign_currency" text not null,
+    "domestic_currency" text not null,
+    "payoff_currency" text not null,
+    "payoff_amount" numeric(28, 10) not null,
+    "option_type" text null,
+    "expiry_date" date not null,
+    "long_short" text not null,
+    "strike" numeric(28, 10) null,
+    "barrier_type" text null,
+    "lower_barrier" numeric(28, 10) null,
+    "upper_barrier" numeric(28, 10) null,
+    "description" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, instrument_id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        instrument_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
+    check ("payoff_amount" > 0),
+    check ("foreign_currency" <> ''),
+    check ("domestic_currency" <> ''),
+    check ("payoff_currency" <> ''),
+    check ("long_short" in ('Long', 'Short')),
+    check ("trade_type_code" in (
+        'FxDigitalOption', 'FxDigitalBarrierOption', 'FxTouchOption', 'FxDoubleTouchOption'
+    ))
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_trading_fx_digital_option_instruments_version_uniq_idx
+on "ores_trading_fx_digital_option_instruments_tbl" (tenant_id, instrument_id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Current record uniqueness
+create unique index if not exists ores_trading_fx_digital_option_instruments_id_uniq_idx
+on "ores_trading_fx_digital_option_instruments_tbl" (tenant_id, instrument_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tenant index
+create index if not exists ores_trading_fx_digital_option_instruments_tenant_idx
+on "ores_trading_fx_digital_option_instruments_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Party index for RLS
+create index if not exists ores_trading_fx_digital_option_instruments_party_idx
+on "ores_trading_fx_digital_option_instruments_tbl" (tenant_id, party_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Soft FK back to trade
+create unique index if not exists ores_trading_fx_digital_option_instruments_trade_id_idx
+on "ores_trading_fx_digital_option_instruments_tbl" (tenant_id, trade_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and trade_id is not null;
+
+create or replace function ores_trading_fx_digital_option_instruments_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+    NEW.party_id := current_setting('app.current_party_id')::uuid;
+    NEW.trade_type_code := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type_code);
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    select version into current_version
+    from "ores_trading_fx_digital_option_instruments_tbl"
+    where tenant_id = NEW.tenant_id
+      and instrument_id = NEW.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_trading_fx_digital_option_instruments_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and instrument_id = NEW.instrument_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return NEW;
+end;
+$$ language plpgsql security definer;
+
+create or replace trigger ores_trading_fx_digital_option_instruments_insert_trg
+before insert on "ores_trading_fx_digital_option_instruments_tbl"
+for each row execute function ores_trading_fx_digital_option_instruments_insert_fn();
+
+create or replace rule ores_trading_fx_digital_option_instruments_delete_rule as
+on delete to "ores_trading_fx_digital_option_instruments_tbl" do instead
+    update "ores_trading_fx_digital_option_instruments_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and instrument_id = OLD.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_fx_digital_option_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_digital_option_instruments_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+create or replace function ores_trading_fx_digital_option_instruments_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.trading.fx_digital_option_instrument';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.instrument_id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.instrument_id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_trading_fx_digital_option_instruments', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_trading_fx_digital_option_instruments_notify_trg
+after insert or update or delete on ores_trading_fx_digital_option_instruments_tbl
+for each row execute function ores_trading_fx_digital_option_instruments_notify_fn();

--- a/projects/ores.sql/create/trading/trading_fx_forward_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_forward_instruments_create.sql
@@ -1,0 +1,152 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- FX Forward Instruments Table
+--
+-- Routes ORE product types: FxForward, FxSwap (near leg only).
+-- FxSwap far leg (FarDate, FarBoughtAmount, FarSoldAmount) is a documented
+-- coverage gap; only the near leg is persisted.
+-- =============================================================================
+
+create table if not exists "ores_trading_fx_forward_instruments_tbl" (
+    "instrument_id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "trade_id" uuid null,
+    "trade_type_code" text not null,
+    "bought_currency" text not null,
+    "bought_amount" numeric(28, 10) not null,
+    "sold_currency" text not null,
+    "sold_amount" numeric(28, 10) not null,
+    "value_date" date not null,
+    "settlement" text null,
+    "description" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, instrument_id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        instrument_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
+    check ("bought_amount" > 0),
+    check ("sold_amount" > 0),
+    check ("bought_currency" <> ''),
+    check ("sold_currency" <> ''),
+    check ("trade_type_code" in ('FxForward', 'FxSwap'))
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_trading_fx_forward_instruments_version_uniq_idx
+on "ores_trading_fx_forward_instruments_tbl" (tenant_id, instrument_id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Current record uniqueness
+create unique index if not exists ores_trading_fx_forward_instruments_id_uniq_idx
+on "ores_trading_fx_forward_instruments_tbl" (tenant_id, instrument_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tenant index
+create index if not exists ores_trading_fx_forward_instruments_tenant_idx
+on "ores_trading_fx_forward_instruments_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Party index for RLS
+create index if not exists ores_trading_fx_forward_instruments_party_idx
+on "ores_trading_fx_forward_instruments_tbl" (tenant_id, party_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Soft FK back to trade (NULL for standalone instruments)
+create unique index if not exists ores_trading_fx_forward_instruments_trade_id_idx
+on "ores_trading_fx_forward_instruments_tbl" (tenant_id, trade_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and trade_id is not null;
+
+create or replace function ores_trading_fx_forward_instruments_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Set party_id from session context
+    NEW.party_id := current_setting('app.current_party_id')::uuid;
+
+    -- Validate trade_type_code
+    NEW.trade_type_code := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type_code);
+
+    -- Validate change_reason_code
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    -- Version management
+    select version into current_version
+    from "ores_trading_fx_forward_instruments_tbl"
+    where tenant_id = NEW.tenant_id
+      and instrument_id = NEW.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_trading_fx_forward_instruments_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and instrument_id = NEW.instrument_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return NEW;
+end;
+$$ language plpgsql security definer;
+
+create or replace trigger ores_trading_fx_forward_instruments_insert_trg
+before insert on "ores_trading_fx_forward_instruments_tbl"
+for each row execute function ores_trading_fx_forward_instruments_insert_fn();
+
+create or replace rule ores_trading_fx_forward_instruments_delete_rule as
+on delete to "ores_trading_fx_forward_instruments_tbl" do instead
+    update "ores_trading_fx_forward_instruments_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and instrument_id = OLD.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_fx_forward_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_forward_instruments_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+create or replace function ores_trading_fx_forward_instruments_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.trading.fx_forward_instrument';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.instrument_id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.instrument_id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_trading_fx_forward_instruments', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_trading_fx_forward_instruments_notify_trg
+after insert or update or delete on ores_trading_fx_forward_instruments_tbl
+for each row execute function ores_trading_fx_forward_instruments_notify_fn();

--- a/projects/ores.sql/create/trading/trading_fx_vanilla_option_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_vanilla_option_instruments_create.sql
@@ -1,0 +1,147 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- FX Vanilla Option Instruments Table
+--
+-- Routes ORE product type: FxOption (European and American vanilla options).
+-- Strike is encoded implicitly via bought/sold amounts, not a separate field.
+-- =============================================================================
+
+create table if not exists "ores_trading_fx_vanilla_option_instruments_tbl" (
+    "instrument_id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "trade_id" uuid null,
+    "trade_type_code" text not null,
+    "bought_currency" text not null,
+    "bought_amount" numeric(28, 10) not null,
+    "sold_currency" text not null,
+    "sold_amount" numeric(28, 10) not null,
+    "option_type" text not null,
+    "expiry_date" date not null,
+    "exercise_style" text not null,
+    "settlement" text null,
+    "description" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, instrument_id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        instrument_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
+    check ("bought_amount" > 0),
+    check ("sold_amount" > 0),
+    check ("bought_currency" <> ''),
+    check ("sold_currency" <> ''),
+    check ("option_type" in ('Call', 'Put')),
+    check ("exercise_style" in ('European', 'American')),
+    check ("trade_type_code" = 'FxOption')
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_trading_fx_vanilla_option_instruments_version_uniq_idx
+on "ores_trading_fx_vanilla_option_instruments_tbl" (tenant_id, instrument_id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Current record uniqueness
+create unique index if not exists ores_trading_fx_vanilla_option_instruments_id_uniq_idx
+on "ores_trading_fx_vanilla_option_instruments_tbl" (tenant_id, instrument_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tenant index
+create index if not exists ores_trading_fx_vanilla_option_instruments_tenant_idx
+on "ores_trading_fx_vanilla_option_instruments_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Party index for RLS
+create index if not exists ores_trading_fx_vanilla_option_instruments_party_idx
+on "ores_trading_fx_vanilla_option_instruments_tbl" (tenant_id, party_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Soft FK back to trade
+create unique index if not exists ores_trading_fx_vanilla_option_instruments_trade_id_idx
+on "ores_trading_fx_vanilla_option_instruments_tbl" (tenant_id, trade_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and trade_id is not null;
+
+create or replace function ores_trading_fx_vanilla_option_instruments_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+    NEW.party_id := current_setting('app.current_party_id')::uuid;
+    NEW.trade_type_code := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type_code);
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    select version into current_version
+    from "ores_trading_fx_vanilla_option_instruments_tbl"
+    where tenant_id = NEW.tenant_id
+      and instrument_id = NEW.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_trading_fx_vanilla_option_instruments_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and instrument_id = NEW.instrument_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return NEW;
+end;
+$$ language plpgsql security definer;
+
+create or replace trigger ores_trading_fx_vanilla_option_instruments_insert_trg
+before insert on "ores_trading_fx_vanilla_option_instruments_tbl"
+for each row execute function ores_trading_fx_vanilla_option_instruments_insert_fn();
+
+create or replace rule ores_trading_fx_vanilla_option_instruments_delete_rule as
+on delete to "ores_trading_fx_vanilla_option_instruments_tbl" do instead
+    update "ores_trading_fx_vanilla_option_instruments_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and instrument_id = OLD.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_fx_vanilla_option_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_vanilla_option_instruments_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+create or replace function ores_trading_fx_vanilla_option_instruments_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.trading.fx_vanilla_option_instrument';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.instrument_id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.instrument_id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_trading_fx_vanilla_option_instruments', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_trading_fx_vanilla_option_instruments_notify_trg
+after insert or update or delete on ores_trading_fx_vanilla_option_instruments_tbl
+for each row execute function ores_trading_fx_vanilla_option_instruments_notify_fn();

--- a/projects/ores.sql/create/trading/trading_fx_variance_swap_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_variance_swap_instruments_create.sql
@@ -1,0 +1,148 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- FX Variance Swap Instruments Table
+--
+-- Routes ORE product type: FxVarianceSwap.
+-- moment_type distinguishes Variance vs. Volatility swaps.
+-- =============================================================================
+
+create table if not exists "ores_trading_fx_variance_swap_instruments_tbl" (
+    "instrument_id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "trade_id" uuid null,
+    "trade_type_code" text not null,
+    "start_date" date not null,
+    "end_date" date not null,
+    "currency" text not null,
+    "underlying_code" text not null,
+    "long_short" text not null,
+    "strike" numeric(28, 10) not null,
+    "notional" numeric(28, 10) not null,
+    "moment_type" text not null,
+    "description" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, instrument_id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        instrument_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
+    check ("end_date" > "start_date"),
+    check ("strike" > 0),
+    check ("notional" > 0),
+    check ("currency" <> ''),
+    check ("underlying_code" <> ''),
+    check ("long_short" in ('Long', 'Short')),
+    check ("moment_type" in ('Variance', 'Volatility')),
+    check ("trade_type_code" = 'FxVarianceSwap')
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_trading_fx_variance_swap_instruments_version_uniq_idx
+on "ores_trading_fx_variance_swap_instruments_tbl" (tenant_id, instrument_id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Current record uniqueness
+create unique index if not exists ores_trading_fx_variance_swap_instruments_id_uniq_idx
+on "ores_trading_fx_variance_swap_instruments_tbl" (tenant_id, instrument_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tenant index
+create index if not exists ores_trading_fx_variance_swap_instruments_tenant_idx
+on "ores_trading_fx_variance_swap_instruments_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Party index for RLS
+create index if not exists ores_trading_fx_variance_swap_instruments_party_idx
+on "ores_trading_fx_variance_swap_instruments_tbl" (tenant_id, party_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Soft FK back to trade
+create unique index if not exists ores_trading_fx_variance_swap_instruments_trade_id_idx
+on "ores_trading_fx_variance_swap_instruments_tbl" (tenant_id, trade_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and trade_id is not null;
+
+create or replace function ores_trading_fx_variance_swap_instruments_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+    NEW.party_id := current_setting('app.current_party_id')::uuid;
+    NEW.trade_type_code := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type_code);
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    select version into current_version
+    from "ores_trading_fx_variance_swap_instruments_tbl"
+    where tenant_id = NEW.tenant_id
+      and instrument_id = NEW.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_trading_fx_variance_swap_instruments_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and instrument_id = NEW.instrument_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return NEW;
+end;
+$$ language plpgsql security definer;
+
+create or replace trigger ores_trading_fx_variance_swap_instruments_insert_trg
+before insert on "ores_trading_fx_variance_swap_instruments_tbl"
+for each row execute function ores_trading_fx_variance_swap_instruments_insert_fn();
+
+create or replace rule ores_trading_fx_variance_swap_instruments_delete_rule as
+on delete to "ores_trading_fx_variance_swap_instruments_tbl" do instead
+    update "ores_trading_fx_variance_swap_instruments_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and instrument_id = OLD.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_fx_variance_swap_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_variance_swap_instruments_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+create or replace function ores_trading_fx_variance_swap_instruments_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.trading.fx_variance_swap_instrument';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.instrument_id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.instrument_id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_trading_fx_variance_swap_instruments', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_trading_fx_variance_swap_instruments_notify_trg
+after insert or update or delete on ores_trading_fx_variance_swap_instruments_tbl
+for each row execute function ores_trading_fx_variance_swap_instruments_notify_fn();

--- a/projects/ores.sql/create/trading/trading_rls_policies_create.sql
+++ b/projects/ores.sql/create/trading/trading_rls_policies_create.sql
@@ -508,3 +508,147 @@ as restrictive
 for select using (
     party_id = ANY(ores_iam_visible_party_ids_fn())
 );
+
+-- =============================================================================
+-- Per-Type FX Instrument Tables (Phase 2)
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- FX Forward Instruments
+-- -----------------------------------------------------------------------------
+alter table ores_trading_fx_forward_instruments_tbl enable row level security;
+
+create policy ores_trading_fx_forward_instruments_tenant_isolation_policy on ores_trading_fx_forward_instruments_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy ores_trading_fx_forward_instruments_party_isolation_policy
+on ores_trading_fx_forward_instruments_tbl
+as restrictive
+for select using (
+    party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
+-- FX Vanilla Option Instruments
+-- -----------------------------------------------------------------------------
+alter table ores_trading_fx_vanilla_option_instruments_tbl enable row level security;
+
+create policy ores_trading_fx_vanilla_option_instruments_tenant_isolation_policy on ores_trading_fx_vanilla_option_instruments_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy ores_trading_fx_vanilla_option_instruments_party_isolation_policy
+on ores_trading_fx_vanilla_option_instruments_tbl
+as restrictive
+for select using (
+    party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
+-- FX Barrier Option Instruments
+-- -----------------------------------------------------------------------------
+alter table ores_trading_fx_barrier_option_instruments_tbl enable row level security;
+
+create policy ores_trading_fx_barrier_option_instruments_tenant_isolation_policy on ores_trading_fx_barrier_option_instruments_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy ores_trading_fx_barrier_option_instruments_party_isolation_policy
+on ores_trading_fx_barrier_option_instruments_tbl
+as restrictive
+for select using (
+    party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
+-- FX Digital Option Instruments
+-- -----------------------------------------------------------------------------
+alter table ores_trading_fx_digital_option_instruments_tbl enable row level security;
+
+create policy ores_trading_fx_digital_option_instruments_tenant_isolation_policy on ores_trading_fx_digital_option_instruments_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy ores_trading_fx_digital_option_instruments_party_isolation_policy
+on ores_trading_fx_digital_option_instruments_tbl
+as restrictive
+for select using (
+    party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
+-- FX Asian Forward Instruments
+-- -----------------------------------------------------------------------------
+alter table ores_trading_fx_asian_forward_instruments_tbl enable row level security;
+
+create policy ores_trading_fx_asian_forward_instruments_tenant_isolation_policy on ores_trading_fx_asian_forward_instruments_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy ores_trading_fx_asian_forward_instruments_party_isolation_policy
+on ores_trading_fx_asian_forward_instruments_tbl
+as restrictive
+for select using (
+    party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
+-- FX Accumulator Instruments
+-- -----------------------------------------------------------------------------
+alter table ores_trading_fx_accumulator_instruments_tbl enable row level security;
+
+create policy ores_trading_fx_accumulator_instruments_tenant_isolation_policy on ores_trading_fx_accumulator_instruments_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy ores_trading_fx_accumulator_instruments_party_isolation_policy
+on ores_trading_fx_accumulator_instruments_tbl
+as restrictive
+for select using (
+    party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
+-- FX Variance Swap Instruments
+-- -----------------------------------------------------------------------------
+alter table ores_trading_fx_variance_swap_instruments_tbl enable row level security;
+
+create policy ores_trading_fx_variance_swap_instruments_tenant_isolation_policy on ores_trading_fx_variance_swap_instruments_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy ores_trading_fx_variance_swap_instruments_party_isolation_policy
+on ores_trading_fx_variance_swap_instruments_tbl
+as restrictive
+for select using (
+    party_id = ANY(ores_iam_visible_party_ids_fn())
+);

--- a/projects/ores.sql/drop/trading/drop_trading.sql
+++ b/projects/ores.sql/drop/trading/drop_trading.sql
@@ -50,7 +50,16 @@
 \ir ./trading_instruments_notify_trigger_drop.sql
 \ir ./trading_instruments_drop.sql
 
--- FX instruments (depend on reference data, drop before reference data)
+-- Per-type FX instruments (Phase 2, drop before generic FX table)
+\ir ./trading_fx_variance_swap_instruments_drop.sql
+\ir ./trading_fx_accumulator_instruments_drop.sql
+\ir ./trading_fx_asian_forward_instruments_drop.sql
+\ir ./trading_fx_digital_option_instruments_drop.sql
+\ir ./trading_fx_barrier_option_instruments_drop.sql
+\ir ./trading_fx_vanilla_option_instruments_drop.sql
+\ir ./trading_fx_forward_instruments_drop.sql
+
+-- FX instruments (generic table, depend on reference data, drop before reference data)
 \ir ./trading_fx_instruments_notify_trigger_drop.sql
 \ir ./trading_fx_instruments_drop.sql
 

--- a/projects/ores.sql/drop/trading/trading_fx_accumulator_instruments_drop.sql
+++ b/projects/ores.sql/drop/trading/trading_fx_accumulator_instruments_drop.sql
@@ -1,0 +1,26 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_trading_fx_accumulator_instruments_notify_trg on "ores_trading_fx_accumulator_instruments_tbl";
+drop function if exists ores_trading_fx_accumulator_instruments_notify_fn;
+drop rule if exists ores_trading_fx_accumulator_instruments_delete_rule on "ores_trading_fx_accumulator_instruments_tbl";
+drop trigger if exists ores_trading_fx_accumulator_instruments_insert_trg on "ores_trading_fx_accumulator_instruments_tbl";
+drop function if exists ores_trading_fx_accumulator_instruments_insert_fn;
+drop table if exists "ores_trading_fx_accumulator_instruments_tbl";

--- a/projects/ores.sql/drop/trading/trading_fx_asian_forward_instruments_drop.sql
+++ b/projects/ores.sql/drop/trading/trading_fx_asian_forward_instruments_drop.sql
@@ -1,0 +1,26 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_trading_fx_asian_forward_instruments_notify_trg on "ores_trading_fx_asian_forward_instruments_tbl";
+drop function if exists ores_trading_fx_asian_forward_instruments_notify_fn;
+drop rule if exists ores_trading_fx_asian_forward_instruments_delete_rule on "ores_trading_fx_asian_forward_instruments_tbl";
+drop trigger if exists ores_trading_fx_asian_forward_instruments_insert_trg on "ores_trading_fx_asian_forward_instruments_tbl";
+drop function if exists ores_trading_fx_asian_forward_instruments_insert_fn;
+drop table if exists "ores_trading_fx_asian_forward_instruments_tbl";

--- a/projects/ores.sql/drop/trading/trading_fx_barrier_option_instruments_drop.sql
+++ b/projects/ores.sql/drop/trading/trading_fx_barrier_option_instruments_drop.sql
@@ -1,0 +1,26 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_trading_fx_barrier_option_instruments_notify_trg on "ores_trading_fx_barrier_option_instruments_tbl";
+drop function if exists ores_trading_fx_barrier_option_instruments_notify_fn;
+drop rule if exists ores_trading_fx_barrier_option_instruments_delete_rule on "ores_trading_fx_barrier_option_instruments_tbl";
+drop trigger if exists ores_trading_fx_barrier_option_instruments_insert_trg on "ores_trading_fx_barrier_option_instruments_tbl";
+drop function if exists ores_trading_fx_barrier_option_instruments_insert_fn;
+drop table if exists "ores_trading_fx_barrier_option_instruments_tbl";

--- a/projects/ores.sql/drop/trading/trading_fx_digital_option_instruments_drop.sql
+++ b/projects/ores.sql/drop/trading/trading_fx_digital_option_instruments_drop.sql
@@ -1,0 +1,26 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_trading_fx_digital_option_instruments_notify_trg on "ores_trading_fx_digital_option_instruments_tbl";
+drop function if exists ores_trading_fx_digital_option_instruments_notify_fn;
+drop rule if exists ores_trading_fx_digital_option_instruments_delete_rule on "ores_trading_fx_digital_option_instruments_tbl";
+drop trigger if exists ores_trading_fx_digital_option_instruments_insert_trg on "ores_trading_fx_digital_option_instruments_tbl";
+drop function if exists ores_trading_fx_digital_option_instruments_insert_fn;
+drop table if exists "ores_trading_fx_digital_option_instruments_tbl";

--- a/projects/ores.sql/drop/trading/trading_fx_forward_instruments_drop.sql
+++ b/projects/ores.sql/drop/trading/trading_fx_forward_instruments_drop.sql
@@ -1,0 +1,26 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_trading_fx_forward_instruments_notify_trg on "ores_trading_fx_forward_instruments_tbl";
+drop function if exists ores_trading_fx_forward_instruments_notify_fn;
+drop rule if exists ores_trading_fx_forward_instruments_delete_rule on "ores_trading_fx_forward_instruments_tbl";
+drop trigger if exists ores_trading_fx_forward_instruments_insert_trg on "ores_trading_fx_forward_instruments_tbl";
+drop function if exists ores_trading_fx_forward_instruments_insert_fn;
+drop table if exists "ores_trading_fx_forward_instruments_tbl";

--- a/projects/ores.sql/drop/trading/trading_fx_vanilla_option_instruments_drop.sql
+++ b/projects/ores.sql/drop/trading/trading_fx_vanilla_option_instruments_drop.sql
@@ -1,0 +1,26 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_trading_fx_vanilla_option_instruments_notify_trg on "ores_trading_fx_vanilla_option_instruments_tbl";
+drop function if exists ores_trading_fx_vanilla_option_instruments_notify_fn;
+drop rule if exists ores_trading_fx_vanilla_option_instruments_delete_rule on "ores_trading_fx_vanilla_option_instruments_tbl";
+drop trigger if exists ores_trading_fx_vanilla_option_instruments_insert_trg on "ores_trading_fx_vanilla_option_instruments_tbl";
+drop function if exists ores_trading_fx_vanilla_option_instruments_insert_fn;
+drop table if exists "ores_trading_fx_vanilla_option_instruments_tbl";

--- a/projects/ores.sql/drop/trading/trading_fx_variance_swap_instruments_drop.sql
+++ b/projects/ores.sql/drop/trading/trading_fx_variance_swap_instruments_drop.sql
@@ -1,0 +1,26 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_trading_fx_variance_swap_instruments_notify_trg on "ores_trading_fx_variance_swap_instruments_tbl";
+drop function if exists ores_trading_fx_variance_swap_instruments_notify_fn;
+drop rule if exists ores_trading_fx_variance_swap_instruments_delete_rule on "ores_trading_fx_variance_swap_instruments_tbl";
+drop trigger if exists ores_trading_fx_variance_swap_instruments_insert_trg on "ores_trading_fx_variance_swap_instruments_tbl";
+drop function if exists ores_trading_fx_variance_swap_instruments_insert_fn;
+drop table if exists "ores_trading_fx_variance_swap_instruments_tbl";

--- a/projects/ores.trading.api/include/ores.trading.api/domain/fx_accumulator_instrument.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/fx_accumulator_instrument.hpp
@@ -1,0 +1,100 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_FX_ACCUMULATOR_INSTRUMENT_HPP
+#define ORES_TRADING_DOMAIN_FX_ACCUMULATOR_INSTRUMENT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief FX Accumulator instrument.
+ *
+ * Routes ORE product type: FxAccumulator.
+ * knock_out_barrier captures the primary UpAndOut barrier.
+ * Multiple barriers and complex fixing schedules are a Phase 2 coverage gap.
+ */
+struct fx_accumulator_instrument final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief UUID uniquely identifying this FX accumulator instrument.
+     */
+    boost::uuids::uuid instrument_id;
+
+    boost::uuids::uuid party_id;
+    std::optional<boost::uuids::uuid> trade_id;
+
+    /**
+     * @brief ORE product type code: FxAccumulator.
+     */
+    std::string trade_type_code;
+
+    /**
+     * @brief Settlement currency (domestic side).
+     */
+    std::string currency;
+
+    /**
+     * @brief Per-fixing notional amount. Must be positive.
+     */
+    double fixing_amount = 0.0;
+
+    /**
+     * @brief Fixed strike rate. Must be positive.
+     */
+    double strike = 0.0;
+
+    /**
+     * @brief FX pair or index identifier (e.g. TR20H-EUR-JPY).
+     */
+    std::string underlying_code;
+
+    /**
+     * @brief Position direction: Long or Short.
+     */
+    std::string long_short;
+
+    /**
+     * @brief Accumulation start date (ISO 8601 date string).
+     */
+    std::string start_date;
+
+    /**
+     * @brief Primary UpAndOut knock-out barrier level. Absent when no barrier.
+     */
+    std::optional<double> knock_out_barrier;
+
+    std::string description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/fx_accumulator_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/fx_accumulator_instrument_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_FX_ACCUMULATOR_INSTRUMENT_JSON_IO_HPP
+#define ORES_TRADING_DOMAIN_FX_ACCUMULATOR_INSTRUMENT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.trading.api/domain/fx_accumulator_instrument.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Dumps the fx_accumulator_instrument to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const fx_accumulator_instrument& v);
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/fx_asian_forward_instrument.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/fx_asian_forward_instrument.hpp
@@ -1,0 +1,123 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_FX_ASIAN_FORWARD_INSTRUMENT_HPP
+#define ORES_TRADING_DOMAIN_FX_ASIAN_FORWARD_INSTRUMENT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief FX Asian Forward instrument.
+ *
+ * Routes: FxAverageForward, FxTaRF (Target Accrual Redemption Forward).
+ *
+ * Complex observation schedules and range bounds are a Phase 2 coverage gap.
+ * fx_index captures Underlying.Name for the FX fixing source.
+ */
+struct fx_asian_forward_instrument final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief UUID uniquely identifying this FX asian forward instrument.
+     */
+    boost::uuids::uuid instrument_id;
+
+    boost::uuids::uuid party_id;
+    std::optional<boost::uuids::uuid> trade_id;
+
+    /**
+     * @brief ORE product type code: FxAverageForward or FxTaRF.
+     */
+    std::string trade_type_code;
+
+    /**
+     * @brief FX index / underlying name (e.g. FX-TR20H-EUR-USD).
+     */
+    std::string fx_index;
+
+    // FxAverageForward-specific fields
+    /**
+     * @brief Reference (fixing) currency for FxAverageForward.
+     */
+    std::string reference_currency;
+
+    /**
+     * @brief Reference notional amount for FxAverageForward.
+     */
+    std::optional<double> reference_notional;
+
+    /**
+     * @brief Settlement currency for FxAverageForward.
+     */
+    std::string settlement_currency;
+
+    /**
+     * @brief Settlement notional amount for FxAverageForward.
+     */
+    std::optional<double> settlement_notional;
+
+    /**
+     * @brief Payment date for FxAverageForward (ISO 8601 date string).
+     */
+    std::string payment_date;
+
+    /**
+     * @brief Position direction for FxAverageForward: Long or Short.
+     */
+    std::string long_short;
+
+    // FxTaRF-specific fields
+    /**
+     * @brief Settlement currency for FxTaRF.
+     */
+    std::string currency;
+
+    /**
+     * @brief Per-fixing notional amount for FxTaRF.
+     */
+    std::optional<double> fixing_amount;
+
+    /**
+     * @brief Profit cap (target amount) for FxTaRF.
+     */
+    std::optional<double> target_amount;
+
+    /**
+     * @brief Fixed strike rate for FxTaRF.
+     */
+    std::optional<double> strike;
+
+    std::string description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/fx_asian_forward_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/fx_asian_forward_instrument_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_FX_ASIAN_FORWARD_INSTRUMENT_JSON_IO_HPP
+#define ORES_TRADING_DOMAIN_FX_ASIAN_FORWARD_INSTRUMENT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.trading.api/domain/fx_asian_forward_instrument.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Dumps the fx_asian_forward_instrument to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const fx_asian_forward_instrument& v);
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/fx_barrier_option_instrument.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/fx_barrier_option_instrument.hpp
@@ -1,0 +1,113 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_FX_BARRIER_OPTION_INSTRUMENT_HPP
+#define ORES_TRADING_DOMAIN_FX_BARRIER_OPTION_INSTRUMENT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief FX Barrier Option instrument.
+ *
+ * Routes: FxBarrierOption, FxDoubleBarrierOption, FxEuropeanBarrierOption,
+ * FxKIKOBarrierOption, FxGenericBarrierOption.
+ *
+ * lower_barrier holds the primary (or KO-side for KIKO) barrier level.
+ * upper_barrier holds the second level for double-barrier and KIKO products;
+ * absent for single-barrier types.
+ * underlying_code is used by KIKO and generic barrier products.
+ */
+struct fx_barrier_option_instrument final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief UUID uniquely identifying this FX barrier option instrument.
+     */
+    boost::uuids::uuid instrument_id;
+
+    boost::uuids::uuid party_id;
+    std::optional<boost::uuids::uuid> trade_id;
+
+    /**
+     * @brief ORE product type code. One of: FxBarrierOption,
+     * FxDoubleBarrierOption, FxEuropeanBarrierOption,
+     * FxKIKOBarrierOption, FxGenericBarrierOption.
+     */
+    std::string trade_type_code;
+
+    std::string bought_currency;
+    double bought_amount = 0.0;
+    std::string sold_currency;
+    double sold_amount = 0.0;
+
+    /**
+     * @brief Option type: Call or Put. Absent for FxGenericBarrierOption
+     * with PayoffType=AssetOrNothing.
+     */
+    std::string option_type;
+
+    /**
+     * @brief Option expiry date (ISO 8601 date string).
+     */
+    std::string expiry_date;
+
+    /**
+     * @brief Optional settlement method (e.g. Cash, Physical).
+     */
+    std::string settlement;
+
+    /**
+     * @brief Primary barrier type (e.g. UpAndIn, DownAndOut, KIKO).
+     */
+    std::string barrier_type;
+
+    /**
+     * @brief Primary (or lower) barrier level. Must be positive.
+     */
+    double lower_barrier = 0.0;
+
+    /**
+     * @brief Second barrier level for double-barrier and KIKO products.
+     */
+    std::optional<double> upper_barrier;
+
+    /**
+     * @brief FX pair or index code (e.g. TR20H-EUR-USD). Used by
+     * KIKO and generic barrier products.
+     */
+    std::string underlying_code;
+
+    std::string description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/fx_barrier_option_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/fx_barrier_option_instrument_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_FX_BARRIER_OPTION_INSTRUMENT_JSON_IO_HPP
+#define ORES_TRADING_DOMAIN_FX_BARRIER_OPTION_INSTRUMENT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.trading.api/domain/fx_barrier_option_instrument.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Dumps the fx_barrier_option_instrument to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const fx_barrier_option_instrument& v);
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/fx_digital_option_instrument.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/fx_digital_option_instrument.hpp
@@ -1,0 +1,126 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_FX_DIGITAL_OPTION_INSTRUMENT_HPP
+#define ORES_TRADING_DOMAIN_FX_DIGITAL_OPTION_INSTRUMENT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief FX Digital Option instrument.
+ *
+ * Routes: FxDigitalOption, FxDigitalBarrierOption, FxTouchOption
+ * (OneTouch / NoTouch), FxDoubleTouchOption.
+ *
+ * Uses ForeignCurrency / DomesticCurrency naming to match ORE XML semantics.
+ * option_type is absent for touch products (no Call/Put distinction).
+ * strike is absent for touch products.
+ * lower_barrier / upper_barrier capture single or double barrier levels.
+ */
+struct fx_digital_option_instrument final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief UUID uniquely identifying this FX digital option instrument.
+     */
+    boost::uuids::uuid instrument_id;
+
+    boost::uuids::uuid party_id;
+    std::optional<boost::uuids::uuid> trade_id;
+
+    /**
+     * @brief ORE product type code. One of: FxDigitalOption,
+     * FxDigitalBarrierOption, FxTouchOption, FxDoubleTouchOption.
+     */
+    std::string trade_type_code;
+
+    /**
+     * @brief ForeignCurrency from ORE XML (source / underlying currency).
+     */
+    std::string foreign_currency;
+
+    /**
+     * @brief DomesticCurrency from ORE XML (quote / settlement currency).
+     */
+    std::string domestic_currency;
+
+    /**
+     * @brief Currency in which the payoff is denominated.
+     */
+    std::string payoff_currency;
+
+    /**
+     * @brief Fixed payoff amount. Must be positive.
+     */
+    double payoff_amount = 0.0;
+
+    /**
+     * @brief Option type: Call or Put. Empty for touch options.
+     */
+    std::string option_type;
+
+    /**
+     * @brief Option expiry date (ISO 8601 date string).
+     */
+    std::string expiry_date;
+
+    /**
+     * @brief Position direction: Long or Short.
+     */
+    std::string long_short;
+
+    /**
+     * @brief Strike level. Absent for touch options.
+     */
+    std::optional<double> strike;
+
+    /**
+     * @brief Barrier type (e.g. DownAndIn, DownAndOut, KnockIn, KnockOut).
+     * Absent for plain digital options.
+     */
+    std::string barrier_type;
+
+    /**
+     * @brief Primary barrier level. Absent for plain digital options.
+     */
+    std::optional<double> lower_barrier;
+
+    /**
+     * @brief Second barrier level for FxDoubleTouchOption.
+     */
+    std::optional<double> upper_barrier;
+
+    std::string description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/fx_digital_option_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/fx_digital_option_instrument_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_FX_DIGITAL_OPTION_INSTRUMENT_JSON_IO_HPP
+#define ORES_TRADING_DOMAIN_FX_DIGITAL_OPTION_INSTRUMENT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.trading.api/domain/fx_digital_option_instrument.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Dumps the fx_digital_option_instrument to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const fx_digital_option_instrument& v);
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/fx_forward_instrument.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/fx_forward_instrument.hpp
@@ -1,0 +1,96 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_FX_FORWARD_INSTRUMENT_HPP
+#define ORES_TRADING_DOMAIN_FX_FORWARD_INSTRUMENT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief FX Forward instrument.
+ *
+ * Represents FxForward and FxSwap (near leg only) trades. The FxSwap far
+ * leg (FarDate, FarBoughtAmount, FarSoldAmount) is a documented coverage gap.
+ */
+struct fx_forward_instrument final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief UUID uniquely identifying this FX forward instrument.
+     */
+    boost::uuids::uuid instrument_id;
+
+    boost::uuids::uuid party_id;
+    std::optional<boost::uuids::uuid> trade_id;
+
+    /**
+     * @brief ORE product type code: FxForward or FxSwap.
+     */
+    std::string trade_type_code;
+
+    /**
+     * @brief ISO 4217 currency code of the bought leg (e.g. EUR).
+     */
+    std::string bought_currency;
+
+    /**
+     * @brief Amount bought in bought_currency. Must be positive.
+     */
+    double bought_amount = 0.0;
+
+    /**
+     * @brief ISO 4217 currency code of the sold leg (e.g. USD).
+     */
+    std::string sold_currency;
+
+    /**
+     * @brief Amount sold in sold_currency. Must be positive.
+     */
+    double sold_amount = 0.0;
+
+    /**
+     * @brief Settlement / value date (ISO 8601 date string).
+     *
+     * For FxSwap this is the near leg date only.
+     */
+    std::string value_date;
+
+    /**
+     * @brief Optional settlement method (e.g. Cash, Physical).
+     */
+    std::string settlement;
+
+    std::string description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/fx_forward_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/fx_forward_instrument_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_FX_FORWARD_INSTRUMENT_JSON_IO_HPP
+#define ORES_TRADING_DOMAIN_FX_FORWARD_INSTRUMENT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.trading.api/domain/fx_forward_instrument.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Dumps the fx_forward_instrument to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const fx_forward_instrument& v);
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/fx_vanilla_option_instrument.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/fx_vanilla_option_instrument.hpp
@@ -1,0 +1,104 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_FX_VANILLA_OPTION_INSTRUMENT_HPP
+#define ORES_TRADING_DOMAIN_FX_VANILLA_OPTION_INSTRUMENT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief FX Vanilla Option instrument (European and American).
+ *
+ * Represents FxOption trades. Strike is implicit in bought/sold amounts;
+ * there is no separate strike field in ORE's FxOptionData.
+ */
+struct fx_vanilla_option_instrument final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief UUID uniquely identifying this FX vanilla option instrument.
+     */
+    boost::uuids::uuid instrument_id;
+
+    boost::uuids::uuid party_id;
+    std::optional<boost::uuids::uuid> trade_id;
+
+    /**
+     * @brief ORE product type code: FxOption.
+     */
+    std::string trade_type_code;
+
+    /**
+     * @brief ISO 4217 currency code of the bought leg.
+     */
+    std::string bought_currency;
+
+    /**
+     * @brief Amount bought in bought_currency. Must be positive.
+     */
+    double bought_amount = 0.0;
+
+    /**
+     * @brief ISO 4217 currency code of the sold leg.
+     */
+    std::string sold_currency;
+
+    /**
+     * @brief Amount sold in sold_currency. Must be positive.
+     */
+    double sold_amount = 0.0;
+
+    /**
+     * @brief Option type: Call or Put.
+     */
+    std::string option_type;
+
+    /**
+     * @brief Option expiry date (ISO 8601 date string).
+     */
+    std::string expiry_date;
+
+    /**
+     * @brief Exercise style: European or American.
+     */
+    std::string exercise_style;
+
+    /**
+     * @brief Optional settlement method (e.g. Cash, Physical).
+     */
+    std::string settlement;
+
+    std::string description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/fx_vanilla_option_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/fx_vanilla_option_instrument_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_FX_VANILLA_OPTION_INSTRUMENT_JSON_IO_HPP
+#define ORES_TRADING_DOMAIN_FX_VANILLA_OPTION_INSTRUMENT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.trading.api/domain/fx_vanilla_option_instrument.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Dumps the fx_vanilla_option_instrument to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const fx_vanilla_option_instrument& v);
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/fx_variance_swap_instrument.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/fx_variance_swap_instrument.hpp
@@ -1,0 +1,106 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_FX_VARIANCE_SWAP_INSTRUMENT_HPP
+#define ORES_TRADING_DOMAIN_FX_VARIANCE_SWAP_INSTRUMENT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief FX Variance Swap instrument.
+ *
+ * Routes ORE product type: FxVarianceSwap.
+ * moment_type distinguishes Variance swaps from Volatility swaps.
+ */
+struct fx_variance_swap_instrument final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief UUID uniquely identifying this FX variance swap instrument.
+     */
+    boost::uuids::uuid instrument_id;
+
+    boost::uuids::uuid party_id;
+    std::optional<boost::uuids::uuid> trade_id;
+
+    /**
+     * @brief ORE product type code: FxVarianceSwap.
+     */
+    std::string trade_type_code;
+
+    /**
+     * @brief Variance observation start date (ISO 8601 date string).
+     */
+    std::string start_date;
+
+    /**
+     * @brief Variance observation end date (ISO 8601 date string).
+     *
+     * Must be after start_date.
+     */
+    std::string end_date;
+
+    /**
+     * @brief Settlement currency.
+     */
+    std::string currency;
+
+    /**
+     * @brief FX pair or index identifier (e.g. TR20H-EUR-USD).
+     */
+    std::string underlying_code;
+
+    /**
+     * @brief Position direction: Long or Short.
+     */
+    std::string long_short;
+
+    /**
+     * @brief Fixed variance or volatility strike. Must be positive.
+     */
+    double strike = 0.0;
+
+    /**
+     * @brief Notional amount for PnL scaling. Must be positive.
+     */
+    double notional = 0.0;
+
+    /**
+     * @brief Whether the product is a Variance or Volatility swap.
+     */
+    std::string moment_type;
+
+    std::string description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/fx_variance_swap_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/fx_variance_swap_instrument_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_FX_VARIANCE_SWAP_INSTRUMENT_JSON_IO_HPP
+#define ORES_TRADING_DOMAIN_FX_VARIANCE_SWAP_INSTRUMENT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.trading.api/domain/fx_variance_swap_instrument.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Dumps the fx_variance_swap_instrument to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const fx_variance_swap_instrument& v);
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/messaging/instrument_protocol.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/messaging/instrument_protocol.hpp
@@ -26,6 +26,13 @@
 #include "ores.trading.api/domain/product_type.hpp"
 #include "ores.trading.api/domain/swap_leg.hpp"
 #include "ores.trading.api/domain/fx_instrument.hpp"
+#include "ores.trading.api/domain/fx_forward_instrument.hpp"
+#include "ores.trading.api/domain/fx_vanilla_option_instrument.hpp"
+#include "ores.trading.api/domain/fx_barrier_option_instrument.hpp"
+#include "ores.trading.api/domain/fx_digital_option_instrument.hpp"
+#include "ores.trading.api/domain/fx_asian_forward_instrument.hpp"
+#include "ores.trading.api/domain/fx_accumulator_instrument.hpp"
+#include "ores.trading.api/domain/fx_variance_swap_instrument.hpp"
 #include "ores.trading.api/domain/bond_instrument.hpp"
 #include "ores.trading.api/domain/credit_instrument.hpp"
 #include "ores.trading.api/domain/equity_instrument.hpp"
@@ -98,6 +105,92 @@ struct get_fx_instrument_history_response {
     bool success = false;
     std::string message;
     std::vector<ores::trading::domain::fx_instrument> history;
+};
+
+// ---- Typed FX instrument protocol ----
+
+struct save_fx_forward_instrument_request {
+    using response_type = struct save_fx_forward_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.fx_forward_instruments.save";
+    ores::trading::domain::fx_forward_instrument data;
+};
+
+struct save_fx_forward_instrument_response {
+    bool success = false;
+    std::string message;
+};
+
+struct save_fx_vanilla_option_instrument_request {
+    using response_type = struct save_fx_vanilla_option_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.fx_vanilla_option_instruments.save";
+    ores::trading::domain::fx_vanilla_option_instrument data;
+};
+
+struct save_fx_vanilla_option_instrument_response {
+    bool success = false;
+    std::string message;
+};
+
+struct save_fx_barrier_option_instrument_request {
+    using response_type = struct save_fx_barrier_option_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.fx_barrier_option_instruments.save";
+    ores::trading::domain::fx_barrier_option_instrument data;
+};
+
+struct save_fx_barrier_option_instrument_response {
+    bool success = false;
+    std::string message;
+};
+
+struct save_fx_digital_option_instrument_request {
+    using response_type = struct save_fx_digital_option_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.fx_digital_option_instruments.save";
+    ores::trading::domain::fx_digital_option_instrument data;
+};
+
+struct save_fx_digital_option_instrument_response {
+    bool success = false;
+    std::string message;
+};
+
+struct save_fx_asian_forward_instrument_request {
+    using response_type = struct save_fx_asian_forward_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.fx_asian_forward_instruments.save";
+    ores::trading::domain::fx_asian_forward_instrument data;
+};
+
+struct save_fx_asian_forward_instrument_response {
+    bool success = false;
+    std::string message;
+};
+
+struct save_fx_accumulator_instrument_request {
+    using response_type = struct save_fx_accumulator_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.fx_accumulator_instruments.save";
+    ores::trading::domain::fx_accumulator_instrument data;
+};
+
+struct save_fx_accumulator_instrument_response {
+    bool success = false;
+    std::string message;
+};
+
+struct save_fx_variance_swap_instrument_request {
+    using response_type = struct save_fx_variance_swap_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.fx_variance_swap_instruments.save";
+    ores::trading::domain::fx_variance_swap_instrument data;
+};
+
+struct save_fx_variance_swap_instrument_response {
+    bool success = false;
+    std::string message;
 };
 
 // ---- Bond instrument protocol ----

--- a/projects/ores.trading.api/src/domain/fx_accumulator_instrument_json_io.cpp
+++ b/projects/ores.trading.api/src/domain/fx_accumulator_instrument_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.api/domain/fx_accumulator_instrument_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::domain {
+
+std::ostream& operator<<(std::ostream& s, const fx_accumulator_instrument& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.api/src/domain/fx_asian_forward_instrument_json_io.cpp
+++ b/projects/ores.trading.api/src/domain/fx_asian_forward_instrument_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.api/domain/fx_asian_forward_instrument_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::domain {
+
+std::ostream& operator<<(std::ostream& s, const fx_asian_forward_instrument& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.api/src/domain/fx_barrier_option_instrument_json_io.cpp
+++ b/projects/ores.trading.api/src/domain/fx_barrier_option_instrument_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.api/domain/fx_barrier_option_instrument_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::domain {
+
+std::ostream& operator<<(std::ostream& s, const fx_barrier_option_instrument& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.api/src/domain/fx_digital_option_instrument_json_io.cpp
+++ b/projects/ores.trading.api/src/domain/fx_digital_option_instrument_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.api/domain/fx_digital_option_instrument_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::domain {
+
+std::ostream& operator<<(std::ostream& s, const fx_digital_option_instrument& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.api/src/domain/fx_forward_instrument_json_io.cpp
+++ b/projects/ores.trading.api/src/domain/fx_forward_instrument_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.api/domain/fx_forward_instrument_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::domain {
+
+std::ostream& operator<<(std::ostream& s, const fx_forward_instrument& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.api/src/domain/fx_vanilla_option_instrument_json_io.cpp
+++ b/projects/ores.trading.api/src/domain/fx_vanilla_option_instrument_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.api/domain/fx_vanilla_option_instrument_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::domain {
+
+std::ostream& operator<<(std::ostream& s, const fx_vanilla_option_instrument& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.api/src/domain/fx_variance_swap_instrument_json_io.cpp
+++ b/projects/ores.trading.api/src/domain/fx_variance_swap_instrument_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.api/domain/fx_variance_swap_instrument_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::domain {
+
+std::ostream& operator<<(std::ostream& s, const fx_variance_swap_instrument& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/include/ores.trading.core/messaging/typed_fx_instrument_handler.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/messaging/typed_fx_instrument_handler.hpp
@@ -1,0 +1,172 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_MESSAGING_TYPED_FX_INSTRUMENT_HANDLER_HPP
+#define ORES_TRADING_MESSAGING_TYPED_FX_INSTRUMENT_HANDLER_HPP
+
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.trading.api/messaging/instrument_protocol.hpp"
+#include "ores.trading.core/service/fx_forward_instrument_service.hpp"
+#include "ores.trading.core/service/fx_vanilla_option_instrument_service.hpp"
+#include "ores.trading.core/service/fx_barrier_option_instrument_service.hpp"
+#include "ores.trading.core/service/fx_digital_option_instrument_service.hpp"
+#include "ores.trading.core/service/fx_asian_forward_instrument_service.hpp"
+#include "ores.trading.core/service/fx_accumulator_instrument_service.hpp"
+#include "ores.trading.core/service/fx_variance_swap_instrument_service.hpp"
+
+namespace ores::trading::messaging {
+
+namespace {
+inline auto& typed_fx_instrument_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.trading.messaging.typed_fx_instrument_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using ores::service::messaging::has_permission;
+using namespace ores::logging;
+
+template<typename Request, typename Response, typename Service, typename SaveFn>
+void handle_typed_fx_save(
+    ores::nats::service::client& nats,
+    ores::nats::message msg,
+    ores::database::context ctx,
+    std::optional<ores::security::jwt::jwt_authenticator> verifier,
+    SaveFn save_fn) {
+    BOOST_LOG_SEV(typed_fx_instrument_handler_lg(), debug)
+        << "Handling " << msg.subject;
+    auto ctx_expected = ores::service::service::make_request_context(
+        ctx, msg, verifier);
+    if (!ctx_expected) {
+        error_reply(nats, msg, ctx_expected.error());
+        return;
+    }
+    const auto& rctx = *ctx_expected;
+    if (!has_permission(rctx, "trading::instruments:write")) {
+        error_reply(nats, msg, ores::service::error_code::forbidden);
+        return;
+    }
+    if (auto req = decode<Request>(msg)) {
+        try {
+            Service svc(rctx);
+            (svc.*save_fn)(req->data);
+            BOOST_LOG_SEV(typed_fx_instrument_handler_lg(), debug)
+                << "Completed " << msg.subject;
+            reply(nats, msg, Response{.success = true});
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(typed_fx_instrument_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            reply(nats, msg, Response{.success = false, .message = e.what()});
+        }
+    } else {
+        BOOST_LOG_SEV(typed_fx_instrument_handler_lg(), warn)
+            << "Failed to decode: " << msg.subject;
+    }
+}
+
+class typed_fx_instrument_handler {
+public:
+    typed_fx_instrument_handler(ores::nats::service::client& nats,
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
+
+    void save_forward(ores::nats::message msg) {
+        using Svc = service::fx_forward_instrument_service;
+        handle_typed_fx_save<
+            save_fx_forward_instrument_request,
+            save_fx_forward_instrument_response,
+            Svc>(nats_, std::move(msg), ctx_, verifier_,
+                &Svc::save_fx_forward_instrument);
+    }
+
+    void save_vanilla_option(ores::nats::message msg) {
+        using Svc = service::fx_vanilla_option_instrument_service;
+        handle_typed_fx_save<
+            save_fx_vanilla_option_instrument_request,
+            save_fx_vanilla_option_instrument_response,
+            Svc>(nats_, std::move(msg), ctx_, verifier_,
+                &Svc::save_fx_vanilla_option_instrument);
+    }
+
+    void save_barrier_option(ores::nats::message msg) {
+        using Svc = service::fx_barrier_option_instrument_service;
+        handle_typed_fx_save<
+            save_fx_barrier_option_instrument_request,
+            save_fx_barrier_option_instrument_response,
+            Svc>(nats_, std::move(msg), ctx_, verifier_,
+                &Svc::save_fx_barrier_option_instrument);
+    }
+
+    void save_digital_option(ores::nats::message msg) {
+        using Svc = service::fx_digital_option_instrument_service;
+        handle_typed_fx_save<
+            save_fx_digital_option_instrument_request,
+            save_fx_digital_option_instrument_response,
+            Svc>(nats_, std::move(msg), ctx_, verifier_,
+                &Svc::save_fx_digital_option_instrument);
+    }
+
+    void save_asian_forward(ores::nats::message msg) {
+        using Svc = service::fx_asian_forward_instrument_service;
+        handle_typed_fx_save<
+            save_fx_asian_forward_instrument_request,
+            save_fx_asian_forward_instrument_response,
+            Svc>(nats_, std::move(msg), ctx_, verifier_,
+                &Svc::save_fx_asian_forward_instrument);
+    }
+
+    void save_accumulator(ores::nats::message msg) {
+        using Svc = service::fx_accumulator_instrument_service;
+        handle_typed_fx_save<
+            save_fx_accumulator_instrument_request,
+            save_fx_accumulator_instrument_response,
+            Svc>(nats_, std::move(msg), ctx_, verifier_,
+                &Svc::save_fx_accumulator_instrument);
+    }
+
+    void save_variance_swap(ores::nats::message msg) {
+        using Svc = service::fx_variance_swap_instrument_service;
+        handle_typed_fx_save<
+            save_fx_variance_swap_instrument_request,
+            save_fx_variance_swap_instrument_response,
+            Svc>(nats_, std::move(msg), ctx_, verifier_,
+                &Svc::save_fx_variance_swap_instrument);
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::trading::messaging
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_accumulator_instrument_entity.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_accumulator_instrument_entity.hpp
@@ -1,0 +1,66 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_ACCUMULATOR_INSTRUMENT_ENTITY_HPP
+#define ORES_TRADING_REPOSITORY_FX_ACCUMULATOR_INSTRUMENT_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Represents an FX accumulator instrument in the database.
+ *
+ * Covers ORE product type: FxAccumulator.
+ */
+struct fx_accumulator_instrument_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_trading_fx_accumulator_instruments_tbl";
+
+    sqlgen::PrimaryKey<std::string> instrument_id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::optional<std::string> trade_id;
+    std::string trade_type_code;
+    std::string currency;
+    double fixing_amount = 0.0;
+    double strike = 0.0;
+    std::string underlying_code;
+    std::string long_short;
+    std::string start_date;
+    std::optional<double> knock_out_barrier;
+    std::optional<std::string> description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const fx_accumulator_instrument_entity& v);
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_accumulator_instrument_mapper.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_accumulator_instrument_mapper.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_ACCUMULATOR_INSTRUMENT_MAPPER_HPP
+#define ORES_TRADING_REPOSITORY_FX_ACCUMULATOR_INSTRUMENT_MAPPER_HPP
+
+#include <vector>
+#include "ores.trading.api/domain/fx_accumulator_instrument.hpp"
+#include "ores.trading.core/repository/fx_accumulator_instrument_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Maps fx_accumulator_instrument domain entities to data storage layer and vice-versa.
+ */
+class fx_accumulator_instrument_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.fx_accumulator_instrument_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::fx_accumulator_instrument map(const fx_accumulator_instrument_entity& v);
+    static fx_accumulator_instrument_entity map(const domain::fx_accumulator_instrument& v);
+
+    static std::vector<domain::fx_accumulator_instrument>
+    map(const std::vector<fx_accumulator_instrument_entity>& v);
+    static std::vector<fx_accumulator_instrument_entity>
+    map(const std::vector<domain::fx_accumulator_instrument>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_accumulator_instrument_repository.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_accumulator_instrument_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_ACCUMULATOR_INSTRUMENT_REPOSITORY_HPP
+#define ORES_TRADING_REPOSITORY_FX_ACCUMULATOR_INSTRUMENT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/fx_accumulator_instrument.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Reads and writes FX accumulator instruments to data storage.
+ */
+class fx_accumulator_instrument_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.fx_accumulator_instrument_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::fx_accumulator_instrument& v);
+    void write(context ctx, const std::vector<domain::fx_accumulator_instrument>& v);
+
+    std::vector<domain::fx_accumulator_instrument> read_latest(context ctx);
+    std::vector<domain::fx_accumulator_instrument>
+    read_latest(context ctx, const std::string& instrument_id);
+    std::vector<domain::fx_accumulator_instrument>
+    read_all(context ctx, const std::string& instrument_id);
+
+    void remove(context ctx, const std::string& instrument_id);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_asian_forward_instrument_entity.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_asian_forward_instrument_entity.hpp
@@ -1,0 +1,72 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_ASIAN_FORWARD_INSTRUMENT_ENTITY_HPP
+#define ORES_TRADING_REPOSITORY_FX_ASIAN_FORWARD_INSTRUMENT_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Represents an FX asian forward instrument in the database.
+ *
+ * Covers ORE product types: FxAverageForward, FxTaRF.
+ */
+struct fx_asian_forward_instrument_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_trading_fx_asian_forward_instruments_tbl";
+
+    sqlgen::PrimaryKey<std::string> instrument_id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::optional<std::string> trade_id;
+    std::string trade_type_code;
+    std::string fx_index;
+    // FxAverageForward-specific
+    std::optional<std::string> reference_currency;
+    std::optional<double> reference_notional;
+    std::optional<std::string> settlement_currency;
+    std::optional<double> settlement_notional;
+    std::optional<std::string> payment_date;
+    std::optional<std::string> long_short;
+    // FxTaRF-specific
+    std::optional<std::string> currency;
+    std::optional<double> fixing_amount;
+    std::optional<double> target_amount;
+    std::optional<double> strike;
+    std::optional<std::string> description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const fx_asian_forward_instrument_entity& v);
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_asian_forward_instrument_mapper.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_asian_forward_instrument_mapper.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_ASIAN_FORWARD_INSTRUMENT_MAPPER_HPP
+#define ORES_TRADING_REPOSITORY_FX_ASIAN_FORWARD_INSTRUMENT_MAPPER_HPP
+
+#include <vector>
+#include "ores.trading.api/domain/fx_asian_forward_instrument.hpp"
+#include "ores.trading.core/repository/fx_asian_forward_instrument_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Maps fx_asian_forward_instrument domain entities to data storage layer and vice-versa.
+ */
+class fx_asian_forward_instrument_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.fx_asian_forward_instrument_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::fx_asian_forward_instrument map(const fx_asian_forward_instrument_entity& v);
+    static fx_asian_forward_instrument_entity map(const domain::fx_asian_forward_instrument& v);
+
+    static std::vector<domain::fx_asian_forward_instrument>
+    map(const std::vector<fx_asian_forward_instrument_entity>& v);
+    static std::vector<fx_asian_forward_instrument_entity>
+    map(const std::vector<domain::fx_asian_forward_instrument>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_asian_forward_instrument_repository.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_asian_forward_instrument_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_ASIAN_FORWARD_INSTRUMENT_REPOSITORY_HPP
+#define ORES_TRADING_REPOSITORY_FX_ASIAN_FORWARD_INSTRUMENT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/fx_asian_forward_instrument.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Reads and writes FX asian forward instruments to data storage.
+ */
+class fx_asian_forward_instrument_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.fx_asian_forward_instrument_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::fx_asian_forward_instrument& v);
+    void write(context ctx, const std::vector<domain::fx_asian_forward_instrument>& v);
+
+    std::vector<domain::fx_asian_forward_instrument> read_latest(context ctx);
+    std::vector<domain::fx_asian_forward_instrument>
+    read_latest(context ctx, const std::string& instrument_id);
+    std::vector<domain::fx_asian_forward_instrument>
+    read_all(context ctx, const std::string& instrument_id);
+
+    void remove(context ctx, const std::string& instrument_id);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_barrier_option_instrument_entity.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_barrier_option_instrument_entity.hpp
@@ -1,0 +1,71 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_BARRIER_OPTION_INSTRUMENT_ENTITY_HPP
+#define ORES_TRADING_REPOSITORY_FX_BARRIER_OPTION_INSTRUMENT_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Represents an FX barrier option instrument in the database.
+ *
+ * Covers ORE product types: FxBarrierOption, FxDoubleBarrierOption,
+ * FxEuropeanBarrierOption, FxKIKOBarrierOption, FxGenericBarrierOption.
+ */
+struct fx_barrier_option_instrument_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_trading_fx_barrier_option_instruments_tbl";
+
+    sqlgen::PrimaryKey<std::string> instrument_id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::optional<std::string> trade_id;
+    std::string trade_type_code;
+    std::string bought_currency;
+    double bought_amount = 0.0;
+    std::string sold_currency;
+    double sold_amount = 0.0;
+    std::optional<std::string> option_type;
+    std::string expiry_date;
+    std::optional<std::string> settlement;
+    std::string barrier_type;
+    double lower_barrier = 0.0;
+    std::optional<double> upper_barrier;
+    std::optional<std::string> underlying_code;
+    std::optional<std::string> description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const fx_barrier_option_instrument_entity& v);
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_barrier_option_instrument_mapper.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_barrier_option_instrument_mapper.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_BARRIER_OPTION_INSTRUMENT_MAPPER_HPP
+#define ORES_TRADING_REPOSITORY_FX_BARRIER_OPTION_INSTRUMENT_MAPPER_HPP
+
+#include <vector>
+#include "ores.trading.api/domain/fx_barrier_option_instrument.hpp"
+#include "ores.trading.core/repository/fx_barrier_option_instrument_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Maps fx_barrier_option_instrument domain entities to data storage layer and vice-versa.
+ */
+class fx_barrier_option_instrument_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.fx_barrier_option_instrument_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::fx_barrier_option_instrument map(const fx_barrier_option_instrument_entity& v);
+    static fx_barrier_option_instrument_entity map(const domain::fx_barrier_option_instrument& v);
+
+    static std::vector<domain::fx_barrier_option_instrument>
+    map(const std::vector<fx_barrier_option_instrument_entity>& v);
+    static std::vector<fx_barrier_option_instrument_entity>
+    map(const std::vector<domain::fx_barrier_option_instrument>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_barrier_option_instrument_repository.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_barrier_option_instrument_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_BARRIER_OPTION_INSTRUMENT_REPOSITORY_HPP
+#define ORES_TRADING_REPOSITORY_FX_BARRIER_OPTION_INSTRUMENT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/fx_barrier_option_instrument.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Reads and writes FX barrier option instruments to data storage.
+ */
+class fx_barrier_option_instrument_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.fx_barrier_option_instrument_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::fx_barrier_option_instrument& v);
+    void write(context ctx, const std::vector<domain::fx_barrier_option_instrument>& v);
+
+    std::vector<domain::fx_barrier_option_instrument> read_latest(context ctx);
+    std::vector<domain::fx_barrier_option_instrument>
+    read_latest(context ctx, const std::string& instrument_id);
+    std::vector<domain::fx_barrier_option_instrument>
+    read_all(context ctx, const std::string& instrument_id);
+
+    void remove(context ctx, const std::string& instrument_id);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_digital_option_instrument_entity.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_digital_option_instrument_entity.hpp
@@ -1,0 +1,71 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_DIGITAL_OPTION_INSTRUMENT_ENTITY_HPP
+#define ORES_TRADING_REPOSITORY_FX_DIGITAL_OPTION_INSTRUMENT_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Represents an FX digital option instrument in the database.
+ *
+ * Covers ORE product types: FxDigitalOption, FxDigitalBarrierOption,
+ * FxTouchOption, FxDoubleTouchOption.
+ */
+struct fx_digital_option_instrument_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_trading_fx_digital_option_instruments_tbl";
+
+    sqlgen::PrimaryKey<std::string> instrument_id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::optional<std::string> trade_id;
+    std::string trade_type_code;
+    std::string foreign_currency;
+    std::string domestic_currency;
+    std::string payoff_currency;
+    double payoff_amount = 0.0;
+    std::optional<std::string> option_type;
+    std::string expiry_date;
+    std::string long_short;
+    std::optional<double> strike;
+    std::optional<std::string> barrier_type;
+    std::optional<double> lower_barrier;
+    std::optional<double> upper_barrier;
+    std::optional<std::string> description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const fx_digital_option_instrument_entity& v);
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_digital_option_instrument_mapper.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_digital_option_instrument_mapper.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_DIGITAL_OPTION_INSTRUMENT_MAPPER_HPP
+#define ORES_TRADING_REPOSITORY_FX_DIGITAL_OPTION_INSTRUMENT_MAPPER_HPP
+
+#include <vector>
+#include "ores.trading.api/domain/fx_digital_option_instrument.hpp"
+#include "ores.trading.core/repository/fx_digital_option_instrument_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Maps fx_digital_option_instrument domain entities to data storage layer and vice-versa.
+ */
+class fx_digital_option_instrument_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.fx_digital_option_instrument_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::fx_digital_option_instrument map(const fx_digital_option_instrument_entity& v);
+    static fx_digital_option_instrument_entity map(const domain::fx_digital_option_instrument& v);
+
+    static std::vector<domain::fx_digital_option_instrument>
+    map(const std::vector<fx_digital_option_instrument_entity>& v);
+    static std::vector<fx_digital_option_instrument_entity>
+    map(const std::vector<domain::fx_digital_option_instrument>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_digital_option_instrument_repository.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_digital_option_instrument_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_DIGITAL_OPTION_INSTRUMENT_REPOSITORY_HPP
+#define ORES_TRADING_REPOSITORY_FX_DIGITAL_OPTION_INSTRUMENT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/fx_digital_option_instrument.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Reads and writes FX digital option instruments to data storage.
+ */
+class fx_digital_option_instrument_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.fx_digital_option_instrument_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::fx_digital_option_instrument& v);
+    void write(context ctx, const std::vector<domain::fx_digital_option_instrument>& v);
+
+    std::vector<domain::fx_digital_option_instrument> read_latest(context ctx);
+    std::vector<domain::fx_digital_option_instrument>
+    read_latest(context ctx, const std::string& instrument_id);
+    std::vector<domain::fx_digital_option_instrument>
+    read_all(context ctx, const std::string& instrument_id);
+
+    void remove(context ctx, const std::string& instrument_id);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_forward_instrument_entity.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_forward_instrument_entity.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_FORWARD_INSTRUMENT_ENTITY_HPP
+#define ORES_TRADING_REPOSITORY_FX_FORWARD_INSTRUMENT_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Represents an FX forward instrument in the database.
+ *
+ * Covers ORE product types: FxForward and FxSwap (near leg only).
+ */
+struct fx_forward_instrument_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_trading_fx_forward_instruments_tbl";
+
+    sqlgen::PrimaryKey<std::string> instrument_id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::optional<std::string> trade_id;
+    std::string trade_type_code;
+    std::string bought_currency;
+    double bought_amount = 0.0;
+    std::string sold_currency;
+    double sold_amount = 0.0;
+    std::string value_date;
+    std::optional<std::string> settlement;
+    std::optional<std::string> description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const fx_forward_instrument_entity& v);
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_forward_instrument_mapper.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_forward_instrument_mapper.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_FORWARD_INSTRUMENT_MAPPER_HPP
+#define ORES_TRADING_REPOSITORY_FX_FORWARD_INSTRUMENT_MAPPER_HPP
+
+#include <vector>
+#include "ores.trading.api/domain/fx_forward_instrument.hpp"
+#include "ores.trading.core/repository/fx_forward_instrument_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Maps fx_forward_instrument domain entities to data storage layer and vice-versa.
+ */
+class fx_forward_instrument_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.fx_forward_instrument_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::fx_forward_instrument map(const fx_forward_instrument_entity& v);
+    static fx_forward_instrument_entity map(const domain::fx_forward_instrument& v);
+
+    static std::vector<domain::fx_forward_instrument>
+    map(const std::vector<fx_forward_instrument_entity>& v);
+    static std::vector<fx_forward_instrument_entity>
+    map(const std::vector<domain::fx_forward_instrument>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_forward_instrument_repository.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_forward_instrument_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_FORWARD_INSTRUMENT_REPOSITORY_HPP
+#define ORES_TRADING_REPOSITORY_FX_FORWARD_INSTRUMENT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/fx_forward_instrument.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Reads and writes FX forward instruments to data storage.
+ */
+class fx_forward_instrument_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.fx_forward_instrument_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::fx_forward_instrument& v);
+    void write(context ctx, const std::vector<domain::fx_forward_instrument>& v);
+
+    std::vector<domain::fx_forward_instrument> read_latest(context ctx);
+    std::vector<domain::fx_forward_instrument>
+    read_latest(context ctx, const std::string& instrument_id);
+    std::vector<domain::fx_forward_instrument>
+    read_all(context ctx, const std::string& instrument_id);
+
+    void remove(context ctx, const std::string& instrument_id);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_vanilla_option_instrument_entity.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_vanilla_option_instrument_entity.hpp
@@ -1,0 +1,67 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_VANILLA_OPTION_INSTRUMENT_ENTITY_HPP
+#define ORES_TRADING_REPOSITORY_FX_VANILLA_OPTION_INSTRUMENT_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Represents an FX vanilla option instrument in the database.
+ *
+ * Covers ORE product type: FxOption.
+ */
+struct fx_vanilla_option_instrument_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_trading_fx_vanilla_option_instruments_tbl";
+
+    sqlgen::PrimaryKey<std::string> instrument_id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::optional<std::string> trade_id;
+    std::string trade_type_code;
+    std::string bought_currency;
+    double bought_amount = 0.0;
+    std::string sold_currency;
+    double sold_amount = 0.0;
+    std::string option_type;
+    std::string expiry_date;
+    std::string exercise_style;
+    std::optional<std::string> settlement;
+    std::optional<std::string> description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const fx_vanilla_option_instrument_entity& v);
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_vanilla_option_instrument_mapper.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_vanilla_option_instrument_mapper.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_VANILLA_OPTION_INSTRUMENT_MAPPER_HPP
+#define ORES_TRADING_REPOSITORY_FX_VANILLA_OPTION_INSTRUMENT_MAPPER_HPP
+
+#include <vector>
+#include "ores.trading.api/domain/fx_vanilla_option_instrument.hpp"
+#include "ores.trading.core/repository/fx_vanilla_option_instrument_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Maps fx_vanilla_option_instrument domain entities to data storage layer and vice-versa.
+ */
+class fx_vanilla_option_instrument_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.fx_vanilla_option_instrument_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::fx_vanilla_option_instrument map(const fx_vanilla_option_instrument_entity& v);
+    static fx_vanilla_option_instrument_entity map(const domain::fx_vanilla_option_instrument& v);
+
+    static std::vector<domain::fx_vanilla_option_instrument>
+    map(const std::vector<fx_vanilla_option_instrument_entity>& v);
+    static std::vector<fx_vanilla_option_instrument_entity>
+    map(const std::vector<domain::fx_vanilla_option_instrument>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_vanilla_option_instrument_repository.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_vanilla_option_instrument_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_VANILLA_OPTION_INSTRUMENT_REPOSITORY_HPP
+#define ORES_TRADING_REPOSITORY_FX_VANILLA_OPTION_INSTRUMENT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/fx_vanilla_option_instrument.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Reads and writes FX vanilla option instruments to data storage.
+ */
+class fx_vanilla_option_instrument_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.fx_vanilla_option_instrument_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::fx_vanilla_option_instrument& v);
+    void write(context ctx, const std::vector<domain::fx_vanilla_option_instrument>& v);
+
+    std::vector<domain::fx_vanilla_option_instrument> read_latest(context ctx);
+    std::vector<domain::fx_vanilla_option_instrument>
+    read_latest(context ctx, const std::string& instrument_id);
+    std::vector<domain::fx_vanilla_option_instrument>
+    read_all(context ctx, const std::string& instrument_id);
+
+    void remove(context ctx, const std::string& instrument_id);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_variance_swap_instrument_entity.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_variance_swap_instrument_entity.hpp
@@ -1,0 +1,67 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_VARIANCE_SWAP_INSTRUMENT_ENTITY_HPP
+#define ORES_TRADING_REPOSITORY_FX_VARIANCE_SWAP_INSTRUMENT_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Represents an FX variance swap instrument in the database.
+ *
+ * Covers ORE product type: FxVarianceSwap.
+ */
+struct fx_variance_swap_instrument_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_trading_fx_variance_swap_instruments_tbl";
+
+    sqlgen::PrimaryKey<std::string> instrument_id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::optional<std::string> trade_id;
+    std::string trade_type_code;
+    std::string start_date;
+    std::string end_date;
+    std::string currency;
+    std::string underlying_code;
+    std::string long_short;
+    double strike = 0.0;
+    double notional = 0.0;
+    std::string moment_type;
+    std::optional<std::string> description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const fx_variance_swap_instrument_entity& v);
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_variance_swap_instrument_mapper.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_variance_swap_instrument_mapper.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_VARIANCE_SWAP_INSTRUMENT_MAPPER_HPP
+#define ORES_TRADING_REPOSITORY_FX_VARIANCE_SWAP_INSTRUMENT_MAPPER_HPP
+
+#include <vector>
+#include "ores.trading.api/domain/fx_variance_swap_instrument.hpp"
+#include "ores.trading.core/repository/fx_variance_swap_instrument_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Maps fx_variance_swap_instrument domain entities to data storage layer and vice-versa.
+ */
+class fx_variance_swap_instrument_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.fx_variance_swap_instrument_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::fx_variance_swap_instrument map(const fx_variance_swap_instrument_entity& v);
+    static fx_variance_swap_instrument_entity map(const domain::fx_variance_swap_instrument& v);
+
+    static std::vector<domain::fx_variance_swap_instrument>
+    map(const std::vector<fx_variance_swap_instrument_entity>& v);
+    static std::vector<fx_variance_swap_instrument_entity>
+    map(const std::vector<domain::fx_variance_swap_instrument>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/fx_variance_swap_instrument_repository.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/fx_variance_swap_instrument_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_FX_VARIANCE_SWAP_INSTRUMENT_REPOSITORY_HPP
+#define ORES_TRADING_REPOSITORY_FX_VARIANCE_SWAP_INSTRUMENT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/fx_variance_swap_instrument.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Reads and writes FX variance swap instruments to data storage.
+ */
+class fx_variance_swap_instrument_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.fx_variance_swap_instrument_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::fx_variance_swap_instrument& v);
+    void write(context ctx, const std::vector<domain::fx_variance_swap_instrument>& v);
+
+    std::vector<domain::fx_variance_swap_instrument> read_latest(context ctx);
+    std::vector<domain::fx_variance_swap_instrument>
+    read_latest(context ctx, const std::string& instrument_id);
+    std::vector<domain::fx_variance_swap_instrument>
+    read_all(context ctx, const std::string& instrument_id);
+
+    void remove(context ctx, const std::string& instrument_id);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/service/fx_accumulator_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/fx_accumulator_instrument_service.hpp
@@ -1,0 +1,57 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_FX_ACCUMULATOR_INSTRUMENT_SERVICE_HPP
+#define ORES_TRADING_SERVICE_FX_ACCUMULATOR_INSTRUMENT_SERVICE_HPP
+
+#include <string>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/fx_accumulator_instrument.hpp"
+#include "ores.trading.core/repository/fx_accumulator_instrument_repository.hpp"
+
+namespace ores::trading::service {
+
+class fx_accumulator_instrument_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.service.fx_accumulator_instrument_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit fx_accumulator_instrument_service(context ctx);
+
+    void save_fx_accumulator_instrument(
+        const domain::fx_accumulator_instrument& v);
+
+private:
+    context ctx_;
+    repository::fx_accumulator_instrument_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/service/fx_asian_forward_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/fx_asian_forward_instrument_service.hpp
@@ -1,0 +1,57 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_FX_ASIAN_FORWARD_INSTRUMENT_SERVICE_HPP
+#define ORES_TRADING_SERVICE_FX_ASIAN_FORWARD_INSTRUMENT_SERVICE_HPP
+
+#include <string>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/fx_asian_forward_instrument.hpp"
+#include "ores.trading.core/repository/fx_asian_forward_instrument_repository.hpp"
+
+namespace ores::trading::service {
+
+class fx_asian_forward_instrument_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.service.fx_asian_forward_instrument_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit fx_asian_forward_instrument_service(context ctx);
+
+    void save_fx_asian_forward_instrument(
+        const domain::fx_asian_forward_instrument& v);
+
+private:
+    context ctx_;
+    repository::fx_asian_forward_instrument_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/service/fx_barrier_option_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/fx_barrier_option_instrument_service.hpp
@@ -1,0 +1,57 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_FX_BARRIER_OPTION_INSTRUMENT_SERVICE_HPP
+#define ORES_TRADING_SERVICE_FX_BARRIER_OPTION_INSTRUMENT_SERVICE_HPP
+
+#include <string>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/fx_barrier_option_instrument.hpp"
+#include "ores.trading.core/repository/fx_barrier_option_instrument_repository.hpp"
+
+namespace ores::trading::service {
+
+class fx_barrier_option_instrument_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.service.fx_barrier_option_instrument_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit fx_barrier_option_instrument_service(context ctx);
+
+    void save_fx_barrier_option_instrument(
+        const domain::fx_barrier_option_instrument& v);
+
+private:
+    context ctx_;
+    repository::fx_barrier_option_instrument_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/service/fx_digital_option_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/fx_digital_option_instrument_service.hpp
@@ -1,0 +1,57 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_FX_DIGITAL_OPTION_INSTRUMENT_SERVICE_HPP
+#define ORES_TRADING_SERVICE_FX_DIGITAL_OPTION_INSTRUMENT_SERVICE_HPP
+
+#include <string>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/fx_digital_option_instrument.hpp"
+#include "ores.trading.core/repository/fx_digital_option_instrument_repository.hpp"
+
+namespace ores::trading::service {
+
+class fx_digital_option_instrument_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.service.fx_digital_option_instrument_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit fx_digital_option_instrument_service(context ctx);
+
+    void save_fx_digital_option_instrument(
+        const domain::fx_digital_option_instrument& v);
+
+private:
+    context ctx_;
+    repository::fx_digital_option_instrument_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/service/fx_forward_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/fx_forward_instrument_service.hpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_FX_FORWARD_INSTRUMENT_SERVICE_HPP
+#define ORES_TRADING_SERVICE_FX_FORWARD_INSTRUMENT_SERVICE_HPP
+
+#include <string>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/fx_forward_instrument.hpp"
+#include "ores.trading.core/repository/fx_forward_instrument_repository.hpp"
+
+namespace ores::trading::service {
+
+class fx_forward_instrument_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.service.fx_forward_instrument_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit fx_forward_instrument_service(context ctx);
+
+    void save_fx_forward_instrument(const domain::fx_forward_instrument& v);
+
+private:
+    context ctx_;
+    repository::fx_forward_instrument_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/service/fx_vanilla_option_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/fx_vanilla_option_instrument_service.hpp
@@ -1,0 +1,57 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_FX_VANILLA_OPTION_INSTRUMENT_SERVICE_HPP
+#define ORES_TRADING_SERVICE_FX_VANILLA_OPTION_INSTRUMENT_SERVICE_HPP
+
+#include <string>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/fx_vanilla_option_instrument.hpp"
+#include "ores.trading.core/repository/fx_vanilla_option_instrument_repository.hpp"
+
+namespace ores::trading::service {
+
+class fx_vanilla_option_instrument_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.service.fx_vanilla_option_instrument_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit fx_vanilla_option_instrument_service(context ctx);
+
+    void save_fx_vanilla_option_instrument(
+        const domain::fx_vanilla_option_instrument& v);
+
+private:
+    context ctx_;
+    repository::fx_vanilla_option_instrument_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/service/fx_variance_swap_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/fx_variance_swap_instrument_service.hpp
@@ -1,0 +1,57 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_FX_VARIANCE_SWAP_INSTRUMENT_SERVICE_HPP
+#define ORES_TRADING_SERVICE_FX_VARIANCE_SWAP_INSTRUMENT_SERVICE_HPP
+
+#include <string>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/fx_variance_swap_instrument.hpp"
+#include "ores.trading.core/repository/fx_variance_swap_instrument_repository.hpp"
+
+namespace ores::trading::service {
+
+class fx_variance_swap_instrument_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.service.fx_variance_swap_instrument_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit fx_variance_swap_instrument_service(context ctx);
+
+    void save_fx_variance_swap_instrument(
+        const domain::fx_variance_swap_instrument& v);
+
+private:
+    context ctx_;
+    repository::fx_variance_swap_instrument_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/src/messaging/registrar.cpp
+++ b/projects/ores.trading.core/src/messaging/registrar.cpp
@@ -23,6 +23,7 @@
 #include "ores.trading.core/messaging/instrument_handler.hpp"
 #include "ores.trading.core/messaging/rates_instrument_handler.hpp"
 #include "ores.trading.core/messaging/fx_instrument_handler.hpp"
+#include "ores.trading.core/messaging/typed_fx_instrument_handler.hpp"
 #include "ores.trading.core/messaging/bond_instrument_handler.hpp"
 #include "ores.trading.core/messaging/credit_instrument_handler.hpp"
 #include "ores.trading.core/messaging/equity_instrument_handler.hpp"
@@ -559,6 +560,56 @@ registrar::register_handlers(ores::nats::service::client& nats,
         [&nats, ctx, verifier](ores::nats::message msg) mutable {
             fx_instrument_handler h(nats, ctx, verifier);
             h.history(std::move(msg));
+        }));
+
+    // Typed FX instruments
+    subs.push_back(nats.queue_subscribe(
+        std::string(save_fx_forward_instrument_request::nats_subject), queue,
+        [&nats, ctx, verifier](ores::nats::message msg) mutable {
+            typed_fx_instrument_handler h(nats, ctx, verifier);
+            h.save_forward(std::move(msg));
+        }));
+
+    subs.push_back(nats.queue_subscribe(
+        std::string(save_fx_vanilla_option_instrument_request::nats_subject), queue,
+        [&nats, ctx, verifier](ores::nats::message msg) mutable {
+            typed_fx_instrument_handler h(nats, ctx, verifier);
+            h.save_vanilla_option(std::move(msg));
+        }));
+
+    subs.push_back(nats.queue_subscribe(
+        std::string(save_fx_barrier_option_instrument_request::nats_subject), queue,
+        [&nats, ctx, verifier](ores::nats::message msg) mutable {
+            typed_fx_instrument_handler h(nats, ctx, verifier);
+            h.save_barrier_option(std::move(msg));
+        }));
+
+    subs.push_back(nats.queue_subscribe(
+        std::string(save_fx_digital_option_instrument_request::nats_subject), queue,
+        [&nats, ctx, verifier](ores::nats::message msg) mutable {
+            typed_fx_instrument_handler h(nats, ctx, verifier);
+            h.save_digital_option(std::move(msg));
+        }));
+
+    subs.push_back(nats.queue_subscribe(
+        std::string(save_fx_asian_forward_instrument_request::nats_subject), queue,
+        [&nats, ctx, verifier](ores::nats::message msg) mutable {
+            typed_fx_instrument_handler h(nats, ctx, verifier);
+            h.save_asian_forward(std::move(msg));
+        }));
+
+    subs.push_back(nats.queue_subscribe(
+        std::string(save_fx_accumulator_instrument_request::nats_subject), queue,
+        [&nats, ctx, verifier](ores::nats::message msg) mutable {
+            typed_fx_instrument_handler h(nats, ctx, verifier);
+            h.save_accumulator(std::move(msg));
+        }));
+
+    subs.push_back(nats.queue_subscribe(
+        std::string(save_fx_variance_swap_instrument_request::nats_subject), queue,
+        [&nats, ctx, verifier](ores::nats::message msg) mutable {
+            typed_fx_instrument_handler h(nats, ctx, verifier);
+            h.save_variance_swap(std::move(msg));
         }));
 
     // Bond instruments

--- a/projects/ores.trading.core/src/repository/fx_accumulator_instrument_entity.cpp
+++ b/projects/ores.trading.core/src/repository/fx_accumulator_instrument_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_accumulator_instrument_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::trading::repository {
+
+std::ostream& operator<<(std::ostream& s, const fx_accumulator_instrument_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_accumulator_instrument_mapper.cpp
+++ b/projects/ores.trading.core/src/repository/fx_accumulator_instrument_mapper.cpp
@@ -1,0 +1,109 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_accumulator_instrument_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.trading.api/domain/fx_accumulator_instrument_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::fx_accumulator_instrument
+fx_accumulator_instrument_mapper::map(const fx_accumulator_instrument_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::fx_accumulator_instrument r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.currency = v.currency;
+    r.fixing_amount = v.fixing_amount;
+    r.strike = v.strike;
+    r.underlying_code = v.underlying_code;
+    r.long_short = v.long_short;
+    r.start_date = v.start_date;
+    r.knock_out_barrier = v.knock_out_barrier;
+    r.description = v.description.value_or("");
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+fx_accumulator_instrument_entity
+fx_accumulator_instrument_mapper::map(const domain::fx_accumulator_instrument& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    fx_accumulator_instrument_entity r;
+    r.instrument_id = boost::uuids::to_string(v.instrument_id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.currency = v.currency;
+    r.fixing_amount = v.fixing_amount;
+    r.strike = v.strike;
+    r.underlying_code = v.underlying_code;
+    r.long_short = v.long_short;
+    r.start_date = v.start_date;
+    r.knock_out_barrier = v.knock_out_barrier;
+    r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::fx_accumulator_instrument>
+fx_accumulator_instrument_mapper::map(const std::vector<fx_accumulator_instrument_entity>& v) {
+    return map_vector<fx_accumulator_instrument_entity, domain::fx_accumulator_instrument>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<fx_accumulator_instrument_entity>
+fx_accumulator_instrument_mapper::map(const std::vector<domain::fx_accumulator_instrument>& v) {
+    return map_vector<domain::fx_accumulator_instrument, fx_accumulator_instrument_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_accumulator_instrument_repository.cpp
+++ b/projects/ores.trading.core/src/repository/fx_accumulator_instrument_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_accumulator_instrument_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.trading.api/domain/fx_accumulator_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.trading.core/repository/fx_accumulator_instrument_entity.hpp"
+#include "ores.trading.core/repository/fx_accumulator_instrument_mapper.hpp"
+
+namespace ores::trading::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string fx_accumulator_instrument_repository::sql() {
+    return generate_create_table_sql<fx_accumulator_instrument_entity>(lg());
+}
+
+void fx_accumulator_instrument_repository::write(context ctx, const domain::fx_accumulator_instrument& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX accumulator instrument: " << v.instrument_id;
+    execute_write_query(ctx, fx_accumulator_instrument_mapper::map(v),
+        lg(), "Writing FX accumulator instrument to database.");
+}
+
+void fx_accumulator_instrument_repository::write(
+    context ctx, const std::vector<domain::fx_accumulator_instrument>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX accumulator instruments. Count: " << v.size();
+    execute_write_query(ctx, fx_accumulator_instrument_mapper::map(v),
+        lg(), "Writing FX accumulator instruments to database.");
+}
+
+std::vector<domain::fx_accumulator_instrument>
+fx_accumulator_instrument_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_accumulator_instrument_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("instrument_id"_c);
+
+    return execute_read_query<fx_accumulator_instrument_entity, domain::fx_accumulator_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_accumulator_instrument_mapper::map(entities); },
+        lg(), "Reading latest FX accumulator instruments");
+}
+
+std::vector<domain::fx_accumulator_instrument>
+fx_accumulator_instrument_repository::read_latest(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest FX accumulator instrument. instrument_id: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_accumulator_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    return execute_read_query<fx_accumulator_instrument_entity, domain::fx_accumulator_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_accumulator_instrument_mapper::map(entities); },
+        lg(), "Reading latest FX accumulator instrument by instrument_id.");
+}
+
+std::vector<domain::fx_accumulator_instrument>
+fx_accumulator_instrument_repository::read_all(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all FX accumulator instrument versions. instrument_id: " << instrument_id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_accumulator_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<fx_accumulator_instrument_entity, domain::fx_accumulator_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_accumulator_instrument_mapper::map(entities); },
+        lg(), "Reading all FX accumulator instrument versions by instrument_id.");
+}
+
+void fx_accumulator_instrument_repository::remove(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing FX accumulator instrument: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<fx_accumulator_instrument_entity> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing FX accumulator instrument from database.");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_asian_forward_instrument_entity.cpp
+++ b/projects/ores.trading.core/src/repository/fx_asian_forward_instrument_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_asian_forward_instrument_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::trading::repository {
+
+std::ostream& operator<<(std::ostream& s, const fx_asian_forward_instrument_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_asian_forward_instrument_mapper.cpp
+++ b/projects/ores.trading.core/src/repository/fx_asian_forward_instrument_mapper.cpp
@@ -1,0 +1,117 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_asian_forward_instrument_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.trading.api/domain/fx_asian_forward_instrument_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::fx_asian_forward_instrument
+fx_asian_forward_instrument_mapper::map(const fx_asian_forward_instrument_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::fx_asian_forward_instrument r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.fx_index = v.fx_index;
+    r.reference_currency = v.reference_currency.value_or("");
+    r.reference_notional = v.reference_notional;
+    r.settlement_currency = v.settlement_currency.value_or("");
+    r.settlement_notional = v.settlement_notional;
+    r.payment_date = v.payment_date.value_or("");
+    r.long_short = v.long_short.value_or("");
+    r.currency = v.currency.value_or("");
+    r.fixing_amount = v.fixing_amount;
+    r.target_amount = v.target_amount;
+    r.strike = v.strike;
+    r.description = v.description.value_or("");
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+fx_asian_forward_instrument_entity
+fx_asian_forward_instrument_mapper::map(const domain::fx_asian_forward_instrument& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    fx_asian_forward_instrument_entity r;
+    r.instrument_id = boost::uuids::to_string(v.instrument_id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.fx_index = v.fx_index;
+    r.reference_currency = v.reference_currency.empty() ? std::nullopt : std::optional(v.reference_currency);
+    r.reference_notional = v.reference_notional;
+    r.settlement_currency = v.settlement_currency.empty() ? std::nullopt : std::optional(v.settlement_currency);
+    r.settlement_notional = v.settlement_notional;
+    r.payment_date = v.payment_date.empty() ? std::nullopt : std::optional(v.payment_date);
+    r.long_short = v.long_short.empty() ? std::nullopt : std::optional(v.long_short);
+    r.currency = v.currency.empty() ? std::nullopt : std::optional(v.currency);
+    r.fixing_amount = v.fixing_amount;
+    r.target_amount = v.target_amount;
+    r.strike = v.strike;
+    r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::fx_asian_forward_instrument>
+fx_asian_forward_instrument_mapper::map(const std::vector<fx_asian_forward_instrument_entity>& v) {
+    return map_vector<fx_asian_forward_instrument_entity, domain::fx_asian_forward_instrument>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<fx_asian_forward_instrument_entity>
+fx_asian_forward_instrument_mapper::map(const std::vector<domain::fx_asian_forward_instrument>& v) {
+    return map_vector<domain::fx_asian_forward_instrument, fx_asian_forward_instrument_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_asian_forward_instrument_repository.cpp
+++ b/projects/ores.trading.core/src/repository/fx_asian_forward_instrument_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_asian_forward_instrument_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.trading.api/domain/fx_asian_forward_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.trading.core/repository/fx_asian_forward_instrument_entity.hpp"
+#include "ores.trading.core/repository/fx_asian_forward_instrument_mapper.hpp"
+
+namespace ores::trading::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string fx_asian_forward_instrument_repository::sql() {
+    return generate_create_table_sql<fx_asian_forward_instrument_entity>(lg());
+}
+
+void fx_asian_forward_instrument_repository::write(context ctx, const domain::fx_asian_forward_instrument& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX asian forward instrument: " << v.instrument_id;
+    execute_write_query(ctx, fx_asian_forward_instrument_mapper::map(v),
+        lg(), "Writing FX asian forward instrument to database.");
+}
+
+void fx_asian_forward_instrument_repository::write(
+    context ctx, const std::vector<domain::fx_asian_forward_instrument>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX asian forward instruments. Count: " << v.size();
+    execute_write_query(ctx, fx_asian_forward_instrument_mapper::map(v),
+        lg(), "Writing FX asian forward instruments to database.");
+}
+
+std::vector<domain::fx_asian_forward_instrument>
+fx_asian_forward_instrument_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_asian_forward_instrument_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("instrument_id"_c);
+
+    return execute_read_query<fx_asian_forward_instrument_entity, domain::fx_asian_forward_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_asian_forward_instrument_mapper::map(entities); },
+        lg(), "Reading latest FX asian forward instruments");
+}
+
+std::vector<domain::fx_asian_forward_instrument>
+fx_asian_forward_instrument_repository::read_latest(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest FX asian forward instrument. instrument_id: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_asian_forward_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    return execute_read_query<fx_asian_forward_instrument_entity, domain::fx_asian_forward_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_asian_forward_instrument_mapper::map(entities); },
+        lg(), "Reading latest FX asian forward instrument by instrument_id.");
+}
+
+std::vector<domain::fx_asian_forward_instrument>
+fx_asian_forward_instrument_repository::read_all(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all FX asian forward instrument versions. instrument_id: " << instrument_id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_asian_forward_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<fx_asian_forward_instrument_entity, domain::fx_asian_forward_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_asian_forward_instrument_mapper::map(entities); },
+        lg(), "Reading all FX asian forward instrument versions by instrument_id.");
+}
+
+void fx_asian_forward_instrument_repository::remove(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing FX asian forward instrument: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<fx_asian_forward_instrument_entity> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing FX asian forward instrument from database.");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_barrier_option_instrument_entity.cpp
+++ b/projects/ores.trading.core/src/repository/fx_barrier_option_instrument_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_barrier_option_instrument_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::trading::repository {
+
+std::ostream& operator<<(std::ostream& s, const fx_barrier_option_instrument_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_barrier_option_instrument_mapper.cpp
+++ b/projects/ores.trading.core/src/repository/fx_barrier_option_instrument_mapper.cpp
@@ -1,0 +1,117 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_barrier_option_instrument_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.trading.api/domain/fx_barrier_option_instrument_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::fx_barrier_option_instrument
+fx_barrier_option_instrument_mapper::map(const fx_barrier_option_instrument_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::fx_barrier_option_instrument r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.bought_currency = v.bought_currency;
+    r.bought_amount = v.bought_amount;
+    r.sold_currency = v.sold_currency;
+    r.sold_amount = v.sold_amount;
+    r.option_type = v.option_type.value_or("");
+    r.expiry_date = v.expiry_date;
+    r.settlement = v.settlement.value_or("");
+    r.barrier_type = v.barrier_type;
+    r.lower_barrier = v.lower_barrier;
+    r.upper_barrier = v.upper_barrier;
+    r.underlying_code = v.underlying_code.value_or("");
+    r.description = v.description.value_or("");
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+fx_barrier_option_instrument_entity
+fx_barrier_option_instrument_mapper::map(const domain::fx_barrier_option_instrument& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    fx_barrier_option_instrument_entity r;
+    r.instrument_id = boost::uuids::to_string(v.instrument_id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.bought_currency = v.bought_currency;
+    r.bought_amount = v.bought_amount;
+    r.sold_currency = v.sold_currency;
+    r.sold_amount = v.sold_amount;
+    r.option_type = v.option_type.empty() ? std::nullopt : std::optional(v.option_type);
+    r.expiry_date = v.expiry_date;
+    r.settlement = v.settlement.empty() ? std::nullopt : std::optional(v.settlement);
+    r.barrier_type = v.barrier_type;
+    r.lower_barrier = v.lower_barrier;
+    r.upper_barrier = v.upper_barrier;
+    r.underlying_code = v.underlying_code.empty() ? std::nullopt : std::optional(v.underlying_code);
+    r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::fx_barrier_option_instrument>
+fx_barrier_option_instrument_mapper::map(const std::vector<fx_barrier_option_instrument_entity>& v) {
+    return map_vector<fx_barrier_option_instrument_entity, domain::fx_barrier_option_instrument>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<fx_barrier_option_instrument_entity>
+fx_barrier_option_instrument_mapper::map(const std::vector<domain::fx_barrier_option_instrument>& v) {
+    return map_vector<domain::fx_barrier_option_instrument, fx_barrier_option_instrument_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_barrier_option_instrument_repository.cpp
+++ b/projects/ores.trading.core/src/repository/fx_barrier_option_instrument_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_barrier_option_instrument_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.trading.api/domain/fx_barrier_option_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.trading.core/repository/fx_barrier_option_instrument_entity.hpp"
+#include "ores.trading.core/repository/fx_barrier_option_instrument_mapper.hpp"
+
+namespace ores::trading::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string fx_barrier_option_instrument_repository::sql() {
+    return generate_create_table_sql<fx_barrier_option_instrument_entity>(lg());
+}
+
+void fx_barrier_option_instrument_repository::write(context ctx, const domain::fx_barrier_option_instrument& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX barrier option instrument: " << v.instrument_id;
+    execute_write_query(ctx, fx_barrier_option_instrument_mapper::map(v),
+        lg(), "Writing FX barrier option instrument to database.");
+}
+
+void fx_barrier_option_instrument_repository::write(
+    context ctx, const std::vector<domain::fx_barrier_option_instrument>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX barrier option instruments. Count: " << v.size();
+    execute_write_query(ctx, fx_barrier_option_instrument_mapper::map(v),
+        lg(), "Writing FX barrier option instruments to database.");
+}
+
+std::vector<domain::fx_barrier_option_instrument>
+fx_barrier_option_instrument_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_barrier_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("instrument_id"_c);
+
+    return execute_read_query<fx_barrier_option_instrument_entity, domain::fx_barrier_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_barrier_option_instrument_mapper::map(entities); },
+        lg(), "Reading latest FX barrier option instruments");
+}
+
+std::vector<domain::fx_barrier_option_instrument>
+fx_barrier_option_instrument_repository::read_latest(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest FX barrier option instrument. instrument_id: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_barrier_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    return execute_read_query<fx_barrier_option_instrument_entity, domain::fx_barrier_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_barrier_option_instrument_mapper::map(entities); },
+        lg(), "Reading latest FX barrier option instrument by instrument_id.");
+}
+
+std::vector<domain::fx_barrier_option_instrument>
+fx_barrier_option_instrument_repository::read_all(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all FX barrier option instrument versions. instrument_id: " << instrument_id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_barrier_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<fx_barrier_option_instrument_entity, domain::fx_barrier_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_barrier_option_instrument_mapper::map(entities); },
+        lg(), "Reading all FX barrier option instrument versions by instrument_id.");
+}
+
+void fx_barrier_option_instrument_repository::remove(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing FX barrier option instrument: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<fx_barrier_option_instrument_entity> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing FX barrier option instrument from database.");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_digital_option_instrument_entity.cpp
+++ b/projects/ores.trading.core/src/repository/fx_digital_option_instrument_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_digital_option_instrument_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::trading::repository {
+
+std::ostream& operator<<(std::ostream& s, const fx_digital_option_instrument_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_digital_option_instrument_mapper.cpp
+++ b/projects/ores.trading.core/src/repository/fx_digital_option_instrument_mapper.cpp
@@ -1,0 +1,117 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_digital_option_instrument_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.trading.api/domain/fx_digital_option_instrument_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::fx_digital_option_instrument
+fx_digital_option_instrument_mapper::map(const fx_digital_option_instrument_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::fx_digital_option_instrument r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.foreign_currency = v.foreign_currency;
+    r.domestic_currency = v.domestic_currency;
+    r.payoff_currency = v.payoff_currency;
+    r.payoff_amount = v.payoff_amount;
+    r.option_type = v.option_type.value_or("");
+    r.expiry_date = v.expiry_date;
+    r.long_short = v.long_short;
+    r.strike = v.strike;
+    r.barrier_type = v.barrier_type.value_or("");
+    r.lower_barrier = v.lower_barrier;
+    r.upper_barrier = v.upper_barrier;
+    r.description = v.description.value_or("");
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+fx_digital_option_instrument_entity
+fx_digital_option_instrument_mapper::map(const domain::fx_digital_option_instrument& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    fx_digital_option_instrument_entity r;
+    r.instrument_id = boost::uuids::to_string(v.instrument_id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.foreign_currency = v.foreign_currency;
+    r.domestic_currency = v.domestic_currency;
+    r.payoff_currency = v.payoff_currency;
+    r.payoff_amount = v.payoff_amount;
+    r.option_type = v.option_type.empty() ? std::nullopt : std::optional(v.option_type);
+    r.expiry_date = v.expiry_date;
+    r.long_short = v.long_short;
+    r.strike = v.strike;
+    r.barrier_type = v.barrier_type.empty() ? std::nullopt : std::optional(v.barrier_type);
+    r.lower_barrier = v.lower_barrier;
+    r.upper_barrier = v.upper_barrier;
+    r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::fx_digital_option_instrument>
+fx_digital_option_instrument_mapper::map(const std::vector<fx_digital_option_instrument_entity>& v) {
+    return map_vector<fx_digital_option_instrument_entity, domain::fx_digital_option_instrument>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<fx_digital_option_instrument_entity>
+fx_digital_option_instrument_mapper::map(const std::vector<domain::fx_digital_option_instrument>& v) {
+    return map_vector<domain::fx_digital_option_instrument, fx_digital_option_instrument_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_digital_option_instrument_repository.cpp
+++ b/projects/ores.trading.core/src/repository/fx_digital_option_instrument_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_digital_option_instrument_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.trading.api/domain/fx_digital_option_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.trading.core/repository/fx_digital_option_instrument_entity.hpp"
+#include "ores.trading.core/repository/fx_digital_option_instrument_mapper.hpp"
+
+namespace ores::trading::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string fx_digital_option_instrument_repository::sql() {
+    return generate_create_table_sql<fx_digital_option_instrument_entity>(lg());
+}
+
+void fx_digital_option_instrument_repository::write(context ctx, const domain::fx_digital_option_instrument& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX digital option instrument: " << v.instrument_id;
+    execute_write_query(ctx, fx_digital_option_instrument_mapper::map(v),
+        lg(), "Writing FX digital option instrument to database.");
+}
+
+void fx_digital_option_instrument_repository::write(
+    context ctx, const std::vector<domain::fx_digital_option_instrument>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX digital option instruments. Count: " << v.size();
+    execute_write_query(ctx, fx_digital_option_instrument_mapper::map(v),
+        lg(), "Writing FX digital option instruments to database.");
+}
+
+std::vector<domain::fx_digital_option_instrument>
+fx_digital_option_instrument_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_digital_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("instrument_id"_c);
+
+    return execute_read_query<fx_digital_option_instrument_entity, domain::fx_digital_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_digital_option_instrument_mapper::map(entities); },
+        lg(), "Reading latest FX digital option instruments");
+}
+
+std::vector<domain::fx_digital_option_instrument>
+fx_digital_option_instrument_repository::read_latest(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest FX digital option instrument. instrument_id: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_digital_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    return execute_read_query<fx_digital_option_instrument_entity, domain::fx_digital_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_digital_option_instrument_mapper::map(entities); },
+        lg(), "Reading latest FX digital option instrument by instrument_id.");
+}
+
+std::vector<domain::fx_digital_option_instrument>
+fx_digital_option_instrument_repository::read_all(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all FX digital option instrument versions. instrument_id: " << instrument_id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_digital_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<fx_digital_option_instrument_entity, domain::fx_digital_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_digital_option_instrument_mapper::map(entities); },
+        lg(), "Reading all FX digital option instrument versions by instrument_id.");
+}
+
+void fx_digital_option_instrument_repository::remove(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing FX digital option instrument: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<fx_digital_option_instrument_entity> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing FX digital option instrument from database.");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_forward_instrument_entity.cpp
+++ b/projects/ores.trading.core/src/repository/fx_forward_instrument_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_forward_instrument_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::trading::repository {
+
+std::ostream& operator<<(std::ostream& s, const fx_forward_instrument_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_forward_instrument_mapper.cpp
+++ b/projects/ores.trading.core/src/repository/fx_forward_instrument_mapper.cpp
@@ -1,0 +1,107 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_forward_instrument_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.trading.api/domain/fx_forward_instrument_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::fx_forward_instrument
+fx_forward_instrument_mapper::map(const fx_forward_instrument_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::fx_forward_instrument r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.bought_currency = v.bought_currency;
+    r.bought_amount = v.bought_amount;
+    r.sold_currency = v.sold_currency;
+    r.sold_amount = v.sold_amount;
+    r.value_date = v.value_date;
+    r.settlement = v.settlement.value_or("");
+    r.description = v.description.value_or("");
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+fx_forward_instrument_entity
+fx_forward_instrument_mapper::map(const domain::fx_forward_instrument& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    fx_forward_instrument_entity r;
+    r.instrument_id = boost::uuids::to_string(v.instrument_id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.bought_currency = v.bought_currency;
+    r.bought_amount = v.bought_amount;
+    r.sold_currency = v.sold_currency;
+    r.sold_amount = v.sold_amount;
+    r.value_date = v.value_date;
+    r.settlement = v.settlement.empty() ? std::nullopt : std::optional(v.settlement);
+    r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::fx_forward_instrument>
+fx_forward_instrument_mapper::map(const std::vector<fx_forward_instrument_entity>& v) {
+    return map_vector<fx_forward_instrument_entity, domain::fx_forward_instrument>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<fx_forward_instrument_entity>
+fx_forward_instrument_mapper::map(const std::vector<domain::fx_forward_instrument>& v) {
+    return map_vector<domain::fx_forward_instrument, fx_forward_instrument_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_forward_instrument_repository.cpp
+++ b/projects/ores.trading.core/src/repository/fx_forward_instrument_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_forward_instrument_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.trading.api/domain/fx_forward_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.trading.core/repository/fx_forward_instrument_entity.hpp"
+#include "ores.trading.core/repository/fx_forward_instrument_mapper.hpp"
+
+namespace ores::trading::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string fx_forward_instrument_repository::sql() {
+    return generate_create_table_sql<fx_forward_instrument_entity>(lg());
+}
+
+void fx_forward_instrument_repository::write(context ctx, const domain::fx_forward_instrument& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX forward instrument: " << v.instrument_id;
+    execute_write_query(ctx, fx_forward_instrument_mapper::map(v),
+        lg(), "Writing FX forward instrument to database.");
+}
+
+void fx_forward_instrument_repository::write(
+    context ctx, const std::vector<domain::fx_forward_instrument>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX forward instruments. Count: " << v.size();
+    execute_write_query(ctx, fx_forward_instrument_mapper::map(v),
+        lg(), "Writing FX forward instruments to database.");
+}
+
+std::vector<domain::fx_forward_instrument>
+fx_forward_instrument_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_forward_instrument_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("instrument_id"_c);
+
+    return execute_read_query<fx_forward_instrument_entity, domain::fx_forward_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_forward_instrument_mapper::map(entities); },
+        lg(), "Reading latest FX forward instruments");
+}
+
+std::vector<domain::fx_forward_instrument>
+fx_forward_instrument_repository::read_latest(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest FX forward instrument. instrument_id: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_forward_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    return execute_read_query<fx_forward_instrument_entity, domain::fx_forward_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_forward_instrument_mapper::map(entities); },
+        lg(), "Reading latest FX forward instrument by instrument_id.");
+}
+
+std::vector<domain::fx_forward_instrument>
+fx_forward_instrument_repository::read_all(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all FX forward instrument versions. instrument_id: " << instrument_id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_forward_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<fx_forward_instrument_entity, domain::fx_forward_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_forward_instrument_mapper::map(entities); },
+        lg(), "Reading all FX forward instrument versions by instrument_id.");
+}
+
+void fx_forward_instrument_repository::remove(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing FX forward instrument: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<fx_forward_instrument_entity> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing FX forward instrument from database.");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_vanilla_option_instrument_entity.cpp
+++ b/projects/ores.trading.core/src/repository/fx_vanilla_option_instrument_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_vanilla_option_instrument_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::trading::repository {
+
+std::ostream& operator<<(std::ostream& s, const fx_vanilla_option_instrument_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_vanilla_option_instrument_mapper.cpp
+++ b/projects/ores.trading.core/src/repository/fx_vanilla_option_instrument_mapper.cpp
@@ -1,0 +1,111 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_vanilla_option_instrument_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.trading.api/domain/fx_vanilla_option_instrument_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::fx_vanilla_option_instrument
+fx_vanilla_option_instrument_mapper::map(const fx_vanilla_option_instrument_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::fx_vanilla_option_instrument r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.bought_currency = v.bought_currency;
+    r.bought_amount = v.bought_amount;
+    r.sold_currency = v.sold_currency;
+    r.sold_amount = v.sold_amount;
+    r.option_type = v.option_type;
+    r.expiry_date = v.expiry_date;
+    r.exercise_style = v.exercise_style;
+    r.settlement = v.settlement.value_or("");
+    r.description = v.description.value_or("");
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+fx_vanilla_option_instrument_entity
+fx_vanilla_option_instrument_mapper::map(const domain::fx_vanilla_option_instrument& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    fx_vanilla_option_instrument_entity r;
+    r.instrument_id = boost::uuids::to_string(v.instrument_id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.bought_currency = v.bought_currency;
+    r.bought_amount = v.bought_amount;
+    r.sold_currency = v.sold_currency;
+    r.sold_amount = v.sold_amount;
+    r.option_type = v.option_type;
+    r.expiry_date = v.expiry_date;
+    r.exercise_style = v.exercise_style;
+    r.settlement = v.settlement.empty() ? std::nullopt : std::optional(v.settlement);
+    r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::fx_vanilla_option_instrument>
+fx_vanilla_option_instrument_mapper::map(const std::vector<fx_vanilla_option_instrument_entity>& v) {
+    return map_vector<fx_vanilla_option_instrument_entity, domain::fx_vanilla_option_instrument>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<fx_vanilla_option_instrument_entity>
+fx_vanilla_option_instrument_mapper::map(const std::vector<domain::fx_vanilla_option_instrument>& v) {
+    return map_vector<domain::fx_vanilla_option_instrument, fx_vanilla_option_instrument_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_vanilla_option_instrument_repository.cpp
+++ b/projects/ores.trading.core/src/repository/fx_vanilla_option_instrument_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_vanilla_option_instrument_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.trading.api/domain/fx_vanilla_option_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.trading.core/repository/fx_vanilla_option_instrument_entity.hpp"
+#include "ores.trading.core/repository/fx_vanilla_option_instrument_mapper.hpp"
+
+namespace ores::trading::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string fx_vanilla_option_instrument_repository::sql() {
+    return generate_create_table_sql<fx_vanilla_option_instrument_entity>(lg());
+}
+
+void fx_vanilla_option_instrument_repository::write(context ctx, const domain::fx_vanilla_option_instrument& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX vanilla option instrument: " << v.instrument_id;
+    execute_write_query(ctx, fx_vanilla_option_instrument_mapper::map(v),
+        lg(), "Writing FX vanilla option instrument to database.");
+}
+
+void fx_vanilla_option_instrument_repository::write(
+    context ctx, const std::vector<domain::fx_vanilla_option_instrument>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX vanilla option instruments. Count: " << v.size();
+    execute_write_query(ctx, fx_vanilla_option_instrument_mapper::map(v),
+        lg(), "Writing FX vanilla option instruments to database.");
+}
+
+std::vector<domain::fx_vanilla_option_instrument>
+fx_vanilla_option_instrument_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_vanilla_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("instrument_id"_c);
+
+    return execute_read_query<fx_vanilla_option_instrument_entity, domain::fx_vanilla_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_vanilla_option_instrument_mapper::map(entities); },
+        lg(), "Reading latest FX vanilla option instruments");
+}
+
+std::vector<domain::fx_vanilla_option_instrument>
+fx_vanilla_option_instrument_repository::read_latest(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest FX vanilla option instrument. instrument_id: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_vanilla_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    return execute_read_query<fx_vanilla_option_instrument_entity, domain::fx_vanilla_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_vanilla_option_instrument_mapper::map(entities); },
+        lg(), "Reading latest FX vanilla option instrument by instrument_id.");
+}
+
+std::vector<domain::fx_vanilla_option_instrument>
+fx_vanilla_option_instrument_repository::read_all(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all FX vanilla option instrument versions. instrument_id: " << instrument_id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_vanilla_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<fx_vanilla_option_instrument_entity, domain::fx_vanilla_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_vanilla_option_instrument_mapper::map(entities); },
+        lg(), "Reading all FX vanilla option instrument versions by instrument_id.");
+}
+
+void fx_vanilla_option_instrument_repository::remove(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing FX vanilla option instrument: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<fx_vanilla_option_instrument_entity> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing FX vanilla option instrument from database.");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_variance_swap_instrument_entity.cpp
+++ b/projects/ores.trading.core/src/repository/fx_variance_swap_instrument_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_variance_swap_instrument_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::trading::repository {
+
+std::ostream& operator<<(std::ostream& s, const fx_variance_swap_instrument_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_variance_swap_instrument_mapper.cpp
+++ b/projects/ores.trading.core/src/repository/fx_variance_swap_instrument_mapper.cpp
@@ -1,0 +1,111 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_variance_swap_instrument_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.trading.api/domain/fx_variance_swap_instrument_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::fx_variance_swap_instrument
+fx_variance_swap_instrument_mapper::map(const fx_variance_swap_instrument_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::fx_variance_swap_instrument r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.start_date = v.start_date;
+    r.end_date = v.end_date;
+    r.currency = v.currency;
+    r.underlying_code = v.underlying_code;
+    r.long_short = v.long_short;
+    r.strike = v.strike;
+    r.notional = v.notional;
+    r.moment_type = v.moment_type;
+    r.description = v.description.value_or("");
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+fx_variance_swap_instrument_entity
+fx_variance_swap_instrument_mapper::map(const domain::fx_variance_swap_instrument& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    fx_variance_swap_instrument_entity r;
+    r.instrument_id = boost::uuids::to_string(v.instrument_id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.start_date = v.start_date;
+    r.end_date = v.end_date;
+    r.currency = v.currency;
+    r.underlying_code = v.underlying_code;
+    r.long_short = v.long_short;
+    r.strike = v.strike;
+    r.notional = v.notional;
+    r.moment_type = v.moment_type;
+    r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::fx_variance_swap_instrument>
+fx_variance_swap_instrument_mapper::map(const std::vector<fx_variance_swap_instrument_entity>& v) {
+    return map_vector<fx_variance_swap_instrument_entity, domain::fx_variance_swap_instrument>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<fx_variance_swap_instrument_entity>
+fx_variance_swap_instrument_mapper::map(const std::vector<domain::fx_variance_swap_instrument>& v) {
+    return map_vector<domain::fx_variance_swap_instrument, fx_variance_swap_instrument_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/fx_variance_swap_instrument_repository.cpp
+++ b/projects/ores.trading.core/src/repository/fx_variance_swap_instrument_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_variance_swap_instrument_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.trading.api/domain/fx_variance_swap_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.trading.core/repository/fx_variance_swap_instrument_entity.hpp"
+#include "ores.trading.core/repository/fx_variance_swap_instrument_mapper.hpp"
+
+namespace ores::trading::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string fx_variance_swap_instrument_repository::sql() {
+    return generate_create_table_sql<fx_variance_swap_instrument_entity>(lg());
+}
+
+void fx_variance_swap_instrument_repository::write(context ctx, const domain::fx_variance_swap_instrument& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX variance swap instrument: " << v.instrument_id;
+    execute_write_query(ctx, fx_variance_swap_instrument_mapper::map(v),
+        lg(), "Writing FX variance swap instrument to database.");
+}
+
+void fx_variance_swap_instrument_repository::write(
+    context ctx, const std::vector<domain::fx_variance_swap_instrument>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX variance swap instruments. Count: " << v.size();
+    execute_write_query(ctx, fx_variance_swap_instrument_mapper::map(v),
+        lg(), "Writing FX variance swap instruments to database.");
+}
+
+std::vector<domain::fx_variance_swap_instrument>
+fx_variance_swap_instrument_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_variance_swap_instrument_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("instrument_id"_c);
+
+    return execute_read_query<fx_variance_swap_instrument_entity, domain::fx_variance_swap_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_variance_swap_instrument_mapper::map(entities); },
+        lg(), "Reading latest FX variance swap instruments");
+}
+
+std::vector<domain::fx_variance_swap_instrument>
+fx_variance_swap_instrument_repository::read_latest(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest FX variance swap instrument. instrument_id: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_variance_swap_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    return execute_read_query<fx_variance_swap_instrument_entity, domain::fx_variance_swap_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_variance_swap_instrument_mapper::map(entities); },
+        lg(), "Reading latest FX variance swap instrument by instrument_id.");
+}
+
+std::vector<domain::fx_variance_swap_instrument>
+fx_variance_swap_instrument_repository::read_all(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all FX variance swap instrument versions. instrument_id: " << instrument_id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_variance_swap_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<fx_variance_swap_instrument_entity, domain::fx_variance_swap_instrument>(
+        ctx, query,
+        [](const auto& entities) { return fx_variance_swap_instrument_mapper::map(entities); },
+        lg(), "Reading all FX variance swap instrument versions by instrument_id.");
+}
+
+void fx_variance_swap_instrument_repository::remove(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing FX variance swap instrument: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<fx_variance_swap_instrument_entity> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing FX variance swap instrument from database.");
+}
+
+}

--- a/projects/ores.trading.core/src/service/fx_accumulator_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/fx_accumulator_instrument_service.cpp
@@ -1,0 +1,48 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/service/fx_accumulator_instrument_service.hpp"
+
+#include <stdexcept>
+#include "ores.service/messaging/handler_helpers.hpp"
+
+using ores::service::messaging::stamp;
+
+namespace ores::trading::service {
+
+using namespace ores::logging;
+
+fx_accumulator_instrument_service::fx_accumulator_instrument_service(
+    context ctx) : ctx_(std::move(ctx)) {}
+
+void fx_accumulator_instrument_service::save_fx_accumulator_instrument(
+    const domain::fx_accumulator_instrument& v) {
+    if (v.instrument_id.is_nil())
+        throw std::invalid_argument(
+            "FX accumulator instrument id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving fx_accumulator_instrument: "
+                               << v.instrument_id;
+    auto t = v;
+    stamp(t, ctx_);
+    repo_.write(ctx_, t);
+    BOOST_LOG_SEV(lg(), info) << "Saved fx_accumulator_instrument: "
+                              << t.instrument_id;
+}
+
+}

--- a/projects/ores.trading.core/src/service/fx_asian_forward_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/fx_asian_forward_instrument_service.cpp
@@ -1,0 +1,48 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/service/fx_asian_forward_instrument_service.hpp"
+
+#include <stdexcept>
+#include "ores.service/messaging/handler_helpers.hpp"
+
+using ores::service::messaging::stamp;
+
+namespace ores::trading::service {
+
+using namespace ores::logging;
+
+fx_asian_forward_instrument_service::fx_asian_forward_instrument_service(
+    context ctx) : ctx_(std::move(ctx)) {}
+
+void fx_asian_forward_instrument_service::save_fx_asian_forward_instrument(
+    const domain::fx_asian_forward_instrument& v) {
+    if (v.instrument_id.is_nil())
+        throw std::invalid_argument(
+            "FX Asian forward instrument id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving fx_asian_forward_instrument: "
+                               << v.instrument_id;
+    auto t = v;
+    stamp(t, ctx_);
+    repo_.write(ctx_, t);
+    BOOST_LOG_SEV(lg(), info) << "Saved fx_asian_forward_instrument: "
+                              << t.instrument_id;
+}
+
+}

--- a/projects/ores.trading.core/src/service/fx_barrier_option_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/fx_barrier_option_instrument_service.cpp
@@ -1,0 +1,48 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/service/fx_barrier_option_instrument_service.hpp"
+
+#include <stdexcept>
+#include "ores.service/messaging/handler_helpers.hpp"
+
+using ores::service::messaging::stamp;
+
+namespace ores::trading::service {
+
+using namespace ores::logging;
+
+fx_barrier_option_instrument_service::fx_barrier_option_instrument_service(
+    context ctx) : ctx_(std::move(ctx)) {}
+
+void fx_barrier_option_instrument_service::save_fx_barrier_option_instrument(
+    const domain::fx_barrier_option_instrument& v) {
+    if (v.instrument_id.is_nil())
+        throw std::invalid_argument(
+            "FX barrier option instrument id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving fx_barrier_option_instrument: "
+                               << v.instrument_id;
+    auto t = v;
+    stamp(t, ctx_);
+    repo_.write(ctx_, t);
+    BOOST_LOG_SEV(lg(), info) << "Saved fx_barrier_option_instrument: "
+                              << t.instrument_id;
+}
+
+}

--- a/projects/ores.trading.core/src/service/fx_digital_option_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/fx_digital_option_instrument_service.cpp
@@ -1,0 +1,48 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/service/fx_digital_option_instrument_service.hpp"
+
+#include <stdexcept>
+#include "ores.service/messaging/handler_helpers.hpp"
+
+using ores::service::messaging::stamp;
+
+namespace ores::trading::service {
+
+using namespace ores::logging;
+
+fx_digital_option_instrument_service::fx_digital_option_instrument_service(
+    context ctx) : ctx_(std::move(ctx)) {}
+
+void fx_digital_option_instrument_service::save_fx_digital_option_instrument(
+    const domain::fx_digital_option_instrument& v) {
+    if (v.instrument_id.is_nil())
+        throw std::invalid_argument(
+            "FX digital option instrument id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving fx_digital_option_instrument: "
+                               << v.instrument_id;
+    auto t = v;
+    stamp(t, ctx_);
+    repo_.write(ctx_, t);
+    BOOST_LOG_SEV(lg(), info) << "Saved fx_digital_option_instrument: "
+                              << t.instrument_id;
+}
+
+}

--- a/projects/ores.trading.core/src/service/fx_forward_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/fx_forward_instrument_service.cpp
@@ -1,0 +1,47 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/service/fx_forward_instrument_service.hpp"
+
+#include <stdexcept>
+#include "ores.service/messaging/handler_helpers.hpp"
+
+using ores::service::messaging::stamp;
+
+namespace ores::trading::service {
+
+using namespace ores::logging;
+
+fx_forward_instrument_service::fx_forward_instrument_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+void fx_forward_instrument_service::save_fx_forward_instrument(
+    const domain::fx_forward_instrument& v) {
+    if (v.instrument_id.is_nil())
+        throw std::invalid_argument("FX forward instrument id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving fx_forward_instrument: "
+                               << v.instrument_id;
+    auto t = v;
+    stamp(t, ctx_);
+    repo_.write(ctx_, t);
+    BOOST_LOG_SEV(lg(), info) << "Saved fx_forward_instrument: "
+                              << t.instrument_id;
+}
+
+}

--- a/projects/ores.trading.core/src/service/fx_vanilla_option_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/fx_vanilla_option_instrument_service.cpp
@@ -1,0 +1,48 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/service/fx_vanilla_option_instrument_service.hpp"
+
+#include <stdexcept>
+#include "ores.service/messaging/handler_helpers.hpp"
+
+using ores::service::messaging::stamp;
+
+namespace ores::trading::service {
+
+using namespace ores::logging;
+
+fx_vanilla_option_instrument_service::fx_vanilla_option_instrument_service(
+    context ctx) : ctx_(std::move(ctx)) {}
+
+void fx_vanilla_option_instrument_service::save_fx_vanilla_option_instrument(
+    const domain::fx_vanilla_option_instrument& v) {
+    if (v.instrument_id.is_nil())
+        throw std::invalid_argument(
+            "FX vanilla option instrument id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving fx_vanilla_option_instrument: "
+                               << v.instrument_id;
+    auto t = v;
+    stamp(t, ctx_);
+    repo_.write(ctx_, t);
+    BOOST_LOG_SEV(lg(), info) << "Saved fx_vanilla_option_instrument: "
+                              << t.instrument_id;
+}
+
+}

--- a/projects/ores.trading.core/src/service/fx_variance_swap_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/fx_variance_swap_instrument_service.cpp
@@ -1,0 +1,48 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/service/fx_variance_swap_instrument_service.hpp"
+
+#include <stdexcept>
+#include "ores.service/messaging/handler_helpers.hpp"
+
+using ores::service::messaging::stamp;
+
+namespace ores::trading::service {
+
+using namespace ores::logging;
+
+fx_variance_swap_instrument_service::fx_variance_swap_instrument_service(
+    context ctx) : ctx_(std::move(ctx)) {}
+
+void fx_variance_swap_instrument_service::save_fx_variance_swap_instrument(
+    const domain::fx_variance_swap_instrument& v) {
+    if (v.instrument_id.is_nil())
+        throw std::invalid_argument(
+            "FX variance swap instrument id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving fx_variance_swap_instrument: "
+                               << v.instrument_id;
+    auto t = v;
+    stamp(t, ctx_);
+    repo_.write(ctx_, t);
+    BOOST_LOG_SEV(lg(), info) << "Saved fx_variance_swap_instrument: "
+                              << t.instrument_id;
+}
+
+}

--- a/projects/ores.trading.core/tests/repository_fx_accumulator_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_fx_accumulator_instrument_repository_tests.cpp
@@ -1,0 +1,130 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_accumulator_instrument_repository.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/fx_accumulator_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.testing/database_helper.hpp"
+
+namespace {
+
+const std::string_view test_suite("ores.trading.core.repository.fx_accumulator.tests");
+const std::string tags("[repository][fx][fx_accumulator]");
+
+using ores::testing::database_helper;
+using ores::trading::repository::fx_accumulator_instrument_repository;
+using ores::trading::domain::fx_accumulator_instrument;
+using namespace ores::logging;
+
+/*
+ * Test data derived from:
+ *   external/ore/examples/Products/Example_Trades/Exotic_FxAccumulator.xml
+ * via fx_instrument_mapper::forward_fx_accumulator.
+ * See tests/test_data/fx_accumulator_instrument.json for the full mapping snapshot.
+ * Notes:
+ *   - long_short is hardcoded to Long by the mapper
+ *   - knock_out_barrier is extracted from the first UpAndOut barrier (level 126)
+ *   - FixingFloor barrier and range bounds are not captured
+ */
+fx_accumulator_instrument make_instrument(database_helper& h) {
+    fx_accumulator_instrument r;
+    r.instrument_id      = boost::uuids::random_generator()();
+    r.tenant_id          = h.tenant_id();
+    r.trade_type_code    = "FxAccumulator";
+    r.currency           = "JPY";
+    r.fixing_amount      = 350000.0;
+    r.strike             = 122.0;
+    r.underlying_code    = "TR20H-EUR-JPY";
+    r.long_short         = "Long";
+    r.start_date         = "2026-01-12";
+    r.knock_out_barrier  = 126.0;
+    r.modified_by        = h.db_user();
+    r.performed_by       = "ores";
+    r.change_reason_code = "system.external_data_import";
+    r.change_commentary  = "Imported from ORE XML";
+    return r;
+}
+
+} // namespace
+
+TEST_CASE("fx_accumulator_instrument_write_and_read_latest", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    BOOST_LOG_SEV(lg, debug) << "Writing FX accumulator instrument: " << instr;
+
+    fx_accumulator_instrument_repository repo;
+    CHECK_NOTHROW(repo.write(ctx, instr));
+
+    const auto read = repo.read_latest(ctx, id_str);
+    REQUIRE(read.size() == 1);
+    CHECK(read[0].trade_type_code == "FxAccumulator");
+    CHECK(read[0].currency == "JPY");
+    CHECK(read[0].fixing_amount == 350000.0);
+    CHECK(read[0].strike == 122.0);
+    CHECK(read[0].underlying_code == "TR20H-EUR-JPY");
+    CHECK(read[0].long_short == "Long");
+    CHECK(read[0].start_date == "2026-01-12");
+    REQUIRE(read[0].knock_out_barrier.has_value());
+    CHECK(*read[0].knock_out_barrier == 126.0);
+    BOOST_LOG_SEV(lg, debug) << "Read FX accumulator instrument: " << read[0];
+}
+
+TEST_CASE("fx_accumulator_instrument_read_nonexistent", tags) {
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    fx_accumulator_instrument_repository repo;
+    const std::string nonexistent = "00000000-0000-0000-0000-000000000001";
+    const auto read = repo.read_latest(ctx, nonexistent);
+    CHECK(read.empty());
+}
+
+TEST_CASE("fx_accumulator_instrument_remove", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+
+    fx_accumulator_instrument_repository repo;
+    repo.write(ctx, instr);
+
+    const auto before = repo.read_latest(ctx, id_str);
+    REQUIRE(!before.empty());
+
+    CHECK_NOTHROW(repo.remove(ctx, id_str));
+
+    const auto after = repo.read_latest(ctx, id_str);
+    BOOST_LOG_SEV(lg, debug) << "After remove count: " << after.size();
+    CHECK(after.empty());
+}

--- a/projects/ores.trading.core/tests/repository_fx_asian_forward_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_fx_asian_forward_instrument_repository_tests.cpp
@@ -1,0 +1,130 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_asian_forward_instrument_repository.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/fx_asian_forward_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.testing/database_helper.hpp"
+
+namespace {
+
+const std::string_view test_suite("ores.trading.core.repository.fx_asian_forward.tests");
+const std::string tags("[repository][fx][fx_asian_forward]");
+
+using ores::testing::database_helper;
+using ores::trading::repository::fx_asian_forward_instrument_repository;
+using ores::trading::domain::fx_asian_forward_instrument;
+using namespace ores::logging;
+
+/*
+ * Test data derived from:
+ *   external/ore/examples/Products/Example_Trades/FX_Average_Forward.xml
+ * via fx_instrument_mapper::forward_fx_average_forward.
+ * See tests/test_data/fx_asian_forward_instrument.json for the full mapping snapshot.
+ * Notes:
+ *   - long_short is hardcoded to Long by the mapper
+ *   - currency, fixing_amount, target_amount, strike are FxTaRF-specific — not populated
+ */
+fx_asian_forward_instrument make_instrument(database_helper& h) {
+    fx_asian_forward_instrument r;
+    r.instrument_id       = boost::uuids::random_generator()();
+    r.tenant_id           = h.tenant_id();
+    r.trade_type_code     = "FxAverageForward";
+    r.fx_index            = "FX-TR20H-EUR-USD";
+    r.reference_currency  = "EUR";
+    r.reference_notional  = 8614.0;
+    r.settlement_currency = "USD";
+    r.settlement_notional = 10000.0;
+    r.payment_date        = "2025-09-30";
+    r.long_short          = "Long";
+    r.modified_by         = h.db_user();
+    r.performed_by        = "ores";
+    r.change_reason_code  = "system.external_data_import";
+    r.change_commentary   = "Imported from ORE XML";
+    return r;
+}
+
+} // namespace
+
+TEST_CASE("fx_asian_forward_instrument_write_and_read_latest", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    BOOST_LOG_SEV(lg, debug) << "Writing FX asian forward instrument: " << instr;
+
+    fx_asian_forward_instrument_repository repo;
+    CHECK_NOTHROW(repo.write(ctx, instr));
+
+    const auto read = repo.read_latest(ctx, id_str);
+    REQUIRE(read.size() == 1);
+    CHECK(read[0].trade_type_code == "FxAverageForward");
+    CHECK(read[0].fx_index == "FX-TR20H-EUR-USD");
+    CHECK(read[0].reference_currency == "EUR");
+    REQUIRE(read[0].reference_notional.has_value());
+    CHECK(*read[0].reference_notional == 8614.0);
+    CHECK(read[0].settlement_currency == "USD");
+    REQUIRE(read[0].settlement_notional.has_value());
+    CHECK(*read[0].settlement_notional == 10000.0);
+    CHECK(read[0].payment_date == "2025-09-30");
+    CHECK(read[0].long_short == "Long");
+    BOOST_LOG_SEV(lg, debug) << "Read FX asian forward instrument: " << read[0];
+}
+
+TEST_CASE("fx_asian_forward_instrument_read_nonexistent", tags) {
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    fx_asian_forward_instrument_repository repo;
+    const std::string nonexistent = "00000000-0000-0000-0000-000000000001";
+    const auto read = repo.read_latest(ctx, nonexistent);
+    CHECK(read.empty());
+}
+
+TEST_CASE("fx_asian_forward_instrument_remove", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+
+    fx_asian_forward_instrument_repository repo;
+    repo.write(ctx, instr);
+
+    const auto before = repo.read_latest(ctx, id_str);
+    REQUIRE(!before.empty());
+
+    CHECK_NOTHROW(repo.remove(ctx, id_str));
+
+    const auto after = repo.read_latest(ctx, id_str);
+    BOOST_LOG_SEV(lg, debug) << "After remove count: " << after.size();
+    CHECK(after.empty());
+}

--- a/projects/ores.trading.core/tests/repository_fx_barrier_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_fx_barrier_option_instrument_repository_tests.cpp
@@ -1,0 +1,130 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_barrier_option_instrument_repository.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/fx_barrier_option_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.testing/database_helper.hpp"
+
+namespace {
+
+const std::string_view test_suite("ores.trading.core.repository.fx_barrier_option.tests");
+const std::string tags("[repository][fx][fx_barrier_option]");
+
+using ores::testing::database_helper;
+using ores::trading::repository::fx_barrier_option_instrument_repository;
+using ores::trading::domain::fx_barrier_option_instrument;
+using namespace ores::logging;
+
+/*
+ * Test data derived from:
+ *   external/ore/examples/Products/Example_Trades/FX_Barrier_Option.xml
+ * via fx_instrument_mapper::forward_fx_barrier_option.
+ * See tests/test_data/fx_barrier_option_instrument.json for the full mapping snapshot.
+ * Note: settlement and underlying_code are empty — not extracted by the mapper
+ * for FxBarrierOption.
+ */
+fx_barrier_option_instrument make_instrument(database_helper& h) {
+    fx_barrier_option_instrument r;
+    r.instrument_id      = boost::uuids::random_generator()();
+    r.tenant_id          = h.tenant_id();
+    r.trade_type_code    = "FxBarrierOption";
+    r.bought_currency    = "EUR";
+    r.bought_amount      = 1000000.0;
+    r.sold_currency      = "USD";
+    r.sold_amount        = 1100000.0;
+    r.option_type        = "Call";
+    r.expiry_date        = "2033-02-20";
+    r.barrier_type       = "UpAndIn";
+    r.lower_barrier      = 1.2;
+    r.modified_by        = h.db_user();
+    r.performed_by       = "ores";
+    r.change_reason_code = "system.external_data_import";
+    r.change_commentary  = "Imported from ORE XML";
+    return r;
+}
+
+} // namespace
+
+TEST_CASE("fx_barrier_option_instrument_write_and_read_latest", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    BOOST_LOG_SEV(lg, debug) << "Writing FX barrier option instrument: " << instr;
+
+    fx_barrier_option_instrument_repository repo;
+    CHECK_NOTHROW(repo.write(ctx, instr));
+
+    const auto read = repo.read_latest(ctx, id_str);
+    REQUIRE(read.size() == 1);
+    CHECK(read[0].trade_type_code == "FxBarrierOption");
+    CHECK(read[0].bought_currency == "EUR");
+    CHECK(read[0].bought_amount == 1000000.0);
+    CHECK(read[0].sold_currency == "USD");
+    CHECK(read[0].sold_amount == 1100000.0);
+    CHECK(read[0].option_type == "Call");
+    CHECK(read[0].expiry_date == "2033-02-20");
+    CHECK(read[0].barrier_type == "UpAndIn");
+    CHECK(read[0].lower_barrier == 1.2);
+    CHECK(!read[0].upper_barrier.has_value());
+    BOOST_LOG_SEV(lg, debug) << "Read FX barrier option instrument: " << read[0];
+}
+
+TEST_CASE("fx_barrier_option_instrument_read_nonexistent", tags) {
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    fx_barrier_option_instrument_repository repo;
+    const std::string nonexistent = "00000000-0000-0000-0000-000000000001";
+    const auto read = repo.read_latest(ctx, nonexistent);
+    CHECK(read.empty());
+}
+
+TEST_CASE("fx_barrier_option_instrument_remove", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+
+    fx_barrier_option_instrument_repository repo;
+    repo.write(ctx, instr);
+
+    const auto before = repo.read_latest(ctx, id_str);
+    REQUIRE(!before.empty());
+
+    CHECK_NOTHROW(repo.remove(ctx, id_str));
+
+    const auto after = repo.read_latest(ctx, id_str);
+    BOOST_LOG_SEV(lg, debug) << "After remove count: " << after.size();
+    CHECK(after.empty());
+}

--- a/projects/ores.trading.core/tests/repository_fx_digital_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_fx_digital_option_instrument_repository_tests.cpp
@@ -1,0 +1,134 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_digital_option_instrument_repository.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/fx_digital_option_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.testing/database_helper.hpp"
+
+namespace {
+
+const std::string_view test_suite("ores.trading.core.repository.fx_digital_option.tests");
+const std::string tags("[repository][fx][fx_digital_option]");
+
+using ores::testing::database_helper;
+using ores::trading::repository::fx_digital_option_instrument_repository;
+using ores::trading::domain::fx_digital_option_instrument;
+using namespace ores::logging;
+
+/*
+ * Test data derived from:
+ *   external/ore/examples/Products/Example_Trades/FX_Digital_Option.xml
+ * via fx_instrument_mapper::forward_fx_digital_option.
+ * See tests/test_data/fx_digital_option_instrument.json for the full mapping snapshot.
+ * Notes:
+ *   - payoff_currency defaults to foreign_currency (EUR)
+ *   - long_short is hardcoded to Long by the mapper
+ *   - barrier_type, lower_barrier, upper_barrier are absent for plain FxDigitalOption
+ */
+fx_digital_option_instrument make_instrument(database_helper& h) {
+    fx_digital_option_instrument r;
+    r.instrument_id      = boost::uuids::random_generator()();
+    r.tenant_id          = h.tenant_id();
+    r.trade_type_code    = "FxDigitalOption";
+    r.foreign_currency   = "EUR";
+    r.domestic_currency  = "USD";
+    r.payoff_currency    = "EUR";
+    r.payoff_amount      = 100.0;
+    r.option_type        = "Call";
+    r.expiry_date        = "2033-02-20";
+    r.long_short         = "Long";
+    r.strike             = 1.1;
+    r.modified_by        = h.db_user();
+    r.performed_by       = "ores";
+    r.change_reason_code = "system.external_data_import";
+    r.change_commentary  = "Imported from ORE XML";
+    return r;
+}
+
+} // namespace
+
+TEST_CASE("fx_digital_option_instrument_write_and_read_latest", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    BOOST_LOG_SEV(lg, debug) << "Writing FX digital option instrument: " << instr;
+
+    fx_digital_option_instrument_repository repo;
+    CHECK_NOTHROW(repo.write(ctx, instr));
+
+    const auto read = repo.read_latest(ctx, id_str);
+    REQUIRE(read.size() == 1);
+    CHECK(read[0].trade_type_code == "FxDigitalOption");
+    CHECK(read[0].foreign_currency == "EUR");
+    CHECK(read[0].domestic_currency == "USD");
+    CHECK(read[0].payoff_currency == "EUR");
+    CHECK(read[0].payoff_amount == 100.0);
+    CHECK(read[0].option_type == "Call");
+    CHECK(read[0].expiry_date == "2033-02-20");
+    CHECK(read[0].long_short == "Long");
+    REQUIRE(read[0].strike.has_value());
+    CHECK(*read[0].strike == 1.1);
+    CHECK(!read[0].lower_barrier.has_value());
+    CHECK(!read[0].upper_barrier.has_value());
+    BOOST_LOG_SEV(lg, debug) << "Read FX digital option instrument: " << read[0];
+}
+
+TEST_CASE("fx_digital_option_instrument_read_nonexistent", tags) {
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    fx_digital_option_instrument_repository repo;
+    const std::string nonexistent = "00000000-0000-0000-0000-000000000001";
+    const auto read = repo.read_latest(ctx, nonexistent);
+    CHECK(read.empty());
+}
+
+TEST_CASE("fx_digital_option_instrument_remove", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+
+    fx_digital_option_instrument_repository repo;
+    repo.write(ctx, instr);
+
+    const auto before = repo.read_latest(ctx, id_str);
+    REQUIRE(!before.empty());
+
+    CHECK_NOTHROW(repo.remove(ctx, id_str));
+
+    const auto after = repo.read_latest(ctx, id_str);
+    BOOST_LOG_SEV(lg, debug) << "After remove count: " << after.size();
+    CHECK(after.empty());
+}

--- a/projects/ores.trading.core/tests/repository_fx_forward_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_fx_forward_instrument_repository_tests.cpp
@@ -1,0 +1,123 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_forward_instrument_repository.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/fx_forward_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.testing/database_helper.hpp"
+
+namespace {
+
+const std::string_view test_suite("ores.trading.core.repository.fx_forward.tests");
+const std::string tags("[repository][fx][fx_forward]");
+
+using ores::testing::database_helper;
+using ores::trading::repository::fx_forward_instrument_repository;
+using ores::trading::domain::fx_forward_instrument;
+using namespace ores::logging;
+
+/*
+ * Test data derived from:
+ *   external/ore/examples/Products/Example_Trades/FX_Forward.xml
+ * via fx_instrument_mapper::forward_fx_forward.
+ * See tests/test_data/fx_forward_instrument.json for the full mapping snapshot.
+ */
+fx_forward_instrument make_instrument(database_helper& h) {
+    fx_forward_instrument r;
+    r.instrument_id      = boost::uuids::random_generator()();
+    r.tenant_id          = h.tenant_id();
+    r.trade_type_code    = "FxForward";
+    r.bought_currency    = "EUR";
+    r.bought_amount      = 1000000.0;
+    r.sold_currency      = "USD";
+    r.sold_amount        = 1100000.0;
+    r.value_date         = "2033-02-20";
+    r.settlement         = "Cash";
+    r.modified_by        = h.db_user();
+    r.performed_by       = "ores";
+    r.change_reason_code = "system.external_data_import";
+    r.change_commentary  = "Imported from ORE XML";
+    return r;
+}
+
+} // namespace
+
+TEST_CASE("fx_forward_instrument_write_and_read_latest", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    BOOST_LOG_SEV(lg, debug) << "Writing FX forward instrument: " << instr;
+
+    fx_forward_instrument_repository repo;
+    CHECK_NOTHROW(repo.write(ctx, instr));
+
+    const auto read = repo.read_latest(ctx, id_str);
+    REQUIRE(read.size() == 1);
+    CHECK(read[0].trade_type_code == "FxForward");
+    CHECK(read[0].bought_currency == "EUR");
+    CHECK(read[0].bought_amount == 1000000.0);
+    CHECK(read[0].sold_currency == "USD");
+    CHECK(read[0].sold_amount == 1100000.0);
+    CHECK(read[0].value_date == "2033-02-20");
+    CHECK(read[0].settlement == "Cash");
+    BOOST_LOG_SEV(lg, debug) << "Read FX forward instrument: " << read[0];
+}
+
+TEST_CASE("fx_forward_instrument_read_nonexistent", tags) {
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    fx_forward_instrument_repository repo;
+    const std::string nonexistent = "00000000-0000-0000-0000-000000000001";
+    const auto read = repo.read_latest(ctx, nonexistent);
+    CHECK(read.empty());
+}
+
+TEST_CASE("fx_forward_instrument_remove", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+
+    fx_forward_instrument_repository repo;
+    repo.write(ctx, instr);
+
+    const auto before = repo.read_latest(ctx, id_str);
+    REQUIRE(!before.empty());
+
+    CHECK_NOTHROW(repo.remove(ctx, id_str));
+
+    const auto after = repo.read_latest(ctx, id_str);
+    BOOST_LOG_SEV(lg, debug) << "After remove count: " << after.size();
+    CHECK(after.empty());
+}

--- a/projects/ores.trading.core/tests/repository_fx_vanilla_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_fx_vanilla_option_instrument_repository_tests.cpp
@@ -1,0 +1,127 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_vanilla_option_instrument_repository.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/fx_vanilla_option_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.testing/database_helper.hpp"
+
+namespace {
+
+const std::string_view test_suite("ores.trading.core.repository.fx_vanilla_option.tests");
+const std::string tags("[repository][fx][fx_vanilla_option]");
+
+using ores::testing::database_helper;
+using ores::trading::repository::fx_vanilla_option_instrument_repository;
+using ores::trading::domain::fx_vanilla_option_instrument;
+using namespace ores::logging;
+
+/*
+ * Test data derived from:
+ *   external/ore/examples/Products/Example_Trades/FX_Option_European.xml
+ * via fx_instrument_mapper::forward_fx_option.
+ * See tests/test_data/fx_vanilla_option_instrument.json for the full mapping snapshot.
+ */
+fx_vanilla_option_instrument make_instrument(database_helper& h) {
+    fx_vanilla_option_instrument r;
+    r.instrument_id      = boost::uuids::random_generator()();
+    r.tenant_id          = h.tenant_id();
+    r.trade_type_code    = "FxOption";
+    r.bought_currency    = "EUR";
+    r.bought_amount      = 1000000.0;
+    r.sold_currency      = "USD";
+    r.sold_amount        = 1100000.0;
+    r.option_type        = "Call";
+    r.expiry_date        = "2033-02-20";
+    r.exercise_style     = "European";
+    r.settlement         = "Cash";
+    r.modified_by        = h.db_user();
+    r.performed_by       = "ores";
+    r.change_reason_code = "system.external_data_import";
+    r.change_commentary  = "Imported from ORE XML";
+    return r;
+}
+
+} // namespace
+
+TEST_CASE("fx_vanilla_option_instrument_write_and_read_latest", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    BOOST_LOG_SEV(lg, debug) << "Writing FX vanilla option instrument: " << instr;
+
+    fx_vanilla_option_instrument_repository repo;
+    CHECK_NOTHROW(repo.write(ctx, instr));
+
+    const auto read = repo.read_latest(ctx, id_str);
+    REQUIRE(read.size() == 1);
+    CHECK(read[0].trade_type_code == "FxOption");
+    CHECK(read[0].bought_currency == "EUR");
+    CHECK(read[0].bought_amount == 1000000.0);
+    CHECK(read[0].sold_currency == "USD");
+    CHECK(read[0].sold_amount == 1100000.0);
+    CHECK(read[0].option_type == "Call");
+    CHECK(read[0].expiry_date == "2033-02-20");
+    CHECK(read[0].exercise_style == "European");
+    CHECK(read[0].settlement == "Cash");
+    BOOST_LOG_SEV(lg, debug) << "Read FX vanilla option instrument: " << read[0];
+}
+
+TEST_CASE("fx_vanilla_option_instrument_read_nonexistent", tags) {
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    fx_vanilla_option_instrument_repository repo;
+    const std::string nonexistent = "00000000-0000-0000-0000-000000000001";
+    const auto read = repo.read_latest(ctx, nonexistent);
+    CHECK(read.empty());
+}
+
+TEST_CASE("fx_vanilla_option_instrument_remove", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+
+    fx_vanilla_option_instrument_repository repo;
+    repo.write(ctx, instr);
+
+    const auto before = repo.read_latest(ctx, id_str);
+    REQUIRE(!before.empty());
+
+    CHECK_NOTHROW(repo.remove(ctx, id_str));
+
+    const auto after = repo.read_latest(ctx, id_str);
+    BOOST_LOG_SEV(lg, debug) << "After remove count: " << after.size();
+    CHECK(after.empty());
+}

--- a/projects/ores.trading.core/tests/repository_fx_variance_swap_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_fx_variance_swap_instrument_repository_tests.cpp
@@ -1,0 +1,131 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/fx_variance_swap_instrument_repository.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/fx_variance_swap_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.testing/database_helper.hpp"
+
+namespace {
+
+const std::string_view test_suite("ores.trading.core.repository.fx_variance_swap.tests");
+const std::string tags("[repository][fx][fx_variance_swap]");
+
+using ores::testing::database_helper;
+using ores::trading::repository::fx_variance_swap_instrument_repository;
+using ores::trading::domain::fx_variance_swap_instrument;
+using namespace ores::logging;
+
+/*
+ * Test data derived from:
+ *   external/ore/examples/Products/Example_Trades/FX_Variance_Swap.xml
+ * via fx_instrument_mapper::forward_fx_variance_swap.
+ * See tests/test_data/fx_variance_swap_instrument.json for the full mapping snapshot.
+ * Notes:
+ *   - long_short is hardcoded to Long by the mapper
+ *   - moment_type is hardcoded to Variance (MomentType in XML is ignored)
+ *   - underlying_code comes from Underlying.Name (no FX prefix)
+ */
+fx_variance_swap_instrument make_instrument(database_helper& h) {
+    fx_variance_swap_instrument r;
+    r.instrument_id      = boost::uuids::random_generator()();
+    r.tenant_id          = h.tenant_id();
+    r.trade_type_code    = "FxVarianceSwap";
+    r.start_date         = "2025-10-22";
+    r.end_date           = "2026-04-26";
+    r.currency           = "USD";
+    r.underlying_code    = "TR20H-EUR-USD";
+    r.long_short         = "Long";
+    r.strike             = 0.02;
+    r.notional           = 50000.0;
+    r.moment_type        = "Variance";
+    r.modified_by        = h.db_user();
+    r.performed_by       = "ores";
+    r.change_reason_code = "system.external_data_import";
+    r.change_commentary  = "Imported from ORE XML";
+    return r;
+}
+
+} // namespace
+
+TEST_CASE("fx_variance_swap_instrument_write_and_read_latest", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    BOOST_LOG_SEV(lg, debug) << "Writing FX variance swap instrument: " << instr;
+
+    fx_variance_swap_instrument_repository repo;
+    CHECK_NOTHROW(repo.write(ctx, instr));
+
+    const auto read = repo.read_latest(ctx, id_str);
+    REQUIRE(read.size() == 1);
+    CHECK(read[0].trade_type_code == "FxVarianceSwap");
+    CHECK(read[0].start_date == "2025-10-22");
+    CHECK(read[0].end_date == "2026-04-26");
+    CHECK(read[0].currency == "USD");
+    CHECK(read[0].underlying_code == "TR20H-EUR-USD");
+    CHECK(read[0].long_short == "Long");
+    CHECK(read[0].strike == 0.02);
+    CHECK(read[0].notional == 50000.0);
+    CHECK(read[0].moment_type == "Variance");
+    BOOST_LOG_SEV(lg, debug) << "Read FX variance swap instrument: " << read[0];
+}
+
+TEST_CASE("fx_variance_swap_instrument_read_nonexistent", tags) {
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    fx_variance_swap_instrument_repository repo;
+    const std::string nonexistent = "00000000-0000-0000-0000-000000000001";
+    const auto read = repo.read_latest(ctx, nonexistent);
+    CHECK(read.empty());
+}
+
+TEST_CASE("fx_variance_swap_instrument_remove", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+
+    fx_variance_swap_instrument_repository repo;
+    repo.write(ctx, instr);
+
+    const auto before = repo.read_latest(ctx, id_str);
+    REQUIRE(!before.empty());
+
+    CHECK_NOTHROW(repo.remove(ctx, id_str));
+
+    const auto after = repo.read_latest(ctx, id_str);
+    BOOST_LOG_SEV(lg, debug) << "After remove count: " << after.size();
+    CHECK(after.empty());
+}

--- a/projects/ores.trading.core/tests/test_data/fx_accumulator_instrument.json
+++ b/projects/ores.trading.core/tests/test_data/fx_accumulator_instrument.json
@@ -1,0 +1,26 @@
+{
+  "source_xml": "external/ore/examples/Products/Example_Trades/Exotic_FxAccumulator.xml",
+  "trade_id_in_xml": "FX_Accumulator-AKO",
+  "mapper": "fx_instrument_mapper::forward_fx_accumulator (via trade_mapper::map_fx_instrument)",
+  "notes": [
+    "long_short is hardcoded to Long by mapper",
+    "knock_out_barrier is extracted from the first UpAndOut barrier (level 126)",
+    "FixingFloor barrier (level 2) and range bounds are not captured (Phase 2 gap)",
+    "observation dates are not captured (Phase 2 gap)"
+  ],
+  "instrument": {
+    "trade_type_code": "FxAccumulator",
+    "currency": "JPY",
+    "fixing_amount": 350000.0,
+    "strike": 122.0,
+    "underlying_code": "TR20H-EUR-JPY",
+    "long_short": "Long",
+    "start_date": "2026-01-12",
+    "knock_out_barrier": 126.0,
+    "description": "",
+    "modified_by": "ores",
+    "performed_by": "ores",
+    "change_reason_code": "system.external_data_import",
+    "change_commentary": "Imported from ORE XML"
+  }
+}

--- a/projects/ores.trading.core/tests/test_data/fx_asian_forward_instrument.json
+++ b/projects/ores.trading.core/tests/test_data/fx_asian_forward_instrument.json
@@ -1,0 +1,29 @@
+{
+  "source_xml": "external/ore/examples/Products/Example_Trades/FX_Average_Forward.xml",
+  "trade_id_in_xml": "FX_AVG_FWD",
+  "mapper": "fx_instrument_mapper::forward_fx_average_forward (via trade_mapper::map_fx_instrument)",
+  "notes": [
+    "long_short is hardcoded to Long by mapper",
+    "currency, fixing_amount, target_amount, strike are FxTaRF-specific — empty/null for FxAverageForward",
+    "observation dates are not captured (Phase 2 gap)"
+  ],
+  "instrument": {
+    "trade_type_code": "FxAverageForward",
+    "fx_index": "FX-TR20H-EUR-USD",
+    "reference_currency": "EUR",
+    "reference_notional": 8614.0,
+    "settlement_currency": "USD",
+    "settlement_notional": 10000.0,
+    "payment_date": "2025-09-30",
+    "long_short": "Long",
+    "currency": "",
+    "fixing_amount": null,
+    "target_amount": null,
+    "strike": null,
+    "description": "",
+    "modified_by": "ores",
+    "performed_by": "ores",
+    "change_reason_code": "system.external_data_import",
+    "change_commentary": "Imported from ORE XML"
+  }
+}

--- a/projects/ores.trading.core/tests/test_data/fx_barrier_option_instrument.json
+++ b/projects/ores.trading.core/tests/test_data/fx_barrier_option_instrument.json
@@ -1,0 +1,29 @@
+{
+  "source_xml": "external/ore/examples/Products/Example_Trades/FX_Barrier_Option.xml",
+  "trade_id_in_xml": "FX_UPIN_BARRIER_CALL_OPTION_EURUSD_10Y",
+  "mapper": "fx_instrument_mapper::forward_fx_barrier_option (via trade_mapper::map_fx_instrument)",
+  "notes": [
+    "settlement is not extracted by forward_fx_barrier_option — field is empty",
+    "underlying_code is not extracted by forward_fx_barrier_option for FxBarrierOption — field is empty",
+    "upper_barrier is absent: XML has a single-level BarrierData block"
+  ],
+  "instrument": {
+    "trade_type_code": "FxBarrierOption",
+    "bought_currency": "EUR",
+    "bought_amount": 1000000.0,
+    "sold_currency": "USD",
+    "sold_amount": 1100000.0,
+    "option_type": "Call",
+    "expiry_date": "2033-02-20",
+    "settlement": "",
+    "barrier_type": "UpAndIn",
+    "lower_barrier": 1.2,
+    "upper_barrier": null,
+    "underlying_code": "",
+    "description": "",
+    "modified_by": "ores",
+    "performed_by": "ores",
+    "change_reason_code": "system.external_data_import",
+    "change_commentary": "Imported from ORE XML"
+  }
+}

--- a/projects/ores.trading.core/tests/test_data/fx_digital_option_instrument.json
+++ b/projects/ores.trading.core/tests/test_data/fx_digital_option_instrument.json
@@ -1,0 +1,29 @@
+{
+  "source_xml": "external/ore/examples/Products/Example_Trades/FX_Digital_Option.xml",
+  "trade_id_in_xml": "FX_DIGITAL_CALL_OPTION_EURUSD_10Y",
+  "mapper": "fx_instrument_mapper::forward_fx_digital_option (via trade_mapper::map_fx_instrument)",
+  "notes": [
+    "payoff_currency defaults to foreign_currency (EUR)",
+    "long_short is hardcoded to Long by mapper",
+    "barrier_type, lower_barrier, upper_barrier are absent for plain FxDigitalOption"
+  ],
+  "instrument": {
+    "trade_type_code": "FxDigitalOption",
+    "foreign_currency": "EUR",
+    "domestic_currency": "USD",
+    "payoff_currency": "EUR",
+    "payoff_amount": 100.0,
+    "option_type": "Call",
+    "expiry_date": "2033-02-20",
+    "long_short": "Long",
+    "strike": 1.1,
+    "barrier_type": "",
+    "lower_barrier": null,
+    "upper_barrier": null,
+    "description": "",
+    "modified_by": "ores",
+    "performed_by": "ores",
+    "change_reason_code": "system.external_data_import",
+    "change_commentary": "Imported from ORE XML"
+  }
+}

--- a/projects/ores.trading.core/tests/test_data/fx_forward_instrument.json
+++ b/projects/ores.trading.core/tests/test_data/fx_forward_instrument.json
@@ -1,0 +1,19 @@
+{
+  "source_xml": "external/ore/examples/Products/Example_Trades/FX_Forward.xml",
+  "trade_id_in_xml": "FXFWD_EURUSD_10Y",
+  "mapper": "fx_instrument_mapper::forward_fx_forward",
+  "instrument": {
+    "trade_type_code": "FxForward",
+    "bought_currency": "EUR",
+    "bought_amount": 1000000.0,
+    "sold_currency": "USD",
+    "sold_amount": 1100000.0,
+    "value_date": "2033-02-20",
+    "settlement": "Cash",
+    "description": "",
+    "modified_by": "ores",
+    "performed_by": "ores",
+    "change_reason_code": "system.external_data_import",
+    "change_commentary": "Imported from ORE XML"
+  }
+}

--- a/projects/ores.trading.core/tests/test_data/fx_vanilla_option_instrument.json
+++ b/projects/ores.trading.core/tests/test_data/fx_vanilla_option_instrument.json
@@ -1,0 +1,21 @@
+{
+  "source_xml": "external/ore/examples/Products/Example_Trades/FX_Option_European.xml",
+  "trade_id_in_xml": "FX_CALL_OPTION",
+  "mapper": "fx_instrument_mapper::forward_fx_option",
+  "instrument": {
+    "trade_type_code": "FxOption",
+    "bought_currency": "EUR",
+    "bought_amount": 1000000.0,
+    "sold_currency": "USD",
+    "sold_amount": 1100000.0,
+    "option_type": "Call",
+    "expiry_date": "2033-02-20",
+    "exercise_style": "European",
+    "settlement": "Cash",
+    "description": "",
+    "modified_by": "ores",
+    "performed_by": "ores",
+    "change_reason_code": "system.external_data_import",
+    "change_commentary": "Imported from ORE XML"
+  }
+}

--- a/projects/ores.trading.core/tests/test_data/fx_variance_swap_instrument.json
+++ b/projects/ores.trading.core/tests/test_data/fx_variance_swap_instrument.json
@@ -1,0 +1,26 @@
+{
+  "source_xml": "external/ore/examples/Products/Example_Trades/FX_Variance_Swap.xml",
+  "trade_id_in_xml": "Fx_Vol_Swap",
+  "mapper": "fx_instrument_mapper::forward_fx_variance_swap (via trade_mapper::map_fx_instrument)",
+  "notes": [
+    "long_short is hardcoded to Long by mapper",
+    "moment_type is hardcoded to Variance by mapper (MomentType element from XML is ignored)",
+    "underlying_code comes from Underlying.Name (TR20H-EUR-USD), not the FX prefix version"
+  ],
+  "instrument": {
+    "trade_type_code": "FxVarianceSwap",
+    "start_date": "2025-10-22",
+    "end_date": "2026-04-26",
+    "currency": "USD",
+    "underlying_code": "TR20H-EUR-USD",
+    "long_short": "Long",
+    "strike": 0.02,
+    "notional": 50000.0,
+    "moment_type": "Variance",
+    "description": "",
+    "modified_by": "ores",
+    "performed_by": "ores",
+    "change_reason_code": "system.external_data_import",
+    "change_commentary": "Imported from ORE XML"
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces the flat `fx_instrument` struct with 7 typed domain structs (`fx_forward_instrument`, `fx_vanilla_option_instrument`, `fx_barrier_option_instrument`, `fx_digital_option_instrument`, `fx_asian_forward_instrument`, `fx_accumulator_instrument`, `fx_variance_swap_instrument`) held in `fx_instrument_variant`
- Adds dedicated DB tables, indexes, insert triggers, and delete rules for all 7 typed FX instrument types, plus RLS policies and notify triggers
- Adds JSON I/O, repository entity/mapper/repository classes, and service + NATS handler plumbing for all 7 types
- Updates ORE XML importer/exporter, OreImporter, ImportTradeDialog, and all affected tests to use the new typed variant dispatch pattern
- Adds 21 new typed FX repository tests (all passing); all 460 `ores.ore.tests` and 35 `ores.trading.core.tests` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)