### PR TITLE
[cmake] Lift libpq Windows workaround to PostgreSQL imported target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,40 @@ find_package(reflectcpp CONFIG REQUIRED)
 # SQLGen
 find_package(sqlgen REQUIRED)
 
+# libpq on Windows is distributed as a static archive whose symbols depend on
+# the PostgreSQL portability libraries (libpgport, libpgcommon), OpenSSL for
+# the SSL connection paths, and a few Windows system libraries. vcpkg's
+# libpq find-module wrapper only attaches these when the triplet linkage is
+# "static"; the x64-windows dynamic triplet skips them, leaving undefined
+# references to pg_tolower / pg_vsnprintf / pg_strong_random / RAND_bytes /
+# BIO_new / OPENSSL_sk_num / ... in every DLL that pulls libpq in
+# transitively (via sqlgen). Attach them directly onto the
+# PostgreSQL::PostgreSQL imported target so that every consumer — not just
+# ores.database — inherits the fix through normal CMake transitivity.
+if(WIN32)
+    find_package(PostgreSQL REQUIRED)
+    find_library(ORES_PGPORT_LIBRARY
+        NAMES pgport libpgport
+        PATHS "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib"
+        NO_DEFAULT_PATH)
+    find_library(ORES_PGCOMMON_LIBRARY
+        NAMES pgcommon libpgcommon
+        PATHS "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib"
+        NO_DEFAULT_PATH)
+    if(TARGET PostgreSQL::PostgreSQL
+       AND ORES_PGPORT_LIBRARY
+       AND ORES_PGCOMMON_LIBRARY)
+        set_property(TARGET PostgreSQL::PostgreSQL APPEND PROPERTY
+            INTERFACE_LINK_LIBRARIES
+                ${ORES_PGPORT_LIBRARY}
+                ${ORES_PGCOMMON_LIBRARY}
+                OpenSSL::SSL
+                OpenSSL::Crypto
+                Secur32
+                Wldap32)
+    endif()
+endif()
+
 # Magic enum
 find_package(magic_enum CONFIG REQUIRED)
 

--- a/projects/ores.database/src/CMakeLists.txt
+++ b/projects/ores.database/src/CMakeLists.txt
@@ -42,34 +42,4 @@ target_link_libraries(${lib_target_name}
     PRIVATE
         ores.utility.lib)
 
-# libpq on Windows is distributed as a static archive that depends on the
-# PostgreSQL portability libraries libpgport and libpgcommon plus OpenSSL
-# for the SSL connection paths. vcpkg's libpq find-module wrapper only
-# attaches these when the triplet linkage is "static"; the x64-windows
-# dynamic triplet skips them and we get undefined references to
-# pg_tolower/pg_vsnprintf/RAND_bytes/BIO_new/OPENSSL_sk_num/... when
-# linking any DLL that pulls libpq in transitively (e.g. via sqlgen).
-# Attach them explicitly on Windows so the symbols resolve.
-if(WIN32)
-    find_library(ORES_PGPORT_LIBRARY
-        NAMES pgport libpgport
-        PATHS "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib"
-        NO_DEFAULT_PATH)
-    find_library(ORES_PGCOMMON_LIBRARY
-        NAMES pgcommon libpgcommon
-        PATHS "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib"
-        NO_DEFAULT_PATH)
-    find_package(OpenSSL REQUIRED)
-    if(ORES_PGPORT_LIBRARY AND ORES_PGCOMMON_LIBRARY)
-        target_link_libraries(${lib_target_name}
-            PRIVATE
-                ${ORES_PGPORT_LIBRARY}
-                ${ORES_PGCOMMON_LIBRARY}
-                OpenSSL::SSL
-                OpenSSL::Crypto
-                Secur32
-                Wldap32)
-    endif()
-endif()
-
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)


### PR DESCRIPTION
## Summary
PRs #708 and #709 patched the Windows libpq link workaround (\`pgport\`, \`pgcommon\`, \`OpenSSL::SSL\`/\`Crypto\`, \`Secur32\`, \`Wldap32\`) onto \`ores.database\`. That cleared the symptom there, but every other DLL that transitively pulls libpq in via \`sqlgen\` now reports the same undefined references — the latest failing build had \`ores.refdata.core.dll\` tripping over \`pg_tolower\`, \`pg_strong_random\`, \`gettimeofday\`, \`strlcpy\`, \`RAND_bytes\`, \`BIO_new\`, ... The per-target patch does not scale.

**Fix**: lift the workaround to the root \`CMakeLists.txt\` and append the libraries directly onto the \`PostgreSQL::PostgreSQL\` imported target. \`sqlgen\`'s exported config already declares \`PostgreSQL::PostgreSQL\` in its \`INTERFACE_LINK_LIBRARIES\`, so every consumer — \`ores.database\`, \`ores.refdata.core\`, and any future one — picks the fix up through normal CMake transitivity with zero per-target edits. The per-target block in \`ores.database/src/CMakeLists.txt\` is removed as now-redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)