### PR TITLE
[cmake] Add /FS to serialise MSVC PDB writes under parallel Ninja builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,9 @@ if(WIN32)
         # Required by large translation units (e.g. registrar.cpp with many
         # template instantiations from rfl and Boost headers).
         add_compile_options(/bigobj)
+        # Serialise PDB writes when Ninja runs multiple cl.exe in parallel.
+        # Without /FS, concurrent writes to the same vc140.pdb cause C1041.
+        add_compile_options(/FS)
     endif()
 endif()
 


### PR DESCRIPTION
## Summary

- Parallel `cl.exe` invocations in Ninja builds race to write to the same `vc140.pdb`, producing `C1041: cannot open program database`
- `/FS` forces serialised access to the PDB file, eliminating the race
- Added alongside the existing `/bigobj` flag in the MSVC-only block in `CMakeLists.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)