### PR TITLE
[vcpkg] Add opt-in qt feature for Windows users

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -45,7 +45,14 @@
         },
         "qt": {
             "description": "Build Qt6 from vcpkg (slow — prefer an external Qt install if available)",
-            "dependencies": [ "qtbase", "qtsvg", "qtcharts" ]
+            "dependencies": [
+                {
+                    "name": "qtbase",
+                    "features": [ "concurrent", "gui", "network", "widgets" ]
+                },
+                "qtsvg",
+                "qtcharts"
+            ]
         }
     }
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -42,6 +42,10 @@
         "wt": {
             "description": "Build the Wt web interface",
             "dependencies": [ "wt" ]
+        },
+        "qt": {
+            "description": "Build Qt6 from vcpkg (slow — prefer an external Qt install if available)",
+            "dependencies": [ "qtbase", "qtsvg", "qtcharts" ]
         }
     }
 }


### PR DESCRIPTION
## Summary

Some Windows users struggle to install Qt externally (e.g. Qt online
installer issues, path setup, or not wanting a system-wide Qt). Expose
Qt behind an optional vcpkg manifest feature so they can build
everything from a single manifest.

- `qtbase` covers `Qt6::Core`, `Qt6::Gui`, `Qt6::Widgets`,
  `Qt6::Concurrent`, and `Qt6::Network` via its default features.
- `qtsvg` covers `Qt6::Svg`.
- `qtcharts` covers `Qt6::Charts`.

Together this matches the `find_package(Qt6 REQUIRED COMPONENTS Core
Gui Widgets Concurrent Network Svg Charts)` in the top-level
`CMakeLists.txt`.

## Usage

```
cmake <your-windows-preset> -DVCPKG_MANIFEST_FEATURES=qt
```

Users who also want Wt should pass both — `VCPKG_MANIFEST_FEATURES`
replaces defaults rather than appending:

```
cmake <your-windows-preset> -DVCPKG_MANIFEST_FEATURES="wt;qt"
```

## CI impact

None. `qt` is not in `default-features`; only the existing `wt` default
is active when no flag is passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)