### PR TITLE
[scheduler/qt] Complete Scheduler UI: Job Instances and Monitor

### DIFF
--- a/doc/plans/2026-04-10-scheduler-realtime-ui.org
+++ b/doc/plans/2026-04-10-scheduler-realtime-ui.org
@@ -1,0 +1,153 @@
+:PROPERTIES:
+:ID: C7E3B2A4-8F95-4D9C-B3E7-H4C95G1F2678
+:END:
+#+title: Scheduler Real-Time UI — Job Lifecycle Events and Live Views
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
+#+startup: inlineimages
+
+* Problem
+
+The =feature/scheduler-ui= branch added =JobInstanceMdiWindow= and
+=SchedulerMonitorMdiWindow= to the Qt client, but both are polling-only and
+neither reacts to server-side job state changes in a timely way:
+
+- =JobInstanceMdiWindow= has no auto-refresh at all — a manual Reload is
+  required to see new runs.
+- =SchedulerMonitorMdiWindow= polls every 30 seconds, which is too coarse for
+  jobs that may start and finish in seconds.
+- =scheduler_loop= writes job lifecycle (started / completed / failed) only to
+  the database; it publishes no NATS event that clients can subscribe to.
+- =JobInstanceController= was constructed without an event-subscription name, so
+  =EntityController='s stale-mark machinery is idle.
+
+* Architecture
+
+The scheduler is a general-purpose service.  Any client — the Qt UI, a
+reporting service, another microservice — can both:
+
+1. *Schedule* a job by sending =schedule_job_request= to
+   =scheduler.v1.job-definitions.schedule=.
+2. *Get notified* of job lifecycle transitions by subscribing to
+   =scheduler.v1.job-instance-events=.
+
+There is nothing special about the Qt client here.  The existing =nats_publish=
+action handler already demonstrates this pattern for service-to-service
+triggering (the scheduler fires a job and publishes to a per-job configurable
+subject).  What is missing is a *fixed lifecycle subject* published for every
+job regardless of action type.
+
+** Event format
+
+Re-use the existing =entity_change_event= format (=ores.eventing= library) so
+no new struct or =ClientManager= code is needed:
+
+#+begin_src
+subject:      scheduler.v1.job-instance-events
+entity:       ores.scheduler.job_instance
+change_type:  created   (job started)
+              updated   (job completed — succeeded or failed)
+entity_ids:   [ job_definition_id ]
+tenant_id:    from job_definition.tenant_id
+#+end_src
+
+Any subscriber that already handles =entity_change_event= events (e.g. via
+=ClientManager::subscribeToEvent=) can consume these without modification.
+
+* Implementation Plan
+
+** Phase 1 — Server: publish lifecycle events from =scheduler_loop=
+
+*** 1.1  Add NATS client reference to =scheduler_loop=
+
+=scheduler_loop= currently has no NATS access.  The registrar already holds a
+=nats::service::client&= (it passes it to =nats_publish_action_handler=); pass
+the same reference to =scheduler_loop=.
+
+Files:
+- =projects/ores.scheduler.core/include/ores.scheduler.core/service/scheduler_loop.hpp=
+  — add =ores::nats::service::client& nats_= member; update constructor signature.
+- =projects/ores.scheduler.core/src/service/scheduler_loop.cpp=
+  — accept =nats::service::client&= in constructor; add publish helper.
+- =projects/ores.scheduler.core/src/messaging/registrar.cpp=
+  — pass =nats= into =scheduler_loop= constructor.
+- =projects/ores.scheduler.service/src/main.cpp= (or wherever =scheduler_loop=
+  is instantiated outside the registrar) — update if needed.
+
+*** 1.2  Publish events in =fire_job()=
+
+Add a private helper =publish_instance_event(change_type, job, inst_id)= that
+serialises an =entity_change_event= and calls =nats_.publish(...)=.
+
+Publish twice:
+1. After =inst_repo.write_started= succeeds → =change_type = "created"=.
+2. After =inst_repo.write_completed= succeeds (both success and failure paths)
+   → =change_type = "updated"=.
+
+Files:
+- =projects/ores.scheduler.core/src/service/scheduler_loop.cpp=
+
+** Phase 2 — Client: =JobInstanceController= subscribes to events
+
+Pass ="scheduler.v1.job-instance-events"= as the =eventName= argument to the
+=EntityController= base constructor inside =JobInstanceController=.  The base
+class then handles subscribe / unsubscribe / reconnect automatically and calls
+=window->markAsStale()= on every event, showing the stale indicator immediately.
+
+Files:
+- =projects/ores.qt.compute/include/ores.qt/JobInstanceController.hpp=
+  — add =static constexpr std::string_view event_subject= constant.
+- =projects/ores.qt.compute/src/JobInstanceController.cpp=
+  — pass =event_subject= to =EntityController= base.
+- =projects/ores.qt.scheduler/src/SchedulerPlugin.cpp=
+  — remove the empty =eventName= passed to =JobInstanceController= (or confirm
+  the default picks it up from the constant).
+
+** Phase 3 — Client: =JobInstanceMdiWindow= auto-refresh
+
+Add an auto-refresh toolbar section to =JobInstanceMdiWindow= following the
+=ServiceDashboardMdiWindow= pattern exactly:
+
+#+begin_src
+[Reload] | sep | [Auto-Refresh toggle] | "Every" label | QSpinBox 5–3600 s | "s" suffix
+#+end_src
+
+Default interval: *15 seconds* (jobs can start and finish within a minute).
+
+The stale-mark from Phase 2 gives an immediate visual indicator; the timer
+provides a fallback refresh if an event is missed.
+
+Files:
+- =projects/ores.qt.compute/include/ores.qt/JobInstanceMdiWindow.hpp=
+  — add =QTimer*=, =QAction* autoRefreshAction_=, =QSpinBox* intervalSpin_=.
+- =projects/ores.qt.compute/src/JobInstanceMdiWindow.cpp=
+  — wire timer in =setupToolbar()=; add =onAutoRefreshToggled= and
+  =onAutoRefreshIntervalChanged= slots.
+
+** Phase 4 — Client: =SchedulerMonitorController= reacts to events
+
+=SchedulerMonitorController= does not inherit =EntityController=, so subscribe
+directly:
+
+- In constructor: connect =clientManager_->notificationReceived= to a lambda
+  that calls =window_->refresh()= when =eventType ==
+  "scheduler.v1.job-instance-events"= and the window is open.
+- On =on_login= (via =SchedulerPlugin=): call
+  =clientManager_->subscribeToEvent("scheduler.v1.job-instance-events")= and
+  unsubscribe in =closeWindow()= / destructor.
+
+This makes the monitor window update immediately when any job fires, instead of
+waiting up to 30 seconds.
+
+Also reduce the default auto-refresh interval from 30 s to *15 s* to match the
+job instances view.
+
+Files:
+- =projects/ores.qt.compute/include/ores.qt/SchedulerMonitorController.hpp=
+- =projects/ores.qt.compute/src/SchedulerMonitorController.cpp=
+
+* Out of Scope
+
+- Pagination in =JobInstanceMdiWindow= (limit currently 200 rows; acceptable for now).
+- Per-job filtering in the instances view.
+- Job cancellation / manual trigger from the UI.

--- a/projects/ores.qt.compute/include/ores.qt/ClientJobInstanceModel.hpp
+++ b/projects/ores.qt.compute/include/ores.qt/ClientJobInstanceModel.hpp
@@ -1,0 +1,99 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CLIENT_JOB_INSTANCE_MODEL_HPP
+#define ORES_QT_CLIENT_JOB_INSTANCE_MODEL_HPP
+
+#include <vector>
+#include <QFutureWatcher>
+#include <QAbstractTableModel>
+#include "ores.qt/AbstractClientModel.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.scheduler.api/messaging/scheduler_protocol.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief Table model for the global job-instance execution history.
+ *
+ * Fetches data via scheduler.v1.job-instances.list and exposes it as a
+ * read-only QAbstractTableModel for display in JobInstanceMdiWindow.
+ */
+class ClientJobInstanceModel final : public AbstractClientModel {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.client_job_instance_model";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    enum Column {
+        JobName,
+        Status,
+        TriggeredAt,
+        StartedAt,
+        Duration,
+        ActionType,
+        ErrorMessage,
+        ColumnCount
+    };
+
+    explicit ClientJobInstanceModel(ClientManager* clientManager,
+                                    QObject* parent = nullptr);
+    ~ClientJobInstanceModel() override = default;
+
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+        int role = Qt::DisplayRole) const override;
+
+    void refresh();
+
+    const scheduler::messaging::job_instance_summary* getInstance(int row) const;
+
+private slots:
+    void onInstancesLoaded();
+
+private:
+    struct FetchResult {
+        bool success;
+        std::vector<scheduler::messaging::job_instance_summary> instances;
+        QString error_message;
+        QString error_details;
+    };
+
+    void fetch_instances();
+
+    ClientManager* clientManager_;
+    std::vector<scheduler::messaging::job_instance_summary> instances_;
+    QFutureWatcher<FetchResult>* watcher_;
+    bool is_fetching_{false};
+};
+
+}
+
+#endif

--- a/projects/ores.qt.compute/include/ores.qt/JobInstanceController.hpp
+++ b/projects/ores.qt.compute/include/ores.qt/JobInstanceController.hpp
@@ -42,6 +42,8 @@ class JobInstanceController final : public EntityController {
 private:
     inline static std::string_view logger_name =
         "ores.qt.job_instance_controller";
+    static constexpr std::string_view event_subject =
+        "scheduler.v1.job-instance-events";
 
     [[nodiscard]] static auto& lg() {
         using namespace ores::logging;

--- a/projects/ores.qt.compute/include/ores.qt/JobInstanceController.hpp
+++ b/projects/ores.qt.compute/include/ores.qt/JobInstanceController.hpp
@@ -1,0 +1,82 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_JOB_INSTANCE_CONTROLLER_HPP
+#define ORES_QT_JOB_INSTANCE_CONTROLLER_HPP
+
+#include <QMdiArea>
+#include <QMainWindow>
+#include "ores.qt/EntityController.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/EntityListMdiWindow.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.scheduler.api/messaging/scheduler_protocol.hpp"
+
+namespace ores::qt {
+
+class JobInstanceMdiWindow;
+class DetachableMdiSubWindow;
+
+/**
+ * @brief Controller for the job-instance execution history window.
+ */
+class JobInstanceController final : public EntityController {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.job_instance_controller";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    JobInstanceController(
+        QMainWindow* mainWindow,
+        QMdiArea* mdiArea,
+        ClientManager* clientManager,
+        QObject* parent = nullptr);
+
+    void showListWindow() override;
+    void closeAllWindows() override;
+    void reloadListWindow() override;
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& error);
+
+protected:
+    EntityListMdiWindow* listWindow() const override;
+
+private slots:
+    void onShowDetails(const scheduler::messaging::job_instance_summary& instance);
+
+private:
+    void showDetailWindow(const scheduler::messaging::job_instance_summary& instance);
+
+    JobInstanceMdiWindow* listWindow_;
+    DetachableMdiSubWindow* listMdiSubWindow_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.compute/include/ores.qt/JobInstanceDetailDialog.hpp
+++ b/projects/ores.qt.compute/include/ores.qt/JobInstanceDetailDialog.hpp
@@ -1,0 +1,43 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_JOB_INSTANCE_DETAIL_DIALOG_HPP
+#define ORES_QT_JOB_INSTANCE_DETAIL_DIALOG_HPP
+
+#include <QDialog>
+#include "ores.scheduler.api/messaging/scheduler_protocol.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief Read-only detail dialog for a single job instance execution record.
+ */
+class JobInstanceDetailDialog final : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit JobInstanceDetailDialog(
+        const scheduler::messaging::job_instance_summary& instance,
+        QWidget* parent = nullptr);
+    ~JobInstanceDetailDialog() override = default;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.compute/include/ores.qt/JobInstanceMdiWindow.hpp
+++ b/projects/ores.qt.compute/include/ores.qt/JobInstanceMdiWindow.hpp
@@ -1,0 +1,95 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_JOB_INSTANCE_MDI_WINDOW_HPP
+#define ORES_QT_JOB_INSTANCE_MDI_WINDOW_HPP
+
+#include <QToolBar>
+#include <QTableView>
+#include <QSortFilterProxyModel>
+#include "ores.qt/EntityListMdiWindow.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ClientJobInstanceModel.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.scheduler.api/messaging/scheduler_protocol.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief MDI window showing the global job-instance execution history.
+ *
+ * Read-only list of all recent job instance runs across all definitions.
+ * Double-clicking a row opens a JobInstanceDetailDialog.
+ */
+class JobInstanceMdiWindow final : public EntityListMdiWindow {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.job_instance_mdi_window";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit JobInstanceMdiWindow(
+        ClientManager* clientManager,
+        QWidget* parent = nullptr);
+    ~JobInstanceMdiWindow() override = default;
+
+public slots:
+    void doReload() override;
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void showInstanceDetails(const scheduler::messaging::job_instance_summary& instance);
+
+protected:
+    QString normalRefreshTooltip() const override {
+        return tr("Refresh job instances");
+    }
+
+private slots:
+    void onDataLoaded();
+    void onLoadError(const QString& error_message, const QString& details = {});
+    void onDoubleClicked(const QModelIndex& index);
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupTable();
+    void setupConnections();
+
+    ClientManager* clientManager_;
+
+    QToolBar* toolbar_;
+    QTableView* tableView_;
+    ClientJobInstanceModel* model_;
+    QSortFilterProxyModel* proxyModel_;
+
+    QAction* reloadAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.compute/include/ores.qt/JobInstanceMdiWindow.hpp
+++ b/projects/ores.qt.compute/include/ores.qt/JobInstanceMdiWindow.hpp
@@ -20,6 +20,9 @@
 #ifndef ORES_QT_JOB_INSTANCE_MDI_WINDOW_HPP
 #define ORES_QT_JOB_INSTANCE_MDI_WINDOW_HPP
 
+#include <QTimer>
+#include <QLabel>
+#include <QSpinBox>
 #include <QToolBar>
 #include <QTableView>
 #include <QSortFilterProxyModel>
@@ -73,6 +76,8 @@ private slots:
     void onDataLoaded();
     void onLoadError(const QString& error_message, const QString& details = {});
     void onDoubleClicked(const QModelIndex& index);
+    void onAutoRefreshToggled(bool enabled);
+    void onAutoRefreshIntervalChanged(int seconds);
 
 private:
     void setupUi();
@@ -88,6 +93,9 @@ private:
     QSortFilterProxyModel* proxyModel_;
 
     QAction* reloadAction_;
+    QAction* autoRefreshAction_;
+    QSpinBox* intervalSpin_;
+    QTimer* autoRefreshTimer_;
 };
 
 }

