### PR TITLE
[cpack/windows] Clear WiX v3 size and file-count limits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,3 +341,24 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/build)
 add_subdirectory(${CMAKE_SOURCE_DIR}/assets)
 add_subdirectory(${CMAKE_SOURCE_DIR}/projects)
 add_subdirectory(${CMAKE_SOURCE_DIR}/doc/skills/modeling)
+
+# On Windows we disable vcpkg's per-target X_VCPKG_APPLOCAL_DEPS_INSTALL hook
+# (set in CMakePresets.json) because it registers one install(CODE ...) block
+# per installed executable. With ~80 installed targets each pulling the
+# transitive Qt+OpenSSL+libpq+Boost closure, WiX accumulates more than 65,535
+# files per cabinet (LGHT0306). The build-time VCPKG_APPLOCAL_DEPS (still ON
+# by default) already populates publish/bin/ with every DLL and Qt plugin
+# exactly once, so we install that directory in one shot — excluding our own
+# binaries (installed individually via install(TARGETS)), test executables
+# (not meant for the installer), and build byproducts.
+if(WIN32)
+    install(DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
+        DESTINATION bin
+        USE_SOURCE_PERMISSIONS
+        REGEX "/ores\\." EXCLUDE
+        REGEX "\\.tests\\." EXCLUDE
+        REGEX "\\.pdb$" EXCLUDE
+        REGEX "\\.ilk$" EXCLUDE
+        REGEX "\\.exp$" EXCLUDE
+        REGEX "\\.lib$" EXCLUDE)
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,7 +22,7 @@
                 "CMAKE_FIND_USE_CMAKE_SYSTEM_PATH": "ON",
                 "CMAKE_PREFIX_PATH": "",
                 "VCPKG_INSTALL_OPTIONS": "--clean-after-build",
-                "X_VCPKG_APPLOCAL_DEPS_INSTALL": true
+                "X_VCPKG_APPLOCAL_DEPS_INSTALL": false
             },
             "warnings": {
                 "uninitialized": true,

--- a/CTest.cmake
+++ b/CTest.cmake
@@ -306,7 +306,15 @@ endif()
 # Only attempt build if configuration succeeded.
 set(build_result 0)
 if(configure_result EQUAL 0)
-    set(CTEST_BUILD_TARGET "package")
+    # On Windows Debug the static ores.trading.core.lib exceeds the WiX v3
+    # 2 GB single-file limit and cpack has no chance of succeeding. Release
+    # is the only Windows deliverable, so on Debug build the default target
+    # (everything + tests) without invoking the package step.
+    if(operative_system STREQUAL "windows" AND configuration STREQUAL "debug")
+        set(CTEST_BUILD_TARGET "all")
+    else()
+        set(CTEST_BUILD_TARGET "package")
+    endif()
     ctest_build(PARALLEL_LEVEL ${nproc} RETURN_VALUE build_result)
     if(NOT build_result EQUAL 0)
         message(WARNING "Build failed with error code: ${build_result}")

--- a/projects/ores.trading.core/src/CMakeLists.txt
+++ b/projects/ores.trading.core/src/CMakeLists.txt
@@ -62,6 +62,12 @@ target_link_libraries(${lib_target_name}
         Boost::boost)
 # Note: reflectcpp comes transitively through ores.utility.lib -> ores.platform.lib (PUBLIC)
 
-install(TARGETS ${lib_target_name}
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib)
+# On Windows ores.trading.core is a static archive (see above) whose Debug
+# build exceeds 2 GB — the WiX v3 single-file cabinet offset limit. The
+# archive is only consumed by our own executables at link time, so nothing
+# downstream needs to find it in the installer. Skip install on Windows.
+if(NOT WIN32)
+    install(TARGETS ${lib_target_name}
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
+endif()


### PR DESCRIPTION
## Summary
Short-term fixes from the WiX analysis in #710, clearing both remaining \`cpack\` errors on Windows.

- **A.** Exclude \`ores.trading.core.lib\` from the installer on Windows. It is STATIC on Windows (PR #693) and its Debug build exceeds 2 GB — the WiX v3 single-file cabinet offset limit (\`LGHT0263\`). Nothing downstream needs it at runtime because consumer executables link it in statically.
- **B.** Skip the \`package\` target on Windows Debug in \`CTest.cmake\`. Debug still builds and tests; only Release invokes \`cpack\`. Release is the sole Windows deliverable.
- **E.** Turn off \`X_VCPKG_APPLOCAL_DEPS_INSTALL\` and replace it with a single \`install(DIRECTORY publish/bin/ ...)\` pass. The per-target \`applocal\`-install hook was registering one \`install(CODE ...)\` block per executable (~80 targets) and each copy of the Qt + OpenSSL + libpq closure piled files into the same cabinet, blowing past the WiX 65,535-file limit (\`LGHT0306\`). The build-time \`VCPKG_APPLOCAL_DEPS\` (still ON) already populates \`publish/bin/\` exactly once, so one directory install — minus our own binaries, tests, and build byproducts — produces the same runtime closure with a fraction of the file count.

G from the analysis (exclude tests) turns out to be a no-op: no \`install(TARGETS)\` call in \`projects/*/tests/CMakeLists.txt\` was installing test binaries in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)