### PR TITLE
[qt.api/database] Fix Windows MSVC export and libpq link

### DIFF
--- a/projects/ores.database/src/CMakeLists.txt
+++ b/projects/ores.database/src/CMakeLists.txt
@@ -60,11 +60,11 @@ if(WIN32)
         NO_DEFAULT_PATH)
     if(ORES_PGPORT_LIBRARY AND ORES_PGCOMMON_LIBRARY)
         target_link_libraries(${lib_target_name}
-            PUBLIC
+            PRIVATE
                 ${ORES_PGPORT_LIBRARY}
                 ${ORES_PGCOMMON_LIBRARY}
-                Secur32.lib
-                Wldap32.lib)
+                Secur32
+                Wldap32)
     endif()
 endif()
 

--- a/projects/ores.database/src/CMakeLists.txt
+++ b/projects/ores.database/src/CMakeLists.txt
@@ -42,4 +42,30 @@ target_link_libraries(${lib_target_name}
     PRIVATE
         ores.utility.lib)
 
+# libpq on Windows is distributed as a static archive that depends on the
+# PostgreSQL portability libraries libpgport and libpgcommon. vcpkg's
+# libpq find-module wrapper only attaches them when the triplet linkage is
+# "static"; the x64-windows dynamic triplet skips them and we get undefined
+# references to pg_tolower/pg_vsnprintf/gettimeofday/... when linking any
+# DLL that pulls libpq in transitively (e.g. via sqlgen). Attach them
+# explicitly on Windows so the symbols resolve.
+if(WIN32)
+    find_library(ORES_PGPORT_LIBRARY
+        NAMES pgport libpgport
+        PATHS "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib"
+        NO_DEFAULT_PATH)
+    find_library(ORES_PGCOMMON_LIBRARY
+        NAMES pgcommon libpgcommon
+        PATHS "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib"
+        NO_DEFAULT_PATH)
+    if(ORES_PGPORT_LIBRARY AND ORES_PGCOMMON_LIBRARY)
+        target_link_libraries(${lib_target_name}
+            PUBLIC
+                ${ORES_PGPORT_LIBRARY}
+                ${ORES_PGCOMMON_LIBRARY}
+                Secur32.lib
+                Wldap32.lib)
+    endif()
+endif()
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.qt.api/include/ores.qt/CronEditorDialog.hpp
+++ b/projects/ores.qt.api/include/ores.qt/CronEditorDialog.hpp
@@ -23,6 +23,7 @@
 #include <QDialog>
 #include <QString>
 #include "ores.qt/CronFieldWidget.hpp"
+#include "ores.qt/export.hpp"
 
 class QLabel;
 class QTabWidget;
@@ -36,7 +37,7 @@ namespace ores::qt {
  * Frequency, Range, and Choice modes for the corresponding cron field.
  * A description label at the top summarises the schedule in plain English.
  */
-class CronEditorDialog : public QDialog {
+class ORES_QT_API CronEditorDialog : public QDialog {
     Q_OBJECT
 
 public:

--- a/projects/ores.qt.api/include/ores.qt/CronExpressionWidget.hpp
+++ b/projects/ores.qt.api/include/ores.qt/CronExpressionWidget.hpp
@@ -23,6 +23,7 @@
 #include <QWidget>
 #include <QLineEdit>
 #include <QString>
+#include "ores.qt/export.hpp"
 
 class QPushButton;
 
@@ -36,7 +37,7 @@ namespace ores::qt {
  * The public API is identical to the old widget so all dialogs that
  * embed it as a custom widget require no changes.
  */
-class CronExpressionWidget : public QWidget {
+class ORES_QT_API CronExpressionWidget : public QWidget {
     Q_OBJECT
 
 public:

--- a/projects/ores.qt.api/include/ores.qt/CronFieldWidget.hpp
+++ b/projects/ores.qt.api/include/ores.qt/CronFieldWidget.hpp
@@ -25,6 +25,7 @@
 #include <QVector>
 #include <QString>
 #include <QStringList>
+#include "ores.qt/export.hpp"
 
 class QRadioButton;
 class QComboBox;
@@ -51,7 +52,7 @@ struct FieldConfig {
  *   - Range:     a min-max span
  *   - Choice:    individually ticked values
  */
-class CronFieldWidget : public QWidget {
+class ORES_QT_API CronFieldWidget : public QWidget {
     Q_OBJECT
 
 public:


### PR DESCRIPTION
## Summary
Two Windows-only fixes from the latest main CI run:

### 1. MSVC export of Cron widget staticMetaObject
PR #706 moved the three cron widgets (\`CronExpressionWidget\`, \`CronEditorDialog\`, \`CronFieldWidget\`) from \`ores.qt.compute\` to the shared \`ores.qt.api\`, but did not decorate them with the \`ORES_QT_API\` macro that every other Q_OBJECT class in the module uses. Clang/lld on Windows auto-exports via \`llvm-nm\`, which hid the oversight; MSVC honours \`__declspec(dllexport/dllimport)\` strictly, so \`ores.qt.compute\`'s \`ReportDefinitionDetailDialog\` could not find \`staticMetaObject\` when linking.

### 2. Explicit \`pgport\`/\`pgcommon\` link for libpq on Windows
The vcpkg bump in PR #707 ships libpq as a static archive whose internal calls to \`pg_tolower\`, \`pg_vsnprintf\`, \`gettimeofday\`, \`pgwin32_fopen\`, etc. come from the PostgreSQL portability libs \`libpgport\` and \`libpgcommon\`. vcpkg's \`libpq/vcpkg-cmake-wrapper.cmake\` only appends these when \`VCPKG_LIBRARY_LINKAGE\` is \`static\`; the dynamic \`x64-windows\` triplet skips them. Any DLL that pulls libpq in transitively (here: \`ores.database.dll\` via \`sqlgen\`) fails to link. Add a Windows-only block in \`ores.database/src/CMakeLists.txt\` that finds and attaches \`pgport\`/\`pgcommon\` plus the Windows system libs (\`Secur32\`, \`Wldap32\`) required by libpq's crypto paths.

Keeps us on latest vcpkg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)