--- a/projects/ores.qt.compute/include/ores.qt/SchedulerMonitorController.hpp
+++ b/projects/ores.qt.compute/include/ores.qt/SchedulerMonitorController.hpp
@@ -47,12 +47,16 @@ private:
         return instance;
     }
 
+    static constexpr std::string_view event_subject =
+        "scheduler.v1.job-instance-events";
+
 public:
     SchedulerMonitorController(
         QMainWindow* mainWindow,
         QMdiArea* mdiArea,
         ClientManager* clientManager,
         QObject* parent = nullptr);
+    ~SchedulerMonitorController() override;
 
     void showWindow();
     void closeWindow();

--- a/projects/ores.qt.compute/include/ores.qt/SchedulerMonitorController.hpp
+++ b/projects/ores.qt.compute/include/ores.qt/SchedulerMonitorController.hpp
@@ -1,0 +1,74 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_SCHEDULER_MONITOR_CONTROLLER_HPP
+#define ORES_QT_SCHEDULER_MONITOR_CONTROLLER_HPP
+
+#include <QObject>
+#include <QMdiArea>
+#include <QMainWindow>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::qt {
+
+class SchedulerMonitorMdiWindow;
+class DetachableMdiSubWindow;
+
+/**
+ * @brief Controller for the Scheduler Monitor singleton window.
+ */
+class SchedulerMonitorController final : public QObject {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.scheduler_monitor_controller";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    SchedulerMonitorController(
+        QMainWindow* mainWindow,
+        QMdiArea* mdiArea,
+        ClientManager* clientManager,
+        QObject* parent = nullptr);
+
+    void showWindow();
+    void closeWindow();
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& error);
+
+private:
+    QMainWindow* mainWindow_;
+    QMdiArea* mdiArea_;
+    ClientManager* clientManager_;
+    SchedulerMonitorMdiWindow* window_{nullptr};
+    DetachableMdiSubWindow* mdiSubWindow_{nullptr};
+};
+
+}
+
+#endif

--- a/projects/ores.qt.compute/include/ores.qt/SchedulerMonitorMdiWindow.hpp
+++ b/projects/ores.qt.compute/include/ores.qt/SchedulerMonitorMdiWindow.hpp
@@ -1,0 +1,103 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_SCHEDULER_MONITOR_MDI_WINDOW_HPP
+#define ORES_QT_SCHEDULER_MONITOR_MDI_WINDOW_HPP
+
+#include <vector>
+#include <QTimer>
+#include <QWidget>
+#include <QAction>
+#include <QSpinBox>
+#include <QToolBar>
+#include <QTableWidget>
+#include <QVBoxLayout>
+#include <QCloseEvent>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.scheduler.api/messaging/scheduler_protocol.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief Singleton MDI window showing a live per-job scheduler status.
+ *
+ * Columns: Job Name | Schedule | Active | Last Run | Last Status | Next Fire | Running
+ * Auto-refreshes on a configurable interval (default: 30 seconds).
+ */
+class SchedulerMonitorMdiWindow final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.scheduler_monitor_mdi_window";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit SchedulerMonitorMdiWindow(
+        ClientManager* clientManager,
+        QWidget* parent = nullptr);
+    ~SchedulerMonitorMdiWindow() override = default;
+
+    QSize sizeHint() const override { return {860, 500}; }
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error);
+
+public slots:
+    void refresh();
+
+private slots:
+    void onAutoRefreshToggled(bool enabled);
+    void onAutoRefreshIntervalChanged(int seconds);
+
+private:
+    void setupUi();
+    void applyStatus(const std::vector<scheduler::messaging::job_schedule_status>& jobs);
+
+    enum Col {
+        ColJobName   = 0,
+        ColSchedule  = 1,
+        ColActive    = 2,
+        ColLastRun   = 3,
+        ColLastStatus= 4,
+        ColNextFire  = 5,
+        ColRunning   = 6,
+        ColCount     = 7
+    };
+
+    ClientManager* clientManager_;
+
+    QToolBar* toolbar_;
+    QAction* refreshAction_;
+    QAction* autoRefreshAction_;
+    QSpinBox* intervalSpin_;
+    QTableWidget* table_;
+    QTimer* autoRefreshTimer_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.compute/src/ClientJobInstanceModel.cpp
+++ b/projects/ores.qt.compute/src/ClientJobInstanceModel.cpp
@@ -1,0 +1,181 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/ClientJobInstanceModel.hpp"
+
+#include <QtConcurrent>
+#include "ores.scheduler.api/rfl/reflectors.hpp"
+#include "ores.qt/ExceptionHelper.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+ClientJobInstanceModel::ClientJobInstanceModel(
+    ClientManager* clientManager, QObject* parent)
+    : AbstractClientModel(parent),
+      clientManager_(clientManager),
+      watcher_(new QFutureWatcher<FetchResult>(this)) {
+
+    connect(watcher_, &QFutureWatcher<FetchResult>::finished,
+            this, &ClientJobInstanceModel::onInstancesLoaded);
+}
+
+int ClientJobInstanceModel::rowCount(const QModelIndex& parent) const {
+    if (parent.isValid()) return 0;
+    return static_cast<int>(instances_.size());
+}
+
+int ClientJobInstanceModel::columnCount(const QModelIndex& parent) const {
+    if (parent.isValid()) return 0;
+    return ColumnCount;
+}
+
+QVariant ClientJobInstanceModel::data(
+    const QModelIndex& index, int role) const {
+    if (!index.isValid()) return {};
+
+    const auto row = static_cast<std::size_t>(index.row());
+    if (row >= instances_.size()) return {};
+
+    const auto& inst = instances_[row];
+
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case JobName:    return QString::fromStdString(inst.job_name);
+        case Status:     return QString::fromStdString(inst.status);
+        case TriggeredAt: return QString::fromStdString(inst.triggered_at);
+        case StartedAt:  return QString::fromStdString(inst.started_at);
+        case Duration:
+            if (inst.duration_ms)
+                return tr("%1 ms").arg(*inst.duration_ms);
+            return tr("—");
+        case ActionType: return QString::fromStdString(inst.action_type);
+        case ErrorMessage:
+            return inst.error_message.empty()
+                ? QVariant{}
+                : QString::fromStdString(inst.error_message);
+        default: return {};
+        }
+    }
+
+    if (role == Qt::ForegroundRole) {
+        if (index.column() == Status) {
+            if (inst.status == "succeeded")
+                return QColor(Qt::darkGreen);
+            if (inst.status == "failed")
+                return QColor(Qt::red);
+        }
+    }
+
+    return {};
+}
+
+QVariant ClientJobInstanceModel::headerData(
+    int section, Qt::Orientation orientation, int role) const {
+    if (orientation != Qt::Horizontal || role != Qt::DisplayRole) return {};
+
+    switch (section) {
+    case JobName:     return tr("Job Name");
+    case Status:      return tr("Status");
+    case TriggeredAt: return tr("Triggered At");
+    case StartedAt:   return tr("Started At");
+    case Duration:    return tr("Duration");
+    case ActionType:  return tr("Action Type");
+    case ErrorMessage:return tr("Error");
+    default:          return {};
+    }
+}
+
+void ClientJobInstanceModel::refresh() {
+    BOOST_LOG_SEV(lg(), debug) << "Refreshing job instances.";
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        emit loadError(tr("Not connected to server"));
+        return;
+    }
+
+    if (!instances_.empty()) {
+        beginResetModel();
+        instances_.clear();
+        endResetModel();
+    }
+
+    fetch_instances();
+}
+
+void ClientJobInstanceModel::fetch_instances() {
+    is_fetching_ = true;
+    QPointer<ClientJobInstanceModel> self = this;
+
+    QFuture<FetchResult> future =
+        QtConcurrent::run([self]() -> FetchResult {
+            return exception_helper::wrap_async_fetch<FetchResult>([&]() -> FetchResult {
+                if (!self || !self->clientManager_)
+                    return {false, {}, tr("Model destroyed"), {}};
+
+                scheduler::messaging::get_job_instances_request req;
+                req.limit = 200;
+
+                auto result = self->clientManager_->
+                    process_authenticated_request(std::move(req));
+
+                if (!result)
+                    return {false, {}, QString::fromStdString(
+                        "Failed to fetch job instances: " + result.error()), {}};
+
+                return {true, std::move(result->instances), {}, {}};
+            }, "job instances");
+        });
+
+    watcher_->setFuture(future);
+}
+
+void ClientJobInstanceModel::onInstancesLoaded() {
+    is_fetching_ = false;
+    const auto result = watcher_->result();
+
+    if (!result.success) {
+        BOOST_LOG_SEV(lg(), error) << "Failed to load job instances: "
+                                   << result.error_message.toStdString();
+        emit loadError(result.error_message, result.error_details);
+        return;
+    }
+
+    beginResetModel();
+    instances_ = std::move(result.instances);
+    endResetModel();
+
+    BOOST_LOG_SEV(lg(), info) << "Loaded " << instances_.size() << " job instances.";
+    emit dataLoaded();
+}
+
+const scheduler::messaging::job_instance_summary*
+ClientJobInstanceModel::getInstance(int row) const {
+    const auto idx = static_cast<std::size_t>(row);
+    if (idx >= instances_.size()) return nullptr;
+    return &instances_[idx];
+}
+
+}

