### PR TITLE
[ores.sql/qt.compute] Large GLEIF counterparty bundle wiring, tenant reset, upload logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ projects/ores.utility/config/config.hpp
 projects/ores.utility/include/ores.utility/version/version.hpp
 
 # VSCode
-.vscode/
+.vscode
 
 # Open Code
 .opencode/

--- a/doc/agile/product_backlog.org
+++ b/doc/agile/product_backlog.org
@@ -1421,6 +1421,87 @@ publication. These datasets are dependencies that load into staging tables and
 don't publish to production directly — this is working as designed. Suppress or
 reclassify these log messages to avoid confusion.
 
+*** Long-running bundle publishes need progress reporting and async execution :code:
+
+Large bundle publishes (notably =gleif.lei_counterparties.large=, ~15k
+counterparties + ~30k identifiers) take more than 5 minutes server-side, which
+exceeds the client's NATS request timeout hard-coded to =std::chrono::minutes(5)=
+at =PartyProvisioningWizard.cpp:378= (=PartyOrganisationSetupPage::startPublish=).
+The request fails with "Failed to communicate with server" even though the
+server is still working — the user has no feedback during the wait, and the
+publish continues running after the client gives up. Any future long-running
+publish or import will hit the same wall.
+
+This is two problems that should be tackled together:
+
+1. The publish runs server-side in one big transaction, with no intermediate
+   progress visible. Even with a longer client timeout, the user stares at an
+   indeterminate spinner for tens of minutes.
+2. The request/response RPC shape assumes the operation completes within a
+   single NATS timeout window. That assumption will not hold for any
+   production-sized import.
+
+**** Part A: Wrap the publish in a workflow saga
+
+Run the publish via =ores.workflow.service= (per its component description it
+already hosts long-running distributed saga handlers — this is what it is
+for). The wizard sends a =start_publish= request that returns a
+=publication_id= immediately; the saga runs the publish in the background and
+emits progress events on NATS (e.g. =ores.dq.publication_progress= keyed by
+=publication_id=). The wizard subscribes until it sees =completed= or
+=failed=.
+
+The existing =ores_dq_bundle_publications_tbl= audit table is the natural
+place to persist progress, so reconnecting clients can pick up where they
+left off and admins can see history.
+
+Note: "background" here does not mean "hidden from the user" — wizard flows
+like =PartyProvisioningWizard= should keep the user on-screen until the saga
+completes. The saga enables progress reporting and survives client
+reconnects; it does not move the operation off the critical path. Non-wizard
+admin imports could opt to dismiss the dialog and reconnect later.
+
+**** Part B: Chunk the SQL publish function
+
+=ores_dq_lei_counterparties_publish_fn= currently inserts all counterparties
+level-by-level in one transaction (see
+=projects/ores.sql/create/dq/dq_lei_counterparties_publish_create.sql=).
+Break the inserts into batches (say, 500 rows), and have the saga advance
+the publication state between batches. This gives the progress reporting in
+Part A something meaningful to say ("counterparties 3500/12959 inserted"
+rather than "started"/"done"), and keeps individual transactions small
+enough to avoid lock escalation and long replication catch-up.
+
+The same pattern applies to any other publish function that may generate
+thousands of rows (=ores_dq_lei_parties_publish_fn=, future report/pricing
+publishes, etc.). Consider a general =publish_in_batches= helper that
+populate functions can call back into.
+
+**** Acceptance Criteria
+
+- =PartyProvisioningWizard='s large-counterparty publish completes without a
+  client timeout even on a slow machine.
+- The wizard shows progress updates (records inserted / total, current step)
+  throughout the publish, not just "working…".
+- Closing the wizard mid-publish does not cancel the server-side work;
+  re-opening reconnects to the in-flight saga.
+- Long-running publishes survive client network blips (re-subscribe to the
+  progress channel on reconnect).
+- =ores_dq_bundle_publications_tbl= has intermediate progress rows visible
+  during the publish, not just start/end.
+
+**** Notes
+
+- Both parts are required. Part A without Part B gives a saga that emits
+  only "started"/"finished". Part B without Part A still dies at the client
+  timeout.
+- Interim workaround if an import is needed before this lands: bump the
+  =std::chrono::minutes(5)= at =PartyProvisioningWizard.cpp:378= to
+  =minutes(30)=. Stop-gap only; does not fix the lack of feedback.
+- See also the per-dataset NOTICE output already emitted by
+  =ores_dq_bundles_publish_fn= — that is the natural progress signal source
+  for Part A before Part B is done.
+
 *** Allow creating new connections from login dialog                   :code:
 
 The login dialog should have a button or link to create a new server connection,

