### PR TITLE
[compute] Per-triplet app_version packages via junction table

### DIFF
--- a/projects/ores.cli/include/ores.cli/config/add_compute_app_version_options.hpp
+++ b/projects/ores.cli/include/ores.cli/config/add_compute_app_version_options.hpp
@@ -31,12 +31,20 @@ namespace ores::cli::config {
  * @brief Configuration for adding a compute app_version entity via command-line arguments.
  */
 struct add_compute_app_version_options final {
+    /**
+     * @brief One (platform_code, package_uri) pair per supported target
+     * triplet, e.g. {"x64-linux", "s3://.../ore-1.8.15.0-x64-linux.tar.gz"}.
+     */
+    struct platform_package {
+        std::string platform_code;
+        std::string package_uri;
+    };
+
     std::string app_id;
     std::string wrapper_version;
     std::string engine_version;
-    std::vector<std::string> platforms;
+    std::vector<platform_package> platform_packages;
     std::string modified_by;
-    std::optional<std::string> package_uri;
     std::optional<int> min_ram_mb;
 };
 

--- a/projects/ores.cli/src/app/application.cpp
+++ b/projects/ores.cli/src/app/application.cpp
@@ -24,6 +24,7 @@
 #include <chrono>
 #include <optional>
 #include <type_traits>
+#include <unordered_map>
 #include "ores.utility/version/version.hpp"
 #include <boost/lexical_cast.hpp>
 #include <boost/throw_exception.hpp>
@@ -1562,13 +1563,16 @@ add_compute_app_version(const config::add_compute_app_version_options& cfg) cons
     // the orchestrator can match incoming workunits against the host triplet.
     compute::repository::platform_repository plat_repo;
     const auto platforms = plat_repo.read_active(context_);
+    std::unordered_map<std::string, boost::uuids::uuid> plat_by_code;
+    plat_by_code.reserve(platforms.size());
+    for (const auto& p : platforms)
+        plat_by_code.emplace(p.code, p.id);
 
     std::vector<compute::domain::app_version_platform> junction_rows;
     junction_rows.reserve(cfg.platform_packages.size());
     for (const auto& pp : cfg.platform_packages) {
-        const auto it = std::find_if(platforms.begin(), platforms.end(),
-            [&](const auto& p) { return p.code == pp.platform_code; });
-        if (it == platforms.end()) {
+        const auto it = plat_by_code.find(pp.platform_code);
+        if (it == plat_by_code.end()) {
             BOOST_THROW_EXCEPTION(application_exception(std::format(
                 "Unknown platform code: {}", pp.platform_code)));
         }
@@ -1576,8 +1580,8 @@ add_compute_app_version(const config::add_compute_app_version_options& cfg) cons
         compute::domain::app_version_platform avp;
         avp.tenant_id = context_.tenant_id();
         avp.app_version_id = record.id;
-        avp.platform_id = it->id;
-        avp.platform_code = it->code;
+        avp.platform_id = it->second;
+        avp.platform_code = it->first;
         avp.package_uri = pp.package_uri;
         junction_rows.push_back(std::move(avp));
     }

--- a/projects/ores.cli/src/app/application.cpp
+++ b/projects/ores.cli/src/app/application.cpp
@@ -20,6 +20,7 @@
  */
 #include "ores.cli/app/application.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <optional>
 #include <type_traits>
@@ -99,6 +100,8 @@
 #include "ores.compute.core/repository/host_repository.hpp"
 #include "ores.compute.core/repository/app_repository.hpp"
 #include "ores.compute.core/repository/app_version_repository.hpp"
+#include "ores.compute.core/repository/app_version_platform_repository.hpp"
+#include "ores.compute.core/repository/platform_repository.hpp"
 #include "ores.compute.core/repository/batch_repository.hpp"
 #include "ores.compute.core/repository/workunit_repository.hpp"
 #include "ores.compute.core/repository/result_repository.hpp"
@@ -1547,14 +1550,43 @@ add_compute_app_version(const config::add_compute_app_version_options& cfg) cons
     record.app_id = app_id;
     record.wrapper_version = cfg.wrapper_version;
     record.engine_version = cfg.engine_version;
-    record.platforms = cfg.platforms;
-    record.package_uri = cfg.package_uri.value_or("");
     record.min_ram_mb = cfg.min_ram_mb.value_or(0);
     record.modified_by = cfg.modified_by;
     record.performed_by = cfg.modified_by;
+    record.change_reason_code = "system.new_record";
 
     compute::repository::app_version_repository repo;
     repo.write(context_, record);
+
+    // Resolve platform codes to IDs and insert one junction row per pair so
+    // the orchestrator can match incoming workunits against the host triplet.
+    compute::repository::platform_repository plat_repo;
+    const auto platforms = plat_repo.read_active(context_);
+
+    std::vector<compute::domain::app_version_platform> junction_rows;
+    junction_rows.reserve(cfg.platform_packages.size());
+    for (const auto& pp : cfg.platform_packages) {
+        const auto it = std::find_if(platforms.begin(), platforms.end(),
+            [&](const auto& p) { return p.code == pp.platform_code; });
+        if (it == platforms.end()) {
+            BOOST_THROW_EXCEPTION(application_exception(std::format(
+                "Unknown platform code: {}", pp.platform_code)));
+        }
+
+        compute::domain::app_version_platform avp;
+        avp.tenant_id = context_.tenant_id();
+        avp.app_version_id = record.id;
+        avp.platform_id = it->id;
+        avp.platform_code = it->code;
+        avp.package_uri = pp.package_uri;
+        junction_rows.push_back(std::move(avp));
+    }
+
+    compute::repository::app_version_platform_repository avp_repo;
+    avp_repo.replace_for_version(context_,
+        boost::uuids::to_string(record.id), junction_rows,
+        cfg.modified_by, cfg.modified_by,
+        record.change_reason_code, "Initial import");
 
     output_stream_ << "Successfully added compute app version: "
                    << record.wrapper_version << "/" << record.engine_version << std::endl;

--- a/projects/ores.cli/src/config/add_compute_app_version_options.cpp
+++ b/projects/ores.cli/src/config/add_compute_app_version_options.cpp
@@ -28,12 +28,17 @@ std::ostream& operator<<(std::ostream& s, const add_compute_app_version_options&
     s << "{ app_id: " << v.app_id
       << ", wrapper_version: " << v.wrapper_version
       << ", engine_version: " << v.engine_version
-      << ", platforms: [" << std::accumulate(v.platforms.begin(), v.platforms.end(),
-             std::string{}, [](const std::string& a, const std::string& b) {
-                 return a.empty() ? b : a + ", " + b; }) << "]"
+      << ", platform_packages: ["
+      << std::accumulate(v.platform_packages.begin(), v.platform_packages.end(),
+             std::string{},
+             [](const std::string& a,
+                 const add_compute_app_version_options::platform_package& b) {
+                 const auto item = b.platform_code + "=" + b.package_uri;
+                 return a.empty() ? item : a + ", " + item;
+             })
+      << "]"
       << ", modified_by: " << v.modified_by;
 
-    if (v.package_uri) s << ", package_uri: " << *v.package_uri;
     if (v.min_ram_mb) s << ", min_ram_mb: " << *v.min_ram_mb;
 
     s << " }";

--- a/projects/ores.cli/src/config/entity_parsers/compute_app_versions_parser.cpp
+++ b/projects/ores.cli/src/config/entity_parsers/compute_app_versions_parser.cpp
@@ -71,12 +71,11 @@ options_description make_add_compute_app_version_options_description() {
         ("engine-version",
             value<std::string>(),
             "Engine version, e.g. 'ORE-Studio-7.1' (required)")
-        ("platform",
+        ("platform-package",
             value<std::vector<std::string>>()->multitoken(),
-            "Supported platforms, e.g. 'linux-x86_64' (required; repeatable)")
-        ("package-uri",
-            value<std::string>()->default_value(""),
-            "URI to the zipped bundle in object storage")
+            "Per-platform package as '<platform-code>=<package-uri>' "
+            "(required; repeatable). Platform codes match vcpkg triplets "
+            "(x64-linux, arm64-osx, x64-windows, ...).")
         ("min-ram-mb",
             value<int>()->default_value(0),
             "Minimum RAM in MB required")
@@ -115,14 +114,22 @@ read_add_compute_app_version_options(const variables_map& vm) {
     }
     r.engine_version = vm["engine-version"].as<std::string>();
 
-    if (vm.count("platform") == 0) {
-        BOOST_THROW_EXCEPTION(
-            parser_exception("Must supply --platform for add app-version command."));
+    if (vm.count("platform-package") == 0) {
+        BOOST_THROW_EXCEPTION(parser_exception(
+            "Must supply at least one --platform-package "
+            "'<platform-code>=<package-uri>' for add app-version command."));
     }
-    r.platforms = vm["platform"].as<std::vector<std::string>>();
+    for (const auto& raw : vm["platform-package"].as<std::vector<std::string>>()) {
+        const auto eq = raw.find('=');
+        if (eq == std::string::npos || eq == 0 || eq == raw.size() - 1) {
+            BOOST_THROW_EXCEPTION(parser_exception(
+                "--platform-package must be '<platform-code>=<package-uri>': "
+                + raw));
+        }
+        r.platform_packages.push_back(
+            {raw.substr(0, eq), raw.substr(eq + 1)});
+    }
 
-    if (vm.count("package-uri") != 0)
-        r.package_uri = vm["package-uri"].as<std::string>();
     if (vm.count("min-ram-mb") != 0)
         r.min_ram_mb = vm["min-ram-mb"].as<int>();
 

--- a/projects/ores.codegen/models/compute/app_version_domain_entity.json
+++ b/projects/ores.codegen/models/compute/app_version_domain_entity.json
@@ -8,7 +8,7 @@
     "entity_title": "App Version",
     "has_tenant_id": true,
     "brief": "A versioned wrapper+engine bundle for a compute grid application.",
-    "description": "Combines a specific wrapper version with a specific engine version for a given\nplatform. The BOINC equivalent of 'app_version'. Nodes download the package_uri\nbundle and launch the wrapper to run the engine.",
+    "description": "Combines a specific wrapper version with a specific engine version. The BOINC\nequivalent of 'app_version'. Per-platform package artefacts are tracked in\nores_compute_app_version_platforms_tbl — each (app_version, platform) row owns\nthe URI of its own packaged bundle.",
 
     "primary_key": {
       "column": "id",
@@ -38,20 +38,6 @@
         "cpp_type": "std::string",
         "nullable": false,
         "description": "Version of the underlying engine, e.g. 'ORE-Studio-7.1'."
-      },
-      {
-        "name": "package_uri",
-        "type": "text",
-        "cpp_type": "std::string",
-        "nullable": false,
-        "description": "URI pointing to the zipped wrapper+engine bundle in object storage."
-      },
-      {
-        "name": "platform",
-        "type": "text",
-        "cpp_type": "std::string",
-        "nullable": false,
-        "description": "Target platform identifier, e.g. 'linux_x86_64', 'win_x64'."
       },
       {
         "name": "min_ram_mb",
@@ -107,9 +93,7 @@
         {"enum_name": "AppId",          "field": "app_id",          "header": "App ID",          "is_uuid": true,   "width": 160},
         {"enum_name": "WrapperVersion", "field": "wrapper_version", "header": "Wrapper Version", "is_string": true, "width": 120},
         {"enum_name": "EngineVersion",  "field": "engine_version",  "header": "Engine Version",  "is_string": true, "width": 120},
-        {"enum_name": "Platform",       "field": "platform",        "header": "Platform",        "is_string": true, "width": 100},
         {"enum_name": "MinRamMb",       "field": "min_ram_mb",      "header": "Min RAM (MB)",    "is_int": true,    "width": 90},
-        {"enum_name": "PackageUri",     "field": "package_uri",     "header": "Package URI",     "is_string": true, "width": 200},
         {"enum_name": "Version",        "field": "version",         "header": "Version",         "is_int": true,    "width": 60},
         {"enum_name": "ModifiedBy",     "field": "modified_by",     "header": "Modified By",     "is_string": true, "width": 120}
       ],

--- a/projects/ores.codegen/models/compute/app_version_platform_junction.json
+++ b/projects/ores.codegen/models/compute/app_version_platform_junction.json
@@ -1,0 +1,77 @@
+{
+  "junction": {
+    "schema": "public",
+    "product": "ores",
+    "component": "compute",
+    "has_tenant_id": true,
+    "name": "app_version_platforms",
+    "name_singular": "app_version_platform",
+    "name_title": "App Version Platform",
+    "name_singular_words": "app version platform association",
+    "brief": "Links an app version to a supported platform and its package URI.",
+    "description": "Associates app versions with the platforms they support, and carries the URI\nof the per-platform packaged bundle (a .tar.gz containing the wrapper+engine\nbinaries built for that target triplet). Each (app_version, platform) row\nowns its own package_uri, so the orchestrator can dispatch per-triplet\nassignments without the wrapper needing to negotiate package selection.",
+
+    "left": {
+      "column": "app_version_id",
+      "column_short": "app_version",
+      "column_title": "App Version",
+      "type": "uuid",
+      "cpp_type": "boost::uuids::uuid",
+      "index_comment": "Index for looking up platforms for an app version",
+      "description": "FK reference to ores_compute_app_versions_tbl.",
+      "detail": "References ores_compute_app_versions_tbl.id (soft FK).",
+      "generator_expr": "ctx.generate_uuid()"
+    },
+
+    "right": {
+      "column": "platform_id",
+      "column_short": "platform",
+      "column_title": "Platform",
+      "type": "uuid",
+      "cpp_type": "boost::uuids::uuid",
+      "index_comment": "Index for finding app versions supporting a platform",
+      "description": "FK reference to ores_compute_platforms_tbl.",
+      "detail": "References ores_compute_platforms_tbl.id (soft FK).",
+      "generator_expr": "ctx.generate_uuid()"
+    },
+
+    "columns": [
+      {
+        "name": "package_uri",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "URI of the per-platform packaged bundle in object storage.",
+        "detail": "One .tar.gz per (app_version, platform). Wrappers download the URI\nmatching their own ORES_PLATFORM_TRIPLET at dispatch time.",
+        "generator_expr": "std::string(faker::internet::url())"
+      }
+    ],
+
+    "sql": {
+      "tablename": "ores_compute_app_version_platforms_tbl"
+    },
+
+    "repository": {
+      "name_singular_short": "app_version_platform",
+      "name_short": "app_version_platforms",
+      "name_singular_words": "app version platform",
+      "name_words": "app version platforms",
+      "order_column": "platform_id"
+    },
+
+    "cpp": {
+      "includes": {
+        "domain": ["<string>", "<boost/uuid/uuid.hpp>"],
+        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\"", "\"sqlgen/PrimaryKey.hpp\""]
+      },
+      "iterator_var": "avp",
+      "table_display": [
+        {"column": "app_version_id", "header": "App Version"},
+        {"column": "platform_id", "header": "Platform"},
+        {"column": "package_uri", "header": "Package URI"},
+        {"column": "modified_by", "header": "Modified By"},
+        {"column": "version", "header": "Version"}
+      ]
+    }
+  }
+}

--- a/projects/ores.codegen/models/plantuml_er_model.json
+++ b/projects/ores.codegen/models/plantuml_er_model.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-02T09:48:25.057318Z",
+  "generated_at": "2026-04-21T22:09:54.950184Z",
   "packages": [
     {
       "name": "iam",
@@ -7,6 +7,103 @@
       "color": "#E8F4FD",
       "order": 1,
       "tables": [
+        {
+          "name": "ores_iam_account_parties_tbl",
+          "component": "iam",
+          "entity": "account_parties",
+          "classification": "junction",
+          "stereotype": "<<junction>>",
+          "color": "#ECECEC",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "account_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "party_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "valid_from",
+                "type": "timestamptz"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/iam/iam_account_party_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_junction_create.mustache\n    To modify, update the template and regenerate.\n    Account Party Table\n    Junction table linking IAM accounts to parties. Each account can be\n    associated with one or more parties, controlling which parties a user\n    can act on behalf of."
+        },
         {
           "name": "ores_iam_account_roles_tbl",
           "component": "iam",
@@ -100,6 +197,133 @@
           "description": "Many-to-many: accounts to roles.\n    Tracks who assigned the role."
         },
         {
+          "name": "ores_iam_account_types_tbl",
+          "component": "iam",
+          "entity": "account_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "type",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "display_order",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/iam/iam_account_types_create.sql",
+          "description": "Account Types - Valid account type classifications"
+        },
+        {
           "name": "ores_iam_accounts_tbl",
           "component": "iam",
           "entity": "accounts",
@@ -132,6 +356,16 @@
               "references": null
             },
             {
+              "name": "account_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'user'",
+              "references": null
+            },
+            {
               "name": "username",
               "type": "text",
               "nullable": false,
@@ -155,6 +389,16 @@
               "name": "password_salt",
               "type": "text",
               "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "service_password_hash",
+              "type": "text",
+              "nullable": true,
               "is_pk": false,
               "is_fk": false,
               "is_unique": false,
@@ -212,6 +456,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "valid_from",
               "type": "timestamptz",
               "nullable": false,
@@ -235,6 +489,102 @@
           "indexes": [],
           "source_file": "create/iam/iam_accounts_create.sql",
           "description": "User accounts with authentication credentials.\n    Supports optimistic locking via version field.\n    Username and email unique for current records."
+        },
+        {
+          "name": "ores_iam_auth_events_tbl",
+          "component": "iam",
+          "entity": "auth_events",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "id",
+                "type": "text"
+              },
+              {
+                "name": "event_time",
+                "type": "timestamptz"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "tenant_id",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "account_id",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "event_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "username",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "session_id",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "error_detail",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/iam/iam_auth_events_create.sql",
+          "description": ""
         },
         {
           "name": "ores_iam_login_info_tbl",
@@ -521,6 +871,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "change_reason_code",
               "type": "text",
               "nullable": false,
@@ -564,6 +924,73 @@
           "indexes": [],
           "source_file": "create/iam/iam_roles_create.sql",
           "description": "Named roles for grouping permissions.\n    Examples: admin, viewer, editor."
+        },
+        {
+          "name": "ores_iam_session_samples_tbl",
+          "component": "iam",
+          "entity": "session_samples",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "session_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "sample_time",
+                "type": "timestamptz"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "bytes_sent",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "bytes_received",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "latency_ms",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/iam/iam_session_samples_create.sql",
+          "description": "Session time-series samples: bytes captured at heartbeat frequency.\n    Designed for TimescaleDB hypertable.\n    Partitioned by sample_time."
         },
         {
           "name": "ores_iam_sessions_tbl",
@@ -729,7 +1156,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -765,6 +1192,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -846,7 +1283,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -882,6 +1319,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -945,13 +1392,23 @@
           "primary_key": {
             "columns": [
               {
-                "name": "tenant_id",
+                "name": "id",
                 "type": "uuid"
               }
             ],
             "composite": true
           },
           "columns": [
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "ores_iam_system_tenant_id_fn()",
+              "references": null
+            },
             {
               "name": "version",
               "type": "integer",
@@ -1033,6 +1490,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "change_reason_code",
               "type": "text",
               "nullable": false,
@@ -1075,7 +1542,7 @@
           ],
           "indexes": [],
           "source_file": "create/iam/iam_tenants_create.sql",
-          "description": "Tenants Table\n    Core table for multi-tenancy support. Each tenant represents an isolated\n    organisation or the system platform tenant."
+          "description": ""
         }
       ]
     },
@@ -1230,6 +1697,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "change_reason_code",
               "type": "text",
               "nullable": false,
@@ -1278,18 +1755,14 @@
           "name": "ores_assets_tags_tbl",
           "component": "assets",
           "entity": "tags",
-          "classification": "junction",
-          "stereotype": "<<junction>>",
-          "color": "#ECECEC",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
           "primary_key": {
             "columns": [
               {
                 "name": "tag_id",
                 "type": "uuid"
-              },
-              {
-                "name": "valid_from",
-                "type": "timestamptz"
               }
             ],
             "composite": true
@@ -1346,6 +1819,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "change_reason_code",
               "type": "text",
               "nullable": false,
@@ -1358,6 +1841,16 @@
             {
               "name": "change_commentary",
               "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
@@ -1421,7 +1914,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -1447,6 +1940,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -1533,7 +2036,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -1559,6 +2062,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -1645,7 +2158,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -1671,6 +2184,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -1757,7 +2280,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -1783,6 +2306,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -1837,6 +2370,330 @@
           "description": "FpML Benchmark rates"
         },
         {
+          "name": "ores_refdata_book_statuses_tbl",
+          "component": "refdata",
+          "entity": "book_statuses",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "display_order",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_book_statuses_create.sql",
+          "description": "Book Statuses - Lifecycle states for book records (Active, Closed, Frozen)"
+        },
+        {
+          "name": "ores_refdata_books_tbl",
+          "component": "refdata",
+          "entity": "books",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "parent_portfolio_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "ledger_ccy",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "gl_account_ref",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "cost_center",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "book_status",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "is_trading_book",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "owner_unit_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_books_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Operational ledger leaves. The only entity that holds trades.\n    Serves as the basis for accounting, ownership, and regulatory\n    capital treatment. Must belong to exactly one portfolio."
+        },
+        {
           "name": "ores_refdata_business_centres_tbl",
           "component": "refdata",
           "entity": "business_centres",
@@ -1869,7 +2726,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -1894,6 +2751,26 @@
               "references": null
             },
             {
+              "name": "city_name",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "country_alpha2_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "image_id",
               "type": "uuid",
               "nullable": true,
@@ -1905,6 +2782,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -1991,7 +2878,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -2017,6 +2904,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -2071,6 +2968,320 @@
           "description": "Contains a code representing the type of business process a message (e.g. a status request) applies to."
         },
         {
+          "name": "ores_refdata_business_unit_types_tbl",
+          "component": "refdata",
+          "entity": "business_unit_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "coding_scheme_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "level",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_business_unit_types_create.sql",
+          "description": "Business Unit Types - Classification of organisational unit roles.\n    Defines the level-based hierarchy of business unit types (Division,\n    Branch, Business Area, Desk, Cost Centre). The `level` field enforces\n    hierarchy ordering: 0 = top-level, higher = lower in hierarchy."
+        },
+        {
+          "name": "ores_refdata_business_units_tbl",
+          "component": "refdata",
+          "entity": "business_units",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "unit_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "parent_business_unit_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "unit_type_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "unit_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "business_centre_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "status",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'Active'",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_business_units_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Represents internal organizational units (e.g., desks, departments, branches).\n    Supports hierarchical structure via self-referencing parent_business_unit_id.\n    Each unit belongs to a top-level legal entity (party)."
+        },
+        {
           "name": "ores_refdata_cashflow_types_tbl",
           "component": "refdata",
           "entity": "cashflow_types",
@@ -2103,7 +3314,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -2129,6 +3340,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -2181,6 +3402,644 @@
           "indexes": [],
           "source_file": "create/refdata/refdata_cashflow_types_create.sql",
           "description": "The type of cash flows associated with OTC derivatives contracts and their lifecycle events."
+        },
+        {
+          "name": "ores_refdata_contact_types_tbl",
+          "component": "refdata",
+          "entity": "contact_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "display_order",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_contact_types_create.sql",
+          "description": "Contact Types - Classification of contact information purpose (Legal, Operations, Settlement, Billing)"
+        },
+        {
+          "name": "ores_refdata_counterparties_tbl",
+          "component": "refdata",
+          "entity": "counterparties",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "full_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "short_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "transliterated_name",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "parent_counterparty_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "business_center_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "status",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'Active'",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_counterparties_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    External trading partners and counterparties that participate in financial\n    transactions with the organisation. Counterparties form a hierarchy through\n    parent_counterparty_id for group structures."
+        },
+        {
+          "name": "ores_refdata_counterparty_contact_informations_tbl",
+          "component": "refdata",
+          "entity": "counterparty_contact_informations",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "counterparty_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "contact_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "street_line_1",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "street_line_2",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "city",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "state",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "country_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "postal_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "phone",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "email",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "web_page",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_counterparty_contact_informations_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Contact details for counterparties organised by purpose (Legal, Operations,\n    Settlement, Billing). Each counterparty can have one contact record per type."
+        },
+        {
+          "name": "ores_refdata_counterparty_identifiers_tbl",
+          "component": "refdata",
+          "entity": "counterparty_identifiers",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "counterparty_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "id_scheme",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "id_value",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_counterparty_identifiers_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    External identifiers for counterparties, such as LEI codes, BIC/SWIFT codes,\n    national registration numbers, and tax identifiers. Each counterparty can have\n    multiple identifiers across different schemes."
         },
         {
           "name": "ores_refdata_countries_tbl",
@@ -2285,6 +4144,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "change_reason_code",
               "type": "text",
               "nullable": false,
@@ -2357,7 +4226,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -2442,7 +4311,17 @@
               "references": null
             },
             {
-              "name": "currency_type",
+              "name": "monetary_nature",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "market_tier",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -2473,6 +4352,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -2527,6 +4416,133 @@
           "description": "ISO 4217 currency definitions"
         },
         {
+          "name": "ores_refdata_currency_market_tiers_tbl",
+          "component": "refdata",
+          "entity": "currency_market_tiers",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "display_order",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_currency_market_tiers_create.sql",
+          "description": "Currency market tier classification. Drives UI priority, liquidity expectations, and risk limits."
+        },
+        {
           "name": "ores_refdata_entity_classifications_tbl",
           "component": "refdata",
           "entity": "entity_classifications",
@@ -2559,7 +4575,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -2585,6 +4601,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -2671,7 +4697,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -2697,6 +4723,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -2751,6 +4787,1227 @@
           "description": "This overrides the countryScheme. Specifies the Local Jurisdiction that applies to a Transaction, for example for the purposes of defining which Local Taxes will apply."
         },
         {
+          "name": "ores_refdata_monetary_natures_tbl",
+          "component": "refdata",
+          "entity": "monetary_natures",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "display_order",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_monetary_natures_create.sql",
+          "description": "Monetary nature classification. Defines the nature of the currency instrument."
+        },
+        {
+          "name": "ores_refdata_parties_tbl",
+          "component": "refdata",
+          "entity": "parties",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "full_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "short_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "codename",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "transliterated_name",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_category",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'Operational'",
+              "references": null
+            },
+            {
+              "name": "party_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "parent_party_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "business_center_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "status",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'Active'",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_parties_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Internal legal entities (the organisation and its subsidiaries) that participate\n    in financial transactions. Parties form a hierarchy through parent_party_id,\n    with exactly one root party per tenant representing the organisation itself."
+        },
+        {
+          "name": "ores_refdata_party_categories_tbl",
+          "component": "refdata",
+          "entity": "party_categories",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "display_order",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_party_categories_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_refdata_party_contact_informations_tbl",
+          "component": "refdata",
+          "entity": "party_contact_informations",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "contact_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "street_line_1",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "street_line_2",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "city",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "state",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "country_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "postal_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "phone",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "email",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "web_page",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_party_contact_informations_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Contact details for parties organised by purpose (Legal, Operations,\n    Settlement, Billing). Each party can have one contact record per type."
+        },
+        {
+          "name": "ores_refdata_party_counterparties_tbl",
+          "component": "refdata",
+          "entity": "party_counterparties",
+          "classification": "junction",
+          "stereotype": "<<junction>>",
+          "color": "#ECECEC",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "party_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "counterparty_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "valid_from",
+                "type": "timestamptz"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_party_counterparty_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_junction_create.mustache\n    To modify, update the template and regenerate.\n    Party Counterparty Table\n    Junction table controlling which counterparties are visible to which parties.\n    Counterparty identity is shared at tenant level; this junction controls\n    party-level visibility."
+        },
+        {
+          "name": "ores_refdata_party_countries_tbl",
+          "component": "refdata",
+          "entity": "party_countries",
+          "classification": "junction",
+          "stereotype": "<<junction>>",
+          "color": "#ECECEC",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "party_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "country_alpha2_code",
+                "type": "text"
+              },
+              {
+                "name": "valid_from",
+                "type": "timestamptz"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_party_country_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_junction_create.mustache\n    To modify, update the template and regenerate.\n    Party Country Table\n    Junction table controlling which countries are visible to which parties.\n    Country definitions are shared at tenant level; this junction controls\n    party-level visibility."
+        },
+        {
+          "name": "ores_refdata_party_currencies_tbl",
+          "component": "refdata",
+          "entity": "party_currencies",
+          "classification": "junction",
+          "stereotype": "<<junction>>",
+          "color": "#ECECEC",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "party_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "currency_iso_code",
+                "type": "text"
+              },
+              {
+                "name": "valid_from",
+                "type": "timestamptz"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_party_currency_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_junction_create.mustache\n    To modify, update the template and regenerate.\n    Party Currency Table\n    Junction table controlling which currencies are visible to which parties.\n    Currency definitions are shared at tenant level; this junction controls\n    party-level visibility."
+        },
+        {
+          "name": "ores_refdata_party_id_schemes_tbl",
+          "component": "refdata",
+          "entity": "party_id_schemes",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "coding_scheme_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "display_order",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "max_cardinality",
+              "type": "integer",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_party_id_schemes_create.sql",
+          "description": "Party Identifier Schemes - Classification of external identifier types (LEI, BIC, MIC, etc.) with cross-reference to DQ coding schemes."
+        },
+        {
+          "name": "ores_refdata_party_identifiers_tbl",
+          "component": "refdata",
+          "entity": "party_identifiers",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "id_scheme",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "id_value",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_party_identifiers_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    External identifiers for parties, such as LEI codes, BIC/SWIFT codes,\n    national registration numbers, and tax identifiers. Each party can have\n    multiple identifiers across different schemes."
+        },
+        {
           "name": "ores_refdata_party_relationships_tbl",
           "component": "refdata",
           "entity": "party_relationships",
@@ -2783,7 +6040,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -2809,6 +6066,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -2895,7 +6162,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -2921,6 +6188,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -2975,6 +6252,260 @@
           "description": "Contains a code representing a related party role. This can be extended to provide custom roles."
         },
         {
+          "name": "ores_refdata_party_statuses_tbl",
+          "component": "refdata",
+          "entity": "party_statuses",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "display_order",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_party_statuses_create.sql",
+          "description": "Party Statuses - Lifecycle states for party and counterparty records (Active, Inactive, Suspended)"
+        },
+        {
+          "name": "ores_refdata_party_types_tbl",
+          "component": "refdata",
+          "entity": "party_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "display_order",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_party_types_create.sql",
+          "description": "Party Types - Classification of legal entities (Bank, Corporate, HedgeFund, etc.)"
+        },
+        {
           "name": "ores_refdata_person_roles_tbl",
           "component": "refdata",
           "entity": "person_roles",
@@ -3007,7 +6538,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -3033,6 +6564,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -3087,6 +6628,320 @@
           "description": "Indicates the role of a person in a transaction."
         },
         {
+          "name": "ores_refdata_portfolios_tbl",
+          "component": "refdata",
+          "entity": "portfolios",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "parent_portfolio_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "owner_unit_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "purpose_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "aggregation_ccy",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "is_virtual",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "status",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'Active'",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_portfolios_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Represents organizational, risk, or reporting groupings.\n    Never holds trades directly. Supports hierarchical structure\n    via self-referencing parent_portfolio_id."
+        },
+        {
+          "name": "ores_refdata_purpose_types_tbl",
+          "component": "refdata",
+          "entity": "purpose_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "display_order",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/refdata/refdata_purpose_types_create.sql",
+          "description": "Purpose Types - Classification of portfolio purpose (Risk, Regulatory, ClientReporting, Internal)"
+        },
+        {
           "name": "ores_refdata_regulatory_corporate_sectors_tbl",
           "component": "refdata",
           "entity": "regulatory_corporate_sectors",
@@ -3119,7 +6974,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -3145,6 +7000,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -3231,7 +7096,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -3257,6 +7122,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -3338,7 +7213,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -3374,6 +7249,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -3460,7 +7345,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -3486,6 +7371,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -3856,6 +7751,133 @@
           "description": "FpML Benchmark rates - Artefact Table"
         },
         {
+          "name": "ores_dq_books_artefact_tbl",
+          "component": "dq",
+          "entity": "books_artefact",
+          "classification": "artefact",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [],
+            "composite": false
+          },
+          "columns": [
+            {
+              "name": "dataset_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "parent_portfolio_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "ledger_ccy",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "gl_account_ref",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "cost_center",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "book_status",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "is_trading_book",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/dq/dq_books_artefact_create.sql",
+          "description": ""
+        },
+        {
           "name": "ores_dq_business_centres_artefact_tbl",
           "component": "dq",
           "entity": "business_centres_artefact",
@@ -4008,6 +8030,113 @@
           "indexes": [],
           "source_file": "create/dq/dq_business_processes_artefact_create.sql",
           "description": "Contains a code representing the type of business process a message (e.g. a status request) applies to. - Artefact Table"
+        },
+        {
+          "name": "ores_dq_business_units_artefact_tbl",
+          "component": "dq",
+          "entity": "business_units_artefact",
+          "classification": "artefact",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [],
+            "composite": false
+          },
+          "columns": [
+            {
+              "name": "dataset_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "unit_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "parent_business_unit_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "unit_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "business_centre_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "unit_type_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/dq/dq_business_units_artefact_create.sql",
+          "description": ""
         },
         {
           "name": "ores_dq_cashflow_types_artefact_tbl",
@@ -4443,7 +8572,17 @@
               "references": null
             },
             {
-              "name": "currency_type",
+              "name": "monetary_nature",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "market_tier",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -4756,6 +8895,537 @@
           "description": "Staging table for IPv4 to country mapping data from iptoasn.com.\n    Data is imported here first, then promoted to geo_ip2country_tbl."
         },
         {
+          "name": "ores_dq_lei_bic_artefact_tbl",
+          "component": "dq",
+          "entity": "lei_bic_artefact",
+          "classification": "artefact",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [],
+            "composite": false
+          },
+          "columns": [
+            {
+              "name": "dataset_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "lei",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "bic",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/dq/dq_lei_bic_artefact_create.sql",
+          "description": "GLEIF LEI to BIC mapping data - Artefact Table"
+        },
+        {
+          "name": "ores_dq_lei_entities_artefact_tbl",
+          "component": "dq",
+          "entity": "lei_entities_artefact",
+          "classification": "artefact",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [],
+            "composite": false
+          },
+          "columns": [
+            {
+              "name": "dataset_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "lei",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_legal_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_entity_category",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_entity_sub_category",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_entity_status",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_legal_form_entity_legal_form_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_legal_form_other_legal_form",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_legal_jurisdiction",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_legal_address_first_address_line",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_legal_address_city",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_legal_address_region",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_legal_address_country",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_legal_address_postal_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_headquarters_address_first_address_line",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_headquarters_address_city",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_headquarters_address_region",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_headquarters_address_country",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_headquarters_address_postal_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_entity_creation_date",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "registration_initial_registration_date",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "registration_last_update_date",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "registration_next_renewal_date",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "registration_registration_status",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_transliterated_name_1",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "entity_transliterated_name_1_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/dq/dq_lei_entities_artefact_create.sql",
+          "description": "GLEIF LEI entity master data from LEI2 golden copy files - Artefact Table"
+        },
+        {
+          "name": "ores_dq_lei_relationships_artefact_tbl",
+          "component": "dq",
+          "entity": "lei_relationships_artefact",
+          "classification": "artefact",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [],
+            "composite": false
+          },
+          "columns": [
+            {
+              "name": "dataset_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "relationship_start_node_node_id",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "relationship_start_node_node_id_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "relationship_end_node_node_id",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "relationship_end_node_node_id_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "relationship_relationship_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "relationship_relationship_status",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "relationship_period_1_start_date",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "relationship_period_1_end_date",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "registration_initial_registration_date",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "registration_last_update_date",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "registration_registration_status",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "registration_validation_sources",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/dq/dq_lei_relationships_artefact_create.sql",
+          "description": "GLEIF LEI corporate hierarchy relationships from RR golden copy files - Artefact Table"
+        },
+        {
           "name": "ores_dq_local_jurisdictions_artefact_tbl",
           "component": "dq",
           "entity": "local_jurisdictions_artefact",
@@ -5064,6 +9734,123 @@
           "description": "Indicates the role of a person in a transaction. - Artefact Table"
         },
         {
+          "name": "ores_dq_portfolios_artefact_tbl",
+          "component": "dq",
+          "entity": "portfolios_artefact",
+          "classification": "artefact",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [],
+            "composite": false
+          },
+          "columns": [
+            {
+              "name": "dataset_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "parent_portfolio_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "owner_unit_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "purpose_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "aggregation_ccy",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "is_virtual",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/dq/dq_portfolios_artefact_create.sql",
+          "description": ""
+        },
+        {
           "name": "ores_dq_regulatory_corporate_sectors_artefact_tbl",
           "component": "dq",
           "entity": "regulatory_corporate_sectors_artefact",
@@ -5139,6 +9926,123 @@
           "indexes": [],
           "source_file": "create/dq/dq_regulatory_corporate_sectors_artefact_create.sql",
           "description": "Defines the corporate sector under HKMA (Hong Kong Monetary Authority) Rewrite fields 190 - Nature of Counterparty 1 and 191 - Nature of Counterparty 2. - Artefact Table"
+        },
+        {
+          "name": "ores_dq_report_definitions_artefact_tbl",
+          "component": "dq",
+          "entity": "report_definitions_artefact",
+          "classification": "artefact",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [],
+            "composite": false
+          },
+          "columns": [
+            {
+              "name": "dataset_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "report_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "schedule_expression",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "concurrency_policy",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "display_order",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/dq/dq_report_definitions_artefact_create.sql",
+          "description": "Report Definition artefacts - default report templates for the ORE analytics bundle - Artefact Table"
         },
         {
           "name": "ores_dq_reporting_regimes_artefact_tbl",
@@ -5397,6 +10301,16 @@
           },
           "columns": [
             {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "bundle_code",
               "type": "text",
               "nullable": false,
@@ -5598,7 +10512,27 @@
               "references": null
             },
             {
+              "name": "optional",
+              "type": "boolean",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "false",
+              "references": null
+            },
+            {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -5650,7 +10584,7 @@
           ],
           "indexes": [],
           "source_file": "create/dq/dq_dataset_bundle_member_create.sql",
-          "description": "Junction table linking bundles to their constituent datasets. Uses codes\n    for loose coupling - allows declaring membership for datasets that may not\n    yet exist in the system.\n    Examples:\n    - Bundle \"slovaris\" contains \"slovaris.countries\", \"slovaris.currencies\", etc.\n    - Bundle \"base\" contains \"iso.countries\", \"iso.currencies\", all FpML datasets"
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_junction_create.mustache\n    To modify, update the template and regenerate.\n    Dataset Bundle Member Table\n    Junction table linking bundles to their constituent datasets. Uses codes\n    for loose coupling - allows declaring membership for datasets that may not\n    yet exist in the system.\n    Examples:\n    - Bundle \"slovaris\" contains \"slovaris.countries\", \"slovaris.currencies\", etc.\n    - Bundle \"base\" contains \"iso.countries\", \"iso.currencies\", all FpML datasets"
         },
         {
           "name": "ores_dq_dataset_bundles_tbl",
@@ -5725,6 +10659,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "change_reason_code",
               "type": "text",
               "nullable": false,
@@ -5767,7 +10711,7 @@
           ],
           "indexes": [],
           "source_file": "create/dq/dq_dataset_bundle_create.sql",
-          "description": "Installing a bundle gets the system into a ready state with a coherent set\n    of reference data. Bundles provide a way to group related datasets that\n    should be installed together.\n    Examples:\n    - \"slovaris\": Synthetic reference data for development and testing\n    - \"base\": Industry-standard reference data (ISO + FpML) for production\n    - \"crypto\": Base system plus cryptocurrency reference data"
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Installing a bundle gets the system into a ready state with a coherent set\n    of reference data. Bundles provide a way to group related datasets that\n    should be installed together.\n    Examples:\n    - \"slovaris\": Synthetic reference data for development and testing\n    - \"base\": Industry-standard reference data (ISO + FpML) for production\n    - \"crypto\": Base system plus cryptocurrency reference data"
         },
         {
           "name": "ores_dq_dataset_dependencies_tbl",
@@ -6225,6 +11169,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "change_reason_code",
               "type": "text",
               "nullable": false,
@@ -6360,6 +11314,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "change_reason_code",
               "type": "text",
               "nullable": false,
@@ -6458,6 +11422,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -6574,6 +11548,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "change_reason_code",
               "type": "text",
               "nullable": false,
@@ -6681,6 +11665,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "change_reason_code",
               "type": "text",
               "nullable": false,
@@ -6761,7 +11755,7 @@
               "nullable": false,
               "is_pk": false,
               "is_fk": false,
-              "is_unique": true,
+              "is_unique": false,
               "default": null,
               "references": null
             },
@@ -6836,6 +11830,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "change_reason_code",
               "type": "text",
               "nullable": false,
@@ -6879,6 +11883,411 @@
           "indexes": [],
           "source_file": "create/dq/dq_artefact_types_create.sql",
           "description": "Artefact Types - Maps artefact type codes to their population functions and tables"
+        },
+        {
+          "name": "ores_dq_badge_definitions_tbl",
+          "component": "dq",
+          "entity": "badge_definitions",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "background_colour",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "text_colour",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "severity_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "css_class",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "display_order",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/dq/dq_badge_definitions_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    The badge catalogue. Each entry defines the complete visual presentation\n    of a badge: display label, tooltip, background colour, text colour,\n    severity level, and an optional Bootstrap CSS class hint for Wt.\n    Badge definitions are the single source of truth for all badge visual\n    metadata across Qt and Wt. They are loaded at client startup as\n    reference data and looked up at render time via BadgeCache."
+        },
+        {
+          "name": "ores_dq_badge_mappings_tbl",
+          "component": "dq",
+          "entity": "badge_mappings",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code_domain_code",
+                "type": "text"
+              },
+              {
+                "name": "entity_code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "badge_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/dq/dq_badge_mapping_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_junction_create.mustache\n    To modify, update the template and regenerate.\n    Badge Mapping Table\n    Universal mapping table that associates any (code_domain, entity_code)\n    pair with a badge definition. This is the single join point between\n    domain values and their visual presentation.\n    Examples:\n    - ('party_status', 'ACTIVE')  -> 'active'\n    - ('party_status', 'FROZEN')  -> 'frozen'\n    - ('fsm_state',    'DRAFT')   -> 'fsm_draft'\n    - ('login_status', 'Online')  -> 'login_online'\n    - ('dq_nature',    'Actual')  -> 'dq_actual'\n    Populated via seed scripts; no management UI needed."
+        },
+        {
+          "name": "ores_dq_badge_severities_tbl",
+          "component": "dq",
+          "entity": "badge_severities",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "display_order",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/dq/dq_badge_severities_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Reference data defining severity levels used to classify badges.\n    Codes align with Bootstrap 5 contextual classes so Wt rendering\n    requires no translation layer.\n    Values: secondary, info, success, warning, danger, primary."
         },
         {
           "name": "ores_dq_catalogs_tbl",
@@ -6934,6 +12343,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -7040,6 +12459,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "change_commentary",
               "type": "text",
               "nullable": false,
@@ -7127,6 +12556,16 @@
               "references": null
             },
             {
+              "name": "applies_to_new",
+              "type": "boolean",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "false",
+              "references": null
+            },
+            {
               "name": "applies_to_amend",
               "type": "boolean",
               "nullable": false,
@@ -7177,6 +12616,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "change_commentary",
               "type": "text",
               "nullable": false,
@@ -7210,6 +12659,133 @@
           "indexes": [],
           "source_file": "create/dq/dq_change_reasons_create.sql",
           "description": ""
+        },
+        {
+          "name": "ores_dq_code_domains_tbl",
+          "component": "dq",
+          "entity": "code_domains",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "display_order",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/dq/dq_code_domains_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    A code domain is a classification registry that names the context in\n    which a code value exists. It disambiguates identical codes used in\n    different entity types \u2014 e.g. 'ACTIVE' in party_status vs 'ACTIVE'\n    in book_status.\n    Code domains are reusable beyond badges: any future system needing\n    to namespace code values (validation rules, audit customisation, etc.)\n    can reference this table."
         },
         {
           "name": "ores_dq_coding_scheme_authority_types_tbl",
@@ -7265,6 +12841,16 @@
             },
             {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -7421,6 +13007,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "change_reason_code",
               "type": "text",
               "nullable": false,
@@ -7518,6 +13114,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "change_reason_code",
               "type": "text",
               "nullable": false,
@@ -7561,6 +13167,407 @@
           "indexes": [],
           "source_file": "create/dq/dq_data_domain_create.sql",
           "description": "High-level data classification.\n    Examples: reference_data, market_data, trade_data."
+        },
+        {
+          "name": "ores_dq_fsm_machines_tbl",
+          "component": "dq",
+          "entity": "fsm_machines",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/dq/dq_fsm_machines_create.sql",
+          "description": "Defines named state machines. Each machine represents a distinct lifecycle\n    domain (e.g., trade lifecycle, row signing, authorisation)."
+        },
+        {
+          "name": "ores_dq_fsm_states_tbl",
+          "component": "dq",
+          "entity": "fsm_states",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "machine_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "is_initial",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "is_terminal",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/dq/dq_fsm_states_create.sql",
+          "description": "Defines valid states within a machine. Each state belongs to exactly one\n    machine and may be designated as initial or terminal."
+        },
+        {
+          "name": "ores_dq_fsm_transitions_tbl",
+          "component": "dq",
+          "entity": "fsm_transitions",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "machine_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "from_state_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "to_state_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "guard_function",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/dq/dq_fsm_transitions_create.sql",
+          "description": "Defines valid state-to-state transitions within a machine. Both from_state_id\n    and to_state_id must belong to the same machine. Optionally references a\n    guard function for business rule enforcement."
         },
         {
           "name": "ores_dq_subject_areas_tbl",
@@ -7619,6 +13626,16 @@
               "references": null
             },
             {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
               "name": "change_reason_code",
               "type": "text",
               "nullable": false,
@@ -7667,7 +13684,7 @@
     },
     {
       "name": "variability",
-      "description": "System Settings",
+      "description": "Feature Flags",
       "color": "#E8F5E9",
       "order": 5,
       "tables": [
@@ -7704,19 +13721,9 @@
               "references": null
             },
             {
-              "name": "enabled",
-              "type": "integer",
-              "nullable": false,
-              "is_pk": false,
-              "is_fk": false,
-              "is_unique": false,
-              "default": "0",
-              "references": null
-            },
-            {
-              "name": "description",
+              "name": "value",
               "type": "text",
-              "nullable": true,
+              "nullable": false,
               "is_pk": false,
               "is_fk": false,
               "is_unique": false,
@@ -7724,7 +13731,37 @@
               "references": null
             },
             {
+              "name": "data_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
               "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
               "type": "text",
               "nullable": false,
               "is_pk": false,
@@ -7775,8 +13812,8 @@
             }
           ],
           "indexes": [],
-          "source_file": "create/variability/variability_feature_flags_create.sql",
-          "description": "Feature toggles for runtime configuration.\n    Uses name as natural key."
+          "source_file": "create/variability/variability_system_settings_create.sql",
+          "description": "Unified typed system settings table.\n    Supports boolean, integer, string, and json value types. Uses name as\n    natural key. System-wide settings use the system tenant; per-tenant\n    settings use the tenant's own tenant_id."
         }
       ]
     },
@@ -7911,6 +13948,205 @@
           "indexes": [],
           "source_file": "create/telemetry/telemetry_logs_create.sql",
           "description": "Application log entries.\n    Designed for TimescaleDB hypertable.\n    Partitioned by timestamp."
+        },
+        {
+          "name": "ores_telemetry_nats_server_samples_tbl",
+          "component": "telemetry",
+          "entity": "nats_server_samples",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "sampled_at",
+                "type": "timestamptz"
+              },
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "in_msgs",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "out_msgs",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "in_bytes",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "out_bytes",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "connections",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "mem_bytes",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "slow_consumers",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/telemetry/nats_server_samples_create.sql",
+          "description": "NATS server-level metrics samples.\n    Populated by ores.telemetry.service polling /varz on the NATS monitoring API.\n    Designed for TimescaleDB hypertable, partitioned by sampled_at."
+        },
+        {
+          "name": "ores_telemetry_nats_stream_samples_tbl",
+          "component": "telemetry",
+          "entity": "nats_stream_samples",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "sampled_at",
+                "type": "timestamptz"
+              },
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "stream_name",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "messages",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "bytes",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "consumer_count",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/telemetry/nats_stream_samples_create.sql",
+          "description": "NATS JetStream per-stream metrics samples.\n    Populated by ores.telemetry.service polling /jsz on the NATS monitoring API.\n    Designed for TimescaleDB hypertable, partitioned by sampled_at."
+        },
+        {
+          "name": "ores_telemetry_service_samples_tbl",
+          "component": "telemetry",
+          "entity": "service_samples",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "sampled_at",
+                "type": "timestamptz"
+              },
+              {
+                "name": "service_name",
+                "type": "text"
+              },
+              {
+                "name": "instance_id",
+                "type": "text",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/telemetry/service_samples_create.sql",
+          "description": "Service heartbeat samples.\n    Populated by the heartbeat_publisher embedded in every domain service.\n    Each service publishes a heartbeat every 15 seconds; the telemetry service\n    subscribes and writes one row here per heartbeat received.\n    Designed for TimescaleDB hypertable, partitioned by sampled_at."
         }
       ]
     },
@@ -7966,6 +14202,14407 @@
           "indexes": [],
           "source_file": "create/geo/geo_ip2country_create.sql",
           "description": "IP range to country code mapping.\n    Uses GiST index for fast lookups."
+        }
+      ]
+    },
+    {
+      "name": "trading",
+      "description": "Trading & Lifecycle",
+      "color": "#E8F5E9",
+      "order": 9,
+      "tables": [
+        {
+          "name": "ores_trading_activity_types_tbl",
+          "component": "trading",
+          "entity": "activity_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "category",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "requires_confirmation",
+              "type": "boolean",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "false",
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "fpml_event_type_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "fsm_transition_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_activity_types_create.sql",
+          "description": "Activity Types - Internal trade activity classification (~30 types).\n    Each activity type maps optionally to an FpML event type and/or to an\n    FSM transition that drives trade status changes."
+        },
+        {
+          "name": "ores_trading_balance_guaranteed_swap_instruments_tbl",
+          "component": "trading",
+          "entity": "balance_guaranteed_swap_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "maturity_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "lockout_days",
+              "type": "integer",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_balance_guaranteed_swap_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_bond_instruments_tbl",
+          "component": "trading",
+          "entity": "bond_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "issuer",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "face_value",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "coupon_rate",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "coupon_frequency_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "day_count_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "issue_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "maturity_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "settlement_days",
+              "type": "integer",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "call_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "conversion_ratio",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_bond_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_business_day_convention_types_tbl",
+          "component": "trading",
+          "entity": "business_day_convention_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_business_day_convention_types_create.sql",
+          "description": "Business Day Convention Types - ORE business day adjustment codes"
+        },
+        {
+          "name": "ores_trading_callable_swap_instruments_tbl",
+          "component": "trading",
+          "entity": "callable_swap_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "maturity_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "call_dates_json",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "call_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_callable_swap_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_cap_floor_instruments_tbl",
+          "component": "trading",
+          "entity": "cap_floor_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "maturity_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_cap_floor_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_commodity_instruments_tbl",
+          "component": "trading",
+          "entity": "commodity_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "commodity_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "quantity",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "unit",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "maturity_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "fixed_price",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "option_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "strike_price",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "exercise_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "average_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "averaging_start_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "averaging_end_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "spread_commodity_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "spread_amount",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "strip_frequency_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "variance_strike",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "accumulation_amount",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "knock_out_barrier",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "barrier_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "lower_barrier",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "upper_barrier",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "basket_json",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "day_count_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "payment_frequency_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "swaption_expiry_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_commodity_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_composite_instruments_tbl",
+          "component": "trading",
+          "entity": "composite_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_composite_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_composite_legs_tbl",
+          "component": "trading",
+          "entity": "composite_legs",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "instrument_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "leg_sequence",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "constituent_trade_id",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_composite_legs_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_credit_instruments_tbl",
+          "component": "trading",
+          "entity": "credit_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "reference_entity",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "notional",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "spread",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "recovery_rate",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "tenor",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "maturity_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "day_count_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "payment_frequency_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "index_name",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "index_series",
+              "type": "integer",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "seniority",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "restructuring",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_credit_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_day_count_fraction_types_tbl",
+          "component": "trading",
+          "entity": "day_count_fraction_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_day_count_fraction_types_create.sql",
+          "description": "Day Count Fraction Types - ORE day count convention codes (Act360, Act365F, etc.)"
+        },
+        {
+          "name": "ores_trading_equity_accumulator_instruments_tbl",
+          "component": "trading",
+          "entity": "equity_accumulator_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "underlying_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "strike",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "fixing_amount",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "expiry_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "fixing_frequency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "long_short",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "knock_out_level",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "target_amount",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "target_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "payoff_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_equity_accumulator_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_equity_asian_option_instruments_tbl",
+          "component": "trading",
+          "entity": "equity_asian_option_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "underlying_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "notional",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "option_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "strike",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "expiry_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "exercise_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "long_short",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "average_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "averaging_start_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "averaging_end_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_equity_asian_option_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_equity_barrier_option_instruments_tbl",
+          "component": "trading",
+          "entity": "equity_barrier_option_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "underlying_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "notional",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "option_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "strike",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "expiry_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "exercise_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "long_short",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "lower_barrier",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "lower_barrier_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "upper_barrier",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "upper_barrier_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "rebate",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_equity_barrier_option_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_equity_digital_option_instruments_tbl",
+          "component": "trading",
+          "entity": "equity_digital_option_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "underlying_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "notional",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "option_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "strike",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "barrier_level",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "barrier_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "expiry_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "long_short",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "payout_amount",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_equity_digital_option_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_equity_forward_instruments_tbl",
+          "component": "trading",
+          "entity": "equity_forward_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "underlying_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "quantity",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "forward_price",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "expiry_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "long_short",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "settlement_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_equity_forward_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_equity_instruments_tbl",
+          "component": "trading",
+          "entity": "equity_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "underlying_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "notional",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "quantity",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "maturity_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "option_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "strike_price",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "exercise_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "barrier_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "lower_barrier",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "upper_barrier",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "average_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "averaging_start_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "variance_strike",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "cliquet_frequency_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "accumulation_amount",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "knock_out_barrier",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "basket_json",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "day_count_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "payment_frequency_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "return_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_equity_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_equity_option_instruments_tbl",
+          "component": "trading",
+          "entity": "equity_option_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "underlying_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "notional",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "option_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "strike",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "expiry_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "exercise_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "long_short",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "settlement_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "cliquet_frequency",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_equity_option_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_equity_position_instruments_tbl",
+          "component": "trading",
+          "entity": "equity_position_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "underlying_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "quantity",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "price",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "option_data_json",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_equity_position_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_equity_swap_instruments_tbl",
+          "component": "trading",
+          "entity": "equity_swap_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "underlying_name",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "basket_json",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "notional",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "return_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "maturity_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "long_short",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "payment_frequency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_equity_swap_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_equity_variance_swap_instruments_tbl",
+          "component": "trading",
+          "entity": "equity_variance_swap_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "underlying_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "notional",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "variance_strike",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "maturity_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "long_short",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_equity_variance_swap_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_floating_index_types_tbl",
+          "component": "trading",
+          "entity": "floating_index_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_floating_index_types_create.sql",
+          "description": "Floating Index Types - interest rate index codes (EURIBOR6M, SOFR, etc.)"
+        },
+        {
+          "name": "ores_trading_fpml_event_types_tbl",
+          "component": "trading",
+          "entity": "fpml_event_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_fpml_event_types_create.sql",
+          "description": "FpML Event Types - Standard FpML lc_EventType_Type coding scheme\n    (New, Amendment, Novation, PartialTermination, FullTermination)"
+        },
+        {
+          "name": "ores_trading_fra_instruments_tbl",
+          "component": "trading",
+          "entity": "fra_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "end_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "rate_index",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "long_short",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "strike",
+              "type": "numeric(18, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "notional",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_fra_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_fx_accumulator_instruments_tbl",
+          "component": "trading",
+          "entity": "fx_accumulator_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "fixing_amount",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "strike",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "underlying_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "long_short",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "knock_out_barrier",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_fx_accumulator_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_fx_asian_forward_instruments_tbl",
+          "component": "trading",
+          "entity": "fx_asian_forward_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "fx_index",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "reference_currency",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "reference_notional",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "settlement_currency",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "settlement_notional",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "payment_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "long_short",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "fixing_amount",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "target_amount",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "strike",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_fx_asian_forward_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_fx_barrier_option_instruments_tbl",
+          "component": "trading",
+          "entity": "fx_barrier_option_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "bought_currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "bought_amount",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "sold_currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "sold_amount",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "option_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "expiry_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "settlement",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "barrier_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "lower_barrier",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "upper_barrier",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "underlying_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_fx_barrier_option_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_fx_digital_option_instruments_tbl",
+          "component": "trading",
+          "entity": "fx_digital_option_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "foreign_currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "domestic_currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "payoff_currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "payoff_amount",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "option_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "expiry_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "long_short",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "strike",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "barrier_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "lower_barrier",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "upper_barrier",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_fx_digital_option_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_fx_forward_instruments_tbl",
+          "component": "trading",
+          "entity": "fx_forward_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "bought_currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "bought_amount",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "sold_currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "sold_amount",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "value_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "settlement",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_fx_forward_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_fx_instruments_tbl",
+          "component": "trading",
+          "entity": "fx_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "bought_currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "bought_amount",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "sold_currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "sold_amount",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "value_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "settlement",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "option_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "strike_price",
+              "type": "numeric(28, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "expiry_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_fx_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_fx_vanilla_option_instruments_tbl",
+          "component": "trading",
+          "entity": "fx_vanilla_option_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "bought_currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "bought_amount",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "sold_currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "sold_amount",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "option_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "expiry_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "exercise_style",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "settlement",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_fx_vanilla_option_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_fx_variance_swap_instruments_tbl",
+          "component": "trading",
+          "entity": "fx_variance_swap_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "end_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "underlying_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "long_short",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "strike",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "notional",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "moment_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_fx_variance_swap_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_identifiers_tbl",
+          "component": "trading",
+          "entity": "identifiers",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "issuing_party_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "id_value",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "id_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "id_scheme",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_identifiers_create.sql",
+          "description": "Junction table for trade external identifiers (UTI, USI, Internal).\n    Each trade can have multiple identifiers of different types.\n    issuing_party_id validates against both parties and counterparties\n    tables since UUIDs are globally unique.\n    Hand-crafted: inline soft FK validations for trade_id, issuing_party_id\n    cannot be expressed by the standard templates."
+        },
+        {
+          "name": "ores_trading_inflation_swap_instruments_tbl",
+          "component": "trading",
+          "entity": "inflation_swap_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "maturity_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "inflation_index_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "base_cpi",
+              "type": "numeric(18, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "lag_convention",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_inflation_swap_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_knock_out_swap_instruments_tbl",
+          "component": "trading",
+          "entity": "knock_out_swap_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "maturity_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "barrier_level",
+              "type": "numeric(18, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "barrier_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "knock_out_dates_json",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_knock_out_swap_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_leg_types_tbl",
+          "component": "trading",
+          "entity": "leg_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_leg_types_create.sql",
+          "description": "Leg Types - swap leg type codes (Fixed, Floating, CMS, etc.)"
+        },
+        {
+          "name": "ores_trading_party_role_types_tbl",
+          "component": "trading",
+          "entity": "party_role_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_party_role_types_create.sql",
+          "description": "Trade Party Role Types - FpML-aligned party role codes (Counterparty, CalculationAgent, ExecutingBroker, NovationTransferee)"
+        },
+        {
+          "name": "ores_trading_party_roles_tbl",
+          "component": "trading",
+          "entity": "party_roles",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "counterparty_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "role",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_party_roles_create.sql",
+          "description": "Junction table assigning counterparties to roles on a trade.\n    The internal party (\"the house\") is derived from book_id -> books.party_id.\n    Hand-crafted: inline soft FK validations for trade_id and counterparty_id\n    cannot be expressed by the standard templates."
+        },
+        {
+          "name": "ores_trading_payment_frequency_types_tbl",
+          "component": "trading",
+          "entity": "payment_frequency_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_payment_frequency_types_create.sql",
+          "description": "Payment Frequency Types - coupon/payment frequency codes"
+        },
+        {
+          "name": "ores_trading_rpa_instruments_tbl",
+          "component": "trading",
+          "entity": "rpa_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "maturity_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "reference_counterparty",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "participation_rate",
+              "type": "numeric(18, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "protection_fee",
+              "type": "numeric(18, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_risk_participation_agreement_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_scripted_instruments_tbl",
+          "component": "trading",
+          "entity": "scripted_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "script_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "script_body",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "events_json",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "underlyings_json",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "parameters_json",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_scripted_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_swap_legs_tbl",
+          "component": "trading",
+          "entity": "swap_legs",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "instrument_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "leg_number",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "leg_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "day_count_fraction_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "business_day_convention_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "payment_frequency_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "floating_index_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "fixed_rate",
+              "type": "numeric(18, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "spread",
+              "type": "numeric(18, 10)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "notional",
+              "type": "numeric(28, 10)",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_swap_legs_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_swaption_instruments_tbl",
+          "component": "trading",
+          "entity": "swaption_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "expiry_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "exercise_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "settlement_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "long_short",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "maturity_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "maturity_date",
+              "type": "is",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_swaption_instruments_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_trading_trade_id_types_tbl",
+          "component": "trading",
+          "entity": "trade_id_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_trade_id_types_create.sql",
+          "description": "Trade Identifier Types - Identifier type codes for trade identifiers (UTI, USI, Internal)"
+        },
+        {
+          "name": "ores_trading_trade_types_tbl",
+          "component": "trading",
+          "entity": "trade_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "product_type",
+              "type": "product_type_t",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "has_options",
+              "type": "boolean",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "false",
+              "references": null
+            },
+            {
+              "name": "has_extension",
+              "type": "boolean",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "false",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_trade_types_create.sql",
+          "description": "Trade Types - ORE instrument type codes (Swap, FxForward, CapFloor, Swaption, etc.)"
+        },
+        {
+          "name": "ores_trading_trades_tbl",
+          "component": "trading",
+          "entity": "trades",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "external_id",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "book_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "portfolio_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "successor_trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "counterparty_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "product_type",
+              "type": "product_type_t",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "instrument_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "asset_class",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "netting_set_id",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "activity_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "status_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "execution_timestamp",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "effective_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "termination_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_trades_create.sql",
+          "description": "Temporal trade record capturing FpML Trade Header properties. Each lifecycle\n    event (New, Amendment, Novation, etc.) creates a new temporal row for the\n    same trade id. The internal party is derived from book_id -> books.party_id.\n    Hand-crafted: inline soft FK validations for book_id, portfolio_id, and\n    successor_trade_id cannot be expressed by the standard templates."
+        },
+        {
+          "name": "ores_trading_vanilla_swap_instruments_tbl",
+          "component": "trading",
+          "entity": "vanilla_swap_instruments",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "instrument_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "start_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "maturity_date",
+              "type": "date",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "settlement_lag",
+              "type": "integer",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "netting_set_id",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/trading/trading_vanilla_swap_instruments_create.sql",
+          "description": ""
+        }
+      ]
+    },
+    {
+      "name": "mq",
+      "description": "Message Queue (pgmq)",
+      "color": "#FBE9E7",
+      "order": 10,
+      "tables": [
+        {
+          "name": "ores_mq_message_archive_tbl",
+          "component": "mq",
+          "entity": "message_archive",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "id",
+                "type": "bigint"
+              },
+              {
+                "name": "archived_at",
+                "type": "timestamptz"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "queue_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "message_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "payload_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'json'",
+              "references": null
+            },
+            {
+              "name": "payload",
+              "type": "jsonb",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "raw_payload",
+              "type": "bytea",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "final_status",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'done'",
+              "references": null
+            },
+            {
+              "name": "created_at",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "now()",
+              "references": null
+            },
+            {
+              "name": "read_count",
+              "type": "int",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "error_message",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/mq/mq_message_archive_create.sql",
+          "description": "MQ message archive table.\n    Stores acknowledged messages. TimescaleDB hypertable on archived_at when\n    available; degrades gracefully to a plain table.\n    Partitioned by archived_at with 1-day chunks and 90-day retention."
+        },
+        {
+          "name": "ores_mq_messages_tbl",
+          "component": "mq",
+          "entity": "messages",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [],
+            "composite": false
+          },
+          "columns": [
+            {
+              "name": "id",
+              "type": "bigserial",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "queue_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "message_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "payload_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'json'",
+              "references": null
+            },
+            {
+              "name": "payload",
+              "type": "jsonb",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "raw_payload",
+              "type": "bytea",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "status",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'pending'",
+              "references": null
+            },
+            {
+              "name": "visible_after",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "now()",
+              "references": null
+            },
+            {
+              "name": "created_at",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "now()",
+              "references": null
+            },
+            {
+              "name": "updated_at",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "now()",
+              "references": null
+            },
+            {
+              "name": "read_count",
+              "type": "int",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "error_message",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/mq/mq_messages_create.sql",
+          "description": "MQ task queue messages table.\n    Regular (non-hypertable) table for pending and in-flight task messages."
+        },
+        {
+          "name": "ores_mq_queue_stats_tbl",
+          "component": "mq",
+          "entity": "queue_stats",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "queue_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "recorded_at",
+                "type": "timestamptz"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "pending_count",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "processing_count",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "total_archived",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/mq/mq_queue_stats_create.sql",
+          "description": "MQ queue statistics time-series table.\n    Populated by ores_mq_queue_stats_scrape_fn() via a pg_cron job.\n    TimescaleDB hypertable when available; degrades gracefully to a plain table.\n    Partitioned by recorded_at with 1-day chunks and 30-day retention."
+        },
+        {
+          "name": "ores_mq_queues_tbl",
+          "component": "mq",
+          "entity": "queues",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [],
+            "composite": false
+          },
+          "columns": [
+            {
+              "name": "id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "gen_random_uuid() primary key",
+              "references": null
+            },
+            {
+              "name": "scope_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'party'",
+              "references": null
+            },
+            {
+              "name": "queue_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'task'",
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "created_at",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "now()",
+              "references": null
+            },
+            {
+              "name": "modified_at",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "now()",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "is_active",
+              "type": "boolean",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "true",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/mq/mq_queues_create.sql",
+          "description": "MQ queue definitions table.\n    Supports party, tenant and system scope; task and channel queue types."
+        }
+      ]
+    },
+    {
+      "name": "scheduler",
+      "description": "Job Scheduler (pg_cron)",
+      "color": "#F1F8E9",
+      "order": 11,
+      "tables": [
+        {
+          "name": "ores_scheduler_job_definitions_tbl",
+          "component": "scheduler",
+          "entity": "job_definitions",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "job_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "command",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "schedule_expression",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "action_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'execute_sql'",
+              "references": null
+            },
+            {
+              "name": "action_payload",
+              "type": "jsonb",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'{}'::jsonb",
+              "references": null
+            },
+            {
+              "name": "is_active",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "1",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/scheduler/scheduler_job_definitions_create.sql",
+          "description": "Stores job definitions for OreStudio's built-in scheduler. Each row\n    represents a versioned, auditable job definition with tenant/party\n    isolation, human-readable description, and a soft-pause mechanism\n    (is_active).\n    Jobs can be system-scoped (tenant_id IS NULL, party_id IS NULL),\n    tenant-scoped (tenant_id set, party_id IS NULL), or party-scoped\n    (both tenant_id and party_id set).\n    The action_type column controls how the scheduler executes the job:\n    - 'execute_sql'    : run the SQL in the command column directly.\n    - 'nats_publish'  : publish a NATS message; action_payload carries\n    the subject and body."
+        },
+        {
+          "name": "ores_scheduler_job_instances_tbl",
+          "component": "scheduler",
+          "entity": "job_instances",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "id",
+                "type": "bigserial"
+              },
+              {
+                "name": "triggered_at",
+                "type": "timestamptz"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "job_definition_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "action_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'execute_sql'",
+              "references": null
+            },
+            {
+              "name": "status",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "started_at",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "now()",
+              "references": null
+            },
+            {
+              "name": "completed_at",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "duration_ms",
+              "type": "bigint",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "error_message",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/scheduler/scheduler_job_instances_create.sql",
+          "description": "Scheduler Job Instances Table\n    Execution history for scheduler jobs.\n    Designed for TimescaleDB hypertable; degrades gracefully to a plain table.\n    Partitioned by triggered_at."
+        }
+      ]
+    },
+    {
+      "name": "reporting",
+      "description": "Reporting & Analytics",
+      "color": "#E0F7FA",
+      "order": 12,
+      "tables": [
+        {
+          "name": "ores_reporting_concurrency_policies_tbl",
+          "component": "reporting",
+          "entity": "concurrency_policies",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "display_order",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/reporting/reporting_concurrency_policies_create.sql",
+          "description": "Enum table for report instance concurrency strategies (skip, queue, fail).\n    Controls what happens when a new report instance is triggered while one for\n    the same definition is already running.\n    The validation function is called from the report_definitions insert trigger\n    so that new policies can be added without schema migrations."
+        },
+        {
+          "name": "ores_reporting_report_definitions_tbl",
+          "component": "reporting",
+          "entity": "report_definitions",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "report_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "fsm_state_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "schedule_expression",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "concurrency_policy",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'skip'",
+              "references": null
+            },
+            {
+              "name": "scheduler_job_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/reporting/reporting_report_definitions_create.sql",
+          "description": "The persistent template for a report. Describes what to run, when to run it,\n    and how to handle concurrent executions. Type-specific configuration (e.g.\n    risk parameters) lives in a separate table keyed by report_definition_id.\n    Lifecycle is managed through the report_definition_lifecycle FSM machine.\n    fsm_state_id points to the current state in ores_dq_fsm_states_tbl.\n    scheduler_job_id links to ores_scheduler_job_definitions_tbl.id and is set\n    by the scheduler service when the definition is activated (state: active).\n    It is cleared when the definition is suspended or archived."
+        },
+        {
+          "name": "ores_reporting_report_input_bundles_tbl",
+          "component": "reporting",
+          "entity": "report_input_bundles",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "report_instance_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "definition_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trades_storage_key",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "market_data_storage_key",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trade_count",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "series_count",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "created_at",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "current_timestamp",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/reporting/reporting_report_input_bundles_create.sql",
+          "description": "An immutable artifact created by the assemble_bundle workflow step.\n    Records the object-storage keys where the MsgPack-serialised trades\n    and market data blobs produced during gather_trades and\n    gather_market_data are stored.\n    One bundle is created per report instance execution.  The bundle is\n    consumed downstream by prepare_ore_package to repackage the data as\n    a tarball for the compute grid."
+        },
+        {
+          "name": "ores_reporting_report_instances_tbl",
+          "component": "reporting",
+          "entity": "report_instances",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "party_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "definition_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "fsm_state_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "trigger_run_id",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "output_message",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "started_at",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "completed_at",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/reporting/reporting_report_instances_create.sql",
+          "description": "A single execution of a report_definition. Created automatically when the\n    scheduler fires a trigger for an active definition.\n    Lifecycle is managed through the report_instance_lifecycle FSM machine.\n    fsm_state_id points to the current state in ores_dq_fsm_states_tbl.\n    The initial fsm_state depends on the definition's concurrency_policy and\n    whether another instance for the same definition is already running:\n    - No running instance          -> pending\n    - Running + policy = queue     -> queued\n    - Running + policy = skip      -> skipped (terminal)\n    - Running + policy = fail      -> failed  (terminal)\n    started_at is NULL when the instance is cancelled or skipped before execution\n    begins. completed_at is NULL while running or in a terminal-before-start state."
+        },
+        {
+          "name": "ores_reporting_report_types_tbl",
+          "component": "reporting",
+          "entity": "report_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "display_order",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/reporting/reporting_report_types_create.sql",
+          "description": "Enum table for the available report types (e.g. risk, grid). Each tenant\n    carries its own copy, populated from system seed data at provisioning time.\n    The validation function is called from the report_definitions insert trigger\n    so that new types can be added without schema migrations."
+        },
+        {
+          "name": "ores_reporting_risk_report_config_books_tbl",
+          "component": "reporting",
+          "entity": "risk_report_config_books",
+          "classification": "junction",
+          "stereotype": "<<junction>>",
+          "color": "#ECECEC",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "risk_report_config_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "book_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "valid_from",
+                "type": "timestamptz"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/reporting/reporting_risk_report_config_books_create.sql",
+          "description": "Associates a risk report configuration with the books it should include.\n    An empty set (no rows for a given risk_report_config_id) means all books\n    within the selected portfolios are included.\n    This is a temporal junction table: entries are closed when removed, preserving\n    historical scope records alongside the config version history."
+        },
+        {
+          "name": "ores_reporting_risk_report_config_portfolios_tbl",
+          "component": "reporting",
+          "entity": "risk_report_config_portfolios",
+          "classification": "junction",
+          "stereotype": "<<junction>>",
+          "color": "#ECECEC",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "risk_report_config_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "portfolio_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "valid_from",
+                "type": "timestamptz"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/reporting/reporting_risk_report_config_portfolios_create.sql",
+          "description": "Associates a risk report configuration with the portfolios it should include.\n    An empty set (no rows for a given risk_report_config_id) means all portfolios\n    visible to the tenant are included.\n    This is a temporal junction table: entries are closed when removed, preserving\n    historical scope records alongside the config version history."
+        },
+        {
+          "name": "ores_reporting_risk_report_configs_tbl",
+          "component": "reporting",
+          "entity": "risk_report_configs",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "report_definition_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "base_currency",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "observation_model",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'disable'",
+              "references": null
+            },
+            {
+              "name": "n_threads",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "1",
+              "references": null
+            },
+            {
+              "name": "market_data_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'eod'",
+              "references": null
+            },
+            {
+              "name": "market_data_date",
+              "type": "date",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "npv_enabled",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "1",
+              "references": null
+            },
+            {
+              "name": "cashflow_enabled",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "1",
+              "references": null
+            },
+            {
+              "name": "curves_enabled",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "sensitivity_enabled",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "simulation_enabled",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "xva_enabled",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "stress_enabled",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "parametric_var_enabled",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "initial_margin_enabled",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "pfe_enabled",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "xva_quantile",
+              "type": "numeric(5,4)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "xva_cva_enabled",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "1",
+              "references": null
+            },
+            {
+              "name": "xva_dva_enabled",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "xva_fva_enabled",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "xva_colva_enabled",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "xva_dim_enabled",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "xva_dim_quantile",
+              "type": "numeric(5,4)",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "xva_dim_horizon_calendar_days",
+              "type": "integer",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "xva_dim_regression_order",
+              "type": "integer",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "var_quantiles",
+              "type": "numeric(5,4)[]",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "var_method",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "simm_version",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "simm_calculation_currency",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/reporting/reporting_risk_report_configs_create.sql",
+          "description": "Stores the ORE-level parameters for a risk report definition. Each row is\n    owned by exactly one report_definition (1:1 relationship, enforced by the\n    unique index on report_definition_id).\n    Analytics flags use integer 0/1 (not boolean) to match the project\n    convention. npv and cashflow default to enabled; all others default to off.\n    Market data convention is split into market_data_type ('live'|'eod'|'date')\n    and market_data_date (set only when type = 'date'), enforced by a CHECK.\n    Portfolio and book scope are stored in separate junction tables. An empty\n    set in either junction table means \"all visible to the tenant\"."
+        }
+      ]
+    },
+    {
+      "name": "compute",
+      "description": "Distributed Compute Grid (BOINC)",
+      "color": "#EDE7F6",
+      "order": 13,
+      "tables": [
+        {
+          "name": "ores_compute_app_version_platforms_tbl",
+          "component": "compute",
+          "entity": "app_version_platforms",
+          "classification": "junction",
+          "stereotype": "<<junction>>",
+          "color": "#ECECEC",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "app_version_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "platform_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "valid_from",
+                "type": "timestamptz"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "package_uri",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/compute/compute_app_version_platforms_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_compute_app_versions_tbl",
+          "component": "compute",
+          "entity": "app_versions",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "app_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "wrapper_version",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "engine_version",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "min_ram_mb",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/compute/compute_app_versions_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Combines a specific wrapper version with a specific engine version. The BOINC\n    equivalent of 'app_version'. Per-platform package artefacts are tracked in\n    ores_compute_app_version_platforms_tbl \u2014 each (app_version, platform) row\n    owns the URI of its own packaged bundle."
+        },
+        {
+          "name": "ores_compute_apps_tbl",
+          "component": "compute",
+          "entity": "apps",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/compute/compute_apps_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Represents the high-level definition of an engine that can be executed on\n    grid nodes (e.g., ORE_STUDIO, LLAMA_CPP, LEDGER). The BOINC equivalent of 'app'."
+        },
+        {
+          "name": "ores_compute_batch_dependencies_tbl",
+          "component": "compute",
+          "entity": "batch_dependencies",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "parent_batch_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "child_batch_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [],
+          "indexes": [],
+          "source_file": "create/compute/compute_batch_dependencies_create.sql",
+          "description": "Records directed dependencies between batches forming a DAG.\n    A child batch should not start until its parent batch is complete."
+        },
+        {
+          "name": "ores_compute_batches_tbl",
+          "component": "compute",
+          "entity": "batches",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "external_ref",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "status",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'open'",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/compute/compute_batches_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Tracks the lifecycle of a collection of workunits that together constitute a\n    financial computation (e.g., a risk report run). The Assimilator monitors\n    batch completion to trigger downstream report generation."
+        },
+        {
+          "name": "ores_compute_grid_samples_tbl",
+          "component": "compute",
+          "entity": "grid_samples",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "sampled_at",
+                "type": "timestamptz"
+              },
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "total_hosts",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "online_hosts",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "idle_hosts",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "results_inactive",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "results_unsent",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "results_in_progress",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "results_done",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "total_workunits",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "total_batches",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "active_batches",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "outcomes_success",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "outcomes_client_error",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "outcomes_no_reply",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/compute/compute_grid_samples_create.sql",
+          "description": "Compute grid server-side telemetry samples.\n    Populated by ores.compute.service every ~30 seconds.\n    One row per sample interval per tenant; designed for TimescaleDB hypertable\n    partitioned by sampled_at."
+        },
+        {
+          "name": "ores_compute_hosts_tbl",
+          "component": "compute",
+          "entity": "hosts",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "external_id",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "location",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "cpu_count",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "ram_mb",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "gpu_type",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "display_name",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "last_rpc_time",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "credit_total",
+              "type": "numeric",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/compute/compute_hosts_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Represents a physical or virtual machine that participates in the BOINC-inspired\n    compute grid. Tracks hardware capabilities, heartbeat, and accumulated credit."
+        },
+        {
+          "name": "ores_compute_node_samples_tbl",
+          "component": "compute",
+          "entity": "node_samples",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "sampled_at",
+                "type": "timestamptz"
+              },
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "host_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "tasks_completed",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "tasks_failed",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "tasks_since_last",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "avg_task_duration_ms",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "max_task_duration_ms",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "input_bytes_fetched",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "output_bytes_uploaded",
+              "type": "bigint",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "seconds_since_hb",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/compute/compute_node_samples_create.sql",
+          "description": "Compute grid per-node telemetry samples.\n    Published by ores.compute.wrapper nodes every ~30 seconds via NATS and\n    persisted by ores.compute.service.\n    One row per node per sample interval; designed for TimescaleDB hypertable\n    partitioned by sampled_at."
+        },
+        {
+          "name": "ores_compute_platforms_tbl",
+          "component": "compute",
+          "entity": "platforms",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "id",
+                "type": "uuid"
+              },
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "display_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "os_family",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "cpu_arch",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "abi",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "is_active",
+              "type": "boolean",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "true",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/compute/compute_platforms_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_compute_results_tbl",
+          "component": "compute",
+          "entity": "results",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "workunit_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "host_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "pgmq_msg_id",
+              "type": "bigint",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "server_state",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "1",
+              "references": null
+            },
+            {
+              "name": "outcome",
+              "type": "integer",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "output_uri",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "error_message",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "received_at",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/compute/compute_results_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Bridges the workunit definition and the actual execution on a grid node.\n    Tracks PGMQ lease state, server-side lifecycle (Inactive/Unsent/InProgress/Done),\n    and the location of output data. The BOINC equivalent of 'result'."
+        },
+        {
+          "name": "ores_compute_workunits_tbl",
+          "component": "compute",
+          "entity": "workunits",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "batch_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "app_version_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "input_uri",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "config_uri",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "priority",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "1",
+              "references": null
+            },
+            {
+              "name": "target_redundancy",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "1",
+              "references": null
+            },
+            {
+              "name": "canonical_result_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/compute/compute_workunits_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Defines the problem to be solved: which app version to use, where the input\n    data lives, and how many times to run it for redundancy. The BOINC equivalent\n    of 'workunit'. Does not track execution state \u2014 that belongs to results."
+        }
+      ]
+    },
+    {
+      "name": "workflow",
+      "description": "Workflow Orchestration (Saga)",
+      "color": "#FFF8E1",
+      "order": 14,
+      "tables": [
+        {
+          "name": "ores_workflow_workflow_instances_tbl",
+          "component": "workflow",
+          "entity": "workflow_instances",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": false
+          },
+          "columns": [
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "state_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "request_json",
+              "type": "jsonb",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "result_json",
+              "type": "jsonb",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "error",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "correlation_id",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "created_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "current_step_index",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "step_count",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "completed_at",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "last_event_at",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "created_at",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "current_timestamp",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/workflow/workflow_workflow_instances_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_non_temporal_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Tracks the lifecycle of a workflow execution, including its type, status,\n    the serialised request that triggered it, and any result or error produced.\n    Instances are append-mostly; status transitions are the primary mutation."
+        },
+        {
+          "name": "ores_workflow_workflow_steps_tbl",
+          "component": "workflow",
+          "entity": "workflow_steps",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": false
+          },
+          "columns": [
+            {
+              "name": "workflow_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "step_index",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "state_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "request_json",
+              "type": "jsonb",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "response_json",
+              "type": "jsonb",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "error",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "command_subject",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "command_json",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "command_published_at",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "idempotency_key",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "compensation_subject",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "compensation_json",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            },
+            {
+              "name": "started_at",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "completed_at",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "created_at",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "current_timestamp",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/workflow/workflow_workflow_steps_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_non_temporal_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Records the execution of one step in a saga workflow, including the step\n    index, name, status, request/response payloads, and timing. Steps reference\n    their parent workflow instance via workflow_id."
+        }
+      ]
+    },
+    {
+      "name": "database",
+      "description": "Database Infrastructure",
+      "color": "#EFEBE9",
+      "order": 17,
+      "tables": [
+        {
+          "name": "ores_database_info_tbl",
+          "component": "database",
+          "entity": "info",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": false
+          },
+          "columns": [
+            {
+              "name": "schema_version",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "build_environment",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "git_commit",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "git_date",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "created_at",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "current_timestamp",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/database/database_info_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_non_temporal_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Stores the schema version, git commit, and build environment inserted at\n    database creation time. Used to correlate service behaviour with the\n    database schema in use. Contains exactly one row."
+        }
+      ]
+    },
+    {
+      "name": "marketdata",
+      "description": "Market Data (Quotes, Fixings, Series)",
+      "color": "#E3F2FD",
+      "order": 18,
+      "tables": [
+        {
+          "name": "ores_marketdata_fixings_tbl",
+          "component": "marketdata",
+          "entity": "fixings",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "id",
+                "type": "uuid"
+              },
+              {
+                "name": "fixing_date",
+                "type": "date"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "series_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "value",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "source",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/marketdata/marketdata_fixings_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_marketdata_observations_tbl",
+          "component": "marketdata",
+          "entity": "observations",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "id",
+                "type": "uuid"
+              },
+              {
+                "name": "observation_date",
+                "type": "date"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "tenant_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "series_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "point_id",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "value",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "source",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/marketdata/marketdata_observations_create.sql",
+          "description": ""
+        },
+        {
+          "name": "ores_marketdata_series_tbl",
+          "component": "marketdata",
+          "entity": "series",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "series_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "metric",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "qualifier",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "asset_class",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "series_subclass",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "is_scalar",
+              "type": "boolean",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "false",
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/marketdata/marketdata_series_create.sql",
+          "description": ""
+        }
+      ]
+    },
+    {
+      "name": "controller",
+      "description": "Service Lifecycle Controller",
+      "color": "#E8EAF6",
+      "order": 19,
+      "tables": [
+        {
+          "name": "ores_controller_service_definitions_tbl",
+          "component": "controller",
+          "entity": "service_definitions",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "service_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "binary_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "desired_replicas",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "1",
+              "references": null
+            },
+            {
+              "name": "restart_policy",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'always'",
+              "references": null
+            },
+            {
+              "name": "max_restart_count",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "3",
+              "references": null
+            },
+            {
+              "name": "enabled",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "1",
+              "references": null
+            },
+            {
+              "name": "args_template",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/controller/controller_service_definitions_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Represents a Kubernetes-style Deployment: the desired configuration for a\n    named service, including how many replicas to run, the binary name, restart\n    policy, and whether the service is enabled. This is a bitemporal table so\n    that the full history of configuration changes is preserved for audit."
+        },
+        {
+          "name": "ores_controller_service_dependencies_tbl",
+          "component": "controller",
+          "entity": "service_dependencies",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "service_name",
+                "type": "text"
+              },
+              {
+                "name": "depends_on",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [],
+          "indexes": [],
+          "source_file": "create/controller/controller_service_dependencies_create.sql",
+          "description": "Records the startup dependencies between managed services. A row\n    (service_name, depends_on) means service_name must not be launched until\n    depends_on has signalled readiness (i.e. \"Service ready\" appears in its\n    log file).\n    The process_supervisor reads this table at startup, builds a directed\n    acyclic graph, and starts services in topological order \u2014 waiting for each\n    service to become ready before launching services that depend on it.\n    This is intentionally non-bitemporal: dependency relationships are static\n    configuration that does not require a full audit history."
+        },
+        {
+          "name": "ores_controller_service_events_tbl",
+          "component": "controller",
+          "entity": "service_events",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "occurred_at",
+                "type": "timestamptz"
+              },
+              {
+                "name": "event_id",
+                "type": "uuid",
+                "is_fk": true
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "service_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "instance_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "replica_index",
+              "type": "integer",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "event_type",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "message",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "''",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/controller/controller_service_events_create.sql",
+          "description": "Service lifecycle events.\n    Kubernetes-style Event log: one row per significant state transition for a\n    service instance (started, stopped, crashed, restarted, etc.).\n    Designed as a TimescaleDB hypertable partitioned by occurred_at for\n    efficient time-range queries and automatic data retention."
+        },
+        {
+          "name": "ores_controller_service_instances_tbl",
+          "component": "controller",
+          "entity": "service_instances",
+          "classification": "current_state",
+          "stereotype": "",
+          "color": "#F7E5FF",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": false
+          },
+          "columns": [
+            {
+              "name": "service_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "replica_index",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "pid",
+              "type": "integer",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "phase",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "'pending'",
+              "references": null
+            },
+            {
+              "name": "started_at",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "stopped_at",
+              "type": "timestamptz",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "restart_count",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "0",
+              "references": null
+            },
+            {
+              "name": "last_error",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "last_log_snippet",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "last_stderr_snippet",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "last_command_line",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "created_at",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": "current_timestamp",
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/controller/controller_service_instances_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_non_temporal_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Represents a Kubernetes-style Pod: one concrete running instance of a\n    service definition. Tracks the OS process ID, lifecycle phase, start/stop\n    times, and how many times the instance has been restarted. Non-temporal:\n    only the current state is kept here; history is captured in service_events."
+        }
+      ]
+    },
+    {
+      "name": "analytics",
+      "description": "Analytics & Pricing Configuration",
+      "color": "#E8F5E9",
+      "order": 20,
+      "tables": [
+        {
+          "name": "ores_analytics_pricing_engine_types_tbl",
+          "component": "analytics",
+          "entity": "pricing_engine_types",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "code",
+                "type": "text"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "instrument_type_code",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/analytics/analytics_pricing_engine_types_create.sql",
+          "description": "Pricing Engine Types - Classification of products at the granularity needed by the pricing engine to select the correct model and numerical method (e.g. EuropeanSwaption, BermudanSwaption, CMS)."
+        },
+        {
+          "name": "ores_analytics_pricing_model_configs_tbl",
+          "component": "analytics",
+          "entity": "pricing_model_configs",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "description",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "config_variant",
+              "type": "text",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/analytics/analytics_pricing_model_configs_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Header entity for a pricing model configuration. Each config contains product mappings\n    (in pricing_model_products) and parameters (in pricing_model_product_parameters).\n    Corresponds to ORE's pricingengine.xml."
+        },
+        {
+          "name": "ores_analytics_pricing_model_product_parameters_tbl",
+          "component": "analytics",
+          "entity": "pricing_model_product_parameters",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "pricing_model_config_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "pricing_model_product_id",
+              "type": "uuid",
+              "nullable": true,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "parameter_scope",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "parameter_name",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "parameter_value",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/analytics/analytics_pricing_model_product_parameters_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Stores model parameters, engine parameters, and global parameters as normalised rows\n    for granular diffing. Product-scoped parameters have pricing_model_product_id set;\n    global parameters have it NULL with parameter_scope = 'global'."
+        },
+        {
+          "name": "ores_analytics_pricing_model_products_tbl",
+          "component": "analytics",
+          "entity": "pricing_model_products",
+          "classification": "temporal",
+          "stereotype": "<<temporal>>",
+          "color": "#C6F0D8",
+          "primary_key": {
+            "columns": [
+              {
+                "name": "tenant_id",
+                "type": "uuid",
+                "is_fk": true
+              },
+              {
+                "name": "id",
+                "type": "uuid"
+              }
+            ],
+            "composite": true
+          },
+          "columns": [
+            {
+              "name": "version",
+              "type": "integer",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "pricing_model_config_id",
+              "type": "uuid",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "pricing_engine_type_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "model",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "engine",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "modified_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "performed_by",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_reason_code",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": true,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "change_commentary",
+              "type": "text",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_from",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            },
+            {
+              "name": "valid_to",
+              "type": "timestamptz",
+              "nullable": false,
+              "is_pk": false,
+              "is_fk": false,
+              "is_unique": false,
+              "default": null,
+              "references": null
+            }
+          ],
+          "indexes": [],
+          "source_file": "create/analytics/analytics_pricing_model_products_create.sql",
+          "description": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY\n    Template: sql_schema_domain_entity_create.mustache\n    To modify, update the template and regenerate.\n    Table\n    Detail row within a pricing model configuration. Each row maps a pricing engine type\n    (e.g. EuropeanSwaption, CMS) to a specific model (e.g. LGM, BlackBachelier) and\n    numerical engine (e.g. Grid, AMC). Product-specific parameters are stored in\n    pricing_model_product_parameters."
         }
       ]
     }

--- a/projects/ores.compute.api/include/ores.compute.api/domain/app_version.hpp
+++ b/projects/ores.compute.api/include/ores.compute.api/domain/app_version.hpp
@@ -21,7 +21,6 @@
 #define ORES_COMPUTE_DOMAIN_APP_VERSION_HPP
 
 #include <string>
-#include <vector>
 #include <boost/uuid/uuid.hpp>
 #include "ores.utility/uuid/tenant_id.hpp"
 
@@ -30,9 +29,10 @@ namespace ores::compute::domain {
 /**
  * @brief A versioned wrapper+engine bundle for a compute grid application.
  *
- * Combines a specific wrapper version with a specific engine version for a given
- * platform. The BOINC equivalent of 'app_version'. Nodes download the package_uri
- * bundle and launch the wrapper to run the engine.
+ * Combines a specific wrapper version with a specific engine version. The BOINC
+ * equivalent of 'app_version'. Per-platform package artefacts are tracked via
+ * ores_compute_app_version_platforms_tbl — each (app_version, platform) row
+ * owns the URI of its own packaged bundle.
  */
 struct app_version final {
     /**
@@ -64,16 +64,6 @@ struct app_version final {
      * @brief Version of the underlying engine, e.g. 'ORE-Studio-7.1'.
      */
     std::string engine_version;
-
-    /**
-     * @brief URI pointing to the zipped wrapper+engine bundle in object storage.
-     */
-    std::string package_uri;
-
-    /**
-     * @brief Supported platform identifiers, e.g. 'linux-x86_64', 'linux-arm64'.
-     */
-    std::vector<std::string> platforms;
 
     /**
      * @brief Minimum RAM in MB required by the node to run this app version.

--- a/projects/ores.compute.api/include/ores.compute.api/domain/app_version_platform.hpp
+++ b/projects/ores.compute.api/include/ores.compute.api/domain/app_version_platform.hpp
@@ -1,0 +1,69 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_COMPUTE_DOMAIN_APP_VERSION_PLATFORM_HPP
+#define ORES_COMPUTE_DOMAIN_APP_VERSION_PLATFORM_HPP
+
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+
+namespace ores::compute::domain {
+
+/**
+ * @brief Association between an app version and a supported target platform,
+ * carrying the URI of the per-platform packaged bundle.
+ *
+ * Each row represents one .tar.gz built for a specific triplet — the wrapper
+ * downloads the URI matching its own @c ORES_PLATFORM_TRIPLET at dispatch
+ * time.
+ */
+struct app_version_platform final {
+    /**
+     * @brief Tenant identifier for multi-tenancy isolation.
+     */
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
+
+    /**
+     * @brief FK reference to ores_compute_app_versions_tbl.
+     */
+    boost::uuids::uuid app_version_id;
+
+    /**
+     * @brief FK reference to ores_compute_platforms_tbl.
+     */
+    boost::uuids::uuid platform_id;
+
+    /**
+     * @brief vcpkg target triplet of the packaged bundle (e.g. 'x64-linux').
+     *
+     * Denormalised from ores_compute_platforms_tbl.code for dispatch paths
+     * that need the code without a second join.
+     */
+    std::string platform_code;
+
+    /**
+     * @brief URI of the per-platform packaged bundle in object storage.
+     */
+    std::string package_uri;
+};
+
+}
+
+#endif

--- a/projects/ores.compute.api/include/ores.compute.api/domain/app_version_platform_json_io.hpp
+++ b/projects/ores.compute.api/include/ores.compute.api/domain/app_version_platform_json_io.hpp
@@ -17,33 +17,19 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#include "ores.compute.api/domain/app_version_table.hpp"
+#ifndef ORES_COMPUTE_DOMAIN_APP_VERSION_PLATFORM_JSON_IO_HPP
+#define ORES_COMPUTE_DOMAIN_APP_VERSION_PLATFORM_JSON_IO_HPP
 
-#include <sstream>
-#include <boost/uuid/uuid_io.hpp>
-#include <fort.hpp>
+#include <iosfwd>
+#include "ores.compute.api/domain/app_version_platform.hpp"
 
 namespace ores::compute::domain {
 
-std::string convert_to_table(const std::vector<app_version>& v) {
-    fort::char_table table;
-    table.set_border_style(FT_BASIC_STYLE);
-
-    table << fort::header
-          << "ID" << "App ID" << "Wrapper Version" << "Engine Version"
-          << "Min RAM (MB)" << "Modified By" << "Recorded At" << fort::endr;
-
-    for (const auto& av : v) {
-        table << boost::uuids::to_string(av.id)
-              << boost::uuids::to_string(av.app_id)
-              << av.wrapper_version << av.engine_version
-              << av.min_ram_mb
-              << av.modified_by << av.recorded_at << fort::endr;
-    }
-
-    std::ostringstream ss;
-    ss << std::endl << table.to_string() << std::endl;
-    return ss.str();
-}
+/**
+ * @brief Dumps the app_version_platform to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const app_version_platform& v);
 
 }
+
+#endif

--- a/projects/ores.compute.api/include/ores.compute.api/domain/compute_platform.hpp
+++ b/projects/ores.compute.api/include/ores.compute.api/domain/compute_platform.hpp
@@ -27,15 +27,17 @@
 namespace ores::compute::domain {
 
 /**
- * @brief A known compute platform, identified by its Rust target triple code.
+ * @brief A known compute platform, identified by its vcpkg target triplet.
  *
  * System-owned data: owned by the system tenant and visible read-only to all
- * tenants via RLS.
+ * tenants via RLS. The @c code matches VCPKG_TARGET_TRIPLET used at build
+ * time and ORES_PLATFORM_TRIPLET stamped into each binary at runtime, so a
+ * single identifier links build output, runtime host and DB row.
  */
 struct compute_platform final {
     boost::uuids::uuid id;
-    std::string code;          // e.g. "x86_64-unknown-linux-gnu"
-    std::string display_name;  // e.g. "Linux x86-64 (GNU libc)"
+    std::string code;          // e.g. "x64-linux"
+    std::string display_name;  // e.g. "Linux x86-64"
     std::string description;
     std::string os_family;     // linux / macos / windows
     std::string cpu_arch;      // x86_64 / aarch64

--- a/projects/ores.compute.api/include/ores.compute.api/messaging/app_version_protocol.hpp
+++ b/projects/ores.compute.api/include/ores.compute.api/messaging/app_version_protocol.hpp
@@ -24,6 +24,7 @@
 #include <string_view>
 #include <vector>
 #include "ores.compute.api/domain/app_version.hpp"
+#include "ores.compute.api/domain/app_version_platform.hpp"
 
 namespace ores::compute::messaging {
 
@@ -45,6 +46,7 @@ struct save_app_version_request {
     static constexpr std::string_view nats_subject =
         "compute.v1.app-versions.save";
     ores::compute::domain::app_version app_version;
+    std::vector<ores::compute::domain::app_version_platform> platforms;
     std::string change_reason_code;
     std::string change_commentary;
 };

--- a/projects/ores.compute.api/include/ores.compute.api/messaging/app_version_protocol.hpp
+++ b/projects/ores.compute.api/include/ores.compute.api/messaging/app_version_protocol.hpp
@@ -69,6 +69,19 @@ struct get_app_version_history_response {
     std::vector<ores::compute::domain::app_version> versions;
 };
 
+struct list_app_version_platforms_request {
+    using response_type = struct list_app_version_platforms_response;
+    static constexpr std::string_view nats_subject =
+        "compute.v1.app-versions.platforms.list";
+    std::string app_version_id;
+};
+
+struct list_app_version_platforms_response {
+    bool success = true;
+    std::string message;
+    std::vector<ores::compute::domain::app_version_platform> platforms;
+};
+
 }
 
 #endif

--- a/projects/ores.compute.api/include/ores.compute.api/net/compute_storage.hpp
+++ b/projects/ores.compute.api/include/ores.compute.api/net/compute_storage.hpp
@@ -32,10 +32,11 @@ namespace ores::compute::net {
  * All compute artifacts live under a single "compute" bucket with
  * hierarchical keys:
  *
- *   packages/{app_version_id}[.ext]   — application package binary
- *   input/{workunit_id}[.ext]         — workunit input archive
- *   config/{workunit_id}[.ext]        — workunit configuration file
- *   output/{result_id}.tar.gz         — result output archive
+ *   packages/{app_version_id}[.ext]                   — single-platform bundle
+ *   packages/{app_version_id}/{platform_code}[.ext]   — per-triplet bundle
+ *   input/{workunit_id}[.ext]                         — workunit input archive
+ *   config/{workunit_id}[.ext]                        — workunit configuration file
+ *   output/{result_id}.tar.gz                         — result output archive
  *
  * Use @c storage_paths::make_object_path / @c make_object_url to build
  * the full HTTP path or URL from the helpers below.
@@ -56,6 +57,27 @@ struct compute_storage {
         std::string_view ext = "") {
         std::string k = "packages/";
         k += id;
+        k += ext;
+        return k;
+    }
+
+    /**
+     * @brief Key for a per-platform application package binary.
+     *
+     * @param id             App version UUID as string.
+     * @param platform_code  vcpkg triplet code (e.g. "x64-linux").
+     * @param ext            File extension including the leading dot.
+     *
+     * Per-platform bundles live one level deeper than the single-platform
+     * key so both layouts can coexist during migration.
+     */
+    static std::string package_key(std::string_view id,
+        std::string_view platform_code,
+        std::string_view ext) {
+        std::string k = "packages/";
+        k += id;
+        k += '/';
+        k += platform_code;
         k += ext;
         return k;
     }
@@ -106,6 +128,20 @@ struct compute_storage {
         std::string_view ext = "") {
         return ores::storage::net::storage_paths::make_object_path(
             bucket, package_key(id, ext));
+    }
+
+    /**
+     * @brief HTTP path for a per-platform package binary.
+     *
+     * Canonical location for the (app_version, platform_code) bundle used
+     * when populating ores_compute_app_version_platforms_tbl.package_uri so
+     * clients don't have to synthesise the path inline.
+     */
+    static std::string package_path(std::string_view id,
+        std::string_view platform_code,
+        std::string_view ext) {
+        return ores::storage::net::storage_paths::make_object_path(
+            bucket, package_key(id, platform_code, ext));
     }
 
     static std::string input_path(std::string_view workunit_id,

--- a/projects/ores.compute.api/src/domain/app_version_platform_json_io.cpp
+++ b/projects/ores.compute.api/src/domain/app_version_platform_json_io.cpp
@@ -17,33 +17,18 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#include "ores.compute.api/domain/app_version_table.hpp"
+#include "ores.compute.api/domain/app_version_platform_json_io.hpp"
 
-#include <sstream>
-#include <boost/uuid/uuid_io.hpp>
-#include <fort.hpp>
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 
 namespace ores::compute::domain {
 
-std::string convert_to_table(const std::vector<app_version>& v) {
-    fort::char_table table;
-    table.set_border_style(FT_BASIC_STYLE);
-
-    table << fort::header
-          << "ID" << "App ID" << "Wrapper Version" << "Engine Version"
-          << "Min RAM (MB)" << "Modified By" << "Recorded At" << fort::endr;
-
-    for (const auto& av : v) {
-        table << boost::uuids::to_string(av.id)
-              << boost::uuids::to_string(av.app_id)
-              << av.wrapper_version << av.engine_version
-              << av.min_ram_mb
-              << av.modified_by << av.recorded_at << fort::endr;
-    }
-
-    std::ostringstream ss;
-    ss << std::endl << table.to_string() << std::endl;
-    return ss.str();
+std::ostream& operator<<(std::ostream& s, const app_version_platform& v) {
+    rfl::json::write(v, s);
+    return s;
 }
 
 }

--- a/projects/ores.compute.api/src/generators/app_version_generator.cpp
+++ b/projects/ores.compute.api/src/generators/app_version_generator.cpp
@@ -44,8 +44,6 @@ domain::app_version generate_synthetic_app_version(
     r.app_id = app_id;
     r.wrapper_version = std::string("v1.0.") + std::to_string(idx);
     r.engine_version = std::string("engine-7.") + std::to_string(idx);
-    r.package_uri = std::string("s3://packages/app-v1.0.") + std::to_string(idx) + ".zip";
-    r.platforms = {"linux-x86_64"};
     r.min_ram_mb = 4096;
     r.modified_by = modified_by;
     r.performed_by = modified_by;

--- a/projects/ores.compute.api/tests/domain_app_version_platform_tests.cpp
+++ b/projects/ores.compute.api/tests/domain_app_version_platform_tests.cpp
@@ -1,0 +1,103 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.compute.api/domain/app_version_platform.hpp"
+
+#include <sstream>
+#include <catch2/catch_test_macros.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.compute.api/domain/app_version_platform_json_io.hpp" // IWYU pragma: keep.
+
+namespace {
+
+const std::string_view test_suite("ores.compute.tests");
+const std::string tags("[domain]");
+
+}
+
+using ores::compute::domain::app_version_platform;
+using namespace ores::logging;
+
+TEST_CASE("create_app_version_platform_with_valid_fields", tags) {
+    auto lg(make_logger(test_suite));
+
+    app_version_platform sut;
+    sut.app_version_id = boost::uuids::random_generator()();
+    sut.platform_id = boost::uuids::random_generator()();
+    sut.platform_code = "x64-linux";
+    sut.package_uri =
+        "/api/v1/storage/compute/packages/ore/1.8.15.0/ore-1.8.15.0-x64-linux.tar.gz";
+
+    BOOST_LOG_SEV(lg, info) << "AppVersionPlatform: " << sut;
+
+    CHECK(sut.platform_code == "x64-linux");
+    CHECK(sut.package_uri.find("x64-linux.tar.gz") != std::string::npos);
+    CHECK(!sut.app_version_id.is_nil());
+    CHECK(!sut.platform_id.is_nil());
+}
+
+TEST_CASE("create_app_version_platform_with_specific_uuids", tags) {
+    auto lg(make_logger(test_suite));
+
+    boost::uuids::string_generator uuid_gen;
+    const auto av_id = uuid_gen("550e8400-e29b-41d4-a716-446655440001");
+    const auto pl_id = uuid_gen("550e8400-e29b-41d4-a716-446655440002");
+
+    app_version_platform sut;
+    sut.app_version_id = av_id;
+    sut.platform_id = pl_id;
+    sut.platform_code = "arm64-osx";
+    sut.package_uri = "s3://example/ore-arm64-osx.tar.gz";
+
+    BOOST_LOG_SEV(lg, info) << "AppVersionPlatform: " << sut;
+
+    CHECK(sut.app_version_id == av_id);
+    CHECK(sut.platform_id == pl_id);
+    CHECK(sut.platform_code == "arm64-osx");
+}
+
+TEST_CASE("app_version_platform_insertion_operator_emits_json", tags) {
+    auto lg(make_logger(test_suite));
+
+    app_version_platform sut;
+    sut.app_version_id = boost::uuids::random_generator()();
+    sut.platform_id = boost::uuids::random_generator()();
+    sut.platform_code = "x64-windows";
+    sut.package_uri = "s3://example/ore-x64-windows.tar.gz";
+
+    std::ostringstream os;
+    os << sut;
+    const std::string json_output = os.str();
+
+    BOOST_LOG_SEV(lg, info) << "AppVersionPlatform JSON: " << json_output;
+
+    CHECK(!json_output.empty());
+    CHECK(json_output.find("x64-windows") != std::string::npos);
+    CHECK(json_output.find("ore-x64-windows.tar.gz") != std::string::npos);
+}
+
+TEST_CASE("app_version_platform_default_construction_has_empty_strings", tags) {
+    const app_version_platform sut;
+
+    CHECK(sut.platform_code.empty());
+    CHECK(sut.package_uri.empty());
+    CHECK(sut.app_version_id.is_nil());
+    CHECK(sut.platform_id.is_nil());
+}

--- a/projects/ores.compute.api/tests/domain_app_version_tests.cpp
+++ b/projects/ores.compute.api/tests/domain_app_version_tests.cpp
@@ -48,8 +48,6 @@ TEST_CASE("create_app_version_with_valid_fields", tags) {
     sut.app_id = boost::uuids::random_generator()();
     sut.wrapper_version = "v1.2.0";
     sut.engine_version = "ORE-Studio-7.1";
-    sut.package_uri = "s3://bucket/ore-studio-v1.2.0-linux-x86_64.tar.gz";
-    sut.platforms = {"linux-x86_64", "linux-arm64"};
     sut.min_ram_mb = 4096;
 
     BOOST_LOG_SEV(lg, info) << "AppVersion: " << sut;
@@ -59,7 +57,6 @@ TEST_CASE("create_app_version_with_valid_fields", tags) {
     CHECK(sut.wrapper_version == "v1.2.0");
     CHECK(sut.engine_version == "ORE-Studio-7.1");
     CHECK(sut.min_ram_mb == 4096);
-    CHECK(sut.platforms.size() == 2);
 }
 
 TEST_CASE("create_app_version_with_specific_uuid", tags) {
@@ -76,8 +73,6 @@ TEST_CASE("create_app_version_with_specific_uuid", tags) {
     sut.app_id = specific_app_id;
     sut.wrapper_version = "v2.0.0";
     sut.engine_version = "ORE-Studio-8.0";
-    sut.package_uri = "s3://bucket/ore-studio-v2.0.0.tar.gz";
-    sut.platforms = {"linux-x86_64"};
     sut.min_ram_mb = 8192;
 
     BOOST_LOG_SEV(lg, info) << "AppVersion: " << sut;
@@ -96,8 +91,6 @@ TEST_CASE("app_version_insertion_operator", tags) {
     sut.app_id = boost::uuids::random_generator()();
     sut.wrapper_version = "v1.0.0";
     sut.engine_version = "ORE-7.0";
-    sut.package_uri = "s3://bucket/package.tar.gz";
-    sut.platforms = {"linux-x86_64"};
     sut.min_ram_mb = 2048;
 
     std::ostringstream os;
@@ -120,8 +113,6 @@ TEST_CASE("app_version_convert_single_to_table", tags) {
     av.app_id = boost::uuids::random_generator()();
     av.wrapper_version = "v1.2.0";
     av.engine_version = "ORE-Studio-7.1";
-    av.package_uri = "s3://bucket/package.tar.gz";
-    av.platforms = {"linux-x86_64"};
     av.min_ram_mb = 4096;
 
     std::vector<app_version> versions = {av};
@@ -145,8 +136,6 @@ TEST_CASE("app_version_convert_multiple_to_table", tags) {
         av.app_id = boost::uuids::random_generator()();
         av.wrapper_version = "v1." + std::to_string(i) + ".0";
         av.engine_version = "ORE-" + std::to_string(i);
-        av.package_uri = "s3://bucket/package-" + std::to_string(i) + ".tar.gz";
-        av.platforms = {"linux-x86_64"};
         av.min_ram_mb = 2048 * (i + 1);
         versions.push_back(av);
     }
@@ -182,8 +171,6 @@ TEST_CASE("create_app_version_with_faker", tags) {
     sut.app_id = boost::uuids::random_generator()();
     sut.wrapper_version = "v" + std::to_string(faker::number::integer(1, 5)) + ".0.0";
     sut.engine_version = "ORE-" + std::to_string(faker::number::integer(7, 9));
-    sut.package_uri = "s3://bucket/" + std::string(faker::word::noun()) + ".tar.gz";
-    sut.platforms = {"linux-x86_64"};
     sut.min_ram_mb = faker::number::integer(1024, 32768);
 
     BOOST_LOG_SEV(lg, info) << "AppVersion: " << sut;

--- a/projects/ores.compute.core/include/ores.compute.core/messaging/app_version_handler.hpp
+++ b/projects/ores.compute.core/include/ores.compute.core/messaging/app_version_handler.hpp
@@ -161,13 +161,18 @@ public:
             return;
         }
         const auto& ctx = *ctx_expected;
+        auto req = decode<list_app_version_platforms_request>(msg);
+        if (!req) {
+            BOOST_LOG_SEV(app_version_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+            return;
+        }
         list_app_version_platforms_response resp;
         try {
-            if (auto req = decode<list_app_version_platforms_request>(msg)) {
-                repository::app_version_platform_repository avp_repo;
-                resp.platforms = avp_repo.list_for_version(
-                    ctx, req->app_version_id);
-            }
+            repository::app_version_platform_repository avp_repo;
+            resp.platforms = avp_repo.list_for_version(
+                ctx, req->app_version_id);
         } catch (const std::exception& e) {
             resp.success = false;
             resp.message = e.what();

--- a/projects/ores.compute.core/include/ores.compute.core/messaging/app_version_handler.hpp
+++ b/projects/ores.compute.core/include/ores.compute.core/messaging/app_version_handler.hpp
@@ -151,6 +151,32 @@ public:
             << "Completed " << msg.subject;
     }
 
+    void list_platforms(ores::nats::message msg) {
+        BOOST_LOG_SEV(app_version_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!ctx_expected) {
+            error_reply(nats_, msg, ctx_expected.error());
+            return;
+        }
+        const auto& ctx = *ctx_expected;
+        list_app_version_platforms_response resp;
+        try {
+            if (auto req = decode<list_app_version_platforms_request>(msg)) {
+                repository::app_version_platform_repository avp_repo;
+                resp.platforms = avp_repo.list_for_version(
+                    ctx, req->app_version_id);
+            }
+        } catch (const std::exception& e) {
+            resp.success = false;
+            resp.message = e.what();
+        }
+        reply(nats_, msg, resp);
+        BOOST_LOG_SEV(app_version_handler_lg(), debug)
+            << "Completed " << msg.subject;
+    }
+
 private:
     ores::nats::service::client& nats_;
     ores::database::context ctx_;

--- a/projects/ores.compute.core/include/ores.compute.core/messaging/app_version_handler.hpp
+++ b/projects/ores.compute.core/include/ores.compute.core/messaging/app_version_handler.hpp
@@ -23,6 +23,7 @@
 #include <optional>
 #include <stdexcept>
 #include <rfl/json.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
@@ -32,6 +33,7 @@
 #include "ores.service/service/request_context.hpp"
 #include "ores.compute.api/messaging/app_version_protocol.hpp"
 #include "ores.compute.core/service/app_version_service.hpp"
+#include "ores.compute.core/repository/app_version_platform_repository.hpp"
 
 namespace ores::compute::messaging {
 
@@ -98,6 +100,18 @@ public:
             try {
                 service::app_version_service svc(ctx);
                 svc.save(req->app_version);
+
+                // Sync the per-platform junction rows in the same request so
+                // Qt / CLI callers only need to make one round-trip.
+                repository::app_version_platform_repository avp_repo;
+                avp_repo.replace_for_version(ctx,
+                    boost::uuids::to_string(req->app_version.id),
+                    req->platforms,
+                    req->app_version.modified_by,
+                    req->app_version.performed_by,
+                    req->app_version.change_reason_code,
+                    req->app_version.change_commentary);
+
                 reply(nats_, msg,
                     save_app_version_response{.success = true});
             } catch (const std::exception& e) {

--- a/projects/ores.compute.core/include/ores.compute.core/messaging/workunit_handler.hpp
+++ b/projects/ores.compute.core/include/ores.compute.core/messaging/workunit_handler.hpp
@@ -39,7 +39,7 @@
 #include "ores.compute.core/service/workunit_service.hpp"
 #include "ores.dq.api/domain/change_reason.hpp"
 #include "ores.compute.core/service/result_service.hpp"
-#include "ores.compute.core/service/app_version_service.hpp"
+#include "ores.compute.core/repository/app_version_platform_repository.hpp"
 
 namespace ores::compute::messaging {
 
@@ -120,17 +120,27 @@ public:
                 const auto tenant_id_str = ctx.tenant_id().to_string();
                 const auto redundancy = req->workunit.target_redundancy;
 
-                // Look up app_version once to get the package_uri.
-                service::app_version_service av_svc(ctx);
-                const auto av = av_svc.find(av_id_str);
-                const auto package_uri = av ? av->package_uri : std::string{};
-                if (!av) {
+                // Look up the per-platform packages for this app_version.
+                // Each assignment is published on the triplet-specific subject
+                // so only wrappers with a matching ORES_PLATFORM_TRIPLET pick
+                // it up. If no packages are available, no dispatch is possible.
+                repository::app_version_platform_repository avp_repo;
+                const auto avps = avp_repo.list_for_version(ctx, av_id_str);
+                if (avps.empty()) {
                     BOOST_LOG_SEV(workunit_handler_lg(), warn)
-                        << "app_version not found: " << av_id_str
-                        << " — package_uri will be empty in assignment event";
+                        << "No platform packages for app_version "
+                        << av_id_str
+                        << " — workunit " << wu_id_str
+                        << " cannot be dispatched.";
+                    reply(nats_, msg, save_workunit_response{.success = true});
+                    return;
                 }
 
+                // Round-robin across available platforms so redundancy copies
+                // spread evenly across compatible host pools.
                 for (int i = 0; i < redundancy; ++i) {
+                    const auto& avp = avps[i % avps.size()];
+
                     domain::result r;
                     r.id = boost::uuids::random_generator()();
                     r.workunit_id = req->workunit.id;
@@ -145,7 +155,7 @@ public:
                         .result_id      = result_id_str,
                         .workunit_id    = wu_id_str,
                         .app_version_id = av_id_str,
-                        .package_uri    = package_uri,
+                        .package_uri    = avp.package_uri,
                         .input_uri      = req->workunit.input_uri,
                         .config_uri     = req->workunit.config_uri,
                         .output_uri     = ores::compute::net::compute_storage::output_path(
@@ -154,11 +164,13 @@ public:
                     const auto* p =
                         reinterpret_cast<const std::byte*>(json.data());
                     nats_.js_publish(
-                        "compute.v1.work.assignments." + tenant_id_str,
+                        "compute.v1.work.assignments." + tenant_id_str
+                            + "." + avp.platform_code,
                         std::span<const std::byte>(p, json.size()));
                     BOOST_LOG_SEV(workunit_handler_lg(), debug)
                         << "Dispatched result " << result_id_str
-                        << " for workunit " << wu_id_str;
+                        << " for workunit " << wu_id_str
+                        << " on platform " << avp.platform_code;
                 }
 
                 reply(nats_, msg, save_workunit_response{.success = true});

--- a/projects/ores.compute.core/include/ores.compute.core/repository/app_version_entity.hpp
+++ b/projects/ores.compute.core/include/ores.compute.core/repository/app_version_entity.hpp
@@ -43,7 +43,6 @@ struct app_version_entity {
     std::string app_id;
     std::string wrapper_version;
     std::string engine_version;
-    std::string package_uri;
     int min_ram_mb;
     std::string modified_by;
     std::string performed_by;

--- a/projects/ores.compute.core/include/ores.compute.core/repository/app_version_platform_repository.hpp
+++ b/projects/ores.compute.core/include/ores.compute.core/repository/app_version_platform_repository.hpp
@@ -1,0 +1,67 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_COMPUTE_REPOSITORY_APP_VERSION_PLATFORM_REPOSITORY_HPP
+#define ORES_COMPUTE_REPOSITORY_APP_VERSION_PLATFORM_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include "ores.database/domain/context.hpp"
+#include "ores.compute.api/domain/app_version_platform.hpp"
+
+namespace ores::compute::repository {
+
+/**
+ * @brief Reads and writes the (app_version, platform) → package_uri junction
+ * table.
+ *
+ * The orchestrator uses @c list_for_version at workunit dispatch time to find
+ * which packaged bundles are available for an app version and pick the URI
+ * matching the target host's triplet. @c replace_for_version is called from
+ * the save_app_version handler to sync the junction rows for an app version
+ * in one pass.
+ */
+class app_version_platform_repository {
+public:
+    /**
+     * @brief Return all active junction rows for a given app version, with
+     * the platform code denormalised from ores_compute_platforms_tbl.
+     */
+    std::vector<domain::app_version_platform>
+    list_for_version(database::context ctx, const std::string& app_version_id);
+
+    /**
+     * @brief Replace all active junction rows for the given app version with
+     * the supplied set. Existing active rows that are not in @p rows are
+     * soft-deleted; rows in @p rows are upserted via the bitemporal insert
+     * trigger which closes any pre-existing active row for the same
+     * (app_version, platform) pair.
+     */
+    void replace_for_version(database::context ctx,
+        const std::string& app_version_id,
+        const std::vector<domain::app_version_platform>& rows,
+        const std::string& modified_by,
+        const std::string& performed_by,
+        const std::string& change_reason_code,
+        const std::string& change_commentary);
+};
+
+}
+
+#endif

--- a/projects/ores.compute.core/modeling/ores.compute.puml
+++ b/projects/ores.compute.core/modeling/ores.compute.puml
@@ -49,10 +49,22 @@ namespace ores #F2F2F2 {
                 + app_id: uuid
                 + wrapper_version: string
                 + engine_version: string
-                + package_uri: string
-                + platform: string
                 + min_ram_mb: int
                 + modified_by: string
+            }
+            class app_version_platform {
+                + app_version_id: uuid
+                + platform_id: uuid
+                + platform_code: string
+                + package_uri: string
+            }
+            class compute_platform {
+                + id: uuid
+                + code: string
+                + display_name: string
+                + os_family: string
+                + cpu_arch: string
+                + is_active: bool
             }
             class batch {
                 + id: uuid
@@ -82,6 +94,8 @@ namespace ores #F2F2F2 {
             }
 
             app_version --> app : app_id
+            app_version_platform --> app_version : app_version_id
+            app_version_platform --> compute_platform : platform_id
             workunit --> batch : batch_id
             workunit --> app_version : app_version_id
             result --> workunit : workunit_id

--- a/projects/ores.compute.core/src/messaging/registrar.cpp
+++ b/projects/ores.compute.core/src/messaging/registrar.cpp
@@ -91,6 +91,10 @@ registrar::register_handlers(ores::nats::service::client& nats,
     subs.push_back(nats.queue_subscribe(
         get_app_version_history_request::nats_subject, "ores.compute.service",
         [avh](ores::nats::message msg) { avh->history(std::move(msg)); }));
+    subs.push_back(nats.queue_subscribe(
+        list_app_version_platforms_request::nats_subject,
+        "ores.compute.service",
+        [avh](ores::nats::message msg) { avh->list_platforms(std::move(msg)); }));
 
     // ----------------------------------------------------------------
     // Batches

--- a/projects/ores.compute.core/src/repository/app_version_mapper.cpp
+++ b/projects/ores.compute.core/src/repository/app_version_mapper.cpp
@@ -40,7 +40,6 @@ app_version_mapper::map(const app_version_entity& v) {
     r.app_id = boost::lexical_cast<boost::uuids::uuid>(v.app_id);
     r.wrapper_version = v.wrapper_version;
     r.engine_version = v.engine_version;
-    r.package_uri = v.package_uri;
     r.min_ram_mb = v.min_ram_mb;
     r.modified_by = v.modified_by;
     r.performed_by = v.performed_by;
@@ -65,7 +64,6 @@ app_version_mapper::map(const domain::app_version& v) {
     r.app_id = boost::uuids::to_string(v.app_id);
     r.wrapper_version = v.wrapper_version;
     r.engine_version = v.engine_version;
-    r.package_uri = v.package_uri;
     r.min_ram_mb = v.min_ram_mb;
     r.modified_by = v.modified_by;
     r.performed_by = v.performed_by;

--- a/projects/ores.compute.core/src/repository/app_version_platform_repository.cpp
+++ b/projects/ores.compute.core/src/repository/app_version_platform_repository.cpp
@@ -1,0 +1,117 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.compute.core/repository/app_version_platform_repository.hpp"
+
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::compute::repository {
+
+namespace {
+
+auto& lg() {
+    using namespace ores::logging;
+    static auto instance = make_logger(
+        "ores.compute.repository.app_version_platform_repository");
+    return instance;
+}
+
+}
+
+std::vector<domain::app_version_platform>
+app_version_platform_repository::list_for_version(database::context ctx,
+    const std::string& app_version_id) {
+
+    const std::string sql =
+        "SELECT avp.app_version_id::text,"
+        "       avp.platform_id::text,"
+        "       p.code,"
+        "       avp.package_uri"
+        "  FROM ores_compute_app_version_platforms_tbl avp"
+        "  JOIN ores_compute_platforms_tbl p"
+        "    ON p.id = avp.platform_id"
+        "   AND p.valid_to = ores_utility_infinity_timestamp_fn()"
+        " WHERE avp.app_version_id = $1::uuid"
+        "   AND avp.valid_to = ores_utility_infinity_timestamp_fn()";
+
+    const auto rows = ores::database::repository::
+        execute_parameterized_multi_column_query(
+            ctx, sql, {app_version_id}, lg(),
+            "Listing platforms for app version " + app_version_id);
+
+    std::vector<domain::app_version_platform> r;
+    r.reserve(rows.size());
+    for (const auto& row : rows) {
+        domain::app_version_platform avp;
+        avp.tenant_id = ctx.tenant_id();
+        avp.app_version_id = boost::lexical_cast<boost::uuids::uuid>(
+            row[0].value_or(""));
+        avp.platform_id = boost::lexical_cast<boost::uuids::uuid>(
+            row[1].value_or(""));
+        avp.platform_code = row[2].value_or("");
+        avp.package_uri = row[3].value_or("");
+        r.push_back(std::move(avp));
+    }
+    return r;
+}
+
+void app_version_platform_repository::replace_for_version(
+    database::context ctx, const std::string& app_version_id,
+    const std::vector<domain::app_version_platform>& rows,
+    const std::string& modified_by, const std::string& performed_by,
+    const std::string& change_reason_code,
+    const std::string& change_commentary) {
+
+    const auto tenant_id_str = ctx.tenant_id().to_string();
+
+    // Soft-close all current active rows for this app version so platforms
+    // removed from @p rows disappear from the active set. Rows in @p rows
+    // are re-inserted below; the insert trigger takes care of bitemporal
+    // bookkeeping.
+    ores::database::repository::execute_parameterized_command(ctx,
+        "UPDATE ores_compute_app_version_platforms_tbl"
+        "   SET valid_to = current_timestamp"
+        " WHERE tenant_id = $1::uuid"
+        "   AND app_version_id = $2::uuid"
+        "   AND valid_to = ores_utility_infinity_timestamp_fn()",
+        {tenant_id_str, app_version_id}, lg(),
+        "Closing existing platform rows for app version " + app_version_id);
+
+    for (const auto& row : rows) {
+        const auto platform_id_str = boost::uuids::to_string(row.platform_id);
+        ores::database::repository::execute_parameterized_command(ctx,
+            "INSERT INTO ores_compute_app_version_platforms_tbl"
+            " (tenant_id, app_version_id, platform_id, package_uri,"
+            "  modified_by, performed_by,"
+            "  change_reason_code, change_commentary,"
+            "  valid_from, valid_to)"
+            " VALUES ($1::uuid, $2::uuid, $3::uuid, $4,"
+            "         $5, $6, $7, $8,"
+            "         now(), ores_utility_infinity_timestamp_fn())",
+            {tenant_id_str, app_version_id, platform_id_str, row.package_uri,
+             modified_by, performed_by,
+             change_reason_code, change_commentary},
+            lg(), "Inserting platform row for app version " + app_version_id);
+    }
+}
+
+}

--- a/projects/ores.compute.core/src/repository/app_version_repository.cpp
+++ b/projects/ores.compute.core/src/repository/app_version_repository.cpp
@@ -42,29 +42,6 @@ void app_version_repository::write(context ctx, const domain::app_version& v) {
     BOOST_LOG_SEV(lg(), debug) << "Writing app version: " << v.id;
     execute_write_query(ctx, app_version_mapper::map(v),
         lg(), "Writing app version to database.");
-
-    // Sync junction table: replace all platform rows for this id
-    const std::string id_str = boost::uuids::to_string(v.id);
-    const std::string tenant_id_str = ctx.tenant_id().to_string();
-    execute_parameterized_command(ctx,
-        "DELETE FROM ores_compute_app_version_platforms_tbl"
-        " WHERE tenant_id = $1::uuid AND app_version_id = $2::uuid"
-        " AND valid_to = ores_utility_infinity_timestamp_fn()",
-        {tenant_id_str, id_str},
-        lg(), "Removing old platform entries for app version.");
-
-    for (const auto& platform : v.platforms) {
-        execute_parameterized_command(ctx,
-            "INSERT INTO ores_compute_app_version_platforms_tbl"
-            " (tenant_id, app_version_id, platform_id, modified_by, performed_by,"
-            " change_reason_code, change_commentary, valid_from, valid_to)"
-            " VALUES ($1::uuid, $2::uuid, $3::uuid, $4, $5, $6, $7,"
-            " now(), ores_utility_infinity_timestamp_fn())",
-            {tenant_id_str, id_str, platform,
-             v.modified_by, v.performed_by,
-             v.change_reason_code, v.change_commentary},
-            lg(), "Inserting platform entry for app version.");
-    }
 }
 
 void app_version_repository::write(
@@ -72,26 +49,6 @@ void app_version_repository::write(
     BOOST_LOG_SEV(lg(), debug) << "Writing app versions. Count: " << v.size();
     execute_write_query(ctx, app_version_mapper::map(v),
         lg(), "Writing app versions to database.");
-}
-
-static void attach_platforms(database::context ctx,
-    std::vector<domain::app_version>& app_versions,
-    logging::logger_t& lg) {
-
-    if (app_versions.empty())
-        return;
-
-    const auto platform_map = execute_raw_grouped_query(ctx,
-        "SELECT avp.app_version_id::text, avp.platform_id::text"
-        " FROM ores_compute_app_version_platforms_tbl avp"
-        " WHERE avp.valid_to = ores_utility_infinity_timestamp_fn()",
-        lg, "Reading app version platforms");
-
-    for (auto& av : app_versions) {
-        const auto id_str = boost::uuids::to_string(av.id);
-        if (auto it = platform_map.find(id_str); it != platform_map.end())
-            av.platforms = it->second;
-    }
 }
 
 std::vector<domain::app_version>
@@ -104,13 +61,10 @@ app_version_repository::read_latest(context ctx) {
               && "valid_to"_c == max.value()) |
         order_by("id"_c);
 
-    auto r = execute_read_query<app_version_entity, domain::app_version>(
+    return execute_read_query<app_version_entity, domain::app_version>(
         ctx, query,
         [](const auto& entities) { return app_version_mapper::map(entities); },
         lg(), "Reading latest app versions");
-
-    attach_platforms(ctx, r, lg());
-    return r;
 }
 
 std::vector<domain::app_version>
@@ -123,13 +77,10 @@ app_version_repository::read_latest(context ctx, const std::string& id) {
         where(("tenant_id"_c == tid || "tenant_id"_c == sys)
               && "id"_c == id && "valid_to"_c == max.value());
 
-    auto r = execute_read_query<app_version_entity, domain::app_version>(
+    return execute_read_query<app_version_entity, domain::app_version>(
         ctx, query,
         [](const auto& entities) { return app_version_mapper::map(entities); },
         lg(), "Reading latest app version by id.");
-
-    attach_platforms(ctx, r, lg());
-    return r;
 }
 
 std::vector<domain::app_version>
@@ -142,13 +93,10 @@ app_version_repository::read_all(context ctx, const std::string& id) {
               && "id"_c == id) |
         order_by("version"_c.desc());
 
-    auto r = execute_read_query<app_version_entity, domain::app_version>(
+    return execute_read_query<app_version_entity, domain::app_version>(
         ctx, query,
         [](const auto& entities) { return app_version_mapper::map(entities); },
         lg(), "Reading all app version versions by id.");
-
-    attach_platforms(ctx, r, lg());
-    return r;
 }
 
 void app_version_repository::remove(context ctx, const std::string& id) {

--- a/projects/ores.compute.wrapper/src/app/application.cpp
+++ b/projects/ores.compute.wrapper/src/app/application.cpp
@@ -718,12 +718,19 @@ application::run(boost::asio::io_context& io_ctx,
     }
     node_stats_reporter* raw_reporter = reporter.get();
 
-    // Durable consumer name scoped to this environment to avoid collisions.
+    // Subject routing is per-triplet: the compute orchestrator publishes each
+    // assignment on compute.v1.work.assignments.{tenant_id}.{platform_code}
+    // with the package URI already resolved for that platform. Wrappers
+    // subscribe only to their own triplet so they never see assignments they
+    // couldn't run.
     std::string sanitised_tenant = cfg.tenant_id;
     std::replace(sanitised_tenant.begin(), sanitised_tenant.end(), '.', '_');
-    const std::string work_subject = "compute.v1.work.assignments.>";
-    const std::string durable_name = "compute_wrapper_" + sanitised_tenant;
-    const std::string queue_group  = "ores.compute.wrapper";
+    const std::string my_triplet(ores::utility::version::platform_triplet());
+    const std::string work_subject =
+        "compute.v1.work.assignments." + cfg.tenant_id + "." + my_triplet;
+    const std::string durable_name =
+        "compute_wrapper_" + sanitised_tenant + "_" + my_triplet;
+    const std::string queue_group = "ores.compute.wrapper." + my_triplet;
 
     co_await ores::service::service::run(
         io_ctx, nats, service_name,

--- a/projects/ores.qt.compute/include/ores.qt/AppVersionDetailDialog.hpp
+++ b/projects/ores.qt.compute/include/ores.qt/AppVersionDetailDialog.hpp
@@ -28,6 +28,7 @@
 #include "ores.logging/make_logger.hpp"
 #include "ores.compute.api/domain/app.hpp"
 #include "ores.compute.api/domain/app_version.hpp"
+#include "ores.compute.api/domain/app_version_platform.hpp"
 #include "ores.compute.api/messaging/platform_protocol.hpp"
 
 namespace Ui {
@@ -115,6 +116,7 @@ private:
     std::string username_;
     QUrl httpBaseUrl_;
     compute::domain::app_version app_version_;
+    std::vector<compute::domain::app_version_platform> platform_rows_;
     std::vector<AppEntry> appEntries_;
     std::vector<PlatformEntry> availablePlatforms_;
     QString selectedPackageFilePath_;

--- a/projects/ores.qt.compute/include/ores.qt/AppVersionDetailDialog.hpp
+++ b/projects/ores.qt.compute/include/ores.qt/AppVersionDetailDialog.hpp
@@ -104,6 +104,7 @@ private:
     void setupConnections();
     void loadApps();
     void loadPlatforms();
+    void loadAssignedPlatforms(const std::string& app_version_id);
     void populateAppCombo();
     void populatePlatformsTab();
     void updateUiFromVersion();

--- a/projects/ores.qt.compute/include/ores.qt/ClientAppVersionModel.hpp
+++ b/projects/ores.qt.compute/include/ores.qt/ClientAppVersionModel.hpp
@@ -59,9 +59,7 @@ public:
         AppId,
         WrapperVersion,
         EngineVersion,
-        Platform,
         MinRamMb,
-        PackageUri,
         Version,
         ModifiedBy,
         ColumnCount

--- a/projects/ores.qt.compute/src/AppProvisionerWizard.cpp
+++ b/projects/ores.qt.compute/src/AppProvisionerWizard.cpp
@@ -51,6 +51,7 @@
 #include "ores.qt/ChangeReasonCache.hpp"
 #include "ores.compute.api/domain/app.hpp"
 #include "ores.compute.api/domain/app_version.hpp"
+#include "ores.compute.api/domain/app_version_platform.hpp"
 #include "ores.compute.api/domain/compute_platform.hpp"
 #include "ores.compute.api/messaging/app_protocol.hpp"
 #include "ores.compute.api/messaging/app_version_protocol.hpp"
@@ -711,15 +712,31 @@ bool AppProvisionerWizard::submit() {
         ver.wrapper_version    = version_details_page_->wrapper_version().toStdString();
         ver.engine_version     = version_details_page_->engine_version().toStdString();
         ver.min_ram_mb         = version_details_page_->min_ram_mb();
-        ver.platforms          = platforms_page_->selected_platform_ids();
-        ver.package_uri        = package_upload_page_->package_uri().toStdString();
         ver.modified_by        = username;
         ver.performed_by       = username;
         ver.change_reason_code = reason_code;
         ver.change_commentary  = commentary;
 
+        // Build junction rows from the selected platforms. The wizard carries
+        // a single uploaded package URI; apply it to every platform for now.
+        // Per-platform uploads are planned as a follow-up once the detail
+        // dialog grows a per-triplet upload row.
+        const auto package_uri =
+            package_upload_page_->package_uri().toStdString();
+        std::vector<compute::domain::app_version_platform> platform_rows;
+        for (const auto& pid : platforms_page_->selected_platform_ids()) {
+            compute::domain::app_version_platform row;
+            row.app_version_id = app_version_id_;
+            try {
+                row.platform_id = boost::lexical_cast<boost::uuids::uuid>(pid);
+            } catch (...) { continue; }
+            row.package_uri = package_uri;
+            platform_rows.push_back(std::move(row));
+        }
+
         compute::messaging::save_app_version_request ver_req;
         ver_req.app_version        = std::move(ver);
+        ver_req.platforms          = std::move(platform_rows);
         ver_req.change_reason_code = reason_code;
         ver_req.change_commentary  = commentary;
 

--- a/projects/ores.qt.compute/src/AppVersionDetailDialog.cpp
+++ b/projects/ores.qt.compute/src/AppVersionDetailDialog.cpp
@@ -242,10 +242,10 @@ void AppVersionDetailDialog::populatePlatformsTab() {
     ui_->assignedPlatformsList->clear();
 
     for (const auto& p : availablePlatforms_) {
-        const bool assigned = std::find(
-            app_version_.platforms.begin(),
-            app_version_.platforms.end(),
-            p.id) != app_version_.platforms.end();
+        const bool assigned = std::find_if(platform_rows_.begin(),
+            platform_rows_.end(), [&](const auto& row) {
+                return boost::uuids::to_string(row.platform_id) == p.id;
+            }) != platform_rows_.end();
 
         auto* item = new QListWidgetItem(QString::fromStdString(p.display_name));
         item->setData(Qt::UserRole, QString::fromStdString(p.id));
@@ -268,6 +268,11 @@ void AppVersionDetailDialog::setHttpBaseUrl(const std::string& url) {
 void AppVersionDetailDialog::setVersion(
     const compute::domain::app_version& app_version) {
     app_version_ = app_version;
+    // Platform rows are intentionally not preloaded from app_version; the
+    // server-side list uses a separate junction fetch that is not yet wired
+    // here. Edit mode therefore treats the platform set as empty until the
+    // user re-assigns rows explicitly.
+    platform_rows_.clear();
     updateUiFromVersion();
 }
 
@@ -315,7 +320,7 @@ void AppVersionDetailDialog::updateUiFromVersion() {
     ui_->nameEdit->setText(QString::fromStdString(app_version_.engine_version));
     populatePlatformsTab();
     ui_->minRamSpinBox->setValue(app_version_.min_ram_mb);
-    ui_->descriptionEdit->setPlainText(QString::fromStdString(app_version_.package_uri));
+    ui_->descriptionEdit->setPlainText({});
 
     populateProvenance(app_version_.version,
                        app_version_.modified_by,
@@ -342,25 +347,36 @@ void AppVersionDetailDialog::updateVersionFromUi() {
         app_version_.wrapper_version = ui_->codeEdit->text().trimmed().toStdString();
     }
     app_version_.engine_version = ui_->nameEdit->text().trimmed().toStdString();
-    app_version_.platforms.clear();
-    for (int i = 0; i < ui_->assignedPlatformsList->count(); ++i) {
-        const auto* item = ui_->assignedPlatformsList->item(i);
-        if (item)
-            app_version_.platforms.push_back(
-                item->data(Qt::UserRole).toString().toStdString());
-    }
     app_version_.min_ram_mb = ui_->minRamSpinBox->value();
-    {
-        // Package URI: always <uuid>.tar.gz — the wrapper assumes tar.gz
-        // format when extracting, so the extension is fixed rather than
-        // derived from the original filename.
-        const std::string base_uri = "api/v1/storage/compute/packages/" +
-            boost::uuids::to_string(app_version_.id) ;
-        if (!selectedPackageFilePath_.isEmpty() || app_version_.package_uri.empty())
-            app_version_.package_uri = base_uri;
-    }
     app_version_.modified_by = username_;
     app_version_.performed_by = username_;
+
+    // Rebuild platform rows from the assigned list. Each platform gets a
+    // triplet-specific package URI; the upload UI PUTs the same pattern so
+    // the orchestrator dispatch and the upload target agree on the blob key.
+    platform_rows_.clear();
+    const auto av_id_str = boost::uuids::to_string(app_version_.id);
+    for (int i = 0; i < ui_->assignedPlatformsList->count(); ++i) {
+        const auto* item = ui_->assignedPlatformsList->item(i);
+        if (!item) continue;
+        const auto id_str = item->data(Qt::UserRole).toString().toStdString();
+        const auto avail = std::find_if(availablePlatforms_.begin(),
+            availablePlatforms_.end(),
+            [&](const auto& p) { return p.id == id_str; });
+        if (avail == availablePlatforms_.end()) continue;
+
+        compute::domain::app_version_platform row;
+        row.tenant_id = app_version_.tenant_id;
+        row.app_version_id = app_version_.id;
+        try {
+            row.platform_id =
+                boost::lexical_cast<boost::uuids::uuid>(avail->id);
+        } catch (...) { continue; }
+        row.platform_code = avail->code;
+        row.package_uri = "api/v1/storage/compute/packages/" + av_id_str
+            + "/" + avail->code + "/package.tar.gz";
+        platform_rows_.push_back(std::move(row));
+    }
 }
 
 void AppVersionDetailDialog::onAddPlatformClicked() {
@@ -497,12 +513,6 @@ void AppVersionDetailDialog::onUploadPackageClicked() {
         BOOST_LOG_SEV(lg(), info) << "Package uploaded successfully for app_version: "
                                   << boost::uuids::to_string(self->app_version_.id);
 
-        // Update in-memory package_uri so any subsequent save persists it.
-        const std::string new_uri = "api/v1/storage/compute/packages/"
-            + boost::uuids::to_string(self->app_version_.id) ;
-        self->app_version_.package_uri = new_uri;
-        BOOST_LOG_SEV(lg(), info) << "Updated in-memory package_uri: " << new_uri;
-
         emit self->statusMessage(tr("Package uploaded successfully"));
         MessageBoxHelper::information(self, tr("Upload Complete"),
             tr("Package uploaded successfully."));
@@ -538,13 +548,15 @@ void AppVersionDetailDialog::onSaveClicked() {
     using FutureResult = std::pair<bool, std::string>;
     QPointer<AppVersionDetailDialog> self = this;
     const compute::domain::app_version versionToSave = app_version_;
+    const auto platformsToSave = platform_rows_;
 
     QFuture<FutureResult> future =
-        QtConcurrent::run([self, versionToSave]() -> FutureResult {
+        QtConcurrent::run([self, versionToSave, platformsToSave]() -> FutureResult {
             if (!self) return {false, ""};
 
             compute::messaging::save_app_version_request request;
             request.app_version = versionToSave;
+            request.platforms = platformsToSave;
 
             auto result =
                 self->clientManager_->process_authenticated_request(

--- a/projects/ores.qt.compute/src/AppVersionDetailDialog.cpp
+++ b/projects/ores.qt.compute/src/AppVersionDetailDialog.cpp
@@ -40,6 +40,7 @@
 #include "ores.compute.api/messaging/app_protocol.hpp"
 #include "ores.compute.api/messaging/app_version_protocol.hpp"
 #include "ores.compute.api/messaging/platform_protocol.hpp"
+#include "ores.compute.api/net/compute_storage.hpp"
 
 namespace ores::qt {
 
@@ -394,9 +395,9 @@ void AppVersionDetailDialog::updateVersionFromUi() {
     app_version_.modified_by = username_;
     app_version_.performed_by = username_;
 
-    // Rebuild platform rows from the assigned list. Each platform gets a
-    // triplet-specific package URI; the upload UI PUTs the same pattern so
-    // the orchestrator dispatch and the upload target agree on the blob key.
+    // Rebuild platform rows from the assigned list. Delegate URI layout to
+    // compute_storage::package_path so the canonical per-triplet key lives
+    // with the rest of the bucket convention, not inline in the UI.
     platform_rows_.clear();
     const auto av_id_str = boost::uuids::to_string(app_version_.id);
     for (int i = 0; i < ui_->assignedPlatformsList->count(); ++i) {
@@ -416,8 +417,8 @@ void AppVersionDetailDialog::updateVersionFromUi() {
                 boost::lexical_cast<boost::uuids::uuid>(avail->id);
         } catch (...) { continue; }
         row.platform_code = avail->code;
-        row.package_uri = "api/v1/storage/compute/packages/" + av_id_str
-            + "/" + avail->code + "/package.tar.gz";
+        row.package_uri = ores::compute::net::compute_storage::package_path(
+            av_id_str, avail->code, ".tar.gz");
         platform_rows_.push_back(std::move(row));
     }
 }

--- a/projects/ores.qt.compute/src/AppVersionDetailDialog.cpp
+++ b/projects/ores.qt.compute/src/AppVersionDetailDialog.cpp
@@ -268,12 +268,55 @@ void AppVersionDetailDialog::setHttpBaseUrl(const std::string& url) {
 void AppVersionDetailDialog::setVersion(
     const compute::domain::app_version& app_version) {
     app_version_ = app_version;
-    // Platform rows are intentionally not preloaded from app_version; the
-    // server-side list uses a separate junction fetch that is not yet wired
-    // here. Edit mode therefore treats the platform set as empty until the
-    // user re-assigns rows explicitly.
+    // Start from an empty set; populatePlatformsTab will re-run once the
+    // junction fetch returns and fills platform_rows_. In create mode there
+    // is nothing to load because the id has just been generated.
     platform_rows_.clear();
     updateUiFromVersion();
+
+    if (!createMode_ && !app_version_.id.is_nil())
+        loadAssignedPlatforms(boost::uuids::to_string(app_version_.id));
+}
+
+void AppVersionDetailDialog::loadAssignedPlatforms(
+    const std::string& app_version_id) {
+    if (!clientManager_ || !clientManager_->isConnected())
+        return;
+
+    QPointer<AppVersionDetailDialog> self = this;
+
+    struct FetchResult {
+        bool success;
+        std::vector<compute::domain::app_version_platform> rows;
+    };
+
+    auto task = [self, app_version_id]() -> FetchResult {
+        if (!self || !self->clientManager_)
+            return {false, {}};
+
+        compute::messaging::list_app_version_platforms_request request;
+        request.app_version_id = app_version_id;
+        auto result = self->clientManager_->process_authenticated_request(
+            std::move(request));
+
+        if (!result || !result->success) return {false, {}};
+        return {true, std::move(result->platforms)};
+    };
+
+    auto* watcher = new QFutureWatcher<FetchResult>(self);
+    connect(watcher, &QFutureWatcher<FetchResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+        if (!self || !result.success) return;
+        self->platform_rows_ = std::move(result.rows);
+        self->populatePlatformsTab();
+        // Re-populating the assigned list flags the dialog as dirty via the
+        // selection-changed signal; reset since the fetch is not a user edit.
+        self->hasChanges_ = false;
+        self->updateSaveButtonState();
+    });
+    watcher->setFuture(QtConcurrent::run(task));
 }
 
 void AppVersionDetailDialog::setCreateMode(bool createMode) {

--- a/projects/ores.qt.compute/src/ClientAppVersionModel.cpp
+++ b/projects/ores.qt.compute/src/ClientAppVersionModel.cpp
@@ -84,18 +84,8 @@ QVariant ClientAppVersionModel::data(
             return QString::fromStdString(app_version.wrapper_version);
         case EngineVersion:
             return QString::fromStdString(app_version.engine_version);
-        case Platform: {
-            QString platforms;
-            for (const auto& p : app_version.platforms) {
-                if (!platforms.isEmpty()) platforms += ", ";
-                platforms += QString::fromStdString(p);
-            }
-            return platforms;
-        }
         case MinRamMb:
             return static_cast<qlonglong>(app_version.min_ram_mb);
-        case PackageUri:
-            return QString::fromStdString(app_version.package_uri);
         case Version:
             return static_cast<qlonglong>(app_version.version);
         case ModifiedBy:
@@ -124,12 +114,8 @@ QVariant ClientAppVersionModel::headerData(
         return tr("Wrapper Version");
     case EngineVersion:
         return tr("Engine Version");
-    case Platform:
-        return tr("Platform");
     case MinRamMb:
         return tr("Min RAM (MB)");
-    case PackageUri:
-        return tr("Package URI");
     case Version:
         return tr("Version");
     case ModifiedBy:

--- a/projects/ores.sql/create/compute/compute_app_version_platforms_create.sql
+++ b/projects/ores.sql/create/compute/compute_app_version_platforms_create.sql
@@ -21,14 +21,17 @@
 -- =============================================================================
 -- Compute App Version Platforms (bitemporal junction table)
 -- =============================================================================
--- Associates app versions with the platforms they support. Tenant-scoped:
--- each tenant manages which platform associations are active for their app
--- versions. Supports re-enabling a previously removed platform association.
+-- Associates app versions with the platforms they support, and carries the URI
+-- of the per-platform packaged bundle (a .tar.gz containing the wrapper+engine
+-- binaries built for that target triplet). Tenant-scoped: each tenant manages
+-- which platform associations are active for their app versions. Supports
+-- re-enabling a previously removed platform association.
 
 create table if not exists "ores_compute_app_version_platforms_tbl" (
     "tenant_id"           uuid not null,
     "app_version_id"      uuid not null,
     "platform_id"         uuid not null,
+    "package_uri"         text not null,
     "modified_by"         text not null,
     "performed_by"        text not null,
     "change_reason_code"  text not null,

--- a/projects/ores.sql/create/compute/compute_app_versions_create.sql
+++ b/projects/ores.sql/create/compute/compute_app_versions_create.sql
@@ -24,9 +24,10 @@
  *
  *  Table
  *
- * Combines a specific wrapper version with a specific engine version for a given
- * platform. The BOINC equivalent of 'app_version'. Nodes download the package_uri
- * bundle and launch the wrapper to run the engine.
+ * Combines a specific wrapper version with a specific engine version. The BOINC
+ * equivalent of 'app_version'. Per-platform package artefacts are tracked in
+ * ores_compute_app_version_platforms_tbl — each (app_version, platform) row
+ * owns the URI of its own packaged bundle.
  */
 
 create table if not exists "ores_compute_app_versions_tbl" (
@@ -36,7 +37,6 @@ create table if not exists "ores_compute_app_versions_tbl" (
     "app_id" uuid not null,
     "wrapper_version" text not null,
     "engine_version" text not null,
-    "package_uri" text not null,
     "min_ram_mb" integer not null default 0,
     "modified_by" text not null,
     "performed_by" text not null,

--- a/projects/ores.sql/modeling/ores_schema.puml
+++ b/projects/ores.sql/modeling/ores_schema.puml
@@ -16,7 +16,7 @@
 ' Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 '
 ' GENERATED FILE - DO NOT EDIT
-' Generated: 2026-02-02T09:48:25.057318Z
+' Generated: 2026-04-21T22:09:54.950184Z
 ' Regenerate with: ./projects/ores.codegen/plantuml_er_generate.sh
 '
 @startuml
@@ -48,6 +48,30 @@ end note
 ' ==================== iam (Identity & Access Management) ====================
 '
 package "iam" #E8F4FD {
+    entity ores_iam_account_parties_tbl <<junction>> #ECECEC {
+        * tenant_id : uuid <<PK, FK>>
+        * account_id : uuid <<PK, FK>>
+        * party_id : uuid <<PK, FK>>
+        * valid_from : timestamptz <<PK>>
+        --
+        * version : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_to : timestamptz
+    }
+
+    note right of ores_iam_account_parties_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_junction_create.mustache
+    To modify, update the template and regenerate.
+    Account Party Table
+    Junction table linking IAM accounts to parties. Each account can be
+    associated with one or more parties, controlling which parties a user
+    can act on behalf of.
+    end note
+
     entity ores_iam_account_roles_tbl <<junction>> #ECECEC {
         * account_id : uuid <<PK, FK>>
         * role_id : uuid <<PK, FK>>
@@ -66,19 +90,42 @@ package "iam" #E8F4FD {
     Tracks who assigned the role.
     end note
 
+    entity ores_iam_account_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * type : text <<PK>>
+        --
+        * version : integer
+        * name : text
+        * description : text
+        * display_order : integer
+        * modified_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * performed_by : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_iam_account_types_tbl
+    Account Types - Valid account type classifications
+    end note
+
     entity ores_iam_accounts_tbl <<temporal>> #C6F0D8 {
         * tenant_id : uuid <<PK, FK>>
         * id : uuid <<PK>>
         --
         * version : integer
+        * account_type : text
         * username : text
         * password_hash : text
         * password_salt : text
+          service_password_hash : text
         * totp_secret : text
         * email : text
         * modified_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
+        * performed_by : text
         * valid_from : timestamptz
         * valid_to : timestamptz
     }
@@ -88,6 +135,19 @@ package "iam" #E8F4FD {
     Supports optimistic locking via version field.
     Username and email unique for current records.
     end note
+
+    entity ores_iam_auth_events_tbl  #F7E5FF {
+        * id : text <<PK>>
+        * event_time : timestamptz <<PK>>
+        --
+        * tenant_id : text <<FK>>
+        * account_id : text <<FK>>
+        * event_type : text
+        * username : text
+        * session_id : text <<FK>>
+        * party_id : text <<FK>>
+        * error_detail : text
+    }
 
     entity ores_iam_login_info_tbl  #F7E5FF {
         * account_id : uuid <<PK, FK>>
@@ -145,6 +205,7 @@ package "iam" #E8F4FD {
         * name : text
         * description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -154,6 +215,22 @@ package "iam" #E8F4FD {
     note right of ores_iam_roles_tbl
     Named roles for grouping permissions.
     Examples: admin, viewer, editor.
+    end note
+
+    entity ores_iam_session_samples_tbl  #F7E5FF {
+        * session_id : uuid <<PK, FK>>
+        * sample_time : timestamptz <<PK>>
+        --
+        * tenant_id : uuid <<FK>>
+        * bytes_sent : bigint
+        * bytes_received : bigint
+        * latency_ms : bigint
+    }
+
+    note right of ores_iam_session_samples_tbl
+    Session time-series samples: bytes captured at heartbeat frequency.
+    Designed for TimescaleDB hypertable.
+    Partitioned by sample_time.
     end note
 
     entity ores_iam_sessions_tbl  #F7E5FF {
@@ -183,11 +260,12 @@ package "iam" #E8F4FD {
         * tenant_id : uuid <<PK, FK>>
         * status : text <<PK>>
         --
-        * version : integer <<unique>>
+        * version : integer
         * name : text
         * description : text
         * display_order : integer
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -202,11 +280,12 @@ package "iam" #E8F4FD {
         * tenant_id : uuid <<PK, FK>>
         * type : text <<PK>>
         --
-        * version : integer <<unique>>
+        * version : integer
         * name : text
         * description : text
         * display_order : integer
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -218,8 +297,9 @@ package "iam" #E8F4FD {
     end note
 
     entity ores_iam_tenants_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK>>
+        * id : uuid <<PK>>
         --
+        * tenant_id : uuid
         * version : integer
         * type : text
         * code : text
@@ -228,36 +308,12 @@ package "iam" #E8F4FD {
         * hostname : text
         * status : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
         * valid_to : timestamptz
     }
-
-    note right of ores_iam_tenants_tbl
-    Tenants Table
-    Core table for multi-tenancy support. Each tenant represents an isolated
-    organisation or the system platform tenant.
-    end note
-
-    entity ores_iam_account_parties_tbl <<junction>> #ECECEC {
-        * account_id : uuid <<PK, FK>>
-        * party_id : uuid <<PK, FK>>
-        * valid_from : timestamptz <<PK>>
-        --
-        * tenant_id : uuid <<FK>>
-        * version : integer
-        * modified_by : text
-        * performed_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_to : timestamptz
-    }
-
-    note right of ores_iam_account_parties_tbl
-    Many-to-many: accounts to parties.
-    Controls which parties a user can act on behalf of.
-    end note
 
 }
 
@@ -289,6 +345,7 @@ package "assets" #F3E5F5 {
         * description : text
         * svg_data : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -300,17 +357,18 @@ package "assets" #F3E5F5 {
     Key provides human-readable lookup.
     end note
 
-    entity ores_assets_tags_tbl <<junction>> #ECECEC {
+    entity ores_assets_tags_tbl <<temporal>> #C6F0D8 {
         * tag_id : uuid <<PK>>
-        * valid_from : timestamptz <<PK>>
         --
         * tenant_id : uuid <<FK>>
         * version : integer
         * name : text
         * description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
+        * valid_from : timestamptz
         * valid_to : timestamptz
     }
 
@@ -330,10 +388,11 @@ package "refdata" #FFF3E0 {
         * code : text <<PK>>
         * coding_scheme_code : text <<PK, FK>>
         --
-        * version : integer <<unique>>
+        * version : integer
           source : text
           description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -349,10 +408,11 @@ package "refdata" #FFF3E0 {
         * code : text <<PK>>
         * coding_scheme_code : text <<PK, FK>>
         --
-        * version : integer <<unique>>
+        * version : integer
           source : text
           description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -368,10 +428,11 @@ package "refdata" #FFF3E0 {
         * code : text <<PK>>
         * coding_scheme_code : text <<PK, FK>>
         --
-        * version : integer <<unique>>
+        * version : integer
           source : text
           description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -387,10 +448,11 @@ package "refdata" #FFF3E0 {
         * code : text <<PK>>
         * coding_scheme_code : text <<PK, FK>>
         --
-        * version : integer <<unique>>
+        * version : integer
           source : text
           description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -401,16 +463,72 @@ package "refdata" #FFF3E0 {
     FpML Benchmark rates
     end note
 
+    entity ores_refdata_book_statuses_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+        * name : text
+        * description : text
+        * display_order : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_book_statuses_tbl
+    Book Statuses - Lifecycle states for book records (Active, Closed, Frozen)
+    end note
+
+    entity ores_refdata_books_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * party_id : uuid <<FK>>
+        * name : text
+        * description : text
+        * parent_portfolio_id : uuid <<FK>>
+        * ledger_ccy : text
+          gl_account_ref : text
+          cost_center : text
+        * book_status : text
+        * is_trading_book : integer
+          owner_unit_id : uuid <<FK>>
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_books_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Operational ledger leaves. The only entity that holds trades.
+    Serves as the basis for accounting, ownership, and regulatory
+    capital treatment. Must belong to exactly one portfolio.
+    end note
+
     entity ores_refdata_business_centres_tbl <<temporal>> #C6F0D8 {
         * tenant_id : uuid <<PK, FK>>
         * code : text <<PK>>
         * coding_scheme_code : text <<PK, FK>>
         --
-        * version : integer <<unique>>
+        * version : integer
           source : text
           description : text
+          city_name : text
+          country_alpha2_code : text
           image_id : uuid <<FK>>
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -426,10 +544,11 @@ package "refdata" #FFF3E0 {
         * code : text <<PK>>
         * coding_scheme_code : text <<PK, FK>>
         --
-        * version : integer <<unique>>
+        * version : integer
           source : text
           description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -440,15 +559,71 @@ package "refdata" #FFF3E0 {
     Contains a code representing the type of business process a message (e.g. a status request) applies to.
     end note
 
+    entity ores_refdata_business_unit_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * coding_scheme_code : text <<FK>>
+        * code : text
+        * name : text
+        * level : integer
+        * description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_business_unit_types_tbl
+    Business Unit Types - Classification of organisational unit roles.
+    Defines the level-based hierarchy of business unit types (Division,
+    Branch, Business Area, Desk, Cost Centre). The `level` field enforces
+    hierarchy ordering: 0 = top-level, higher = lower in hierarchy.
+    end note
+
+    entity ores_refdata_business_units_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * party_id : uuid <<FK>>
+        * unit_name : text
+          parent_business_unit_id : uuid <<FK>>
+          unit_type_id : uuid <<FK>>
+          unit_code : text
+          business_centre_code : text
+        * status : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_business_units_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Represents internal organizational units (e.g., desks, departments, branches).
+    Supports hierarchical structure via self-referencing parent_business_unit_id.
+    Each unit belongs to a top-level legal entity (party).
+    end note
+
     entity ores_refdata_cashflow_types_tbl <<temporal>> #C6F0D8 {
         * tenant_id : uuid <<PK, FK>>
         * code : text <<PK>>
         * coding_scheme_code : text <<PK, FK>>
         --
-        * version : integer <<unique>>
+        * version : integer
           source : text
           description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -459,303 +634,11 @@ package "refdata" #FFF3E0 {
     The type of cash flows associated with OTC derivatives contracts and their lifecycle events.
     end note
 
-    entity ores_refdata_countries_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * alpha2_code : text <<PK>>
-        --
-        * version : integer
-        * alpha3_code : text
-        * numeric_code : text
-        * name : text
-        * official_name : text
-          coding_scheme_code : text <<FK>>
-          image_id : uuid <<FK>>
-        * modified_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_countries_tbl
-    ISO 3166-1 country definitions.
-    Includes alpha-2, alpha-3, and numeric codes.
-    Optional flag image reference.
-    coding_scheme_code tracks data provenance.
-    end note
-
-    entity ores_refdata_currencies_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * iso_code : text <<PK>>
-        --
-        * version : integer <<unique>>
-        * name : text
-        * numeric_code : text
-        * symbol : text
-        * fraction_symbol : text
-        * fractions_per_unit : integer
-        * rounding_type : text
-        * rounding_precision : integer
-        * format : text
-        * asset_class : text
-        * market_tier : text
-          coding_scheme_code : text <<FK>>
-          image_id : uuid <<FK>>
-        * modified_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_currencies_tbl
-    ISO 4217 currency definitions
-    end note
-
-    entity ores_refdata_entity_classifications_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * code : text <<PK>>
-        * coding_scheme_code : text <<PK, FK>>
-        --
-        * version : integer <<unique>>
-          source : text
-          description : text
-        * modified_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_entity_classifications_tbl
-    Financial Entity Indicator as defined by the CFTC.
-    end note
-
-    entity ores_refdata_local_jurisdictions_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * code : text <<PK>>
-        * coding_scheme_code : text <<PK, FK>>
-        --
-        * version : integer <<unique>>
-          source : text
-          description : text
-        * modified_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_local_jurisdictions_tbl
-    This overrides the countryScheme. Specifies the Local Jurisdiction that applies to a Transaction, for example for the purposes of defining which Local Taxes will apply.
-    end note
-
-    entity ores_refdata_party_relationships_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * code : text <<PK>>
-        * coding_scheme_code : text <<PK, FK>>
-        --
-        * version : integer <<unique>>
-          source : text
-          description : text
-        * modified_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_party_relationships_tbl
-    Indicates the relationship between two parties as defined by Hong Kong Monetary Authority (HKMA) Rewrite field 189 - Intragroup.
-    end note
-
-    entity ores_refdata_party_roles_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * code : text <<PK>>
-        * coding_scheme_code : text <<PK, FK>>
-        --
-        * version : integer <<unique>>
-          source : text
-          description : text
-        * modified_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_party_roles_tbl
-    Contains a code representing a related party role. This can be extended to provide custom roles.
-    end note
-
-    entity ores_refdata_person_roles_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * code : text <<PK>>
-        * coding_scheme_code : text <<PK, FK>>
-        --
-        * version : integer <<unique>>
-          source : text
-          description : text
-        * modified_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_person_roles_tbl
-    Indicates the role of a person in a transaction.
-    end note
-
-    entity ores_refdata_regulatory_corporate_sectors_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * code : text <<PK>>
-        * coding_scheme_code : text <<PK, FK>>
-        --
-        * version : integer <<unique>>
-          source : text
-          description : text
-        * modified_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_regulatory_corporate_sectors_tbl
-    Defines the corporate sector under HKMA (Hong Kong Monetary Authority) Rewrite fields 190 - Nature of Counterparty 1 and 191 - Nature of Counterparty 2.
-    end note
-
-    entity ores_refdata_reporting_regimes_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * code : text <<PK>>
-        * coding_scheme_code : text <<PK, FK>>
-        --
-        * version : integer <<unique>>
-          source : text
-          description : text
-        * modified_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_reporting_regimes_tbl
-    Contains a code representing a reporting regime under which this transaction may be reported.
-    end note
-
-    entity ores_refdata_rounding_types_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * code : text <<PK>>
-        --
-        * version : integer <<unique>>
-        * name : text
-        * description : text
-        * display_order : integer
-        * modified_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_rounding_types_tbl
-    Rounding Types - Valid rounding methods per ORE XML schema (roundingType)
-    end note
-
-    entity ores_refdata_supervisory_bodies_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * code : text <<PK>>
-        * coding_scheme_code : text <<PK, FK>>
-        --
-        * version : integer <<unique>>
-          source : text
-          description : text
-        * modified_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_supervisory_bodies_tbl
-    Contains a code representing a supervisory-body that may be supervising this transaction.
-    end note
-
-    entity ores_refdata_party_types_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * code : text <<PK>>
-        --
-        * version : integer <<unique>>
-        * name : text
-        * description : text
-        * display_order : integer
-        * modified_by : text
-        * performed_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_party_types_tbl
-    Party Types - Classification of parties.
-    Values: Bank, CorporateGroup, HedgeFund,
-    Corporate, CentralBank, Exchange, Individual.
-    end note
-
-    entity ores_refdata_party_statuses_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * code : text <<PK>>
-        --
-        * version : integer <<unique>>
-        * name : text
-        * description : text
-        * display_order : integer
-        * modified_by : text
-        * performed_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_party_statuses_tbl
-    Party Statuses - Lifecycle status of parties.
-    Values: Active, Inactive, Suspended.
-    end note
-
-    entity ores_refdata_party_id_schemes_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * code : text <<PK>>
-        --
-        * version : integer <<unique>>
-        * name : text
-        * description : text
-          coding_scheme_code : text <<FK>>
-        * display_order : integer
-        * modified_by : text
-        * performed_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_party_id_schemes_tbl
-    Identifier scheme types for parties.
-    Cross-references dq_coding_schemes for provenance.
-    Values: LEI, BIC, MIC, NATIONAL_ID, CEDB,
-    NATURAL_PERSON, ACER, DTCC_PARTICIPANT_ID,
-    MPID, INTERNAL.
-    end note
-
     entity ores_refdata_contact_types_tbl <<temporal>> #C6F0D8 {
         * tenant_id : uuid <<PK, FK>>
         * code : text <<PK>>
         --
-        * version : integer <<unique>>
+        * version : integer
         * name : text
         * description : text
         * display_order : integer
@@ -768,33 +651,7 @@ package "refdata" #FFF3E0 {
     }
 
     note right of ores_refdata_contact_types_tbl
-    Contact information categories.
-    Values: Legal, Operations, Settlement, Billing.
-    end note
-
-    entity ores_refdata_parties_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * id : uuid <<PK>>
-        --
-        * version : integer
-        * full_name : text <<unique>>
-        * short_code : text <<unique>>
-        * party_type : text <<FK>>
-          parent_party_id : uuid <<FK>>
-          business_center_code : text <<FK>>
-        * status : text <<FK>>
-        * modified_by : text
-        * performed_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_parties_tbl
-    Internal legal entities (own organisation).
-    Hierarchical via parent_party_id.
-    Root party (parent_party_id IS NULL) unique per tenant.
+    Contact Types - Classification of contact information purpose (Legal, Operations, Settlement, Billing)
     end note
 
     entity ores_refdata_counterparties_tbl <<temporal>> #C6F0D8 {
@@ -802,12 +659,13 @@ package "refdata" #FFF3E0 {
         * id : uuid <<PK>>
         --
         * version : integer
-        * full_name : text <<unique>>
-        * short_code : text <<unique>>
-        * party_type : text <<FK>>
+        * full_name : text
+        * short_code : text
+          transliterated_name : text
+        * party_type : text
           parent_counterparty_id : uuid <<FK>>
-          business_center_code : text <<FK>>
-        * status : text <<FK>>
+        * business_center_code : text
+        * status : text
         * modified_by : text
         * performed_by : text
         * change_reason_code : text <<FK>>
@@ -817,81 +675,13 @@ package "refdata" #FFF3E0 {
     }
 
     note right of ores_refdata_counterparties_tbl
-    External trading partners.
-    Hierarchical via parent_counterparty_id.
-    end note
-
-    entity ores_refdata_party_identifiers_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * id : uuid <<PK>>
-        --
-        * version : integer
-        * party_id : uuid <<FK>>
-        * id_scheme : text <<FK>>
-        * id_value : text
-          description : text
-        * modified_by : text
-        * performed_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_party_identifiers_tbl
-    External identifiers for parties (LEI, BIC, etc.).
-    Unique on (party_id, id_scheme) for active records.
-    end note
-
-    entity ores_refdata_counterparty_identifiers_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * id : uuid <<PK>>
-        --
-        * version : integer
-        * counterparty_id : uuid <<FK>>
-        * id_scheme : text <<FK>>
-        * id_value : text
-          description : text
-        * modified_by : text
-        * performed_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_counterparty_identifiers_tbl
-    External identifiers for counterparties (LEI, BIC, etc.).
-    Unique on (counterparty_id, id_scheme) for active records.
-    end note
-
-    entity ores_refdata_party_contact_informations_tbl <<temporal>> #C6F0D8 {
-        * tenant_id : uuid <<PK, FK>>
-        * id : uuid <<PK>>
-        --
-        * version : integer
-        * party_id : uuid <<FK>>
-        * contact_type : text <<FK>>
-          street_line_1 : text
-          street_line_2 : text
-          city : text
-          state : text
-          country_code : text <<FK>>
-          postal_code : text
-          phone : text
-          email : text
-          web_page : text
-        * modified_by : text
-        * performed_by : text
-        * change_reason_code : text <<FK>>
-        * change_commentary : text
-        * valid_from : timestamptz
-        * valid_to : timestamptz
-    }
-
-    note right of ores_refdata_party_contact_informations_tbl
-    Contact details for parties by purpose.
-    Unique on (party_id, contact_type) for active records.
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    External trading partners and counterparties that participate in financial
+    transactions with the organisation. Counterparties form a hierarchy through
+    parent_counterparty_id for group structures.
     end note
 
     entity ores_refdata_counterparty_contact_informations_tbl <<temporal>> #C6F0D8 {
@@ -900,7 +690,7 @@ package "refdata" #FFF3E0 {
         --
         * version : integer
         * counterparty_id : uuid <<FK>>
-        * contact_type : text <<FK>>
+        * contact_type : text
           street_line_1 : text
           street_line_2 : text
           city : text
@@ -919,8 +709,608 @@ package "refdata" #FFF3E0 {
     }
 
     note right of ores_refdata_counterparty_contact_informations_tbl
-    Contact details for counterparties by purpose.
-    Unique on (counterparty_id, contact_type) for active records.
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Contact details for counterparties organised by purpose (Legal, Operations,
+    Settlement, Billing). Each counterparty can have one contact record per type.
+    end note
+
+    entity ores_refdata_counterparty_identifiers_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * counterparty_id : uuid <<FK>>
+        * id_scheme : text
+        * id_value : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_counterparty_identifiers_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    External identifiers for counterparties, such as LEI codes, BIC/SWIFT codes,
+    national registration numbers, and tax identifiers. Each counterparty can have
+    multiple identifiers across different schemes.
+    end note
+
+    entity ores_refdata_countries_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * alpha2_code : text <<PK>>
+        --
+        * version : integer
+        * alpha3_code : text
+        * numeric_code : text
+        * name : text
+        * official_name : text
+          coding_scheme_code : text <<FK>>
+          image_id : uuid <<FK>>
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_countries_tbl
+    ISO 3166-1 country definitions.
+    Includes alpha-2, alpha-3, and numeric codes.
+    Optional flag image reference.
+    coding_scheme_code tracks data provenance.
+    end note
+
+    entity ores_refdata_currencies_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * iso_code : text <<PK>>
+        --
+        * version : integer
+        * name : text
+        * numeric_code : text
+        * symbol : text
+        * fraction_symbol : text
+        * fractions_per_unit : integer
+        * rounding_type : text
+        * rounding_precision : integer
+        * format : text
+        * monetary_nature : text
+        * market_tier : text
+          coding_scheme_code : text <<FK>>
+          image_id : uuid <<FK>>
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_currencies_tbl
+    ISO 4217 currency definitions
+    end note
+
+    entity ores_refdata_currency_market_tiers_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+        * name : text
+        * description : text
+        * display_order : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_currency_market_tiers_tbl
+    Currency market tier classification. Drives UI priority, liquidity expectations, and risk limits.
+    end note
+
+    entity ores_refdata_entity_classifications_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        * coding_scheme_code : text <<PK, FK>>
+        --
+        * version : integer
+          source : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_entity_classifications_tbl
+    Financial Entity Indicator as defined by the CFTC.
+    end note
+
+    entity ores_refdata_local_jurisdictions_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        * coding_scheme_code : text <<PK, FK>>
+        --
+        * version : integer
+          source : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_local_jurisdictions_tbl
+    This overrides the countryScheme. Specifies the Local Jurisdiction that applies to a Transaction, for example for the purposes of defining which Local Taxes will apply.
+    end note
+
+    entity ores_refdata_monetary_natures_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+        * name : text
+        * description : text
+        * display_order : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_monetary_natures_tbl
+    Monetary nature classification. Defines the nature of the currency instrument.
+    end note
+
+    entity ores_refdata_parties_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * full_name : text
+        * short_code : text
+        * codename : text
+          transliterated_name : text
+        * party_category : text
+        * party_type : text
+          parent_party_id : uuid <<FK>>
+        * business_center_code : text
+        * status : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_parties_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Internal legal entities (the organisation and its subsidiaries) that participate
+    in financial transactions. Parties form a hierarchy through parent_party_id,
+    with exactly one root party per tenant representing the organisation itself.
+    end note
+
+    entity ores_refdata_party_categories_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+        * name : text
+        * description : text
+        * display_order : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_refdata_party_contact_informations_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * party_id : uuid <<FK>>
+        * contact_type : text
+          street_line_1 : text
+          street_line_2 : text
+          city : text
+          state : text
+          country_code : text <<FK>>
+          postal_code : text
+          phone : text
+          email : text
+          web_page : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_party_contact_informations_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Contact details for parties organised by purpose (Legal, Operations,
+    Settlement, Billing). Each party can have one contact record per type.
+    end note
+
+    entity ores_refdata_party_counterparties_tbl <<junction>> #ECECEC {
+        * tenant_id : uuid <<PK, FK>>
+        * party_id : uuid <<PK, FK>>
+        * counterparty_id : uuid <<PK, FK>>
+        * valid_from : timestamptz <<PK>>
+        --
+        * version : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_party_counterparties_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_junction_create.mustache
+    To modify, update the template and regenerate.
+    Party Counterparty Table
+    Junction table controlling which counterparties are visible to which parties.
+    Counterparty identity is shared at tenant level; this junction controls
+    party-level visibility.
+    end note
+
+    entity ores_refdata_party_countries_tbl <<junction>> #ECECEC {
+        * tenant_id : uuid <<PK, FK>>
+        * party_id : uuid <<PK, FK>>
+        * country_alpha2_code : text <<PK>>
+        * valid_from : timestamptz <<PK>>
+        --
+        * version : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_party_countries_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_junction_create.mustache
+    To modify, update the template and regenerate.
+    Party Country Table
+    Junction table controlling which countries are visible to which parties.
+    Country definitions are shared at tenant level; this junction controls
+    party-level visibility.
+    end note
+
+    entity ores_refdata_party_currencies_tbl <<junction>> #ECECEC {
+        * tenant_id : uuid <<PK, FK>>
+        * party_id : uuid <<PK, FK>>
+        * currency_iso_code : text <<PK>>
+        * valid_from : timestamptz <<PK>>
+        --
+        * version : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_party_currencies_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_junction_create.mustache
+    To modify, update the template and regenerate.
+    Party Currency Table
+    Junction table controlling which currencies are visible to which parties.
+    Currency definitions are shared at tenant level; this junction controls
+    party-level visibility.
+    end note
+
+    entity ores_refdata_party_id_schemes_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+        * name : text
+        * description : text
+          coding_scheme_code : text <<FK>>
+        * display_order : integer
+          max_cardinality : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_party_id_schemes_tbl
+    Party Identifier Schemes - Classification of external identifier types (LEI, BIC, MIC, etc.) with cross-reference to DQ coding schemes.
+    end note
+
+    entity ores_refdata_party_identifiers_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * party_id : uuid <<FK>>
+        * id_scheme : text
+        * id_value : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_party_identifiers_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    External identifiers for parties, such as LEI codes, BIC/SWIFT codes,
+    national registration numbers, and tax identifiers. Each party can have
+    multiple identifiers across different schemes.
+    end note
+
+    entity ores_refdata_party_relationships_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        * coding_scheme_code : text <<PK, FK>>
+        --
+        * version : integer
+          source : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_party_relationships_tbl
+    Indicates the relationship between two parties as defined by Hong Kong Monetary Authority (HKMA) Rewrite field 189 - Intragroup.
+    end note
+
+    entity ores_refdata_party_roles_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        * coding_scheme_code : text <<PK, FK>>
+        --
+        * version : integer
+          source : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_party_roles_tbl
+    Contains a code representing a related party role. This can be extended to provide custom roles.
+    end note
+
+    entity ores_refdata_party_statuses_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+        * name : text
+        * description : text
+        * display_order : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_party_statuses_tbl
+    Party Statuses - Lifecycle states for party and counterparty records (Active, Inactive, Suspended)
+    end note
+
+    entity ores_refdata_party_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+        * name : text
+        * description : text
+        * display_order : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_party_types_tbl
+    Party Types - Classification of legal entities (Bank, Corporate, HedgeFund, etc.)
+    end note
+
+    entity ores_refdata_person_roles_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        * coding_scheme_code : text <<PK, FK>>
+        --
+        * version : integer
+          source : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_person_roles_tbl
+    Indicates the role of a person in a transaction.
+    end note
+
+    entity ores_refdata_portfolios_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * party_id : uuid <<FK>>
+        * name : text
+        * description : text
+          parent_portfolio_id : uuid <<FK>>
+          owner_unit_id : uuid <<FK>>
+        * purpose_type : text
+          aggregation_ccy : text
+        * is_virtual : integer
+        * status : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_portfolios_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Represents organizational, risk, or reporting groupings.
+    Never holds trades directly. Supports hierarchical structure
+    via self-referencing parent_portfolio_id.
+    end note
+
+    entity ores_refdata_purpose_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+        * name : text
+        * description : text
+        * display_order : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_purpose_types_tbl
+    Purpose Types - Classification of portfolio purpose (Risk, Regulatory, ClientReporting, Internal)
+    end note
+
+    entity ores_refdata_regulatory_corporate_sectors_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        * coding_scheme_code : text <<PK, FK>>
+        --
+        * version : integer
+          source : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_regulatory_corporate_sectors_tbl
+    Defines the corporate sector under HKMA (Hong Kong Monetary Authority) Rewrite fields 190 - Nature of Counterparty 1 and 191 - Nature of Counterparty 2.
+    end note
+
+    entity ores_refdata_reporting_regimes_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        * coding_scheme_code : text <<PK, FK>>
+        --
+        * version : integer
+          source : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_reporting_regimes_tbl
+    Contains a code representing a reporting regime under which this transaction may be reported.
+    end note
+
+    entity ores_refdata_rounding_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+        * name : text
+        * description : text
+        * display_order : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_rounding_types_tbl
+    Rounding Types - Valid rounding methods per ORE XML schema (roundingType)
+    end note
+
+    entity ores_refdata_supervisory_bodies_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        * coding_scheme_code : text <<PK, FK>>
+        --
+        * version : integer
+          source : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_refdata_supervisory_bodies_tbl
+    Contains a code representing a supervisory-body that may be supervising this transaction.
     end note
 
 }
@@ -985,6 +1375,21 @@ package "dq_staging" #F3E5F5 {
     FpML Benchmark rates - Artefact Table
     end note
 
+    entity ores_dq_books_artefact_tbl  #F7E5FF {
+        --
+        * dataset_id : uuid <<FK>>
+        * tenant_id : uuid <<FK>>
+        * id : uuid
+        * version : integer
+        * name : text
+        * parent_portfolio_id : uuid <<FK>>
+        * ledger_ccy : text
+          gl_account_ref : text
+          cost_center : text
+        * book_status : text
+        * is_trading_book : integer
+    }
+
     entity ores_dq_business_centres_artefact_tbl  #F7E5FF {
         --
         * dataset_id : uuid <<FK>>
@@ -1012,6 +1417,19 @@ package "dq_staging" #F3E5F5 {
     note right of ores_dq_business_processes_artefact_tbl
     Contains a code representing the type of business process a message (e.g. a status request) applies to. - Artefact Table
     end note
+
+    entity ores_dq_business_units_artefact_tbl  #F7E5FF {
+        --
+        * dataset_id : uuid <<FK>>
+        * tenant_id : uuid <<FK>>
+        * id : uuid
+        * version : integer
+        * unit_name : text
+          parent_business_unit_id : uuid <<FK>>
+          unit_code : text
+          business_centre_code : text
+          unit_type_code : text
+    }
 
     entity ores_dq_cashflow_types_artefact_tbl  #F7E5FF {
         --
@@ -1068,7 +1486,7 @@ package "dq_staging" #F3E5F5 {
         * rounding_type : text
         * rounding_precision : integer
         * format : text
-        * asset_class : text
+        * monetary_nature : text
         * market_tier : text
           image_id : uuid <<FK>>
     }
@@ -1118,6 +1536,78 @@ package "dq_staging" #F3E5F5 {
     note right of ores_dq_ip2country_artefact_tbl
     Staging table for IPv4 to country mapping data from iptoasn.com.
     Data is imported here first, then promoted to geo_ip2country_tbl.
+    end note
+
+    entity ores_dq_lei_bic_artefact_tbl  #F7E5FF {
+        --
+        * dataset_id : uuid <<FK>>
+        * tenant_id : uuid <<FK>>
+        * lei : text
+        * version : integer
+        * bic : text
+    }
+
+    note right of ores_dq_lei_bic_artefact_tbl
+    GLEIF LEI to BIC mapping data - Artefact Table
+    end note
+
+    entity ores_dq_lei_entities_artefact_tbl  #F7E5FF {
+        --
+        * dataset_id : uuid <<FK>>
+        * tenant_id : uuid <<FK>>
+        * lei : text
+        * version : integer
+        * entity_legal_name : text
+        * entity_entity_category : text
+          entity_entity_sub_category : text
+        * entity_entity_status : text
+          entity_legal_form_entity_legal_form_code : text
+          entity_legal_form_other_legal_form : text
+          entity_legal_jurisdiction : text
+          entity_legal_address_first_address_line : text
+          entity_legal_address_city : text
+          entity_legal_address_region : text
+        * entity_legal_address_country : text
+          entity_legal_address_postal_code : text
+          entity_headquarters_address_first_address_line : text
+          entity_headquarters_address_city : text
+          entity_headquarters_address_region : text
+          entity_headquarters_address_country : text
+          entity_headquarters_address_postal_code : text
+          entity_entity_creation_date : timestamptz
+          registration_initial_registration_date : timestamptz
+          registration_last_update_date : timestamptz
+          registration_next_renewal_date : timestamptz
+          registration_registration_status : text
+          entity_transliterated_name_1 : text
+          entity_transliterated_name_1_type : text
+    }
+
+    note right of ores_dq_lei_entities_artefact_tbl
+    GLEIF LEI entity master data from LEI2 golden copy files - Artefact Table
+    end note
+
+    entity ores_dq_lei_relationships_artefact_tbl  #F7E5FF {
+        --
+        * dataset_id : uuid <<FK>>
+        * tenant_id : uuid <<FK>>
+        * relationship_start_node_node_id : text <<FK>>
+        * version : integer
+        * relationship_start_node_node_id_type : text
+        * relationship_end_node_node_id : text <<FK>>
+        * relationship_end_node_node_id_type : text
+        * relationship_relationship_type : text
+        * relationship_relationship_status : text
+          relationship_period_1_start_date : timestamptz
+          relationship_period_1_end_date : timestamptz
+          registration_initial_registration_date : timestamptz
+          registration_last_update_date : timestamptz
+          registration_registration_status : text
+          registration_validation_sources : text
+    }
+
+    note right of ores_dq_lei_relationships_artefact_tbl
+    GLEIF LEI corporate hierarchy relationships from RR golden copy files - Artefact Table
     end note
 
     entity ores_dq_local_jurisdictions_artefact_tbl  #F7E5FF {
@@ -1176,6 +1666,20 @@ package "dq_staging" #F3E5F5 {
     Indicates the role of a person in a transaction. - Artefact Table
     end note
 
+    entity ores_dq_portfolios_artefact_tbl  #F7E5FF {
+        --
+        * dataset_id : uuid <<FK>>
+        * tenant_id : uuid <<FK>>
+        * id : uuid
+        * version : integer
+        * name : text
+          parent_portfolio_id : uuid <<FK>>
+          owner_unit_id : uuid <<FK>>
+        * purpose_type : text
+          aggregation_ccy : text
+        * is_virtual : integer
+    }
+
     entity ores_dq_regulatory_corporate_sectors_artefact_tbl  #F7E5FF {
         --
         * dataset_id : uuid <<FK>>
@@ -1188,6 +1692,24 @@ package "dq_staging" #F3E5F5 {
 
     note right of ores_dq_regulatory_corporate_sectors_artefact_tbl
     Defines the corporate sector under HKMA (Hong Kong Monetary Authority) Rewrite fields 190 - Nature of Counterparty 1 and 191 - Nature of Counterparty 2. - Artefact Table
+    end note
+
+    entity ores_dq_report_definitions_artefact_tbl  #F7E5FF {
+        --
+        * dataset_id : uuid <<FK>>
+        * tenant_id : uuid <<FK>>
+        * id : uuid
+        * version : integer
+        * name : text
+          description : text
+        * report_type : text
+        * schedule_expression : text
+        * concurrency_policy : text
+        * display_order : integer
+    }
+
+    note right of ores_dq_report_definitions_artefact_tbl
+    Report Definition artefacts - default report templates for the ORE analytics bundle - Artefact Table
     end note
 
     entity ores_dq_reporting_regimes_artefact_tbl  #F7E5FF {
@@ -1237,6 +1759,7 @@ package "dq_datasets" #E3F2FD {
     entity ores_dq_bundle_publications_tbl  #F7E5FF {
         * id : uuid <<PK>>
         --
+        * tenant_id : uuid <<FK>>
         * bundle_code : text
         * bundle_name : text
         * mode : text
@@ -1265,7 +1788,9 @@ package "dq_datasets" #E3F2FD {
         --
         * version : integer
         * display_order : integer
+        * optional : boolean
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -1273,6 +1798,10 @@ package "dq_datasets" #E3F2FD {
     }
 
     note right of ores_dq_dataset_bundle_members_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_junction_create.mustache
+    To modify, update the template and regenerate.
+    Dataset Bundle Member Table
     Junction table linking bundles to their constituent datasets. Uses codes
     for loose coupling - allows declaring membership for datasets that may not
     yet exist in the system.
@@ -1290,6 +1819,7 @@ package "dq_datasets" #E3F2FD {
         * name : text
         * description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -1297,6 +1827,10 @@ package "dq_datasets" #E3F2FD {
     }
 
     note right of ores_dq_dataset_bundles_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
     Installing a bundle gets the system into a ready state with a coherent set
     of reference data. Bundles provide a way to group related datasets that
     should be installed together.
@@ -1312,7 +1846,7 @@ package "dq_datasets" #E3F2FD {
         * dependency_code : text <<PK>>
         --
         * role : text
-        * recorded_by : text
+        * modified_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -1378,6 +1912,7 @@ package "dq_datasets" #E3F2FD {
           license_info : text
         * artefact_type : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -1406,6 +1941,7 @@ package "dq_methodology" #E8F5E9 {
           logic_reference : text
           implementation_details : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -1425,6 +1961,7 @@ package "dq_methodology" #E8F5E9 {
         * name : text
         * description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -1444,6 +1981,7 @@ package "dq_methodology" #E8F5E9 {
         * name : text
         * description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -1463,6 +2001,7 @@ package "dq_methodology" #E8F5E9 {
         * name : text
         * description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -1484,7 +2023,7 @@ package "dq_metadata" #E1F5FE {
         * tenant_id : uuid <<PK, FK>>
         * code : text <<PK>>
         --
-        * version : integer <<unique>>
+        * version : integer
         * name : text
           description : text
           artefact_table : text
@@ -1492,6 +2031,7 @@ package "dq_metadata" #E1F5FE {
           populate_function : text
         * display_order : integer
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -1502,6 +2042,98 @@ package "dq_metadata" #E1F5FE {
     Artefact Types - Maps artefact type codes to their population functions and tables
     end note
 
+    entity ores_dq_badge_definitions_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+        * name : text
+        * description : text
+        * background_colour : text
+        * text_colour : text
+        * severity_code : text
+          css_class : text
+        * display_order : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_dq_badge_definitions_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    The badge catalogue. Each entry defines the complete visual presentation
+    of a badge: display label, tooltip, background colour, text colour,
+    severity level, and an optional Bootstrap CSS class hint for Wt.
+    Badge definitions are the single source of truth for all badge visual
+    metadata across Qt and Wt. They are loaded at client startup as
+    reference data and looked up at render time via BadgeCache.
+    end note
+
+    entity ores_dq_badge_mappings_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code_domain_code : text <<PK>>
+        * entity_code : text <<PK>>
+        --
+        * version : integer
+        * badge_code : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_dq_badge_mappings_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_junction_create.mustache
+    To modify, update the template and regenerate.
+    Badge Mapping Table
+    Universal mapping table that associates any (code_domain, entity_code)
+    pair with a badge definition. This is the single join point between
+    domain values and their visual presentation.
+    Examples:
+    - ('party_status', 'ACTIVE')  -> 'active'
+    - ('party_status', 'FROZEN')  -> 'frozen'
+    - ('fsm_state',    'DRAFT')   -> 'fsm_draft'
+    - ('login_status', 'Online')  -> 'login_online'
+    - ('dq_nature',    'Actual')  -> 'dq_actual'
+    Populated via seed scripts; no management UI needed.
+    end note
+
+    entity ores_dq_badge_severities_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+        * name : text
+        * description : text
+        * display_order : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_dq_badge_severities_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Reference data defining severity levels used to classify badges.
+    Codes align with Bootstrap 5 contextual classes so Wt rendering
+    requires no translation layer.
+    Values: secondary, info, success, warning, danger, primary.
+    end note
+
     entity ores_dq_catalogs_tbl <<temporal>> #C6F0D8 {
         * tenant_id : uuid <<PK, FK>>
         * name : text <<PK>>
@@ -1510,6 +2142,7 @@ package "dq_metadata" #E1F5FE {
         * description : text
           owner : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -1532,6 +2165,7 @@ package "dq_metadata" #E1F5FE {
         * version : integer
         * description : text
         * modified_by : text
+        * performed_by : text
         * change_commentary : text
         * valid_from : timestamptz
         * valid_to : timestamptz
@@ -1544,15 +2178,47 @@ package "dq_metadata" #E1F5FE {
         * version : integer
         * description : text
         * category_code : text <<FK>>
+        * applies_to_new : boolean
         * applies_to_amend : boolean
         * applies_to_delete : boolean
         * requires_commentary : boolean
         * display_order : integer
         * modified_by : text
+        * performed_by : text
         * change_commentary : text
         * valid_from : timestamptz
         * valid_to : timestamptz
     }
+
+    entity ores_dq_code_domains_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+        * name : text
+        * description : text
+        * display_order : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_dq_code_domains_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    A code domain is a classification registry that names the context in
+    which a code value exists. It disambiguates identical codes used in
+    different entity types — e.g. 'ACTIVE' in party_status vs 'ACTIVE'
+    in book_status.
+    Code domains are reusable beyond badges: any future system needing
+    to namespace code values (validation rules, audit customisation, etc.)
+    can reference this table.
+    end note
 
     entity ores_dq_coding_scheme_authority_types_tbl <<temporal>> #C6F0D8 {
         * tenant_id : uuid <<PK, FK>>
@@ -1562,6 +2228,7 @@ package "dq_metadata" #E1F5FE {
         * name : text
         * description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -1590,6 +2257,7 @@ package "dq_metadata" #E1F5FE {
           uri : text
         * description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -1616,6 +2284,7 @@ package "dq_metadata" #E1F5FE {
         * version : integer
         * description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -1627,6 +2296,72 @@ package "dq_metadata" #E1F5FE {
     Examples: reference_data, market_data, trade_data.
     end note
 
+    entity ores_dq_fsm_machines_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * name : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_dq_fsm_machines_tbl
+    Defines named state machines. Each machine represents a distinct lifecycle
+    domain (e.g., trade lifecycle, row signing, authorisation).
+    end note
+
+    entity ores_dq_fsm_states_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * machine_id : uuid <<FK>>
+        * name : text
+        * is_initial : integer
+        * is_terminal : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_dq_fsm_states_tbl
+    Defines valid states within a machine. Each state belongs to exactly one
+    machine and may be designated as initial or terminal.
+    end note
+
+    entity ores_dq_fsm_transitions_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * machine_id : uuid <<FK>>
+          from_state_id : uuid <<FK>>
+        * to_state_id : uuid <<FK>>
+        * name : text
+          guard_function : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_dq_fsm_transitions_tbl
+    Defines valid state-to-state transitions within a machine. Both from_state_id
+    and to_state_id must belong to the same machine. Optionally references a
+    guard function for business rule enforcement.
+    end note
+
     entity ores_dq_subject_areas_tbl <<temporal>> #C6F0D8 {
         * tenant_id : uuid <<PK, FK>>
         * name : text <<PK>>
@@ -1635,6 +2370,7 @@ package "dq_metadata" #E1F5FE {
         * version : integer
         * description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
@@ -1652,23 +2388,27 @@ package "dq_metadata" #E1F5FE {
 ' ==================== variability (Feature Flags) ====================
 '
 package "variability" #E8F5E9 {
-    entity ores_variability_feature_flags_tbl <<temporal>> #C6F0D8 {
+    entity ores_variability_system_settings_tbl <<temporal>> #C6F0D8 {
         * tenant_id : uuid <<PK, FK>>
         * name : text <<PK>>
         --
         * version : integer
-        * enabled : integer
-          description : text
+        * value : text
+        * data_type : text
+        * description : text
         * modified_by : text
+        * performed_by : text
         * change_reason_code : text <<FK>>
         * change_commentary : text
         * valid_from : timestamptz
         * valid_to : timestamptz
     }
 
-    note right of ores_variability_feature_flags_tbl
-    Feature toggles for runtime configuration.
-    Uses name as natural key.
+    note right of ores_variability_system_settings_tbl
+    Unified typed system settings table.
+    Supports boolean, integer, string, and json value types. Uses name as
+    natural key. System-wide settings use the system tenant; per-tenant
+    settings use the tenant's own tenant_id.
     end note
 
 }
@@ -1699,6 +2439,57 @@ package "telemetry" #FCE4EC {
     Partitioned by timestamp.
     end note
 
+    entity ores_telemetry_nats_server_samples_tbl  #F7E5FF {
+        * sampled_at : timestamptz <<PK>>
+        * tenant_id : uuid <<PK, FK>>
+        --
+        * in_msgs : bigint
+        * out_msgs : bigint
+        * in_bytes : bigint
+        * out_bytes : bigint
+        * connections : integer
+        * mem_bytes : bigint
+        * slow_consumers : integer
+    }
+
+    note right of ores_telemetry_nats_server_samples_tbl
+    NATS server-level metrics samples.
+    Populated by ores.telemetry.service polling /varz on the NATS monitoring API.
+    Designed for TimescaleDB hypertable, partitioned by sampled_at.
+    end note
+
+    entity ores_telemetry_nats_stream_samples_tbl  #F7E5FF {
+        * sampled_at : timestamptz <<PK>>
+        * tenant_id : uuid <<PK, FK>>
+        * stream_name : text <<PK>>
+        --
+        * messages : bigint
+        * bytes : bigint
+        * consumer_count : integer
+    }
+
+    note right of ores_telemetry_nats_stream_samples_tbl
+    NATS JetStream per-stream metrics samples.
+    Populated by ores.telemetry.service polling /jsz on the NATS monitoring API.
+    Designed for TimescaleDB hypertable, partitioned by sampled_at.
+    end note
+
+    entity ores_telemetry_service_samples_tbl  #F7E5FF {
+        * sampled_at : timestamptz <<PK>>
+        * service_name : text <<PK>>
+        * instance_id : text <<PK, FK>>
+        --
+        * version : text
+    }
+
+    note right of ores_telemetry_service_samples_tbl
+    Service heartbeat samples.
+    Populated by the heartbeat_publisher embedded in every domain service.
+    Each service publishes a heartbeat every 15 seconds; the telemetry service
+    subscribes and writes one row here per heartbeat received.
+    Designed for TimescaleDB hypertable, partitioned by sampled_at.
+    end note
+
 }
 
 '
@@ -1719,35 +2510,2159 @@ package "geo" #FFF9C4 {
 
 }
 
+'
+' ==================== trading (Trading & Lifecycle) ====================
+'
+package "trading" #E8F5E9 {
+    entity ores_trading_activity_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+        * category : text
+        * requires_confirmation : boolean
+          description : text
+          fpml_event_type_code : text
+          fsm_transition_id : uuid <<FK>>
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_trading_activity_types_tbl
+    Activity Types - Internal trade activity classification (~30 types).
+    Each activity type maps optionally to an FpML event type and/or to an
+    FSM transition that drives trade status changes.
+    end note
+
+    entity ores_trading_balance_guaranteed_swap_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * start_date : date
+        * maturity_date : date
+          lockout_days : integer
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_bond_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * party_id : uuid <<FK>>
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * issuer : text
+        * currency : text
+        * face_value : numeric(28, 10)
+        * coupon_rate : numeric(28, 10)
+        * coupon_frequency_code : text
+        * day_count_code : text
+        * issue_date : date
+        * maturity_date : date
+          settlement_days : integer
+          call_date : date
+          conversion_ratio : numeric(28, 10)
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_business_day_convention_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_trading_business_day_convention_types_tbl
+    Business Day Convention Types - ORE business day adjustment codes
+    end note
+
+    entity ores_trading_callable_swap_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * start_date : date
+        * maturity_date : date
+          call_dates_json : text
+          call_type : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_cap_floor_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * start_date : date
+        * maturity_date : date
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_commodity_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * party_id : uuid <<FK>>
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * commodity_code : text
+        * currency : text
+        * quantity : numeric(28, 10)
+        * unit : text
+          start_date : date
+          maturity_date : date
+          fixed_price : numeric(28, 10)
+          option_type : text
+          strike_price : numeric(28, 10)
+          exercise_type : text
+          average_type : text
+          averaging_start_date : date
+          averaging_end_date : date
+          spread_commodity_code : text
+          spread_amount : numeric(28, 10)
+          strip_frequency_code : text
+          variance_strike : numeric(28, 10)
+          accumulation_amount : numeric(28, 10)
+          knock_out_barrier : numeric(28, 10)
+          barrier_type : text
+          lower_barrier : numeric(28, 10)
+          upper_barrier : numeric(28, 10)
+          basket_json : text
+          day_count_code : text
+          payment_frequency_code : text
+          swaption_expiry_date : date
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_composite_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * party_id : uuid <<FK>>
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_composite_legs_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * party_id : uuid <<FK>>
+        * instrument_id : uuid <<FK>>
+        * leg_sequence : integer
+        * constituent_trade_id : text <<FK>>
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_credit_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * party_id : uuid <<FK>>
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * reference_entity : text
+        * currency : text
+        * notional : numeric(28, 10)
+        * spread : numeric(28, 10)
+        * recovery_rate : numeric(28, 10)
+        * tenor : text
+        * start_date : date
+        * maturity_date : date
+        * day_count_code : text
+        * payment_frequency_code : text
+          index_name : text
+          index_series : integer
+          seniority : text
+          restructuring : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_day_count_fraction_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_trading_day_count_fraction_types_tbl
+    Day Count Fraction Types - ORE day count convention codes (Act360, Act365F, etc.)
+    end note
+
+    entity ores_trading_equity_accumulator_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * underlying_name : text
+        * currency : text
+        * strike : numeric(28, 10)
+        * fixing_amount : numeric(28, 10)
+        * start_date : date
+        * expiry_date : date
+        * fixing_frequency : text
+        * long_short : text
+          knock_out_level : numeric(28, 10)
+          target_amount : numeric(28, 10)
+          target_type : text
+        * payoff_type : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_equity_asian_option_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * underlying_name : text
+        * currency : text
+        * notional : numeric(28, 10)
+        * option_type : text
+        * strike : numeric(28, 10)
+        * expiry_date : date
+        * exercise_type : text
+        * long_short : text
+        * average_type : text
+        * averaging_start_date : date
+        * averaging_end_date : date
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_equity_barrier_option_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * underlying_name : text
+        * currency : text
+        * notional : numeric(28, 10)
+        * option_type : text
+        * strike : numeric(28, 10)
+        * expiry_date : date
+        * exercise_type : text
+        * long_short : text
+        * lower_barrier : numeric(28, 10)
+        * lower_barrier_type : text
+          upper_barrier : numeric(28, 10)
+          upper_barrier_type : text
+          rebate : numeric(28, 10)
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_equity_digital_option_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * underlying_name : text
+        * currency : text
+        * notional : numeric(28, 10)
+          option_type : text
+          strike : numeric(28, 10)
+          barrier_level : numeric(28, 10)
+          barrier_type : text
+        * expiry_date : date
+        * long_short : text
+          payout_amount : numeric(28, 10)
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_equity_forward_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * underlying_name : text
+        * currency : text
+        * quantity : numeric(28, 10)
+          forward_price : numeric(28, 10)
+        * expiry_date : date
+        * long_short : text
+          settlement_type : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_equity_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * party_id : uuid <<FK>>
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * underlying_code : text
+        * currency : text
+        * notional : numeric(28, 10)
+          quantity : numeric(28, 10)
+          start_date : date
+          maturity_date : date
+          option_type : text
+          strike_price : numeric(28, 10)
+          exercise_type : text
+          barrier_type : text
+          lower_barrier : numeric(28, 10)
+          upper_barrier : numeric(28, 10)
+          average_type : text
+          averaging_start_date : date
+          variance_strike : numeric(28, 10)
+          cliquet_frequency_code : text
+          accumulation_amount : numeric(28, 10)
+          knock_out_barrier : numeric(28, 10)
+          basket_json : text
+          day_count_code : text
+          payment_frequency_code : text
+          return_type : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_equity_option_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * underlying_name : text
+        * currency : text
+        * notional : numeric(28, 10)
+        * option_type : text
+        * strike : numeric(28, 10)
+        * expiry_date : date
+        * exercise_type : text
+        * long_short : text
+          settlement_type : text
+          cliquet_frequency : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_equity_position_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * underlying_name : text
+        * currency : text
+        * quantity : numeric(28, 10)
+          price : numeric(28, 10)
+          option_data_json : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_equity_swap_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+          underlying_name : text
+          basket_json : text
+        * currency : text
+        * notional : numeric(28, 10)
+        * return_type : text
+        * start_date : date
+        * maturity_date : date
+        * long_short : text
+        * payment_frequency : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_equity_variance_swap_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * underlying_name : text
+        * currency : text
+        * notional : numeric(28, 10)
+        * variance_strike : numeric(28, 10)
+        * start_date : date
+        * maturity_date : date
+        * long_short : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_floating_index_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_trading_floating_index_types_tbl
+    Floating Index Types - interest rate index codes (EURIBOR6M, SOFR, etc.)
+    end note
+
+    entity ores_trading_fpml_event_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_trading_fpml_event_types_tbl
+    FpML Event Types - Standard FpML lc_EventType_Type coding scheme
+    (New, Amendment, Novation, PartialTermination, FullTermination)
+    end note
+
+    entity ores_trading_fra_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * start_date : date
+        * end_date : date
+        * currency : text
+        * rate_index : text
+        * long_short : text
+        * strike : numeric(18, 10)
+        * notional : numeric(28, 10)
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_fx_accumulator_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * currency : text
+        * fixing_amount : numeric(28, 10)
+        * strike : numeric(28, 10)
+        * underlying_code : text
+        * long_short : text
+        * start_date : date
+          knock_out_barrier : numeric(28, 10)
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_fx_asian_forward_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * fx_index : text
+          reference_currency : text
+          reference_notional : numeric(28, 10)
+          settlement_currency : text
+          settlement_notional : numeric(28, 10)
+          payment_date : date
+          long_short : text
+          currency : text
+          fixing_amount : numeric(28, 10)
+          target_amount : numeric(28, 10)
+          strike : numeric(28, 10)
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_fx_barrier_option_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * bought_currency : text
+        * bought_amount : numeric(28, 10)
+        * sold_currency : text
+        * sold_amount : numeric(28, 10)
+          option_type : text
+        * expiry_date : date
+          settlement : text
+        * barrier_type : text
+        * lower_barrier : numeric(28, 10)
+          upper_barrier : numeric(28, 10)
+          underlying_code : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_fx_digital_option_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * foreign_currency : text
+        * domestic_currency : text
+        * payoff_currency : text
+        * payoff_amount : numeric(28, 10)
+          option_type : text
+        * expiry_date : date
+        * long_short : text
+          strike : numeric(28, 10)
+          barrier_type : text
+          lower_barrier : numeric(28, 10)
+          upper_barrier : numeric(28, 10)
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_fx_forward_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * bought_currency : text
+        * bought_amount : numeric(28, 10)
+        * sold_currency : text
+        * sold_amount : numeric(28, 10)
+        * value_date : date
+          settlement : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_fx_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * party_id : uuid <<FK>>
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * bought_currency : text
+        * bought_amount : numeric(28, 10)
+        * sold_currency : text
+        * sold_amount : numeric(28, 10)
+          value_date : date
+          settlement : text
+          option_type : text
+          strike_price : numeric(28, 10)
+          expiry_date : date
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_fx_vanilla_option_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * bought_currency : text
+        * bought_amount : numeric(28, 10)
+        * sold_currency : text
+        * sold_amount : numeric(28, 10)
+        * option_type : text
+        * expiry_date : date
+        * exercise_style : text
+          settlement : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_fx_variance_swap_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * start_date : date
+        * end_date : date
+        * currency : text
+        * underlying_code : text
+        * long_short : text
+        * strike : numeric(28, 10)
+        * notional : numeric(28, 10)
+        * moment_type : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_identifiers_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * trade_id : uuid <<FK>>
+          issuing_party_id : uuid <<FK>>
+        * id_value : text
+        * id_type : text
+          id_scheme : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_trading_identifiers_tbl
+    Junction table for trade external identifiers (UTI, USI, Internal).
+    Each trade can have multiple identifiers of different types.
+    issuing_party_id validates against both parties and counterparties
+    tables since UUIDs are globally unique.
+    Hand-crafted: inline soft FK validations for trade_id, issuing_party_id
+    cannot be expressed by the standard templates.
+    end note
+
+    entity ores_trading_inflation_swap_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * start_date : date
+        * maturity_date : date
+        * inflation_index_code : text
+          base_cpi : numeric(18, 10)
+          lag_convention : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_knock_out_swap_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * start_date : date
+        * maturity_date : date
+        * barrier_level : numeric(18, 10)
+        * barrier_type : text
+          knock_out_dates_json : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_leg_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_trading_leg_types_tbl
+    Leg Types - swap leg type codes (Fixed, Floating, CMS, etc.)
+    end note
+
+    entity ores_trading_party_role_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_trading_party_role_types_tbl
+    Trade Party Role Types - FpML-aligned party role codes (Counterparty, CalculationAgent, ExecutingBroker, NovationTransferee)
+    end note
+
+    entity ores_trading_party_roles_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * trade_id : uuid <<FK>>
+        * counterparty_id : uuid <<FK>>
+        * role : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_trading_party_roles_tbl
+    Junction table assigning counterparties to roles on a trade.
+    The internal party ("the house") is derived from book_id -> books.party_id.
+    Hand-crafted: inline soft FK validations for trade_id and counterparty_id
+    cannot be expressed by the standard templates.
+    end note
+
+    entity ores_trading_payment_frequency_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_trading_payment_frequency_types_tbl
+    Payment Frequency Types - coupon/payment frequency codes
+    end note
+
+    entity ores_trading_rpa_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * start_date : date
+        * maturity_date : date
+        * reference_counterparty : text
+        * participation_rate : numeric(18, 10)
+          protection_fee : numeric(18, 10)
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_scripted_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * party_id : uuid <<FK>>
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * script_name : text
+          script_body : text
+          events_json : text
+          underlyings_json : text
+          parameters_json : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_swap_legs_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+        * instrument_id : uuid <<FK>>
+        * leg_number : integer
+        * leg_type_code : text
+        * day_count_fraction_code : text
+        * business_day_convention_code : text
+        * payment_frequency_code : text
+          floating_index_code : text
+          fixed_rate : numeric(18, 10)
+          spread : numeric(18, 10)
+        * notional : numeric(28, 10)
+        * currency : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_swaption_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * expiry_date : date
+        * exercise_type : text
+        * settlement_type : text
+        * long_short : text
+          start_date : date
+          maturity_date : date
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+          maturity_date : is
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_trading_trade_id_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_trading_trade_id_types_tbl
+    Trade Identifier Types - Identifier type codes for trade identifiers (UTI, USI, Internal)
+    end note
+
+    entity ores_trading_trade_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+          description : text
+        * product_type : product_type_t
+        * has_options : boolean
+        * has_extension : boolean
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_trading_trade_types_tbl
+    Trade Types - ORE instrument type codes (Swap, FxForward, CapFloor, Swaption, etc.)
+    end note
+
+    entity ores_trading_trades_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * party_id : uuid <<FK>>
+          external_id : text <<FK>>
+        * book_id : uuid <<FK>>
+        * portfolio_id : uuid <<FK>>
+          successor_trade_id : uuid <<FK>>
+          counterparty_id : uuid <<FK>>
+        * trade_type : text
+          product_type : product_type_t
+          instrument_id : uuid <<FK>>
+          asset_class : text
+        * netting_set_id : text <<FK>>
+        * activity_type_code : text
+        * status_id : uuid <<FK>>
+          trade_date : date
+          execution_timestamp : timestamptz
+          effective_date : date
+          termination_date : date
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_trading_trades_tbl
+    Temporal trade record capturing FpML Trade Header properties. Each lifecycle
+    event (New, Amendment, Novation, etc.) creates a new temporal row for the
+    same trade id. The internal party is derived from book_id -> books.party_id.
+    Hand-crafted: inline soft FK validations for book_id, portfolio_id, and
+    successor_trade_id cannot be expressed by the standard templates.
+    end note
+
+    entity ores_trading_vanilla_swap_instruments_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * instrument_id : uuid <<PK, FK>>
+        --
+        * party_id : uuid <<FK>>
+        * version : integer
+          trade_id : uuid <<FK>>
+        * trade_type_code : text
+        * start_date : date
+        * maturity_date : date
+          settlement_lag : integer
+          netting_set_id : text <<FK>>
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+}
+
+'
+' ==================== mq (Message Queue (pgmq)) ====================
+'
+package "mq" #FBE9E7 {
+    entity ores_mq_message_archive_tbl  #F7E5FF {
+        * id : bigint <<PK>>
+        * archived_at : timestamptz <<PK>>
+        --
+        * queue_id : uuid <<FK>>
+          tenant_id : uuid <<FK>>
+          party_id : uuid <<FK>>
+        * message_type : text
+        * payload_type : text
+          payload : jsonb
+          raw_payload : bytea
+        * final_status : text
+        * created_at : timestamptz
+        * read_count : int
+        * error_message : text
+    }
+
+    note right of ores_mq_message_archive_tbl
+    MQ message archive table.
+    Stores acknowledged messages. TimescaleDB hypertable on archived_at when
+    available; degrades gracefully to a plain table.
+    Partitioned by archived_at with 1-day chunks and 90-day retention.
+    end note
+
+    entity ores_mq_messages_tbl  #F7E5FF {
+        --
+          id : bigserial
+        * queue_id : uuid <<FK>>
+          tenant_id : uuid <<FK>>
+          party_id : uuid <<FK>>
+        * message_type : text
+        * payload_type : text
+          payload : jsonb
+          raw_payload : bytea
+        * status : text
+        * visible_after : timestamptz
+        * created_at : timestamptz
+        * updated_at : timestamptz
+        * read_count : int
+        * error_message : text
+    }
+
+    note right of ores_mq_messages_tbl
+    MQ task queue messages table.
+    Regular (non-hypertable) table for pending and in-flight task messages.
+    end note
+
+    entity ores_mq_queue_stats_tbl  #F7E5FF {
+        * queue_id : uuid <<PK, FK>>
+        * recorded_at : timestamptz <<PK>>
+        --
+          tenant_id : uuid <<FK>>
+          party_id : uuid <<FK>>
+        * pending_count : bigint
+        * processing_count : bigint
+        * total_archived : bigint
+    }
+
+    note right of ores_mq_queue_stats_tbl
+    MQ queue statistics time-series table.
+    Populated by ores_mq_queue_stats_scrape_fn() via a pg_cron job.
+    TimescaleDB hypertable when available; degrades gracefully to a plain table.
+    Partitioned by recorded_at with 1-day chunks and 30-day retention.
+    end note
+
+    entity ores_mq_queues_tbl  #F7E5FF {
+        --
+        * id : uuid
+        * scope_type : text
+        * queue_type : text
+        * name : text
+        * description : text
+        * created_at : timestamptz
+        * modified_at : timestamptz
+        * modified_by : text
+        * is_active : boolean
+    }
+
+    note right of ores_mq_queues_tbl
+    MQ queue definitions table.
+    Supports party, tenant and system scope; task and channel queue types.
+    end note
+
+}
+
+'
+' ==================== scheduler (Job Scheduler (pg_cron)) ====================
+'
+package "scheduler" #F1F8E9 {
+    entity ores_scheduler_job_definitions_tbl <<temporal>> #C6F0D8 {
+        * id : uuid <<PK>>
+        --
+          tenant_id : uuid <<FK>>
+        * version : integer
+          party_id : uuid <<FK>>
+        * job_name : text
+        * description : text
+        * command : text
+        * schedule_expression : text
+        * action_type : text
+        * action_payload : jsonb
+        * is_active : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_scheduler_job_definitions_tbl
+    Stores job definitions for OreStudio's built-in scheduler. Each row
+    represents a versioned, auditable job definition with tenant/party
+    isolation, human-readable description, and a soft-pause mechanism
+    (is_active).
+    Jobs can be system-scoped (tenant_id IS NULL, party_id IS NULL),
+    tenant-scoped (tenant_id set, party_id IS NULL), or party-scoped
+    (both tenant_id and party_id set).
+    The action_type column controls how the scheduler executes the job:
+    - 'execute_sql'    : run the SQL in the command column directly.
+    - 'nats_publish'  : publish a NATS message; action_payload carries
+    the subject and body.
+    end note
+
+    entity ores_scheduler_job_instances_tbl  #F7E5FF {
+        * id : bigserial <<PK>>
+        * triggered_at : timestamptz <<PK>>
+        --
+          tenant_id : uuid <<FK>>
+          party_id : uuid <<FK>>
+        * job_definition_id : uuid <<FK>>
+        * action_type : text
+        * status : text
+        * started_at : timestamptz
+          completed_at : timestamptz
+          duration_ms : bigint
+        * error_message : text
+    }
+
+    note right of ores_scheduler_job_instances_tbl
+    Scheduler Job Instances Table
+    Execution history for scheduler jobs.
+    Designed for TimescaleDB hypertable; degrades gracefully to a plain table.
+    Partitioned by triggered_at.
+    end note
+
+}
+
+'
+' ==================== reporting (Reporting & Analytics) ====================
+'
+package "reporting" #E0F7FA {
+    entity ores_reporting_concurrency_policies_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+        * name : text
+        * description : text
+        * display_order : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_reporting_concurrency_policies_tbl
+    Enum table for report instance concurrency strategies (skip, queue, fail).
+    Controls what happens when a new report instance is triggered while one for
+    the same definition is already running.
+    The validation function is called from the report_definitions insert trigger
+    so that new policies can be added without schema migrations.
+    end note
+
+    entity ores_reporting_report_definitions_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * party_id : uuid <<FK>>
+        * name : text
+        * description : text
+        * report_type : text
+          fsm_state_id : uuid <<FK>>
+        * schedule_expression : text
+        * concurrency_policy : text
+          scheduler_job_id : uuid <<FK>>
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_reporting_report_definitions_tbl
+    The persistent template for a report. Describes what to run, when to run it,
+    and how to handle concurrent executions. Type-specific configuration (e.g.
+    risk parameters) lives in a separate table keyed by report_definition_id.
+    Lifecycle is managed through the report_definition_lifecycle FSM machine.
+    fsm_state_id points to the current state in ores_dq_fsm_states_tbl.
+    scheduler_job_id links to ores_scheduler_job_definitions_tbl.id and is set
+    by the scheduler service when the definition is activated (state: active).
+    It is cleared when the definition is suspended or archived.
+    end note
+
+    entity ores_reporting_report_input_bundles_tbl  #F7E5FF {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * report_instance_id : uuid <<FK>>
+        * definition_id : uuid <<FK>>
+        * trades_storage_key : text
+        * market_data_storage_key : text
+        * trade_count : integer
+        * series_count : integer
+        * created_at : timestamptz
+    }
+
+    note right of ores_reporting_report_input_bundles_tbl
+    An immutable artifact created by the assemble_bundle workflow step.
+    Records the object-storage keys where the MsgPack-serialised trades
+    and market data blobs produced during gather_trades and
+    gather_market_data are stored.
+    One bundle is created per report instance execution.  The bundle is
+    consumed downstream by prepare_ore_package to repackage the data as
+    a tarball for the compute grid.
+    end note
+
+    entity ores_reporting_report_instances_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * name : text
+        * description : text
+        * party_id : uuid <<FK>>
+        * definition_id : uuid <<FK>>
+          fsm_state_id : uuid <<FK>>
+        * trigger_run_id : bigint <<FK>>
+        * output_message : text
+          started_at : timestamptz
+          completed_at : timestamptz
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_reporting_report_instances_tbl
+    A single execution of a report_definition. Created automatically when the
+    scheduler fires a trigger for an active definition.
+    Lifecycle is managed through the report_instance_lifecycle FSM machine.
+    fsm_state_id points to the current state in ores_dq_fsm_states_tbl.
+    The initial fsm_state depends on the definition's concurrency_policy and
+    whether another instance for the same definition is already running:
+    - No running instance          -> pending
+    - Running + policy = queue     -> queued
+    - Running + policy = skip      -> skipped (terminal)
+    - Running + policy = fail      -> failed  (terminal)
+    started_at is NULL when the instance is cancelled or skipped before execution
+    begins. completed_at is NULL while running or in a terminal-before-start state.
+    end note
+
+    entity ores_reporting_report_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+        * name : text
+        * description : text
+        * display_order : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_reporting_report_types_tbl
+    Enum table for the available report types (e.g. risk, grid). Each tenant
+    carries its own copy, populated from system seed data at provisioning time.
+    The validation function is called from the report_definitions insert trigger
+    so that new types can be added without schema migrations.
+    end note
+
+    entity ores_reporting_risk_report_config_books_tbl <<junction>> #ECECEC {
+        * risk_report_config_id : uuid <<PK, FK>>
+        * book_id : uuid <<PK, FK>>
+        * valid_from : timestamptz <<PK>>
+        --
+        * tenant_id : uuid <<FK>>
+        * valid_to : timestamptz
+    }
+
+    note right of ores_reporting_risk_report_config_books_tbl
+    Associates a risk report configuration with the books it should include.
+    An empty set (no rows for a given risk_report_config_id) means all books
+    within the selected portfolios are included.
+    This is a temporal junction table: entries are closed when removed, preserving
+    historical scope records alongside the config version history.
+    end note
+
+    entity ores_reporting_risk_report_config_portfolios_tbl <<junction>> #ECECEC {
+        * risk_report_config_id : uuid <<PK, FK>>
+        * portfolio_id : uuid <<PK, FK>>
+        * valid_from : timestamptz <<PK>>
+        --
+        * tenant_id : uuid <<FK>>
+        * valid_to : timestamptz
+    }
+
+    note right of ores_reporting_risk_report_config_portfolios_tbl
+    Associates a risk report configuration with the portfolios it should include.
+    An empty set (no rows for a given risk_report_config_id) means all portfolios
+    visible to the tenant are included.
+    This is a temporal junction table: entries are closed when removed, preserving
+    historical scope records alongside the config version history.
+    end note
+
+    entity ores_reporting_risk_report_configs_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * report_definition_id : uuid <<FK>>
+        * base_currency : text
+        * observation_model : text
+        * n_threads : integer
+        * market_data_type : text
+          market_data_date : date
+        * npv_enabled : integer
+        * cashflow_enabled : integer
+        * curves_enabled : integer
+        * sensitivity_enabled : integer
+        * simulation_enabled : integer
+        * xva_enabled : integer
+        * stress_enabled : integer
+        * parametric_var_enabled : integer
+        * initial_margin_enabled : integer
+        * pfe_enabled : integer
+          xva_quantile : numeric(5,4)
+        * xva_cva_enabled : integer
+        * xva_dva_enabled : integer
+        * xva_fva_enabled : integer
+        * xva_colva_enabled : integer
+        * xva_dim_enabled : integer
+          xva_dim_quantile : numeric(5,4)
+          xva_dim_horizon_calendar_days : integer
+          xva_dim_regression_order : integer
+          var_quantiles : numeric(5,4)[]
+          var_method : text
+          simm_version : text
+          simm_calculation_currency : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_reporting_risk_report_configs_tbl
+    Stores the ORE-level parameters for a risk report definition. Each row is
+    owned by exactly one report_definition (1:1 relationship, enforced by the
+    unique index on report_definition_id).
+    Analytics flags use integer 0/1 (not boolean) to match the project
+    convention. npv and cashflow default to enabled; all others default to off.
+    Market data convention is split into market_data_type ('live'|'eod'|'date')
+    and market_data_date (set only when type = 'date'), enforced by a CHECK.
+    Portfolio and book scope are stored in separate junction tables. An empty
+    set in either junction table means "all visible to the tenant".
+    end note
+
+}
+
+'
+' ==================== compute (Distributed Compute Grid (BOINC)) ====================
+'
+package "compute" #EDE7F6 {
+    entity ores_compute_app_version_platforms_tbl <<junction>> #ECECEC {
+        * tenant_id : uuid <<PK, FK>>
+        * app_version_id : uuid <<PK, FK>>
+        * platform_id : uuid <<PK, FK>>
+        * valid_from : timestamptz <<PK>>
+        --
+        * package_uri : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_to : timestamptz
+    }
+
+    entity ores_compute_app_versions_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * app_id : uuid <<FK>>
+        * wrapper_version : text
+        * engine_version : text
+        * min_ram_mb : integer
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_compute_app_versions_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Combines a specific wrapper version with a specific engine version. The BOINC
+    equivalent of 'app_version'. Per-platform package artefacts are tracked in
+    ores_compute_app_version_platforms_tbl — each (app_version, platform) row
+    owns the URI of its own packaged bundle.
+    end note
+
+    entity ores_compute_apps_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * name : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_compute_apps_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Represents the high-level definition of an engine that can be executed on
+    grid nodes (e.g., ORE_STUDIO, LLAMA_CPP, LEDGER). The BOINC equivalent of 'app'.
+    end note
+
+    entity ores_compute_batch_dependencies_tbl  #F7E5FF {
+        * tenant_id : uuid <<PK, FK>>
+        * parent_batch_id : uuid <<PK, FK>>
+        * child_batch_id : uuid <<PK, FK>>
+        --
+    }
+
+    note right of ores_compute_batch_dependencies_tbl
+    Records directed dependencies between batches forming a DAG.
+    A child batch should not start until its parent batch is complete.
+    end note
+
+    entity ores_compute_batches_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * external_ref : text
+        * status : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_compute_batches_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Tracks the lifecycle of a collection of workunits that together constitute a
+    financial computation (e.g., a risk report run). The Assimilator monitors
+    batch completion to trigger downstream report generation.
+    end note
+
+    entity ores_compute_grid_samples_tbl  #F7E5FF {
+        * sampled_at : timestamptz <<PK>>
+        * tenant_id : uuid <<PK, FK>>
+        --
+        * total_hosts : integer
+        * online_hosts : integer
+        * idle_hosts : integer
+        * results_inactive : integer
+        * results_unsent : integer
+        * results_in_progress : integer
+        * results_done : integer
+        * total_workunits : integer
+        * total_batches : integer
+        * active_batches : integer
+        * outcomes_success : integer
+        * outcomes_client_error : integer
+        * outcomes_no_reply : integer
+    }
+
+    note right of ores_compute_grid_samples_tbl
+    Compute grid server-side telemetry samples.
+    Populated by ores.compute.service every ~30 seconds.
+    One row per sample interval per tenant; designed for TimescaleDB hypertable
+    partitioned by sampled_at.
+    end note
+
+    entity ores_compute_hosts_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * external_id : text <<FK>>
+          location : text
+        * cpu_count : integer
+        * ram_mb : bigint
+          gpu_type : text
+          display_name : text
+          last_rpc_time : timestamptz
+        * credit_total : numeric
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_compute_hosts_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Represents a physical or virtual machine that participates in the BOINC-inspired
+    compute grid. Tracks hardware capabilities, heartbeat, and accumulated credit.
+    end note
+
+    entity ores_compute_node_samples_tbl  #F7E5FF {
+        * sampled_at : timestamptz <<PK>>
+        * tenant_id : uuid <<PK, FK>>
+        * host_id : uuid <<PK, FK>>
+        --
+        * tasks_completed : integer
+        * tasks_failed : integer
+        * tasks_since_last : integer
+        * avg_task_duration_ms : bigint
+        * max_task_duration_ms : bigint
+        * input_bytes_fetched : bigint
+        * output_bytes_uploaded : bigint
+        * seconds_since_hb : integer
+    }
+
+    note right of ores_compute_node_samples_tbl
+    Compute grid per-node telemetry samples.
+    Published by ores.compute.wrapper nodes every ~30 seconds via NATS and
+    persisted by ores.compute.service.
+    One row per node per sample interval; designed for TimescaleDB hypertable
+    partitioned by sampled_at.
+    end note
+
+    entity ores_compute_platforms_tbl <<temporal>> #C6F0D8 {
+        * id : uuid <<PK>>
+        * tenant_id : uuid <<PK, FK>>
+        --
+        * version : integer
+        * code : text
+        * display_name : text
+        * description : text
+        * os_family : text
+        * cpu_arch : text
+          abi : text
+        * is_active : boolean
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_compute_results_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * workunit_id : uuid <<FK>>
+          host_id : uuid <<FK>>
+          pgmq_msg_id : bigint <<FK>>
+        * server_state : integer
+          outcome : integer
+          output_uri : text
+          error_message : text
+          received_at : timestamptz
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_compute_results_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Bridges the workunit definition and the actual execution on a grid node.
+    Tracks PGMQ lease state, server-side lifecycle (Inactive/Unsent/InProgress/Done),
+    and the location of output data. The BOINC equivalent of 'result'.
+    end note
+
+    entity ores_compute_workunits_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * batch_id : uuid <<FK>>
+        * app_version_id : uuid <<FK>>
+        * input_uri : text
+          config_uri : text
+        * priority : integer
+        * target_redundancy : integer
+          canonical_result_id : uuid <<FK>>
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_compute_workunits_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Defines the problem to be solved: which app version to use, where the input
+    data lives, and how many times to run it for redundancy. The BOINC equivalent
+    of 'workunit'. Does not track execution state — that belongs to results.
+    end note
+
+}
+
+'
+' ==================== workflow (Workflow Orchestration (Saga)) ====================
+'
+package "workflow" #FFF8E1 {
+    entity ores_workflow_workflow_instances_tbl  #F7E5FF {
+        * id : uuid <<PK>>
+        --
+        * tenant_id : uuid <<FK>>
+        * type : text
+        * state_id : uuid <<FK>>
+        * request_json : jsonb
+          result_json : jsonb
+          error : text
+          correlation_id : text <<FK>>
+        * created_by : text
+        * current_step_index : integer
+        * step_count : integer
+          completed_at : timestamptz
+          last_event_at : timestamptz
+        * created_at : timestamptz
+    }
+
+    note right of ores_workflow_workflow_instances_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_non_temporal_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Tracks the lifecycle of a workflow execution, including its type, status,
+    the serialised request that triggered it, and any result or error produced.
+    Instances are append-mostly; status transitions are the primary mutation.
+    end note
+
+    entity ores_workflow_workflow_steps_tbl  #F7E5FF {
+        * id : uuid <<PK>>
+        --
+        * workflow_id : uuid <<FK>>
+        * step_index : integer
+        * name : text
+        * state_id : uuid <<FK>>
+        * request_json : jsonb
+          response_json : jsonb
+          error : text
+        * command_subject : text
+        * command_json : text
+          command_published_at : timestamptz
+        * idempotency_key : text
+        * compensation_subject : text
+        * compensation_json : text
+          started_at : timestamptz
+          completed_at : timestamptz
+        * created_at : timestamptz
+    }
+
+    note right of ores_workflow_workflow_steps_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_non_temporal_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Records the execution of one step in a saga workflow, including the step
+    index, name, status, request/response payloads, and timing. Steps reference
+    their parent workflow instance via workflow_id.
+    end note
+
+}
+
+'
+' ==================== database (Database Infrastructure) ====================
+'
+package "database" #EFEBE9 {
+    entity ores_database_info_tbl  #F7E5FF {
+        * id : uuid <<PK>>
+        --
+        * schema_version : text
+        * build_environment : text
+        * git_commit : text
+        * git_date : text
+        * created_at : timestamptz
+    }
+
+    note right of ores_database_info_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_non_temporal_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Stores the schema version, git commit, and build environment inserted at
+    database creation time. Used to correlate service behaviour with the
+    database schema in use. Contains exactly one row.
+    end note
+
+}
+
+'
+' ==================== marketdata (Market Data (Quotes, Fixings, Series)) ====================
+'
+package "marketdata" #E3F2FD {
+    entity ores_marketdata_fixings_tbl <<temporal>> #C6F0D8 {
+        * id : uuid <<PK>>
+        * fixing_date : date <<PK>>
+        --
+        * tenant_id : uuid <<FK>>
+        * series_id : uuid <<FK>>
+        * value : text
+          source : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_marketdata_observations_tbl <<temporal>> #C6F0D8 {
+        * id : uuid <<PK>>
+        * observation_date : date <<PK>>
+        --
+        * tenant_id : uuid <<FK>>
+        * series_id : uuid <<FK>>
+          point_id : text <<FK>>
+        * value : text
+          source : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    entity ores_marketdata_series_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * series_type : text
+        * metric : text
+        * qualifier : text
+        * asset_class : text
+        * series_subclass : text
+        * is_scalar : boolean
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+}
+
+'
+' ==================== controller (Service Lifecycle Controller) ====================
+'
+package "controller" #E8EAF6 {
+    entity ores_controller_service_definitions_tbl <<temporal>> #C6F0D8 {
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * service_name : text
+        * binary_name : text
+        * desired_replicas : integer
+        * restart_policy : text
+        * max_restart_count : integer
+        * enabled : integer
+          args_template : text
+          description : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_controller_service_definitions_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Represents a Kubernetes-style Deployment: the desired configuration for a
+    named service, including how many replicas to run, the binary name, restart
+    policy, and whether the service is enabled. This is a bitemporal table so
+    that the full history of configuration changes is preserved for audit.
+    end note
+
+    entity ores_controller_service_dependencies_tbl  #F7E5FF {
+        * service_name : text <<PK>>
+        * depends_on : text <<PK>>
+        --
+    }
+
+    note right of ores_controller_service_dependencies_tbl
+    Records the startup dependencies between managed services. A row
+    (service_name, depends_on) means service_name must not be launched until
+    depends_on has signalled readiness (i.e. "Service ready" appears in its
+    log file).
+    The process_supervisor reads this table at startup, builds a directed
+    acyclic graph, and starts services in topological order — waiting for each
+    service to become ready before launching services that depend on it.
+    This is intentionally non-bitemporal: dependency relationships are static
+    configuration that does not require a full audit history.
+    end note
+
+    entity ores_controller_service_events_tbl  #F7E5FF {
+        * occurred_at : timestamptz <<PK>>
+        * event_id : uuid <<PK, FK>>
+        --
+        * service_name : text
+          instance_id : uuid <<FK>>
+          replica_index : integer
+        * event_type : text
+        * message : text
+    }
+
+    note right of ores_controller_service_events_tbl
+    Service lifecycle events.
+    Kubernetes-style Event log: one row per significant state transition for a
+    service instance (started, stopped, crashed, restarted, etc.).
+    Designed as a TimescaleDB hypertable partitioned by occurred_at for
+    efficient time-range queries and automatic data retention.
+    end note
+
+    entity ores_controller_service_instances_tbl  #F7E5FF {
+        * id : uuid <<PK>>
+        --
+        * service_name : text
+        * replica_index : integer
+          pid : integer
+        * phase : text
+          started_at : timestamptz
+          stopped_at : timestamptz
+        * restart_count : integer
+          last_error : text
+          last_log_snippet : text
+          last_stderr_snippet : text
+          last_command_line : text
+        * created_at : timestamptz
+    }
+
+    note right of ores_controller_service_instances_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_non_temporal_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Represents a Kubernetes-style Pod: one concrete running instance of a
+    service definition. Tracks the OS process ID, lifecycle phase, start/stop
+    times, and how many times the instance has been restarted. Non-temporal:
+    only the current state is kept here; history is captured in service_events.
+    end note
+
+}
+
+'
+' ==================== analytics (Analytics & Pricing Configuration) ====================
+'
+package "analytics" #E8F5E9 {
+    entity ores_analytics_pricing_engine_types_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * code : text <<PK>>
+        --
+        * version : integer
+          description : text
+          instrument_type_code : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_analytics_pricing_engine_types_tbl
+    Pricing Engine Types - Classification of products at the granularity needed by the pricing engine to select the correct model and numerical method (e.g. EuropeanSwaption, BermudanSwaption, CMS).
+    end note
+
+    entity ores_analytics_pricing_model_configs_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * name : text
+          description : text
+          config_variant : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_analytics_pricing_model_configs_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Header entity for a pricing model configuration. Each config contains product mappings
+    (in pricing_model_products) and parameters (in pricing_model_product_parameters).
+    Corresponds to ORE's pricingengine.xml.
+    end note
+
+    entity ores_analytics_pricing_model_product_parameters_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * pricing_model_config_id : uuid <<FK>>
+          pricing_model_product_id : uuid <<FK>>
+        * parameter_scope : text
+        * parameter_name : text
+        * parameter_value : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_analytics_pricing_model_product_parameters_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Stores model parameters, engine parameters, and global parameters as normalised rows
+    for granular diffing. Product-scoped parameters have pricing_model_product_id set;
+    global parameters have it NULL with parameter_scope = 'global'.
+    end note
+
+    entity ores_analytics_pricing_model_products_tbl <<temporal>> #C6F0D8 {
+        * tenant_id : uuid <<PK, FK>>
+        * id : uuid <<PK>>
+        --
+        * version : integer
+        * pricing_model_config_id : uuid <<FK>>
+        * pricing_engine_type_code : text
+        * model : text
+        * engine : text
+        * modified_by : text
+        * performed_by : text
+        * change_reason_code : text <<FK>>
+        * change_commentary : text
+        * valid_from : timestamptz
+        * valid_to : timestamptz
+    }
+
+    note right of ores_analytics_pricing_model_products_tbl
+    AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+    Template: sql_schema_domain_entity_create.mustache
+    To modify, update the template and regenerate.
+    Table
+    Detail row within a pricing model configuration. Each row maps a pricing engine type
+    (e.g. EuropeanSwaption, CMS) to a specific model (e.g. LGM, BlackBachelier) and
+    numerical engine (e.g. Grid, AMC). Product-specific parameters are stored in
+    pricing_model_product_parameters.
+    end note
+
+}
+
 
 '
 ' ==================== Relationships ====================
 '