--- a/projects/ores.qt.compute/src/ClientJobInstanceModel.cpp
+++ b/projects/ores.qt.compute/src/ClientJobInstanceModel.cpp
@@ -19,6 +19,7 @@
  */
 #include "ores.qt/ClientJobInstanceModel.hpp"
 
+#include <QColor>
 #include <QtConcurrent>
 #include "ores.scheduler.api/rfl/reflectors.hpp"
 #include "ores.qt/ExceptionHelper.hpp"

--- a/projects/ores.qt.compute/src/JobInstanceController.cpp
+++ b/projects/ores.qt.compute/src/JobInstanceController.cpp
@@ -1,0 +1,111 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/JobInstanceController.hpp"
+
+#include <QPointer>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/JobInstanceMdiWindow.hpp"
+#include "ores.qt/JobInstanceDetailDialog.hpp"
+#include "ores.qt/DetachableMdiSubWindow.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+JobInstanceController::JobInstanceController(
+    QMainWindow* mainWindow,
+    QMdiArea* mdiArea,
+    ClientManager* clientManager,
+    QObject* parent)
+    : EntityController(mainWindow, mdiArea, clientManager, {},
+          std::string_view{}, parent),
+      listWindow_(nullptr),
+      listMdiSubWindow_(nullptr) {
+
+    BOOST_LOG_SEV(lg(), debug) << "JobInstanceController created";
+}
+
+void JobInstanceController::showListWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "showListWindow";
+
+    const QString key = build_window_key("list", "job_instances");
+    if (try_reuse_window(key)) return;
+
+    listWindow_ = new JobInstanceMdiWindow(clientManager_);
+
+    connect(listWindow_, &JobInstanceMdiWindow::statusChanged,
+            this, &JobInstanceController::statusMessage);
+    connect(listWindow_, &JobInstanceMdiWindow::errorOccurred,
+            this, &JobInstanceController::errorMessage);
+    connect(listWindow_, &JobInstanceMdiWindow::showInstanceDetails,
+            this, &JobInstanceController::onShowDetails);
+
+    listMdiSubWindow_ = new DetachableMdiSubWindow(mainWindow_);
+    listMdiSubWindow_->setWidget(listWindow_);
+    listMdiSubWindow_->setWindowTitle("Job Instances");
+    listMdiSubWindow_->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::TasksApp, IconUtils::DefaultIconColor));
+    listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
+    listMdiSubWindow_->resize(listWindow_->sizeHint());
+
+    mdiArea_->addSubWindow(listMdiSubWindow_);
+    listMdiSubWindow_->show();
+
+    track_window(key, listMdiSubWindow_);
+    register_detachable_window(listMdiSubWindow_);
+
+    connect(listMdiSubWindow_, &QObject::destroyed,
+            this, [self = QPointer<JobInstanceController>(this), key]() {
+        if (!self) return;
+        self->untrack_window(key);
+        self->listWindow_ = nullptr;
+        self->listMdiSubWindow_ = nullptr;
+    });
+}
+
+void JobInstanceController::closeAllWindows() {
+    QList<QString> keys = managed_windows_.keys();
+    for (const QString& k : keys)
+        if (auto* w = managed_windows_.value(k)) w->close();
+    managed_windows_.clear();
+    listWindow_ = nullptr;
+    listMdiSubWindow_ = nullptr;
+}
+
+void JobInstanceController::reloadListWindow() {
+    if (listWindow_) listWindow_->reload();
+}
+
+EntityListMdiWindow* JobInstanceController::listWindow() const {
+    return listWindow_;
+}
+
+void JobInstanceController::onShowDetails(
+    const scheduler::messaging::job_instance_summary& instance) {
+    showDetailWindow(instance);
+}
+
+void JobInstanceController::showDetailWindow(
+    const scheduler::messaging::job_instance_summary& instance) {
+    auto* dlg = new JobInstanceDetailDialog(instance, mainWindow_);
+    dlg->exec();
+}
+
+}

--- a/projects/ores.qt.compute/src/JobInstanceController.cpp
+++ b/projects/ores.qt.compute/src/JobInstanceController.cpp
@@ -35,7 +35,7 @@ JobInstanceController::JobInstanceController(
     ClientManager* clientManager,
     QObject* parent)
     : EntityController(mainWindow, mdiArea, clientManager, {},
-          std::string_view{}, parent),
+          event_subject, parent),
       listWindow_(nullptr),
       listMdiSubWindow_(nullptr) {
 

--- a/projects/ores.qt.compute/src/JobInstanceDetailDialog.cpp
+++ b/projects/ores.qt.compute/src/JobInstanceDetailDialog.cpp
@@ -1,0 +1,95 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/JobInstanceDetailDialog.hpp"
+
+#include <QVBoxLayout>
+#include <QFormLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QDialogButtonBox>
+#include <QGroupBox>
+
+namespace ores::qt {
+
+namespace {
+
+QLineEdit* readOnlyField(const QString& text, QWidget* parent) {
+    auto* e = new QLineEdit(text, parent);
+    e->setReadOnly(true);
+    return e;
+}
+
+} // namespace
+
+JobInstanceDetailDialog::JobInstanceDetailDialog(
+    const scheduler::messaging::job_instance_summary& inst,
+    QWidget* parent)
+    : QDialog(parent) {
+
+    setWindowTitle(tr("Job Instance — %1").arg(
+        QString::fromStdString(inst.job_name)));
+    setAttribute(Qt::WA_DeleteOnClose);
+    resize(560, 400);
+
+    auto* mainLayout = new QVBoxLayout(this);
+
+    // Execution details group
+    auto* grp = new QGroupBox(tr("Execution Details"), this);
+    auto* form = new QFormLayout(grp);
+
+    form->addRow(tr("Job Name:"),
+        readOnlyField(QString::fromStdString(inst.job_name), grp));
+    form->addRow(tr("Status:"),
+        readOnlyField(QString::fromStdString(inst.status), grp));
+    form->addRow(tr("Action Type:"),
+        readOnlyField(QString::fromStdString(inst.action_type), grp));
+    form->addRow(tr("Triggered At:"),
+        readOnlyField(QString::fromStdString(inst.triggered_at), grp));
+    form->addRow(tr("Started At:"),
+        readOnlyField(QString::fromStdString(inst.started_at), grp));
+    form->addRow(tr("Completed At:"),
+        readOnlyField(inst.completed_at
+            ? QString::fromStdString(*inst.completed_at) : tr("—"), grp));
+    form->addRow(tr("Duration:"),
+        readOnlyField(inst.duration_ms
+            ? tr("%1 ms").arg(*inst.duration_ms) : tr("—"), grp));
+    form->addRow(tr("Job Definition ID:"),
+        readOnlyField(QString::fromStdString(inst.job_definition_id), grp));
+
+    mainLayout->addWidget(grp);
+
+    if (!inst.error_message.empty()) {
+        auto* errGrp = new QGroupBox(tr("Error"), this);
+        auto* errLayout = new QVBoxLayout(errGrp);
+        auto* errEdit = new QPlainTextEdit(
+            QString::fromStdString(inst.error_message), errGrp);
+        errEdit->setReadOnly(true);
+        errEdit->setMaximumHeight(100);
+        errLayout->addWidget(errEdit);
+        mainLayout->addWidget(errGrp);
+    }
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Close, this);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    mainLayout->addWidget(buttons);
+}
+
+}

--- a/projects/ores.qt.compute/src/JobInstanceMdiWindow.cpp
+++ b/projects/ores.qt.compute/src/JobInstanceMdiWindow.cpp
@@ -1,0 +1,129 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/JobInstanceMdiWindow.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+JobInstanceMdiWindow::JobInstanceMdiWindow(
+    ClientManager* clientManager,
+    QWidget* parent)
+    : EntityListMdiWindow(parent),
+      clientManager_(clientManager),
+      toolbar_(nullptr),
+      tableView_(nullptr),
+      model_(nullptr),
+      proxyModel_(nullptr),
+      reloadAction_(nullptr) {
+
+    setupUi();
+    setupConnections();
+    reload();
+}
+
+void JobInstanceMdiWindow::setupUi() {
+    auto* layout = new QVBoxLayout(this);
+    setupToolbar();
+    layout->addWidget(toolbar_);
+    layout->addWidget(loadingBar());
+    setupTable();
+    layout->addWidget(tableView_);
+}
+
+void JobInstanceMdiWindow::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    reloadAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowClockwise, IconUtils::DefaultIconColor),
+        tr("Reload"));
+    connect(reloadAction_, &QAction::triggered,
+            this, &EntityListMdiWindow::reload);
+
+    initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
+}
+
+void JobInstanceMdiWindow::setupTable() {
+    model_ = new ClientJobInstanceModel(clientManager_, this);
+    proxyModel_ = new QSortFilterProxyModel(this);
+    proxyModel_->setSourceModel(model_);
+    proxyModel_->setSortCaseSensitivity(Qt::CaseInsensitive);
+
+    tableView_ = new QTableView(this);
+    tableView_->setModel(proxyModel_);
+    tableView_->setSelectionBehavior(QAbstractItemView::SelectRows);
+    tableView_->setSelectionMode(QAbstractItemView::SingleSelection);
+    tableView_->setSortingEnabled(true);
+    tableView_->setAlternatingRowColors(true);
+    tableView_->verticalHeader()->setVisible(false);
+
+    initializeTableSettings(tableView_, model_,
+        "JobInstanceListWindow",
+        {ClientJobInstanceModel::ErrorMessage},
+        {960, 420}, 1);
+}
+
+void JobInstanceMdiWindow::setupConnections() {
+    connect(model_, &ClientJobInstanceModel::dataLoaded,
+            this, &JobInstanceMdiWindow::onDataLoaded);
+    connect(model_, &ClientJobInstanceModel::loadError,
+            this, &JobInstanceMdiWindow::onLoadError);
+    connectModel(model_);
+
+    connect(tableView_, &QTableView::doubleClicked,
+            this, &JobInstanceMdiWindow::onDoubleClicked);
+}
+
+void JobInstanceMdiWindow::doReload() {
+    BOOST_LOG_SEV(lg(), debug) << "Reloading job instances";
+    emit statusChanged(tr("Loading job instances..."));
+    model_->refresh();
+}
+
+void JobInstanceMdiWindow::onDataLoaded() {
+    const auto loaded = model_->rowCount();
+    emit statusChanged(tr("Loaded %1 job instances").arg(loaded));
+}
+
+void JobInstanceMdiWindow::onLoadError(const QString& error_message,
+                                        const QString& details) {
+    BOOST_LOG_SEV(lg(), error) << "Load error: " << error_message.toStdString();
+    emit errorOccurred(error_message);
+    MessageBoxHelper::critical(this, tr("Load Error"), error_message, details);
+}
+
+void JobInstanceMdiWindow::onDoubleClicked(const QModelIndex& index) {
+    if (!index.isValid()) return;
+
+    const auto sourceIndex = proxyModel_->mapToSource(index);
+    if (const auto* inst = model_->getInstance(sourceIndex.row()))
+        emit showInstanceDetails(*inst);
+}
+
+}

--- a/projects/ores.qt.compute/src/JobInstanceMdiWindow.cpp
+++ b/projects/ores.qt.compute/src/JobInstanceMdiWindow.cpp
@@ -19,6 +19,7 @@
  */
 #include "ores.qt/JobInstanceMdiWindow.hpp"
 
+#include <QLabel>
 #include <QVBoxLayout>
 #include <QHeaderView>
 #include "ores.qt/IconUtils.hpp"
