### PR TITLE
[http,qt] Require JWT for HTTP URL discovery; fail login on missing URL

### DIFF
--- a/projects/ores.http.server/include/ores.http.server/messaging/http_info_handler.hpp
+++ b/projects/ores.http.server/include/ores.http.server/messaging/http_info_handler.hpp
@@ -22,8 +22,12 @@
 
 #include <string>
 #include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/headers.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.security/jwt/jwt_error.hpp"
+#include "ores.service/error_code.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.http.api/messaging/http_info_protocol.hpp"
 
@@ -38,24 +42,47 @@ inline auto& http_info_handler_lg() {
 } // namespace
 
 using ores::service::messaging::reply;
-using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
 using namespace ores::logging;
 
 /**
  * @brief Handles service discovery requests for the HTTP server's base URL.
  *
- * No authentication is required — clients need this URL before they can
- * make authenticated HTTP calls.
+ * Requires a valid JWT. The base URL is internal infrastructure information
+ * and is not exposed to unauthenticated callers.
  */
 class http_info_handler {
 public:
-    explicit http_info_handler(ores::nats::service::client& nats,
-                               std::string base_url)
-        : nats_(nats), base_url_(std::move(base_url)) {}
+    http_info_handler(ores::nats::service::client& nats,
+                      ores::security::jwt::jwt_authenticator verifier,
+                      std::string base_url)
+        : nats_(nats)
+        , verifier_(std::move(verifier))
+        , base_url_(std::move(base_url)) {}
 
     void get(ores::nats::message msg) {
         BOOST_LOG_SEV(http_info_handler_lg(), debug)
             << "Handling " << msg.subject;
+
+        const auto auth_it = msg.headers.find(
+            std::string(ores::nats::headers::authorization));
+        if (auth_it == msg.headers.end()
+            || !auth_it->second.starts_with(ores::nats::headers::bearer_prefix)) {
+            error_reply(nats_, msg, ores::service::error_code::unauthorized);
+            return;
+        }
+
+        const auto token = auth_it->second.substr(
+            ores::nats::headers::bearer_prefix.size());
+        auto claims = verifier_.validate(token);
+        if (!claims) {
+            const auto code = (claims.error()
+                == ores::security::jwt::jwt_error::expired_token)
+                ? ores::service::error_code::token_expired
+                : ores::service::error_code::unauthorized;
+            error_reply(nats_, msg, code);
+            return;
+        }
 
         http::messaging::get_http_info_response resp;
         resp.base_url = base_url_;
@@ -68,6 +95,7 @@ public:
 
 private:
     ores::nats::service::client& nats_;
+    ores::security::jwt::jwt_authenticator verifier_;
     std::string base_url_;
 };
 

--- a/projects/ores.http.server/include/ores.http.server/messaging/registrar.hpp
+++ b/projects/ores.http.server/include/ores.http.server/messaging/registrar.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include "ores.nats/service/client.hpp"
 #include "ores.nats/service/subscription.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
 
 namespace ores::http_server::messaging {
 
@@ -33,12 +34,14 @@ public:
      * @brief Registers all NATS message handlers for the HTTP server.
      *
      * @param nats Connected NATS client.
+     * @param verifier JWT verifier used to authenticate inbound requests.
      * @param base_url The HTTP server's externally accessible base URL.
      * @return Subscription handles that must be kept alive for the lifetime
      *         of the server.
      */
     static std::vector<ores::nats::service::subscription>
     register_handlers(ores::nats::service::client& nats,
+                      ores::security::jwt::jwt_authenticator verifier,
                       const std::string& base_url);
 };
 

--- a/projects/ores.http.server/src/app/application.cpp
+++ b/projects/ores.http.server/src/app/application.cpp
@@ -178,8 +178,12 @@ boost::asio::awaitable<void> application::run(asio::io_context& io_ctx,
 
     co_await ores::service::service::run(
         io_ctx, nats, service_name,
-        [&http_base_url](auto& n, auto /*verifier*/) {
-            return http_server::messaging::registrar::register_handlers(n, http_base_url);
+        [&http_base_url](auto& n, auto verifier) {
+            if (!verifier)
+                throw std::runtime_error(
+                    "JWT verifier is required to register HTTP server handlers.");
+            return http_server::messaging::registrar::register_handlers(
+                n, std::move(*verifier), http_base_url);
         },
         [&](asio::io_context& ioc) {
             auto hb = std::make_shared<ores::service::service::heartbeat_publisher>(

--- a/projects/ores.http.server/src/messaging/registrar.cpp
+++ b/projects/ores.http.server/src/messaging/registrar.cpp
@@ -36,8 +36,10 @@ using namespace ores::logging;
 
 std::vector<ores::nats::service::subscription>
 registrar::register_handlers(ores::nats::service::client& nats,
+                              ores::security::jwt::jwt_authenticator verifier,
                               const std::string& base_url) {
-    auto handler = std::make_shared<http_info_handler>(nats, base_url);
+    auto handler = std::make_shared<http_info_handler>(
+        nats, std::move(verifier), base_url);
 
     std::vector<ores::nats::service::subscription> subs;
     subs.push_back(nats.subscribe(

--- a/projects/ores.qt.api/include/ores.qt/ClientManager.hpp
+++ b/projects/ores.qt.api/include/ores.qt/ClientManager.hpp
@@ -84,11 +84,6 @@ struct LoginResult {
     bool party_setup_required = false;
     boost::uuids::uuid selected_party_id;
     std::vector<PartyInfo> available_parties;
-    /**
-     * @brief HTTP base URL discovered from the HTTP server via NATS.
-     * Empty if discovery failed or the HTTP server has no NATS support.
-     */
-    std::string http_base_url;
 };
 
 /**
@@ -303,6 +298,14 @@ public:
      * @brief Whether the last selectParty call indicated the party needs setup.
      */
     bool lastPartySetupRequired() const { return last_party_setup_required_; }
+
+    /**
+     * @brief HTTP base URL discovered during login via NATS service discovery.
+     *
+     * Populated by login() on success. Empty between disconnect() and the next
+     * successful login.
+     */
+    const std::string& httpBaseUrl() const { return http_base_url_; }
 
     /**
      * @brief Select a party for the current session.
@@ -528,6 +531,9 @@ private:
     QString current_party_name_;
     QString current_party_category_;
     bool last_party_setup_required_ = false;
+
+    // HTTP server base URL discovered post-login via NATS.
+    std::string http_base_url_;
 
     // Active NATS event subscriptions keyed by subject
     std::unordered_map<std::string, nats::service::subscription> nats_subscriptions_;

--- a/projects/ores.qt.api/src/ClientManager.cpp
+++ b/projects/ores.qt.api/src/ClientManager.cpp
@@ -303,24 +303,33 @@ LoginResult ClientManager::login(const std::string& username,
         }
 
         arm_refresh_timer(response.access_lifetime_s);
-        emit loggedIn();
 
-        // Discover HTTP base URL via NATS service discovery
-        std::string discovered_base_url;
-        try {
-            auto http_info = process_request(http::messaging::get_http_info_request{});
-            if (http_info) {
-                discovered_base_url = http_info->base_url;
-                BOOST_LOG_SEV(lg(), info) << "Discovered HTTP base URL: "
-                                          << discovered_base_url;
-            } else {
-                BOOST_LOG_SEV(lg(), warn)
-                    << "HTTP service discovery failed: " << http_info.error();
-            }
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(lg(), warn)
-                << "HTTP service discovery unavailable: " << e.what();
+        // Discover HTTP base URL via authenticated NATS service discovery.
+        // The URL is internal infrastructure information and must not be served
+        // to unauthenticated callers. Failure here fails the login so the user
+        // is not left in a half-configured state where HTTP-dependent features
+        // silently break (e.g. compute package upload, report downloads).
+        auto http_info = process_authenticated_request(
+            http::messaging::get_http_info_request{});
+        if (!http_info || http_info->base_url.empty()) {
+            const std::string err = http_info
+                ? std::string("empty base URL")
+                : http_info.error();
+            BOOST_LOG_SEV(lg(), error)
+                << "HTTP service discovery failed: " << err;
+            logout();
+            return {.success = false,
+                    .error_message = QString(
+                        "Authenticated with IAM but the HTTP server did not "
+                        "respond to service discovery.\n\n"
+                        "Please ensure ores.http.server is running "
+                        "(details: %1).").arg(QString::fromStdString(err))};
         }
+        http_base_url_ = http_info->base_url;
+        BOOST_LOG_SEV(lg(), info) << "Discovered HTTP base URL: "
+                                  << http_base_url_;
+
+        emit loggedIn();
 
         return {
             .success = true,
@@ -329,8 +338,7 @@ LoginResult ClientManager::login(const std::string& username,
             .tenant_bootstrap_mode = response.tenant_bootstrap_mode,
             .party_setup_required = response.party_setup_required,
             .selected_party_id = selected_party_id,
-            .available_parties = std::move(available_parties),
-            .http_base_url = std::move(discovered_base_url)
+            .available_parties = std::move(available_parties)
         };
 
     } catch (const std::exception& e) {
@@ -536,6 +544,7 @@ void ClientManager::disconnect() {
     session_id_.clear();
     stored_username_.clear();
     stored_password_.clear();
+    http_base_url_.clear();
     disconnected_since_ = std::chrono::steady_clock::now();
     QMetaObject::invokeMethod(this, "disconnected", Qt::QueuedConnection);
 }
@@ -549,10 +558,12 @@ bool ClientManager::logout() {
     try {
         auto result = process_authenticated_request(iam::messaging::logout_request{});
         session_.clear_auth();
+        http_base_url_.clear();
         return result && result->success;
     } catch (const std::exception& e) {
         BOOST_LOG_SEV(lg(), error) << "Logout failed: " << e.what();
         session_.clear_auth();
+        http_base_url_.clear();
         return false;
     }
 }

--- a/projects/ores.qt/include/ores.qt/LoginDialog.hpp
+++ b/projects/ores.qt/include/ores.qt/LoginDialog.hpp
@@ -154,13 +154,6 @@ signals:
     void loginSucceeded(const QString& username);
 
     /**
-     * @brief Emitted when the HTTP base URL is discovered via NATS service
-     *        discovery during login. May not be emitted if the HTTP server
-     *        does not have NATS enabled.
-     */
-    void httpBaseUrlDiscovered(const QString& baseUrl);
-
-    /**
      * @brief Emitted when login fails.
      */
     void loginFailed(const QString& errorMessage);

--- a/projects/ores.qt/src/LoginDialog.cpp
+++ b/projects/ores.qt/src/LoginDialog.cpp
@@ -587,11 +587,6 @@ void LoginDialog::onLoginResult(const LoginResult& result) {
     if (result.success) {
         BOOST_LOG_SEV(lg(), debug) << "Login was successful";
 
-        // Emit discovered HTTP base URL so MainWindow can configure it
-        if (!result.http_base_url.empty()) {
-            emit httpBaseUrlDiscovered(QString::fromStdString(result.http_base_url));
-        }
-
         if (result.password_reset_required) {
             BOOST_LOG_SEV(lg(), info) << "Password reset required";
             statusLabel_->setText("Password change required...");

--- a/projects/ores.qt/src/MainWindow.cpp
+++ b/projects/ores.qt/src/MainWindow.cpp
@@ -1584,7 +1584,13 @@ void MainWindow::onLoginSuccess(const QString& username) {
     ctx.badge_cache         = badgeCache_;
     ctx.event_bus           = eventBus_;
     ctx.username            = username;
-    ctx.http_base_url       = httpBaseUrl_;
+    // CLI override (--http-base-url) wins; otherwise use the URL discovered
+    // post-login via NATS. Sourcing from ClientManager means every login path
+    // (normal, bootstrap, tenant provisioning) surfaces the URL uniformly
+    // without routing it through a dedicated signal.
+    ctx.http_base_url = httpBaseUrl_.empty() && clientManager_
+        ? clientManager_->httpBaseUrl()
+        : httpBaseUrl_;
 
     // Drive plugin lifecycle in load_order sequence.
     // Menus were already created in the constructor; on_login() wires up controllers.
@@ -1772,12 +1778,6 @@ void MainWindow::showLoginDialog(const LoginDialogOptions& options) {
 
     // Connect close signal
     connect(loginWidget, &LoginDialog::closeRequested, subWindow, &QWidget::close);
-
-    // Connect HTTP base URL discovery signal (from NATS service discovery)
-    connect(loginWidget, &LoginDialog::httpBaseUrlDiscovered,
-            this, [this](const QString& url) {
-        setHttpBaseUrl(url.toStdString());
-    });
 
     // Connect login success signal
     connect(loginWidget, &LoginDialog::loginSucceeded,


### PR DESCRIPTION
## Summary

- Makes the NATS `http-server.v1.info.get` request require a JWT. Previously the handler was unauthenticated, leaking the HTTP server's internal base URL to any NATS client. Rationale for not being chicken-and-egg: authentication happens over NATS (login → JWT), not HTTP, so a client has a JWT before it ever needs the HTTP URL.
- Moves HTTP URL discovery from a best-effort, silently-swallowed step into a hard post-login requirement on `ClientManager`. Discovery now uses `process_authenticated_request`; on failure `login()` fails with a user-visible error and a server-side logout.
- Fixes the bootstrap-flow bug where `LoginResult.http_base_url` was lost. The in-wizard login never routed through `LoginDialog::httpBaseUrlDiscovered`, so `MainWindow::httpBaseUrl_` stayed empty and `ComputePlugin` received an empty `plugin_context.http_base_url`. The symptom was *"HTTP base URL is not configured. Cannot upload package."* immediately after bootstrapping a new system. `MainWindow::onLoginSuccess` now sources the URL from `ClientManager::httpBaseUrl()`, which is populated on every login path (normal, bootstrap, tenant provisioning).
- Removes now-dead plumbing: `LoginResult::http_base_url`, `LoginDialog::httpBaseUrlDiscovered` signal, and the `MainWindow` → `LoginDialog` connection. The `--http-base-url` CLI override still wins when present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)