-
-' --- Party reference data ---
-ores_refdata_parties_tbl ||--o{ ores_refdata_party_identifiers_tbl : "has"
-ores_refdata_parties_tbl ||--o{ ores_refdata_party_contact_informations_tbl : "has"
-ores_refdata_parties_tbl }o--|| ores_refdata_party_types_tbl : "type"
-ores_refdata_parties_tbl }o--|| ores_refdata_party_statuses_tbl : "status"
-ores_refdata_parties_tbl }o--o| ores_refdata_business_centres_tbl : "business center"
-ores_refdata_party_identifiers_tbl }o--|| ores_refdata_party_id_schemes_tbl : "scheme"
-ores_refdata_party_contact_informations_tbl }o--|| ores_refdata_contact_types_tbl : "type"
-ores_refdata_party_contact_informations_tbl }o--o| ores_refdata_countries_tbl : "country"
-ores_refdata_party_id_schemes_tbl }o--o| ores_dq_coding_schemes_tbl : "coding scheme"
-
-' --- Counterparty reference data ---
-ores_refdata_counterparties_tbl ||--o{ ores_refdata_counterparty_identifiers_tbl : "has"
-ores_refdata_counterparties_tbl ||--o{ ores_refdata_counterparty_contact_informations_tbl : "has"
-ores_refdata_counterparties_tbl }o--|| ores_refdata_party_types_tbl : "type"
-ores_refdata_counterparties_tbl }o--|| ores_refdata_party_statuses_tbl : "status"
-ores_refdata_counterparties_tbl }o--o| ores_refdata_business_centres_tbl : "business center"
-ores_refdata_counterparty_identifiers_tbl }o--|| ores_refdata_party_id_schemes_tbl : "scheme"
-ores_refdata_counterparty_contact_informations_tbl }o--|| ores_refdata_contact_types_tbl : "type"
-ores_refdata_counterparty_contact_informations_tbl }o--o| ores_refdata_countries_tbl : "country"
-
-' --- Account-party association ---
-ores_iam_account_parties_tbl }o--|| ores_iam_accounts_tbl : "account"
-ores_iam_account_parties_tbl }o--|| ores_refdata_parties_tbl : "party"
 
 ' Local Variables:
 ' compile-command: "java -Djava.awt.headless=true -DPLANTUML_LIMIT_SIZE=131072 -jar /usr/share/plantuml/plantuml.jar ores_schema.puml"