@@ -37,7 +38,14 @@ JobInstanceMdiWindow::JobInstanceMdiWindow(
       tableView_(nullptr),
       model_(nullptr),
       proxyModel_(nullptr),
-      reloadAction_(nullptr) {
+      reloadAction_(nullptr),
+      autoRefreshAction_(nullptr),
+      intervalSpin_(nullptr),
+      autoRefreshTimer_(new QTimer(this)) {
+
+    autoRefreshTimer_->setInterval(15000); // default 15 s
+    connect(autoRefreshTimer_, &QTimer::timeout,
+            this, &EntityListMdiWindow::reload);
 
     setupUi();
     setupConnections();
@@ -67,6 +75,27 @@ void JobInstanceMdiWindow::setupToolbar() {
             this, &EntityListMdiWindow::reload);
 
     initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
+
+    toolbar_->addSeparator();
+
+    autoRefreshAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(Icon::Clock, IconUtils::DefaultIconColor),
+        tr("Auto Refresh"));
+    autoRefreshAction_->setCheckable(true);
+    autoRefreshAction_->setChecked(false);
+    connect(autoRefreshAction_, &QAction::toggled,
+            this, &JobInstanceMdiWindow::onAutoRefreshToggled);
+
+    toolbar_->addWidget(new QLabel(tr(" Every "), this));
+
+    intervalSpin_ = new QSpinBox(this);
+    intervalSpin_->setRange(5, 3600);
+    intervalSpin_->setValue(15);
+    intervalSpin_->setSuffix(tr(" s"));
+    intervalSpin_->setToolTip(tr("Auto-refresh interval in seconds"));
+    connect(intervalSpin_, &QSpinBox::valueChanged,
+            this, &JobInstanceMdiWindow::onAutoRefreshIntervalChanged);
+    toolbar_->addWidget(intervalSpin_);
 }
 
 void JobInstanceMdiWindow::setupTable() {
@@ -124,6 +153,17 @@ void JobInstanceMdiWindow::onDoubleClicked(const QModelIndex& index) {
     const auto sourceIndex = proxyModel_->mapToSource(index);
     if (const auto* inst = model_->getInstance(sourceIndex.row()))
         emit showInstanceDetails(*inst);
+}
+
+void JobInstanceMdiWindow::onAutoRefreshToggled(bool enabled) {
+    if (enabled)
+        autoRefreshTimer_->start();
+    else
+        autoRefreshTimer_->stop();
+}
+
+void JobInstanceMdiWindow::onAutoRefreshIntervalChanged(int seconds) {
+    autoRefreshTimer_->setInterval(seconds * 1000);
 }
 
 }

--- a/projects/ores.qt.compute/src/SchedulerMonitorController.cpp
+++ b/projects/ores.qt.compute/src/SchedulerMonitorController.cpp
@@ -1,0 +1,83 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/SchedulerMonitorController.hpp"
+
+#include <QPointer>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/SchedulerMonitorMdiWindow.hpp"
+#include "ores.qt/DetachableMdiSubWindow.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+SchedulerMonitorController::SchedulerMonitorController(
+    QMainWindow* mainWindow,
+    QMdiArea* mdiArea,
+    ClientManager* clientManager,
+    QObject* parent)
+    : QObject(parent),
+      mainWindow_(mainWindow),
+      mdiArea_(mdiArea),
+      clientManager_(clientManager) {}
+
+void SchedulerMonitorController::showWindow() {
+    // Singleton: if the window already exists, bring it to front.
+    if (mdiSubWindow_) {
+        mdiArea_->setActiveSubWindow(mdiSubWindow_);
+        mdiSubWindow_->showNormal();
+        return;
+    }
+
+    window_ = new SchedulerMonitorMdiWindow(clientManager_);
+
+    connect(window_, &SchedulerMonitorMdiWindow::statusChanged,
+            this, &SchedulerMonitorController::statusMessage);
+    connect(window_, &SchedulerMonitorMdiWindow::errorOccurred,
+            this, &SchedulerMonitorController::errorMessage);
+
+    mdiSubWindow_ = new DetachableMdiSubWindow(mainWindow_);
+    mdiSubWindow_->setWidget(window_);
+    mdiSubWindow_->setWindowTitle(tr("Scheduler Monitor"));
+    mdiSubWindow_->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Clock, IconUtils::DefaultIconColor));
+    mdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
+    mdiSubWindow_->resize(window_->sizeHint());
+
+    mdiArea_->addSubWindow(mdiSubWindow_);
+    mdiSubWindow_->show();
+
+    connect(mdiSubWindow_, &QObject::destroyed,
+            this, [self = QPointer<SchedulerMonitorController>(this)]() {
+        if (!self) return;
+        self->window_ = nullptr;
+        self->mdiSubWindow_ = nullptr;
+    });
+}
+
+void SchedulerMonitorController::closeWindow() {
+    if (mdiSubWindow_) {
+        mdiSubWindow_->close();
+        mdiSubWindow_ = nullptr;
+        window_ = nullptr;
+    }
+}
+
+}

