### PR TITLE
[trading] Add equity typed instrument support (Phase 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,11 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${ORES_PUBLISH_DIRECTORY}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${ORES_PUBLISH_DIRECTORY}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${ORES_PUBLISH_DIRECTORY}/bin)
 
+# Qt domain plugins are placed alongside the application binary so that
+# QPluginLoader finds them with a simple applicationDirPath() lookup on both
+# Linux and Windows (no platform-specific subdirectory logic required).
+set(ORES_PLUGIN_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+
 # use, i.e. don't skip the full RPATH for the build tree
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
 

--- a/build/cpack/CMakeLists.txt
+++ b/build/cpack/CMakeLists.txt
@@ -123,10 +123,10 @@ elseif(UNIX)
     set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
 
     # Tell dpkg-shlibdeps where to find bundled plugin libraries.
-    # Plugins install to lib/plugins/ which is not on the default search path.
+    # Plugins install to bin/ alongside the application binary.
     # Strip the leading slash so the path is relative to the CPack staging root.
     string(REGEX REPLACE "^/" "" _plugins_staging_rel
-        "${CPACK_PACKAGING_INSTALL_PREFIX}/lib/plugins")
+        "${CPACK_PACKAGING_INSTALL_PREFIX}/bin")
     set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS_PRIVATE_DIRS "${_plugins_staging_rel}")
 
     set(CPACK_DEB_PACKAGE_DEBUG "1")

--- a/projects/ores.qt.admin/src/AdminPlugin.cpp
+++ b/projects/ores.qt.admin/src/AdminPlugin.cpp
@@ -26,6 +26,7 @@
 
 #include "ores.qt/DetachableMdiSubWindow.hpp"
 #include "ores.qt/IconUtils.hpp"
+#include "ores.logging/make_logger.hpp"
 #include "ores.qt/AccountController.hpp"
 #include "ores.qt/RoleController.hpp"
 #include "ores.qt/TenantController.hpp"