--- a/projects/ores.sql/populate/compute/compute_ore_app_seed.sql
+++ b/projects/ores.sql/populate/compute/compute_ore_app_seed.sql
@@ -69,7 +69,7 @@ where not exists (
 );
 
 -- -------------------------------------------------------------------------
--- ORE App Version 1.8.15.0 (linux-x86_64)
+-- ORE App Version 1.8.15.0
 -- -------------------------------------------------------------------------
 with ore_app as (
     select id from ores_compute_apps_tbl
@@ -88,7 +88,6 @@ inserted_version as (
         app_id,
         wrapper_version,
         engine_version,
-        package_uri,
         min_ram_mb,
         modified_by,
         performed_by,
@@ -104,7 +103,6 @@ inserted_version as (
         ore_app.id,
         '1.0.0',
         '1.8.15.0',
-        '/api/v1/storage/compute/packages/' || new_version_id.uuid::text,
         512,
         current_user,
         current_user,
@@ -137,12 +135,13 @@ app_version_id as (
     limit 1
 )
 -- -------------------------------------------------------------------------
--- ORE App Version Platform (x86_64-unknown-linux-gnu)
+-- ORE App Version Platform Package (x64-linux)
 -- -------------------------------------------------------------------------
 insert into ores_compute_app_version_platforms_tbl (
     tenant_id,
     app_version_id,
     platform_id,
+    package_uri,
     modified_by,
     performed_by,
     change_reason_code,
@@ -154,6 +153,7 @@ select
     ores_iam_system_tenant_id_fn(),
     app_version_id.id,
     p.id,
+    '/api/v1/storage/compute/packages/ore/1.8.15.0/ore-1.8.15.0-x64-linux.tar.gz',
     current_user,
     current_user,
     'system.new_record',
@@ -162,13 +162,13 @@ select
     ores_utility_infinity_timestamp_fn()
 from app_version_id
 join ores_compute_platforms_tbl p
-    on p.code = 'x86_64-unknown-linux-gnu'
+    on p.code = 'x64-linux'
    and p.valid_to = ores_utility_infinity_timestamp_fn()
 where not exists (
     select 1 from ores_compute_app_version_platforms_tbl avp
     join ores_compute_platforms_tbl pl
         on pl.id = avp.platform_id
-       and pl.code = 'x86_64-unknown-linux-gnu'
+       and pl.code = 'x64-linux'
        and pl.valid_to = ores_utility_infinity_timestamp_fn()
     where avp.app_version_id = app_version_id.id
       and avp.tenant_id = ores_iam_system_tenant_id_fn()

--- a/projects/ores.sql/populate/compute/compute_platforms_seed.sql
+++ b/projects/ores.sql/populate/compute/compute_platforms_seed.sql
@@ -21,15 +21,17 @@
 /**
  * Compute Platforms Seed Script
  *
- * Seeds the known compute platforms using Rust target triple codes. The system
- * tenant owns all records, making them visible to all tenants through RLS.
- * Idempotent: guarded by code lookups so it is safe to run on every database
- * recreation.
+ * Seeds the known compute platforms using vcpkg target triplet codes so that
+ * the same identifier is used across the build system (VCPKG_TARGET_TRIPLET),
+ * runtime (ORES_PLATFORM_TRIPLET stamped into each binary) and the database.
+ * The system tenant owns all records, making them visible to all tenants
+ * through RLS. Idempotent: guarded by code lookups so it is safe to run on
+ * every database recreation.
  */
 
 \echo '--- Compute Platforms Seed ---'
 
--- Linux x86-64 (GNU libc)
+-- Linux x86-64
 insert into ores_compute_platforms_tbl (
     id, tenant_id, version, code, display_name, description,
     os_family, cpu_arch, abi, is_active,
@@ -40,11 +42,11 @@ select
     gen_random_uuid(),
     ores_iam_system_tenant_id_fn(),
     1,
-    'x86_64-unknown-linux-gnu',
-    'Linux x86-64 (GNU libc)',
-    '64-bit x86 Linux using the GNU C Library (glibc). The standard platform '
-    'for most Linux server and desktop installations. Compatible with Debian, '
-    'Ubuntu, RHEL, and most mainstream distributions.',
+    'x64-linux',
+    'Linux x86-64',
+    '64-bit x86 Linux. The standard platform for most Linux server and '
+    'desktop installations. Compatible with Debian, Ubuntu, RHEL, and most '
+    'mainstream distributions.',
     'linux',
     'x86_64',
     'gnu',
@@ -57,11 +59,11 @@ select
     ores_utility_infinity_timestamp_fn()
 where not exists (
     select 1 from ores_compute_platforms_tbl
-    where code = 'x86_64-unknown-linux-gnu'
+    where code = 'x64-linux'
       and valid_to = ores_utility_infinity_timestamp_fn()
 );
 
--- Linux ARM64 (GNU libc)
+-- Linux ARM64
 insert into ores_compute_platforms_tbl (
     id, tenant_id, version, code, display_name, description,
     os_family, cpu_arch, abi, is_active,
@@ -72,10 +74,10 @@ select
     gen_random_uuid(),
     ores_iam_system_tenant_id_fn(),
     1,
-    'aarch64-unknown-linux-gnu',
-    'Linux ARM64 (GNU libc)',
-    '64-bit ARM (ARMv8-A) Linux using the GNU C Library. Used on AWS Graviton '
-    '2/3/4 instances, Ampere Altra servers, and ARM-based developer boards.',
+    'arm64-linux',
+    'Linux ARM64',
+    '64-bit ARM (ARMv8-A) Linux. Used on AWS Graviton 2/3/4 instances, '
+    'Ampere Altra servers, and ARM-based developer boards.',
     'linux',
     'aarch64',
     'gnu',
@@ -88,70 +90,7 @@ select
     ores_utility_infinity_timestamp_fn()
 where not exists (
     select 1 from ores_compute_platforms_tbl
-    where code = 'aarch64-unknown-linux-gnu'
-      and valid_to = ores_utility_infinity_timestamp_fn()
-);
-
--- Linux x86-64 (musl libc)
-insert into ores_compute_platforms_tbl (
-    id, tenant_id, version, code, display_name, description,
-    os_family, cpu_arch, abi, is_active,
-    modified_by, performed_by, change_reason_code, change_commentary,
-    valid_from, valid_to
-)
-select
-    gen_random_uuid(),
-    ores_iam_system_tenant_id_fn(),
-    1,
-    'x86_64-unknown-linux-musl',
-    'Linux x86-64 (musl libc)',
-    '64-bit x86 Linux using musl libc. Produces fully statically-linked '
-    'binaries with no external libc dependency, suitable for minimal container '
-    'images such as Alpine Linux.',
-    'linux',
-    'x86_64',
-    'musl',
-    true,
-    current_user,
-    current_user,
-    'system.initial_load',
-    '',
-    current_timestamp,
-    ores_utility_infinity_timestamp_fn()
-where not exists (
-    select 1 from ores_compute_platforms_tbl
-    where code = 'x86_64-unknown-linux-musl'
-      and valid_to = ores_utility_infinity_timestamp_fn()
-);
-
--- Linux ARM64 (musl libc)
-insert into ores_compute_platforms_tbl (
-    id, tenant_id, version, code, display_name, description,
-    os_family, cpu_arch, abi, is_active,
-    modified_by, performed_by, change_reason_code, change_commentary,
-    valid_from, valid_to
-)
-select
-    gen_random_uuid(),
-    ores_iam_system_tenant_id_fn(),
-    1,
-    'aarch64-unknown-linux-musl',
-    'Linux ARM64 (musl libc)',
-    '64-bit ARM Linux using musl libc. Statically-linked binaries for ARM, '
-    'suitable for Alpine Linux containers and embedded ARM deployments.',
-    'linux',
-    'aarch64',
-    'musl',
-    true,
-    current_user,
-    current_user,
-    'system.initial_load',
-    '',
-    current_timestamp,
-    ores_utility_infinity_timestamp_fn()
-where not exists (
-    select 1 from ores_compute_platforms_tbl
-    where code = 'aarch64-unknown-linux-musl'
+    where code = 'arm64-linux'
       and valid_to = ores_utility_infinity_timestamp_fn()
 );
 
@@ -166,7 +105,7 @@ select
     gen_random_uuid(),
     ores_iam_system_tenant_id_fn(),
     1,
-    'x86_64-apple-darwin',
+    'x64-osx',
     'macOS Intel',
     '64-bit x86 macOS for Intel processors. Covers all Intel Mac hardware '
     'produced between 2006 and 2023. Requires macOS 10.12 Sierra or later '
@@ -183,7 +122,7 @@ select
     ores_utility_infinity_timestamp_fn()
 where not exists (
     select 1 from ores_compute_platforms_tbl
-    where code = 'x86_64-apple-darwin'
+    where code = 'x64-osx'
       and valid_to = ores_utility_infinity_timestamp_fn()
 );
 
@@ -198,7 +137,7 @@ select
     gen_random_uuid(),
     ores_iam_system_tenant_id_fn(),
     1,
-    'aarch64-apple-darwin',
+    'arm64-osx',
     'macOS Apple Silicon (M-series)',
     '64-bit ARM macOS for Apple Silicon (M1, M2, M3 and later). All new Mac '
     'hardware since November 2020. Native ARM execution with no Rosetta 2 '
@@ -215,11 +154,11 @@ select
     ores_utility_infinity_timestamp_fn()
 where not exists (
     select 1 from ores_compute_platforms_tbl
-    where code = 'aarch64-apple-darwin'
+    where code = 'arm64-osx'
       and valid_to = ores_utility_infinity_timestamp_fn()
 );
 
--- Windows x86-64 (MSVC)
+-- Windows x86-64
 insert into ores_compute_platforms_tbl (
     id, tenant_id, version, code, display_name, description,
     os_family, cpu_arch, abi, is_active,
@@ -230,8 +169,8 @@ select
     gen_random_uuid(),
     ores_iam_system_tenant_id_fn(),
     1,
-    'x86_64-pc-windows-msvc',
-    'Windows x86-64 (MSVC)',
+    'x64-windows',
+    'Windows x86-64',
     '64-bit x86 Windows using the Microsoft Visual C++ runtime (MSVC ABI). '
     'Standard for native Windows applications and the recommended target for '
     'Windows deployment. Requires the MSVC redistributable at runtime.',
@@ -247,11 +186,11 @@ select
     ores_utility_infinity_timestamp_fn()
 where not exists (
     select 1 from ores_compute_platforms_tbl
-    where code = 'x86_64-pc-windows-msvc'
+    where code = 'x64-windows'
       and valid_to = ores_utility_infinity_timestamp_fn()
 );
 
--- Windows x86-64 (MinGW)
+-- Windows ARM64
 insert into ores_compute_platforms_tbl (
     id, tenant_id, version, code, display_name, description,
     os_family, cpu_arch, abi, is_active,
@@ -262,40 +201,8 @@ select
     gen_random_uuid(),
     ores_iam_system_tenant_id_fn(),
     1,
-    'x86_64-pc-windows-gnu',
-    'Windows x86-64 (MinGW)',
-    '64-bit x86 Windows using the GNU toolchain (MinGW-w64). Produces Windows '
-    'executables built with GCC without requiring the MSVC runtime. Compatible '
-    'with MSYS2 and Cygwin environments.',
-    'windows',
-    'x86_64',
-    'mingw',
-    true,
-    current_user,
-    current_user,
-    'system.initial_load',
-    '',
-    current_timestamp,
-    ores_utility_infinity_timestamp_fn()
-where not exists (
-    select 1 from ores_compute_platforms_tbl
-    where code = 'x86_64-pc-windows-gnu'
-      and valid_to = ores_utility_infinity_timestamp_fn()
-);
-
--- Windows ARM64 (MSVC)
-insert into ores_compute_platforms_tbl (
-    id, tenant_id, version, code, display_name, description,
-    os_family, cpu_arch, abi, is_active,
-    modified_by, performed_by, change_reason_code, change_commentary,
-    valid_from, valid_to
-)
-select
-    gen_random_uuid(),
-    ores_iam_system_tenant_id_fn(),
-    1,
-    'aarch64-pc-windows-msvc',
-    'Windows ARM64 (MSVC)',
+    'arm64-windows',
+    'Windows ARM64',
     '64-bit ARM Windows using the MSVC runtime. Targets ARM-based Windows '
     'devices including Microsoft Surface Pro X, Surface Pro 11, and Qualcomm '
     'Snapdragon X Elite laptops.',
@@ -311,7 +218,7 @@ select
     ores_utility_infinity_timestamp_fn()
 where not exists (
     select 1 from ores_compute_platforms_tbl
-    where code = 'aarch64-pc-windows-msvc'
+    where code = 'arm64-windows'
       and valid_to = ores_utility_infinity_timestamp_fn()
 );
 

--- a/projects/ores.utility/include/ores.utility/version/version.hpp.in
+++ b/projects/ores.utility/include/ores.utility/version/version.hpp.in
@@ -27,6 +27,17 @@
 #define ORES_VERSION_PATCH @OreStudio_VERSION_PATCH@
 #define ORES_VERSION "@OreStudio_VERSION_MAJOR@.@OreStudio_VERSION_MINOR@.@OreStudio_VERSION_PATCH@"
 
+/**
+ * @brief The target triplet this binary was built for.
+ *
+ * Stamped at configure time. Sourced from CMake's @c VCPKG_TARGET_TRIPLET
+ * when vcpkg is in use (e.g. @c x64-linux, @c x64-windows, @c arm64-osx);
+ * otherwise synthesized from @c CMAKE_SYSTEM_NAME / @c CMAKE_SYSTEM_PROCESSOR
+ * as a best-effort fallback. Identifies the architecture/OS combination the
+ * binary is compatible with.
+ */
+#define ORES_PLATFORM_TRIPLET "@ORES_PLATFORM_TRIPLET@"
+
 namespace ores::utility::version {
 
 /**
@@ -37,6 +48,15 @@ namespace ores::utility::version {
  * Implemented in a generated .cpp so only that one TU recompiles per build.
  */
 const char* build_info();
+
+/**
+ * @brief Returns the vcpkg target triplet this binary was built for.
+ *
+ * Thin accessor over the @c ORES_PLATFORM_TRIPLET macro for use at
+ * runtime (e.g. when the triplet needs to be included in a heartbeat
+ * payload sent to a service).
+ */
+const char* platform_triplet();
 
 /**
  * @brief Formats a startup message with version and build info.

--- a/projects/ores.utility/src/CMakeLists.txt
+++ b/projects/ores.utility/src/CMakeLists.txt
@@ -24,9 +24,35 @@ file(GLOB_RECURSE files RELATIVE
     "${CMAKE_CURRENT_SOURCE_DIR}/"
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 
-# version.hpp: stable between builds — only contains version number macros
-# and function declarations. Generated once at configure time via
-# configure_file(); never touched again unless the version changes.
+# version.hpp: stable between builds — only contains version number macros,
+# the platform triplet, and function declarations. Generated once at configure
+# time via configure_file(); never touched again unless the inputs change.
+#
+# Platform triplet: prefer vcpkg's canonical value when available; otherwise
+# synthesize a best-effort <arch>-<os> string from CMake's own probes so
+# non-vcpkg builds still produce a usable identifier. A warning is emitted
+# in the fallback path because the synthesized value is unlikely to match a
+# compute platforms table entry verbatim.
+if(VCPKG_TARGET_TRIPLET)
+    set(ORES_PLATFORM_TRIPLET "${VCPKG_TARGET_TRIPLET}")
+else()
+    string(TOLOWER "${CMAKE_SYSTEM_NAME}" _ores_triplet_os)
+    if(_ores_triplet_os STREQUAL "darwin")
+        set(_ores_triplet_os "osx")
+    endif()
+    string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _ores_triplet_arch)
+    if(_ores_triplet_arch MATCHES "^(x86_64|amd64)$")
+        set(_ores_triplet_arch "x64")
+    elseif(_ores_triplet_arch MATCHES "^(aarch64|arm64)$")
+        set(_ores_triplet_arch "arm64")
+    endif()
+    set(ORES_PLATFORM_TRIPLET "${_ores_triplet_arch}-${_ores_triplet_os}")
+    message(WARNING
+        "VCPKG_TARGET_TRIPLET is not set; synthesized platform triplet "
+        "'${ORES_PLATFORM_TRIPLET}' from CMAKE_SYSTEM_* variables. This "
+        "value may not match an entry in the compute platforms table; "
+        "set VCPKG_TARGET_TRIPLET explicitly to silence this warning.")
+endif()
 set(generated_include_dir "${CMAKE_CURRENT_BINARY_DIR}/include")
 set(generated_version_dir "${generated_include_dir}/ores.utility/version")
 set(version_hpp_in  "${CMAKE_SOURCE_DIR}/projects/ores.utility/include/ores.utility/version/version.hpp.in")

--- a/projects/ores.utility/src/version/version.cpp.in
+++ b/projects/ores.utility/src/version/version.cpp.in
@@ -29,9 +29,14 @@ const char* build_info() {
     return "@ORES_BUILD_INFO@";
 }
 
+const char* platform_triplet() {
+    return ORES_PLATFORM_TRIPLET;
+}
+
 std::string format_startup_message(const std::string& service_name) {
     std::ostringstream ss;
     ss << "Starting " << service_name << " v" ORES_VERSION
+       << " [" << ORES_PLATFORM_TRIPLET << "]"
        << " (" << build_info()
        << " " << ores::platform::process::executable_build_time() << ")";
     return ss.str();
@@ -41,6 +46,7 @@ std::string format_startup_message(const std::string& service_name,
     std::uint16_t protocol_major, std::uint16_t protocol_minor) {
     std::ostringstream ss;
     ss << "Starting " << service_name << " v" ORES_VERSION
+       << " [" << ORES_PLATFORM_TRIPLET << "]"
        << " Protocol " << protocol_major << "." << protocol_minor
        << " (" << build_info()
        << " " << ores::platform::process::executable_build_time() << ")";


### PR DESCRIPTION
## Summary

Each app_version now carries one packaged bundle per target triplet rather than a single blob shared across platforms. The orchestrator resolves the URI at dispatch time and routes assignments on triplet-scoped NATS subjects so wrappers only receive work they can actually run.

- **Schema** (`13192c3de`): `package_uri` moved from `ores_compute_app_versions_tbl` to the `ores_compute_app_version_platforms_tbl` junction; platform codes switched to vcpkg triplets (`x64-linux`, `arm64-osx`, ...) so build-time (`VCPKG_TARGET_TRIPLET`), runtime (`ORES_PLATFORM_TRIPLET`) and DB rows all share one canonical key.
- **Wrapper version banner** (`c7d8c605f`): stamps the platform triplet into version info.
- **C++ cutover** (`7b0acca53`): new `app_version_platform` domain type + repository (`list_for_version`, `replace_for_version`); `save_app_version_request` now carries `std::vector<app_version_platform>` and the handler syncs both tables in one request; `workunit_handler` looks up per-platform packages and publishes each assignment on `compute.v1.work.assignments.{tenant}.{triplet}`; wrappers subscribe only to their own triplet. CLI replaces `--platform`/`--package-uri` with repeatable `--platform-package '<code>=<uri>'`. Qt list model drops Platform/PackageUri columns; detail dialog and provisioner wizard build junction rows on save.
- **Edit-mode preload** (`5d5e14794`): new `list_app_version_platforms` RPC so opening an existing app_version populates the platforms tab instead of silently wiping the set on save.
- **Tests & diagrams** (`bffa14d9c`): domain tests for `app_version_platform`; component class diagram refreshed; ER diagram regenerated from the SQL schema.

## Follow-ups (deferred)

- Per-platform upload UI — today the wizard applies one URI to every selected triplet (placeholder). A row-per-platform browse/upload flow will require a separate UX pass.
- Repository + handler integration tests for the junction sync path (the service-layer tests we have cover the domain but not the replace_for_version round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)