--- a/projects/ores.qt.compute/src/SchedulerMonitorController.cpp
+++ b/projects/ores.qt.compute/src/SchedulerMonitorController.cpp
@@ -36,7 +36,31 @@ SchedulerMonitorController::SchedulerMonitorController(
     : QObject(parent),
       mainWindow_(mainWindow),
       mdiArea_(mdiArea),
-      clientManager_(clientManager) {}
+      clientManager_(clientManager) {
+
+    connect(clientManager_, &ClientManager::notificationReceived,
+        this, [this](const QString& eventType, const QDateTime&,
+                     const QStringList&, const QString&) {
+            if (eventType == QString::fromUtf8(event_subject.data(),
+                    static_cast<int>(event_subject.size())) && window_) {
+                window_->refresh();
+            }
+        });
+
+    connect(clientManager_, &ClientManager::loggedIn, this, [this]() {
+        clientManager_->subscribeToEvent(std::string(event_subject));
+    });
+    connect(clientManager_, &ClientManager::reconnected, this, [this]() {
+        clientManager_->subscribeToEvent(std::string(event_subject));
+    });
+    if (clientManager_->isConnected())
+        clientManager_->subscribeToEvent(std::string(event_subject));
+}
+
+SchedulerMonitorController::~SchedulerMonitorController() {
+    if (clientManager_)
+        clientManager_->unsubscribeFromEvent(std::string(event_subject));
+}
 
 void SchedulerMonitorController::showWindow() {
     // Singleton: if the window already exists, bring it to front.

--- a/projects/ores.qt.compute/src/SchedulerMonitorMdiWindow.cpp
+++ b/projects/ores.qt.compute/src/SchedulerMonitorMdiWindow.cpp
@@ -123,14 +123,21 @@ void SchedulerMonitorMdiWindow::refresh() {
 
     QPointer<SchedulerMonitorMdiWindow> self = this;
 
-    using FetchResult = scheduler::messaging::get_scheduler_status_response;
+    struct FetchResult {
+        scheduler::messaging::get_scheduler_status_response response;
+        QString error;
+    };
 
     auto future = QtConcurrent::run([self]() -> FetchResult {
-        if (!self || !self->clientManager_) return {};
+        if (!self || !self->clientManager_)
+            return {.error = tr("Widget destroyed during fetch")};
         scheduler::messaging::get_scheduler_status_request req;
         auto result = self->clientManager_->process_authenticated_request(std::move(req));
-        if (!result) return {};
-        return std::move(*result);
+        if (!result)
+            return {.error = QString::fromStdString(result.error())};
+        if (!result->success)
+            return {.error = QString::fromStdString(result->message)};
+        return {.response = std::move(*result)};
     });
 
     auto* watcher = new QFutureWatcher<FetchResult>(this);
@@ -139,11 +146,18 @@ void SchedulerMonitorMdiWindow::refresh() {
         watcher->deleteLater();
         if (!self) return;
 
-        const auto resp = watcher->result();
-        self->applyStatus(resp.jobs);
+        const auto res = watcher->result();
+        if (!res.error.isEmpty()) {
+            BOOST_LOG_SEV(lg(), error) << "Scheduler status fetch failed: "
+                                       << res.error.toStdString();
+            emit self->errorOccurred(res.error);
+            return;
+        }
 
-        const int active = resp.total_active;
-        const int running = resp.total_running;
+        self->applyStatus(res.response.jobs);
+
+        const int active = res.response.total_active;
+        const int running = res.response.total_running;
         emit self->statusChanged(
             tr("Scheduler: %1 active job(s), %2 currently running")
                 .arg(active).arg(running));

--- a/projects/ores.qt.compute/src/SchedulerMonitorMdiWindow.cpp
+++ b/projects/ores.qt.compute/src/SchedulerMonitorMdiWindow.cpp
@@ -44,7 +44,7 @@ SchedulerMonitorMdiWindow::SchedulerMonitorMdiWindow(
 
     setupUi();
 
-    autoRefreshTimer_->setInterval(30000); // default 30 s
+    autoRefreshTimer_->setInterval(15000); // default 15 s
     connect(autoRefreshTimer_, &QTimer::timeout, this, &SchedulerMonitorMdiWindow::refresh);
 
     refresh();
@@ -78,7 +78,7 @@ void SchedulerMonitorMdiWindow::setupUi() {
 
     intervalSpin_ = new QSpinBox(this);
     intervalSpin_->setRange(5, 3600);
-    intervalSpin_->setValue(30);
+    intervalSpin_->setValue(15);
     intervalSpin_->setSuffix(tr(" s"));
     intervalSpin_->setToolTip(tr("Auto-refresh interval in seconds"));
     connect(intervalSpin_, &QSpinBox::valueChanged,

--- a/projects/ores.qt.compute/src/SchedulerMonitorMdiWindow.cpp
+++ b/projects/ores.qt.compute/src/SchedulerMonitorMdiWindow.cpp
@@ -1,0 +1,204 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/SchedulerMonitorMdiWindow.hpp"
+
+#include <QHeaderView>
+#include <QLabel>
+#include <QPointer>
+#include <QtConcurrent>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+SchedulerMonitorMdiWindow::SchedulerMonitorMdiWindow(
+    ClientManager* clientManager,
+    QWidget* parent)
+    : QWidget(parent),
+      clientManager_(clientManager),
+      toolbar_(nullptr),
+      refreshAction_(nullptr),
+      autoRefreshAction_(nullptr),
+      intervalSpin_(nullptr),
+      table_(nullptr),
+      autoRefreshTimer_(new QTimer(this)) {
+
+    setupUi();
+
+    autoRefreshTimer_->setInterval(30000); // default 30 s
+    connect(autoRefreshTimer_, &QTimer::timeout, this, &SchedulerMonitorMdiWindow::refresh);
+
+    refresh();
+}
+
+void SchedulerMonitorMdiWindow::setupUi() {
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    refreshAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(Icon::ArrowClockwise, IconUtils::DefaultIconColor),
+        tr("Refresh"));
+    connect(refreshAction_, &QAction::triggered, this, &SchedulerMonitorMdiWindow::refresh);
+
+    toolbar_->addSeparator();
+
+    autoRefreshAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(Icon::Clock, IconUtils::DefaultIconColor),
+        tr("Auto Refresh"));
+    autoRefreshAction_->setCheckable(true);
+    autoRefreshAction_->setChecked(false);
+    connect(autoRefreshAction_, &QAction::toggled,
+            this, &SchedulerMonitorMdiWindow::onAutoRefreshToggled);
+
+    toolbar_->addWidget(new QLabel(tr(" Every "), this));
+
+    intervalSpin_ = new QSpinBox(this);
+    intervalSpin_->setRange(5, 3600);
+    intervalSpin_->setValue(30);
+    intervalSpin_->setSuffix(tr(" s"));
+    intervalSpin_->setToolTip(tr("Auto-refresh interval in seconds"));
+    connect(intervalSpin_, &QSpinBox::valueChanged,
+            this, &SchedulerMonitorMdiWindow::onAutoRefreshIntervalChanged);
+    toolbar_->addWidget(intervalSpin_);
+
+    layout->addWidget(toolbar_);
+
+    table_ = new QTableWidget(0, ColCount, this);
+    table_->setHorizontalHeaderLabels({
+        tr("Job Name"), tr("Schedule"), tr("Active"),
+        tr("Last Run"), tr("Last Status"), tr("Next Fire"), tr("Running")});
+    table_->setSelectionBehavior(QAbstractItemView::SelectRows);
+    table_->setSelectionMode(QAbstractItemView::SingleSelection);
+    table_->setAlternatingRowColors(true);
+    table_->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    table_->verticalHeader()->setVisible(false);
+    table_->horizontalHeader()->setStretchLastSection(true);
+    table_->setSortingEnabled(true);
+
+    layout->addWidget(table_);
+}
+
+void SchedulerMonitorMdiWindow::onAutoRefreshToggled(bool enabled) {
+    if (enabled)
+        autoRefreshTimer_->start();
+    else
+        autoRefreshTimer_->stop();
+}
+
+void SchedulerMonitorMdiWindow::onAutoRefreshIntervalChanged(int seconds) {
+    autoRefreshTimer_->setInterval(seconds * 1000);
+}
+
+void SchedulerMonitorMdiWindow::refresh() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        emit errorOccurred(tr("Not connected to server"));
+        return;
+    }
+
+    emit statusChanged(tr("Loading scheduler status..."));
+
+    QPointer<SchedulerMonitorMdiWindow> self = this;
+
+    using FetchResult = scheduler::messaging::get_scheduler_status_response;
+
+    auto future = QtConcurrent::run([self]() -> FetchResult {
+        if (!self || !self->clientManager_) return {};
+        scheduler::messaging::get_scheduler_status_request req;
+        auto result = self->clientManager_->process_authenticated_request(std::move(req));
+        if (!result) return {};
+        return std::move(*result);
+    });
+
+    auto* watcher = new QFutureWatcher<FetchResult>(this);
+    connect(watcher, &QFutureWatcher<FetchResult>::finished,
+            this, [self, watcher]() {
+        watcher->deleteLater();
+        if (!self) return;
+
+        const auto resp = watcher->result();
+        self->applyStatus(resp.jobs);
+
+        const int active = resp.total_active;
+        const int running = resp.total_running;
+        emit self->statusChanged(
+            tr("Scheduler: %1 active job(s), %2 currently running")
+                .arg(active).arg(running));
+    });
+
+    watcher->setFuture(future);
+}
+
+void SchedulerMonitorMdiWindow::applyStatus(
+    const std::vector<scheduler::messaging::job_schedule_status>& jobs) {
+
+    table_->setSortingEnabled(false);
+    table_->setRowCount(static_cast<int>(jobs.size()));
+
+    auto cell = [this](int row, int col, const QString& text) {
+        auto* item = table_->item(row, col);
+        if (!item) {
+            item = new QTableWidgetItem(text);
+            item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+            table_->setItem(row, col, item);
+        } else {
+            item->setText(text);
+        }
+    };
+
+    for (int r = 0; r < static_cast<int>(jobs.size()); ++r) {
+        const auto& j = jobs[static_cast<std::size_t>(r)];
+
+        cell(r, ColJobName,    QString::fromStdString(j.job_name));
+        cell(r, ColSchedule,   QString::fromStdString(j.schedule_expression));
+        cell(r, ColActive,     j.is_active ? tr("Active") : tr("Paused"));
+        cell(r, ColLastRun,    j.last_run_at
+            ? QString::fromStdString(*j.last_run_at) : tr("Never"));
+        cell(r, ColLastStatus, j.last_run_status
+            ? QString::fromStdString(*j.last_run_status) : tr("—"));
+        cell(r, ColNextFire,   (j.is_active && j.next_fire_at)
+            ? QString::fromStdString(*j.next_fire_at) : tr("—"));
+        cell(r, ColRunning,    j.running_count > 0
+            ? QString::number(j.running_count) : tr("—"));
+
+        // Colour last-status cell
+        if (auto* statusItem = table_->item(r, ColLastStatus)) {
+            if (j.last_run_status) {
+                if (*j.last_run_status == "failed")
+                    statusItem->setForeground(Qt::red);
+                else if (*j.last_run_status == "succeeded")
+                    statusItem->setForeground(Qt::darkGreen);
+                else
+                    statusItem->setForeground(Qt::darkYellow);
+            }
+        }
+    }
+
+    table_->setSortingEnabled(true);
+    table_->resizeColumnsToContents();
+}
+
+}

--- a/projects/ores.qt.scheduler/include/ores.qt/SchedulerPlugin.hpp
+++ b/projects/ores.qt.scheduler/include/ores.qt/SchedulerPlugin.hpp
@@ -26,12 +26,16 @@
 namespace ores::qt {
 
 class JobDefinitionController;
+class JobInstanceController;
+class SchedulerMonitorController;
 
 /**
- * @brief Qt plugin providing the Scheduler top-level menu.
+ * @brief Qt plugin providing the top-level &Scheduler menu.
  *
- * Manages job definitions and the Scheduler menu bar entry.
- * Loaded as a shared library by QPluginLoader at application startup.
+ * Owns all three scheduler UI controllers:
+ *   - JobDefinitionController  — &Job Definitions
+ *   - JobInstanceController    — &Job Instances
+ *   - SchedulerMonitorController — &Monitor
  */
 class SchedulerPlugin : public PluginBase {
     Q_OBJECT
@@ -52,7 +56,9 @@ public:
 private:
     plugin_context ctx_;
 
-    std::unique_ptr<JobDefinitionController> jobDefinitionController_;
+    std::unique_ptr<JobDefinitionController>     jobDefinitionController_;
+    std::unique_ptr<JobInstanceController>       jobInstanceController_;
+    std::unique_ptr<SchedulerMonitorController>  schedulerMonitorController_;
 };
 
 }

--- a/projects/ores.qt.scheduler/src/SchedulerPlugin.cpp
+++ b/projects/ores.qt.scheduler/src/SchedulerPlugin.cpp
@@ -24,6 +24,8 @@
 #include "ores.qt/IconUtils.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/JobDefinitionController.hpp"
+#include "ores.qt/JobInstanceController.hpp"
+#include "ores.qt/SchedulerMonitorController.hpp"
 
 namespace ores::qt {
 
@@ -58,6 +60,17 @@ void SchedulerPlugin::on_login(const plugin_context& ctx) {
         ctx_.main_window, ctx_.mdi_area, ctx_.client_manager, ctx_.username,
         ctx_.change_reason_cache, this);
     connectControllerSignals(jobDefinitionController_.get());
+
+    jobInstanceController_ = std::make_unique<JobInstanceController>(
+        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager, this);
+    connectControllerSignals(jobInstanceController_.get());
+
+    schedulerMonitorController_ = std::make_unique<SchedulerMonitorController>(
+        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager, this);
+    connect(schedulerMonitorController_.get(), &SchedulerMonitorController::statusMessage,
+            this, &SchedulerPlugin::statusMessage);
+    connect(schedulerMonitorController_.get(), &SchedulerMonitorController::errorMessage,
+            this, &SchedulerPlugin::statusMessage);
 }
 
 QList<QMenu*> SchedulerPlugin::create_menus() {
@@ -70,15 +83,19 @@ QList<QMenu*> SchedulerPlugin::create_menus() {
         if (jobDefinitionController_) jobDefinitionController_->showListWindow();
     });
 
-    auto* actJobInstances = menuScheduler->addAction(tr("&Job Instances"));
-    actJobInstances->setEnabled(false);
-    actJobInstances->setToolTip(tr("Not yet implemented"));
+    auto* actJobInstances = menuScheduler->addAction(
+        ico(Icon::Clock), tr("&Job Instances"));
+    connect(actJobInstances, &QAction::triggered, this, [this]() {
+        if (jobInstanceController_) jobInstanceController_->showListWindow();
+    });
 
     menuScheduler->addSeparator();
 
-    auto* actMonitor = menuScheduler->addAction(tr("&Monitor"));
-    actMonitor->setEnabled(false);
-    actMonitor->setToolTip(tr("Not yet implemented"));
+    auto* actMonitor = menuScheduler->addAction(
+        ico(Icon::Clock), tr("&Monitor"));
+    connect(actMonitor, &QAction::triggered, this, [this]() {
+        if (schedulerMonitorController_) schedulerMonitorController_->showWindow();
+    });
 
     BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
     return {menuScheduler};
@@ -86,6 +103,8 @@ QList<QMenu*> SchedulerPlugin::create_menus() {
 
 void SchedulerPlugin::on_logout() {
     BOOST_LOG_SEV(lg(), debug) << "Logout event received.";
+    schedulerMonitorController_.reset();
+    jobInstanceController_.reset();
     jobDefinitionController_.reset();
     ctx_ = {};
 }

--- a/projects/ores.scheduler.api/include/ores.scheduler.api/messaging/scheduler_protocol.hpp
+++ b/projects/ores.scheduler.api/include/ores.scheduler.api/messaging/scheduler_protocol.hpp
@@ -20,6 +20,8 @@
 #ifndef ORES_SCHEDULER_MESSAGING_SCHEDULER_PROTOCOL_HPP
 #define ORES_SCHEDULER_MESSAGING_SCHEDULER_PROTOCOL_HPP
 
+#include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -97,6 +99,73 @@ struct get_job_history_response {
     bool success = false;
     std::string message;
     std::vector<ores::scheduler::domain::job_instance> instances;
+};
+
+// ---------------------------------------------------------------------------
+// Job instances — global execution history view
+// ---------------------------------------------------------------------------
+
+struct get_job_instances_request {
+    using response_type = struct get_job_instances_response;
+    static constexpr std::string_view nats_subject =
+        "scheduler.v1.job-instances.list";
+    int offset = 0;
+    int limit = 100;
+};
+
+/**
+ * @brief A job_instance enriched with the parent job's display name.
+ *
+ * Returned by get_job_instances so the Qt layer can render the job name
+ * without a separate look-up.
+ */
+struct job_instance_summary {
+    std::int64_t id = 0;
+    std::string job_definition_id;
+    std::string job_name;
+    std::string action_type;
+    std::string status;          ///< "starting" | "succeeded" | "failed"
+    std::string triggered_at;    ///< ISO-8601 UTC
+    std::string started_at;      ///< ISO-8601 UTC
+    std::optional<std::string> completed_at;
+    std::optional<std::int64_t> duration_ms;
+    std::string error_message;
+};
+
+struct get_job_instances_response {
+    std::vector<job_instance_summary> instances;
+    int total_available_count = 0;
+};
+
+// ---------------------------------------------------------------------------
+// Scheduler status — live overview for the Monitor window
+// ---------------------------------------------------------------------------
+
+struct get_scheduler_status_request {
+    using response_type = struct get_scheduler_status_response;
+    static constexpr std::string_view nats_subject =
+        "scheduler.v1.status";
+};
+
+/**
+ * @brief Per-job status snapshot used by the Scheduler Monitor window.
+ */
+struct job_schedule_status {
+    std::string job_definition_id;
+    std::string job_name;
+    std::string description;
+    std::string schedule_expression;
+    bool is_active = false;
+    std::optional<std::string> last_run_at;     ///< ISO-8601 UTC, if ever run
+    std::optional<std::string> last_run_status; ///< "succeeded" | "failed" | "starting"
+    std::optional<std::string> next_fire_at;    ///< ISO-8601 UTC, null if inactive
+    int running_count = 0;                      ///< currently running instances
+};
+
+struct get_scheduler_status_response {
+    std::vector<job_schedule_status> jobs;
+    int total_running = 0;
+    int total_active = 0;
 };
 
 }

--- a/projects/ores.scheduler.api/include/ores.scheduler.api/messaging/scheduler_protocol.hpp
+++ b/projects/ores.scheduler.api/include/ores.scheduler.api/messaging/scheduler_protocol.hpp
@@ -133,6 +133,8 @@ struct job_instance_summary {
 };
 
 struct get_job_instances_response {
+    bool success = true;
+    std::string message;
     std::vector<job_instance_summary> instances;
     int total_available_count = 0;
 };
@@ -163,6 +165,8 @@ struct job_schedule_status {
 };
 
 struct get_scheduler_status_response {
+    bool success = true;
+    std::string message;
     std::vector<job_schedule_status> jobs;
     int total_running = 0;
     int total_active = 0;

--- a/projects/ores.scheduler.core/include/ores.scheduler.core/messaging/job_instance_handler.hpp
+++ b/projects/ores.scheduler.core/include/ores.scheduler.core/messaging/job_instance_handler.hpp
@@ -69,53 +69,64 @@ public:
         }
         const auto& ctx = *ctx_expected;
 
