### PR TITLE
[service] Fix Windows Clang build: replace SIGQUIT with platform shutdown_signals

### DIFF
--- a/projects/ores.service/include/ores.service/service/domain_service_runner_impl.hpp
+++ b/projects/ores.service/include/ores.service/service/domain_service_runner_impl.hpp
@@ -130,7 +130,9 @@ run(boost::asio::io_context& io_ctx,
     }();
 
     boost::asio::cancellation_signal startup_cancel;
-    boost::asio::signal_set signals(io_ctx, SIGINT, SIGTERM, SIGQUIT);
+    boost::asio::signal_set signals(io_ctx);
+    for (int s : ores::platform::process::shutdown_signals)
+        signals.add(s);
     signals.async_wait([&startup_cancel](const boost::system::error_code& ec, int) {
         if (!ec) startup_cancel.emit(boost::asio::cancellation_type::all);
     });

--- a/projects/ores.service/include/ores.service/service/signing_service_runner_impl.hpp
+++ b/projects/ores.service/include/ores.service/service/signing_service_runner_impl.hpp
@@ -20,12 +20,12 @@
 #ifndef ORES_SERVICE_SERVICE_SIGNING_SERVICE_RUNNER_IMPL_HPP
 #define ORES_SERVICE_SERVICE_SIGNING_SERVICE_RUNNER_IMPL_HPP
 
-#include <csignal>
 #include <functional>
 #include <boost/asio/signal_set.hpp>
 #include <boost/asio/use_awaitable.hpp>
 #include <boost/system/error_code.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.platform/process/signals.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 
 namespace ores::service::service {
@@ -49,7 +49,9 @@ run_signing(boost::asio::io_context& io_ctx,
         return instance;
     }();
 
-    boost::asio::signal_set signals(io_ctx, SIGINT, SIGTERM, SIGQUIT);
+    boost::asio::signal_set signals(io_ctx);
+    for (int s : ores::platform::process::shutdown_signals)
+        signals.add(s);
 
     auto signer = ores::security::jwt::jwt_authenticator::create_rs256_signer(
         jwt_private_key);


### PR DESCRIPTION
## Summary

- `SIGQUIT` is undefined on Windows, causing a Clang build failure in `ores.refdata.service` (and any other service that includes `signing_service_runner_impl.hpp`)
- `ores.platform/process/signals.hpp` already abstracts this correctly: `shutdown_signals` is `{SIGINT, SIGTERM, SIGQUIT}` on POSIX and `{SIGINT, SIGTERM}` on Windows
- Replace the hardcoded `boost::asio::signal_set signals(io_ctx, SIGINT, SIGTERM, SIGQUIT)` in both `domain_service_runner_impl.hpp` and `signing_service_runner_impl.hpp` with a loop over `ores::platform::process::shutdown_signals`

🤖 Generated with [Claude Code](https://claude.com/claude-code)