--- a/projects/ores.qt.compute/src/AppProvisionerWizard.cpp
+++ b/projects/ores.qt.compute/src/AppProvisionerWizard.cpp
@@ -60,6 +60,15 @@ namespace ores::qt {
 
 using namespace ores::logging;
 
+namespace {
+
+auto& page_lg() {
+    static auto instance = make_logger("ores.qt.app_provisioner_page");
+    return instance;
+}
+
+}
+
 // ── Page 1: Application identity ─────────────────────────────────────────────
 
 class AppIdentityPage : public QWizardPage {
@@ -309,6 +318,10 @@ public:
         : QWizardPage(parent),
           http_base_url_(httpBaseUrl),
           app_version_id_(app_version_id) {
+        BOOST_LOG_SEV(page_lg(), info)
+            << "PackageUploadPage constructed with http_base_url='"
+            << (http_base_url_.empty() ? "(empty)" : http_base_url_)
+            << "'";
         setTitle(tr("Package"));
         setSubTitle(tr("Upload the wrapper+engine bundle for this version."));
 
@@ -389,8 +402,15 @@ private slots:
     void on_upload() {
         if (file_path_edit_->text().isEmpty()) return;
 
+        BOOST_LOG_SEV(page_lg(), info)
+            << "on_upload invoked; http_base_url='"
+            << (http_base_url_.empty() ? "(empty)" : http_base_url_)
+            << "', file='" << file_path_edit_->text().toStdString() << "'";
+
         const QString http_base = QString::fromStdString(http_base_url_);
         if (http_base.isEmpty()) {
+            BOOST_LOG_SEV(page_lg(), error)
+                << "HTTP base URL not configured; aborting package upload";
             MessageBoxHelper::warning(this, tr("No Server URL"),
                 tr("HTTP base URL is not configured. Cannot upload package."));
             return;
@@ -611,6 +631,11 @@ AppProvisionerWizard::AppProvisionerWizard(ClientManager* clientManager,
       http_base_url_(httpBaseUrl),
       app_id_(boost::uuids::random_generator()()),
       app_version_id_(boost::uuids::random_generator()()) {
+
+    BOOST_LOG_SEV(lg(), info)
+        << "AppProvisionerWizard constructed with http_base_url='"
+        << (http_base_url_.empty() ? "(empty)" : http_base_url_)
+        << "'";
 
     setWindowTitle(tr("New Application"));
     setWizardStyle(QWizard::ModernStyle);

--- a/projects/ores.qt.compute/src/ComputeConsoleController.cpp
+++ b/projects/ores.qt.compute/src/ComputeConsoleController.cpp
@@ -91,6 +91,9 @@ void ComputeConsoleController::showConsole() {
 }
 
 void ComputeConsoleController::setHttpBaseUrl(const std::string& url) {
+    BOOST_LOG_SEV(lg(), info)
+        << "setHttpBaseUrl url='" << (url.empty() ? "(empty)" : url)
+        << "', console_window=" << (consoleWindow_ ? "present" : "null");
     http_base_url_ = url;
     if (consoleWindow_)
         consoleWindow_->setHttpBaseUrl(url);

--- a/projects/ores.qt.compute/src/ComputePlugin.cpp
+++ b/projects/ores.qt.compute/src/ComputePlugin.cpp
@@ -67,6 +67,11 @@ void ComputePlugin::on_login(const plugin_context& ctx) {
     BOOST_LOG_SEV(lg(), debug) << "Login event received.";
     ctx_ = ctx;
 
+    BOOST_LOG_SEV(lg(), info)
+        << "on_login ctx http_base_url='"
+        << (ctx_.http_base_url.empty() ? "(empty)" : ctx_.http_base_url)
+        << "'";
+
     appController_ = std::make_unique<AppController>(
         ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
         ctx_.change_reason_cache, ctx_.username, this);

--- a/projects/ores.sql/create/dq/dq_bundle_publication_create.sql
+++ b/projects/ores.sql/create/dq/dq_bundle_publication_create.sql
@@ -288,6 +288,15 @@ begin
     -- 'gleif.lei_counterparties.large' when only '.small' is a member) would
     -- silently produce a successful no-op.
     if p_params ? 'opted_in_datasets' then
+        -- Reject non-array opted_in_datasets explicitly rather than letting
+        -- jsonb_array_elements_text raise a generic "cannot extract elements"
+        -- error that is hard to correlate to the caller's payload.
+        if jsonb_typeof(p_params->'opted_in_datasets') <> 'array' then
+            raise exception
+                'opted_in_datasets must be a JSON array, got %',
+                jsonb_typeof(p_params->'opted_in_datasets');
+        end if;
+
         declare
             v_unknown_datasets text;
         begin

--- a/projects/ores.sql/create/dq/dq_bundle_publication_create.sql
+++ b/projects/ores.sql/create/dq/dq_bundle_publication_create.sql
@@ -283,6 +283,31 @@ begin
         raise exception 'Bundle not found: %', p_bundle_code;
     end if;
 
+    -- Validate that every opted_in_datasets entry is actually a member of
+    -- this bundle. Without this check, a misconfigured or typo'd opt-in (e.g.
+    -- 'gleif.lei_counterparties.large' when only '.small' is a member) would
+    -- silently produce a successful no-op.
+    if p_params ? 'opted_in_datasets' then
+        declare
+            v_unknown_datasets text;
+        begin
+            select string_agg(oid, ', ')
+            into v_unknown_datasets
+            from jsonb_array_elements_text(p_params->'opted_in_datasets') oid
+            where not exists (
+                select 1 from ores_dq_dataset_bundle_members_tbl m
+                where m.bundle_code = p_bundle_code
+                  and m.dataset_code = oid
+                  and m.valid_to = ores_utility_infinity_timestamp_fn()
+            );
+            if v_unknown_datasets is not null then
+                raise exception
+                    'opted_in_datasets contains entries that are not members of bundle %: %',
+                    p_bundle_code, v_unknown_datasets;
+            end if;
+        end;
+    end if;
+
     -- Create bundle publication audit record
     insert into ores_dq_bundle_publications_tbl (
         tenant_id, bundle_code, bundle_name, mode, atomic, published_by

--- a/projects/ores.sql/create/iam/iam_create.sql
+++ b/projects/ores.sql/create/iam/iam_create.sql
@@ -56,6 +56,7 @@
 \ir ./iam_system_provisioner_create.sql
 \ir ./iam_tenant_provisioner_create.sql
 \ir ./iam_tenant_deprovisioner_create.sql
+\ir ./iam_tenant_reset_create.sql
 \ir ./iam_tenant_terminator_create.sql
 
 -- Admin utilities (helper functions for administrative tasks)

--- a/projects/ores.sql/create/iam/iam_tenant_reset_create.sql
+++ b/projects/ores.sql/create/iam/iam_tenant_reset_create.sql
@@ -1,0 +1,178 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+-- =============================================================================
+-- Tenant Reset Function
+-- =============================================================================
+-- Soft-deletes admin-created data for a tenant, returning it to the state
+-- right after tenant onboarding completed. Intended for development iteration:
+-- wipe the outputs of the party-level provisioning wizard and admin activity,
+-- so those flows can be re-run without re-creating the tenant, its admin
+-- account, or its tenant-onboarding state (parties, account_parties, refdata).
+--
+-- Sits alongside the other tenant-lifecycle functions:
+--   * terminate    -- mark inactive, preserve ALL data
+--   * reset        -- soft-delete admin-created data (this fn)
+--   * deprovision  -- soft-delete ALL temporal data including IAM
+--   * purge        -- hard-delete everything
+--
+-- IMPLEMENTATION NOTE — curated, default-preserve wipe list
+--
+-- This function soft-deletes an explicit list of tables (see v_wipe_tables
+-- below). Everything else is preserved. The list is tightly coupled to the
+-- PartyProvisioningWizard's publish steps and admin-activity tables:
+--
+--   * Counterparties (+ identifiers, contacts, party-counterparty links) —
+--     written by ores_dq_lei_counterparties_publish_fn via the
+--     gleif.lei_counterparties.* datasets.
+--   * Business units, portfolios, books — written by the `organisation`
+--     bundle (testdata.business_units / .portfolios / .books).
+--   * Report definitions and scheduler job definitions — created by the
+--     wizard's report-setup step and admin activity.
+--
+-- An earlier revision of this function used a dynamic info_schema loop with a
+-- default-delete, opt-out preservation list. That was wrong: the preservation
+-- list had to grow to include parties and account_parties (mandatory for
+-- login — tenant onboarding sets them up and bootstrap mode does not skip the
+-- check), plus all base-bundle refdata (currencies, countries, fpml, etc.).
+-- A missed entry locked the admin out. Curated default-preserve is the safer
+-- failure mode: a missing entry leaves the tenant in a partially-reset state,
+-- which is easier to spot and fix than a broken login.
+--
+-- When extending: add tables only for data the tenant admin or a post-
+-- onboarding wizard creates. Do NOT add tables populated by tenant
+-- onboarding (base bundle publish or tenant provisioner) — those are
+-- tenant infrastructure.
+--
+-- Trading data (trades, instruments, identifiers) is intentionally not in
+-- the list today. Add it here if the dev workflow starts requiring trade
+-- wipes as part of reset.
+-- -----------------------------------------------------------------------------
+
+-- -----------------------------------------------------------------------------
+-- Reset a tenant (soft-delete admin-created data)
+-- -----------------------------------------------------------------------------
+-- The system tenant cannot be reset.
+-- Caller must have system tenant context set.
+--
+-- Parameters:
+--   p_tenant_id: The tenant ID to reset
+--
+create or replace function ores_iam_reset_tenant_fn(
+    p_tenant_id uuid
+) returns void as $$
+declare
+    v_system_tenant_id uuid;
+    v_tenant_code text;
+    v_table_name text;
+    v_affected_count integer;
+    v_total_soft_deleted integer := 0;
+    v_sql text;
+    v_wipe_tables text[] := array[
+        -- Counterparties and related, populated by the PartyProvisioningWizard
+        -- via ores_dq_lei_counterparties_publish_fn (gleif.lei_counterparties.*).
+        'ores_refdata_counterparties_tbl',
+        'ores_refdata_counterparty_identifiers_tbl',
+        'ores_refdata_counterparty_contact_informations_tbl',
+        'ores_refdata_party_counterparties_tbl',
+
+        -- Organisation bundle outputs, populated by the PartyProvisioningWizard
+        -- via the `organisation` bundle (testdata.business_units/.portfolios/
+        -- .books).
+        'ores_refdata_business_units_tbl',
+        'ores_refdata_portfolios_tbl',
+        'ores_refdata_books_tbl',
+
+        -- Report and scheduler definitions, created by the wizard's report
+        -- setup step and by admin activity.
+        'ores_reporting_report_definitions_tbl',
+        'ores_scheduler_job_definitions_tbl'
+    ];
+begin
+    v_system_tenant_id := ores_iam_system_tenant_id_fn();
+
+    -- Cannot reset system tenant
+    if p_tenant_id = v_system_tenant_id then
+        raise exception 'Cannot reset the system tenant' using errcode = '42501';
+    end if;
+
+    -- Verify we're in system tenant context
+    if ores_iam_current_tenant_id_fn() != v_system_tenant_id then
+        raise exception 'Must be in system tenant context to reset a tenant. Current tenant: %',
+            ores_iam_current_tenant_id_fn() using errcode = '42501';
+    end if;
+
+    -- Get tenant code for logging; must be active
+    select code into v_tenant_code
+    from ores_iam_tenants_tbl
+    where id = p_tenant_id
+      and valid_to = ores_utility_infinity_timestamp_fn();
+
+    if not found then
+        raise exception 'Tenant not found or inactive: %', p_tenant_id
+            using errcode = '23503';
+    end if;
+
+    raise notice 'Resetting tenant (tenant-onboarding state preserved): % (id: %)',
+        v_tenant_code, p_tenant_id;
+
+    -- Soft-delete only the explicitly listed tables.
+    foreach v_table_name in array v_wipe_tables
+    loop
+        v_sql := format(
+            'UPDATE %I SET valid_to = current_timestamp ' ||
+            'WHERE tenant_id = $1 AND valid_to = ores_utility_infinity_timestamp_fn()',
+            v_table_name
+        );
+
+        execute v_sql using p_tenant_id;
+        get diagnostics v_affected_count = row_count;
+
+        if v_affected_count > 0 then
+            raise notice 'Soft-deleted % rows from %', v_affected_count, v_table_name;
+            v_total_soft_deleted := v_total_soft_deleted + v_affected_count;
+        end if;
+    end loop;
+
+    raise notice 'Total soft-deleted: % rows', v_total_soft_deleted;
+
+    -- Flip Operational parties back to 'Inactive'. The login flow computes
+    -- party_setup_required from party.status == 'Inactive' (see
+    -- ores.iam.core/messaging/account_handler.hpp), so leaving parties Active
+    -- means the PartyProvisioningWizard will not re-trigger on next login.
+    -- Direct UPDATE bypasses the insert trigger's actor validation, which is
+    -- acceptable for a dev reset — the notify trigger still fires so clients
+    -- pick up the change.
+    update ores_refdata_parties_tbl
+    set status = 'Inactive'
+    where tenant_id = p_tenant_id
+      and party_category = 'Operational'
+      and status = 'Active'
+      and valid_to = ores_utility_infinity_timestamp_fn();
+
+    get diagnostics v_affected_count = row_count;
+    if v_affected_count > 0 then
+        raise notice 'Marked % Operational parties as Inactive (wizard will fire on next login)',
+            v_affected_count;
+    end if;
+
+    raise notice 'Tenant reset complete: % (id: %)', v_tenant_code, p_tenant_id;
+end;
+$$ language plpgsql;

--- a/projects/ores.sql/drop/iam/iam_drop.sql
+++ b/projects/ores.sql/drop/iam/iam_drop.sql
@@ -21,6 +21,7 @@
 -- Tenant lifecycle (dropped first - depends on all tables)
 \ir ./iam_system_provisioner_drop.sql
 \ir ./iam_tenant_deprovisioner_drop.sql
+\ir ./iam_tenant_reset_drop.sql
 \ir ./iam_tenant_provisioner_drop.sql
 
 -- Account-party association (dropped before accounts and RBAC)

--- a/projects/ores.sql/drop/iam/iam_tenant_reset_drop.sql
+++ b/projects/ores.sql/drop/iam/iam_tenant_reset_drop.sql
@@ -1,0 +1,21 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop function if exists ores_iam_reset_tenant_fn(uuid);

--- a/projects/ores.sql/populate/dq/dq_dataset_bundle_member_populate.sql
+++ b/projects/ores.sql/populate/dq/dq_dataset_bundle_member_populate.sql
@@ -83,6 +83,8 @@ select ores_dq_dataset_bundle_members_upsert_fn(ores_iam_system_tenant_id_fn(), 
 select ores_dq_dataset_bundle_members_upsert_fn(ores_iam_system_tenant_id_fn(), 'base', 'gleif.lei_relationships.small', 201);
 select ores_dq_dataset_bundle_members_upsert_fn(ores_iam_system_tenant_id_fn(), 'base', 'gleif.lei_counterparties.small', 202, true);
 select ores_dq_dataset_bundle_members_upsert_fn(ores_iam_system_tenant_id_fn(), 'base', 'gleif.lei_parties.small', 203, true);
+select ores_dq_dataset_bundle_members_upsert_fn(ores_iam_system_tenant_id_fn(), 'base', 'gleif.lei_counterparties.large', 204, true);
+select ores_dq_dataset_bundle_members_upsert_fn(ores_iam_system_tenant_id_fn(), 'base', 'gleif.lei_parties.large', 205, true);
 
 -- =============================================================================
 -- Crypto Bundle Members

--- a/projects/ores.sql/populate/lei/lei_dataset_dependency_populate.sql
+++ b/projects/ores.sql/populate/lei/lei_dataset_dependency_populate.sql
@@ -97,3 +97,57 @@ select ores_dq_dataset_dependencies_upsert_fn(ores_iam_system_tenant_id_fn(),
     'bic_reference'
 );
 
+select ores_dq_dataset_dependencies_upsert_fn(ores_iam_system_tenant_id_fn(),
+    'gleif.lei_parties.large',
+    'fpml.business_center',
+    'business_centres'
+);
+
+select ores_dq_dataset_dependencies_upsert_fn(ores_iam_system_tenant_id_fn(),
+    'gleif.lei_parties.large',
+    'gleif.lei_entities.large',
+    'entity_reference'
+);
+
+select ores_dq_dataset_dependencies_upsert_fn(ores_iam_system_tenant_id_fn(),
+    'gleif.lei_parties.large',
+    'gleif.lei_relationships.large',
+    'hierarchy'
+);
+
+select ores_dq_dataset_dependencies_upsert_fn(ores_iam_system_tenant_id_fn(),
+    'gleif.lei_parties.large',
+    'gleif.lei_bic',
+    'bic_reference'
+);
+
+select ores_dq_dataset_dependencies_upsert_fn(ores_iam_system_tenant_id_fn(),
+    'gleif.lei_counterparties.large',
+    'fpml.business_center',
+    'business_centres'
+);
+
+select ores_dq_dataset_dependencies_upsert_fn(ores_iam_system_tenant_id_fn(),
+    'gleif.lei_counterparties.large',
+    'gleif.lei_entities.large',
+    'entity_reference'
+);
+
+select ores_dq_dataset_dependencies_upsert_fn(ores_iam_system_tenant_id_fn(),
+    'gleif.lei_counterparties.large',
+    'gleif.lei_relationships.large',
+    'hierarchy'
+);
+
+select ores_dq_dataset_dependencies_upsert_fn(ores_iam_system_tenant_id_fn(),
+    'gleif.lei_counterparties.large',
+    'gleif.lei_parties.large',
+    'party_reference'
+);
+
+select ores_dq_dataset_dependencies_upsert_fn(ores_iam_system_tenant_id_fn(),
+    'gleif.lei_counterparties.large',
+    'gleif.lei_bic',
+    'bic_reference'
+);
+

--- a/projects/ores.sql/run_sql.sh
+++ b/projects/ores.sql/run_sql.sh
@@ -8,8 +8,13 @@
 # variables override .env values when set.
 #
 # Usage:
-#   ./run_sql.sh <sql_file>           # Execute a SQL file
-#   ./run_sql.sh -c "SELECT 1"        # Execute a SQL command
+#   ./run_sql.sh <sql_file>                    # Execute a SQL file as postgres
+#   ./run_sql.sh -c "SELECT 1"                 # Execute a SQL command
+#   ./run_sql.sh --user ddl <sql_file>         # Execute as the DDL user
+#                                              # (needed when inserts flow
+#                                              # through the account-validation
+#                                              # trigger, which rejects
+#                                              # postgres as an actor)
 #
 set -e
 
@@ -24,9 +29,48 @@ if [[ -f "${ENV_FILE}" ]]; then
     set +a
 fi
 
+DB_ROLE="postgres"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -u|--user)
+            DB_ROLE="$2"
+            shift 2
+            ;;
+        --user=*)
+            DB_ROLE="${1#--user=}"
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
 DB_HOST="${ORES_TEST_DB_HOST:-localhost}"
 DB_NAME="${ORES_TEST_DB_DATABASE}"
-DB_USER="postgres"
+
+case "$DB_ROLE" in
+    postgres)
+        DB_USER="postgres"
+        # PGPASSWORD comes from .env
+        ;;
+    ddl)
+        DB_USER="${ORES_DB_DDL_USER}"
+        export PGPASSWORD="${ORES_DB_DDL_PASSWORD}"
+        if [[ -z "$DB_USER" ]]; then
+            echo "Error: ORES_DB_DDL_USER not set in .env" >&2
+            exit 1
+        fi
+        if [[ -z "$PGPASSWORD" ]]; then
+            echo "Error: ORES_DB_DDL_PASSWORD not set in .env" >&2
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Error: --user must be 'postgres' or 'ddl' (got: $DB_ROLE)" >&2
+        exit 1
+        ;;
+esac
 
 if [[ -z "$PGPASSWORD" ]]; then
     echo "Error: PGPASSWORD not set and not found in .env" >&2

--- a/projects/ores.sql/run_sql.sh
+++ b/projects/ores.sql/run_sql.sh
@@ -33,6 +33,10 @@ DB_ROLE="postgres"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -u|--user)
+            if [[ -z "${2:-}" || "$2" == -* ]]; then
+                echo "Error: -u/--user requires a valid argument" >&2
+                exit 1
+            fi
             DB_ROLE="$2"
             shift 2
             ;;


### PR DESCRIPTION
## Summary

Work from a bug-hunt session on the PartyProvisioningWizard's Large (~15k) counterparty import path.

- **Bundle publish validation fixed.** `ores_dq_bundles_publish_fn` silently ignored `opted_in_datasets` entries that were not members of the target bundle, so selecting *Large* in the wizard (opting in `gleif.lei_counterparties.large`) succeeded as a no-op. It now raises a clear exception naming the offending entries, which flows through `publication_service`'s catch block into the wizard's error dialog.
- **Large GLEIF variants wired into the base bundle.** Added `gleif.lei_counterparties.large` and `gleif.lei_parties.large` as optional members of `base` (display orders 204–205), mirroring the `.small` pattern, plus the matching dataset-dependency declarations.
- **New `ores_iam_reset_tenant_fn`.** Soft-deletes admin-created data (counterparties, cp identifiers, cp contacts, party_counterparties, business units, portfolios, books, report definitions, scheduler job definitions) and flips Operational parties back to `Inactive` so the PartyProvisioningWizard re-triggers on next login. Tenant onboarding state (tenant record, accounts, roles, permissions, parties, `account_parties`, base-bundle refdata) is preserved. Uses a curated wipe list with a design-note header on the default-preserve vs default-delete trade-off.
- **`run_sql.sh --user postgres|ddl` flag.** Lets callers run as the DDL user so writes through account-validating triggers (`ores_iam_validate_account_username_fn`) don't hit "Invalid modified_by: postgres".
- **Backlog story** for the two-part proper fix to long-running bundle publishes (workflow saga + chunked SQL) — client currently times out at 5 minutes on `.large` imports. Story at `doc/agile/product_backlog.org` includes acceptance criteria and the interim timeout-bump workaround.
- **Diagnostic logging for the HTTP upload URL path** (`ComputePlugin::on_login`, `ComputeConsoleController::setHttpBaseUrl`, `AppProvisionerWizard` ctor, `PackageUploadPage` ctor + `on_upload`) so the empty-URL case that drives "HTTP base URL is not configured. Cannot upload package." can be traced to its entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)