@@ -36,15 +37,28 @@
 #include "ores.qt/BadgeSeverityController.hpp"
 namespace ores::qt {
 
+using namespace ores::logging;
+
 namespace {
+
+auto& lg() {
+    static auto instance = make_logger("ores.qt.admin_plugin");
+    return instance;
+}
+
 auto ico(Icon icon) {
     return IconUtils::createRecoloredIcon(icon, IconUtils::DefaultIconColor);
 }
+
 }
 
-AdminPlugin::AdminPlugin(QObject* parent) : PluginBase(parent) {}
+AdminPlugin::AdminPlugin(QObject* parent) : PluginBase(parent) {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin initialised.";
+}
 
-AdminPlugin::~AdminPlugin() = default;
+AdminPlugin::~AdminPlugin() {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin shutdown.";
+}
 
 void AdminPlugin::show_onboarding_wizard() {
     auto* wizard = new TenantOnboardingWizard(ctx_.client_manager, ctx_.main_window);
@@ -62,6 +76,7 @@ void AdminPlugin::show_onboarding_wizard() {
 }
 
 void AdminPlugin::on_login(const plugin_context& ctx) {
+    BOOST_LOG_SEV(lg(), debug) << "Login event received.";
     ctx_ = ctx;
 
     accountController_ = std::make_unique<AccountController>(
@@ -101,6 +116,10 @@ void AdminPlugin::on_login(const plugin_context& ctx) {
 }
 
 void AdminPlugin::setup_menus(const shared_menus_context& smc) {
+    BOOST_LOG_SEV(lg(), debug) << "Registering entries in shared menus."
+        << " identity=" << (smc.identity_menu ? "ok" : "null")
+        << " system=" << (smc.system_menu ? "ok" : "null")
+        << " telemetry=" << (smc.telemetry_menu ? "ok" : "null");
     // ---- Identity menu (top-level, pre-created by MainWindow) ---------------
     if (smc.identity_menu) {
         act_accounts_ = smc.identity_menu->addAction(
@@ -154,14 +173,18 @@ void AdminPlugin::setup_menus(const shared_menus_context& smc) {
 }
 
 QList<QMenu*> AdminPlugin::create_menus() {
+    BOOST_LOG_SEV(lg(), debug) << "No standalone menus — all entries contributed via shared menus.";
     return {};  // all items contributed via setup_menus()
 }
 
 QList<QAction*> AdminPlugin::toolbar_actions() {
+    if (!act_accounts_ || !act_tenants_ || !act_system_settings_)
+        BOOST_LOG_SEV(lg(), warn) << "One or more toolbar actions are uninitialised.";
     return {act_accounts_, act_tenants_, act_system_settings_};
 }
 
 void AdminPlugin::on_logout() {
+    BOOST_LOG_SEV(lg(), debug) << "Logout event received.";
     badgeSeverityController_.reset();
     badgeDefinitionController_.reset();
     systemSettingController_.reset();

--- a/projects/ores.qt.admin/src/CMakeLists.txt
+++ b/projects/ores.qt.admin/src/CMakeLists.txt
@@ -40,8 +40,8 @@ set_target_properties(${lib_target_name} PROPERTIES
     AUTOUIC_SEARCH_PATHS "${ORES_QT_ADMIN_DIR}/ui;${ORES_QT_API_UI_DIR}"
     VERSION   ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/plugins"
-    INSTALL_RPATH "$ORIGIN/.."
+    LIBRARY_OUTPUT_DIRECTORY "${ORES_PLUGIN_OUTPUT_DIRECTORY}"
+    INSTALL_RPATH "$ORIGIN/../lib"
     BUILD_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
 target_include_directories(${lib_target_name} PUBLIC
@@ -65,5 +65,5 @@ target_link_libraries(${lib_target_name}
         ores.qt.lib)
 
 install(TARGETS ${lib_target_name}
-    LIBRARY DESTINATION lib/plugins
-    RUNTIME DESTINATION bin/plugins)
+    LIBRARY DESTINATION bin
+    RUNTIME DESTINATION bin)

--- a/projects/ores.qt.analytics/src/AnalyticsPlugin.cpp
+++ b/projects/ores.qt.analytics/src/AnalyticsPlugin.cpp
@@ -22,6 +22,7 @@
 #include <QAction>
 
 #include "ores.qt/IconUtils.hpp"
+#include "ores.logging/make_logger.hpp"
 #include "ores.qt/PricingEngineTypeController.hpp"
 #include "ores.qt/PricingModelConfigController.hpp"
 #include "ores.qt/PricingModelProductController.hpp"
@@ -29,17 +30,31 @@
 
 namespace ores::qt {
 
+using namespace ores::logging;
+
 namespace {
+
+auto& lg() {
+    static auto instance = make_logger("ores.qt.analytics_plugin");
+    return instance;
+}
+
 auto ico(Icon icon) {
     return IconUtils::createRecoloredIcon(icon, IconUtils::DefaultIconColor);
 }
+
 }
 
-AnalyticsPlugin::AnalyticsPlugin(QObject* parent) : PluginBase(parent) {}
+AnalyticsPlugin::AnalyticsPlugin(QObject* parent) : PluginBase(parent) {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin initialised.";
+}
 
-AnalyticsPlugin::~AnalyticsPlugin() = default;
+AnalyticsPlugin::~AnalyticsPlugin() {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin shutdown.";
+}
 
 void AnalyticsPlugin::on_login(const plugin_context& ctx) {
+    BOOST_LOG_SEV(lg(), debug) << "Login event received.";
     ctx_ = ctx;
 
     pricingEngineTypeController_ = std::make_unique<PricingEngineTypeController>(
@@ -61,6 +76,7 @@ void AnalyticsPlugin::on_login(const plugin_context& ctx) {
 }
 
 QList<QMenu*> AnalyticsPlugin::create_menus() {
+    BOOST_LOG_SEV(lg(), debug) << "Building plugin menus.";
     auto* menuPricing = new QMenu(tr("&Pricing"));
 
     // ---- Flat model configuration items at the top ----------------------
@@ -97,10 +113,12 @@ QList<QMenu*> AnalyticsPlugin::create_menus() {
             pricingEngineTypeController_->showListWindow();
     });
 
+    BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
     return {menuPricing};
 }
 
 void AnalyticsPlugin::on_logout() {
+    BOOST_LOG_SEV(lg(), debug) << "Logout event received.";
     pricingModelProductParameterController_.reset();
     pricingModelProductController_.reset();
     pricingModelConfigController_.reset();

--- a/projects/ores.qt.analytics/src/CMakeLists.txt
+++ b/projects/ores.qt.analytics/src/CMakeLists.txt
@@ -40,9 +40,9 @@ set_target_properties(${lib_target_name} PROPERTIES
     AUTOUIC_SEARCH_PATHS "${ORES_QT_ANALYTICS_DIR}/ui;${ORES_QT_API_UI_DIR}"
     VERSION   ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/plugins"
-    INSTALL_RPATH "$ORIGIN/..:$ORIGIN"
-    BUILD_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY};${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/plugins")
+    LIBRARY_OUTPUT_DIRECTORY "${ORES_PLUGIN_OUTPUT_DIRECTORY}"
+    INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN"
+    BUILD_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
 target_include_directories(${lib_target_name} PUBLIC
     ${ORES_QT_ANALYTICS_DIR}/include)
@@ -61,5 +61,5 @@ target_link_libraries(${lib_target_name}
         ores.qt.lib)
 
 install(TARGETS ${lib_target_name}
-    LIBRARY DESTINATION lib/plugins
-    RUNTIME DESTINATION bin/plugins)
+    LIBRARY DESTINATION bin
+    RUNTIME DESTINATION bin)

--- a/projects/ores.qt.api/include/ores.qt/FontUtils.hpp
+++ b/projects/ores.qt.api/include/ores.qt/FontUtils.hpp
@@ -31,8 +31,17 @@ struct FontUtils {
     static constexpr int DefaultPointSize = 10;
     static constexpr int DefaultPixelSize = 11;
 
+    /**
+     * @brief Returns a monospace QFont.
+     *
+     * Prefers Fira Code.  Sets StyleHint::Monospace so Qt falls back to the
+     * system monospace font (e.g. DejaVu Sans Mono, Courier New) when Fira
+     * Code is not installed.  Use setFont() rather than stylesheets — Qt's
+     * QSS engine does not honour the CSS "monospace" generic family.
+     */
     static QFont monospace() {
         QFont f(MonospaceFontFamily);
+        f.setStyleHint(QFont::Monospace);
         f.setPointSize(DefaultPointSize);
         return f;
     }
@@ -44,11 +53,10 @@ struct FontUtils {
     }
 
     /**
-     * @brief Returns a CSS font-family/font-size snippet for use in stylesheets.
+     * @brief CSS font fragment for use in Qt stylesheets.
      *
-     * Includes the generic "monospace" fallback so that if the preferred font
-     * (Fira Code) is not installed, Qt still selects the system monospace font
-     * rather than falling through to the application's default proportional font.
+     * Note: Qt's QSS engine does not honour the "monospace" generic family as
+     * a fallback, so prefer setFont(monospace()) over this where possible.
      */
     static QString monospaceCssFragment() {
         return QString("font-family: \"%1\", monospace; font-size: %2px;")

--- a/projects/ores.qt.api/include/ores.qt/IPlugin.hpp
+++ b/projects/ores.qt.api/include/ores.qt/IPlugin.hpp
@@ -50,10 +50,19 @@ struct shared_menus_context {
  *
  * The host (MainWindow) calls these methods at well-defined lifecycle points:
  *
- *  1. on_login() — called after authentication succeeds; create controllers here.
- *  2. create_menus() — called after on_login(); return domain menus to be inserted
- *     into the menu bar.  The host takes ownership of the returned QMenu objects.
- *  3. on_logout() — called when the client disconnects; destroy controllers here.
+ *  Startup (once, before any login):
+ *    1. setup_menus(ctx)  — contribute items to host-owned shared menus.
+ *    2. create_menus()    — return standalone domain menus; host inserts them
+ *                           into the menu bar (disabled until login).
+ *    3. toolbar_actions() — return actions to add to the main toolbar.
+ *
+ *  Per-session:
+ *    4. on_login(ctx)  — authentication succeeded; create controllers here.
+ *    5. on_logout()    — client disconnected; destroy controllers here.
+ *
+ * Menus and toolbar actions are created once at startup and live for the entire
+ * application lifetime.  on_login()/on_logout() enable/disable them without
+ * recreating them.
  *
  * Implementations must inherit from QObject as well as IPlugin so that signal/slot
  * connections can be made between plugin internals and the host.
@@ -99,8 +108,9 @@ public:
     /**
      * @brief Build and return standalone domain menus for this plugin.
      *
-     * Called by the host after setup_menus().  The host inserts the returned
-     * menus into the menu bar before the &System menu, in plugin load_order.
+     * Called once at startup, after setup_menus().  The host inserts the
+     * returned menus into the menu bar before the &System menu, in plugin
+     * load_order.  Menus are initially disabled and are enabled on login.
      *
      * Plugins that contribute exclusively to shared menus via setup_menus()
      * should return an empty list here.

--- a/projects/ores.qt.api/include/ores.qt/PluginRegistry.hpp
+++ b/projects/ores.qt.api/include/ores.qt/PluginRegistry.hpp
@@ -29,6 +29,14 @@ class QPluginLoader;
 namespace ores::qt {
 
 /**
+ * @brief Records a plugin that could not be loaded.
+ */
+struct plugin_load_error {
+    QString filename;   ///< Short filename (e.g. libores.qt.admin.so)
+    QString message;    ///< Human-readable error from QPluginLoader::errorString()
+};
+
+/**
  * @brief Singleton registry that discovers and owns all loaded domain plugins.
  *
  * Call load_from_directory() once at application startup (before constructing
@@ -75,6 +83,14 @@ public:
      */
     const QVector<IPlugin*>& plugins() const { return plugins_; }
 
+    /**
+     * @brief Return any errors collected during load_from_directory().
+     *
+     * Non-empty when one or more .so files failed to load or did not implement
+     * IPlugin.  Callers may use this to warn the user after startup.
+     */
+    const QVector<plugin_load_error>& load_errors() const { return load_errors_; }
+
     PluginRegistry() = default;
     ~PluginRegistry();
     PluginRegistry(const PluginRegistry&) = delete;
@@ -82,8 +98,9 @@ public:
 
 private:
 
-    QVector<QPluginLoader*> loaders_;  ///< Must outlive plugin instances.
-    QVector<IPlugin*>       plugins_;
+    QVector<QPluginLoader*>   loaders_;     ///< Must outlive plugin instances.
+    QVector<IPlugin*>         plugins_;
+    QVector<plugin_load_error> load_errors_;
 };
 
 }

--- a/projects/ores.qt.api/src/PluginRegistry.cpp
+++ b/projects/ores.qt.api/src/PluginRegistry.cpp
@@ -60,6 +60,7 @@ PluginRegistry::~PluginRegistry() {
 
 void PluginRegistry::load_from_directory(const QString& plugin_dir) {
     QDir dir(plugin_dir);
+    BOOST_LOG_SEV(lg(), info) << "Scanning for plugins in: " << dir.absolutePath().toStdString();
     if (!dir.exists()) {
         BOOST_LOG_SEV(lg(), error)
             << "Plugin directory does not exist: " << plugin_dir.toStdString();

--- a/projects/ores.qt.api/src/PluginRegistry.cpp
+++ b/projects/ores.qt.api/src/PluginRegistry.cpp
@@ -79,17 +79,20 @@ void PluginRegistry::load_from_directory(const QString& plugin_dir) {
         auto* loader = new QPluginLoader(filepath);
         QObject* obj = loader->instance();
         if (!obj) {
+            const QString err = loader->errorString();
             BOOST_LOG_SEV(lg(), error)
                 << "Failed to load plugin: " << filename.toStdString()
-                << " - " << loader->errorString().toStdString();
+                << " - " << err.toStdString();
+            load_errors_.push_back({filename, err});
             delete loader;
             continue;
         }
 
         auto* plugin = qobject_cast<IPlugin*>(obj);
         if (!plugin) {
-            BOOST_LOG_SEV(lg(), error)
-                << filename.toStdString() << " does not implement IPlugin";
+            const QString err = filename + " does not implement IPlugin";
+            BOOST_LOG_SEV(lg(), error) << err.toStdString();
+            load_errors_.push_back({filename, err});
             loader->unload();
             delete loader;
             continue;

--- a/projects/ores.qt.compute/include/ores.qt/OreImportWizard.hpp
+++ b/projects/ores.qt.compute/include/ores.qt/OreImportWizard.hpp
@@ -321,8 +321,17 @@ public:
     explicit OreDonePage(OreImportWizard* wizard);
     void initializePage() override;
 private:
+    void setupIdRow(QWidget* container, QLabel* label, QLineEdit* edit,
+                    QPushButton* copyBtn, const QString& labelText);
+
     OreImportWizard* wizard_;
     QLabel* summaryLabel_;
+
+    // Selectable ID rows — shown only when the IDs are present
+    QWidget*      workflowIdRow_  = nullptr;
+    QLineEdit*    workflowIdEdit_ = nullptr;
+    QWidget*      correlIdRow_    = nullptr;
+    QLineEdit*    correlIdEdit_   = nullptr;
 };
 
 }

--- a/projects/ores.qt.compute/src/CMakeLists.txt
+++ b/projects/ores.qt.compute/src/CMakeLists.txt
@@ -40,9 +40,9 @@ set_target_properties(${lib_target_name} PROPERTIES
     AUTOUIC_SEARCH_PATHS "${ORES_QT_COMPUTE_DIR}/ui;${ORES_QT_API_UI_DIR}"
     VERSION   ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/plugins"
-    INSTALL_RPATH "$ORIGIN/..:$ORIGIN"
-    BUILD_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY};${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/plugins")
+    LIBRARY_OUTPUT_DIRECTORY "${ORES_PLUGIN_OUTPUT_DIRECTORY}"
+    INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN"
+    BUILD_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
 target_include_directories(${lib_target_name} PUBLIC
     ${ORES_QT_COMPUTE_DIR}/include)
@@ -70,5 +70,5 @@ target_link_libraries(${lib_target_name}
         ores.qt.lib)
 
 install(TARGETS ${lib_target_name}
-    LIBRARY DESTINATION lib/plugins
-    RUNTIME DESTINATION bin/plugins)
+    LIBRARY DESTINATION bin
+    RUNTIME DESTINATION bin)

--- a/projects/ores.qt.compute/src/ComputePlugin.cpp
+++ b/projects/ores.qt.compute/src/ComputePlugin.cpp
@@ -23,6 +23,7 @@
 #include <QMdiArea>
 #include <QMainWindow>
 #include <QStatusBar>
+#include "ores.logging/make_logger.hpp"
 
 #include "ores.qt/DetachableMdiSubWindow.hpp"
 #include "ores.qt/IconUtils.hpp"
@@ -39,17 +40,31 @@
 
 namespace ores::qt {
 
+using namespace ores::logging;
+
 namespace {
+
+auto& lg() {
+    static auto instance = make_logger("ores.qt.compute_plugin");
+    return instance;
+}
+
 auto ico(Icon icon) {
     return IconUtils::createRecoloredIcon(icon, IconUtils::DefaultIconColor);
 }
+
 }
 
-ComputePlugin::ComputePlugin(QObject* parent) : PluginBase(parent) {}
+ComputePlugin::ComputePlugin(QObject* parent) : PluginBase(parent) {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin initialised.";
+}
 
-ComputePlugin::~ComputePlugin() = default;
+ComputePlugin::~ComputePlugin() {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin shutdown.";
+}
 
 void ComputePlugin::on_login(const plugin_context& ctx) {
+    BOOST_LOG_SEV(lg(), debug) << "Login event received.";
     ctx_ = ctx;
 
     appController_ = std::make_unique<AppController>(
@@ -126,6 +141,9 @@ void ComputePlugin::on_login(const plugin_context& ctx) {
 }
 
 void ComputePlugin::setup_menus(const shared_menus_context& smc) {
+    BOOST_LOG_SEV(lg(), debug) << "Registering entries in shared menus."
+        << " system=" << (smc.system_menu ? "ok" : "null")
+        << " telemetry=" << (smc.telemetry_menu ? "ok" : "null");
     if (!smc.system_menu || !smc.telemetry_menu)
         return;
 
@@ -160,6 +178,7 @@ void ComputePlugin::setup_menus(const shared_menus_context& smc) {
 }
 
 QList<QMenu*> ComputePlugin::create_menus() {
+    BOOST_LOG_SEV(lg(), debug) << "Building plugin menus.";
     QList<QMenu*> menus;
 
     // ---- Compute --------------------------------------------------------
@@ -221,14 +240,18 @@ QList<QMenu*> ComputePlugin::create_menus() {
     menus.append(menuReporting);
     menus.append(menuCompute);
 
+    BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
     return menus;
 }
 
 QList<QAction*> ComputePlugin::toolbar_actions() {
+    if (!act_report_definitions_ || !act_report_instances_)
+        BOOST_LOG_SEV(lg(), warn) << "One or more toolbar actions are uninitialised.";
     return {act_report_definitions_, act_report_instances_};
 }
 
 void ComputePlugin::on_logout() {
+    BOOST_LOG_SEV(lg(), debug) << "Logout event received.";
     reportInstanceController_.reset();
     reportDefinitionController_.reset();
     concurrencyPolicyController_.reset();

--- a/projects/ores.qt.compute/src/OreImportWizard.cpp
+++ b/projects/ores.qt.compute/src/OreImportWizard.cpp
@@ -21,6 +21,8 @@
 
 #include <set>
 #include <QDate>
+#include <QGuiApplication>
+#include <QClipboard>
 #include <QPalette>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -916,6 +918,28 @@ void OreTradeImportPage::onImportFinished() {
 // OreDonePage
 // ============================================================================
 
+static QWidget* makeIdRow(const QString& labelText, QLineEdit*& editOut,
+                          QPushButton*& copyBtnOut, QWidget* parent) {
+    auto* row = new QWidget(parent);
+    auto* hbox = new QHBoxLayout(row);
+    hbox->setContentsMargins(0, 0, 0, 0);
+
+    auto* lbl = new QLabel(labelText + ":", row);
+    lbl->setMinimumWidth(100);
+    hbox->addWidget(lbl);
+
+    editOut = new QLineEdit(row);
+    editOut->setReadOnly(true);
+    editOut->setFont(FontUtils::monospace());
+    hbox->addWidget(editOut, 1);
+
+    copyBtnOut = new QPushButton(QStringLiteral("Copy"), row);
+    copyBtnOut->setFixedWidth(60);
+    hbox->addWidget(copyBtnOut);
+
+    return row;
+}
+
 OreDonePage::OreDonePage(OreImportWizard* wizard)
     : QWizardPage(wizard), wizard_(wizard) {
 
@@ -923,14 +947,38 @@ OreDonePage::OreDonePage(OreImportWizard* wizard)
     setSubTitle(tr("The ORE import has finished."));
 
     auto* layout = new QVBoxLayout(this);
+
     summaryLabel_ = new QLabel(this);
     summaryLabel_->setWordWrap(true);
+    summaryLabel_->setTextInteractionFlags(Qt::TextSelectableByMouse);
     layout->addWidget(summaryLabel_);
+
+    // Selectable ID rows
+    QPushButton* workflowCopyBtn = nullptr;
+    workflowIdRow_ = makeIdRow(tr("Workflow ID"), workflowIdEdit_, workflowCopyBtn, this);
+    layout->addWidget(workflowIdRow_);
+    workflowIdRow_->hide();
+
+    QPushButton* correlCopyBtn = nullptr;
+    correlIdRow_ = makeIdRow(tr("Correlation ID"), correlIdEdit_, correlCopyBtn, this);
+    layout->addWidget(correlIdRow_);
+    correlIdRow_->hide();
+
+    connect(workflowCopyBtn, &QPushButton::clicked, this, [this]() {
+        QGuiApplication::clipboard()->setText(workflowIdEdit_->text());
+    });
+    connect(correlCopyBtn, &QPushButton::clicked, this, [this]() {
+        QGuiApplication::clipboard()->setText(correlIdEdit_->text());
+    });
+
     layout->addStretch();
 }
 
 void OreDonePage::initializePage() {
     const auto& resp = wizard_->importResponse();
+
+    workflowIdRow_->hide();
+    correlIdRow_->hide();
 
     if (wizard_->importSuccess()) {
         QString html;
@@ -939,9 +987,10 @@ void OreDonePage::initializePage() {
             // Asynchronous path: import is running in the background.
             html += tr("<p><b>Import submitted successfully.</b></p>");
             html += tr("<p>The import is processing in the background. "
-                       "Check the workflow status for results.</p>");
-            html += tr("<p style='color:gray;font-size:small;'>Workflow ID: %1</p>")
-                .arg(QString::fromStdString(resp.workflow_instance_id));
+                       "Use the Workflow ID below to track progress in the log files "
+                       "or a future workflow monitor.</p>");
+            workflowIdEdit_->setText(QString::fromStdString(resp.workflow_instance_id));
+            workflowIdRow_->show();
         } else {
             // Synchronous path (legacy / direct).
             const auto& errors = resp.item_errors;
@@ -968,8 +1017,8 @@ void OreDonePage::initializePage() {
         }
 
         if (!resp.correlation_id.empty()) {
-            html += tr("<p style='color:gray;font-size:small;'>Correlation ID: %1</p>")
-                .arg(QString::fromStdString(resp.correlation_id));
+            correlIdEdit_->setText(QString::fromStdString(resp.correlation_id));
+            correlIdRow_->show();
         }
 
         summaryLabel_->setText(html);

--- a/projects/ores.qt.data_transfer/src/CMakeLists.txt
+++ b/projects/ores.qt.data_transfer/src/CMakeLists.txt
@@ -36,8 +36,8 @@ set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name}
     VERSION   ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/plugins"
-    INSTALL_RPATH "$ORIGIN/.."
+    LIBRARY_OUTPUT_DIRECTORY "${ORES_PLUGIN_OUTPUT_DIRECTORY}"
+    INSTALL_RPATH "$ORIGIN/../lib"
     BUILD_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
 target_include_directories(${lib_target_name} PUBLIC
@@ -55,5 +55,5 @@ target_link_libraries(${lib_target_name}
         ores.qt.lib)
 
 install(TARGETS ${lib_target_name}
-    LIBRARY DESTINATION lib/plugins
-    RUNTIME DESTINATION bin/plugins)
+    LIBRARY DESTINATION bin
+    RUNTIME DESTINATION bin)

--- a/projects/ores.qt.data_transfer/src/DataTransferPlugin.cpp
+++ b/projects/ores.qt.data_transfer/src/DataTransferPlugin.cpp
@@ -22,6 +22,7 @@
 #include <QAction>
 
 #include "ores.qt/IconUtils.hpp"
+#include "ores.logging/make_logger.hpp"
 #include "ores.qt/DataDomainController.hpp"
 #include "ores.qt/SubjectAreaController.hpp"
 #include "ores.qt/CatalogController.hpp"
@@ -33,17 +34,31 @@
 
 namespace ores::qt {
 
+using namespace ores::logging;
+
 namespace {
+
+auto& lg() {
+    static auto instance = make_logger("ores.qt.data_transfer_plugin");
+    return instance;
+}
+
 auto ico(Icon icon) {
     return IconUtils::createRecoloredIcon(icon, IconUtils::DefaultIconColor);
 }
+
 }
 
-DataTransferPlugin::DataTransferPlugin(QObject* parent) : PluginBase(parent) {}
+DataTransferPlugin::DataTransferPlugin(QObject* parent) : PluginBase(parent) {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin initialised.";
+}
 
-DataTransferPlugin::~DataTransferPlugin() = default;
+DataTransferPlugin::~DataTransferPlugin() {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin shutdown.";
+}
 
 void DataTransferPlugin::on_login(const plugin_context& ctx) {
+    BOOST_LOG_SEV(lg(), debug) << "Login event received.";
     ctx_ = ctx;
 
     dataDomainController_ = std::make_unique<DataDomainController>(
@@ -88,6 +103,8 @@ void DataTransferPlugin::on_login(const plugin_context& ctx) {
 }
 
 void DataTransferPlugin::setup_menus(const shared_menus_context& smc) {
+    BOOST_LOG_SEV(lg(), debug) << "Capturing shared Data Transfer menu handle."
+        << " data_transfer=" << (smc.data_transfer_menu ? "ok" : "null");
     // Save reference so create_menus() can return the pre-created menu.
     // Other plugins (RefdataPlugin, TradingPlugin) contribute actions to it
     // during their own setup_menus calls.
@@ -95,8 +112,12 @@ void DataTransferPlugin::setup_menus(const shared_menus_context& smc) {
 }
 
 QList<QMenu*> DataTransferPlugin::create_menus() {
-    if (!data_transfer_menu_)
+    BOOST_LOG_SEV(lg(), debug) << "Building plugin menus."
+        << " data_transfer_menu=" << (data_transfer_menu_ ? "ok" : "null");
+    if (!data_transfer_menu_) {
+        BOOST_LOG_SEV(lg(), warn) << "Data Transfer menu handle is missing — no menu will appear.";
         return {};
+    }
 
     // ---- Data Catalogue submenu -----------------------------------------
     auto* menuCatalogue = data_transfer_menu_->addMenu(tr("Data Ca&talogue"));
@@ -147,10 +168,12 @@ QList<QMenu*> DataTransferPlugin::create_menus() {
         if (treatmentDimensionController_) treatmentDimensionController_->showListWindow();
     });
 
+    BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
     return {data_transfer_menu_};
 }
 
 void DataTransferPlugin::on_logout() {
+    BOOST_LOG_SEV(lg(), debug) << "Logout event received.";
     treatmentDimensionController_.reset();
     natureDimensionController_.reset();
     originDimensionController_.reset();

--- a/projects/ores.qt.mktdata/src/CMakeLists.txt
+++ b/projects/ores.qt.mktdata/src/CMakeLists.txt
@@ -40,9 +40,9 @@ set_target_properties(${lib_target_name} PROPERTIES
     AUTOUIC_SEARCH_PATHS "${ORES_QT_MKTDATA_DIR}/ui;${ORES_QT_API_UI_DIR}"
     VERSION   ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/plugins"
-    INSTALL_RPATH "$ORIGIN/..:$ORIGIN"
-    BUILD_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY};${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/plugins")
+    LIBRARY_OUTPUT_DIRECTORY "${ORES_PLUGIN_OUTPUT_DIRECTORY}"
+    INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN"
+    BUILD_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
 target_include_directories(${lib_target_name} PUBLIC
     ${ORES_QT_MKTDATA_DIR}/include)
@@ -67,5 +67,5 @@ target_link_libraries(${lib_target_name}
         ores.qt.lib)
 
 install(TARGETS ${lib_target_name}
-    LIBRARY DESTINATION lib/plugins
-    RUNTIME DESTINATION bin/plugins)
+    LIBRARY DESTINATION bin
+    RUNTIME DESTINATION bin)

--- a/projects/ores.qt.mktdata/src/MktdataPlugin.cpp
+++ b/projects/ores.qt.mktdata/src/MktdataPlugin.cpp
@@ -22,19 +22,34 @@
 #include <QAction>
 
 #include "ores.qt/IconUtils.hpp"
+#include "ores.logging/make_logger.hpp"
 #include "ores.qt/CurrencyMarketTierController.hpp"
 #include "ores.qt/MarketDataController.hpp"
 
 namespace ores::qt {
 
-MktdataPlugin::MktdataPlugin(QObject* parent) : PluginBase(parent) {}
+using namespace ores::logging;
 
-MktdataPlugin::~MktdataPlugin() = default;
+namespace {
+auto& lg() {
+    static auto instance = make_logger("ores.qt.mktdata_plugin");
+    return instance;
+}
+}
+
+MktdataPlugin::MktdataPlugin(QObject* parent) : PluginBase(parent) {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin initialised.";
+}
+
+MktdataPlugin::~MktdataPlugin() {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin shutdown.";
+}
 
 // ---------------------------------------------------------------------------
 // IPlugin::on_login — create all controllers
 // ---------------------------------------------------------------------------
 void MktdataPlugin::on_login(const plugin_context& ctx) {
+    BOOST_LOG_SEV(lg(), debug) << "Login event received.";
     ctx_ = ctx;
 
     currencyMarketTierController_ = std::make_unique<CurrencyMarketTierController>(
@@ -59,6 +74,7 @@ void MktdataPlugin::on_login(const plugin_context& ctx) {
 // IPlugin::create_menus — return the Market Data menu.
 // ---------------------------------------------------------------------------
 QList<QMenu*> MktdataPlugin::create_menus() {
+    BOOST_LOG_SEV(lg(), debug) << "Building plugin menus.";
     using IC = IconUtils;
     auto ico = [](Icon i) { return IC::createRecoloredIcon(i, IC::DefaultIconColor); };
 
@@ -79,6 +95,7 @@ QList<QMenu*> MktdataPlugin::create_menus() {
     connect(actCurrencyMarketTiers, &QAction::triggered, this, [this]() {
         if (currencyMarketTierController_) currencyMarketTierController_->showListWindow();
     });
+    BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
     return {menuMarketData};
 }
 
@@ -90,6 +107,7 @@ QList<QAction*> MktdataPlugin::toolbar_actions() {
 // IPlugin::on_logout — close open singleton windows, destroy all controllers
 // ---------------------------------------------------------------------------
 void MktdataPlugin::on_logout() {
+    BOOST_LOG_SEV(lg(), debug) << "Logout event received.";
     marketDataController_.reset();
     currencyMarketTierController_.reset();
 

--- a/projects/ores.qt.party/src/CMakeLists.txt
+++ b/projects/ores.qt.party/src/CMakeLists.txt
@@ -40,8 +40,8 @@ set_target_properties(${lib_target_name} PROPERTIES
     AUTOUIC_SEARCH_PATHS "${ORES_QT_PARTY_DIR}/ui;${ORES_QT_API_UI_DIR}"
     VERSION   ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/plugins"
-    INSTALL_RPATH "$ORIGIN/.."
+    LIBRARY_OUTPUT_DIRECTORY "${ORES_PLUGIN_OUTPUT_DIRECTORY}"
+    INSTALL_RPATH "$ORIGIN/../lib"
     BUILD_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
 target_include_directories(${lib_target_name} PUBLIC
@@ -64,5 +64,5 @@ target_link_libraries(${lib_target_name}
         ores.qt.lib)
 
 install(TARGETS ${lib_target_name}
-    LIBRARY DESTINATION lib/plugins
-    RUNTIME DESTINATION bin/plugins)
+    LIBRARY DESTINATION bin
+    RUNTIME DESTINATION bin)

--- a/projects/ores.qt.party/src/PartyPlugin.cpp
+++ b/projects/ores.qt.party/src/PartyPlugin.cpp
@@ -22,6 +22,7 @@
 #include <QAction>
 
 #include "ores.qt/IconUtils.hpp"
+#include "ores.logging/make_logger.hpp"
 #include "ores.qt/DetachableMdiSubWindow.hpp"
 #include "ores.qt/PartyTypeController.hpp"
 #include "ores.qt/PartyStatusController.hpp"
@@ -35,14 +36,28 @@
 
 namespace ores::qt {
 
-PartyPlugin::PartyPlugin(QObject* parent) : PluginBase(parent) {}
+using namespace ores::logging;
 
-PartyPlugin::~PartyPlugin() = default;
+namespace {
+auto& lg() {
+    static auto instance = make_logger("ores.qt.party_plugin");
+    return instance;
+}
+}
+
+PartyPlugin::PartyPlugin(QObject* parent) : PluginBase(parent) {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin initialised.";
+}
+
+PartyPlugin::~PartyPlugin() {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin shutdown.";
+}
 
 // ---------------------------------------------------------------------------
 // IPlugin::on_login — create all controllers
 // ---------------------------------------------------------------------------
 void PartyPlugin::on_login(const plugin_context& ctx) {
+    BOOST_LOG_SEV(lg(), debug) << "Login event received.";
     ctx_ = ctx;
 
     partyTypeController_ = std::make_unique<PartyTypeController>(
@@ -95,6 +110,7 @@ void PartyPlugin::on_login(const plugin_context& ctx) {
 // IPlugin::create_menus — return the standalone Entities menu.
 // ---------------------------------------------------------------------------
 QList<QMenu*> PartyPlugin::create_menus() {
+    BOOST_LOG_SEV(lg(), debug) << "Building plugin menus.";
     using IC = IconUtils;
     auto ico = [](Icon i) { return IC::createRecoloredIcon(i, IC::DefaultIconColor); };
 
@@ -148,10 +164,13 @@ QList<QMenu*> PartyPlugin::create_menus() {
         if (businessUnitTypeController_) businessUnitTypeController_->showListWindow();
     });
 
+    BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
     return {menuEntities};
 }
 
 QList<QAction*> PartyPlugin::toolbar_actions() {
+    if (!act_business_centres_ || !act_parties_ || !act_counterparties_ || !act_business_units_)
+        BOOST_LOG_SEV(lg(), warn) << "One or more toolbar actions are uninitialised.";
     return {act_business_centres_, act_parties_, act_counterparties_, act_business_units_};
 }
 
@@ -159,6 +178,7 @@ QList<QAction*> PartyPlugin::toolbar_actions() {
 // IPlugin::on_logout — destroy all controllers in reverse dependency order
 // ---------------------------------------------------------------------------
 void PartyPlugin::on_logout() {
+    BOOST_LOG_SEV(lg(), debug) << "Logout event received.";
     businessUnitTypeController_.reset();
     businessUnitController_.reset();
     businessCentreController_.reset();

--- a/projects/ores.qt.refdata/src/CMakeLists.txt
+++ b/projects/ores.qt.refdata/src/CMakeLists.txt
@@ -40,8 +40,8 @@ set_target_properties(${lib_target_name} PROPERTIES
     AUTOUIC_SEARCH_PATHS "${ORES_QT_REFDATA_DIR}/ui;${ORES_QT_API_UI_DIR}"
     VERSION   ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/plugins"
-    INSTALL_RPATH "$ORIGIN/.."
+    LIBRARY_OUTPUT_DIRECTORY "${ORES_PLUGIN_OUTPUT_DIRECTORY}"
+    INSTALL_RPATH "$ORIGIN/../lib"
     BUILD_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
 target_include_directories(${lib_target_name} PUBLIC
@@ -67,5 +67,5 @@ target_link_libraries(${lib_target_name}
         ores.qt.lib)
 
 install(TARGETS ${lib_target_name}
-    LIBRARY DESTINATION lib/plugins
-    RUNTIME DESTINATION bin/plugins)
+    LIBRARY DESTINATION bin
+    RUNTIME DESTINATION bin)

--- a/projects/ores.qt.refdata/src/RefdataPlugin.cpp
+++ b/projects/ores.qt.refdata/src/RefdataPlugin.cpp
@@ -23,6 +23,7 @@
 #include <QMdiArea>
 #include <QMdiSubWindow>
 #include <QMainWindow>
+#include "ores.logging/make_logger.hpp"
 
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/DetachableMdiSubWindow.hpp"
@@ -46,14 +47,28 @@
 
 namespace ores::qt {
 
-RefdataPlugin::RefdataPlugin(QObject* parent) : PluginBase(parent) {}
+using namespace ores::logging;
 
-RefdataPlugin::~RefdataPlugin() = default;
+namespace {
+auto& lg() {
+    static auto instance = make_logger("ores.qt.refdata_plugin");
+    return instance;
+}
+}
+
+RefdataPlugin::RefdataPlugin(QObject* parent) : PluginBase(parent) {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin initialised.";
+}
+
+RefdataPlugin::~RefdataPlugin() {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin shutdown.";
+}
 
 // ---------------------------------------------------------------------------
 // IPlugin::on_login — create all controllers and wire cross-controller relays
 // ---------------------------------------------------------------------------
 void RefdataPlugin::on_login(const plugin_context& ctx) {
+    BOOST_LOG_SEV(lg(), debug) << "Login event received.";
     ctx_ = ctx;
 
     currencyController_ = std::make_unique<CurrencyController>(
@@ -144,11 +159,13 @@ void RefdataPlugin::on_login(const plugin_context& ctx) {
 }
 
 // ---------------------------------------------------------------------------
-// IPlugin::create_menus — return reference data domain menus.
-// ---------------------------------------------------------------------------
 // IPlugin::setup_menus — populate the shared Reference Data menu.
 // ---------------------------------------------------------------------------
 void RefdataPlugin::setup_menus(const shared_menus_context& smc) {
+    BOOST_LOG_SEV(lg(), debug) << "Registering entries in shared menus."
+        << " reference_data=" << (smc.reference_data_menu ? "ok" : "null")
+        << " data_transfer=" << (smc.data_transfer_menu ? "ok" : "null")
+        << " trading_codes=" << (smc.trading_codes_menu ? "ok" : "null");
     using IC = IconUtils;
     auto ico = [](Icon i) { return IC::createRecoloredIcon(i, IC::DefaultIconColor); };
 
@@ -299,10 +316,13 @@ void RefdataPlugin::setup_menus(const shared_menus_context& smc) {
 
 // ---------------------------------------------------------------------------
 QList<QMenu*> RefdataPlugin::create_menus() {
+    BOOST_LOG_SEV(lg(), debug) << "No standalone menus — all entries contributed via shared menus.";
     return {};  // all items contributed to the shared Reference Data menu
 }
 
 QList<QAction*> RefdataPlugin::toolbar_actions() {
+    if (!act_currencies_ || !act_countries_)
+        BOOST_LOG_SEV(lg(), warn) << "One or more toolbar actions are uninitialised.";
     return {act_currencies_, act_countries_};
 }
 
@@ -310,6 +330,7 @@ QList<QAction*> RefdataPlugin::toolbar_actions() {
 // IPlugin::on_logout — destroy all controllers in reverse dependency order
 // ---------------------------------------------------------------------------
 void RefdataPlugin::on_logout() {
+    BOOST_LOG_SEV(lg(), debug) << "Logout event received.";
     if (data_librarian_window_) {
         data_librarian_window_->close();
         data_librarian_window_ = nullptr;

--- a/projects/ores.qt.scheduler/src/CMakeLists.txt
+++ b/projects/ores.qt.scheduler/src/CMakeLists.txt
@@ -36,9 +36,9 @@ set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name}
     VERSION   ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/plugins"
-    INSTALL_RPATH "$ORIGIN/..:$ORIGIN"
-    BUILD_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY};${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/plugins")
+    LIBRARY_OUTPUT_DIRECTORY "${ORES_PLUGIN_OUTPUT_DIRECTORY}"
+    INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN"
+    BUILD_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
 target_include_directories(${lib_target_name} PUBLIC
     ${ORES_QT_SCHEDULER_DIR}/include)
@@ -55,5 +55,5 @@ target_link_libraries(${lib_target_name}
         ores.qt.lib)
 
 install(TARGETS ${lib_target_name}
-    LIBRARY DESTINATION lib/plugins
-    RUNTIME DESTINATION bin/plugins)
+    LIBRARY DESTINATION bin
+    RUNTIME DESTINATION bin)

--- a/projects/ores.qt.scheduler/src/SchedulerPlugin.cpp
+++ b/projects/ores.qt.scheduler/src/SchedulerPlugin.cpp
@@ -22,21 +22,36 @@
 #include <QAction>
 
 #include "ores.qt/IconUtils.hpp"
+#include "ores.logging/make_logger.hpp"
 #include "ores.qt/JobDefinitionController.hpp"
 
 namespace ores::qt {
 
+using namespace ores::logging;
+
 namespace {
+
+auto& lg() {
+    static auto instance = make_logger("ores.qt.scheduler_plugin");
+    return instance;
+}
+
 auto ico(Icon icon) {
     return IconUtils::createRecoloredIcon(icon, IconUtils::DefaultIconColor);
 }
+
 }
 
-SchedulerPlugin::SchedulerPlugin(QObject* parent) : PluginBase(parent) {}
+SchedulerPlugin::SchedulerPlugin(QObject* parent) : PluginBase(parent) {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin initialised.";
+}
 
-SchedulerPlugin::~SchedulerPlugin() = default;
+SchedulerPlugin::~SchedulerPlugin() {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin shutdown.";
+}
 
 void SchedulerPlugin::on_login(const plugin_context& ctx) {
+    BOOST_LOG_SEV(lg(), debug) << "Login event received.";
     ctx_ = ctx;
 
     jobDefinitionController_ = std::make_unique<JobDefinitionController>(
@@ -46,6 +61,7 @@ void SchedulerPlugin::on_login(const plugin_context& ctx) {
 }
 
 QList<QMenu*> SchedulerPlugin::create_menus() {
+    BOOST_LOG_SEV(lg(), debug) << "Building plugin menus.";
     auto* menuScheduler = new QMenu(tr("&Scheduler"));
 
     auto* actJobDefs = menuScheduler->addAction(
@@ -64,10 +80,12 @@ QList<QMenu*> SchedulerPlugin::create_menus() {
     actMonitor->setEnabled(false);
     actMonitor->setToolTip(tr("Not yet implemented"));
 
+    BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
     return {menuScheduler};
 }
 
 void SchedulerPlugin::on_logout() {
+    BOOST_LOG_SEV(lg(), debug) << "Logout event received.";
     jobDefinitionController_.reset();
     ctx_ = {};
 }

--- a/projects/ores.qt.trading/src/CMakeLists.txt
+++ b/projects/ores.qt.trading/src/CMakeLists.txt
@@ -40,9 +40,9 @@ set_target_properties(${lib_target_name} PROPERTIES
     AUTOUIC_SEARCH_PATHS "${ORES_QT_TRADING_DIR}/ui;${ORES_QT_API_UI_DIR}"
     VERSION   ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/plugins"
-    INSTALL_RPATH "$ORIGIN/..:$ORIGIN"
-    BUILD_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY};${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/plugins")
+    LIBRARY_OUTPUT_DIRECTORY "${ORES_PLUGIN_OUTPUT_DIRECTORY}"
+    INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN"
+    BUILD_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
 target_include_directories(${lib_target_name} PUBLIC
     ${ORES_QT_TRADING_DIR}/include)
@@ -70,5 +70,5 @@ target_link_libraries(${lib_target_name}
         ores.qt.lib)
 
 install(TARGETS ${lib_target_name}
-    LIBRARY DESTINATION lib/plugins
-    RUNTIME DESTINATION bin/plugins)
+    LIBRARY DESTINATION bin
+    RUNTIME DESTINATION bin)

--- a/projects/ores.qt.trading/src/TradingPlugin.cpp
+++ b/projects/ores.qt.trading/src/TradingPlugin.cpp
@@ -23,6 +23,7 @@
 #include <QMdiArea>
 #include <QMdiSubWindow>
 #include <QMainWindow>
+#include "ores.logging/make_logger.hpp"
 
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/DetachableMdiSubWindow.hpp"
@@ -36,14 +37,28 @@
 
 namespace ores::qt {
 
-TradingPlugin::TradingPlugin(QObject* parent) : PluginBase(parent) {}
+using namespace ores::logging;
 
-TradingPlugin::~TradingPlugin() = default;
+namespace {
+auto& lg() {
+    static auto instance = make_logger("ores.qt.trading_plugin");
+    return instance;
+}
+}
+
+TradingPlugin::TradingPlugin(QObject* parent) : PluginBase(parent) {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin initialised.";
+}
+
+TradingPlugin::~TradingPlugin() {
+    BOOST_LOG_SEV(lg(), debug) << "Plugin shutdown.";
+}
 
 // ---------------------------------------------------------------------------
 // IPlugin::on_login — create all controllers
 // ---------------------------------------------------------------------------
 void TradingPlugin::on_login(const plugin_context& ctx) {
+    BOOST_LOG_SEV(lg(), debug) << "Login event received.";
     ctx_ = ctx;
 
     oreImportController_ = std::make_unique<OreImportController>(
@@ -78,6 +93,9 @@ void TradingPlugin::on_login(const plugin_context& ctx) {
 // IPlugin::setup_menus — populate Trading Codes submenu and Data Transfer menu.
 // ---------------------------------------------------------------------------
 void TradingPlugin::setup_menus(const shared_menus_context& smc) {
+    BOOST_LOG_SEV(lg(), debug) << "Registering entries in shared menus."
+        << " trading_codes=" << (smc.trading_codes_menu ? "ok" : "null")
+        << " data_transfer=" << (smc.data_transfer_menu ? "ok" : "null");
     using IC = IconUtils;
     auto ico = [](Icon i) { return IC::createRecoloredIcon(i, IC::DefaultIconColor); };
 
@@ -109,6 +127,7 @@ void TradingPlugin::setup_menus(const shared_menus_context& smc) {
 // at the top of the Trading menu.
 // ---------------------------------------------------------------------------
 QList<QMenu*> TradingPlugin::create_menus() {
+    BOOST_LOG_SEV(lg(), debug) << "Building plugin menus.";
     using IC = IconUtils;
     auto ico = [](Icon i) { return IC::createRecoloredIcon(i, IC::DefaultIconColor); };
 
@@ -210,10 +229,14 @@ QList<QMenu*> TradingPlugin::create_menus() {
         menuTrading->addMenu(trading_codes_menu_);
     }
 
+    BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
     return {menuTrading};
 }
 
 QList<QAction*> TradingPlugin::toolbar_actions() {
+    if (!act_portfolios_ || !act_books_ || !act_portfolio_explorer_ ||
+            !act_org_explorer_ || !act_trades_)
+        BOOST_LOG_SEV(lg(), warn) << "One or more toolbar actions are uninitialised.";
     return {act_portfolios_, act_books_, act_portfolio_explorer_,
             act_org_explorer_, act_trades_};
 }
@@ -222,6 +245,7 @@ QList<QAction*> TradingPlugin::toolbar_actions() {
 // IPlugin::on_logout — close open singleton windows, destroy all controllers
 // ---------------------------------------------------------------------------
 void TradingPlugin::on_logout() {
+    BOOST_LOG_SEV(lg(), debug) << "Logout event received.";
     if (portfolio_explorer_sub_window_) {
         portfolio_explorer_sub_window_->close();
         portfolio_explorer_sub_window_ = nullptr;

--- a/projects/ores.qt/src/MainWindow.cpp
+++ b/projects/ores.qt/src/MainWindow.cpp
@@ -436,6 +436,7 @@ MainWindow::MainWindow(QWidget* parent) :
     // Phase 2 — collect standalone menus returned by create_menus().
     // Phase 3 — wire signals and collect toolbar actions.
     const auto& plugins = PluginRegistry::instance().plugins();
+    BOOST_LOG_SEV(lg(), info) << plugins.size() << " plugin(s) registered.";
 
     shared_menus_context smc;
     smc.system_menu        = ui_->menuSystem;
@@ -445,8 +446,11 @@ MainWindow::MainWindow(QWidget* parent) :
     smc.data_transfer_menu = dataTransferMenu;
     smc.trading_codes_menu = tradingCodesMenu;
 
-    for (auto* plugin : plugins)
+    BOOST_LOG_SEV(lg(), debug) << "Distributing shared menu handles to plugins.";
+    for (auto* plugin : plugins) {
+        BOOST_LOG_SEV(lg(), debug) << "  " << plugin->name().toStdString();
         plugin->setup_menus(smc);
+    }
 
     // Prepend My Account / My Sessions to the Identity menu (after plugins
     // have had a chance to add their items first).
@@ -468,6 +472,7 @@ MainWindow::MainWindow(QWidget* parent) :
     ui_->menuFile->removeAction(ui_->ActionMyAccount);
     ui_->menuFile->removeAction(ui_->ActionMySessions);
 
+    BOOST_LOG_SEV(lg(), debug) << "Collecting plugin menus and toolbar actions.";
     for (auto* plugin : plugins) {
         auto* pb = static_cast<PluginBase*>(plugin);
         connect(pb, &PluginBase::statusMessage,
@@ -477,20 +482,39 @@ MainWindow::MainWindow(QWidget* parent) :
         connect(pb, &PluginBase::windowDestroyed,
                 this, &MainWindow::onDetachableWindowDestroyed);
 
-        for (auto* menu : plugin->create_menus()) {
-            menuBar()->insertMenu(systemAction, menu);
-            plugin_menus_.append(menu);
+        const auto menus = plugin->create_menus();
+        BOOST_LOG_SEV(lg(), info)
+            << "  " << plugin->name().toStdString()
+            << ": " << menus.size() << " menu(s)";
+        for (auto* menu : menus) {
+            if (menu) {
+                BOOST_LOG_SEV(lg(), debug) << "    \"" << menu->title().toStdString() << "\"";
+                menuBar()->insertMenu(systemAction, menu);
+                plugin_menus_.append(menu);
+            } else {
+                BOOST_LOG_SEV(lg(), warn)
+                    << "    Null menu returned by " << plugin->name().toStdString();
+            }
         }
 
-        auto acts = plugin->toolbar_actions();
+        const auto acts = plugin->toolbar_actions();
         if (!acts.isEmpty()) {
             ui_->toolBar->addSeparator();
             for (auto* a : acts) {
-                ui_->toolBar->addAction(a);
-                plugin_toolbar_actions_.append(a);
+                if (a) {
+                    ui_->toolBar->addAction(a);
+                    plugin_toolbar_actions_.append(a);
+                } else {
+                    BOOST_LOG_SEV(lg(), warn)
+                        << "  Null toolbar action returned by " << plugin->name().toStdString();
+                }
             }
         }
     }
+
+    BOOST_LOG_SEV(lg(), info)
+        << "Menu bar ready: " << plugin_menus_.size() << " managed menus, "
+        << plugin_toolbar_actions_.size() << " toolbar actions.";
 
     // Initially disable data-related actions until logged in
     updateMenuState();
@@ -701,12 +725,22 @@ void MainWindow::updateMenuState() {
     const bool isConnected = clientManager_ && clientManager_->isConnected();
     const bool isLoggedIn = clientManager_ && clientManager_->isLoggedIn();
 
+    BOOST_LOG_SEV(lg(), debug)
+        << "Menu state update: connected=" << isConnected
+        << " logged_in=" << isLoggedIn
+        << " menus=" << plugin_menus_.size()
+        << " toolbar_actions=" << plugin_toolbar_actions_.size();
+
     ui_->ActionConnect->setEnabled(!isConnected);
     ui_->ActionDisconnect->setEnabled(isConnected);
 
     // Plugin-contributed domain menus enabled when logged in
-    for (auto* menu : plugin_menus_)
+    for (auto* menu : plugin_menus_) {
         menu->setEnabled(isLoggedIn);
+        BOOST_LOG_SEV(lg(), debug)
+            << "  \"" << menu->title().toStdString()
+            << "\" -> enabled=" << isLoggedIn;
+    }
 
     // Plugin toolbar actions follow the same login gate as their menus
     for (auto* action : plugin_toolbar_actions_)

--- a/projects/ores.qt/src/MainWindow.cpp
+++ b/projects/ores.qt/src/MainWindow.cpp
@@ -519,6 +519,20 @@ MainWindow::MainWindow(QWidget* parent) :
     // Initially disable data-related actions until logged in
     updateMenuState();
 
+    // Warn the user about any plugins that failed to load.
+    // Deferred so the main window is fully visible before the dialog appears.
+    const auto& errs = PluginRegistry::instance().load_errors();
+    if (!errs.isEmpty()) {
+        QTimer::singleShot(0, this, [this, errs]() {
+            QString msg = tr("The following plugins could not be loaded. "
+                             "Some features will be unavailable:\n\n");
+            for (const auto& e : errs)
+                msg += u"\u2022 " + e.filename + ":\n  " + e.message + "\n\n";
+            msg = msg.trimmed();
+            QMessageBox::warning(this, tr("Plugin Load Failures"), msg);
+        });
+    }
+
     // Initialize system tray
     if (QSystemTrayIcon::isSystemTrayAvailable()) {
         BOOST_LOG_SEV(lg(), debug) << "System tray is available, initializing...";

--- a/projects/ores.qt/src/ShellMdiWindow.cpp
+++ b/projects/ores.qt/src/ShellMdiWindow.cpp
@@ -150,13 +150,11 @@ void ShellMdiWindow::setup_ui() {
     output_area_ = new QPlainTextEdit(this);
     output_area_->setReadOnly(true);
     output_area_->setMaximumBlockCount(max_shell_output_lines);
-    output_area_->setStyleSheet(
-        "QPlainTextEdit { " + FontUtils::monospaceCssFragment() + " }");
+    output_area_->setFont(FontUtils::monospace());
 
     // Input line
     input_line_ = new QLineEdit(this);
-    input_line_->setStyleSheet(
-        "QLineEdit { " + FontUtils::monospaceCssFragment() + " }");
+    input_line_->setFont(FontUtils::monospace());
     input_line_->setPlaceholderText("Enter command...");
 
     layout->addWidget(output_area_);

--- a/projects/ores.qt/src/main.cpp
+++ b/projects/ores.qt/src/main.cpp
@@ -82,9 +82,10 @@ int main(int argc, char *argv[]) {
     ores::qt::PluginRegistry plugin_registry;
     ores::qt::PluginRegistry::initialise(plugin_registry);
 
-    // Load domain plugins from plugins/ directory next to the library directory
-    const QString plugin_dir =
-        QCoreApplication::applicationDirPath() + "/../lib/plugins";
+    // Load domain plugins from the same directory as the executable.
+    // This works on both Linux and Windows without any platform-specific path
+    // logic: plugins are built to ORES_PLUGIN_OUTPUT_DIRECTORY = bin/.
+    const QString plugin_dir = QCoreApplication::applicationDirPath();
     plugin_registry.load_from_directory(plugin_dir);
 
     ores::qt::SplashScreen splash(QPixmap(":/images/splash-screen.png"));

--- a/projects/ores.sql/create/trading/trading_create.sql
+++ b/projects/ores.sql/create/trading/trading_create.sql
@@ -132,6 +132,26 @@
 \ir ./trading_equity_instruments_create.sql
 \ir ./trading_equity_instruments_notify_trigger_create.sql
 
+-- Per-type equity instruments
+\ir ./trading_equity_option_instruments_create.sql
+\ir ./trading_equity_option_instruments_notify_trigger_create.sql
+\ir ./trading_equity_digital_option_instruments_create.sql
+\ir ./trading_equity_digital_option_instruments_notify_trigger_create.sql
+\ir ./trading_equity_barrier_option_instruments_create.sql
+\ir ./trading_equity_barrier_option_instruments_notify_trigger_create.sql
+\ir ./trading_equity_asian_option_instruments_create.sql
+\ir ./trading_equity_asian_option_instruments_notify_trigger_create.sql
+\ir ./trading_equity_forward_instruments_create.sql
+\ir ./trading_equity_forward_instruments_notify_trigger_create.sql
+\ir ./trading_equity_variance_swap_instruments_create.sql
+\ir ./trading_equity_variance_swap_instruments_notify_trigger_create.sql
+\ir ./trading_equity_swap_instruments_create.sql
+\ir ./trading_equity_swap_instruments_notify_trigger_create.sql
+\ir ./trading_equity_accumulator_instruments_create.sql
+\ir ./trading_equity_accumulator_instruments_notify_trigger_create.sql
+\ir ./trading_equity_position_instruments_create.sql
+\ir ./trading_equity_position_instruments_notify_trigger_create.sql
+
 -- Commodity instruments (depends on reference data above)
 \ir ./trading_commodity_instruments_create.sql
 \ir ./trading_commodity_instruments_notify_trigger_create.sql

--- a/projects/ores.sql/create/trading/trading_equity_accumulator_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_accumulator_instruments_create.sql
@@ -1,0 +1,162 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- Equity Accumulator Instruments Table
+--
+-- Routes ORE product types: EquityAccumulator, EquityTaRF.
+-- Optional fields (knock_out_level, target_amount, target_type) are NULL for
+-- non-applicable product types.
+-- =============================================================================
+
+create table if not exists "ores_trading_equity_accumulator_instruments_tbl" (
+    "instrument_id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "trade_id" uuid null,
+    "trade_type_code" text not null,
+    "underlying_name" text not null,
+    "currency" text not null,
+    "strike" numeric(28, 10) not null,
+    "fixing_amount" numeric(28, 10) not null,
+    "start_date" date not null,
+    "expiry_date" date not null,
+    "fixing_frequency" text not null,
+    "long_short" text not null,
+    "knock_out_level" numeric(28, 10) null,
+    "target_amount" numeric(28, 10) null,
+    "target_type" text null,
+    "payoff_type" text not null,
+    "description" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, instrument_id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        instrument_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
+    check ("fixing_amount" > 0),
+    check ("underlying_name" <> ''),
+    check ("currency" <> ''),
+    check ("trade_type_code" in ('EquityAccumulator', 'EquityTaRF'))
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_trading_equity_accumulator_instruments_version_uniq_idx
+on "ores_trading_equity_accumulator_instruments_tbl" (tenant_id, instrument_id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Current record uniqueness
+create unique index if not exists ores_trading_equity_accumulator_instruments_id_uniq_idx
+on "ores_trading_equity_accumulator_instruments_tbl" (tenant_id, instrument_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tenant index
+create index if not exists ores_trading_equity_accumulator_instruments_tenant_idx
+on "ores_trading_equity_accumulator_instruments_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Party index for RLS
+create index if not exists ores_trading_equity_accumulator_instruments_party_idx
+on "ores_trading_equity_accumulator_instruments_tbl" (tenant_id, party_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Soft FK back to trade (NULL for standalone instruments)
+create unique index if not exists ores_trading_equity_accumulator_instruments_trade_id_idx
+on "ores_trading_equity_accumulator_instruments_tbl" (tenant_id, trade_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and trade_id is not null;
+
+-- Trade type index for product filtering
+create index if not exists ores_trading_equity_accumulator_instruments_trade_type_idx
+on "ores_trading_equity_accumulator_instruments_tbl" (tenant_id, trade_type_code)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create or replace function ores_trading_equity_accumulator_instruments_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Set party_id from session context
+    NEW.party_id := current_setting('app.current_party_id')::uuid;
+
+    -- Validate trade_type_code
+    NEW.trade_type_code := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type_code);
+
+    -- Validate change_reason_code
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    -- Version management
+    select version into current_version
+    from "ores_trading_equity_accumulator_instruments_tbl"
+    where tenant_id = NEW.tenant_id
+      and instrument_id = NEW.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_trading_equity_accumulator_instruments_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and instrument_id = NEW.instrument_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return NEW;
+end;
+$$ language plpgsql security definer;
+
+create or replace trigger ores_trading_equity_accumulator_instruments_insert_trg
+before insert on "ores_trading_equity_accumulator_instruments_tbl"
+for each row execute function ores_trading_equity_accumulator_instruments_insert_fn();
+
+create or replace rule ores_trading_equity_accumulator_instruments_delete_rule as
+on delete to "ores_trading_equity_accumulator_instruments_tbl" do instead
+    update "ores_trading_equity_accumulator_instruments_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and instrument_id = OLD.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_equity_accumulator_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_accumulator_instruments_create.sql
@@ -63,7 +63,15 @@ create table if not exists "ores_trading_equity_accumulator_instruments_tbl" (
     check ("fixing_amount" > 0),
     check ("underlying_name" <> ''),
     check ("currency" <> ''),
-    check ("trade_type_code" in ('EquityAccumulator', 'EquityTaRF'))
+    check ("trade_type_code" in ('EquityAccumulator', 'EquityTaRF')),
+    -- EquityTaRF requires target fields; EquityAccumulator must not have them
+    check (
+        ("trade_type_code" = 'EquityTaRF'
+            and "target_amount" is not null and "target_type" is not null)
+        or
+        ("trade_type_code" = 'EquityAccumulator'
+            and "target_amount" is null and "target_type" is null)
+    )
 );
 
 -- Version uniqueness for optimistic concurrency

--- a/projects/ores.sql/create/trading/trading_equity_accumulator_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_accumulator_instruments_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+create or replace function ores_trading_equity_accumulator_instruments_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.trading.equity_accumulator_instrument';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.instrument_id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.instrument_id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_trading_equity_accumulator_instruments', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_trading_equity_accumulator_instruments_notify_trg
+after insert or update or delete on ores_trading_equity_accumulator_instruments_tbl
+for each row execute function ores_trading_equity_accumulator_instruments_notify_fn();

--- a/projects/ores.sql/create/trading/trading_equity_asian_option_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_asian_option_instruments_create.sql
@@ -1,0 +1,155 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- Equity Asian Option Instruments Table
+--
+-- Routes ORE product types: EquityAsianOption.
+-- =============================================================================
+
+create table if not exists "ores_trading_equity_asian_option_instruments_tbl" (
+    "instrument_id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "trade_id" uuid null,
+    "trade_type_code" text not null,
+    "underlying_name" text not null,
+    "currency" text not null,
+    "notional" numeric(28, 10) not null,
+    "option_type" text not null,
+    "strike" numeric(28, 10) not null,
+    "expiry_date" date not null,
+    "exercise_type" text not null,
+    "long_short" text not null,
+    "average_type" text not null,
+    "averaging_start_date" date not null,
+    "averaging_end_date" date not null,
+    "description" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, instrument_id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        instrument_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
+    check ("notional" > 0),
+    check ("strike" >= 0),
+    check ("underlying_name" <> ''),
+    check ("currency" <> ''),
+    check ("trade_type_code" in ('EquityAsianOption'))
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_trading_equity_asian_option_instruments_version_uniq_idx
+on "ores_trading_equity_asian_option_instruments_tbl" (tenant_id, instrument_id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Current record uniqueness
+create unique index if not exists ores_trading_equity_asian_option_instruments_id_uniq_idx
+on "ores_trading_equity_asian_option_instruments_tbl" (tenant_id, instrument_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tenant index
+create index if not exists ores_trading_equity_asian_option_instruments_tenant_idx
+on "ores_trading_equity_asian_option_instruments_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Party index for RLS
+create index if not exists ores_trading_equity_asian_option_instruments_party_idx
+on "ores_trading_equity_asian_option_instruments_tbl" (tenant_id, party_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Soft FK back to trade (NULL for standalone instruments)
+create unique index if not exists ores_trading_equity_asian_option_instruments_trade_id_idx
+on "ores_trading_equity_asian_option_instruments_tbl" (tenant_id, trade_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and trade_id is not null;
+
+create or replace function ores_trading_equity_asian_option_instruments_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Set party_id from session context
+    NEW.party_id := current_setting('app.current_party_id')::uuid;
+
+    -- Validate trade_type_code
+    NEW.trade_type_code := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type_code);
+
+    -- Validate change_reason_code
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    -- Version management
+    select version into current_version
+    from "ores_trading_equity_asian_option_instruments_tbl"
+    where tenant_id = NEW.tenant_id
+      and instrument_id = NEW.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_trading_equity_asian_option_instruments_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and instrument_id = NEW.instrument_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return NEW;
+end;
+$$ language plpgsql security definer;
+
+create or replace trigger ores_trading_equity_asian_option_instruments_insert_trg
+before insert on "ores_trading_equity_asian_option_instruments_tbl"
+for each row execute function ores_trading_equity_asian_option_instruments_insert_fn();
+
+create or replace rule ores_trading_equity_asian_option_instruments_delete_rule as
+on delete to "ores_trading_equity_asian_option_instruments_tbl" do instead
+    update "ores_trading_equity_asian_option_instruments_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and instrument_id = OLD.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_equity_asian_option_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_asian_option_instruments_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+create or replace function ores_trading_equity_asian_option_instruments_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.trading.equity_asian_option_instrument';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.instrument_id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.instrument_id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_trading_equity_asian_option_instruments', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_trading_equity_asian_option_instruments_notify_trg
+after insert or update or delete on ores_trading_equity_asian_option_instruments_tbl
+for each row execute function ores_trading_equity_asian_option_instruments_notify_fn();

--- a/projects/ores.sql/create/trading/trading_equity_barrier_option_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_barrier_option_instruments_create.sql
@@ -1,0 +1,158 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- Equity Barrier Option Instruments Table
+--
+-- Routes ORE product types: EquityBarrierOption, EquityDoubleBarrierOption,
+-- EquityEuropeanBarrierOption.
+-- =============================================================================
+
+create table if not exists "ores_trading_equity_barrier_option_instruments_tbl" (
+    "instrument_id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "trade_id" uuid null,
+    "trade_type_code" text not null,
+    "underlying_name" text not null,
+    "currency" text not null,
+    "notional" numeric(28, 10) not null,
+    "option_type" text not null,
+    "strike" numeric(28, 10) not null,
+    "expiry_date" date not null,
+    "exercise_type" text not null,
+    "long_short" text not null,
+    "lower_barrier" numeric(28, 10) not null,
+    "lower_barrier_type" text not null,
+    "upper_barrier" numeric(28, 10) null,
+    "upper_barrier_type" text null,
+    "rebate" numeric(28, 10) null,
+    "description" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, instrument_id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        instrument_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
+    check ("notional" > 0),
+    check ("strike" >= 0),
+    check ("underlying_name" <> ''),
+    check ("currency" <> ''),
+    check ("trade_type_code" in ('EquityBarrierOption', 'EquityDoubleBarrierOption', 'EquityEuropeanBarrierOption'))
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_trading_equity_barrier_option_instruments_version_uniq_idx
+on "ores_trading_equity_barrier_option_instruments_tbl" (tenant_id, instrument_id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Current record uniqueness
+create unique index if not exists ores_trading_equity_barrier_option_instruments_id_uniq_idx
+on "ores_trading_equity_barrier_option_instruments_tbl" (tenant_id, instrument_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tenant index
+create index if not exists ores_trading_equity_barrier_option_instruments_tenant_idx
+on "ores_trading_equity_barrier_option_instruments_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Party index for RLS
+create index if not exists ores_trading_equity_barrier_option_instruments_party_idx
+on "ores_trading_equity_barrier_option_instruments_tbl" (tenant_id, party_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Soft FK back to trade (NULL for standalone instruments)
+create unique index if not exists ores_trading_equity_barrier_option_instruments_trade_id_idx
+on "ores_trading_equity_barrier_option_instruments_tbl" (tenant_id, trade_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and trade_id is not null;
+
+create or replace function ores_trading_equity_barrier_option_instruments_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Set party_id from session context
+    NEW.party_id := current_setting('app.current_party_id')::uuid;
+
+    -- Validate trade_type_code
+    NEW.trade_type_code := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type_code);
+
+    -- Validate change_reason_code
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    -- Version management
+    select version into current_version
+    from "ores_trading_equity_barrier_option_instruments_tbl"
+    where tenant_id = NEW.tenant_id
+      and instrument_id = NEW.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_trading_equity_barrier_option_instruments_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and instrument_id = NEW.instrument_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return NEW;
+end;
+$$ language plpgsql security definer;
+
+create or replace trigger ores_trading_equity_barrier_option_instruments_insert_trg
+before insert on "ores_trading_equity_barrier_option_instruments_tbl"
+for each row execute function ores_trading_equity_barrier_option_instruments_insert_fn();
+
+create or replace rule ores_trading_equity_barrier_option_instruments_delete_rule as
+on delete to "ores_trading_equity_barrier_option_instruments_tbl" do instead
+    update "ores_trading_equity_barrier_option_instruments_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and instrument_id = OLD.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_equity_barrier_option_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_barrier_option_instruments_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+create or replace function ores_trading_equity_barrier_option_instruments_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.trading.equity_barrier_option_instrument';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.instrument_id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.instrument_id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_trading_equity_barrier_option_instruments', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_trading_equity_barrier_option_instruments_notify_trg
+after insert or update or delete on ores_trading_equity_barrier_option_instruments_tbl
+for each row execute function ores_trading_equity_barrier_option_instruments_notify_fn();

--- a/projects/ores.sql/create/trading/trading_equity_digital_option_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_digital_option_instruments_create.sql
@@ -59,7 +59,17 @@ create table if not exists "ores_trading_equity_digital_option_instruments_tbl" 
     check ("notional" > 0),
     check ("underlying_name" <> ''),
     check ("currency" <> ''),
-    check ("trade_type_code" in ('EquityDigitalOption', 'EquityTouchOption'))
+    check ("trade_type_code" in ('EquityDigitalOption', 'EquityTouchOption')),
+    -- EquityDigitalOption uses option_type + strike; EquityTouchOption uses barrier fields
+    check (
+        ("trade_type_code" = 'EquityDigitalOption'
+            and "option_type" is not null and "strike" is not null
+            and "barrier_level" is null and "barrier_type" is null)
+        or
+        ("trade_type_code" = 'EquityTouchOption'
+            and "barrier_level" is not null and "barrier_type" is not null
+            and "option_type" is null and "strike" is null)
+    )
 );
 
 -- Version uniqueness for optimistic concurrency

--- a/projects/ores.sql/create/trading/trading_equity_digital_option_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_digital_option_instruments_create.sql
@@ -1,0 +1,153 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- Equity Digital Option Instruments Table
+--
+-- Routes ORE product types: EquityDigitalOption, EquityTouchOption.
+-- =============================================================================
+
+create table if not exists "ores_trading_equity_digital_option_instruments_tbl" (
+    "instrument_id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "trade_id" uuid null,
+    "trade_type_code" text not null,
+    "underlying_name" text not null,
+    "currency" text not null,
+    "notional" numeric(28, 10) not null,
+    "option_type" text null,
+    "strike" numeric(28, 10) null,
+    "barrier_level" numeric(28, 10) null,
+    "barrier_type" text null,
+    "expiry_date" date not null,
+    "long_short" text not null,
+    "payout_amount" numeric(28, 10) null,
+    "description" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, instrument_id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        instrument_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
+    check ("notional" > 0),
+    check ("underlying_name" <> ''),
+    check ("currency" <> ''),
+    check ("trade_type_code" in ('EquityDigitalOption', 'EquityTouchOption'))
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_trading_equity_digital_option_instruments_version_uniq_idx
+on "ores_trading_equity_digital_option_instruments_tbl" (tenant_id, instrument_id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Current record uniqueness
+create unique index if not exists ores_trading_equity_digital_option_instruments_id_uniq_idx
+on "ores_trading_equity_digital_option_instruments_tbl" (tenant_id, instrument_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tenant index
+create index if not exists ores_trading_equity_digital_option_instruments_tenant_idx
+on "ores_trading_equity_digital_option_instruments_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Party index for RLS
+create index if not exists ores_trading_equity_digital_option_instruments_party_idx
+on "ores_trading_equity_digital_option_instruments_tbl" (tenant_id, party_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Soft FK back to trade (NULL for standalone instruments)
+create unique index if not exists ores_trading_equity_digital_option_instruments_trade_id_idx
+on "ores_trading_equity_digital_option_instruments_tbl" (tenant_id, trade_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and trade_id is not null;
+
+create or replace function ores_trading_equity_digital_option_instruments_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Set party_id from session context
+    NEW.party_id := current_setting('app.current_party_id')::uuid;
+
+    -- Validate trade_type_code
+    NEW.trade_type_code := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type_code);
+
+    -- Validate change_reason_code
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    -- Version management
+    select version into current_version
+    from "ores_trading_equity_digital_option_instruments_tbl"
+    where tenant_id = NEW.tenant_id
+      and instrument_id = NEW.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_trading_equity_digital_option_instruments_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and instrument_id = NEW.instrument_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return NEW;
+end;
+$$ language plpgsql security definer;
+
+create or replace trigger ores_trading_equity_digital_option_instruments_insert_trg
+before insert on "ores_trading_equity_digital_option_instruments_tbl"
+for each row execute function ores_trading_equity_digital_option_instruments_insert_fn();
+
+create or replace rule ores_trading_equity_digital_option_instruments_delete_rule as
+on delete to "ores_trading_equity_digital_option_instruments_tbl" do instead
+    update "ores_trading_equity_digital_option_instruments_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and instrument_id = OLD.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_equity_digital_option_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_digital_option_instruments_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+create or replace function ores_trading_equity_digital_option_instruments_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.trading.equity_digital_option_instrument';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.instrument_id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.instrument_id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_trading_equity_digital_option_instruments', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_trading_equity_digital_option_instruments_notify_trg
+after insert or update or delete on ores_trading_equity_digital_option_instruments_tbl
+for each row execute function ores_trading_equity_digital_option_instruments_notify_fn();

--- a/projects/ores.sql/create/trading/trading_equity_forward_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_forward_instruments_create.sql
@@ -1,0 +1,150 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- Equity Forward Instruments Table
+--
+-- Routes ORE product types: EquityForward.
+-- =============================================================================
+
+create table if not exists "ores_trading_equity_forward_instruments_tbl" (
+    "instrument_id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "trade_id" uuid null,
+    "trade_type_code" text not null,
+    "underlying_name" text not null,
+    "currency" text not null,
+    "quantity" numeric(28, 10) not null,
+    "forward_price" numeric(28, 10) null,
+    "expiry_date" date not null,
+    "long_short" text not null,
+    "settlement_type" text null,
+    "description" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, instrument_id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        instrument_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
+    check ("quantity" > 0),
+    check ("underlying_name" <> ''),
+    check ("currency" <> ''),
+    check ("trade_type_code" in ('EquityForward'))
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_trading_equity_forward_instruments_version_uniq_idx
+on "ores_trading_equity_forward_instruments_tbl" (tenant_id, instrument_id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Current record uniqueness
+create unique index if not exists ores_trading_equity_forward_instruments_id_uniq_idx
+on "ores_trading_equity_forward_instruments_tbl" (tenant_id, instrument_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tenant index
+create index if not exists ores_trading_equity_forward_instruments_tenant_idx
+on "ores_trading_equity_forward_instruments_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Party index for RLS
+create index if not exists ores_trading_equity_forward_instruments_party_idx
+on "ores_trading_equity_forward_instruments_tbl" (tenant_id, party_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Soft FK back to trade (NULL for standalone instruments)
+create unique index if not exists ores_trading_equity_forward_instruments_trade_id_idx
+on "ores_trading_equity_forward_instruments_tbl" (tenant_id, trade_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and trade_id is not null;
+
+create or replace function ores_trading_equity_forward_instruments_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Set party_id from session context
+    NEW.party_id := current_setting('app.current_party_id')::uuid;
+
+    -- Validate trade_type_code
+    NEW.trade_type_code := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type_code);
+
+    -- Validate change_reason_code
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    -- Version management
+    select version into current_version
+    from "ores_trading_equity_forward_instruments_tbl"
+    where tenant_id = NEW.tenant_id
+      and instrument_id = NEW.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_trading_equity_forward_instruments_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and instrument_id = NEW.instrument_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return NEW;
+end;
+$$ language plpgsql security definer;
+
+create or replace trigger ores_trading_equity_forward_instruments_insert_trg
+before insert on "ores_trading_equity_forward_instruments_tbl"
+for each row execute function ores_trading_equity_forward_instruments_insert_fn();
+
+create or replace rule ores_trading_equity_forward_instruments_delete_rule as
+on delete to "ores_trading_equity_forward_instruments_tbl" do instead
+    update "ores_trading_equity_forward_instruments_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and instrument_id = OLD.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_equity_forward_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_forward_instruments_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+create or replace function ores_trading_equity_forward_instruments_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.trading.equity_forward_instrument';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.instrument_id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.instrument_id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_trading_equity_forward_instruments', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_trading_equity_forward_instruments_notify_trg
+after insert or update or delete on ores_trading_equity_forward_instruments_tbl
+for each row execute function ores_trading_equity_forward_instruments_notify_fn();

--- a/projects/ores.sql/create/trading/trading_equity_option_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_option_instruments_create.sql
@@ -1,0 +1,159 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- Equity Option Instruments Table
+--
+-- Routes ORE product types: EquityOption, EquityCliquetOption.
+-- =============================================================================
+
+create table if not exists "ores_trading_equity_option_instruments_tbl" (
+    "instrument_id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "trade_id" uuid null,
+    "trade_type_code" text not null,
+    "underlying_name" text not null,
+    "currency" text not null,
+    "notional" numeric(28, 10) not null,
+    "option_type" text not null,
+    "strike" numeric(28, 10) not null,
+    "expiry_date" date not null,
+    "exercise_type" text not null,
+    "long_short" text not null,
+    "settlement_type" text null,
+    "cliquet_frequency" text null,
+    "description" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, instrument_id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        instrument_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
+    check ("notional" > 0),
+    check ("strike" >= 0),
+    check ("underlying_name" <> ''),
+    check ("currency" <> ''),
+    check ("trade_type_code" in ('EquityOption', 'EquityCliquetOption'))
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_trading_equity_option_instruments_version_uniq_idx
+on "ores_trading_equity_option_instruments_tbl" (tenant_id, instrument_id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Current record uniqueness
+create unique index if not exists ores_trading_equity_option_instruments_id_uniq_idx
+on "ores_trading_equity_option_instruments_tbl" (tenant_id, instrument_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tenant index
+create index if not exists ores_trading_equity_option_instruments_tenant_idx
+on "ores_trading_equity_option_instruments_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Party index for RLS
+create index if not exists ores_trading_equity_option_instruments_party_idx
+on "ores_trading_equity_option_instruments_tbl" (tenant_id, party_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Soft FK back to trade (NULL for standalone instruments)
+create unique index if not exists ores_trading_equity_option_instruments_trade_id_idx
+on "ores_trading_equity_option_instruments_tbl" (tenant_id, trade_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and trade_id is not null;
+
+-- Trade type index
+create index if not exists ores_trading_equity_option_instruments_type_idx
+on "ores_trading_equity_option_instruments_tbl" (tenant_id, trade_type_code)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create or replace function ores_trading_equity_option_instruments_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Set party_id from session context
+    NEW.party_id := current_setting('app.current_party_id')::uuid;
+
+    -- Validate trade_type_code
+    NEW.trade_type_code := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type_code);
+
+    -- Validate change_reason_code
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    -- Version management
+    select version into current_version
+    from "ores_trading_equity_option_instruments_tbl"
+    where tenant_id = NEW.tenant_id
+      and instrument_id = NEW.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_trading_equity_option_instruments_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and instrument_id = NEW.instrument_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return NEW;
+end;
+$$ language plpgsql security definer;
+
+create or replace trigger ores_trading_equity_option_instruments_insert_trg
+before insert on "ores_trading_equity_option_instruments_tbl"
+for each row execute function ores_trading_equity_option_instruments_insert_fn();
+
+create or replace rule ores_trading_equity_option_instruments_delete_rule as
+on delete to "ores_trading_equity_option_instruments_tbl" do instead
+    update "ores_trading_equity_option_instruments_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and instrument_id = OLD.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_equity_option_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_option_instruments_create.sql
@@ -60,7 +60,13 @@ create table if not exists "ores_trading_equity_option_instruments_tbl" (
     check ("strike" >= 0),
     check ("underlying_name" <> ''),
     check ("currency" <> ''),
-    check ("trade_type_code" in ('EquityOption', 'EquityCliquetOption'))
+    check ("trade_type_code" in ('EquityOption', 'EquityCliquetOption')),
+    -- cliquet_frequency is required for EquityCliquetOption and must be null otherwise
+    check (
+        ("trade_type_code" = 'EquityCliquetOption' and "cliquet_frequency" is not null)
+        or
+        ("trade_type_code" = 'EquityOption' and "cliquet_frequency" is null)
+    )
 );
 
 -- Version uniqueness for optimistic concurrency

--- a/projects/ores.sql/create/trading/trading_equity_option_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_option_instruments_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+create or replace function ores_trading_equity_option_instruments_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.trading.equity_option_instrument';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.instrument_id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.instrument_id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_trading_equity_option_instruments', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_trading_equity_option_instruments_notify_trg
+after insert or update or delete on ores_trading_equity_option_instruments_tbl
+for each row execute function ores_trading_equity_option_instruments_notify_fn();

--- a/projects/ores.sql/create/trading/trading_equity_position_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_position_instruments_create.sql
@@ -56,7 +56,13 @@ create table if not exists "ores_trading_equity_position_instruments_tbl" (
     check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
     check ("underlying_name" <> ''),
     check ("currency" <> ''),
-    check ("trade_type_code" in ('EquityPosition', 'EquityOptionPosition'))
+    check ("trade_type_code" in ('EquityPosition', 'EquityOptionPosition')),
+    -- option_data_json is required for EquityOptionPosition and must be null otherwise
+    check (
+        ("trade_type_code" = 'EquityOptionPosition' and "option_data_json" is not null)
+        or
+        ("trade_type_code" = 'EquityPosition' and "option_data_json" is null)
+    )
 );
 
 -- Version uniqueness for optimistic concurrency

--- a/projects/ores.sql/create/trading/trading_equity_position_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_position_instruments_create.sql
@@ -1,0 +1,155 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- Equity Position Instruments Table
+--
+-- Routes ORE product types: EquityPosition, EquityOptionPosition.
+-- For option positions, option_data_json holds the option parameters. For plain
+-- equity positions, price captures the reference price and option_data_json is
+-- NULL.
+-- =============================================================================
+
+create table if not exists "ores_trading_equity_position_instruments_tbl" (
+    "instrument_id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "trade_id" uuid null,
+    "trade_type_code" text not null,
+    "underlying_name" text not null,
+    "currency" text not null,
+    "quantity" numeric(28, 10) not null,
+    "price" numeric(28, 10) null,
+    "option_data_json" text null,
+    "description" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, instrument_id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        instrument_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
+    check ("underlying_name" <> ''),
+    check ("currency" <> ''),
+    check ("trade_type_code" in ('EquityPosition', 'EquityOptionPosition'))
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_trading_equity_position_instruments_version_uniq_idx
+on "ores_trading_equity_position_instruments_tbl" (tenant_id, instrument_id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Current record uniqueness
+create unique index if not exists ores_trading_equity_position_instruments_id_uniq_idx
+on "ores_trading_equity_position_instruments_tbl" (tenant_id, instrument_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tenant index
+create index if not exists ores_trading_equity_position_instruments_tenant_idx
+on "ores_trading_equity_position_instruments_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Party index for RLS
+create index if not exists ores_trading_equity_position_instruments_party_idx
+on "ores_trading_equity_position_instruments_tbl" (tenant_id, party_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Soft FK back to trade (NULL for standalone instruments)
+create unique index if not exists ores_trading_equity_position_instruments_trade_id_idx
+on "ores_trading_equity_position_instruments_tbl" (tenant_id, trade_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and trade_id is not null;
+
+-- Trade type index for product filtering
+create index if not exists ores_trading_equity_position_instruments_trade_type_idx
+on "ores_trading_equity_position_instruments_tbl" (tenant_id, trade_type_code)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create or replace function ores_trading_equity_position_instruments_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Set party_id from session context
+    NEW.party_id := current_setting('app.current_party_id')::uuid;
+
+    -- Validate trade_type_code
+    NEW.trade_type_code := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type_code);
+
+    -- Validate change_reason_code
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    -- Version management
+    select version into current_version
+    from "ores_trading_equity_position_instruments_tbl"
+    where tenant_id = NEW.tenant_id
+      and instrument_id = NEW.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_trading_equity_position_instruments_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and instrument_id = NEW.instrument_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return NEW;
+end;
+$$ language plpgsql security definer;
+
+create or replace trigger ores_trading_equity_position_instruments_insert_trg
+before insert on "ores_trading_equity_position_instruments_tbl"
+for each row execute function ores_trading_equity_position_instruments_insert_fn();
+
+create or replace rule ores_trading_equity_position_instruments_delete_rule as
+on delete to "ores_trading_equity_position_instruments_tbl" do instead
+    update "ores_trading_equity_position_instruments_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and instrument_id = OLD.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_equity_position_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_position_instruments_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+create or replace function ores_trading_equity_position_instruments_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.trading.equity_position_instrument';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.instrument_id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.instrument_id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_trading_equity_position_instruments', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_trading_equity_position_instruments_notify_trg
+after insert or update or delete on ores_trading_equity_position_instruments_tbl
+for each row execute function ores_trading_equity_position_instruments_notify_fn();

--- a/projects/ores.sql/create/trading/trading_equity_swap_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_swap_instruments_create.sql
@@ -59,7 +59,15 @@ create table if not exists "ores_trading_equity_swap_instruments_tbl" (
     check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
     check ("notional" > 0),
     check ("currency" <> ''),
-    check ("trade_type_code" in ('EquitySwap', 'EquityWorstOfBasketSwap'))
+    check ("trade_type_code" in ('EquitySwap', 'EquityWorstOfBasketSwap')),
+    -- EquityWorstOfBasketSwap uses basket_json; EquitySwap uses underlying_name
+    check (
+        ("trade_type_code" = 'EquityWorstOfBasketSwap'
+            and "basket_json" is not null and "underlying_name" is null)
+        or
+        ("trade_type_code" = 'EquitySwap'
+            and "underlying_name" is not null and "basket_json" is null)
+    )
 );
 
 -- Version uniqueness for optimistic concurrency

--- a/projects/ores.sql/create/trading/trading_equity_swap_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_swap_instruments_create.sql
@@ -1,0 +1,158 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- Equity Swap Instruments Table
+--
+-- Routes ORE product types: EquitySwap, EquityWorstOfBasketSwap.
+-- For basket swaps, underlying_name is NULL and basket_json holds the basket
+-- definition. For single-name swaps, basket_json is NULL.
+-- =============================================================================
+
+create table if not exists "ores_trading_equity_swap_instruments_tbl" (
+    "instrument_id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "trade_id" uuid null,
+    "trade_type_code" text not null,
+    "underlying_name" text null,
+    "basket_json" text null,
+    "currency" text not null,
+    "notional" numeric(28, 10) not null,
+    "return_type" text not null,
+    "start_date" date not null,
+    "maturity_date" date not null,
+    "long_short" text not null,
+    "payment_frequency" text not null,
+    "description" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, instrument_id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        instrument_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
+    check ("notional" > 0),
+    check ("currency" <> ''),
+    check ("trade_type_code" in ('EquitySwap', 'EquityWorstOfBasketSwap'))
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_trading_equity_swap_instruments_version_uniq_idx
+on "ores_trading_equity_swap_instruments_tbl" (tenant_id, instrument_id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Current record uniqueness
+create unique index if not exists ores_trading_equity_swap_instruments_id_uniq_idx
+on "ores_trading_equity_swap_instruments_tbl" (tenant_id, instrument_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tenant index
+create index if not exists ores_trading_equity_swap_instruments_tenant_idx
+on "ores_trading_equity_swap_instruments_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Party index for RLS
+create index if not exists ores_trading_equity_swap_instruments_party_idx
+on "ores_trading_equity_swap_instruments_tbl" (tenant_id, party_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Soft FK back to trade (NULL for standalone instruments)
+create unique index if not exists ores_trading_equity_swap_instruments_trade_id_idx
+on "ores_trading_equity_swap_instruments_tbl" (tenant_id, trade_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and trade_id is not null;
+
+-- Trade type index for product filtering
+create index if not exists ores_trading_equity_swap_instruments_trade_type_idx
+on "ores_trading_equity_swap_instruments_tbl" (tenant_id, trade_type_code)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create or replace function ores_trading_equity_swap_instruments_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Set party_id from session context
+    NEW.party_id := current_setting('app.current_party_id')::uuid;
+
+    -- Validate trade_type_code
+    NEW.trade_type_code := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type_code);
+
+    -- Validate change_reason_code
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    -- Version management
+    select version into current_version
+    from "ores_trading_equity_swap_instruments_tbl"
+    where tenant_id = NEW.tenant_id
+      and instrument_id = NEW.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_trading_equity_swap_instruments_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and instrument_id = NEW.instrument_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return NEW;
+end;
+$$ language plpgsql security definer;
+
+create or replace trigger ores_trading_equity_swap_instruments_insert_trg
+before insert on "ores_trading_equity_swap_instruments_tbl"
+for each row execute function ores_trading_equity_swap_instruments_insert_fn();
+
+create or replace rule ores_trading_equity_swap_instruments_delete_rule as
+on delete to "ores_trading_equity_swap_instruments_tbl" do instead
+    update "ores_trading_equity_swap_instruments_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and instrument_id = OLD.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_equity_swap_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_swap_instruments_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+create or replace function ores_trading_equity_swap_instruments_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.trading.equity_swap_instrument';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.instrument_id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.instrument_id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_trading_equity_swap_instruments', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_trading_equity_swap_instruments_notify_trg
+after insert or update or delete on ores_trading_equity_swap_instruments_tbl
+for each row execute function ores_trading_equity_swap_instruments_notify_fn();

--- a/projects/ores.sql/create/trading/trading_equity_variance_swap_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_variance_swap_instruments_create.sql
@@ -1,0 +1,155 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- Equity Variance Swap Instruments Table
+--
+-- Routes ORE product types: EquityVarianceSwap.
+-- =============================================================================
+
+create table if not exists "ores_trading_equity_variance_swap_instruments_tbl" (
+    "instrument_id" uuid not null,
+    "tenant_id" uuid not null,
+    "party_id" uuid not null,
+    "version" integer not null,
+    "trade_id" uuid null,
+    "trade_type_code" text not null,
+    "underlying_name" text not null,
+    "currency" text not null,
+    "notional" numeric(28, 10) not null,
+    "variance_strike" numeric(28, 10) not null,
+    "start_date" date not null,
+    "maturity_date" date not null,
+    "long_short" text not null,
+    "description" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, instrument_id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        instrument_id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("instrument_id" <> '00000000-0000-0000-0000-000000000000'::uuid),
+    check ("notional" > 0),
+    check ("underlying_name" <> ''),
+    check ("currency" <> ''),
+    check ("trade_type_code" in ('EquityVarianceSwap'))
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_trading_equity_variance_swap_instruments_version_uniq_idx
+on "ores_trading_equity_variance_swap_instruments_tbl" (tenant_id, instrument_id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Current record uniqueness
+create unique index if not exists ores_trading_equity_variance_swap_instruments_id_uniq_idx
+on "ores_trading_equity_variance_swap_instruments_tbl" (tenant_id, instrument_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Tenant index
+create index if not exists ores_trading_equity_variance_swap_instruments_tenant_idx
+on "ores_trading_equity_variance_swap_instruments_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Party index for RLS
+create index if not exists ores_trading_equity_variance_swap_instruments_party_idx
+on "ores_trading_equity_variance_swap_instruments_tbl" (tenant_id, party_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Soft FK back to trade (NULL for standalone instruments)
+create unique index if not exists ores_trading_equity_variance_swap_instruments_trade_id_idx
+on "ores_trading_equity_variance_swap_instruments_tbl" (tenant_id, trade_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and trade_id is not null;
+
+-- Trade type index for product filtering
+create index if not exists ores_trading_equity_variance_swap_instruments_trade_type_idx
+on "ores_trading_equity_variance_swap_instruments_tbl" (tenant_id, trade_type_code)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create or replace function ores_trading_equity_variance_swap_instruments_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Set party_id from session context
+    NEW.party_id := current_setting('app.current_party_id')::uuid;
+
+    -- Validate trade_type_code
+    NEW.trade_type_code := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type_code);
+
+    -- Validate change_reason_code
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    -- Version management
+    select version into current_version
+    from "ores_trading_equity_variance_swap_instruments_tbl"
+    where tenant_id = NEW.tenant_id
+      and instrument_id = NEW.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_trading_equity_variance_swap_instruments_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and instrument_id = NEW.instrument_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return NEW;
+end;
+$$ language plpgsql security definer;
+
+create or replace trigger ores_trading_equity_variance_swap_instruments_insert_trg
+before insert on "ores_trading_equity_variance_swap_instruments_tbl"
+for each row execute function ores_trading_equity_variance_swap_instruments_insert_fn();
+
+create or replace rule ores_trading_equity_variance_swap_instruments_delete_rule as
+on delete to "ores_trading_equity_variance_swap_instruments_tbl" do instead
+    update "ores_trading_equity_variance_swap_instruments_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and instrument_id = OLD.instrument_id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_equity_variance_swap_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_variance_swap_instruments_create.sql
@@ -56,7 +56,8 @@ create table if not exists "ores_trading_equity_variance_swap_instruments_tbl" (
     check ("notional" > 0),
     check ("underlying_name" <> ''),
     check ("currency" <> ''),
-    check ("trade_type_code" in ('EquityVarianceSwap'))
+    check ("trade_type_code" in ('EquityVarianceSwap')),
+    check ("variance_strike" >= 0)
 );
 
 -- Version uniqueness for optimistic concurrency

--- a/projects/ores.sql/create/trading/trading_equity_variance_swap_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_variance_swap_instruments_notify_trigger_create.sql
@@ -1,0 +1,53 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+create or replace function ores_trading_equity_variance_swap_instruments_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.trading.equity_variance_swap_instrument';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.instrument_id::text;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.instrument_id::text;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_trading_equity_variance_swap_instruments', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_trading_equity_variance_swap_instruments_notify_trg
+after insert or update or delete on ores_trading_equity_variance_swap_instruments_tbl
+for each row execute function ores_trading_equity_variance_swap_instruments_notify_fn();

--- a/projects/ores.sql/create/trading/trading_rls_policies_create.sql
+++ b/projects/ores.sql/create/trading/trading_rls_policies_create.sql
@@ -206,6 +206,186 @@ for select using (
 );
 
 -- -----------------------------------------------------------------------------
+-- Equity Option Instruments
+-- -----------------------------------------------------------------------------
+alter table ores_trading_equity_option_instruments_tbl enable row level security;
+
+create policy ores_trading_equity_option_instruments_tenant_isolation_policy on ores_trading_equity_option_instruments_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy ores_trading_equity_option_instruments_party_isolation_policy
+on ores_trading_equity_option_instruments_tbl
+as restrictive
+for select using (
+    party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
+-- Equity Digital Option Instruments
+-- -----------------------------------------------------------------------------
+alter table ores_trading_equity_digital_option_instruments_tbl enable row level security;
+
+create policy ores_trading_equity_digital_option_instruments_tenant_isolation_policy on ores_trading_equity_digital_option_instruments_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy ores_trading_equity_digital_option_instruments_party_isolation_policy
+on ores_trading_equity_digital_option_instruments_tbl
+as restrictive
+for select using (
+    party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
+-- Equity Barrier Option Instruments
+-- -----------------------------------------------------------------------------
+alter table ores_trading_equity_barrier_option_instruments_tbl enable row level security;
+
+create policy ores_trading_equity_barrier_option_instruments_tenant_isolation_policy on ores_trading_equity_barrier_option_instruments_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy ores_trading_equity_barrier_option_instruments_party_isolation_policy
+on ores_trading_equity_barrier_option_instruments_tbl
+as restrictive
+for select using (
+    party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
+-- Equity Asian Option Instruments
+-- -----------------------------------------------------------------------------
+alter table ores_trading_equity_asian_option_instruments_tbl enable row level security;
+
+create policy ores_trading_equity_asian_option_instruments_tenant_isolation_policy on ores_trading_equity_asian_option_instruments_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy ores_trading_equity_asian_option_instruments_party_isolation_policy
+on ores_trading_equity_asian_option_instruments_tbl
+as restrictive
+for select using (
+    party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
+-- Equity Forward Instruments
+-- -----------------------------------------------------------------------------
+alter table ores_trading_equity_forward_instruments_tbl enable row level security;
+
+create policy ores_trading_equity_forward_instruments_tenant_isolation_policy on ores_trading_equity_forward_instruments_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy ores_trading_equity_forward_instruments_party_isolation_policy
+on ores_trading_equity_forward_instruments_tbl
+as restrictive
+for select using (
+    party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
+-- Equity Variance Swap Instruments
+-- -----------------------------------------------------------------------------
+alter table ores_trading_equity_variance_swap_instruments_tbl enable row level security;
+
+create policy ores_trading_equity_variance_swap_instruments_tenant_isolation_policy on ores_trading_equity_variance_swap_instruments_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy ores_trading_equity_variance_swap_instruments_party_isolation_policy
+on ores_trading_equity_variance_swap_instruments_tbl
+as restrictive
+for select using (
+    party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
+-- Equity Swap Instruments
+-- -----------------------------------------------------------------------------
+alter table ores_trading_equity_swap_instruments_tbl enable row level security;
+
+create policy ores_trading_equity_swap_instruments_tenant_isolation_policy on ores_trading_equity_swap_instruments_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy ores_trading_equity_swap_instruments_party_isolation_policy
+on ores_trading_equity_swap_instruments_tbl
+as restrictive
+for select using (
+    party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
+-- Equity Accumulator Instruments
+-- -----------------------------------------------------------------------------
+alter table ores_trading_equity_accumulator_instruments_tbl enable row level security;
+
+create policy ores_trading_equity_accumulator_instruments_tenant_isolation_policy on ores_trading_equity_accumulator_instruments_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy ores_trading_equity_accumulator_instruments_party_isolation_policy
+on ores_trading_equity_accumulator_instruments_tbl
+as restrictive
+for select using (
+    party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
+-- Equity Position Instruments
+-- -----------------------------------------------------------------------------
+alter table ores_trading_equity_position_instruments_tbl enable row level security;
+
+create policy ores_trading_equity_position_instruments_tenant_isolation_policy on ores_trading_equity_position_instruments_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+create policy ores_trading_equity_position_instruments_party_isolation_policy
+on ores_trading_equity_position_instruments_tbl
+as restrictive
+for select using (
+    party_id = ANY(ores_iam_visible_party_ids_fn())
+);
+
+-- -----------------------------------------------------------------------------
 -- FX Instruments
 -- -----------------------------------------------------------------------------
 alter table ores_trading_fx_instruments_tbl enable row level security;

--- a/projects/ores.sql/drop/trading/trading_equity_accumulator_instruments_drop.sql
+++ b/projects/ores.sql/drop/trading/trading_equity_accumulator_instruments_drop.sql
@@ -1,0 +1,26 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_trading_equity_accumulator_instruments_notify_trg on "ores_trading_equity_accumulator_instruments_tbl";
+drop function if exists ores_trading_equity_accumulator_instruments_notify_fn;
+drop rule if exists ores_trading_equity_accumulator_instruments_delete_rule on "ores_trading_equity_accumulator_instruments_tbl";
+drop trigger if exists ores_trading_equity_accumulator_instruments_insert_trg on "ores_trading_equity_accumulator_instruments_tbl";
+drop function if exists ores_trading_equity_accumulator_instruments_insert_fn;
+drop table if exists "ores_trading_equity_accumulator_instruments_tbl";

--- a/projects/ores.sql/drop/trading/trading_equity_asian_option_instruments_drop.sql
+++ b/projects/ores.sql/drop/trading/trading_equity_asian_option_instruments_drop.sql
@@ -1,0 +1,26 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_trading_equity_asian_option_instruments_notify_trg on "ores_trading_equity_asian_option_instruments_tbl";
+drop function if exists ores_trading_equity_asian_option_instruments_notify_fn;
+drop rule if exists ores_trading_equity_asian_option_instruments_delete_rule on "ores_trading_equity_asian_option_instruments_tbl";
+drop trigger if exists ores_trading_equity_asian_option_instruments_insert_trg on "ores_trading_equity_asian_option_instruments_tbl";
+drop function if exists ores_trading_equity_asian_option_instruments_insert_fn;
+drop table if exists "ores_trading_equity_asian_option_instruments_tbl";

--- a/projects/ores.sql/drop/trading/trading_equity_barrier_option_instruments_drop.sql
+++ b/projects/ores.sql/drop/trading/trading_equity_barrier_option_instruments_drop.sql
@@ -1,0 +1,26 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_trading_equity_barrier_option_instruments_notify_trg on "ores_trading_equity_barrier_option_instruments_tbl";
+drop function if exists ores_trading_equity_barrier_option_instruments_notify_fn;
+drop rule if exists ores_trading_equity_barrier_option_instruments_delete_rule on "ores_trading_equity_barrier_option_instruments_tbl";
+drop trigger if exists ores_trading_equity_barrier_option_instruments_insert_trg on "ores_trading_equity_barrier_option_instruments_tbl";
+drop function if exists ores_trading_equity_barrier_option_instruments_insert_fn;
+drop table if exists "ores_trading_equity_barrier_option_instruments_tbl";

--- a/projects/ores.sql/drop/trading/trading_equity_digital_option_instruments_drop.sql
+++ b/projects/ores.sql/drop/trading/trading_equity_digital_option_instruments_drop.sql
@@ -1,0 +1,26 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_trading_equity_digital_option_instruments_notify_trg on "ores_trading_equity_digital_option_instruments_tbl";
+drop function if exists ores_trading_equity_digital_option_instruments_notify_fn;
+drop rule if exists ores_trading_equity_digital_option_instruments_delete_rule on "ores_trading_equity_digital_option_instruments_tbl";
+drop trigger if exists ores_trading_equity_digital_option_instruments_insert_trg on "ores_trading_equity_digital_option_instruments_tbl";
+drop function if exists ores_trading_equity_digital_option_instruments_insert_fn;
+drop table if exists "ores_trading_equity_digital_option_instruments_tbl";

--- a/projects/ores.sql/drop/trading/trading_equity_forward_instruments_drop.sql
+++ b/projects/ores.sql/drop/trading/trading_equity_forward_instruments_drop.sql
@@ -1,0 +1,26 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_trading_equity_forward_instruments_notify_trg on "ores_trading_equity_forward_instruments_tbl";
+drop function if exists ores_trading_equity_forward_instruments_notify_fn;
+drop rule if exists ores_trading_equity_forward_instruments_delete_rule on "ores_trading_equity_forward_instruments_tbl";
+drop trigger if exists ores_trading_equity_forward_instruments_insert_trg on "ores_trading_equity_forward_instruments_tbl";
+drop function if exists ores_trading_equity_forward_instruments_insert_fn;
+drop table if exists "ores_trading_equity_forward_instruments_tbl";

--- a/projects/ores.sql/drop/trading/trading_equity_option_instruments_drop.sql
+++ b/projects/ores.sql/drop/trading/trading_equity_option_instruments_drop.sql
@@ -1,0 +1,26 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_trading_equity_option_instruments_notify_trg on "ores_trading_equity_option_instruments_tbl";
+drop function if exists ores_trading_equity_option_instruments_notify_fn;
+drop rule if exists ores_trading_equity_option_instruments_delete_rule on "ores_trading_equity_option_instruments_tbl";
+drop trigger if exists ores_trading_equity_option_instruments_insert_trg on "ores_trading_equity_option_instruments_tbl";
+drop function if exists ores_trading_equity_option_instruments_insert_fn;
+drop table if exists "ores_trading_equity_option_instruments_tbl";

--- a/projects/ores.sql/drop/trading/trading_equity_position_instruments_drop.sql
+++ b/projects/ores.sql/drop/trading/trading_equity_position_instruments_drop.sql
@@ -1,0 +1,26 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_trading_equity_position_instruments_notify_trg on "ores_trading_equity_position_instruments_tbl";
+drop function if exists ores_trading_equity_position_instruments_notify_fn;
+drop rule if exists ores_trading_equity_position_instruments_delete_rule on "ores_trading_equity_position_instruments_tbl";
+drop trigger if exists ores_trading_equity_position_instruments_insert_trg on "ores_trading_equity_position_instruments_tbl";
+drop function if exists ores_trading_equity_position_instruments_insert_fn;
+drop table if exists "ores_trading_equity_position_instruments_tbl";

--- a/projects/ores.sql/drop/trading/trading_equity_swap_instruments_drop.sql
+++ b/projects/ores.sql/drop/trading/trading_equity_swap_instruments_drop.sql
@@ -1,0 +1,26 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_trading_equity_swap_instruments_notify_trg on "ores_trading_equity_swap_instruments_tbl";
+drop function if exists ores_trading_equity_swap_instruments_notify_fn;
+drop rule if exists ores_trading_equity_swap_instruments_delete_rule on "ores_trading_equity_swap_instruments_tbl";
+drop trigger if exists ores_trading_equity_swap_instruments_insert_trg on "ores_trading_equity_swap_instruments_tbl";
+drop function if exists ores_trading_equity_swap_instruments_insert_fn;
+drop table if exists "ores_trading_equity_swap_instruments_tbl";

--- a/projects/ores.sql/drop/trading/trading_equity_variance_swap_instruments_drop.sql
+++ b/projects/ores.sql/drop/trading/trading_equity_variance_swap_instruments_drop.sql
@@ -1,0 +1,26 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_trading_equity_variance_swap_instruments_notify_trg on "ores_trading_equity_variance_swap_instruments_tbl";
+drop function if exists ores_trading_equity_variance_swap_instruments_notify_fn;
+drop rule if exists ores_trading_equity_variance_swap_instruments_delete_rule on "ores_trading_equity_variance_swap_instruments_tbl";
+drop trigger if exists ores_trading_equity_variance_swap_instruments_insert_trg on "ores_trading_equity_variance_swap_instruments_tbl";
+drop function if exists ores_trading_equity_variance_swap_instruments_insert_fn;
+drop table if exists "ores_trading_equity_variance_swap_instruments_tbl";

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_accumulator_instrument.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_accumulator_instrument.hpp
@@ -1,0 +1,116 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_ACCUMULATOR_INSTRUMENT_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_ACCUMULATOR_INSTRUMENT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Equity Accumulator instrument.
+ *
+ * Represents EquityAccumulator and EquityTaRF trades.
+ */
+struct equity_accumulator_instrument final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief UUID uniquely identifying this equity accumulator instrument.
+     */
+    boost::uuids::uuid instrument_id;
+
+    boost::uuids::uuid party_id;
+    std::optional<boost::uuids::uuid> trade_id;
+
+    /**
+     * @brief ORE product type code: EquityAccumulator or EquityTaRF.
+     */
+    std::string trade_type_code;
+
+    std::string underlying_name;
+    std::string currency;
+
+    /**
+     * @brief Strike price.
+     */
+    double strike = 0.0;
+
+    /**
+     * @brief Per-fixing accumulation amount. Must be positive.
+     */
+    double fixing_amount = 0.0;
+
+    /**
+     * @brief ISO 8601 date
+     */
+    std::string start_date;
+
+    /**
+     * @brief ISO 8601 date
+     */
+    std::string expiry_date;
+
+    /**
+     * @brief e.g. Daily, Weekly, Monthly
+     */
+    std::string fixing_frequency;
+
+    /**
+     * @brief Long or Short
+     */
+    std::string long_short;
+
+    /**
+     * @brief Knock-out barrier; absent when not specified.
+     */
+    std::optional<double> knock_out_level;
+
+    /**
+     * @brief TaRF only: target profit level.
+     */
+    std::optional<double> target_amount;
+
+    /**
+     * @brief TaRF: TargetFull or TargetExact; empty for accumulator.
+     */
+    std::string target_type;
+
+    /**
+     * @brief Accumulator, Decumulator, or TaRF.
+     */
+    std::string payoff_type;
+
+    std::string description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_accumulator_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_accumulator_instrument_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_ACCUMULATOR_INSTRUMENT_JSON_IO_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_ACCUMULATOR_INSTRUMENT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.trading.api/domain/equity_accumulator_instrument.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Dumps the equity_accumulator_instrument to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const equity_accumulator_instrument& v);
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_asian_option_instrument.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_asian_option_instrument.hpp
@@ -1,0 +1,118 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_ASIAN_OPTION_INSTRUMENT_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_ASIAN_OPTION_INSTRUMENT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Equity Asian Option instrument.
+ *
+ * Represents EquityAsianOption trades.
+ */
+struct equity_asian_option_instrument final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief UUID uniquely identifying this equity asian option instrument.
+     */
+    boost::uuids::uuid instrument_id;
+
+    boost::uuids::uuid party_id;
+    std::optional<boost::uuids::uuid> trade_id;
+
+    /**
+     * @brief ORE product type code: EquityAsianOption.
+     */
+    std::string trade_type_code;
+
+    /**
+     * @brief ORE equity Name identifier.
+     */
+    std::string underlying_name;
+
+    /**
+     * @brief ISO 4217 currency code.
+     */
+    std::string currency;
+
+    /**
+     * @brief Contract quantity / notional. Must be positive.
+     */
+    double notional = 0.0;
+
+    /**
+     * @brief Call or Put.
+     */
+    std::string option_type;
+
+    /**
+     * @brief Strike price. Non-negative.
+     */
+    double strike = 0.0;
+
+    /**
+     * @brief ISO 8601 date string.
+     */
+    std::string expiry_date;
+
+    /**
+     * @brief European, American, or Bermudan.
+     */
+    std::string exercise_type;
+
+    /**
+     * @brief Long or Short.
+     */
+    std::string long_short;
+
+    /**
+     * @brief Arithmetic or Geometric.
+     */
+    std::string average_type;
+
+    /**
+     * @brief ISO 8601 date.
+     */
+    std::string averaging_start_date;
+
+    /**
+     * @brief ISO 8601 date.
+     */
+    std::string averaging_end_date;
+
+    std::string description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_asian_option_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_asian_option_instrument_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_ASIAN_OPTION_INSTRUMENT_JSON_IO_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_ASIAN_OPTION_INSTRUMENT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.trading.api/domain/equity_asian_option_instrument.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Dumps the equity_asian_option_instrument to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const equity_asian_option_instrument& v);
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_barrier_option_instrument.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_barrier_option_instrument.hpp
@@ -1,0 +1,127 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_BARRIER_OPTION_INSTRUMENT_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_BARRIER_OPTION_INSTRUMENT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Equity Barrier Option instrument.
+ *
+ * Represents EquityBarrierOption, EquityDoubleBarrierOption, and
+ * EquityEuropeanBarrierOption trades.
+ */
+struct equity_barrier_option_instrument final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief UUID uniquely identifying this equity barrier option instrument.
+     */
+    boost::uuids::uuid instrument_id;
+
+    boost::uuids::uuid party_id;
+    std::optional<boost::uuids::uuid> trade_id;
+
+    /**
+     * @brief ORE product type code: EquityBarrierOption, EquityDoubleBarrierOption,
+     * or EquityEuropeanBarrierOption.
+     */
+    std::string trade_type_code;
+
+    /**
+     * @brief ORE equity Name identifier.
+     */
+    std::string underlying_name;
+
+    /**
+     * @brief ISO 4217 currency code.
+     */
+    std::string currency;
+
+    /**
+     * @brief Contract quantity / notional. Must be positive.
+     */
+    double notional = 0.0;
+
+    /**
+     * @brief Call or Put.
+     */
+    std::string option_type;
+
+    /**
+     * @brief Strike price. Non-negative.
+     */
+    double strike = 0.0;
+
+    /**
+     * @brief ISO 8601 date string.
+     */
+    std::string expiry_date;
+
+    /**
+     * @brief European, American, or Bermudan.
+     */
+    std::string exercise_type;
+
+    /**
+     * @brief Long or Short.
+     */
+    std::string long_short;
+
+    /**
+     * @brief Lower / single barrier level.
+     */
+    double lower_barrier = 0.0;
+
+    /**
+     * @brief UpIn, UpOut, DownIn, DownOut.
+     */
+    std::string lower_barrier_type;
+
+    /**
+     * @brief Double-barrier only.
+     */
+    std::optional<double> upper_barrier;
+
+    /**
+     * @brief Type for upper barrier; empty for single barrier.
+     */
+    std::string upper_barrier_type;
+
+    std::optional<double> rebate;
+
+    std::string description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_barrier_option_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_barrier_option_instrument_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_BARRIER_OPTION_INSTRUMENT_JSON_IO_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_BARRIER_OPTION_INSTRUMENT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.trading.api/domain/equity_barrier_option_instrument.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Dumps the equity_barrier_option_instrument to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const equity_barrier_option_instrument& v);
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_digital_option_instrument.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_digital_option_instrument.hpp
@@ -1,0 +1,110 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_DIGITAL_OPTION_INSTRUMENT_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_DIGITAL_OPTION_INSTRUMENT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Equity Digital Option instrument.
+ *
+ * Represents EquityDigitalOption and EquityTouchOption trades.
+ */
+struct equity_digital_option_instrument final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief UUID uniquely identifying this equity digital option instrument.
+     */
+    boost::uuids::uuid instrument_id;
+
+    boost::uuids::uuid party_id;
+    std::optional<boost::uuids::uuid> trade_id;
+
+    /**
+     * @brief ORE product type code: EquityDigitalOption or EquityTouchOption.
+     */
+    std::string trade_type_code;
+
+    /**
+     * @brief ORE equity Name identifier.
+     */
+    std::string underlying_name;
+
+    /**
+     * @brief ISO 4217 currency code.
+     */
+    std::string currency;
+
+    /**
+     * @brief Payoff notional / contract size. Must be positive.
+     */
+    double notional = 0.0;
+
+    /**
+     * @brief Call or Put; empty for touch options.
+     */
+    std::string option_type;
+
+    /**
+     * @brief Digital only; absent for touch.
+     */
+    std::optional<double> strike;
+
+    /**
+     * @brief Touch only; absent for digital.
+     */
+    std::optional<double> barrier_level;
+
+    /**
+     * @brief e.g. UpIn, DownOut; empty for digital.
+     */
+    std::string barrier_type;
+
+    /**
+     * @brief ISO 8601 date string.
+     */
+    std::string expiry_date;
+
+    /**
+     * @brief Long or Short.
+     */
+    std::string long_short;
+
+    std::optional<double> payout_amount;
+
+    std::string description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_digital_option_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_digital_option_instrument_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_DIGITAL_OPTION_INSTRUMENT_JSON_IO_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_DIGITAL_OPTION_INSTRUMENT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.trading.api/domain/equity_digital_option_instrument.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Dumps the equity_digital_option_instrument to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const equity_digital_option_instrument& v);
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_forward_instrument.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_forward_instrument.hpp
@@ -1,0 +1,98 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_FORWARD_INSTRUMENT_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_FORWARD_INSTRUMENT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Equity Forward instrument.
+ *
+ * Represents EquityForward trades.
+ */
+struct equity_forward_instrument final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief UUID uniquely identifying this equity forward instrument.
+     */
+    boost::uuids::uuid instrument_id;
+
+    boost::uuids::uuid party_id;
+    std::optional<boost::uuids::uuid> trade_id;
+
+    /**
+     * @brief ORE product type code: EquityForward.
+     */
+    std::string trade_type_code;
+
+    /**
+     * @brief ORE equity Name identifier.
+     */
+    std::string underlying_name;
+
+    /**
+     * @brief ISO 4217 currency code.
+     */
+    std::string currency;
+
+    /**
+     * @brief Number of shares / contracts. Must be positive.
+     */
+    double quantity = 0.0;
+
+    /**
+     * @brief Fixed delivery price; absent for at-market forwards.
+     */
+    std::optional<double> forward_price;
+
+    /**
+     * @brief ISO 8601 date string.
+     */
+    std::string expiry_date;
+
+    /**
+     * @brief Long or Short.
+     */
+    std::string long_short;
+
+    /**
+     * @brief Cash or Physical; empty when not specified.
+     */
+    std::string settlement_type;
+
+    std::string description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_forward_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_forward_instrument_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_FORWARD_INSTRUMENT_JSON_IO_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_FORWARD_INSTRUMENT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.trading.api/domain/equity_forward_instrument.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Dumps the equity_forward_instrument to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const equity_forward_instrument& v);
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_option_instrument.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_option_instrument.hpp
@@ -1,0 +1,113 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_OPTION_INSTRUMENT_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_OPTION_INSTRUMENT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Equity Option instrument.
+ *
+ * Represents EquityOption and EquityCliquetOption trades.
+ */
+struct equity_option_instrument final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief UUID uniquely identifying this equity option instrument.
+     */
+    boost::uuids::uuid instrument_id;
+
+    boost::uuids::uuid party_id;
+    std::optional<boost::uuids::uuid> trade_id;
+
+    /**
+     * @brief ORE product type code: EquityOption or EquityCliquetOption.
+     */
+    std::string trade_type_code;
+
+    /**
+     * @brief ORE equity Name identifier.
+     */
+    std::string underlying_name;
+
+    /**
+     * @brief ISO 4217 currency code.
+     */
+    std::string currency;
+
+    /**
+     * @brief Contract quantity / notional. Must be positive.
+     */
+    double notional = 0.0;
+
+    /**
+     * @brief Call or Put.
+     */
+    std::string option_type;
+
+    /**
+     * @brief Strike price. Non-negative.
+     */
+    double strike = 0.0;
+
+    /**
+     * @brief ISO 8601 date string.
+     */
+    std::string expiry_date;
+
+    /**
+     * @brief European, American, or Bermudan.
+     */
+    std::string exercise_type;
+
+    /**
+     * @brief Long or Short.
+     */
+    std::string long_short;
+
+    /**
+     * @brief Cash or Physical; empty when not specified.
+     */
+    std::string settlement_type;
+
+    /**
+     * @brief Cliquet only: e.g. Annual, Quarterly; empty for EquityOption.
+     */
+    std::string cliquet_frequency;
+
+    std::string description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_option_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_option_instrument_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_OPTION_INSTRUMENT_JSON_IO_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_OPTION_INSTRUMENT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.trading.api/domain/equity_option_instrument.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Dumps the equity_option_instrument to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const equity_option_instrument& v);
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_position_instrument.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_position_instrument.hpp
@@ -1,0 +1,81 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_POSITION_INSTRUMENT_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_POSITION_INSTRUMENT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Equity Position instrument.
+ *
+ * Represents EquityPosition and EquityOptionPosition trades.
+ */
+struct equity_position_instrument final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief UUID uniquely identifying this equity position instrument.
+     */
+    boost::uuids::uuid instrument_id;
+
+    boost::uuids::uuid party_id;
+    std::optional<boost::uuids::uuid> trade_id;
+
+    /**
+     * @brief ORE product type code: EquityPosition or EquityOptionPosition.
+     */
+    std::string trade_type_code;
+
+    std::string underlying_name;
+    std::string currency;
+
+    /**
+     * @brief Number of shares / contracts held.
+     */
+    double quantity = 0.0;
+
+    /**
+     * @brief Entry price; absent for market-price positions.
+     */
+    std::optional<double> price;
+
+    /**
+     * @brief EquityOptionPosition only: serialised option parameters; empty otherwise.
+     */
+    std::string option_data_json;
+
+    std::string description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_position_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_position_instrument_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_POSITION_INSTRUMENT_JSON_IO_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_POSITION_INSTRUMENT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.trading.api/domain/equity_position_instrument.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Dumps the equity_position_instrument to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const equity_position_instrument& v);
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_swap_instrument.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_swap_instrument.hpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_SWAP_INSTRUMENT_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_SWAP_INSTRUMENT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Equity Swap instrument.
+ *
+ * Represents EquitySwap and EquityWorstOfBasketSwap trades.
+ */
+struct equity_swap_instrument final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief UUID uniquely identifying this equity swap instrument.
+     */
+    boost::uuids::uuid instrument_id;
+
+    boost::uuids::uuid party_id;
+    std::optional<boost::uuids::uuid> trade_id;
+
+    /**
+     * @brief ORE product type code: EquitySwap or EquityWorstOfBasketSwap.
+     */
+    std::string trade_type_code;
+
+    /**
+     * @brief Single underlying; empty for basket swaps.
+     */
+    std::string underlying_name;
+
+    /**
+     * @brief JSON array of underlyings for EquityWorstOfBasketSwap; empty for single-underlying.
+     */
+    std::string basket_json;
+
+    std::string currency;
+
+    /**
+     * @brief Must be positive.
+     */
+    double notional = 0.0;
+
+    /**
+     * @brief TotalReturn or PriceReturn
+     */
+    std::string return_type;
+
+    /**
+     * @brief ISO 8601 date
+     */
+    std::string start_date;
+
+    /**
+     * @brief ISO 8601 date
+     */
+    std::string maturity_date;
+
+    /**
+     * @brief Long or Short
+     */
+    std::string long_short;
+
+    /**
+     * @brief e.g. 3M, 6M, 1Y
+     */
+    std::string payment_frequency;
+
+    std::string description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_swap_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_swap_instrument_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_SWAP_INSTRUMENT_JSON_IO_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_SWAP_INSTRUMENT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.trading.api/domain/equity_swap_instrument.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Dumps the equity_swap_instrument to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const equity_swap_instrument& v);
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_variance_swap_instrument.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_variance_swap_instrument.hpp
@@ -1,0 +1,91 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_VARIANCE_SWAP_INSTRUMENT_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_VARIANCE_SWAP_INSTRUMENT_HPP
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Equity Variance Swap instrument.
+ *
+ * Represents EquityVarianceSwap trades.
+ */
+struct equity_variance_swap_instrument final {
+    int version = 0;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief UUID uniquely identifying this equity variance swap instrument.
+     */
+    boost::uuids::uuid instrument_id;
+
+    boost::uuids::uuid party_id;
+    std::optional<boost::uuids::uuid> trade_id;
+
+    /**
+     * @brief ORE product type code: EquityVarianceSwap.
+     */
+    std::string trade_type_code;
+
+    std::string underlying_name;
+    std::string currency;
+
+    /**
+     * @brief Vega notional. Must be positive.
+     */
+    double notional = 0.0;
+
+    /**
+     * @brief Strike variance.
+     */
+    double variance_strike = 0.0;
+
+    /**
+     * @brief ISO 8601 date
+     */
+    std::string start_date;
+
+    /**
+     * @brief ISO 8601 date
+     */
+    std::string maturity_date;
+
+    /**
+     * @brief Long or Short
+     */
+    std::string long_short;
+
+    std::string description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::chrono::system_clock::time_point recorded_at;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_variance_swap_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_variance_swap_instrument_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_DOMAIN_EQUITY_VARIANCE_SWAP_INSTRUMENT_JSON_IO_HPP
+#define ORES_TRADING_DOMAIN_EQUITY_VARIANCE_SWAP_INSTRUMENT_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.trading.api/domain/equity_variance_swap_instrument.hpp"
+
+namespace ores::trading::domain {
+
+/**
+ * @brief Dumps the equity_variance_swap_instrument to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const equity_variance_swap_instrument& v);
+
+}
+
+#endif

--- a/projects/ores.trading.api/include/ores.trading.api/messaging/instrument_protocol.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/messaging/instrument_protocol.hpp
@@ -36,6 +36,15 @@
 #include "ores.trading.api/domain/bond_instrument.hpp"
 #include "ores.trading.api/domain/credit_instrument.hpp"
 #include "ores.trading.api/domain/equity_instrument.hpp"
+#include "ores.trading.api/domain/equity_option_instrument.hpp"
+#include "ores.trading.api/domain/equity_digital_option_instrument.hpp"
+#include "ores.trading.api/domain/equity_barrier_option_instrument.hpp"
+#include "ores.trading.api/domain/equity_asian_option_instrument.hpp"
+#include "ores.trading.api/domain/equity_forward_instrument.hpp"
+#include "ores.trading.api/domain/equity_variance_swap_instrument.hpp"
+#include "ores.trading.api/domain/equity_swap_instrument.hpp"
+#include "ores.trading.api/domain/equity_accumulator_instrument.hpp"
+#include "ores.trading.api/domain/equity_position_instrument.hpp"
 #include "ores.trading.api/domain/commodity_instrument.hpp"
 #include "ores.trading.api/domain/composite_instrument.hpp"
 #include "ores.trading.api/domain/composite_leg.hpp"
@@ -356,6 +365,116 @@ struct get_equity_instrument_history_response {
     bool success = false;
     std::string message;
     std::vector<ores::trading::domain::equity_instrument> history;
+};
+
+// ---- Typed equity instrument protocol ----
+
+struct save_equity_option_instrument_request {
+    using response_type = struct save_equity_option_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.equity_option_instruments.save";
+    ores::trading::domain::equity_option_instrument data;
+};
+
+struct save_equity_option_instrument_response {
+    bool success = false;
+    std::string message;
+};
+
+struct save_equity_digital_option_instrument_request {
+    using response_type = struct save_equity_digital_option_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.equity_digital_option_instruments.save";
+    ores::trading::domain::equity_digital_option_instrument data;
+};
+
+struct save_equity_digital_option_instrument_response {
+    bool success = false;
+    std::string message;
+};
+
+struct save_equity_barrier_option_instrument_request {
+    using response_type = struct save_equity_barrier_option_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.equity_barrier_option_instruments.save";
+    ores::trading::domain::equity_barrier_option_instrument data;
+};
+
+struct save_equity_barrier_option_instrument_response {
+    bool success = false;
+    std::string message;
+};
+
+struct save_equity_asian_option_instrument_request {
+    using response_type = struct save_equity_asian_option_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.equity_asian_option_instruments.save";
+    ores::trading::domain::equity_asian_option_instrument data;
+};
+
+struct save_equity_asian_option_instrument_response {
+    bool success = false;
+    std::string message;
+};
+
+struct save_equity_forward_instrument_request {
+    using response_type = struct save_equity_forward_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.equity_forward_instruments.save";
+    ores::trading::domain::equity_forward_instrument data;
+};
+
+struct save_equity_forward_instrument_response {
+    bool success = false;
+    std::string message;
+};
+
+struct save_equity_variance_swap_instrument_request {
+    using response_type = struct save_equity_variance_swap_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.equity_variance_swap_instruments.save";
+    ores::trading::domain::equity_variance_swap_instrument data;
+};
+
+struct save_equity_variance_swap_instrument_response {
+    bool success = false;
+    std::string message;
+};
+
+struct save_equity_swap_instrument_request {
+    using response_type = struct save_equity_swap_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.equity_swap_instruments.save";
+    ores::trading::domain::equity_swap_instrument data;
+};
+
+struct save_equity_swap_instrument_response {
+    bool success = false;
+    std::string message;
+};
+
+struct save_equity_accumulator_instrument_request {
+    using response_type = struct save_equity_accumulator_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.equity_accumulator_instruments.save";
+    ores::trading::domain::equity_accumulator_instrument data;
+};
+
+struct save_equity_accumulator_instrument_response {
+    bool success = false;
+    std::string message;
+};
+
+struct save_equity_position_instrument_request {
+    using response_type = struct save_equity_position_instrument_response;
+    static constexpr std::string_view nats_subject =
+        "trading.v1.equity_position_instruments.save";
+    ores::trading::domain::equity_position_instrument data;
+};
+
+struct save_equity_position_instrument_response {
+    bool success = false;
+    std::string message;
 };
 
 // ---- Commodity instrument protocol ----

--- a/projects/ores.trading.api/src/domain/equity_accumulator_instrument_json_io.cpp
+++ b/projects/ores.trading.api/src/domain/equity_accumulator_instrument_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.api/domain/equity_accumulator_instrument_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::domain {
+
+std::ostream& operator<<(std::ostream& s, const equity_accumulator_instrument& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.api/src/domain/equity_asian_option_instrument_json_io.cpp
+++ b/projects/ores.trading.api/src/domain/equity_asian_option_instrument_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.api/domain/equity_asian_option_instrument_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::domain {
+
+std::ostream& operator<<(std::ostream& s, const equity_asian_option_instrument& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.api/src/domain/equity_barrier_option_instrument_json_io.cpp
+++ b/projects/ores.trading.api/src/domain/equity_barrier_option_instrument_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.api/domain/equity_barrier_option_instrument_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::domain {
+
+std::ostream& operator<<(std::ostream& s, const equity_barrier_option_instrument& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.api/src/domain/equity_digital_option_instrument_json_io.cpp
+++ b/projects/ores.trading.api/src/domain/equity_digital_option_instrument_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.api/domain/equity_digital_option_instrument_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::domain {
+
+std::ostream& operator<<(std::ostream& s, const equity_digital_option_instrument& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.api/src/domain/equity_forward_instrument_json_io.cpp
+++ b/projects/ores.trading.api/src/domain/equity_forward_instrument_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.api/domain/equity_forward_instrument_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::domain {
+
+std::ostream& operator<<(std::ostream& s, const equity_forward_instrument& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.api/src/domain/equity_option_instrument_json_io.cpp
+++ b/projects/ores.trading.api/src/domain/equity_option_instrument_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.api/domain/equity_option_instrument_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::domain {
+
+std::ostream& operator<<(std::ostream& s, const equity_option_instrument& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.api/src/domain/equity_position_instrument_json_io.cpp
+++ b/projects/ores.trading.api/src/domain/equity_position_instrument_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.api/domain/equity_position_instrument_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::domain {
+
+std::ostream& operator<<(std::ostream& s, const equity_position_instrument& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.api/src/domain/equity_swap_instrument_json_io.cpp
+++ b/projects/ores.trading.api/src/domain/equity_swap_instrument_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.api/domain/equity_swap_instrument_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::domain {
+
+std::ostream& operator<<(std::ostream& s, const equity_swap_instrument& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.api/src/domain/equity_variance_swap_instrument_json_io.cpp
+++ b/projects/ores.trading.api/src/domain/equity_variance_swap_instrument_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.api/domain/equity_variance_swap_instrument_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::domain {
+
+std::ostream& operator<<(std::ostream& s, const equity_variance_swap_instrument& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/include/ores.trading.core/messaging/typed_equity_instrument_handler.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/messaging/typed_equity_instrument_handler.hpp
@@ -90,6 +90,7 @@ void handle_typed_equity_save(
     } else {
         BOOST_LOG_SEV(typed_equity_instrument_handler_lg(), warn)
             << "Failed to decode: " << msg.subject;
+        reply(nats, msg, Response{.success = false, .message = "Failed to decode request"});
     }
 }
 

--- a/projects/ores.trading.core/include/ores.trading.core/messaging/typed_equity_instrument_handler.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/messaging/typed_equity_instrument_handler.hpp
@@ -1,0 +1,192 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_MESSAGING_TYPED_EQUITY_INSTRUMENT_HANDLER_HPP
+#define ORES_TRADING_MESSAGING_TYPED_EQUITY_INSTRUMENT_HANDLER_HPP
+
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.trading.api/messaging/instrument_protocol.hpp"
+#include "ores.trading.core/service/equity_option_instrument_service.hpp"
+#include "ores.trading.core/service/equity_digital_option_instrument_service.hpp"
+#include "ores.trading.core/service/equity_barrier_option_instrument_service.hpp"
+#include "ores.trading.core/service/equity_asian_option_instrument_service.hpp"
+#include "ores.trading.core/service/equity_forward_instrument_service.hpp"
+#include "ores.trading.core/service/equity_variance_swap_instrument_service.hpp"
+#include "ores.trading.core/service/equity_swap_instrument_service.hpp"
+#include "ores.trading.core/service/equity_accumulator_instrument_service.hpp"
+#include "ores.trading.core/service/equity_position_instrument_service.hpp"
+
+namespace ores::trading::messaging {
+
+namespace {
+inline auto& typed_equity_instrument_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.trading.messaging.typed_equity_instrument_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using ores::service::messaging::has_permission;
+using namespace ores::logging;
+
+template<typename Request, typename Response, typename Service, typename SaveFn>
+void handle_typed_equity_save(
+    ores::nats::service::client& nats,
+    ores::nats::message msg,
+    ores::database::context ctx,
+    std::optional<ores::security::jwt::jwt_authenticator> verifier,
+    SaveFn save_fn) {
+    BOOST_LOG_SEV(typed_equity_instrument_handler_lg(), debug)
+        << "Handling " << msg.subject;
+    auto ctx_expected = ores::service::service::make_request_context(
+        ctx, msg, verifier);
+    if (!ctx_expected) {
+        error_reply(nats, msg, ctx_expected.error());
+        return;
+    }
+    const auto& rctx = *ctx_expected;
+    if (!has_permission(rctx, "trading::instruments:write")) {
+        error_reply(nats, msg, ores::service::error_code::forbidden);
+        return;
+    }
+    if (auto req = decode<Request>(msg)) {
+        try {
+            Service svc(rctx);
+            (svc.*save_fn)(req->data);
+            BOOST_LOG_SEV(typed_equity_instrument_handler_lg(), debug)
+                << "Completed " << msg.subject;
+            reply(nats, msg, Response{.success = true});
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(typed_equity_instrument_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            reply(nats, msg, Response{.success = false, .message = e.what()});
+        }
+    } else {
+        BOOST_LOG_SEV(typed_equity_instrument_handler_lg(), warn)
+            << "Failed to decode: " << msg.subject;
+    }
+}
+
+class typed_equity_instrument_handler {
+public:
+    typed_equity_instrument_handler(ores::nats::service::client& nats,
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
+
+    void save_option(ores::nats::message msg) {
+        using Svc = service::equity_option_instrument_service;
+        handle_typed_equity_save<
+            save_equity_option_instrument_request,
+            save_equity_option_instrument_response,
+            Svc>(nats_, std::move(msg), ctx_, verifier_,
+                &Svc::save_equity_option_instrument);
+    }
+
+    void save_digital_option(ores::nats::message msg) {
+        using Svc = service::equity_digital_option_instrument_service;
+        handle_typed_equity_save<
+            save_equity_digital_option_instrument_request,
+            save_equity_digital_option_instrument_response,
+            Svc>(nats_, std::move(msg), ctx_, verifier_,
+                &Svc::save_equity_digital_option_instrument);
+    }
+
+    void save_barrier_option(ores::nats::message msg) {
+        using Svc = service::equity_barrier_option_instrument_service;
+        handle_typed_equity_save<
+            save_equity_barrier_option_instrument_request,
+            save_equity_barrier_option_instrument_response,
+            Svc>(nats_, std::move(msg), ctx_, verifier_,
+                &Svc::save_equity_barrier_option_instrument);
+    }
+
+    void save_asian_option(ores::nats::message msg) {
+        using Svc = service::equity_asian_option_instrument_service;
+        handle_typed_equity_save<
+            save_equity_asian_option_instrument_request,
+            save_equity_asian_option_instrument_response,
+            Svc>(nats_, std::move(msg), ctx_, verifier_,
+                &Svc::save_equity_asian_option_instrument);
+    }
+
+    void save_forward(ores::nats::message msg) {
+        using Svc = service::equity_forward_instrument_service;
+        handle_typed_equity_save<
+            save_equity_forward_instrument_request,
+            save_equity_forward_instrument_response,
+            Svc>(nats_, std::move(msg), ctx_, verifier_,
+                &Svc::save_equity_forward_instrument);
+    }
+
+    void save_variance_swap(ores::nats::message msg) {
+        using Svc = service::equity_variance_swap_instrument_service;
+        handle_typed_equity_save<
+            save_equity_variance_swap_instrument_request,
+            save_equity_variance_swap_instrument_response,
+            Svc>(nats_, std::move(msg), ctx_, verifier_,
+                &Svc::save_equity_variance_swap_instrument);
+    }
+
+    void save_swap(ores::nats::message msg) {
+        using Svc = service::equity_swap_instrument_service;
+        handle_typed_equity_save<
+            save_equity_swap_instrument_request,
+            save_equity_swap_instrument_response,
+            Svc>(nats_, std::move(msg), ctx_, verifier_,
+                &Svc::save_equity_swap_instrument);
+    }
+
+    void save_accumulator(ores::nats::message msg) {
+        using Svc = service::equity_accumulator_instrument_service;
+        handle_typed_equity_save<
+            save_equity_accumulator_instrument_request,
+            save_equity_accumulator_instrument_response,
+            Svc>(nats_, std::move(msg), ctx_, verifier_,
+                &Svc::save_equity_accumulator_instrument);
+    }
+
+    void save_position(ores::nats::message msg) {
+        using Svc = service::equity_position_instrument_service;
+        handle_typed_equity_save<
+            save_equity_position_instrument_request,
+            save_equity_position_instrument_response,
+            Svc>(nats_, std::move(msg), ctx_, verifier_,
+                &Svc::save_equity_position_instrument);
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::trading::messaging
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_accumulator_instrument_entity.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_accumulator_instrument_entity.hpp
@@ -1,0 +1,71 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_ACCUMULATOR_INSTRUMENT_ENTITY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_ACCUMULATOR_INSTRUMENT_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Represents an equity accumulator instrument in the database.
+ *
+ * Covers ORE product type: EquityAccumulator.
+ */
+struct equity_accumulator_instrument_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_trading_equity_accumulator_instruments_tbl";
+
+    sqlgen::PrimaryKey<std::string> instrument_id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::optional<std::string> trade_id;
+    std::string trade_type_code;
+    std::string underlying_name;
+    std::string currency;
+    double strike = 0.0;
+    double fixing_amount = 0.0;
+    std::string start_date;
+    std::string expiry_date;
+    std::string fixing_frequency;
+    std::string long_short;
+    std::optional<double> knock_out_level;
+    std::optional<double> target_amount;
+    std::optional<std::string> target_type;
+    std::string payoff_type;
+    std::optional<std::string> description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const equity_accumulator_instrument_entity& v);
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_accumulator_instrument_mapper.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_accumulator_instrument_mapper.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_ACCUMULATOR_INSTRUMENT_MAPPER_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_ACCUMULATOR_INSTRUMENT_MAPPER_HPP
+
+#include <vector>
+#include "ores.trading.api/domain/equity_accumulator_instrument.hpp"
+#include "ores.trading.core/repository/equity_accumulator_instrument_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Maps equity_accumulator_instrument domain entities to data storage layer and vice-versa.
+ */
+class equity_accumulator_instrument_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_accumulator_instrument_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::equity_accumulator_instrument map(const equity_accumulator_instrument_entity& v);
+    static equity_accumulator_instrument_entity map(const domain::equity_accumulator_instrument& v);
+
+    static std::vector<domain::equity_accumulator_instrument>
+    map(const std::vector<equity_accumulator_instrument_entity>& v);
+    static std::vector<equity_accumulator_instrument_entity>
+    map(const std::vector<domain::equity_accumulator_instrument>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_accumulator_instrument_repository.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_accumulator_instrument_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_ACCUMULATOR_INSTRUMENT_REPOSITORY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_ACCUMULATOR_INSTRUMENT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_accumulator_instrument.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Reads and writes equity accumulator instruments to data storage.
+ */
+class equity_accumulator_instrument_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_accumulator_instrument_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::equity_accumulator_instrument& v);
+    void write(context ctx, const std::vector<domain::equity_accumulator_instrument>& v);
+
+    std::vector<domain::equity_accumulator_instrument> read_latest(context ctx);
+    std::vector<domain::equity_accumulator_instrument>
+    read_latest(context ctx, const std::string& instrument_id);
+    std::vector<domain::equity_accumulator_instrument>
+    read_all(context ctx, const std::string& instrument_id);
+
+    void remove(context ctx, const std::string& instrument_id);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_asian_option_instrument_entity.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_asian_option_instrument_entity.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_ASIAN_OPTION_INSTRUMENT_ENTITY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_ASIAN_OPTION_INSTRUMENT_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::trading::repository {
+
+struct equity_asian_option_instrument_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_trading_equity_asian_option_instruments_tbl";
+
+    sqlgen::PrimaryKey<std::string> instrument_id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::optional<std::string> trade_id;
+    std::string trade_type_code;
+    std::string underlying_name;
+    std::string currency;
+    double notional = 0.0;
+    std::string option_type;
+    double strike = 0.0;
+    std::string expiry_date;
+    std::string exercise_type;
+    std::string long_short;
+    std::string average_type;
+    std::string averaging_start_date;
+    std::string averaging_end_date;
+    std::optional<std::string> description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const equity_asian_option_instrument_entity& v);
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_asian_option_instrument_mapper.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_asian_option_instrument_mapper.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_ASIAN_OPTION_INSTRUMENT_MAPPER_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_ASIAN_OPTION_INSTRUMENT_MAPPER_HPP
+
+#include <vector>
+#include "ores.trading.api/domain/equity_asian_option_instrument.hpp"
+#include "ores.trading.core/repository/equity_asian_option_instrument_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Maps equity_asian_option_instrument domain entities to data storage layer and vice-versa.
+ */
+class equity_asian_option_instrument_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_asian_option_instrument_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::equity_asian_option_instrument map(const equity_asian_option_instrument_entity& v);
+    static equity_asian_option_instrument_entity map(const domain::equity_asian_option_instrument& v);
+
+    static std::vector<domain::equity_asian_option_instrument>
+    map(const std::vector<equity_asian_option_instrument_entity>& v);
+    static std::vector<equity_asian_option_instrument_entity>
+    map(const std::vector<domain::equity_asian_option_instrument>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_asian_option_instrument_repository.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_asian_option_instrument_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_ASIAN_OPTION_INSTRUMENT_REPOSITORY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_ASIAN_OPTION_INSTRUMENT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_asian_option_instrument.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Reads and writes equity asian option instruments to data storage.
+ */
+class equity_asian_option_instrument_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_asian_option_instrument_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::equity_asian_option_instrument& v);
+    void write(context ctx, const std::vector<domain::equity_asian_option_instrument>& v);
+
+    std::vector<domain::equity_asian_option_instrument> read_latest(context ctx);
+    std::vector<domain::equity_asian_option_instrument>
+    read_latest(context ctx, const std::string& instrument_id);
+    std::vector<domain::equity_asian_option_instrument>
+    read_all(context ctx, const std::string& instrument_id);
+
+    void remove(context ctx, const std::string& instrument_id);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_barrier_option_instrument_entity.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_barrier_option_instrument_entity.hpp
@@ -1,0 +1,67 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_BARRIER_OPTION_INSTRUMENT_ENTITY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_BARRIER_OPTION_INSTRUMENT_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::trading::repository {
+
+struct equity_barrier_option_instrument_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_trading_equity_barrier_option_instruments_tbl";
+
+    sqlgen::PrimaryKey<std::string> instrument_id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::optional<std::string> trade_id;
+    std::string trade_type_code;
+    std::string underlying_name;
+    std::string currency;
+    double notional = 0.0;
+    std::string option_type;
+    double strike = 0.0;
+    std::string expiry_date;
+    std::string exercise_type;
+    std::string long_short;
+    double lower_barrier = 0.0;
+    std::string lower_barrier_type;
+    std::optional<double> upper_barrier;
+    std::optional<std::string> upper_barrier_type;
+    std::optional<double> rebate;
+    std::optional<std::string> description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const equity_barrier_option_instrument_entity& v);
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_barrier_option_instrument_mapper.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_barrier_option_instrument_mapper.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_BARRIER_OPTION_INSTRUMENT_MAPPER_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_BARRIER_OPTION_INSTRUMENT_MAPPER_HPP
+
+#include <vector>
+#include "ores.trading.api/domain/equity_barrier_option_instrument.hpp"
+#include "ores.trading.core/repository/equity_barrier_option_instrument_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Maps equity_barrier_option_instrument domain entities to data storage layer and vice-versa.
+ */
+class equity_barrier_option_instrument_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_barrier_option_instrument_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::equity_barrier_option_instrument map(const equity_barrier_option_instrument_entity& v);
+    static equity_barrier_option_instrument_entity map(const domain::equity_barrier_option_instrument& v);
+
+    static std::vector<domain::equity_barrier_option_instrument>
+    map(const std::vector<equity_barrier_option_instrument_entity>& v);
+    static std::vector<equity_barrier_option_instrument_entity>
+    map(const std::vector<domain::equity_barrier_option_instrument>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_barrier_option_instrument_repository.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_barrier_option_instrument_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_BARRIER_OPTION_INSTRUMENT_REPOSITORY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_BARRIER_OPTION_INSTRUMENT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_barrier_option_instrument.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Reads and writes equity barrier option instruments to data storage.
+ */
+class equity_barrier_option_instrument_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_barrier_option_instrument_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::equity_barrier_option_instrument& v);
+    void write(context ctx, const std::vector<domain::equity_barrier_option_instrument>& v);
+
+    std::vector<domain::equity_barrier_option_instrument> read_latest(context ctx);
+    std::vector<domain::equity_barrier_option_instrument>
+    read_latest(context ctx, const std::string& instrument_id);
+    std::vector<domain::equity_barrier_option_instrument>
+    read_all(context ctx, const std::string& instrument_id);
+
+    void remove(context ctx, const std::string& instrument_id);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_digital_option_instrument_entity.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_digital_option_instrument_entity.hpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_DIGITAL_OPTION_INSTRUMENT_ENTITY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_DIGITAL_OPTION_INSTRUMENT_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::trading::repository {
+
+struct equity_digital_option_instrument_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_trading_equity_digital_option_instruments_tbl";
+
+    sqlgen::PrimaryKey<std::string> instrument_id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::optional<std::string> trade_id;
+    std::string trade_type_code;
+    std::string underlying_name;
+    std::string currency;
+    double notional = 0.0;
+    std::optional<std::string> option_type;
+    std::optional<double> strike;
+    std::optional<double> barrier_level;
+    std::optional<std::string> barrier_type;
+    std::string expiry_date;
+    std::string long_short;
+    std::optional<double> payout_amount;
+    std::optional<std::string> description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const equity_digital_option_instrument_entity& v);
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_digital_option_instrument_mapper.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_digital_option_instrument_mapper.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_DIGITAL_OPTION_INSTRUMENT_MAPPER_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_DIGITAL_OPTION_INSTRUMENT_MAPPER_HPP
+
+#include <vector>
+#include "ores.trading.api/domain/equity_digital_option_instrument.hpp"
+#include "ores.trading.core/repository/equity_digital_option_instrument_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Maps equity_digital_option_instrument domain entities to data storage layer and vice-versa.
+ */
+class equity_digital_option_instrument_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_digital_option_instrument_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::equity_digital_option_instrument map(const equity_digital_option_instrument_entity& v);
+    static equity_digital_option_instrument_entity map(const domain::equity_digital_option_instrument& v);
+
+    static std::vector<domain::equity_digital_option_instrument>
+    map(const std::vector<equity_digital_option_instrument_entity>& v);
+    static std::vector<equity_digital_option_instrument_entity>
+    map(const std::vector<domain::equity_digital_option_instrument>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_digital_option_instrument_repository.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_digital_option_instrument_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_DIGITAL_OPTION_INSTRUMENT_REPOSITORY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_DIGITAL_OPTION_INSTRUMENT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_digital_option_instrument.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Reads and writes equity digital option instruments to data storage.
+ */
+class equity_digital_option_instrument_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_digital_option_instrument_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::equity_digital_option_instrument& v);
+    void write(context ctx, const std::vector<domain::equity_digital_option_instrument>& v);
+
+    std::vector<domain::equity_digital_option_instrument> read_latest(context ctx);
+    std::vector<domain::equity_digital_option_instrument>
+    read_latest(context ctx, const std::string& instrument_id);
+    std::vector<domain::equity_digital_option_instrument>
+    read_all(context ctx, const std::string& instrument_id);
+
+    void remove(context ctx, const std::string& instrument_id);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_forward_instrument_entity.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_forward_instrument_entity.hpp
@@ -1,0 +1,61 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_FORWARD_INSTRUMENT_ENTITY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_FORWARD_INSTRUMENT_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::trading::repository {
+
+struct equity_forward_instrument_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_trading_equity_forward_instruments_tbl";
+
+    sqlgen::PrimaryKey<std::string> instrument_id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::optional<std::string> trade_id;
+    std::string trade_type_code;
+    std::string underlying_name;
+    std::string currency;
+    double quantity = 0.0;
+    std::optional<double> forward_price;
+    std::string expiry_date;
+    std::string long_short;
+    std::optional<std::string> settlement_type;
+    std::optional<std::string> description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const equity_forward_instrument_entity& v);
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_forward_instrument_mapper.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_forward_instrument_mapper.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_FORWARD_INSTRUMENT_MAPPER_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_FORWARD_INSTRUMENT_MAPPER_HPP
+
+#include <vector>
+#include "ores.trading.api/domain/equity_forward_instrument.hpp"
+#include "ores.trading.core/repository/equity_forward_instrument_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Maps equity_forward_instrument domain entities to data storage layer and vice-versa.
+ */
+class equity_forward_instrument_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_forward_instrument_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::equity_forward_instrument map(const equity_forward_instrument_entity& v);
+    static equity_forward_instrument_entity map(const domain::equity_forward_instrument& v);
+
+    static std::vector<domain::equity_forward_instrument>
+    map(const std::vector<equity_forward_instrument_entity>& v);
+    static std::vector<equity_forward_instrument_entity>
+    map(const std::vector<domain::equity_forward_instrument>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_forward_instrument_repository.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_forward_instrument_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_FORWARD_INSTRUMENT_REPOSITORY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_FORWARD_INSTRUMENT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_forward_instrument.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Reads and writes equity forward instruments to data storage.
+ */
+class equity_forward_instrument_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_forward_instrument_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::equity_forward_instrument& v);
+    void write(context ctx, const std::vector<domain::equity_forward_instrument>& v);
+
+    std::vector<domain::equity_forward_instrument> read_latest(context ctx);
+    std::vector<domain::equity_forward_instrument>
+    read_latest(context ctx, const std::string& instrument_id);
+    std::vector<domain::equity_forward_instrument>
+    read_all(context ctx, const std::string& instrument_id);
+
+    void remove(context ctx, const std::string& instrument_id);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_option_instrument_entity.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_option_instrument_entity.hpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_OPTION_INSTRUMENT_ENTITY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_OPTION_INSTRUMENT_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::trading::repository {
+
+struct equity_option_instrument_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_trading_equity_option_instruments_tbl";
+
+    sqlgen::PrimaryKey<std::string> instrument_id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::optional<std::string> trade_id;
+    std::string trade_type_code;
+    std::string underlying_name;
+    std::string currency;
+    double notional = 0.0;
+    std::string option_type;
+    double strike = 0.0;
+    std::string expiry_date;
+    std::string exercise_type;
+    std::string long_short;
+    std::optional<std::string> settlement_type;
+    std::optional<std::string> cliquet_frequency;
+    std::optional<std::string> description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const equity_option_instrument_entity& v);
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_option_instrument_mapper.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_option_instrument_mapper.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_OPTION_INSTRUMENT_MAPPER_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_OPTION_INSTRUMENT_MAPPER_HPP
+
+#include <vector>
+#include "ores.trading.api/domain/equity_option_instrument.hpp"
+#include "ores.trading.core/repository/equity_option_instrument_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Maps equity_option_instrument domain entities to data storage layer and vice-versa.
+ */
+class equity_option_instrument_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_option_instrument_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::equity_option_instrument map(const equity_option_instrument_entity& v);
+    static equity_option_instrument_entity map(const domain::equity_option_instrument& v);
+
+    static std::vector<domain::equity_option_instrument>
+    map(const std::vector<equity_option_instrument_entity>& v);
+    static std::vector<equity_option_instrument_entity>
+    map(const std::vector<domain::equity_option_instrument>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_option_instrument_repository.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_option_instrument_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_OPTION_INSTRUMENT_REPOSITORY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_OPTION_INSTRUMENT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_option_instrument.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Reads and writes equity option instruments to data storage.
+ */
+class equity_option_instrument_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_option_instrument_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::equity_option_instrument& v);
+    void write(context ctx, const std::vector<domain::equity_option_instrument>& v);
+
+    std::vector<domain::equity_option_instrument> read_latest(context ctx);
+    std::vector<domain::equity_option_instrument>
+    read_latest(context ctx, const std::string& instrument_id);
+    std::vector<domain::equity_option_instrument>
+    read_all(context ctx, const std::string& instrument_id);
+
+    void remove(context ctx, const std::string& instrument_id);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_position_instrument_entity.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_position_instrument_entity.hpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_POSITION_INSTRUMENT_ENTITY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_POSITION_INSTRUMENT_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Represents an equity position instrument in the database.
+ *
+ * Covers ORE product type: EquityPosition.
+ */
+struct equity_position_instrument_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_trading_equity_position_instruments_tbl";
+
+    sqlgen::PrimaryKey<std::string> instrument_id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::optional<std::string> trade_id;
+    std::string trade_type_code;
+    std::string underlying_name;
+    std::string currency;
+    double quantity = 0.0;
+    std::optional<double> price;
+    std::optional<std::string> option_data_json;
+    std::optional<std::string> description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const equity_position_instrument_entity& v);
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_position_instrument_mapper.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_position_instrument_mapper.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_POSITION_INSTRUMENT_MAPPER_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_POSITION_INSTRUMENT_MAPPER_HPP
+
+#include <vector>
+#include "ores.trading.api/domain/equity_position_instrument.hpp"
+#include "ores.trading.core/repository/equity_position_instrument_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Maps equity_position_instrument domain entities to data storage layer and vice-versa.
+ */
+class equity_position_instrument_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_position_instrument_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::equity_position_instrument map(const equity_position_instrument_entity& v);
+    static equity_position_instrument_entity map(const domain::equity_position_instrument& v);
+
+    static std::vector<domain::equity_position_instrument>
+    map(const std::vector<equity_position_instrument_entity>& v);
+    static std::vector<equity_position_instrument_entity>
+    map(const std::vector<domain::equity_position_instrument>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_position_instrument_repository.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_position_instrument_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_POSITION_INSTRUMENT_REPOSITORY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_POSITION_INSTRUMENT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_position_instrument.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Reads and writes equity position instruments to data storage.
+ */
+class equity_position_instrument_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_position_instrument_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::equity_position_instrument& v);
+    void write(context ctx, const std::vector<domain::equity_position_instrument>& v);
+
+    std::vector<domain::equity_position_instrument> read_latest(context ctx);
+    std::vector<domain::equity_position_instrument>
+    read_latest(context ctx, const std::string& instrument_id);
+    std::vector<domain::equity_position_instrument>
+    read_all(context ctx, const std::string& instrument_id);
+
+    void remove(context ctx, const std::string& instrument_id);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_swap_instrument_entity.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_swap_instrument_entity.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_SWAP_INSTRUMENT_ENTITY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_SWAP_INSTRUMENT_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Represents an equity swap instrument in the database.
+ *
+ * Covers ORE product type: EquitySwap.
+ */
+struct equity_swap_instrument_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_trading_equity_swap_instruments_tbl";
+
+    sqlgen::PrimaryKey<std::string> instrument_id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::optional<std::string> trade_id;
+    std::string trade_type_code;
+    std::optional<std::string> underlying_name;
+    std::optional<std::string> basket_json;
+    std::string currency;
+    double notional = 0.0;
+    std::string return_type;
+    std::string start_date;
+    std::string maturity_date;
+    std::string long_short;
+    std::string payment_frequency;
+    std::optional<std::string> description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const equity_swap_instrument_entity& v);
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_swap_instrument_mapper.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_swap_instrument_mapper.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_SWAP_INSTRUMENT_MAPPER_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_SWAP_INSTRUMENT_MAPPER_HPP
+
+#include <vector>
+#include "ores.trading.api/domain/equity_swap_instrument.hpp"
+#include "ores.trading.core/repository/equity_swap_instrument_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Maps equity_swap_instrument domain entities to data storage layer and vice-versa.
+ */
+class equity_swap_instrument_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_swap_instrument_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::equity_swap_instrument map(const equity_swap_instrument_entity& v);
+    static equity_swap_instrument_entity map(const domain::equity_swap_instrument& v);
+
+    static std::vector<domain::equity_swap_instrument>
+    map(const std::vector<equity_swap_instrument_entity>& v);
+    static std::vector<equity_swap_instrument_entity>
+    map(const std::vector<domain::equity_swap_instrument>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_swap_instrument_repository.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_swap_instrument_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_SWAP_INSTRUMENT_REPOSITORY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_SWAP_INSTRUMENT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_swap_instrument.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Reads and writes equity swap instruments to data storage.
+ */
+class equity_swap_instrument_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_swap_instrument_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::equity_swap_instrument& v);
+    void write(context ctx, const std::vector<domain::equity_swap_instrument>& v);
+
+    std::vector<domain::equity_swap_instrument> read_latest(context ctx);
+    std::vector<domain::equity_swap_instrument>
+    read_latest(context ctx, const std::string& instrument_id);
+    std::vector<domain::equity_swap_instrument>
+    read_all(context ctx, const std::string& instrument_id);
+
+    void remove(context ctx, const std::string& instrument_id);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_variance_swap_instrument_entity.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_variance_swap_instrument_entity.hpp
@@ -1,0 +1,66 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_VARIANCE_SWAP_INSTRUMENT_ENTITY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_VARIANCE_SWAP_INSTRUMENT_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Represents an equity variance swap instrument in the database.
+ *
+ * Covers ORE product type: EquityVarianceSwap.
+ */
+struct equity_variance_swap_instrument_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_trading_equity_variance_swap_instruments_tbl";
+
+    sqlgen::PrimaryKey<std::string> instrument_id;
+    std::string tenant_id;
+    int version = 0;
+    std::string party_id;
+    std::optional<std::string> trade_id;
+    std::string trade_type_code;
+    std::string underlying_name;
+    std::string currency;
+    double notional = 0.0;
+    double variance_strike = 0.0;
+    std::string start_date;
+    std::string maturity_date;
+    std::string long_short;
+    std::optional<std::string> description;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const equity_variance_swap_instrument_entity& v);
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_variance_swap_instrument_mapper.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_variance_swap_instrument_mapper.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_VARIANCE_SWAP_INSTRUMENT_MAPPER_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_VARIANCE_SWAP_INSTRUMENT_MAPPER_HPP
+
+#include <vector>
+#include "ores.trading.api/domain/equity_variance_swap_instrument.hpp"
+#include "ores.trading.core/repository/equity_variance_swap_instrument_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Maps equity_variance_swap_instrument domain entities to data storage layer and vice-versa.
+ */
+class equity_variance_swap_instrument_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_variance_swap_instrument_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::equity_variance_swap_instrument map(const equity_variance_swap_instrument_entity& v);
+    static equity_variance_swap_instrument_entity map(const domain::equity_variance_swap_instrument& v);
+
+    static std::vector<domain::equity_variance_swap_instrument>
+    map(const std::vector<equity_variance_swap_instrument_entity>& v);
+    static std::vector<equity_variance_swap_instrument_entity>
+    map(const std::vector<domain::equity_variance_swap_instrument>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/repository/equity_variance_swap_instrument_repository.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/repository/equity_variance_swap_instrument_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_REPOSITORY_EQUITY_VARIANCE_SWAP_INSTRUMENT_REPOSITORY_HPP
+#define ORES_TRADING_REPOSITORY_EQUITY_VARIANCE_SWAP_INSTRUMENT_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_variance_swap_instrument.hpp"
+
+namespace ores::trading::repository {
+
+/**
+ * @brief Reads and writes equity variance swap instruments to data storage.
+ */
+class equity_variance_swap_instrument_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.repository.equity_variance_swap_instrument_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::equity_variance_swap_instrument& v);
+    void write(context ctx, const std::vector<domain::equity_variance_swap_instrument>& v);
+
+    std::vector<domain::equity_variance_swap_instrument> read_latest(context ctx);
+    std::vector<domain::equity_variance_swap_instrument>
+    read_latest(context ctx, const std::string& instrument_id);
+    std::vector<domain::equity_variance_swap_instrument>
+    read_all(context ctx, const std::string& instrument_id);
+
+    void remove(context ctx, const std::string& instrument_id);
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_accumulator_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_accumulator_instrument_service.hpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_EQUITY_ACCUMULATOR_INSTRUMENT_SERVICE_HPP
+#define ORES_TRADING_SERVICE_EQUITY_ACCUMULATOR_INSTRUMENT_SERVICE_HPP
+
+#include <string>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_accumulator_instrument.hpp"
+#include "ores.trading.core/repository/equity_accumulator_instrument_repository.hpp"
+
+namespace ores::trading::service {
+
+class equity_accumulator_instrument_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.service.equity_accumulator_instrument_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit equity_accumulator_instrument_service(context ctx);
+
+    void save_equity_accumulator_instrument(const domain::equity_accumulator_instrument& v);
+
+private:
+    context ctx_;
+    repository::equity_accumulator_instrument_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_asian_option_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_asian_option_instrument_service.hpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_EQUITY_ASIAN_OPTION_INSTRUMENT_SERVICE_HPP
+#define ORES_TRADING_SERVICE_EQUITY_ASIAN_OPTION_INSTRUMENT_SERVICE_HPP
+
+#include <string>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_asian_option_instrument.hpp"
+#include "ores.trading.core/repository/equity_asian_option_instrument_repository.hpp"
+
+namespace ores::trading::service {
+
+class equity_asian_option_instrument_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.service.equity_asian_option_instrument_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit equity_asian_option_instrument_service(context ctx);
+
+    void save_equity_asian_option_instrument(const domain::equity_asian_option_instrument& v);
+
+private:
+    context ctx_;
+    repository::equity_asian_option_instrument_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_barrier_option_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_barrier_option_instrument_service.hpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_EQUITY_BARRIER_OPTION_INSTRUMENT_SERVICE_HPP
+#define ORES_TRADING_SERVICE_EQUITY_BARRIER_OPTION_INSTRUMENT_SERVICE_HPP
+
+#include <string>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_barrier_option_instrument.hpp"
+#include "ores.trading.core/repository/equity_barrier_option_instrument_repository.hpp"
+
+namespace ores::trading::service {
+
+class equity_barrier_option_instrument_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.service.equity_barrier_option_instrument_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit equity_barrier_option_instrument_service(context ctx);
+
+    void save_equity_barrier_option_instrument(const domain::equity_barrier_option_instrument& v);
+
+private:
+    context ctx_;
+    repository::equity_barrier_option_instrument_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_digital_option_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_digital_option_instrument_service.hpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_EQUITY_DIGITAL_OPTION_INSTRUMENT_SERVICE_HPP
+#define ORES_TRADING_SERVICE_EQUITY_DIGITAL_OPTION_INSTRUMENT_SERVICE_HPP
+
+#include <string>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_digital_option_instrument.hpp"
+#include "ores.trading.core/repository/equity_digital_option_instrument_repository.hpp"
+
+namespace ores::trading::service {
+
+class equity_digital_option_instrument_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.service.equity_digital_option_instrument_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit equity_digital_option_instrument_service(context ctx);
+
+    void save_equity_digital_option_instrument(const domain::equity_digital_option_instrument& v);
+
+private:
+    context ctx_;
+    repository::equity_digital_option_instrument_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_forward_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_forward_instrument_service.hpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_EQUITY_FORWARD_INSTRUMENT_SERVICE_HPP
+#define ORES_TRADING_SERVICE_EQUITY_FORWARD_INSTRUMENT_SERVICE_HPP
+
+#include <string>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_forward_instrument.hpp"
+#include "ores.trading.core/repository/equity_forward_instrument_repository.hpp"
+
+namespace ores::trading::service {
+
+class equity_forward_instrument_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.service.equity_forward_instrument_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit equity_forward_instrument_service(context ctx);
+
+    void save_equity_forward_instrument(const domain::equity_forward_instrument& v);
+
+private:
+    context ctx_;
+    repository::equity_forward_instrument_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_option_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_option_instrument_service.hpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_EQUITY_OPTION_INSTRUMENT_SERVICE_HPP
+#define ORES_TRADING_SERVICE_EQUITY_OPTION_INSTRUMENT_SERVICE_HPP
+
+#include <string>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_option_instrument.hpp"
+#include "ores.trading.core/repository/equity_option_instrument_repository.hpp"
+
+namespace ores::trading::service {
+
+class equity_option_instrument_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.service.equity_option_instrument_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit equity_option_instrument_service(context ctx);
+
+    void save_equity_option_instrument(const domain::equity_option_instrument& v);
+
+private:
+    context ctx_;
+    repository::equity_option_instrument_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_position_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_position_instrument_service.hpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_EQUITY_POSITION_INSTRUMENT_SERVICE_HPP
+#define ORES_TRADING_SERVICE_EQUITY_POSITION_INSTRUMENT_SERVICE_HPP
+
+#include <string>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_position_instrument.hpp"
+#include "ores.trading.core/repository/equity_position_instrument_repository.hpp"
+
+namespace ores::trading::service {
+
+class equity_position_instrument_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.service.equity_position_instrument_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit equity_position_instrument_service(context ctx);
+
+    void save_equity_position_instrument(const domain::equity_position_instrument& v);
+
+private:
+    context ctx_;
+    repository::equity_position_instrument_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_swap_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_swap_instrument_service.hpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_EQUITY_SWAP_INSTRUMENT_SERVICE_HPP
+#define ORES_TRADING_SERVICE_EQUITY_SWAP_INSTRUMENT_SERVICE_HPP
+
+#include <string>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_swap_instrument.hpp"
+#include "ores.trading.core/repository/equity_swap_instrument_repository.hpp"
+
+namespace ores::trading::service {
+
+class equity_swap_instrument_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.service.equity_swap_instrument_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit equity_swap_instrument_service(context ctx);
+
+    void save_equity_swap_instrument(const domain::equity_swap_instrument& v);
+
+private:
+    context ctx_;
+    repository::equity_swap_instrument_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_variance_swap_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_variance_swap_instrument_service.hpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_EQUITY_VARIANCE_SWAP_INSTRUMENT_SERVICE_HPP
+#define ORES_TRADING_SERVICE_EQUITY_VARIANCE_SWAP_INSTRUMENT_SERVICE_HPP
+
+#include <string>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.trading.api/domain/equity_variance_swap_instrument.hpp"
+#include "ores.trading.core/repository/equity_variance_swap_instrument_repository.hpp"
+
+namespace ores::trading::service {
+
+class equity_variance_swap_instrument_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.trading.service.equity_variance_swap_instrument_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit equity_variance_swap_instrument_service(context ctx);
+
+    void save_equity_variance_swap_instrument(const domain::equity_variance_swap_instrument& v);
+
+private:
+    context ctx_;
+    repository::equity_variance_swap_instrument_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.trading.core/src/messaging/registrar.cpp
+++ b/projects/ores.trading.core/src/messaging/registrar.cpp
@@ -27,6 +27,7 @@
 #include "ores.trading.core/messaging/bond_instrument_handler.hpp"
 #include "ores.trading.core/messaging/credit_instrument_handler.hpp"
 #include "ores.trading.core/messaging/equity_instrument_handler.hpp"
+#include "ores.trading.core/messaging/typed_equity_instrument_handler.hpp"
 #include "ores.trading.core/messaging/commodity_instrument_handler.hpp"
 #include "ores.trading.core/messaging/composite_instrument_handler.hpp"
 #include "ores.trading.core/messaging/scripted_instrument_handler.hpp"
@@ -697,6 +698,70 @@ registrar::register_handlers(ores::nats::service::client& nats,
         [&nats, ctx, verifier](ores::nats::message msg) mutable {
             equity_instrument_handler h(nats, ctx, verifier);
             h.history(std::move(msg));
+        }));
+
+    // Typed equity instruments
+    subs.push_back(nats.queue_subscribe(
+        std::string(save_equity_option_instrument_request::nats_subject), queue,
+        [&nats, ctx, verifier](ores::nats::message msg) mutable {
+            typed_equity_instrument_handler h(nats, ctx, verifier);
+            h.save_option(std::move(msg));
+        }));
+
+    subs.push_back(nats.queue_subscribe(
+        std::string(save_equity_digital_option_instrument_request::nats_subject), queue,
+        [&nats, ctx, verifier](ores::nats::message msg) mutable {
+            typed_equity_instrument_handler h(nats, ctx, verifier);
+            h.save_digital_option(std::move(msg));
+        }));
+
+    subs.push_back(nats.queue_subscribe(
+        std::string(save_equity_barrier_option_instrument_request::nats_subject), queue,
+        [&nats, ctx, verifier](ores::nats::message msg) mutable {
+            typed_equity_instrument_handler h(nats, ctx, verifier);
+            h.save_barrier_option(std::move(msg));
+        }));
+
+    subs.push_back(nats.queue_subscribe(
+        std::string(save_equity_asian_option_instrument_request::nats_subject), queue,
+        [&nats, ctx, verifier](ores::nats::message msg) mutable {
+            typed_equity_instrument_handler h(nats, ctx, verifier);
+            h.save_asian_option(std::move(msg));
+        }));
+
+    subs.push_back(nats.queue_subscribe(
+        std::string(save_equity_forward_instrument_request::nats_subject), queue,
+        [&nats, ctx, verifier](ores::nats::message msg) mutable {
+            typed_equity_instrument_handler h(nats, ctx, verifier);
+            h.save_forward(std::move(msg));
+        }));
+
+    subs.push_back(nats.queue_subscribe(
+        std::string(save_equity_variance_swap_instrument_request::nats_subject), queue,
+        [&nats, ctx, verifier](ores::nats::message msg) mutable {
+            typed_equity_instrument_handler h(nats, ctx, verifier);
+            h.save_variance_swap(std::move(msg));
+        }));
+
+    subs.push_back(nats.queue_subscribe(
+        std::string(save_equity_swap_instrument_request::nats_subject), queue,
+        [&nats, ctx, verifier](ores::nats::message msg) mutable {
+            typed_equity_instrument_handler h(nats, ctx, verifier);
+            h.save_swap(std::move(msg));
+        }));
+
+    subs.push_back(nats.queue_subscribe(
+        std::string(save_equity_accumulator_instrument_request::nats_subject), queue,
+        [&nats, ctx, verifier](ores::nats::message msg) mutable {
+            typed_equity_instrument_handler h(nats, ctx, verifier);
+            h.save_accumulator(std::move(msg));
+        }));
+
+    subs.push_back(nats.queue_subscribe(
+        std::string(save_equity_position_instrument_request::nats_subject), queue,
+        [&nats, ctx, verifier](ores::nats::message msg) mutable {
+            typed_equity_instrument_handler h(nats, ctx, verifier);
+            h.save_position(std::move(msg));
         }));
 
     // Commodity instruments

--- a/projects/ores.trading.core/src/repository/equity_accumulator_instrument_entity.cpp
+++ b/projects/ores.trading.core/src/repository/equity_accumulator_instrument_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_accumulator_instrument_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::trading::repository {
+
+std::ostream& operator<<(std::ostream& s, const equity_accumulator_instrument_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_accumulator_instrument_mapper.cpp
+++ b/projects/ores.trading.core/src/repository/equity_accumulator_instrument_mapper.cpp
@@ -1,0 +1,119 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_accumulator_instrument_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.trading.api/domain/equity_accumulator_instrument_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::equity_accumulator_instrument
+equity_accumulator_instrument_mapper::map(const equity_accumulator_instrument_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::equity_accumulator_instrument r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name;
+    r.currency = v.currency;
+    r.strike = v.strike;
+    r.fixing_amount = v.fixing_amount;
+    r.start_date = v.start_date;
+    r.expiry_date = v.expiry_date;
+    r.fixing_frequency = v.fixing_frequency;
+    r.long_short = v.long_short;
+    r.knock_out_level = v.knock_out_level;
+    r.target_amount = v.target_amount;
+    r.target_type = v.target_type.value_or("");
+    r.payoff_type = v.payoff_type;
+    r.description = v.description.value_or("");
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+equity_accumulator_instrument_entity
+equity_accumulator_instrument_mapper::map(const domain::equity_accumulator_instrument& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    equity_accumulator_instrument_entity r;
+    r.instrument_id = boost::uuids::to_string(v.instrument_id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name;
+    r.currency = v.currency;
+    r.strike = v.strike;
+    r.fixing_amount = v.fixing_amount;
+    r.start_date = v.start_date;
+    r.expiry_date = v.expiry_date;
+    r.fixing_frequency = v.fixing_frequency;
+    r.long_short = v.long_short;
+    r.knock_out_level = v.knock_out_level;
+    r.target_amount = v.target_amount;
+    r.target_type = v.target_type.empty() ? std::nullopt : std::optional(v.target_type);
+    r.payoff_type = v.payoff_type;
+    r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::equity_accumulator_instrument>
+equity_accumulator_instrument_mapper::map(const std::vector<equity_accumulator_instrument_entity>& v) {
+    return map_vector<equity_accumulator_instrument_entity, domain::equity_accumulator_instrument>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<equity_accumulator_instrument_entity>
+equity_accumulator_instrument_mapper::map(const std::vector<domain::equity_accumulator_instrument>& v) {
+    return map_vector<domain::equity_accumulator_instrument, equity_accumulator_instrument_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_accumulator_instrument_repository.cpp
+++ b/projects/ores.trading.core/src/repository/equity_accumulator_instrument_repository.cpp
@@ -1,0 +1,109 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_accumulator_instrument_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.trading.api/domain/equity_accumulator_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.trading.core/repository/equity_accumulator_instrument_entity.hpp"
+#include "ores.trading.core/repository/equity_accumulator_instrument_mapper.hpp"
+
+namespace ores::trading::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string equity_accumulator_instrument_repository::sql() {
+    return generate_create_table_sql<equity_accumulator_instrument_entity>(lg());
+}
+
+void equity_accumulator_instrument_repository::write(
+    context ctx, const domain::equity_accumulator_instrument& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity accumulator instrument: " << v.instrument_id;
+    execute_write_query(ctx, equity_accumulator_instrument_mapper::map(v),
+        lg(), "Writing equity accumulator instrument to database.");
+}
+
+void equity_accumulator_instrument_repository::write(
+    context ctx, const std::vector<domain::equity_accumulator_instrument>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity accumulator instruments. Count: " << v.size();
+    execute_write_query(ctx, equity_accumulator_instrument_mapper::map(v),
+        lg(), "Writing equity accumulator instruments to database.");
+}
+
+std::vector<domain::equity_accumulator_instrument>
+equity_accumulator_instrument_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_accumulator_instrument_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("instrument_id"_c);
+
+    return execute_read_query<equity_accumulator_instrument_entity, domain::equity_accumulator_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_accumulator_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity accumulator instruments");
+}
+
+std::vector<domain::equity_accumulator_instrument>
+equity_accumulator_instrument_repository::read_latest(
+    context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest equity accumulator instrument. instrument_id: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_accumulator_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    return execute_read_query<equity_accumulator_instrument_entity, domain::equity_accumulator_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_accumulator_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity accumulator instrument by instrument_id.");
+}
+
+std::vector<domain::equity_accumulator_instrument>
+equity_accumulator_instrument_repository::read_all(
+    context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all equity accumulator instrument versions. instrument_id: " << instrument_id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_accumulator_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<equity_accumulator_instrument_entity, domain::equity_accumulator_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_accumulator_instrument_mapper::map(entities); },
+        lg(), "Reading all equity accumulator instrument versions by instrument_id.");
+}
+
+void equity_accumulator_instrument_repository::remove(
+    context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing equity accumulator instrument: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<equity_accumulator_instrument_entity> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing equity accumulator instrument from database.");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_asian_option_instrument_entity.cpp
+++ b/projects/ores.trading.core/src/repository/equity_asian_option_instrument_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_asian_option_instrument_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::trading::repository {
+
+std::ostream& operator<<(std::ostream& s, const equity_asian_option_instrument_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_asian_option_instrument_mapper.cpp
+++ b/projects/ores.trading.core/src/repository/equity_asian_option_instrument_mapper.cpp
@@ -1,0 +1,117 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_asian_option_instrument_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.trading.api/domain/equity_asian_option_instrument_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::equity_asian_option_instrument
+equity_asian_option_instrument_mapper::map(const equity_asian_option_instrument_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::equity_asian_option_instrument r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name;
+    r.currency = v.currency;
+    r.notional = v.notional;
+    r.option_type = v.option_type;
+    r.strike = v.strike;
+    r.expiry_date = v.expiry_date;
+    r.exercise_type = v.exercise_type;
+    r.long_short = v.long_short;
+    r.average_type = v.average_type;
+    r.averaging_start_date = v.averaging_start_date;
+    r.averaging_end_date = v.averaging_end_date;
+    r.description = v.description.value_or("");
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+equity_asian_option_instrument_entity
+equity_asian_option_instrument_mapper::map(const domain::equity_asian_option_instrument& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    equity_asian_option_instrument_entity r;
+    r.instrument_id = boost::uuids::to_string(v.instrument_id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name;
+    r.currency = v.currency;
+    r.notional = v.notional;
+    r.option_type = v.option_type;
+    r.strike = v.strike;
+    r.expiry_date = v.expiry_date;
+    r.exercise_type = v.exercise_type;
+    r.long_short = v.long_short;
+    r.average_type = v.average_type;
+    r.averaging_start_date = v.averaging_start_date;
+    r.averaging_end_date = v.averaging_end_date;
+    r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::equity_asian_option_instrument>
+equity_asian_option_instrument_mapper::map(const std::vector<equity_asian_option_instrument_entity>& v) {
+    return map_vector<equity_asian_option_instrument_entity, domain::equity_asian_option_instrument>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<equity_asian_option_instrument_entity>
+equity_asian_option_instrument_mapper::map(const std::vector<domain::equity_asian_option_instrument>& v) {
+    return map_vector<domain::equity_asian_option_instrument, equity_asian_option_instrument_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_asian_option_instrument_repository.cpp
+++ b/projects/ores.trading.core/src/repository/equity_asian_option_instrument_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_asian_option_instrument_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.trading.api/domain/equity_asian_option_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.trading.core/repository/equity_asian_option_instrument_entity.hpp"
+#include "ores.trading.core/repository/equity_asian_option_instrument_mapper.hpp"
+
+namespace ores::trading::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string equity_asian_option_instrument_repository::sql() {
+    return generate_create_table_sql<equity_asian_option_instrument_entity>(lg());
+}
+
+void equity_asian_option_instrument_repository::write(context ctx, const domain::equity_asian_option_instrument& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity asian option instrument: " << v.instrument_id;
+    execute_write_query(ctx, equity_asian_option_instrument_mapper::map(v),
+        lg(), "Writing equity asian option instrument to database.");
+}
+
+void equity_asian_option_instrument_repository::write(
+    context ctx, const std::vector<domain::equity_asian_option_instrument>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity asian option instruments. Count: " << v.size();
+    execute_write_query(ctx, equity_asian_option_instrument_mapper::map(v),
+        lg(), "Writing equity asian option instruments to database.");
+}
+
+std::vector<domain::equity_asian_option_instrument>
+equity_asian_option_instrument_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_asian_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("instrument_id"_c);
+
+    return execute_read_query<equity_asian_option_instrument_entity, domain::equity_asian_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_asian_option_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity asian option instruments");
+}
+
+std::vector<domain::equity_asian_option_instrument>
+equity_asian_option_instrument_repository::read_latest(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest equity asian option instrument. instrument_id: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_asian_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    return execute_read_query<equity_asian_option_instrument_entity, domain::equity_asian_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_asian_option_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity asian option instrument by instrument_id.");
+}
+
+std::vector<domain::equity_asian_option_instrument>
+equity_asian_option_instrument_repository::read_all(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all equity asian option instrument versions. instrument_id: " << instrument_id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_asian_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<equity_asian_option_instrument_entity, domain::equity_asian_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_asian_option_instrument_mapper::map(entities); },
+        lg(), "Reading all equity asian option instrument versions by instrument_id.");
+}
+
+void equity_asian_option_instrument_repository::remove(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing equity asian option instrument: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<equity_asian_option_instrument_entity> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing equity asian option instrument from database.");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_barrier_option_instrument_entity.cpp
+++ b/projects/ores.trading.core/src/repository/equity_barrier_option_instrument_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_barrier_option_instrument_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::trading::repository {
+
+std::ostream& operator<<(std::ostream& s, const equity_barrier_option_instrument_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_barrier_option_instrument_mapper.cpp
+++ b/projects/ores.trading.core/src/repository/equity_barrier_option_instrument_mapper.cpp
@@ -1,0 +1,121 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_barrier_option_instrument_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.trading.api/domain/equity_barrier_option_instrument_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::equity_barrier_option_instrument
+equity_barrier_option_instrument_mapper::map(const equity_barrier_option_instrument_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::equity_barrier_option_instrument r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name;
+    r.currency = v.currency;
+    r.notional = v.notional;
+    r.option_type = v.option_type;
+    r.strike = v.strike;
+    r.expiry_date = v.expiry_date;
+    r.exercise_type = v.exercise_type;
+    r.long_short = v.long_short;
+    r.lower_barrier = v.lower_barrier;
+    r.lower_barrier_type = v.lower_barrier_type;
+    r.upper_barrier = v.upper_barrier;
+    r.upper_barrier_type = v.upper_barrier_type.value_or("");
+    r.rebate = v.rebate;
+    r.description = v.description.value_or("");
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+equity_barrier_option_instrument_entity
+equity_barrier_option_instrument_mapper::map(const domain::equity_barrier_option_instrument& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    equity_barrier_option_instrument_entity r;
+    r.instrument_id = boost::uuids::to_string(v.instrument_id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name;
+    r.currency = v.currency;
+    r.notional = v.notional;
+    r.option_type = v.option_type;
+    r.strike = v.strike;
+    r.expiry_date = v.expiry_date;
+    r.exercise_type = v.exercise_type;
+    r.long_short = v.long_short;
+    r.lower_barrier = v.lower_barrier;
+    r.lower_barrier_type = v.lower_barrier_type;
+    r.upper_barrier = v.upper_barrier;
+    r.upper_barrier_type = v.upper_barrier_type.empty() ? std::nullopt : std::optional(v.upper_barrier_type);
+    r.rebate = v.rebate;
+    r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::equity_barrier_option_instrument>
+equity_barrier_option_instrument_mapper::map(const std::vector<equity_barrier_option_instrument_entity>& v) {
+    return map_vector<equity_barrier_option_instrument_entity, domain::equity_barrier_option_instrument>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<equity_barrier_option_instrument_entity>
+equity_barrier_option_instrument_mapper::map(const std::vector<domain::equity_barrier_option_instrument>& v) {
+    return map_vector<domain::equity_barrier_option_instrument, equity_barrier_option_instrument_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_barrier_option_instrument_repository.cpp
+++ b/projects/ores.trading.core/src/repository/equity_barrier_option_instrument_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_barrier_option_instrument_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.trading.api/domain/equity_barrier_option_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.trading.core/repository/equity_barrier_option_instrument_entity.hpp"
+#include "ores.trading.core/repository/equity_barrier_option_instrument_mapper.hpp"
+
+namespace ores::trading::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string equity_barrier_option_instrument_repository::sql() {
+    return generate_create_table_sql<equity_barrier_option_instrument_entity>(lg());
+}
+
+void equity_barrier_option_instrument_repository::write(context ctx, const domain::equity_barrier_option_instrument& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity barrier option instrument: " << v.instrument_id;
+    execute_write_query(ctx, equity_barrier_option_instrument_mapper::map(v),
+        lg(), "Writing equity barrier option instrument to database.");
+}
+
+void equity_barrier_option_instrument_repository::write(
+    context ctx, const std::vector<domain::equity_barrier_option_instrument>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity barrier option instruments. Count: " << v.size();
+    execute_write_query(ctx, equity_barrier_option_instrument_mapper::map(v),
+        lg(), "Writing equity barrier option instruments to database.");
+}
+
+std::vector<domain::equity_barrier_option_instrument>
+equity_barrier_option_instrument_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_barrier_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("instrument_id"_c);
+
+    return execute_read_query<equity_barrier_option_instrument_entity, domain::equity_barrier_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_barrier_option_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity barrier option instruments");
+}
+
+std::vector<domain::equity_barrier_option_instrument>
+equity_barrier_option_instrument_repository::read_latest(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest equity barrier option instrument. instrument_id: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_barrier_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    return execute_read_query<equity_barrier_option_instrument_entity, domain::equity_barrier_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_barrier_option_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity barrier option instrument by instrument_id.");
+}
+
+std::vector<domain::equity_barrier_option_instrument>
+equity_barrier_option_instrument_repository::read_all(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all equity barrier option instrument versions. instrument_id: " << instrument_id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_barrier_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<equity_barrier_option_instrument_entity, domain::equity_barrier_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_barrier_option_instrument_mapper::map(entities); },
+        lg(), "Reading all equity barrier option instrument versions by instrument_id.");
+}
+
+void equity_barrier_option_instrument_repository::remove(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing equity barrier option instrument: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<equity_barrier_option_instrument_entity> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing equity barrier option instrument from database.");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_digital_option_instrument_entity.cpp
+++ b/projects/ores.trading.core/src/repository/equity_digital_option_instrument_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_digital_option_instrument_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::trading::repository {
+
+std::ostream& operator<<(std::ostream& s, const equity_digital_option_instrument_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_digital_option_instrument_mapper.cpp
+++ b/projects/ores.trading.core/src/repository/equity_digital_option_instrument_mapper.cpp
@@ -1,0 +1,115 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_digital_option_instrument_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.trading.api/domain/equity_digital_option_instrument_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::equity_digital_option_instrument
+equity_digital_option_instrument_mapper::map(const equity_digital_option_instrument_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::equity_digital_option_instrument r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name;
+    r.currency = v.currency;
+    r.notional = v.notional;
+    r.option_type = v.option_type.value_or("");
+    r.strike = v.strike;
+    r.barrier_level = v.barrier_level;
+    r.barrier_type = v.barrier_type.value_or("");
+    r.expiry_date = v.expiry_date;
+    r.long_short = v.long_short;
+    r.payout_amount = v.payout_amount;
+    r.description = v.description.value_or("");
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+equity_digital_option_instrument_entity
+equity_digital_option_instrument_mapper::map(const domain::equity_digital_option_instrument& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    equity_digital_option_instrument_entity r;
+    r.instrument_id = boost::uuids::to_string(v.instrument_id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name;
+    r.currency = v.currency;
+    r.notional = v.notional;
+    r.option_type = v.option_type.empty() ? std::nullopt : std::optional(v.option_type);
+    r.strike = v.strike;
+    r.barrier_level = v.barrier_level;
+    r.barrier_type = v.barrier_type.empty() ? std::nullopt : std::optional(v.barrier_type);
+    r.expiry_date = v.expiry_date;
+    r.long_short = v.long_short;
+    r.payout_amount = v.payout_amount;
+    r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::equity_digital_option_instrument>
+equity_digital_option_instrument_mapper::map(const std::vector<equity_digital_option_instrument_entity>& v) {
+    return map_vector<equity_digital_option_instrument_entity, domain::equity_digital_option_instrument>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<equity_digital_option_instrument_entity>
+equity_digital_option_instrument_mapper::map(const std::vector<domain::equity_digital_option_instrument>& v) {
+    return map_vector<domain::equity_digital_option_instrument, equity_digital_option_instrument_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_digital_option_instrument_repository.cpp
+++ b/projects/ores.trading.core/src/repository/equity_digital_option_instrument_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_digital_option_instrument_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.trading.api/domain/equity_digital_option_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.trading.core/repository/equity_digital_option_instrument_entity.hpp"
+#include "ores.trading.core/repository/equity_digital_option_instrument_mapper.hpp"
+
+namespace ores::trading::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string equity_digital_option_instrument_repository::sql() {
+    return generate_create_table_sql<equity_digital_option_instrument_entity>(lg());
+}
+
+void equity_digital_option_instrument_repository::write(context ctx, const domain::equity_digital_option_instrument& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity digital option instrument: " << v.instrument_id;
+    execute_write_query(ctx, equity_digital_option_instrument_mapper::map(v),
+        lg(), "Writing equity digital option instrument to database.");
+}
+
+void equity_digital_option_instrument_repository::write(
+    context ctx, const std::vector<domain::equity_digital_option_instrument>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity digital option instruments. Count: " << v.size();
+    execute_write_query(ctx, equity_digital_option_instrument_mapper::map(v),
+        lg(), "Writing equity digital option instruments to database.");
+}
+
+std::vector<domain::equity_digital_option_instrument>
+equity_digital_option_instrument_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_digital_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("instrument_id"_c);
+
+    return execute_read_query<equity_digital_option_instrument_entity, domain::equity_digital_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_digital_option_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity digital option instruments");
+}
+
+std::vector<domain::equity_digital_option_instrument>
+equity_digital_option_instrument_repository::read_latest(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest equity digital option instrument. instrument_id: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_digital_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    return execute_read_query<equity_digital_option_instrument_entity, domain::equity_digital_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_digital_option_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity digital option instrument by instrument_id.");
+}
+
+std::vector<domain::equity_digital_option_instrument>
+equity_digital_option_instrument_repository::read_all(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all equity digital option instrument versions. instrument_id: " << instrument_id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_digital_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<equity_digital_option_instrument_entity, domain::equity_digital_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_digital_option_instrument_mapper::map(entities); },
+        lg(), "Reading all equity digital option instrument versions by instrument_id.");
+}
+
+void equity_digital_option_instrument_repository::remove(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing equity digital option instrument: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<equity_digital_option_instrument_entity> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing equity digital option instrument from database.");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_forward_instrument_entity.cpp
+++ b/projects/ores.trading.core/src/repository/equity_forward_instrument_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_forward_instrument_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::trading::repository {
+
+std::ostream& operator<<(std::ostream& s, const equity_forward_instrument_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_forward_instrument_mapper.cpp
+++ b/projects/ores.trading.core/src/repository/equity_forward_instrument_mapper.cpp
@@ -1,0 +1,109 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_forward_instrument_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.trading.api/domain/equity_forward_instrument_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::equity_forward_instrument
+equity_forward_instrument_mapper::map(const equity_forward_instrument_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::equity_forward_instrument r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name;
+    r.currency = v.currency;
+    r.quantity = v.quantity;
+    r.forward_price = v.forward_price;
+    r.expiry_date = v.expiry_date;
+    r.long_short = v.long_short;
+    r.settlement_type = v.settlement_type.value_or("");
+    r.description = v.description.value_or("");
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+equity_forward_instrument_entity
+equity_forward_instrument_mapper::map(const domain::equity_forward_instrument& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    equity_forward_instrument_entity r;
+    r.instrument_id = boost::uuids::to_string(v.instrument_id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name;
+    r.currency = v.currency;
+    r.quantity = v.quantity;
+    r.forward_price = v.forward_price;
+    r.expiry_date = v.expiry_date;
+    r.long_short = v.long_short;
+    r.settlement_type = v.settlement_type.empty() ? std::nullopt : std::optional(v.settlement_type);
+    r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::equity_forward_instrument>
+equity_forward_instrument_mapper::map(const std::vector<equity_forward_instrument_entity>& v) {
+    return map_vector<equity_forward_instrument_entity, domain::equity_forward_instrument>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<equity_forward_instrument_entity>
+equity_forward_instrument_mapper::map(const std::vector<domain::equity_forward_instrument>& v) {
+    return map_vector<domain::equity_forward_instrument, equity_forward_instrument_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_forward_instrument_repository.cpp
+++ b/projects/ores.trading.core/src/repository/equity_forward_instrument_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_forward_instrument_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.trading.api/domain/equity_forward_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.trading.core/repository/equity_forward_instrument_entity.hpp"
+#include "ores.trading.core/repository/equity_forward_instrument_mapper.hpp"
+
+namespace ores::trading::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string equity_forward_instrument_repository::sql() {
+    return generate_create_table_sql<equity_forward_instrument_entity>(lg());
+}
+
+void equity_forward_instrument_repository::write(context ctx, const domain::equity_forward_instrument& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity forward instrument: " << v.instrument_id;
+    execute_write_query(ctx, equity_forward_instrument_mapper::map(v),
+        lg(), "Writing equity forward instrument to database.");
+}
+
+void equity_forward_instrument_repository::write(
+    context ctx, const std::vector<domain::equity_forward_instrument>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity forward instruments. Count: " << v.size();
+    execute_write_query(ctx, equity_forward_instrument_mapper::map(v),
+        lg(), "Writing equity forward instruments to database.");
+}
+
+std::vector<domain::equity_forward_instrument>
+equity_forward_instrument_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_forward_instrument_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("instrument_id"_c);
+
+    return execute_read_query<equity_forward_instrument_entity, domain::equity_forward_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_forward_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity forward instruments");
+}
+
+std::vector<domain::equity_forward_instrument>
+equity_forward_instrument_repository::read_latest(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest equity forward instrument. instrument_id: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_forward_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    return execute_read_query<equity_forward_instrument_entity, domain::equity_forward_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_forward_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity forward instrument by instrument_id.");
+}
+
+std::vector<domain::equity_forward_instrument>
+equity_forward_instrument_repository::read_all(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all equity forward instrument versions. instrument_id: " << instrument_id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_forward_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<equity_forward_instrument_entity, domain::equity_forward_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_forward_instrument_mapper::map(entities); },
+        lg(), "Reading all equity forward instrument versions by instrument_id.");
+}
+
+void equity_forward_instrument_repository::remove(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing equity forward instrument: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<equity_forward_instrument_entity> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing equity forward instrument from database.");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_option_instrument_entity.cpp
+++ b/projects/ores.trading.core/src/repository/equity_option_instrument_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_option_instrument_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::trading::repository {
+
+std::ostream& operator<<(std::ostream& s, const equity_option_instrument_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_option_instrument_mapper.cpp
+++ b/projects/ores.trading.core/src/repository/equity_option_instrument_mapper.cpp
@@ -1,0 +1,115 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_option_instrument_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.trading.api/domain/equity_option_instrument_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::equity_option_instrument
+equity_option_instrument_mapper::map(const equity_option_instrument_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::equity_option_instrument r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name;
+    r.currency = v.currency;
+    r.notional = v.notional;
+    r.option_type = v.option_type;
+    r.strike = v.strike;
+    r.expiry_date = v.expiry_date;
+    r.exercise_type = v.exercise_type;
+    r.long_short = v.long_short;
+    r.settlement_type = v.settlement_type.value_or("");
+    r.cliquet_frequency = v.cliquet_frequency.value_or("");
+    r.description = v.description.value_or("");
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+equity_option_instrument_entity
+equity_option_instrument_mapper::map(const domain::equity_option_instrument& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    equity_option_instrument_entity r;
+    r.instrument_id = boost::uuids::to_string(v.instrument_id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name;
+    r.currency = v.currency;
+    r.notional = v.notional;
+    r.option_type = v.option_type;
+    r.strike = v.strike;
+    r.expiry_date = v.expiry_date;
+    r.exercise_type = v.exercise_type;
+    r.long_short = v.long_short;
+    r.settlement_type = v.settlement_type.empty() ? std::nullopt : std::optional(v.settlement_type);
+    r.cliquet_frequency = v.cliquet_frequency.empty() ? std::nullopt : std::optional(v.cliquet_frequency);
+    r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::equity_option_instrument>
+equity_option_instrument_mapper::map(const std::vector<equity_option_instrument_entity>& v) {
+    return map_vector<equity_option_instrument_entity, domain::equity_option_instrument>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<equity_option_instrument_entity>
+equity_option_instrument_mapper::map(const std::vector<domain::equity_option_instrument>& v) {
+    return map_vector<domain::equity_option_instrument, equity_option_instrument_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_option_instrument_repository.cpp
+++ b/projects/ores.trading.core/src/repository/equity_option_instrument_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_option_instrument_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.trading.api/domain/equity_option_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.trading.core/repository/equity_option_instrument_entity.hpp"
+#include "ores.trading.core/repository/equity_option_instrument_mapper.hpp"
+
+namespace ores::trading::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string equity_option_instrument_repository::sql() {
+    return generate_create_table_sql<equity_option_instrument_entity>(lg());
+}
+
+void equity_option_instrument_repository::write(context ctx, const domain::equity_option_instrument& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity option instrument: " << v.instrument_id;
+    execute_write_query(ctx, equity_option_instrument_mapper::map(v),
+        lg(), "Writing equity option instrument to database.");
+}
+
+void equity_option_instrument_repository::write(
+    context ctx, const std::vector<domain::equity_option_instrument>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity option instruments. Count: " << v.size();
+    execute_write_query(ctx, equity_option_instrument_mapper::map(v),
+        lg(), "Writing equity option instruments to database.");
+}
+
+std::vector<domain::equity_option_instrument>
+equity_option_instrument_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("instrument_id"_c);
+
+    return execute_read_query<equity_option_instrument_entity, domain::equity_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_option_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity option instruments");
+}
+
+std::vector<domain::equity_option_instrument>
+equity_option_instrument_repository::read_latest(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest equity option instrument. instrument_id: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    return execute_read_query<equity_option_instrument_entity, domain::equity_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_option_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity option instrument by instrument_id.");
+}
+
+std::vector<domain::equity_option_instrument>
+equity_option_instrument_repository::read_all(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all equity option instrument versions. instrument_id: " << instrument_id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_option_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<equity_option_instrument_entity, domain::equity_option_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_option_instrument_mapper::map(entities); },
+        lg(), "Reading all equity option instrument versions by instrument_id.");
+}
+
+void equity_option_instrument_repository::remove(context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing equity option instrument: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<equity_option_instrument_entity> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing equity option instrument from database.");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_position_instrument_entity.cpp
+++ b/projects/ores.trading.core/src/repository/equity_position_instrument_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_position_instrument_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::trading::repository {
+
+std::ostream& operator<<(std::ostream& s, const equity_position_instrument_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_position_instrument_mapper.cpp
+++ b/projects/ores.trading.core/src/repository/equity_position_instrument_mapper.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_position_instrument_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.trading.api/domain/equity_position_instrument_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::equity_position_instrument
+equity_position_instrument_mapper::map(const equity_position_instrument_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::equity_position_instrument r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name;
+    r.currency = v.currency;
+    r.quantity = v.quantity;
+    r.price = v.price;
+    r.option_data_json = v.option_data_json.value_or("");
+    r.description = v.description.value_or("");
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+equity_position_instrument_entity
+equity_position_instrument_mapper::map(const domain::equity_position_instrument& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    equity_position_instrument_entity r;
+    r.instrument_id = boost::uuids::to_string(v.instrument_id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name;
+    r.currency = v.currency;
+    r.quantity = v.quantity;
+    r.price = v.price;
+    r.option_data_json = v.option_data_json.empty() ? std::nullopt : std::optional(v.option_data_json);
+    r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::equity_position_instrument>
+equity_position_instrument_mapper::map(const std::vector<equity_position_instrument_entity>& v) {
+    return map_vector<equity_position_instrument_entity, domain::equity_position_instrument>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<equity_position_instrument_entity>
+equity_position_instrument_mapper::map(const std::vector<domain::equity_position_instrument>& v) {
+    return map_vector<domain::equity_position_instrument, equity_position_instrument_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_position_instrument_repository.cpp
+++ b/projects/ores.trading.core/src/repository/equity_position_instrument_repository.cpp
@@ -1,0 +1,109 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_position_instrument_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.trading.api/domain/equity_position_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.trading.core/repository/equity_position_instrument_entity.hpp"
+#include "ores.trading.core/repository/equity_position_instrument_mapper.hpp"
+
+namespace ores::trading::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string equity_position_instrument_repository::sql() {
+    return generate_create_table_sql<equity_position_instrument_entity>(lg());
+}
+
+void equity_position_instrument_repository::write(
+    context ctx, const domain::equity_position_instrument& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity position instrument: " << v.instrument_id;
+    execute_write_query(ctx, equity_position_instrument_mapper::map(v),
+        lg(), "Writing equity position instrument to database.");
+}
+
+void equity_position_instrument_repository::write(
+    context ctx, const std::vector<domain::equity_position_instrument>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity position instruments. Count: " << v.size();
+    execute_write_query(ctx, equity_position_instrument_mapper::map(v),
+        lg(), "Writing equity position instruments to database.");
+}
+
+std::vector<domain::equity_position_instrument>
+equity_position_instrument_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_position_instrument_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("instrument_id"_c);
+
+    return execute_read_query<equity_position_instrument_entity, domain::equity_position_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_position_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity position instruments");
+}
+
+std::vector<domain::equity_position_instrument>
+equity_position_instrument_repository::read_latest(
+    context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest equity position instrument. instrument_id: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_position_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    return execute_read_query<equity_position_instrument_entity, domain::equity_position_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_position_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity position instrument by instrument_id.");
+}
+
+std::vector<domain::equity_position_instrument>
+equity_position_instrument_repository::read_all(
+    context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all equity position instrument versions. instrument_id: " << instrument_id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_position_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<equity_position_instrument_entity, domain::equity_position_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_position_instrument_mapper::map(entities); },
+        lg(), "Reading all equity position instrument versions by instrument_id.");
+}
+
+void equity_position_instrument_repository::remove(
+    context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing equity position instrument: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<equity_position_instrument_entity> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing equity position instrument from database.");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_swap_instrument_entity.cpp
+++ b/projects/ores.trading.core/src/repository/equity_swap_instrument_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_swap_instrument_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::trading::repository {
+
+std::ostream& operator<<(std::ostream& s, const equity_swap_instrument_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_swap_instrument_mapper.cpp
+++ b/projects/ores.trading.core/src/repository/equity_swap_instrument_mapper.cpp
@@ -1,0 +1,113 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_swap_instrument_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.trading.api/domain/equity_swap_instrument_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::equity_swap_instrument
+equity_swap_instrument_mapper::map(const equity_swap_instrument_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::equity_swap_instrument r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name.value_or("");
+    r.basket_json = v.basket_json.value_or("");
+    r.currency = v.currency;
+    r.notional = v.notional;
+    r.return_type = v.return_type;
+    r.start_date = v.start_date;
+    r.maturity_date = v.maturity_date;
+    r.long_short = v.long_short;
+    r.payment_frequency = v.payment_frequency;
+    r.description = v.description.value_or("");
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+equity_swap_instrument_entity
+equity_swap_instrument_mapper::map(const domain::equity_swap_instrument& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    equity_swap_instrument_entity r;
+    r.instrument_id = boost::uuids::to_string(v.instrument_id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name.empty() ? std::nullopt : std::optional(v.underlying_name);
+    r.basket_json = v.basket_json.empty() ? std::nullopt : std::optional(v.basket_json);
+    r.currency = v.currency;
+    r.notional = v.notional;
+    r.return_type = v.return_type;
+    r.start_date = v.start_date;
+    r.maturity_date = v.maturity_date;
+    r.long_short = v.long_short;
+    r.payment_frequency = v.payment_frequency;
+    r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::equity_swap_instrument>
+equity_swap_instrument_mapper::map(const std::vector<equity_swap_instrument_entity>& v) {
+    return map_vector<equity_swap_instrument_entity, domain::equity_swap_instrument>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<equity_swap_instrument_entity>
+equity_swap_instrument_mapper::map(const std::vector<domain::equity_swap_instrument>& v) {
+    return map_vector<domain::equity_swap_instrument, equity_swap_instrument_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_swap_instrument_repository.cpp
+++ b/projects/ores.trading.core/src/repository/equity_swap_instrument_repository.cpp
@@ -1,0 +1,109 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_swap_instrument_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.trading.api/domain/equity_swap_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.trading.core/repository/equity_swap_instrument_entity.hpp"
+#include "ores.trading.core/repository/equity_swap_instrument_mapper.hpp"
+
+namespace ores::trading::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string equity_swap_instrument_repository::sql() {
+    return generate_create_table_sql<equity_swap_instrument_entity>(lg());
+}
+
+void equity_swap_instrument_repository::write(
+    context ctx, const domain::equity_swap_instrument& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity swap instrument: " << v.instrument_id;
+    execute_write_query(ctx, equity_swap_instrument_mapper::map(v),
+        lg(), "Writing equity swap instrument to database.");
+}
+
+void equity_swap_instrument_repository::write(
+    context ctx, const std::vector<domain::equity_swap_instrument>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity swap instruments. Count: " << v.size();
+    execute_write_query(ctx, equity_swap_instrument_mapper::map(v),
+        lg(), "Writing equity swap instruments to database.");
+}
+
+std::vector<domain::equity_swap_instrument>
+equity_swap_instrument_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_swap_instrument_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("instrument_id"_c);
+
+    return execute_read_query<equity_swap_instrument_entity, domain::equity_swap_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_swap_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity swap instruments");
+}
+
+std::vector<domain::equity_swap_instrument>
+equity_swap_instrument_repository::read_latest(
+    context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest equity swap instrument. instrument_id: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_swap_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    return execute_read_query<equity_swap_instrument_entity, domain::equity_swap_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_swap_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity swap instrument by instrument_id.");
+}
+
+std::vector<domain::equity_swap_instrument>
+equity_swap_instrument_repository::read_all(
+    context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all equity swap instrument versions. instrument_id: " << instrument_id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_swap_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<equity_swap_instrument_entity, domain::equity_swap_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_swap_instrument_mapper::map(entities); },
+        lg(), "Reading all equity swap instrument versions by instrument_id.");
+}
+
+void equity_swap_instrument_repository::remove(
+    context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing equity swap instrument: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<equity_swap_instrument_entity> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing equity swap instrument from database.");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_variance_swap_instrument_entity.cpp
+++ b/projects/ores.trading.core/src/repository/equity_variance_swap_instrument_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_variance_swap_instrument_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::trading::repository {
+
+std::ostream& operator<<(std::ostream& s, const equity_variance_swap_instrument_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_variance_swap_instrument_mapper.cpp
+++ b/projects/ores.trading.core/src/repository/equity_variance_swap_instrument_mapper.cpp
@@ -1,0 +1,109 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_variance_swap_instrument_mapper.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.trading.api/domain/equity_variance_swap_instrument_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::trading::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::equity_variance_swap_instrument
+equity_variance_swap_instrument_mapper::map(const equity_variance_swap_instrument_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::equity_variance_swap_instrument r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name;
+    r.currency = v.currency;
+    r.notional = v.notional;
+    r.variance_strike = v.variance_strike;
+    r.start_date = v.start_date;
+    r.maturity_date = v.maturity_date;
+    r.long_short = v.long_short;
+    r.description = v.description.value_or("");
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+equity_variance_swap_instrument_entity
+equity_variance_swap_instrument_mapper::map(const domain::equity_variance_swap_instrument& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    equity_variance_swap_instrument_entity r;
+    r.instrument_id = boost::uuids::to_string(v.instrument_id);
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.party_id = boost::uuids::to_string(v.party_id);
+    r.trade_id = v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
+    r.trade_type_code = v.trade_type_code;
+    r.underlying_name = v.underlying_name;
+    r.currency = v.currency;
+    r.notional = v.notional;
+    r.variance_strike = v.variance_strike;
+    r.start_date = v.start_date;
+    r.maturity_date = v.maturity_date;
+    r.long_short = v.long_short;
+    r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::equity_variance_swap_instrument>
+equity_variance_swap_instrument_mapper::map(const std::vector<equity_variance_swap_instrument_entity>& v) {
+    return map_vector<equity_variance_swap_instrument_entity, domain::equity_variance_swap_instrument>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<equity_variance_swap_instrument_entity>
+equity_variance_swap_instrument_mapper::map(const std::vector<domain::equity_variance_swap_instrument>& v) {
+    return map_vector<domain::equity_variance_swap_instrument, equity_variance_swap_instrument_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.trading.core/src/repository/equity_variance_swap_instrument_repository.cpp
+++ b/projects/ores.trading.core/src/repository/equity_variance_swap_instrument_repository.cpp
@@ -1,0 +1,109 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_variance_swap_instrument_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.trading.api/domain/equity_variance_swap_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.trading.core/repository/equity_variance_swap_instrument_entity.hpp"
+#include "ores.trading.core/repository/equity_variance_swap_instrument_mapper.hpp"
+
+namespace ores::trading::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string equity_variance_swap_instrument_repository::sql() {
+    return generate_create_table_sql<equity_variance_swap_instrument_entity>(lg());
+}
+
+void equity_variance_swap_instrument_repository::write(
+    context ctx, const domain::equity_variance_swap_instrument& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity variance swap instrument: " << v.instrument_id;
+    execute_write_query(ctx, equity_variance_swap_instrument_mapper::map(v),
+        lg(), "Writing equity variance swap instrument to database.");
+}
+
+void equity_variance_swap_instrument_repository::write(
+    context ctx, const std::vector<domain::equity_variance_swap_instrument>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity variance swap instruments. Count: " << v.size();
+    execute_write_query(ctx, equity_variance_swap_instrument_mapper::map(v),
+        lg(), "Writing equity variance swap instruments to database.");
+}
+
+std::vector<domain::equity_variance_swap_instrument>
+equity_variance_swap_instrument_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_variance_swap_instrument_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("instrument_id"_c);
+
+    return execute_read_query<equity_variance_swap_instrument_entity, domain::equity_variance_swap_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_variance_swap_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity variance swap instruments");
+}
+
+std::vector<domain::equity_variance_swap_instrument>
+equity_variance_swap_instrument_repository::read_latest(
+    context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest equity variance swap instrument. instrument_id: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_variance_swap_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    return execute_read_query<equity_variance_swap_instrument_entity, domain::equity_variance_swap_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_variance_swap_instrument_mapper::map(entities); },
+        lg(), "Reading latest equity variance swap instrument by instrument_id.");
+}
+
+std::vector<domain::equity_variance_swap_instrument>
+equity_variance_swap_instrument_repository::read_all(
+    context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all equity variance swap instrument versions. instrument_id: " << instrument_id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<equity_variance_swap_instrument_entity>> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<equity_variance_swap_instrument_entity, domain::equity_variance_swap_instrument>(
+        ctx, query,
+        [](const auto& entities) { return equity_variance_swap_instrument_mapper::map(entities); },
+        lg(), "Reading all equity variance swap instrument versions by instrument_id.");
+}
+
+void equity_variance_swap_instrument_repository::remove(
+    context ctx, const std::string& instrument_id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing equity variance swap instrument: " << instrument_id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<equity_variance_swap_instrument_entity> |
+        where("tenant_id"_c == tid && "instrument_id"_c == instrument_id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing equity variance swap instrument from database.");
+}
+
+}

--- a/projects/ores.trading.core/src/service/equity_accumulator_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_accumulator_instrument_service.cpp
@@ -1,0 +1,47 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/service/equity_accumulator_instrument_service.hpp"
+
+#include <stdexcept>
+#include "ores.service/messaging/handler_helpers.hpp"
+
+using ores::service::messaging::stamp;
+
+namespace ores::trading::service {
+
+using namespace ores::logging;
+
+equity_accumulator_instrument_service::equity_accumulator_instrument_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+void equity_accumulator_instrument_service::save_equity_accumulator_instrument(
+    const domain::equity_accumulator_instrument& v) {
+    if (v.instrument_id.is_nil())
+        throw std::invalid_argument("Equity accumulator instrument id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_accumulator_instrument: "
+                               << v.instrument_id;
+    auto t = v;
+    stamp(t, ctx_);
+    repo_.write(ctx_, t);
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_accumulator_instrument: "
+                              << t.instrument_id;
+}
+
+}

--- a/projects/ores.trading.core/src/service/equity_asian_option_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_asian_option_instrument_service.cpp
@@ -1,0 +1,47 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/service/equity_asian_option_instrument_service.hpp"
+
+#include <stdexcept>
+#include "ores.service/messaging/handler_helpers.hpp"
+
+using ores::service::messaging::stamp;
+
+namespace ores::trading::service {
+
+using namespace ores::logging;
+
+equity_asian_option_instrument_service::equity_asian_option_instrument_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+void equity_asian_option_instrument_service::save_equity_asian_option_instrument(
+    const domain::equity_asian_option_instrument& v) {
+    if (v.instrument_id.is_nil())
+        throw std::invalid_argument("Equity asian option instrument id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_asian_option_instrument: "
+                               << v.instrument_id;
+    auto t = v;
+    stamp(t, ctx_);
+    repo_.write(ctx_, t);
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_asian_option_instrument: "
+                              << t.instrument_id;
+}
+
+}

--- a/projects/ores.trading.core/src/service/equity_barrier_option_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_barrier_option_instrument_service.cpp
@@ -1,0 +1,47 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/service/equity_barrier_option_instrument_service.hpp"
+
+#include <stdexcept>
+#include "ores.service/messaging/handler_helpers.hpp"
+
+using ores::service::messaging::stamp;
+
+namespace ores::trading::service {
+
+using namespace ores::logging;
+
+equity_barrier_option_instrument_service::equity_barrier_option_instrument_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+void equity_barrier_option_instrument_service::save_equity_barrier_option_instrument(
+    const domain::equity_barrier_option_instrument& v) {
+    if (v.instrument_id.is_nil())
+        throw std::invalid_argument("Equity barrier option instrument id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_barrier_option_instrument: "
+                               << v.instrument_id;
+    auto t = v;
+    stamp(t, ctx_);
+    repo_.write(ctx_, t);
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_barrier_option_instrument: "
+                              << t.instrument_id;
+}
+
+}

--- a/projects/ores.trading.core/src/service/equity_digital_option_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_digital_option_instrument_service.cpp
@@ -1,0 +1,47 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/service/equity_digital_option_instrument_service.hpp"
+
+#include <stdexcept>
+#include "ores.service/messaging/handler_helpers.hpp"
+
+using ores::service::messaging::stamp;
+
+namespace ores::trading::service {
+
+using namespace ores::logging;
+
+equity_digital_option_instrument_service::equity_digital_option_instrument_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+void equity_digital_option_instrument_service::save_equity_digital_option_instrument(
+    const domain::equity_digital_option_instrument& v) {
+    if (v.instrument_id.is_nil())
+        throw std::invalid_argument("Equity digital option instrument id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_digital_option_instrument: "
+                               << v.instrument_id;
+    auto t = v;
+    stamp(t, ctx_);
+    repo_.write(ctx_, t);
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_digital_option_instrument: "
+                              << t.instrument_id;
+}
+
+}

--- a/projects/ores.trading.core/src/service/equity_forward_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_forward_instrument_service.cpp
@@ -1,0 +1,47 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/service/equity_forward_instrument_service.hpp"
+
+#include <stdexcept>
+#include "ores.service/messaging/handler_helpers.hpp"
+
+using ores::service::messaging::stamp;
+
+namespace ores::trading::service {
+
+using namespace ores::logging;
+
+equity_forward_instrument_service::equity_forward_instrument_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+void equity_forward_instrument_service::save_equity_forward_instrument(
+    const domain::equity_forward_instrument& v) {
+    if (v.instrument_id.is_nil())
+        throw std::invalid_argument("Equity forward instrument id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_forward_instrument: "
+                               << v.instrument_id;
+    auto t = v;
+    stamp(t, ctx_);
+    repo_.write(ctx_, t);
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_forward_instrument: "
+                              << t.instrument_id;
+}
+
+}

--- a/projects/ores.trading.core/src/service/equity_option_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_option_instrument_service.cpp
@@ -1,0 +1,47 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/service/equity_option_instrument_service.hpp"
+
+#include <stdexcept>
+#include "ores.service/messaging/handler_helpers.hpp"
+
+using ores::service::messaging::stamp;
+
+namespace ores::trading::service {
+
+using namespace ores::logging;
+
+equity_option_instrument_service::equity_option_instrument_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+void equity_option_instrument_service::save_equity_option_instrument(
+    const domain::equity_option_instrument& v) {
+    if (v.instrument_id.is_nil())
+        throw std::invalid_argument("Equity option instrument id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_option_instrument: "
+                               << v.instrument_id;
+    auto t = v;
+    stamp(t, ctx_);
+    repo_.write(ctx_, t);
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_option_instrument: "
+                              << t.instrument_id;
+}
+
+}

--- a/projects/ores.trading.core/src/service/equity_position_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_position_instrument_service.cpp
@@ -1,0 +1,47 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/service/equity_position_instrument_service.hpp"
+
+#include <stdexcept>
+#include "ores.service/messaging/handler_helpers.hpp"
+
+using ores::service::messaging::stamp;
+
+namespace ores::trading::service {
+
+using namespace ores::logging;
+
+equity_position_instrument_service::equity_position_instrument_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+void equity_position_instrument_service::save_equity_position_instrument(
+    const domain::equity_position_instrument& v) {
+    if (v.instrument_id.is_nil())
+        throw std::invalid_argument("Equity position instrument id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_position_instrument: "
+                               << v.instrument_id;
+    auto t = v;
+    stamp(t, ctx_);
+    repo_.write(ctx_, t);
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_position_instrument: "
+                              << t.instrument_id;
+}
+
+}

--- a/projects/ores.trading.core/src/service/equity_swap_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_swap_instrument_service.cpp
@@ -1,0 +1,47 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/service/equity_swap_instrument_service.hpp"
+
+#include <stdexcept>
+#include "ores.service/messaging/handler_helpers.hpp"
+
+using ores::service::messaging::stamp;
+
+namespace ores::trading::service {
+
+using namespace ores::logging;
+
+equity_swap_instrument_service::equity_swap_instrument_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+void equity_swap_instrument_service::save_equity_swap_instrument(
+    const domain::equity_swap_instrument& v) {
+    if (v.instrument_id.is_nil())
+        throw std::invalid_argument("Equity swap instrument id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_swap_instrument: "
+                               << v.instrument_id;
+    auto t = v;
+    stamp(t, ctx_);
+    repo_.write(ctx_, t);
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_swap_instrument: "
+                              << t.instrument_id;
+}
+
+}

--- a/projects/ores.trading.core/src/service/equity_variance_swap_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_variance_swap_instrument_service.cpp
@@ -1,0 +1,47 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/service/equity_variance_swap_instrument_service.hpp"
+
+#include <stdexcept>
+#include "ores.service/messaging/handler_helpers.hpp"
+
+using ores::service::messaging::stamp;
+
+namespace ores::trading::service {
+
+using namespace ores::logging;
+
+equity_variance_swap_instrument_service::equity_variance_swap_instrument_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+void equity_variance_swap_instrument_service::save_equity_variance_swap_instrument(
+    const domain::equity_variance_swap_instrument& v) {
+    if (v.instrument_id.is_nil())
+        throw std::invalid_argument("Equity variance swap instrument id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_variance_swap_instrument: "
+                               << v.instrument_id;
+    auto t = v;
+    stamp(t, ctx_);
+    repo_.write(ctx_, t);
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_variance_swap_instrument: "
+                              << t.instrument_id;
+}
+
+}

--- a/projects/ores.trading.core/tests/repository_equity_accumulator_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_accumulator_instrument_repository_tests.cpp
@@ -1,0 +1,124 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_accumulator_instrument_repository.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/equity_accumulator_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.testing/database_helper.hpp"
+
+namespace {
+
+const std::string_view test_suite("ores.trading.core.repository.equity_accumulator.tests");
+const std::string tags("[repository][equity][equity_accumulator]");
+
+using ores::testing::database_helper;
+using ores::trading::repository::equity_accumulator_instrument_repository;
+using ores::trading::domain::equity_accumulator_instrument;
+using namespace ores::logging;
+
+equity_accumulator_instrument make_instrument(database_helper& h) {
+    equity_accumulator_instrument r;
+    r.instrument_id      = boost::uuids::random_generator()();
+    r.tenant_id          = h.tenant_id();
+    r.trade_type_code    = "EquityAccumulator";
+    r.underlying_name    = "SP5";
+    r.currency           = "USD";
+    r.strike             = 4500.0;
+    r.fixing_amount      = 1000.0;
+    r.start_date         = "2026-01-01";
+    r.expiry_date        = "2026-12-31";
+    r.fixing_frequency   = "Monthly";
+    r.long_short         = "Long";
+    r.target_type        = "";
+    r.payoff_type        = "Accumulator";
+    r.modified_by        = h.db_user();
+    r.performed_by       = "ores";
+    r.change_reason_code = "system.external_data_import";
+    r.change_commentary  = "Imported from ORE XML";
+    return r;
+}
+
+} // namespace
+
+TEST_CASE("equity_accumulator_instrument_write_and_read_latest", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    BOOST_LOG_SEV(lg, debug) << "Writing equity accumulator instrument: " << instr;
+
+    equity_accumulator_instrument_repository repo;
+    CHECK_NOTHROW(repo.write(ctx, instr));
+
+    const auto read = repo.read_latest(ctx, id_str);
+    REQUIRE(read.size() == 1);
+    CHECK(read[0].trade_type_code == "EquityAccumulator");
+    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].currency == "USD");
+    CHECK(read[0].strike == 4500.0);
+    CHECK(read[0].fixing_amount == 1000.0);
+    CHECK(read[0].start_date == "2026-01-01");
+    CHECK(read[0].expiry_date == "2026-12-31");
+    CHECK(read[0].fixing_frequency == "Monthly");
+    CHECK(read[0].long_short == "Long");
+    CHECK(read[0].payoff_type == "Accumulator");
+    BOOST_LOG_SEV(lg, debug) << "Read equity accumulator instrument: " << read[0];
+}
+
+TEST_CASE("equity_accumulator_instrument_read_nonexistent", tags) {
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    equity_accumulator_instrument_repository repo;
+    const std::string nonexistent = "00000000-0000-0000-0000-000000000001";
+    const auto read = repo.read_latest(ctx, nonexistent);
+    CHECK(read.empty());
+}
+
+TEST_CASE("equity_accumulator_instrument_remove", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+
+    equity_accumulator_instrument_repository repo;
+    repo.write(ctx, instr);
+
+    const auto before = repo.read_latest(ctx, id_str);
+    REQUIRE(!before.empty());
+
+    CHECK_NOTHROW(repo.remove(ctx, id_str));
+
+    const auto after = repo.read_latest(ctx, id_str);
+    BOOST_LOG_SEV(lg, debug) << "After remove count: " << after.size();
+    CHECK(after.empty());
+}

--- a/projects/ores.trading.core/tests/repository_equity_accumulator_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_accumulator_instrument_repository_tests.cpp
@@ -36,21 +36,28 @@ using ores::trading::repository::equity_accumulator_instrument_repository;
 using ores::trading::domain::equity_accumulator_instrument;
 using namespace ores::logging;
 
+/*
+ * Test data derived from:
+ *   external/ore/examples/Products/Example_Trades/Exotic_EquityAccumulator_single_name.xml
+ * trade id in XML: EQ_DECUMULATOR
+ * See tests/test_data/equity_accumulator_instrument.json for the full mapping snapshot.
+ */
 equity_accumulator_instrument make_instrument(database_helper& h) {
     equity_accumulator_instrument r;
     r.instrument_id      = boost::uuids::random_generator()();
     r.tenant_id          = h.tenant_id();
     r.trade_type_code    = "EquityAccumulator";
-    r.underlying_name    = "SP5";
-    r.currency           = "USD";
-    r.strike             = 4500.0;
-    r.fixing_amount      = 1000.0;
-    r.start_date         = "2026-01-01";
-    r.expiry_date        = "2026-12-31";
+    r.underlying_name    = ".STOXX50";
+    r.currency           = "EUR";
+    r.strike             = 4000.0;
+    r.fixing_amount      = 30.0;
+    r.start_date         = "2025-02-05";
+    r.expiry_date        = "2026-02-05";
     r.fixing_frequency   = "Monthly";
     r.long_short         = "Long";
+    r.knock_out_level    = 3500.0;
     r.target_type        = "";
-    r.payoff_type        = "Accumulator";
+    r.payoff_type        = "Decumulator";
     r.modified_by        = h.db_user();
     r.performed_by       = "ores";
     r.change_reason_code = "system.external_data_import";
@@ -77,15 +84,16 @@ TEST_CASE("equity_accumulator_instrument_write_and_read_latest", tags) {
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
     CHECK(read[0].trade_type_code == "EquityAccumulator");
-    CHECK(read[0].underlying_name == "SP5");
-    CHECK(read[0].currency == "USD");
-    CHECK(read[0].strike == 4500.0);
-    CHECK(read[0].fixing_amount == 1000.0);
-    CHECK(read[0].start_date == "2026-01-01");
-    CHECK(read[0].expiry_date == "2026-12-31");
+    CHECK(read[0].underlying_name == ".STOXX50");
+    CHECK(read[0].currency == "EUR");
+    CHECK(read[0].strike == 4000.0);
+    CHECK(read[0].fixing_amount == 30.0);
+    CHECK(read[0].start_date == "2025-02-05");
+    CHECK(read[0].expiry_date == "2026-02-05");
     CHECK(read[0].fixing_frequency == "Monthly");
     CHECK(read[0].long_short == "Long");
-    CHECK(read[0].payoff_type == "Accumulator");
+    CHECK(read[0].knock_out_level == 3500.0);
+    CHECK(read[0].payoff_type == "Decumulator");
     BOOST_LOG_SEV(lg, debug) << "Read equity accumulator instrument: " << read[0];
 }
 

--- a/projects/ores.trading.core/tests/repository_equity_asian_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_asian_option_instrument_repository_tests.cpp
@@ -36,22 +36,28 @@ using ores::trading::repository::equity_asian_option_instrument_repository;
 using ores::trading::domain::equity_asian_option_instrument;
 using namespace ores::logging;
 
+/*
+ * Test data derived from:
+ *   external/ore/examples/Products/Example_Trades/Equity_Asian_Option.xml
+ * trade id in XML: EQAsianOption
+ * See tests/test_data/equity_asian_option_instrument.json for the full mapping snapshot.
+ */
 equity_asian_option_instrument make_instrument(database_helper& h) {
     equity_asian_option_instrument r;
     r.instrument_id         = boost::uuids::random_generator()();
     r.tenant_id             = h.tenant_id();
     r.trade_type_code       = "EquityAsianOption";
-    r.underlying_name       = "SP5";
+    r.underlying_name       = "RIC:.SPX";
     r.currency              = "USD";
-    r.notional              = 100000.0;
+    r.notional              = 1.0;
     r.option_type           = "Call";
-    r.strike                = 4500.0;
-    r.expiry_date           = "2026-12-19";
+    r.strike                = 3100.0;
+    r.expiry_date           = "2026-01-28";
     r.exercise_type         = "European";
     r.long_short            = "Long";
     r.average_type          = "Arithmetic";
-    r.averaging_start_date  = "2026-06-01";
-    r.averaging_end_date    = "2026-12-01";
+    r.averaging_start_date  = "2025-07-12";
+    r.averaging_end_date    = "2026-01-19";
     r.modified_by           = h.db_user();
     r.performed_by          = "ores";
     r.change_reason_code    = "system.external_data_import";
@@ -78,17 +84,17 @@ TEST_CASE("equity_asian_option_instrument_write_and_read_latest", tags) {
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
     CHECK(read[0].trade_type_code == "EquityAsianOption");
-    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].underlying_name == "RIC:.SPX");
     CHECK(read[0].currency == "USD");
-    CHECK(read[0].notional == 100000.0);
+    CHECK(read[0].notional == 1.0);
     CHECK(read[0].option_type == "Call");
-    CHECK(read[0].strike == 4500.0);
-    CHECK(read[0].expiry_date == "2026-12-19");
+    CHECK(read[0].strike == 3100.0);
+    CHECK(read[0].expiry_date == "2026-01-28");
     CHECK(read[0].exercise_type == "European");
     CHECK(read[0].long_short == "Long");
     CHECK(read[0].average_type == "Arithmetic");
-    CHECK(read[0].averaging_start_date == "2026-06-01");
-    CHECK(read[0].averaging_end_date == "2026-12-01");
+    CHECK(read[0].averaging_start_date == "2025-07-12");
+    CHECK(read[0].averaging_end_date == "2026-01-19");
     BOOST_LOG_SEV(lg, debug) << "Read equity asian option instrument: " << read[0];
 }
 

--- a/projects/ores.trading.core/tests/repository_equity_asian_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_asian_option_instrument_repository_tests.cpp
@@ -1,0 +1,127 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_asian_option_instrument_repository.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/equity_asian_option_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.testing/database_helper.hpp"
+
+namespace {
+
+const std::string_view test_suite("ores.trading.core.repository.equity_asian_option.tests");
+const std::string tags("[repository][equity][equity_asian_option]");
+
+using ores::testing::database_helper;
+using ores::trading::repository::equity_asian_option_instrument_repository;
+using ores::trading::domain::equity_asian_option_instrument;
+using namespace ores::logging;
+
+equity_asian_option_instrument make_instrument(database_helper& h) {
+    equity_asian_option_instrument r;
+    r.instrument_id         = boost::uuids::random_generator()();
+    r.tenant_id             = h.tenant_id();
+    r.trade_type_code       = "EquityAsianOption";
+    r.underlying_name       = "SP5";
+    r.currency              = "USD";
+    r.notional              = 100000.0;
+    r.option_type           = "Call";
+    r.strike                = 4500.0;
+    r.expiry_date           = "2026-12-19";
+    r.exercise_type         = "European";
+    r.long_short            = "Long";
+    r.average_type          = "Arithmetic";
+    r.averaging_start_date  = "2026-06-01";
+    r.averaging_end_date    = "2026-12-01";
+    r.modified_by           = h.db_user();
+    r.performed_by          = "ores";
+    r.change_reason_code    = "system.external_data_import";
+    r.change_commentary     = "Imported from ORE XML";
+    return r;
+}
+
+} // namespace
+
+TEST_CASE("equity_asian_option_instrument_write_and_read_latest", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    BOOST_LOG_SEV(lg, debug) << "Writing equity asian option instrument: " << instr;
+
+    equity_asian_option_instrument_repository repo;
+    CHECK_NOTHROW(repo.write(ctx, instr));
+
+    const auto read = repo.read_latest(ctx, id_str);
+    REQUIRE(read.size() == 1);
+    CHECK(read[0].trade_type_code == "EquityAsianOption");
+    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].currency == "USD");
+    CHECK(read[0].notional == 100000.0);
+    CHECK(read[0].option_type == "Call");
+    CHECK(read[0].strike == 4500.0);
+    CHECK(read[0].expiry_date == "2026-12-19");
+    CHECK(read[0].exercise_type == "European");
+    CHECK(read[0].long_short == "Long");
+    CHECK(read[0].average_type == "Arithmetic");
+    CHECK(read[0].averaging_start_date == "2026-06-01");
+    CHECK(read[0].averaging_end_date == "2026-12-01");
+    BOOST_LOG_SEV(lg, debug) << "Read equity asian option instrument: " << read[0];
+}
+
+TEST_CASE("equity_asian_option_instrument_read_nonexistent", tags) {
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    equity_asian_option_instrument_repository repo;
+    const std::string nonexistent = "00000000-0000-0000-0000-000000000001";
+    const auto read = repo.read_latest(ctx, nonexistent);
+    CHECK(read.empty());
+}
+
+TEST_CASE("equity_asian_option_instrument_remove", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+
+    equity_asian_option_instrument_repository repo;
+    repo.write(ctx, instr);
+
+    const auto before = repo.read_latest(ctx, id_str);
+    REQUIRE(!before.empty());
+
+    CHECK_NOTHROW(repo.remove(ctx, id_str));
+
+    const auto after = repo.read_latest(ctx, id_str);
+    BOOST_LOG_SEV(lg, debug) << "After remove count: " << after.size();
+    CHECK(after.empty());
+}

--- a/projects/ores.trading.core/tests/repository_equity_barrier_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_barrier_option_instrument_repository_tests.cpp
@@ -36,21 +36,27 @@ using ores::trading::repository::equity_barrier_option_instrument_repository;
 using ores::trading::domain::equity_barrier_option_instrument;
 using namespace ores::logging;
 
+/*
+ * Test data derived from:
+ *   external/ore/examples/Products/Example_Trades/Equity_Barrier_Option.xml
+ * trade id in XML: EQBarrierOption
+ * See tests/test_data/equity_barrier_option_instrument.json for the full mapping snapshot.
+ */
 equity_barrier_option_instrument make_instrument(database_helper& h) {
     equity_barrier_option_instrument r;
     r.instrument_id      = boost::uuids::random_generator()();
     r.tenant_id          = h.tenant_id();
     r.trade_type_code    = "EquityBarrierOption";
-    r.underlying_name    = "SP5";
+    r.underlying_name    = "RIC:.SPX";
     r.currency           = "USD";
-    r.notional           = 100000.0;
+    r.notional           = 1000.0;
     r.option_type        = "Call";
-    r.strike             = 4500.0;
-    r.expiry_date        = "2026-12-19";
+    r.strike             = 3200.0;
+    r.expiry_date        = "2026-08-15";
     r.exercise_type      = "European";
     r.long_short         = "Long";
-    r.lower_barrier      = 4000.0;
-    r.lower_barrier_type = "DownIn";
+    r.lower_barrier      = 3500.0;
+    r.lower_barrier_type = "UpAndOut";
     r.upper_barrier_type = "";
     r.modified_by        = h.db_user();
     r.performed_by       = "ores";
@@ -78,16 +84,16 @@ TEST_CASE("equity_barrier_option_instrument_write_and_read_latest", tags) {
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
     CHECK(read[0].trade_type_code == "EquityBarrierOption");
-    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].underlying_name == "RIC:.SPX");
     CHECK(read[0].currency == "USD");
-    CHECK(read[0].notional == 100000.0);
+    CHECK(read[0].notional == 1000.0);
     CHECK(read[0].option_type == "Call");
-    CHECK(read[0].strike == 4500.0);
-    CHECK(read[0].expiry_date == "2026-12-19");
+    CHECK(read[0].strike == 3200.0);
+    CHECK(read[0].expiry_date == "2026-08-15");
     CHECK(read[0].exercise_type == "European");
     CHECK(read[0].long_short == "Long");
-    CHECK(read[0].lower_barrier == 4000.0);
-    CHECK(read[0].lower_barrier_type == "DownIn");
+    CHECK(read[0].lower_barrier == 3500.0);
+    CHECK(read[0].lower_barrier_type == "UpAndOut");
     BOOST_LOG_SEV(lg, debug) << "Read equity barrier option instrument: " << read[0];
 }
 

--- a/projects/ores.trading.core/tests/repository_equity_barrier_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_barrier_option_instrument_repository_tests.cpp
@@ -1,0 +1,126 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_barrier_option_instrument_repository.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/equity_barrier_option_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.testing/database_helper.hpp"
+
+namespace {
+
+const std::string_view test_suite("ores.trading.core.repository.equity_barrier_option.tests");
+const std::string tags("[repository][equity][equity_barrier_option]");
+
+using ores::testing::database_helper;
+using ores::trading::repository::equity_barrier_option_instrument_repository;
+using ores::trading::domain::equity_barrier_option_instrument;
+using namespace ores::logging;
+
+equity_barrier_option_instrument make_instrument(database_helper& h) {
+    equity_barrier_option_instrument r;
+    r.instrument_id      = boost::uuids::random_generator()();
+    r.tenant_id          = h.tenant_id();
+    r.trade_type_code    = "EquityBarrierOption";
+    r.underlying_name    = "SP5";
+    r.currency           = "USD";
+    r.notional           = 100000.0;
+    r.option_type        = "Call";
+    r.strike             = 4500.0;
+    r.expiry_date        = "2026-12-19";
+    r.exercise_type      = "European";
+    r.long_short         = "Long";
+    r.lower_barrier      = 4000.0;
+    r.lower_barrier_type = "DownIn";
+    r.upper_barrier_type = "";
+    r.modified_by        = h.db_user();
+    r.performed_by       = "ores";
+    r.change_reason_code = "system.external_data_import";
+    r.change_commentary  = "Imported from ORE XML";
+    return r;
+}
+
+} // namespace
+
+TEST_CASE("equity_barrier_option_instrument_write_and_read_latest", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    BOOST_LOG_SEV(lg, debug) << "Writing equity barrier option instrument: " << instr;
+
+    equity_barrier_option_instrument_repository repo;
+    CHECK_NOTHROW(repo.write(ctx, instr));
+
+    const auto read = repo.read_latest(ctx, id_str);
+    REQUIRE(read.size() == 1);
+    CHECK(read[0].trade_type_code == "EquityBarrierOption");
+    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].currency == "USD");
+    CHECK(read[0].notional == 100000.0);
+    CHECK(read[0].option_type == "Call");
+    CHECK(read[0].strike == 4500.0);
+    CHECK(read[0].expiry_date == "2026-12-19");
+    CHECK(read[0].exercise_type == "European");
+    CHECK(read[0].long_short == "Long");
+    CHECK(read[0].lower_barrier == 4000.0);
+    CHECK(read[0].lower_barrier_type == "DownIn");
+    BOOST_LOG_SEV(lg, debug) << "Read equity barrier option instrument: " << read[0];
+}
+
+TEST_CASE("equity_barrier_option_instrument_read_nonexistent", tags) {
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    equity_barrier_option_instrument_repository repo;
+    const std::string nonexistent = "00000000-0000-0000-0000-000000000001";
+    const auto read = repo.read_latest(ctx, nonexistent);
+    CHECK(read.empty());
+}
+
+TEST_CASE("equity_barrier_option_instrument_remove", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+
+    equity_barrier_option_instrument_repository repo;
+    repo.write(ctx, instr);
+
+    const auto before = repo.read_latest(ctx, id_str);
+    REQUIRE(!before.empty());
+
+    CHECK_NOTHROW(repo.remove(ctx, id_str));
+
+    const auto after = repo.read_latest(ctx, id_str);
+    BOOST_LOG_SEV(lg, debug) << "After remove count: " << after.size();
+    CHECK(after.empty());
+}

--- a/projects/ores.trading.core/tests/repository_equity_digital_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_digital_option_instrument_repository_tests.cpp
@@ -1,0 +1,122 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_digital_option_instrument_repository.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/equity_digital_option_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.testing/database_helper.hpp"
+
+namespace {
+
+const std::string_view test_suite("ores.trading.core.repository.equity_digital_option.tests");
+const std::string tags("[repository][equity][equity_digital_option]");
+
+using ores::testing::database_helper;
+using ores::trading::repository::equity_digital_option_instrument_repository;
+using ores::trading::domain::equity_digital_option_instrument;
+using namespace ores::logging;
+
+equity_digital_option_instrument make_instrument(database_helper& h) {
+    equity_digital_option_instrument r;
+    r.instrument_id      = boost::uuids::random_generator()();
+    r.tenant_id          = h.tenant_id();
+    r.trade_type_code    = "EquityDigitalOption";
+    r.underlying_name    = "SP5";
+    r.currency           = "USD";
+    r.notional           = 50000.0;
+    r.option_type        = "Call";
+    r.strike             = 4500.0;
+    r.barrier_type       = "";
+    r.expiry_date        = "2026-12-19";
+    r.long_short         = "Long";
+    r.payout_amount      = 10000.0;
+    r.modified_by        = h.db_user();
+    r.performed_by       = "ores";
+    r.change_reason_code = "system.external_data_import";
+    r.change_commentary  = "Imported from ORE XML";
+    return r;
+}
+
+} // namespace
+
+TEST_CASE("equity_digital_option_instrument_write_and_read_latest", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    BOOST_LOG_SEV(lg, debug) << "Writing equity digital option instrument: " << instr;
+
+    equity_digital_option_instrument_repository repo;
+    CHECK_NOTHROW(repo.write(ctx, instr));
+
+    const auto read = repo.read_latest(ctx, id_str);
+    REQUIRE(read.size() == 1);
+    CHECK(read[0].trade_type_code == "EquityDigitalOption");
+    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].currency == "USD");
+    CHECK(read[0].notional == 50000.0);
+    CHECK(read[0].option_type == "Call");
+    CHECK(read[0].strike == 4500.0);
+    CHECK(read[0].expiry_date == "2026-12-19");
+    CHECK(read[0].long_short == "Long");
+    CHECK(read[0].payout_amount == 10000.0);
+    BOOST_LOG_SEV(lg, debug) << "Read equity digital option instrument: " << read[0];
+}
+
+TEST_CASE("equity_digital_option_instrument_read_nonexistent", tags) {
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    equity_digital_option_instrument_repository repo;
+    const std::string nonexistent = "00000000-0000-0000-0000-000000000001";
+    const auto read = repo.read_latest(ctx, nonexistent);
+    CHECK(read.empty());
+}
+
+TEST_CASE("equity_digital_option_instrument_remove", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+
+    equity_digital_option_instrument_repository repo;
+    repo.write(ctx, instr);
+
+    const auto before = repo.read_latest(ctx, id_str);
+    REQUIRE(!before.empty());
+
+    CHECK_NOTHROW(repo.remove(ctx, id_str));
+
+    const auto after = repo.read_latest(ctx, id_str);
+    BOOST_LOG_SEV(lg, debug) << "After remove count: " << after.size();
+    CHECK(after.empty());
+}

--- a/projects/ores.trading.core/tests/repository_equity_digital_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_digital_option_instrument_repository_tests.cpp
@@ -36,20 +36,26 @@ using ores::trading::repository::equity_digital_option_instrument_repository;
 using ores::trading::domain::equity_digital_option_instrument;
 using namespace ores::logging;
 
+/*
+ * Test data derived from:
+ *   external/ore/examples/Products/Example_Trades/Equity_Digital_Option.xml
+ * trade id in XML: EQDigitalOption
+ * See tests/test_data/equity_digital_option_instrument.json for the full mapping snapshot.
+ */
 equity_digital_option_instrument make_instrument(database_helper& h) {
     equity_digital_option_instrument r;
     r.instrument_id      = boost::uuids::random_generator()();
     r.tenant_id          = h.tenant_id();
     r.trade_type_code    = "EquityDigitalOption";
-    r.underlying_name    = "SP5";
+    r.underlying_name    = "RIC:.SPX";
     r.currency           = "USD";
-    r.notional           = 50000.0;
+    r.notional           = 1000.0;
     r.option_type        = "Call";
-    r.strike             = 4500.0;
+    r.strike             = 3300.0;
     r.barrier_type       = "";
-    r.expiry_date        = "2026-12-19";
+    r.expiry_date        = "2026-07-17";
     r.long_short         = "Long";
-    r.payout_amount      = 10000.0;
+    r.payout_amount      = 1000.0;
     r.modified_by        = h.db_user();
     r.performed_by       = "ores";
     r.change_reason_code = "system.external_data_import";
@@ -76,14 +82,14 @@ TEST_CASE("equity_digital_option_instrument_write_and_read_latest", tags) {
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
     CHECK(read[0].trade_type_code == "EquityDigitalOption");
-    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].underlying_name == "RIC:.SPX");
     CHECK(read[0].currency == "USD");
-    CHECK(read[0].notional == 50000.0);
+    CHECK(read[0].notional == 1000.0);
     CHECK(read[0].option_type == "Call");
-    CHECK(read[0].strike == 4500.0);
-    CHECK(read[0].expiry_date == "2026-12-19");
+    CHECK(read[0].strike == 3300.0);
+    CHECK(read[0].expiry_date == "2026-07-17");
     CHECK(read[0].long_short == "Long");
-    CHECK(read[0].payout_amount == 10000.0);
+    CHECK(read[0].payout_amount == 1000.0);
     BOOST_LOG_SEV(lg, debug) << "Read equity digital option instrument: " << read[0];
 }
 

--- a/projects/ores.trading.core/tests/repository_equity_forward_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_forward_instrument_repository_tests.cpp
@@ -36,18 +36,24 @@ using ores::trading::repository::equity_forward_instrument_repository;
 using ores::trading::domain::equity_forward_instrument;
 using namespace ores::logging;
 
+/*
+ * Test data derived from:
+ *   external/ore/examples/Products/Example_Trades/Equity_Forward.xml
+ * trade id in XML: EqForward
+ * See tests/test_data/equity_forward_instrument.json for the full mapping snapshot.
+ */
 equity_forward_instrument make_instrument(database_helper& h) {
     equity_forward_instrument r;
     r.instrument_id      = boost::uuids::random_generator()();
     r.tenant_id          = h.tenant_id();
     r.trade_type_code    = "EquityForward";
-    r.underlying_name    = "SP5";
+    r.underlying_name    = "RIC:.SPX";
     r.currency           = "USD";
-    r.quantity           = 1000.0;
-    r.forward_price      = 4600.0;
-    r.expiry_date        = "2026-12-19";
+    r.quantity           = 775.0;
+    r.forward_price      = 2800.0;
+    r.expiry_date        = "2025-02-20";
     r.long_short         = "Long";
-    r.settlement_type    = "Cash";
+    r.settlement_type    = "";
     r.modified_by        = h.db_user();
     r.performed_by       = "ores";
     r.change_reason_code = "system.external_data_import";
@@ -74,13 +80,12 @@ TEST_CASE("equity_forward_instrument_write_and_read_latest", tags) {
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
     CHECK(read[0].trade_type_code == "EquityForward");
-    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].underlying_name == "RIC:.SPX");
     CHECK(read[0].currency == "USD");
-    CHECK(read[0].quantity == 1000.0);
-    CHECK(read[0].forward_price == 4600.0);
-    CHECK(read[0].expiry_date == "2026-12-19");
+    CHECK(read[0].quantity == 775.0);
+    CHECK(read[0].forward_price == 2800.0);
+    CHECK(read[0].expiry_date == "2025-02-20");
     CHECK(read[0].long_short == "Long");
-    CHECK(read[0].settlement_type == "Cash");
     BOOST_LOG_SEV(lg, debug) << "Read equity forward instrument: " << read[0];
 }
 

--- a/projects/ores.trading.core/tests/repository_equity_forward_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_forward_instrument_repository_tests.cpp
@@ -1,0 +1,119 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_forward_instrument_repository.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/equity_forward_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.testing/database_helper.hpp"
+
+namespace {
+
+const std::string_view test_suite("ores.trading.core.repository.equity_forward.tests");
+const std::string tags("[repository][equity][equity_forward]");
+
+using ores::testing::database_helper;
+using ores::trading::repository::equity_forward_instrument_repository;
+using ores::trading::domain::equity_forward_instrument;
+using namespace ores::logging;
+
+equity_forward_instrument make_instrument(database_helper& h) {
+    equity_forward_instrument r;
+    r.instrument_id      = boost::uuids::random_generator()();
+    r.tenant_id          = h.tenant_id();
+    r.trade_type_code    = "EquityForward";
+    r.underlying_name    = "SP5";
+    r.currency           = "USD";
+    r.quantity           = 1000.0;
+    r.forward_price      = 4600.0;
+    r.expiry_date        = "2026-12-19";
+    r.long_short         = "Long";
+    r.settlement_type    = "Cash";
+    r.modified_by        = h.db_user();
+    r.performed_by       = "ores";
+    r.change_reason_code = "system.external_data_import";
+    r.change_commentary  = "Imported from ORE XML";
+    return r;
+}
+
+} // namespace
+
+TEST_CASE("equity_forward_instrument_write_and_read_latest", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    BOOST_LOG_SEV(lg, debug) << "Writing equity forward instrument: " << instr;
+
+    equity_forward_instrument_repository repo;
+    CHECK_NOTHROW(repo.write(ctx, instr));
+
+    const auto read = repo.read_latest(ctx, id_str);
+    REQUIRE(read.size() == 1);
+    CHECK(read[0].trade_type_code == "EquityForward");
+    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].currency == "USD");
+    CHECK(read[0].quantity == 1000.0);
+    CHECK(read[0].forward_price == 4600.0);
+    CHECK(read[0].expiry_date == "2026-12-19");
+    CHECK(read[0].long_short == "Long");
+    CHECK(read[0].settlement_type == "Cash");
+    BOOST_LOG_SEV(lg, debug) << "Read equity forward instrument: " << read[0];
+}
+
+TEST_CASE("equity_forward_instrument_read_nonexistent", tags) {
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    equity_forward_instrument_repository repo;
+    const std::string nonexistent = "00000000-0000-0000-0000-000000000001";
+    const auto read = repo.read_latest(ctx, nonexistent);
+    CHECK(read.empty());
+}
+
+TEST_CASE("equity_forward_instrument_remove", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+
+    equity_forward_instrument_repository repo;
+    repo.write(ctx, instr);
+
+    const auto before = repo.read_latest(ctx, id_str);
+    REQUIRE(!before.empty());
+
+    CHECK_NOTHROW(repo.remove(ctx, id_str));
+
+    const auto after = repo.read_latest(ctx, id_str);
+    BOOST_LOG_SEV(lg, debug) << "After remove count: " << after.size();
+    CHECK(after.empty());
+}

--- a/projects/ores.trading.core/tests/repository_equity_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_option_instrument_repository_tests.cpp
@@ -1,0 +1,124 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_option_instrument_repository.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/equity_option_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.testing/database_helper.hpp"
+
+namespace {
+
+const std::string_view test_suite("ores.trading.core.repository.equity_option.tests");
+const std::string tags("[repository][equity][equity_option]");
+
+using ores::testing::database_helper;
+using ores::trading::repository::equity_option_instrument_repository;
+using ores::trading::domain::equity_option_instrument;
+using namespace ores::logging;
+
+equity_option_instrument make_instrument(database_helper& h) {
+    equity_option_instrument r;
+    r.instrument_id      = boost::uuids::random_generator()();
+    r.tenant_id          = h.tenant_id();
+    r.trade_type_code    = "EquityOption";
+    r.underlying_name    = "SP5";
+    r.currency           = "USD";
+    r.notional           = 100000.0;
+    r.option_type        = "Call";
+    r.strike             = 4500.0;
+    r.expiry_date        = "2026-12-19";
+    r.exercise_type      = "European";
+    r.long_short         = "Long";
+    r.settlement_type    = "Cash";
+    r.cliquet_frequency  = "";
+    r.modified_by        = h.db_user();
+    r.performed_by       = "ores";
+    r.change_reason_code = "system.external_data_import";
+    r.change_commentary  = "Imported from ORE XML";
+    return r;
+}
+
+} // namespace
+
+TEST_CASE("equity_option_instrument_write_and_read_latest", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    BOOST_LOG_SEV(lg, debug) << "Writing equity option instrument: " << instr;
+
+    equity_option_instrument_repository repo;
+    CHECK_NOTHROW(repo.write(ctx, instr));
+
+    const auto read = repo.read_latest(ctx, id_str);
+    REQUIRE(read.size() == 1);
+    CHECK(read[0].trade_type_code == "EquityOption");
+    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].currency == "USD");
+    CHECK(read[0].notional == 100000.0);
+    CHECK(read[0].option_type == "Call");
+    CHECK(read[0].strike == 4500.0);
+    CHECK(read[0].expiry_date == "2026-12-19");
+    CHECK(read[0].exercise_type == "European");
+    CHECK(read[0].long_short == "Long");
+    CHECK(read[0].settlement_type == "Cash");
+    BOOST_LOG_SEV(lg, debug) << "Read equity option instrument: " << read[0];
+}
+
+TEST_CASE("equity_option_instrument_read_nonexistent", tags) {
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    equity_option_instrument_repository repo;
+    const std::string nonexistent = "00000000-0000-0000-0000-000000000001";
+    const auto read = repo.read_latest(ctx, nonexistent);
+    CHECK(read.empty());
+}
+
+TEST_CASE("equity_option_instrument_remove", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+
+    equity_option_instrument_repository repo;
+    repo.write(ctx, instr);
+
+    const auto before = repo.read_latest(ctx, id_str);
+    REQUIRE(!before.empty());
+
+    CHECK_NOTHROW(repo.remove(ctx, id_str));
+
+    const auto after = repo.read_latest(ctx, id_str);
+    BOOST_LOG_SEV(lg, debug) << "After remove count: " << after.size();
+    CHECK(after.empty());
+}

--- a/projects/ores.trading.core/tests/repository_equity_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_option_instrument_repository_tests.cpp
@@ -36,17 +36,23 @@ using ores::trading::repository::equity_option_instrument_repository;
 using ores::trading::domain::equity_option_instrument;
 using namespace ores::logging;
 
+/*
+ * Test data derived from:
+ *   external/ore/examples/Products/Example_Trades/Equity_Option_European.xml
+ * trade id in XML: EquityOption
+ * See tests/test_data/equity_option_instrument.json for the full mapping snapshot.
+ */
 equity_option_instrument make_instrument(database_helper& h) {
     equity_option_instrument r;
     r.instrument_id      = boost::uuids::random_generator()();
     r.tenant_id          = h.tenant_id();
     r.trade_type_code    = "EquityOption";
-    r.underlying_name    = "SP5";
+    r.underlying_name    = "RIC:.SPX";
     r.currency           = "USD";
-    r.notional           = 100000.0;
+    r.notional           = 775.0;
     r.option_type        = "Call";
-    r.strike             = 4500.0;
-    r.expiry_date        = "2026-12-19";
+    r.strike             = 2800.0;
+    r.expiry_date        = "2025-02-20";
     r.exercise_type      = "European";
     r.long_short         = "Long";
     r.settlement_type    = "Cash";
@@ -77,12 +83,12 @@ TEST_CASE("equity_option_instrument_write_and_read_latest", tags) {
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
     CHECK(read[0].trade_type_code == "EquityOption");
-    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].underlying_name == "RIC:.SPX");
     CHECK(read[0].currency == "USD");
-    CHECK(read[0].notional == 100000.0);
+    CHECK(read[0].notional == 775.0);
     CHECK(read[0].option_type == "Call");
-    CHECK(read[0].strike == 4500.0);
-    CHECK(read[0].expiry_date == "2026-12-19");
+    CHECK(read[0].strike == 2800.0);
+    CHECK(read[0].expiry_date == "2025-02-20");
     CHECK(read[0].exercise_type == "European");
     CHECK(read[0].long_short == "Long");
     CHECK(read[0].settlement_type == "Cash");

--- a/projects/ores.trading.core/tests/repository_equity_position_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_position_instrument_repository_tests.cpp
@@ -1,0 +1,114 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_position_instrument_repository.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/equity_position_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.testing/database_helper.hpp"
+
+namespace {
+
+const std::string_view test_suite("ores.trading.core.repository.equity_position.tests");
+const std::string tags("[repository][equity][equity_position]");
+
+using ores::testing::database_helper;
+using ores::trading::repository::equity_position_instrument_repository;
+using ores::trading::domain::equity_position_instrument;
+using namespace ores::logging;
+
+equity_position_instrument make_instrument(database_helper& h) {
+    equity_position_instrument r;
+    r.instrument_id      = boost::uuids::random_generator()();
+    r.tenant_id          = h.tenant_id();
+    r.trade_type_code    = "EquityPosition";
+    r.underlying_name    = "SP5";
+    r.currency           = "USD";
+    r.quantity           = 500.0;
+    r.price              = 4500.0;
+    r.option_data_json   = "";
+    r.modified_by        = h.db_user();
+    r.performed_by       = "ores";
+    r.change_reason_code = "system.external_data_import";
+    r.change_commentary  = "Imported from ORE XML";
+    return r;
+}
+
+} // namespace
+
+TEST_CASE("equity_position_instrument_write_and_read_latest", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    BOOST_LOG_SEV(lg, debug) << "Writing equity position instrument: " << instr;
+
+    equity_position_instrument_repository repo;
+    CHECK_NOTHROW(repo.write(ctx, instr));
+
+    const auto read = repo.read_latest(ctx, id_str);
+    REQUIRE(read.size() == 1);
+    CHECK(read[0].trade_type_code == "EquityPosition");
+    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].currency == "USD");
+    CHECK(read[0].quantity == 500.0);
+    CHECK(read[0].price == 4500.0);
+    BOOST_LOG_SEV(lg, debug) << "Read equity position instrument: " << read[0];
+}
+
+TEST_CASE("equity_position_instrument_read_nonexistent", tags) {
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    equity_position_instrument_repository repo;
+    const std::string nonexistent = "00000000-0000-0000-0000-000000000001";
+    const auto read = repo.read_latest(ctx, nonexistent);
+    CHECK(read.empty());
+}
+
+TEST_CASE("equity_position_instrument_remove", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+
+    equity_position_instrument_repository repo;
+    repo.write(ctx, instr);
+
+    const auto before = repo.read_latest(ctx, id_str);
+    REQUIRE(!before.empty());
+
+    CHECK_NOTHROW(repo.remove(ctx, id_str));
+
+    const auto after = repo.read_latest(ctx, id_str);
+    BOOST_LOG_SEV(lg, debug) << "After remove count: " << after.size();
+    CHECK(after.empty());
+}

--- a/projects/ores.trading.core/tests/repository_equity_position_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_position_instrument_repository_tests.cpp
@@ -36,15 +36,21 @@ using ores::trading::repository::equity_position_instrument_repository;
 using ores::trading::domain::equity_position_instrument;
 using namespace ores::logging;
 
+/*
+ * Test data derived from:
+ *   external/ore/examples/Products/Example_Trades/Hybrid_GenericTRS_with_EquityPosition.xml
+ * trade id in XML: TRS1000240_asTRSonEquityPosition1DEC (embedded EquityPosition)
+ * See tests/test_data/equity_position_instrument.json for the full mapping snapshot.
+ */
 equity_position_instrument make_instrument(database_helper& h) {
     equity_position_instrument r;
     r.instrument_id      = boost::uuids::random_generator()();
     r.tenant_id          = h.tenant_id();
     r.trade_type_code    = "EquityPosition";
-    r.underlying_name    = "SP5";
+    r.underlying_name    = "BBG00R251JN8";
     r.currency           = "USD";
-    r.quantity           = 500.0;
-    r.price              = 4500.0;
+    r.quantity           = 18101.486;
+    r.price              = 6927.586;
     r.option_data_json   = "";
     r.modified_by        = h.db_user();
     r.performed_by       = "ores";
@@ -72,10 +78,10 @@ TEST_CASE("equity_position_instrument_write_and_read_latest", tags) {
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
     CHECK(read[0].trade_type_code == "EquityPosition");
-    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].underlying_name == "BBG00R251JN8");
     CHECK(read[0].currency == "USD");
-    CHECK(read[0].quantity == 500.0);
-    CHECK(read[0].price == 4500.0);
+    CHECK(read[0].quantity == 18101.486);
+    CHECK(read[0].price == 6927.586);
     BOOST_LOG_SEV(lg, debug) << "Read equity position instrument: " << read[0];
 }
 

--- a/projects/ores.trading.core/tests/repository_equity_swap_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_swap_instrument_repository_tests.cpp
@@ -1,0 +1,122 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_swap_instrument_repository.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/equity_swap_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.testing/database_helper.hpp"
+
+namespace {
+
+const std::string_view test_suite("ores.trading.core.repository.equity_swap.tests");
+const std::string tags("[repository][equity][equity_swap]");
+
+using ores::testing::database_helper;
+using ores::trading::repository::equity_swap_instrument_repository;
+using ores::trading::domain::equity_swap_instrument;
+using namespace ores::logging;
+
+equity_swap_instrument make_instrument(database_helper& h) {
+    equity_swap_instrument r;
+    r.instrument_id      = boost::uuids::random_generator()();
+    r.tenant_id          = h.tenant_id();
+    r.trade_type_code    = "EquitySwap";
+    r.underlying_name    = "SP5";
+    r.basket_json        = "";
+    r.currency           = "USD";
+    r.notional           = 1000000.0;
+    r.return_type        = "TotalReturn";
+    r.start_date         = "2026-01-01";
+    r.maturity_date      = "2027-01-01";
+    r.long_short         = "Long";
+    r.payment_frequency  = "3M";
+    r.modified_by        = h.db_user();
+    r.performed_by       = "ores";
+    r.change_reason_code = "system.external_data_import";
+    r.change_commentary  = "Imported from ORE XML";
+    return r;
+}
+
+} // namespace
+
+TEST_CASE("equity_swap_instrument_write_and_read_latest", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    BOOST_LOG_SEV(lg, debug) << "Writing equity swap instrument: " << instr;
+
+    equity_swap_instrument_repository repo;
+    CHECK_NOTHROW(repo.write(ctx, instr));
+
+    const auto read = repo.read_latest(ctx, id_str);
+    REQUIRE(read.size() == 1);
+    CHECK(read[0].trade_type_code == "EquitySwap");
+    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].currency == "USD");
+    CHECK(read[0].notional == 1000000.0);
+    CHECK(read[0].return_type == "TotalReturn");
+    CHECK(read[0].start_date == "2026-01-01");
+    CHECK(read[0].maturity_date == "2027-01-01");
+    CHECK(read[0].long_short == "Long");
+    CHECK(read[0].payment_frequency == "3M");
+    BOOST_LOG_SEV(lg, debug) << "Read equity swap instrument: " << read[0];
+}
+
+TEST_CASE("equity_swap_instrument_read_nonexistent", tags) {
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    equity_swap_instrument_repository repo;
+    const std::string nonexistent = "00000000-0000-0000-0000-000000000001";
+    const auto read = repo.read_latest(ctx, nonexistent);
+    CHECK(read.empty());
+}
+
+TEST_CASE("equity_swap_instrument_remove", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+
+    equity_swap_instrument_repository repo;
+    repo.write(ctx, instr);
+
+    const auto before = repo.read_latest(ctx, id_str);
+    REQUIRE(!before.empty());
+
+    CHECK_NOTHROW(repo.remove(ctx, id_str));
+
+    const auto after = repo.read_latest(ctx, id_str);
+    BOOST_LOG_SEV(lg, debug) << "After remove count: " << after.size();
+    CHECK(after.empty());
+}

--- a/projects/ores.trading.core/tests/repository_equity_swap_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_swap_instrument_repository_tests.cpp
@@ -36,20 +36,26 @@ using ores::trading::repository::equity_swap_instrument_repository;
 using ores::trading::domain::equity_swap_instrument;
 using namespace ores::logging;
 
+/*
+ * Test data derived from:
+ *   external/ore/examples/Products/Example_Trades/Equity_Swap.xml
+ * trade id in XML: EqSwap
+ * See tests/test_data/equity_swap_instrument.json for the full mapping snapshot.
+ */
 equity_swap_instrument make_instrument(database_helper& h) {
     equity_swap_instrument r;
     r.instrument_id      = boost::uuids::random_generator()();
     r.tenant_id          = h.tenant_id();
     r.trade_type_code    = "EquitySwap";
-    r.underlying_name    = "SP5";
+    r.underlying_name    = ".SPX";
     r.basket_json        = "";
     r.currency           = "USD";
-    r.notional           = 1000000.0;
+    r.notional           = 2000000.0;
     r.return_type        = "TotalReturn";
-    r.start_date         = "2026-01-01";
-    r.maturity_date      = "2027-01-01";
+    r.start_date         = "2025-10-16";
+    r.maturity_date      = "2025-12-31";
     r.long_short         = "Long";
-    r.payment_frequency  = "3M";
+    r.payment_frequency  = "1M";
     r.modified_by        = h.db_user();
     r.performed_by       = "ores";
     r.change_reason_code = "system.external_data_import";
@@ -76,14 +82,14 @@ TEST_CASE("equity_swap_instrument_write_and_read_latest", tags) {
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
     CHECK(read[0].trade_type_code == "EquitySwap");
-    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].underlying_name == ".SPX");
     CHECK(read[0].currency == "USD");
-    CHECK(read[0].notional == 1000000.0);
+    CHECK(read[0].notional == 2000000.0);
     CHECK(read[0].return_type == "TotalReturn");
-    CHECK(read[0].start_date == "2026-01-01");
-    CHECK(read[0].maturity_date == "2027-01-01");
+    CHECK(read[0].start_date == "2025-10-16");
+    CHECK(read[0].maturity_date == "2025-12-31");
     CHECK(read[0].long_short == "Long");
-    CHECK(read[0].payment_frequency == "3M");
+    CHECK(read[0].payment_frequency == "1M");
     BOOST_LOG_SEV(lg, debug) << "Read equity swap instrument: " << read[0];
 }
 

--- a/projects/ores.trading.core/tests/repository_equity_variance_swap_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_variance_swap_instrument_repository_tests.cpp
@@ -1,0 +1,119 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.trading.core/repository/equity_variance_swap_instrument_repository.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/equity_variance_swap_instrument_json_io.hpp" // IWYU pragma: keep.
+#include "ores.testing/database_helper.hpp"
+
+namespace {
+
+const std::string_view test_suite("ores.trading.core.repository.equity_variance_swap.tests");
+const std::string tags("[repository][equity][equity_variance_swap]");
+
+using ores::testing::database_helper;
+using ores::trading::repository::equity_variance_swap_instrument_repository;
+using ores::trading::domain::equity_variance_swap_instrument;
+using namespace ores::logging;
+
+equity_variance_swap_instrument make_instrument(database_helper& h) {
+    equity_variance_swap_instrument r;
+    r.instrument_id      = boost::uuids::random_generator()();
+    r.tenant_id          = h.tenant_id();
+    r.trade_type_code    = "EquityVarianceSwap";
+    r.underlying_name    = "SP5";
+    r.currency           = "USD";
+    r.notional           = 1000000.0;
+    r.variance_strike    = 0.04;
+    r.start_date         = "2026-01-01";
+    r.maturity_date      = "2026-12-31";
+    r.long_short         = "Long";
+    r.modified_by        = h.db_user();
+    r.performed_by       = "ores";
+    r.change_reason_code = "system.external_data_import";
+    r.change_commentary  = "Imported from ORE XML";
+    return r;
+}
+
+} // namespace
+
+TEST_CASE("equity_variance_swap_instrument_write_and_read_latest", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    BOOST_LOG_SEV(lg, debug) << "Writing equity variance swap instrument: " << instr;
+
+    equity_variance_swap_instrument_repository repo;
+    CHECK_NOTHROW(repo.write(ctx, instr));
+
+    const auto read = repo.read_latest(ctx, id_str);
+    REQUIRE(read.size() == 1);
+    CHECK(read[0].trade_type_code == "EquityVarianceSwap");
+    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].currency == "USD");
+    CHECK(read[0].notional == 1000000.0);
+    CHECK(read[0].variance_strike == 0.04);
+    CHECK(read[0].start_date == "2026-01-01");
+    CHECK(read[0].maturity_date == "2026-12-31");
+    CHECK(read[0].long_short == "Long");
+    BOOST_LOG_SEV(lg, debug) << "Read equity variance swap instrument: " << read[0];
+}
+
+TEST_CASE("equity_variance_swap_instrument_read_nonexistent", tags) {
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    equity_variance_swap_instrument_repository repo;
+    const std::string nonexistent = "00000000-0000-0000-0000-000000000001";
+    const auto read = repo.read_latest(ctx, nonexistent);
+    CHECK(read.empty());
+}
+
+TEST_CASE("equity_variance_swap_instrument_remove", tags) {
+    auto lg(make_logger(test_suite));
+
+    database_helper h;
+    const auto party_id = boost::uuids::random_generator()();
+    auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
+
+    auto instr = make_instrument(h);
+    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+
+    equity_variance_swap_instrument_repository repo;
+    repo.write(ctx, instr);
+
+    const auto before = repo.read_latest(ctx, id_str);
+    REQUIRE(!before.empty());
+
+    CHECK_NOTHROW(repo.remove(ctx, id_str));
+
+    const auto after = repo.read_latest(ctx, id_str);
+    BOOST_LOG_SEV(lg, debug) << "After remove count: " << after.size();
+    CHECK(after.empty());
+}

--- a/projects/ores.trading.core/tests/repository_equity_variance_swap_instrument_repository_tests.cpp
+++ b/projects/ores.trading.core/tests/repository_equity_variance_swap_instrument_repository_tests.cpp
@@ -36,17 +36,23 @@ using ores::trading::repository::equity_variance_swap_instrument_repository;
 using ores::trading::domain::equity_variance_swap_instrument;
 using namespace ores::logging;
 
+/*
+ * Test data derived from:
+ *   external/ore/examples/Products/Example_Trades/Equity_Variance_Swap.xml
+ * trade id in XML: Var_Swap
+ * See tests/test_data/equity_variance_swap_instrument.json for the full mapping snapshot.
+ */
 equity_variance_swap_instrument make_instrument(database_helper& h) {
     equity_variance_swap_instrument r;
     r.instrument_id      = boost::uuids::random_generator()();
     r.tenant_id          = h.tenant_id();
     r.trade_type_code    = "EquityVarianceSwap";
-    r.underlying_name    = "SP5";
+    r.underlying_name    = ".SPX";
     r.currency           = "USD";
-    r.notional           = 1000000.0;
-    r.variance_strike    = 0.04;
-    r.start_date         = "2026-01-01";
-    r.maturity_date      = "2026-12-31";
+    r.notional           = 50000.0;
+    r.variance_strike    = 0.20;
+    r.start_date         = "2025-02-20";
+    r.maturity_date      = "2025-05-20";
     r.long_short         = "Long";
     r.modified_by        = h.db_user();
     r.performed_by       = "ores";
@@ -74,12 +80,12 @@ TEST_CASE("equity_variance_swap_instrument_write_and_read_latest", tags) {
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
     CHECK(read[0].trade_type_code == "EquityVarianceSwap");
-    CHECK(read[0].underlying_name == "SP5");
+    CHECK(read[0].underlying_name == ".SPX");
     CHECK(read[0].currency == "USD");
-    CHECK(read[0].notional == 1000000.0);
-    CHECK(read[0].variance_strike == 0.04);
-    CHECK(read[0].start_date == "2026-01-01");
-    CHECK(read[0].maturity_date == "2026-12-31");
+    CHECK(read[0].notional == 50000.0);
+    CHECK(read[0].variance_strike == 0.20);
+    CHECK(read[0].start_date == "2025-02-20");
+    CHECK(read[0].maturity_date == "2025-05-20");
     CHECK(read[0].long_short == "Long");
     BOOST_LOG_SEV(lg, debug) << "Read equity variance swap instrument: " << read[0];
 }

--- a/projects/ores.trading.core/tests/test_data/equity_accumulator_instrument.json
+++ b/projects/ores.trading.core/tests/test_data/equity_accumulator_instrument.json
@@ -1,0 +1,34 @@
+{
+  "source_xml": "external/ore/examples/Products/Example_Trades/Exotic_EquityAccumulator_single_name.xml",
+  "trade_id_in_xml": "EQ_DECUMULATOR",
+  "mapper": "equity_instrument_mapper::forward_equity_accumulator (planned Phase 3 mapper)",
+  "notes": [
+    "long_short is hardcoded to Long by mapper",
+    "knock_out_level maps from first DownAndOut barrier level (3500)",
+    "FixingFloor barrier (level 1) and RangeBounds are not captured (Phase 3 gap)",
+    "fixing_frequency defaults to Monthly derived from PricingDates cadence (not explicit in XML)",
+    "expiry_date maps from ObservationDates.Rules.EndDate (2026-02-05)",
+    "target_type is empty for Decumulator (used only for TaRF)",
+    "target_amount is absent for Decumulator"
+  ],
+  "instrument": {
+    "trade_type_code": "EquityAccumulator",
+    "underlying_name": ".STOXX50",
+    "currency": "EUR",
+    "strike": 4000.0,
+    "fixing_amount": 30.0,
+    "start_date": "2025-02-05",
+    "expiry_date": "2026-02-05",
+    "fixing_frequency": "Monthly",
+    "long_short": "Long",
+    "knock_out_level": 3500.0,
+    "target_amount": null,
+    "target_type": "",
+    "payoff_type": "Decumulator",
+    "description": "",
+    "modified_by": "ores",
+    "performed_by": "ores",
+    "change_reason_code": "system.external_data_import",
+    "change_commentary": "Imported from ORE XML"
+  }
+}

--- a/projects/ores.trading.core/tests/test_data/equity_asian_option_instrument.json
+++ b/projects/ores.trading.core/tests/test_data/equity_asian_option_instrument.json
@@ -1,0 +1,33 @@
+{
+  "source_xml": "external/ore/examples/Products/Example_Trades/Equity_Asian_Option.xml",
+  "trade_id_in_xml": "EQAsianOption",
+  "mapper": "equity_instrument_mapper::forward_equity_asian_option (planned Phase 3 mapper)",
+  "notes": [
+    "notional maps from Quantity (1)",
+    "strike maps from StrikeData.Value (3100)",
+    "expiry_date maps from ExerciseDates.ExerciseDate (2026-01-28)",
+    "exercise_type defaults to European (not present in XML for Asian options)",
+    "average_type defaults to Arithmetic (not present in XML; implied by ObservationDates rules)",
+    "averaging_start_date maps from ObservationDates.Rules.StartDate (2025-07-12)",
+    "averaging_end_date maps from ObservationDates.Rules.EndDate (2026-01-19)"
+  ],
+  "instrument": {
+    "trade_type_code": "EquityAsianOption",
+    "underlying_name": "RIC:.SPX",
+    "currency": "USD",
+    "notional": 1.0,
+    "option_type": "Call",
+    "strike": 3100.0,
+    "expiry_date": "2026-01-28",
+    "exercise_type": "European",
+    "long_short": "Long",
+    "average_type": "Arithmetic",
+    "averaging_start_date": "2025-07-12",
+    "averaging_end_date": "2026-01-19",
+    "description": "",
+    "modified_by": "ores",
+    "performed_by": "ores",
+    "change_reason_code": "system.external_data_import",
+    "change_commentary": "Imported from ORE XML"
+  }
+}

--- a/projects/ores.trading.core/tests/test_data/equity_barrier_option_instrument.json
+++ b/projects/ores.trading.core/tests/test_data/equity_barrier_option_instrument.json
@@ -1,0 +1,32 @@
+{
+  "source_xml": "external/ore/examples/Products/Example_Trades/Equity_Barrier_Option.xml",
+  "trade_id_in_xml": "EQBarrierOption",
+  "mapper": "equity_instrument_mapper::forward_equity_barrier_option (planned Phase 3 mapper)",
+  "notes": [
+    "notional maps from Quantity (1000)",
+    "lower_barrier maps from BarrierData.Levels.Level (3500)",
+    "lower_barrier_type maps from BarrierData.Type (UpAndOut)",
+    "upper_barrier is absent: XML has a single-level BarrierData block"
+  ],
+  "instrument": {
+    "trade_type_code": "EquityBarrierOption",
+    "underlying_name": "RIC:.SPX",
+    "currency": "USD",
+    "notional": 1000.0,
+    "option_type": "Call",
+    "strike": 3200.0,
+    "expiry_date": "2026-08-15",
+    "exercise_type": "European",
+    "long_short": "Long",
+    "lower_barrier": 3500.0,
+    "lower_barrier_type": "UpAndOut",
+    "upper_barrier": null,
+    "upper_barrier_type": "",
+    "rebate": null,
+    "description": "",
+    "modified_by": "ores",
+    "performed_by": "ores",
+    "change_reason_code": "system.external_data_import",
+    "change_commentary": "Imported from ORE XML"
+  }
+}

--- a/projects/ores.trading.core/tests/test_data/equity_digital_option_instrument.json
+++ b/projects/ores.trading.core/tests/test_data/equity_digital_option_instrument.json
@@ -1,0 +1,28 @@
+{
+  "source_xml": "external/ore/examples/Products/Example_Trades/Equity_Digital_Option.xml",
+  "trade_id_in_xml": "EQDigitalOption",
+  "mapper": "equity_instrument_mapper::forward_equity_digital_option (planned Phase 3 mapper)",
+  "notes": [
+    "notional maps from Quantity (1000), not a separate Notional element",
+    "payout_amount maps from PayoffAmount; PayoffCurrency is captured separately in currency",
+    "barrier_level is absent for digital options (present only for touch options)"
+  ],
+  "instrument": {
+    "trade_type_code": "EquityDigitalOption",
+    "underlying_name": "RIC:.SPX",
+    "currency": "USD",
+    "notional": 1000.0,
+    "option_type": "Call",
+    "strike": 3300.0,
+    "barrier_level": null,
+    "barrier_type": "",
+    "expiry_date": "2026-07-17",
+    "long_short": "Long",
+    "payout_amount": 1000.0,
+    "description": "",
+    "modified_by": "ores",
+    "performed_by": "ores",
+    "change_reason_code": "system.external_data_import",
+    "change_commentary": "Imported from ORE XML"
+  }
+}

--- a/projects/ores.trading.core/tests/test_data/equity_forward_instrument.json
+++ b/projects/ores.trading.core/tests/test_data/equity_forward_instrument.json
@@ -1,0 +1,26 @@
+{
+  "source_xml": "external/ore/examples/Products/Example_Trades/Equity_Forward.xml",
+  "trade_id_in_xml": "EqForward",
+  "mapper": "equity_instrument_mapper::forward_equity_forward (planned Phase 3 mapper)",
+  "notes": [
+    "quantity maps from Quantity (775)",
+    "forward_price maps from Strike (2800)",
+    "expiry_date maps from Maturity (2025-02-20)",
+    "settlement_type is not present in XML — field is empty"
+  ],
+  "instrument": {
+    "trade_type_code": "EquityForward",
+    "underlying_name": "RIC:.SPX",
+    "currency": "USD",
+    "quantity": 775.0,
+    "forward_price": 2800.0,
+    "expiry_date": "2025-02-20",
+    "long_short": "Long",
+    "settlement_type": "",
+    "description": "",
+    "modified_by": "ores",
+    "performed_by": "ores",
+    "change_reason_code": "system.external_data_import",
+    "change_commentary": "Imported from ORE XML"
+  }
+}

--- a/projects/ores.trading.core/tests/test_data/equity_option_instrument.json
+++ b/projects/ores.trading.core/tests/test_data/equity_option_instrument.json
@@ -1,0 +1,23 @@
+{
+  "source_xml": "external/ore/examples/Products/Example_Trades/Equity_Option_European.xml",
+  "trade_id_in_xml": "EquityOption",
+  "mapper": "equity_instrument_mapper::forward_equity_option (planned Phase 3 mapper)",
+  "instrument": {
+    "trade_type_code": "EquityOption",
+    "underlying_name": "RIC:.SPX",
+    "currency": "USD",
+    "notional": 775.0,
+    "option_type": "Call",
+    "strike": 2800.0,
+    "expiry_date": "2025-02-20",
+    "exercise_type": "European",
+    "long_short": "Long",
+    "settlement_type": "Cash",
+    "cliquet_frequency": "",
+    "description": "",
+    "modified_by": "ores",
+    "performed_by": "ores",
+    "change_reason_code": "system.external_data_import",
+    "change_commentary": "Imported from ORE XML"
+  }
+}

--- a/projects/ores.trading.core/tests/test_data/equity_position_instrument.json
+++ b/projects/ores.trading.core/tests/test_data/equity_position_instrument.json
@@ -1,0 +1,25 @@
+{
+  "source_xml": "external/ore/examples/Products/Example_Trades/Hybrid_GenericTRS_with_EquityPosition.xml",
+  "trade_id_in_xml": "TRS1000240_asTRSonEquityPosition1DEC (embedded EquityPosition)",
+  "mapper": "equity_instrument_mapper::forward_equity_position (planned Phase 3 mapper)",
+  "notes": [
+    "underlying_name maps from Underlying.Name (BBG00R251JN8, FIGI identifier)",
+    "quantity maps from Quantity (18101.486)",
+    "price maps from InitialPrice (6927.586) on the TRS ReturnData",
+    "option_data_json is empty for plain EquityPosition (used only for EquityOptionPosition)",
+    "currency maps from ReturnData.Currency (USD)"
+  ],
+  "instrument": {
+    "trade_type_code": "EquityPosition",
+    "underlying_name": "BBG00R251JN8",
+    "currency": "USD",
+    "quantity": 18101.486,
+    "price": 6927.586,
+    "option_data_json": "",
+    "description": "",
+    "modified_by": "ores",
+    "performed_by": "ores",
+    "change_reason_code": "system.external_data_import",
+    "change_commentary": "Imported from ORE XML"
+  }
+}

--- a/projects/ores.trading.core/tests/test_data/equity_swap_instrument.json
+++ b/projects/ores.trading.core/tests/test_data/equity_swap_instrument.json
@@ -1,0 +1,31 @@
+{
+  "source_xml": "external/ore/examples/Products/Example_Trades/Equity_Swap.xml",
+  "trade_id_in_xml": "EqSwap",
+  "mapper": "equity_instrument_mapper::forward_equity_swap (planned Phase 3 mapper)",
+  "notes": [
+    "notional maps from equity leg Notional (2000000)",
+    "underlying_name maps from EquityLegData.Underlying.Name (.SPX)",
+    "return_type maps from ReturnType (Total -> TotalReturn)",
+    "start_date and maturity_date map from equity leg ScheduleData.Rules",
+    "payment_frequency maps from equity leg ScheduleData.Rules.Tenor (1M)",
+    "long_short maps from equity leg Payer (true -> Short; false -> Long); here Payer=true on equity leg means Short in equity convention, set Long as perspective is receiver of equity return",
+    "basket_json is empty for single-underlying swaps"
+  ],
+  "instrument": {
+    "trade_type_code": "EquitySwap",
+    "underlying_name": ".SPX",
+    "basket_json": "",
+    "currency": "USD",
+    "notional": 2000000.0,
+    "return_type": "TotalReturn",
+    "start_date": "2025-10-16",
+    "maturity_date": "2025-12-31",
+    "long_short": "Long",
+    "payment_frequency": "1M",
+    "description": "",
+    "modified_by": "ores",
+    "performed_by": "ores",
+    "change_reason_code": "system.external_data_import",
+    "change_commentary": "Imported from ORE XML"
+  }
+}

--- a/projects/ores.trading.core/tests/test_data/equity_variance_swap_instrument.json
+++ b/projects/ores.trading.core/tests/test_data/equity_variance_swap_instrument.json
@@ -1,0 +1,26 @@
+{
+  "source_xml": "external/ore/examples/Products/Example_Trades/Equity_Variance_Swap.xml",
+  "trade_id_in_xml": "Var_Swap",
+  "mapper": "equity_instrument_mapper::forward_equity_variance_swap (planned Phase 3 mapper)",
+  "notes": [
+    "long_short is hardcoded to Long by mapper",
+    "variance_strike maps from Strike (0.20)",
+    "maturity_date maps from EndDate (2025-05-20)",
+    "MomentType (Variance) is implicit in the trade type — not stored separately"
+  ],
+  "instrument": {
+    "trade_type_code": "EquityVarianceSwap",
+    "underlying_name": ".SPX",
+    "currency": "USD",
+    "notional": 50000.0,
+    "variance_strike": 0.20,
+    "start_date": "2025-02-20",
+    "maturity_date": "2025-05-20",
+    "long_short": "Long",
+    "description": "",
+    "modified_by": "ores",
+    "performed_by": "ores",
+    "change_reason_code": "system.external_data_import",
+    "change_commentary": "Imported from ORE XML"
+  }
+}


### PR DESCRIPTION
## Summary

- Add per-type SQL tables for 9 equity instrument types (option, digital option, barrier option, asian option, forward, variance swap, swap, accumulator, position) with temporal history, version management, soft-delete, notify triggers, and RLS party isolation policies
- Add typed domain structs and JSON I/O for all 9 equity instrument types
- Add entity/mapper/repository layer for all 9 types using sqlgen bitemporal pattern
- Add service classes, NATS handler, protocol request/response structs, and registrar subscriptions
- Add repository tests (write_and_read_latest, read_nonexistent, remove) for all 9 types

Follows the same pattern established for FX typed instruments in Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)