+        auto req = decode<get_job_instances_request>(msg);
+        if (!req) {
+            BOOST_LOG_SEV(job_instance_handler_lg(), warn)
+                << "Failed to decode get_job_instances_request";
+            reply(nats_, msg, get_job_instances_response{
+                .success = false, .message = "Failed to decode request"});
+            return;
+        }
+
         get_job_instances_response resp;
         try {
-            if (auto req = decode<get_job_instances_request>(msg)) {
-                // Load all job definitions to build a name look-up map.
-                repository::job_definition_repository def_repo;
-                const auto defs = def_repo.read_latest(ctx);
-                std::unordered_map<std::string, std::string> id_to_name;
-                for (const auto& d : defs)
-                    id_to_name[boost::uuids::to_string(d.id)] = d.job_name;
+            // Load all job definitions to build a name look-up map.
+            repository::job_definition_repository def_repo;
+            const auto defs = def_repo.read_latest(ctx);
+            std::unordered_map<std::string, std::string> id_to_name;
+            for (const auto& d : defs)
+                id_to_name[boost::uuids::to_string(d.id)] = d.job_name;
 
-                // Load recent instances across all jobs.
-                repository::job_instance_repository inst_repo;
-                const auto limit = static_cast<std::size_t>(
-                    req->limit > 0 ? req->limit : 100);
-                const auto instances = inst_repo.read_all_latest(ctx, limit);
+            // Load recent instances across all jobs.
+            repository::job_instance_repository inst_repo;
+            const auto limit = static_cast<std::size_t>(
+                req->limit > 0 ? req->limit : 100);
+            const auto instances = inst_repo.read_all_latest(ctx, limit);
 
-                resp.instances.reserve(instances.size());
-                for (const auto& inst : instances) {
-                    job_instance_summary s;
-                    s.id = inst.id;
-                    s.job_definition_id = boost::uuids::to_string(inst.job_definition_id);
-                    const auto it = id_to_name.find(s.job_definition_id);
-                    s.job_name = (it != id_to_name.end()) ? it->second : s.job_definition_id;
-                    s.action_type = inst.action_type;
-                    s.status = [&]() -> std::string {
-                        switch (inst.status) {
-                        case domain::job_status::succeeded: return "succeeded";
-                        case domain::job_status::failed:    return "failed";
-                        default:                            return "starting";
-                        }
-                    }();
-                    s.triggered_at =
-                        ores::platform::time::datetime::to_iso8601_utc(inst.triggered_at);
-                    s.started_at =
-                        ores::platform::time::datetime::to_iso8601_utc(inst.started_at);
-                    if (inst.completed_at)
-                        s.completed_at =
-                            ores::platform::time::datetime::to_iso8601_utc(*inst.completed_at);
-                    s.duration_ms = inst.duration_ms;
-                    s.error_message = inst.error_message;
-                    resp.instances.push_back(std::move(s));
-                }
-                resp.total_available_count = static_cast<int>(resp.instances.size());
+            resp.instances.reserve(instances.size());
+            for (const auto& inst : instances) {
+                job_instance_summary s;
+                s.id = inst.id;
+                s.job_definition_id = boost::uuids::to_string(inst.job_definition_id);
+                const auto it = id_to_name.find(s.job_definition_id);
+                s.job_name = (it != id_to_name.end()) ? it->second : s.job_definition_id;
+                s.action_type = inst.action_type;
+                s.status = [&]() -> std::string {
+                    switch (inst.status) {
+                    case domain::job_status::succeeded: return "succeeded";
+                    case domain::job_status::failed:    return "failed";
+                    default:                            return "starting";
+                    }
+                }();
+                s.triggered_at =
+                    ores::platform::time::datetime::to_iso8601_utc(inst.triggered_at);
+                s.started_at =
+                    ores::platform::time::datetime::to_iso8601_utc(inst.started_at);
+                if (inst.completed_at)
+                    s.completed_at =
+                        ores::platform::time::datetime::to_iso8601_utc(*inst.completed_at);
+                s.duration_ms = inst.duration_ms;
+                s.error_message = inst.error_message;
+                resp.instances.push_back(std::move(s));
             }
+            resp.total_available_count = static_cast<int>(resp.instances.size());
+            resp.success = true;
         } catch (const std::exception& e) {
             BOOST_LOG_SEV(job_instance_handler_lg(), error)
                 << "Error listing job instances: " << e.what();
+            reply(nats_, msg, get_job_instances_response{
+                .success = false, .message = e.what()});
+            return;
         }
 
         reply(nats_, msg, resp);

--- a/projects/ores.scheduler.core/include/ores.scheduler.core/messaging/job_instance_handler.hpp
+++ b/projects/ores.scheduler.core/include/ores.scheduler.core/messaging/job_instance_handler.hpp
@@ -1,0 +1,134 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SCHEDULER_MESSAGING_JOB_INSTANCE_HANDLER_HPP
+#define ORES_SCHEDULER_MESSAGING_JOB_INSTANCE_HANDLER_HPP
+
+#include <optional>
+#include <rfl/json.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.platform/time/datetime.hpp"
+#include "ores.scheduler.api/messaging/scheduler_protocol.hpp"
+#include "ores.scheduler.core/repository/job_definition_repository.hpp"
+#include "ores.scheduler.core/repository/job_instance_repository.hpp"
+
+namespace ores::scheduler::messaging {
+
+namespace {
+inline auto& job_instance_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.scheduler.messaging.job_instance_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using namespace ores::logging;
+
+class job_instance_handler {
+public:
+    job_instance_handler(ores::nats::service::client& nats,
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
+
+    void list(ores::nats::message msg) {
+        BOOST_LOG_SEV(job_instance_handler_lg(), debug)
+            << "Handling " << msg.subject;
+
+        auto ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!ctx_expected) {
+            error_reply(nats_, msg, ctx_expected.error());
+            return;
+        }
+        const auto& ctx = *ctx_expected;
+
+        get_job_instances_response resp;
+        try {
+            if (auto req = decode<get_job_instances_request>(msg)) {
+                // Load all job definitions to build a name look-up map.
+                repository::job_definition_repository def_repo;
+                const auto defs = def_repo.read_latest(ctx);
+                std::unordered_map<std::string, std::string> id_to_name;
+                for (const auto& d : defs)
+                    id_to_name[boost::uuids::to_string(d.id)] = d.job_name;
+
+                // Load recent instances across all jobs.
+                repository::job_instance_repository inst_repo;
+                const auto limit = static_cast<std::size_t>(
+                    req->limit > 0 ? req->limit : 100);
+                const auto instances = inst_repo.read_all_latest(ctx, limit);
+
+                resp.instances.reserve(instances.size());
+                for (const auto& inst : instances) {
+                    job_instance_summary s;
+                    s.id = inst.id;
+                    s.job_definition_id = boost::uuids::to_string(inst.job_definition_id);
+                    const auto it = id_to_name.find(s.job_definition_id);
+                    s.job_name = (it != id_to_name.end()) ? it->second : s.job_definition_id;
+                    s.action_type = inst.action_type;
+                    s.status = [&]() -> std::string {
+                        switch (inst.status) {
+                        case domain::job_status::succeeded: return "succeeded";
+                        case domain::job_status::failed:    return "failed";
+                        default:                            return "starting";
+                        }
+                    }();
+                    s.triggered_at =
+                        ores::platform::time::datetime::to_iso8601_utc(inst.triggered_at);
+                    s.started_at =
+                        ores::platform::time::datetime::to_iso8601_utc(inst.started_at);
+                    if (inst.completed_at)
+                        s.completed_at =
+                            ores::platform::time::datetime::to_iso8601_utc(*inst.completed_at);
+                    s.duration_ms = inst.duration_ms;
+                    s.error_message = inst.error_message;
+                    resp.instances.push_back(std::move(s));
+                }
+                resp.total_available_count = static_cast<int>(resp.instances.size());
+            }
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(job_instance_handler_lg(), error)
+                << "Error listing job instances: " << e.what();
+        }
+
+        reply(nats_, msg, resp);
+        BOOST_LOG_SEV(job_instance_handler_lg(), debug)
+            << "Completed " << msg.subject;
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::scheduler::messaging
+
+#endif

--- a/projects/ores.scheduler.core/include/ores.scheduler.core/messaging/scheduler_status_handler.hpp
+++ b/projects/ores.scheduler.core/include/ores.scheduler.core/messaging/scheduler_status_handler.hpp
@@ -69,6 +69,14 @@ public:
         }
         const auto& ctx = *ctx_expected;
 
+        if (!decode<get_scheduler_status_request>(msg)) {
+            BOOST_LOG_SEV(scheduler_status_handler_lg(), warn)
+                << "Failed to decode get_scheduler_status_request";
+            reply(nats_, msg, get_scheduler_status_response{
+                .success = false, .message = "Failed to decode request"});
+            return;
+        }
+
         get_scheduler_status_response resp;
         try {
             repository::job_definition_repository def_repo;
@@ -115,9 +123,13 @@ public:
 
                 resp.jobs.push_back(std::move(jss));
             }
+            resp.success = true;
         } catch (const std::exception& e) {
             BOOST_LOG_SEV(scheduler_status_handler_lg(), error)
                 << "Error computing scheduler status: " << e.what();
+            reply(nats_, msg, get_scheduler_status_response{
+                .success = false, .message = e.what()});
+            return;
         }
 
         reply(nats_, msg, resp);

--- a/projects/ores.scheduler.core/include/ores.scheduler.core/messaging/scheduler_status_handler.hpp
+++ b/projects/ores.scheduler.core/include/ores.scheduler.core/messaging/scheduler_status_handler.hpp
@@ -1,0 +1,136 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SCHEDULER_MESSAGING_SCHEDULER_STATUS_HANDLER_HPP
+#define ORES_SCHEDULER_MESSAGING_SCHEDULER_STATUS_HANDLER_HPP
+
+#include <optional>
+#include <rfl/json.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.platform/time/datetime.hpp"
+#include "ores.scheduler.api/messaging/scheduler_protocol.hpp"
+#include "ores.scheduler.core/repository/job_definition_repository.hpp"
+#include "ores.scheduler.core/repository/job_instance_repository.hpp"
+
+namespace ores::scheduler::messaging {
+
+namespace {
+inline auto& scheduler_status_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.scheduler.messaging.scheduler_status_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using namespace ores::logging;
+
+class scheduler_status_handler {
+public:
+    scheduler_status_handler(ores::nats::service::client& nats,
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
+
+    void status(ores::nats::message msg) {
+        BOOST_LOG_SEV(scheduler_status_handler_lg(), debug)
+            << "Handling " << msg.subject;
+
+        auto ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!ctx_expected) {
+            error_reply(nats_, msg, ctx_expected.error());
+            return;
+        }
+        const auto& ctx = *ctx_expected;
+
+        get_scheduler_status_response resp;
+        try {
+            repository::job_definition_repository def_repo;
+            const auto defs = def_repo.read_latest(ctx);
+
+            repository::job_instance_repository inst_repo;
+
+            for (const auto& def : defs) {
+                job_schedule_status jss;
+                jss.job_definition_id = boost::uuids::to_string(def.id);
+                jss.job_name = def.job_name;
+                jss.description = def.description;
+                jss.schedule_expression = def.schedule_expression.to_string();
+                jss.is_active = def.is_active;
+
+                // Last run info: most recent instance (limit=1).
+                const auto recent = inst_repo.read_latest(ctx, def.id, 1);
+                if (!recent.empty()) {
+                    const auto& last = recent.front();
+                    jss.last_run_at =
+                        ores::platform::time::datetime::to_iso8601_utc(last.triggered_at);
+                    switch (last.status) {
+                    case domain::job_status::succeeded:
+                        jss.last_run_status = "succeeded"; break;
+                    case domain::job_status::failed:
+                        jss.last_run_status = "failed"; break;
+                    default:
+                        jss.last_run_status = "starting";
+                        jss.running_count = 1;
+                        ++resp.total_running;
+                        break;
+                    }
+                }
+
+                // Next fire time from cron expression (only if active).
+                if (def.is_active) {
+                    try {
+                        const auto next = def.schedule_expression.next_occurrence();
+                        jss.next_fire_at =
+                            ores::platform::time::datetime::to_iso8601_utc(next);
+                    } catch (...) {}
+                    ++resp.total_active;
+                }
+
+                resp.jobs.push_back(std::move(jss));
+            }
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(scheduler_status_handler_lg(), error)
+                << "Error computing scheduler status: " << e.what();
+        }
+
+        reply(nats_, msg, resp);
+        BOOST_LOG_SEV(scheduler_status_handler_lg(), debug)
+            << "Completed " << msg.subject;
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::scheduler::messaging
+
+#endif

--- a/projects/ores.scheduler.core/include/ores.scheduler.core/repository/job_instance_entity.hpp
+++ b/projects/ores.scheduler.core/include/ores.scheduler.core/repository/job_instance_entity.hpp
@@ -1,0 +1,50 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SCHEDULER_REPOSITORY_JOB_INSTANCE_ENTITY_HPP
+#define ORES_SCHEDULER_REPOSITORY_JOB_INSTANCE_ENTITY_HPP
+
+#include <string>
+#include <optional>
+
+namespace ores::scheduler::repository {
+
+/**
+ * @brief Raw database row for a job instance.
+ *
+ * All fields are strings as returned by the SQL query. The mapper converts
+ * this to the domain::job_instance type with proper C++ types.
+ */
+struct job_instance_entity {
+    std::optional<std::string> id;
+    std::optional<std::string> tenant_id;
+    std::optional<std::string> party_id;
+    std::optional<std::string> job_definition_id;
+    std::optional<std::string> action_type;
+    std::optional<std::string> status;
+    std::optional<std::string> triggered_at;
+    std::optional<std::string> started_at;
+    std::optional<std::string> completed_at;
+    std::optional<std::string> duration_ms;
+    std::optional<std::string> error_message;
+};
+
+}
+
+#endif

--- a/projects/ores.scheduler.core/include/ores.scheduler.core/repository/job_instance_mapper.hpp
+++ b/projects/ores.scheduler.core/include/ores.scheduler.core/repository/job_instance_mapper.hpp
@@ -1,0 +1,39 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SCHEDULER_REPOSITORY_JOB_INSTANCE_MAPPER_HPP
+#define ORES_SCHEDULER_REPOSITORY_JOB_INSTANCE_MAPPER_HPP
+
+#include <vector>
+#include <optional>
+#include "ores.scheduler.api/domain/job_instance.hpp"
+#include "ores.scheduler.core/repository/job_instance_entity.hpp"
+
+namespace ores::scheduler::repository {
+
+class job_instance_mapper {
+public:
+    static domain::job_instance map(const job_instance_entity& e);
+    static std::vector<domain::job_instance>
+        map(const std::vector<job_instance_entity>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.scheduler.core/include/ores.scheduler.core/repository/job_instance_repository.hpp
+++ b/projects/ores.scheduler.core/include/ores.scheduler.core/repository/job_instance_repository.hpp
@@ -68,6 +68,11 @@ public:
         const boost::uuids::uuid& job_definition_id, std::size_t limit = 100);
 
     /**
+     * @brief Returns the most recent job instances across all job definitions, newest-first.
+     */
+    std::vector<domain::job_instance> read_all_latest(context ctx, std::size_t limit = 100);
+
+    /**
      * @brief Returns the triggered_at of the most recent run for a job definition, if any.
      */
     std::optional<std::chrono::system_clock::time_point> last_run_at(

--- a/projects/ores.scheduler.core/include/ores.scheduler.core/service/scheduler_loop.hpp
+++ b/projects/ores.scheduler.core/include/ores.scheduler.core/service/scheduler_loop.hpp
@@ -23,10 +23,12 @@
 #include <chrono>
 #include <map>
 #include <memory>
+#include <string_view>
 #include <vector>
 #include <boost/asio.hpp>
 #include <boost/uuid/uuid.hpp>
 #include "ores.database/domain/context.hpp"
+#include "ores.nats/service/client.hpp"
 #include "ores.scheduler.api/domain/job_definition.hpp"
 #include "ores.scheduler.core/service/action_handler.hpp"
 
@@ -44,7 +46,11 @@ namespace ores::scheduler::service {
  */
 class scheduler_loop final {
 public:
-    scheduler_loop(database::context system_ctx,
+    static constexpr std::string_view job_instance_events_subject =
+        "scheduler.v1.job-instance-events";
+
+    scheduler_loop(ores::nats::service::client& nats,
+        database::context system_ctx,
         std::vector<std::unique_ptr<action_handler>> handlers);
 
     /**
@@ -64,7 +70,10 @@ private:
     boost::asio::awaitable<void> tick(boost::asio::io_context& ioc);
     boost::asio::awaitable<void> fire_job(const domain::job_definition& job);
     void load_jobs();
+    void publish_instance_event(std::string_view change_type,
+        const domain::job_definition& job, std::int64_t inst_id);
 
+    ores::nats::service::client& nats_;
     database::context system_ctx_;
     std::vector<std::unique_ptr<action_handler>> handlers_;
     std::vector<domain::job_definition> jobs_;

--- a/projects/ores.scheduler.core/src/CMakeLists.txt
+++ b/projects/ores.scheduler.core/src/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${lib_target_name}
         ores.database.lib
         ores.nats.lib
     PRIVATE
+        ores.eventing.lib
         ores.service.lib
         ores.utility.lib
         ores.security.lib

--- a/projects/ores.scheduler.core/src/messaging/registrar.cpp
+++ b/projects/ores.scheduler.core/src/messaging/registrar.cpp
@@ -23,6 +23,8 @@
 #include <optional>
 #include "ores.scheduler.api/messaging/scheduler_protocol.hpp"
 #include "ores.scheduler.core/messaging/job_definition_handler.hpp"
+#include "ores.scheduler.core/messaging/job_instance_handler.hpp"
+#include "ores.scheduler.core/messaging/scheduler_status_handler.hpp"
 
 namespace ores::scheduler::messaging {
 
@@ -51,6 +53,22 @@ registrar::register_handlers(ores::nats::service::client& nats,
     subs.push_back(nats.queue_subscribe(
         get_job_history_request::nats_subject, "ores.scheduler.service",
         [jdh](ores::nats::message msg) { jdh->history(std::move(msg)); }));
+
+    // ----------------------------------------------------------------
+    // Job instances
+    // ----------------------------------------------------------------
+    auto jih = std::make_shared<job_instance_handler>(nats, ctx, verifier);
+    subs.push_back(nats.queue_subscribe(
+        get_job_instances_request::nats_subject, "ores.scheduler.service",
+        [jih](ores::nats::message msg) { jih->list(std::move(msg)); }));
+
+    // ----------------------------------------------------------------
+    // Scheduler status (Monitor window)
+    // ----------------------------------------------------------------
+    auto ssh = std::make_shared<scheduler_status_handler>(nats, ctx, verifier);
+    subs.push_back(nats.queue_subscribe(
+        get_scheduler_status_request::nats_subject, "ores.scheduler.service",
+        [ssh](ores::nats::message msg) { ssh->status(std::move(msg)); }));
 
     return subs;
 }

--- a/projects/ores.scheduler.core/src/repository/job_instance_mapper.cpp
+++ b/projects/ores.scheduler.core/src/repository/job_instance_mapper.cpp
@@ -1,0 +1,90 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.scheduler.core/repository/job_instance_mapper.hpp"
+
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.platform/time/datetime.hpp"
+#include "ores.scheduler.api/domain/job_status.hpp"
+
+namespace ores::scheduler::repository {
+
+namespace {
+
+domain::job_status status_from_string(const std::string& s) {
+    if (s == "succeeded") return domain::job_status::succeeded;
+    if (s == "failed")    return domain::job_status::failed;
+    return domain::job_status::starting;
+}
+
+} // anonymous namespace
+
+domain::job_instance job_instance_mapper::map(const job_instance_entity& e) {
+    domain::job_instance inst;
+
+    if (e.id)
+        inst.id = std::stoll(*e.id);
+    if (e.tenant_id)
+        inst.tenant_id = boost::lexical_cast<boost::uuids::uuid>(*e.tenant_id);
+    if (e.party_id)
+        inst.party_id = boost::lexical_cast<boost::uuids::uuid>(*e.party_id);
+    if (e.job_definition_id)
+        inst.job_definition_id =
+            boost::lexical_cast<boost::uuids::uuid>(*e.job_definition_id);
+    if (e.action_type)
+        inst.action_type = *e.action_type;
+    if (e.status)
+        inst.status = status_from_string(*e.status);
+    if (e.triggered_at) {
+        try {
+            inst.triggered_at =
+                ores::platform::time::datetime::from_iso8601_utc(*e.triggered_at);
+        } catch (...) {}
+    }
+    if (e.started_at) {
+        try {
+            inst.started_at =
+                ores::platform::time::datetime::from_iso8601_utc(*e.started_at);
+        } catch (...) {}
+    }
+    if (e.completed_at) {
+        try {
+            inst.completed_at =
+                ores::platform::time::datetime::from_iso8601_utc(*e.completed_at);
+        } catch (...) {}
+    }
+    if (e.duration_ms)
+        inst.duration_ms = std::stoll(*e.duration_ms);
+    if (e.error_message)
+        inst.error_message = *e.error_message;
+
+    return inst;
+}
+
+std::vector<domain::job_instance>
+job_instance_mapper::map(const std::vector<job_instance_entity>& v) {
+    std::vector<domain::job_instance> result;
+    result.reserve(v.size());
+    for (const auto& e : v)
+        result.push_back(map(e));
+    return result;
+}
+
+} // namespace ores::scheduler::repository

--- a/projects/ores.scheduler.core/src/repository/job_instance_repository.cpp
+++ b/projects/ores.scheduler.core/src/repository/job_instance_repository.cpp
@@ -181,6 +181,66 @@ std::vector<domain::job_instance> job_instance_repository::read_latest(
     return result;
 }
 
+std::vector<domain::job_instance> job_instance_repository::read_all_latest(
+    context ctx, std::size_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all latest job instances, limit=" << limit;
+
+    const auto limit_str = std::to_string(limit);
+
+    const std::string sql =
+        "SELECT id::text, tenant_id::text, party_id::text, "
+        "       job_definition_id::text, action_type, status, "
+        "       triggered_at::text, started_at::text, "
+        "       completed_at::text, duration_ms::text, error_message "
+        "FROM ores_scheduler_job_instances_tbl "
+        "ORDER BY triggered_at DESC "
+        "LIMIT $1::bigint";
+
+    const auto rows = execute_parameterized_multi_column_query(ctx, sql,
+        {limit_str}, lg(), "Reading all latest job instances.");
+
+    std::vector<domain::job_instance> result;
+    result.reserve(rows.size());
+
+    for (const auto& row : rows) {
+        if (row.size() < 11) continue;
+
+        domain::job_instance inst;
+        if (row[0]) inst.id = std::stoll(*row[0]);
+        if (row[1]) inst.tenant_id = boost::lexical_cast<boost::uuids::uuid>(*row[1]);
+        if (row[2]) inst.party_id = boost::lexical_cast<boost::uuids::uuid>(*row[2]);
+        if (row[3])
+            inst.job_definition_id = boost::lexical_cast<boost::uuids::uuid>(*row[3]);
+        if (row[4]) inst.action_type = *row[4];
+        if (row[5]) inst.status = job_status_from_string(*row[5]);
+        if (row[6]) {
+            try {
+                inst.triggered_at =
+                    ores::platform::time::datetime::from_iso8601_utc(*row[6]);
+            } catch (...) {}
+        }
+        if (row[7]) {
+            try {
+                inst.started_at =
+                    ores::platform::time::datetime::from_iso8601_utc(*row[7]);
+            } catch (...) {}
+        }
+        if (row[8]) {
+            try {
+                inst.completed_at =
+                    ores::platform::time::datetime::from_iso8601_utc(*row[8]);
+            } catch (...) {}
+        }
+        if (row[9]) inst.duration_ms = std::stoll(*row[9]);
+        if (row[10]) inst.error_message = *row[10];
+
+        result.push_back(std::move(inst));
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Retrieved " << result.size() << " job instances.";
+    return result;
+}
+
 std::optional<std::chrono::system_clock::time_point>
 job_instance_repository::last_run_at(
     context ctx, const boost::uuids::uuid& job_definition_id) {

--- a/projects/ores.scheduler.core/src/repository/job_instance_repository.cpp
+++ b/projects/ores.scheduler.core/src/repository/job_instance_repository.cpp
@@ -23,6 +23,7 @@
 #include <boost/lexical_cast.hpp>
 #include "ores.database/repository/bitemporal_operations.hpp"
 #include "ores.platform/time/datetime.hpp"
+#include "ores.scheduler.core/repository/job_instance_mapper.hpp"
 
 namespace ores::scheduler::repository {
 
@@ -40,10 +41,28 @@ std::string job_status_to_string(domain::job_status s) {
     return "starting";
 }
 
-domain::job_status job_status_from_string(const std::string& s) {
-    if (s == "succeeded") return domain::job_status::succeeded;
-    if (s == "failed")    return domain::job_status::failed;
-    return domain::job_status::starting;
+// Maps raw SQL result rows to domain objects via job_instance_entity.
+std::vector<domain::job_instance> parse_rows(
+    const std::vector<std::vector<std::optional<std::string>>>& rows) {
+    std::vector<job_instance_entity> entities;
+    entities.reserve(rows.size());
+    for (const auto& row : rows) {
+        if (row.size() < 11) continue;
+        job_instance_entity e;
+        e.id             = row[0];
+        e.tenant_id      = row[1];
+        e.party_id       = row[2];
+        e.job_definition_id = row[3];
+        e.action_type    = row[4];
+        e.status         = row[5];
+        e.triggered_at   = row[6];
+        e.started_at     = row[7];
+        e.completed_at   = row[8];
+        e.duration_ms    = row[9];
+        e.error_message  = row[10];
+        entities.push_back(std::move(e));
+    }
+    return job_instance_mapper::map(entities);
 }
 
 } // anonymous namespace
@@ -138,44 +157,7 @@ std::vector<domain::job_instance> job_instance_repository::read_latest(
         {job_def_id_str, limit_str},
         lg(), "Reading latest job instances.");
 
-    std::vector<domain::job_instance> result;
-    result.reserve(rows.size());
-
-    for (const auto& row : rows) {
-        if (row.size() < 11) continue;
-
-        domain::job_instance inst;
-        if (row[0]) inst.id = std::stoll(*row[0]);
-        if (row[1]) inst.tenant_id = boost::lexical_cast<boost::uuids::uuid>(*row[1]);
-        if (row[2]) inst.party_id = boost::lexical_cast<boost::uuids::uuid>(*row[2]);
-        if (row[3])
-            inst.job_definition_id = boost::lexical_cast<boost::uuids::uuid>(*row[3]);
-        if (row[4]) inst.action_type = *row[4];
-        if (row[5]) inst.status = job_status_from_string(*row[5]);
-        if (row[6]) {
-            try {
-                inst.triggered_at =
-                    ores::platform::time::datetime::from_iso8601_utc(*row[6]);
-            } catch (...) {}
-        }
-        if (row[7]) {
-            try {
-                inst.started_at =
-                    ores::platform::time::datetime::from_iso8601_utc(*row[7]);
-            } catch (...) {}
-        }
-        if (row[8]) {
-            try {
-                inst.completed_at =
-                    ores::platform::time::datetime::from_iso8601_utc(*row[8]);
-            } catch (...) {}
-        }
-        if (row[9]) inst.duration_ms = std::stoll(*row[9]);
-        if (row[10]) inst.error_message = *row[10];
-
-        result.push_back(std::move(inst));
-    }
-
+    auto result = parse_rows(rows);
     BOOST_LOG_SEV(lg(), debug) << "Retrieved " << result.size()
                                << " job instances for: " << job_definition_id;
     return result;
@@ -199,44 +181,7 @@ std::vector<domain::job_instance> job_instance_repository::read_all_latest(
     const auto rows = execute_parameterized_multi_column_query(ctx, sql,
         {limit_str}, lg(), "Reading all latest job instances.");
 
-    std::vector<domain::job_instance> result;
-    result.reserve(rows.size());
-
-    for (const auto& row : rows) {
-        if (row.size() < 11) continue;
-
-        domain::job_instance inst;
-        if (row[0]) inst.id = std::stoll(*row[0]);
-        if (row[1]) inst.tenant_id = boost::lexical_cast<boost::uuids::uuid>(*row[1]);
-        if (row[2]) inst.party_id = boost::lexical_cast<boost::uuids::uuid>(*row[2]);
-        if (row[3])
-            inst.job_definition_id = boost::lexical_cast<boost::uuids::uuid>(*row[3]);
-        if (row[4]) inst.action_type = *row[4];
-        if (row[5]) inst.status = job_status_from_string(*row[5]);
-        if (row[6]) {
-            try {
-                inst.triggered_at =
-                    ores::platform::time::datetime::from_iso8601_utc(*row[6]);
-            } catch (...) {}
-        }
-        if (row[7]) {
-            try {
-                inst.started_at =
-                    ores::platform::time::datetime::from_iso8601_utc(*row[7]);
-            } catch (...) {}
-        }
-        if (row[8]) {
-            try {
-                inst.completed_at =
-                    ores::platform::time::datetime::from_iso8601_utc(*row[8]);
-            } catch (...) {}
-        }
-        if (row[9]) inst.duration_ms = std::stoll(*row[9]);
-        if (row[10]) inst.error_message = *row[10];
-
-        result.push_back(std::move(inst));
-    }
-
+    auto result = parse_rows(rows);
     BOOST_LOG_SEV(lg(), debug) << "Retrieved " << result.size() << " job instances.";
     return result;
 }

--- a/projects/ores.scheduler.core/src/service/scheduler_loop.cpp
+++ b/projects/ores.scheduler.core/src/service/scheduler_loop.cpp
@@ -29,6 +29,7 @@
 #include <rfl.hpp>
 #include <rfl/json.hpp>
 #include "ores.eventing/domain/entity_change_event.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include "ores.logging/make_logger.hpp"
 #include "ores.scheduler.api/domain/job_instance.hpp"
 #include "ores.scheduler.api/domain/job_status.hpp"

--- a/projects/ores.scheduler.core/src/service/scheduler_loop.cpp
+++ b/projects/ores.scheduler.core/src/service/scheduler_loop.cpp
@@ -19,12 +19,16 @@
  */
 #include "ores.scheduler.core/service/scheduler_loop.hpp"
 
+#include <span>
 #include <stdexcept>
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/use_awaitable.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.eventing/domain/entity_change_event.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.scheduler.api/domain/job_instance.hpp"
 #include "ores.scheduler.api/domain/job_status.hpp"
@@ -44,13 +48,37 @@ auto& lg() {
 
 } // anonymous namespace
 
-scheduler_loop::scheduler_loop(database::context system_ctx,
+scheduler_loop::scheduler_loop(ores::nats::service::client& nats,
+    database::context system_ctx,
     std::vector<std::unique_ptr<action_handler>> handlers)
-    : system_ctx_(std::move(system_ctx))
+    : nats_(nats)
+    , system_ctx_(std::move(system_ctx))
     , handlers_(std::move(handlers)) {}
 
 void scheduler_loop::reload() {
     needs_reload_.store(true, std::memory_order_relaxed);
+}
+
+void scheduler_loop::publish_instance_event(std::string_view change_type,
+    const domain::job_definition& job, std::int64_t inst_id) {
+    try {
+        eventing::domain::entity_change_event ev;
+        ev.entity = "ores.scheduler.job_instance";
+        ev.timestamp = std::chrono::system_clock::now();
+        ev.entity_ids = {boost::uuids::to_string(job.id),
+                         std::to_string(inst_id)};
+        if (job.tenant_id)
+            ev.tenant_id = boost::uuids::to_string(*job.tenant_id);
+
+        const auto json = rfl::json::write(ev);
+        const auto* p = reinterpret_cast<const std::byte*>(json.data());
+        nats_.publish(job_instance_events_subject,
+            std::span<const std::byte>(p, json.size()));
+    } catch (const std::exception& e) {
+        BOOST_LOG_SEV(lg(), warn)
+            << "Failed to publish instance event (" << change_type
+            << ") for job " << job.job_name << ": " << e.what();
+    }
 }
 
 void scheduler_loop::load_jobs() {
@@ -99,6 +127,7 @@ scheduler_loop::fire_job(const domain::job_definition& job) {
             << job.job_name << ": " << e.what();
         co_return;
     }
+    publish_instance_event("created", job, inst_id);
 
     // Find the handler matching the job's action_type.
     action_handler* chosen = nullptr;
@@ -116,6 +145,7 @@ scheduler_loop::fire_job(const domain::job_definition& job) {
             inst_repo.write_completed(system_ctx_, inst_id, now,
                 domain::job_status::failed, msg);
         } catch (...) {}
+        publish_instance_event("updated", job, inst_id);
         last_run_[job.id] = now;
         co_return;
     }
@@ -131,6 +161,7 @@ scheduler_loop::fire_job(const domain::job_definition& job) {
             BOOST_LOG_SEV(lg(), warn) << "Failed to write completion for "
                 << job.job_name << ": " << e.what();
         }
+        publish_instance_event("updated", job, inst_id);
         last_run_[job.id] = now;
         BOOST_LOG_SEV(lg(), info) << "Job succeeded: " << job.job_name;
     } else {
@@ -142,6 +173,7 @@ scheduler_loop::fire_job(const domain::job_definition& job) {
             BOOST_LOG_SEV(lg(), warn) << "Failed to write failure for "
                 << job.job_name << ": " << e.what();
         }
+        publish_instance_event("updated", job, inst_id);
         last_run_[job.id] = now;
         BOOST_LOG_SEV(lg(), error) << "Job failed: " << job.job_name
                                    << " error: " << err;

--- a/projects/ores.scheduler.service/src/app/application.cpp
+++ b/projects/ores.scheduler.service/src/app/application.cpp
@@ -84,7 +84,7 @@ application::run(boost::asio::io_context& io_ctx,
         std::make_unique<ores::scheduler::service::nats_publish_action_handler>(nats));
 
     auto loop = std::make_shared<ores::scheduler::service::scheduler_loop>(
-        db_ctx, std::move(handlers));
+        nats, db_ctx, std::move(handlers));
 
     co_await ores::service::service::run(
         io_ctx, nats, db_ctx, "ores.scheduler.service",


### PR DESCRIPTION
## Summary

- Adds `job_instance_summary` DTO and two new NATS endpoints (`scheduler.v1.job-instances.list`, `scheduler.v1.status`) to `scheduler_protocol.hpp`
- Implements `job_instance_handler` and `scheduler_status_handler` on the server side; registers both subjects in the scheduler registrar
- Adds `read_all_latest()` to `job_instance_repository` for fetching recent execution history
- New Qt widgets in `ores.qt.compute`: `ClientJobInstanceModel`, `JobInstanceMdiWindow`, `JobInstanceDetailDialog`, `JobInstanceController` — read-only history browser with double-click detail view
- New `SchedulerMonitorMdiWindow` + `SchedulerMonitorController` — singleton window showing live per-job scheduler status (last run, next fire, running count) with configurable auto-refresh
- `SchedulerPlugin` now instantiates all three controllers in `on_login()` and enables the previously-disabled &Job Instances and &Monitor menu items

🤖 Generated with [Claude Code](https://claude.com/claude-code)