### PR TITLE
[cmake] Switch MSVC debug info to Embedded (/Z7) to fix PDB contention

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,9 +174,6 @@ if(WIN32)
         # Required by large translation units (e.g. registrar.cpp with many
         # template instantiations from rfl and Boost headers).
         add_compile_options(/bigobj)
-        # Serialise PDB writes when Ninja runs multiple cl.exe in parallel.
-        # Without /FS, concurrent writes to the same vc140.pdb cause C1041.
-        add_compile_options(/FS)
     endif()
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -220,7 +220,7 @@
                 "msvc-cl"
             ],
             "cacheVariables": {
-                "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "ProgramDatabase"
+                "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded"
             },
             "vendor": {
                 "microsoft.com/VisualStudioSettings/CMake/1.0": {


### PR DESCRIPTION
## Summary

- C1041 PDB contention persists even with /FS when sccache wraps cl.exe — the serialisation flag doesn't help when the compiler is invoked through a caching wrapper
- Switch `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` from `ProgramDatabase` (/Zi, shared `.pdb`) to `Embedded` (/Z7, debug info in each `.obj`) — eliminates the shared PDB file entirely
- Removes the now-unnecessary `/FS` flag from CMakeLists.txt
- /Z7 is also more compatible with sccache caching (sccache cannot cache /Zi builds due to the external PDB dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)