### PR TITLE
[database] Link OpenSSL for libpq on Windows

### DIFF
--- a/projects/ores.database/src/CMakeLists.txt
+++ b/projects/ores.database/src/CMakeLists.txt
@@ -43,12 +43,13 @@ target_link_libraries(${lib_target_name}
         ores.utility.lib)
 
 # libpq on Windows is distributed as a static archive that depends on the
-# PostgreSQL portability libraries libpgport and libpgcommon. vcpkg's
-# libpq find-module wrapper only attaches them when the triplet linkage is
-# "static"; the x64-windows dynamic triplet skips them and we get undefined
-# references to pg_tolower/pg_vsnprintf/gettimeofday/... when linking any
-# DLL that pulls libpq in transitively (e.g. via sqlgen). Attach them
-# explicitly on Windows so the symbols resolve.
+# PostgreSQL portability libraries libpgport and libpgcommon plus OpenSSL
+# for the SSL connection paths. vcpkg's libpq find-module wrapper only
+# attaches these when the triplet linkage is "static"; the x64-windows
+# dynamic triplet skips them and we get undefined references to
+# pg_tolower/pg_vsnprintf/RAND_bytes/BIO_new/OPENSSL_sk_num/... when
+# linking any DLL that pulls libpq in transitively (e.g. via sqlgen).
+# Attach them explicitly on Windows so the symbols resolve.
 if(WIN32)
     find_library(ORES_PGPORT_LIBRARY
         NAMES pgport libpgport
@@ -58,11 +59,14 @@ if(WIN32)
         NAMES pgcommon libpgcommon
         PATHS "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib"
         NO_DEFAULT_PATH)
+    find_package(OpenSSL REQUIRED)
     if(ORES_PGPORT_LIBRARY AND ORES_PGCOMMON_LIBRARY)
         target_link_libraries(${lib_target_name}
             PRIVATE
                 ${ORES_PGPORT_LIBRARY}
                 ${ORES_PGCOMMON_LIBRARY}
+                OpenSSL::SSL
+                OpenSSL::Crypto
                 Secur32
                 Wldap32)
     endif()


### PR DESCRIPTION
## Summary
Windows clang builds still fail linking \`ores.database.dll\` after #708:

\`\`\`
lld-link: error: undefined symbol: RAND_bytes
lld-link: error: undefined symbol: BIO_new
lld-link: error: undefined symbol: OPENSSL_sk_num
lld-link: error: undefined symbol: ASN1_STRING_get0_data
\`\`\`

libpq's SSL connection paths pull in OpenSSL. vcpkg's libpq cmake wrapper only attaches \`OpenSSL::SSL\` when the triplet linkage is \`static\`; the dynamic \`x64-windows\` triplet skips it. Same root cause as the pgport/pgcommon gap — extend the Windows compensation block in \`ores.database/src/CMakeLists.txt\` to also link \`OpenSSL::SSL\` and \`OpenSSL::Crypto\`.

The two MSVC WiX packaging failures (\`LGHT0263\` on \`ores.trading.core.lib\` exceeding 2GB and \`LGHT0306\` on >65k files in a single CAB) are packaging-level issues, not build errors, and will be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)