### PR TITLE
[refdata] deposit_convention: Phase 2 first type

### DIFF
--- a/projects/ores.codegen/library/profiles.json
+++ b/projects/ores.codegen/library/profiles.json
@@ -10,6 +10,11 @@
           "model_types": ["domain_entity"]
         },
         {
+          "template": "sql_schema_notify_trigger.mustache",
+          "output": "projects/ores.sql/create/{component}/{component}_{entity_plural}_notify_trigger_create.sql",
+          "model_types": ["domain_entity"]
+        },
+        {
           "template": "sql_schema_junction_create.mustache",
           "output": "projects/ores.sql/create/{component}/{component}_{entity}_create.sql",
           "model_types": ["junction"]

--- a/projects/ores.codegen/library/profiles.json
+++ b/projects/ores.codegen/library/profiles.json
@@ -15,6 +15,16 @@
           "model_types": ["domain_entity"]
         },
         {
+          "template": "sql_schema_domain_entity_drop.mustache",
+          "output": "projects/ores.sql/drop/{component}/{component}_{entity_plural}_drop.sql",
+          "model_types": ["domain_entity"]
+        },
+        {
+          "template": "sql_schema_notify_trigger_drop.mustache",
+          "output": "projects/ores.sql/drop/{component}/{component}_{entity_plural}_notify_trigger_drop.sql",
+          "model_types": ["domain_entity"]
+        },
+        {
           "template": "sql_schema_junction_create.mustache",
           "output": "projects/ores.sql/create/{component}/{component}_{entity}_create.sql",
           "model_types": ["junction"]

--- a/projects/ores.codegen/library/templates/cpp_domain_type_generator.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_generator.cpp.mustache
@@ -3,6 +3,7 @@
 #include "ores.{{component_include}}/{{generator_facet_name}}/{{entity_singular}}_generator.hpp"
 
 #include <atomic>
+#include <string>
 #include <faker-cxx/faker.h> // IWYU pragma: keep.
 #include "ores.utility/generation/generation_keys.hpp"
 
@@ -19,7 +20,8 @@ domain::{{entity_singular}} generate_synthetic_{{entity_singular}}(
     domain::{{entity_singular}} r;
     r.version = 1;
 {{#primary_key.is_text}}
-    r.{{primary_key.column}} = {{{primary_key.generator_expr}}};
+    r.{{primary_key.column}} = {{{primary_key.generator_expr}}} + "-"
+        + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
 {{/primary_key.is_text}}
 {{#primary_key.is_uuid}}
     r.{{primary_key.column}} = ctx.generate_uuid();

--- a/projects/ores.codegen/library/templates/cpp_qt_client_model.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_client_model.cpp.mustache
@@ -79,6 +79,9 @@ QVariant Client{{domain_entity.entity_pascal}}Model::data(
 {{#is_int}}
             return static_cast<qlonglong>({{domain_entity.qt.item_var}}.{{field}});
 {{/is_int}}
+{{#is_bool}}
+            return {{domain_entity.qt.item_var}}.{{field}} ? tr("true") : tr("false");
+{{/is_bool}}
 {{#is_timestamp}}
             return relative_time_helper::format({{domain_entity.qt.item_var}}.{{field}});
 {{/is_timestamp}}

--- a/projects/ores.codegen/library/templates/cpp_qt_detail_dialog.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_detail_dialog.cpp.mustache
@@ -226,6 +226,25 @@ void {{domain_entity.entity_pascal}}DetailDialog::updateUiFrom{{domain_entity.en
     ui_->{{widget}}->setPlainText(QString::fromStdString({{domain_entity.qt.item_var}}_.{{field}}));
 {{/is_optional_string}}
 {{/is_text_edit}}
+{{#is_check_box}}
+{{#is_tristate}}
+    ui_->{{widget}}->setCheckState({{domain_entity.qt.item_var}}_.{{field}}
+        ? (*{{domain_entity.qt.item_var}}_.{{field}} ? Qt::Checked : Qt::Unchecked)
+        : Qt::PartiallyChecked);
+{{/is_tristate}}
+{{^is_tristate}}
+    ui_->{{widget}}->setChecked({{domain_entity.qt.item_var}}_.{{field}});
+{{/is_tristate}}
+{{/is_check_box}}
+{{#is_spin_box}}
+{{#is_nullable_int}}
+    ui_->{{widget}}->setValue({{domain_entity.qt.item_var}}_.{{field}}.value_or(
+        ui_->{{widget}}->minimum()));
+{{/is_nullable_int}}
+{{^is_nullable_int}}
+    ui_->{{widget}}->setValue({{domain_entity.qt.item_var}}_.{{field}});
+{{/is_nullable_int}}
+{{/is_spin_box}}
 {{#is_static_combo}}
     {
         const int idx = ui_->{{widget}}->findData(
@@ -293,6 +312,35 @@ void {{domain_entity.entity_pascal}}DetailDialog::update{{domain_entity.entity_p
     {{domain_entity.qt.item_var}}_.{{field}} = ui_->{{widget}}->toPlainText().trimmed().toStdString();
 {{/is_optional_string}}
 {{/is_text_edit}}
+{{#is_check_box}}
+{{#is_tristate}}
+    switch (ui_->{{widget}}->checkState()) {
+    case Qt::Checked:
+        {{domain_entity.qt.item_var}}_.{{field}} = std::optional<bool>(true);
+        break;
+    case Qt::Unchecked:
+        {{domain_entity.qt.item_var}}_.{{field}} = std::optional<bool>(false);
+        break;
+    default:
+        {{domain_entity.qt.item_var}}_.{{field}} = std::nullopt;
+        break;
+    }
+{{/is_tristate}}
+{{^is_tristate}}
+    {{domain_entity.qt.item_var}}_.{{field}} = ui_->{{widget}}->isChecked();
+{{/is_tristate}}
+{{/is_check_box}}
+{{#is_spin_box}}
+{{#is_nullable_int}}
+    if (ui_->{{widget}}->value() == ui_->{{widget}}->minimum())
+        {{domain_entity.qt.item_var}}_.{{field}} = std::nullopt;
+    else
+        {{domain_entity.qt.item_var}}_.{{field}} = ui_->{{widget}}->value();
+{{/is_nullable_int}}
+{{^is_nullable_int}}
+    {{domain_entity.qt.item_var}}_.{{field}} = ui_->{{widget}}->value();
+{{/is_nullable_int}}
+{{/is_spin_box}}
 {{#is_static_combo}}
     {{domain_entity.qt.item_var}}_.{{field}} =
         ui_->{{widget}}->currentData().toString().toStdString();

--- a/projects/ores.codegen/library/templates/cpp_qt_history_dialog.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_history_dialog.cpp.mustache
@@ -265,10 +265,38 @@ void {{domain_entity.entity_pascal}}HistoryDialog::updateChangesTable(int curren
                   previous.{{field}} ? QString::fromStdString(*previous.{{field}}) : QString{},
                   current.{{field}} ? QString::fromStdString(*current.{{field}}) : QString{});
 {{/is_optional_string}}
+{{#is_tristate}}
+        addChange("{{label}}",
+                  previous.{{field}} ? (*previous.{{field}} ? tr("true") : tr("false")) : tr("(unset)"),
+                  current.{{field}} ? (*current.{{field}} ? tr("true") : tr("false")) : tr("(unset)"));
+{{/is_tristate}}
+{{#is_check_box}}
+{{^is_tristate}}
+        addChange("{{label}}",
+                  previous.{{field}} ? tr("true") : tr("false"),
+                  current.{{field}} ? tr("true") : tr("false"));
+{{/is_tristate}}
+{{/is_check_box}}
+{{#is_nullable_int}}
+        addChange("{{label}}",
+                  previous.{{field}} ? QString::number(*previous.{{field}}) : tr("(unset)"),
+                  current.{{field}} ? QString::number(*current.{{field}}) : tr("(unset)"));
+{{/is_nullable_int}}
+{{#is_spin_box}}
+{{^is_nullable_int}}
+        addChange("{{label}}",
+                  QString::number(previous.{{field}}),
+                  QString::number(current.{{field}}));
+{{/is_nullable_int}}
+{{/is_spin_box}}
 {{^is_optional_string}}
+{{^is_check_box}}
+{{^is_spin_box}}
         addChange("{{label}}",
                   QString::fromStdString(previous.{{field}}),
                   QString::fromStdString(current.{{field}}));
+{{/is_spin_box}}
+{{/is_check_box}}
 {{/is_optional_string}}
     }
 
@@ -297,8 +325,32 @@ void {{domain_entity.entity_pascal}}HistoryDialog::updateFullDetails(int version
         ? QString::fromStdString(*version.{{field}})
         : QString{});
 {{/is_optional_string}}
+{{#is_tristate}}
+    ui_->{{value_widget}}->setText(version.{{field}}
+        ? (*version.{{field}} ? tr("true") : tr("false"))
+        : tr("(unset)"));
+{{/is_tristate}}
+{{#is_check_box}}
+{{^is_tristate}}
+    ui_->{{value_widget}}->setText(version.{{field}} ? tr("true") : tr("false"));
+{{/is_tristate}}
+{{/is_check_box}}
+{{#is_nullable_int}}
+    ui_->{{value_widget}}->setText(version.{{field}}
+        ? QString::number(*version.{{field}})
+        : tr("(unset)"));
+{{/is_nullable_int}}
+{{#is_spin_box}}
+{{^is_nullable_int}}
+    ui_->{{value_widget}}->setText(QString::number(version.{{field}}));
+{{/is_nullable_int}}
+{{/is_spin_box}}
 {{^is_optional_string}}
+{{^is_check_box}}
+{{^is_spin_box}}
     ui_->{{value_widget}}->setText(QString::fromStdString(version.{{field}}));
+{{/is_spin_box}}
+{{/is_check_box}}
 {{/is_optional_string}}
 {{/domain_entity.qt.detail_fields}}
     ui_->versionNumberValue->setText(QString::number(version.version));

--- a/projects/ores.codegen/library/templates/qt_detail_dialog_ui.mustache
+++ b/projects/ores.codegen/library/templates/qt_detail_dialog_ui.mustache
@@ -87,6 +87,33 @@
             </property>
            </widget>
 {{/is_dynamic_combo}}
+{{#is_check_box}}
+           <widget class="QCheckBox" name="{{widget}}">
+            <property name="text">
+             <string/>
+            </property>
+{{#is_tristate}}
+            <property name="tristate">
+             <bool>true</bool>
+            </property>
+{{/is_tristate}}
+           </widget>
+{{/is_check_box}}
+{{#is_spin_box}}
+           <widget class="QSpinBox" name="{{widget}}">
+            <property name="minimum">
+             <number>{{spin_min}}</number>
+            </property>
+            <property name="maximum">
+             <number>{{spin_max}}</number>
+            </property>
+{{#is_nullable_int}}
+            <property name="specialValueText">
+             <string>(unset)</string>
+            </property>
+{{/is_nullable_int}}
+           </widget>
+{{/is_spin_box}}
           </item>
 {{/domain_entity.qt.detail_fields}}
          </layout>

--- a/projects/ores.codegen/library/templates/sql_schema_domain_entity_drop.mustache
+++ b/projects/ores.codegen/library/templates/sql_schema_domain_entity_drop.mustache
@@ -1,0 +1,9 @@
+{{! Template to generate SQL drop script for a domain entity table }}
+{{{sql_license}}}
+{{#domain_entity}}
+
+drop rule if exists {{product}}_{{component}}_{{entity_plural}}_delete_rule on "{{product}}_{{component}}_{{entity_plural}}_tbl";
+drop trigger if exists {{product}}_{{component}}_{{entity_plural}}_insert_trg on "{{product}}_{{component}}_{{entity_plural}}_tbl";
+drop function if exists {{product}}_{{component}}_{{entity_plural}}_insert_fn;
+drop table if exists "{{product}}_{{component}}_{{entity_plural}}_tbl";
+{{/domain_entity}}

--- a/projects/ores.codegen/library/templates/sql_schema_notify_trigger.mustache
+++ b/projects/ores.codegen/library/templates/sql_schema_notify_trigger.mustache
@@ -1,41 +1,43 @@
 {{! Template to generate SQL notification trigger for entity changes }}
 {{{sql_license}}}
+{{#domain_entity}}
 /*
  * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
  * Template: sql_schema_notify_trigger.mustache
  * To modify, update the template and regenerate.
  */
 
-create or replace function {{entity.product}}_{{entity.component}}_{{entity.entity_plural}}_notify_fn()
+create or replace function {{product}}_{{component}}_{{entity_plural}}_notify_fn()
 returns trigger as $$
 declare
     notification_payload jsonb;
-    entity_name text := '{{entity.product}}.{{entity.component}}.{{entity.entity_singular}}';
+    entity_name text := '{{product}}.{{component}}.{{entity_singular}}';
     change_timestamp timestamptz := NOW();
-    changed_{{entity.primary_key.column}} {{entity.primary_key.type}};
+    changed_{{primary_key.column}} {{primary_key.type}};
     changed_tenant_id text;
 begin
     if TG_OP = 'DELETE' then
-        changed_{{entity.primary_key.column}} := OLD.{{entity.primary_key.column}};
+        changed_{{primary_key.column}} := OLD.{{primary_key.column}};
         changed_tenant_id := OLD.tenant_id::text;
     else
-        changed_{{entity.primary_key.column}} := NEW.{{entity.primary_key.column}};
+        changed_{{primary_key.column}} := NEW.{{primary_key.column}};
         changed_tenant_id := NEW.tenant_id::text;
     end if;
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
         'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
-        'entity_ids', jsonb_build_array(changed_{{entity.primary_key.column}}),
+        'entity_ids', jsonb_build_array(changed_{{primary_key.column}}),
         'tenant_id', changed_tenant_id
     );
 
-    perform pg_notify('{{entity.product}}_{{entity.entity_plural}}', notification_payload::text);
+    perform pg_notify('{{product}}_{{entity_plural}}', notification_payload::text);
 
     return null;
 end;
 $$ language plpgsql;
 
-create or replace trigger {{entity.product}}_{{entity.component}}_{{entity.entity_plural}}_notify_trg
-after insert or update or delete on {{entity.product}}_{{entity.component}}_{{entity.entity_plural}}_tbl
-for each row execute function {{entity.product}}_{{entity.component}}_{{entity.entity_plural}}_notify_fn();
+create or replace trigger {{product}}_{{component}}_{{entity_plural}}_notify_trg
+after insert or update or delete on {{product}}_{{component}}_{{entity_plural}}_tbl
+for each row execute function {{product}}_{{component}}_{{entity_plural}}_notify_fn();
+{{/domain_entity}}

--- a/projects/ores.codegen/library/templates/sql_schema_notify_trigger_drop.mustache
+++ b/projects/ores.codegen/library/templates/sql_schema_notify_trigger_drop.mustache
@@ -1,0 +1,7 @@
+{{! Template to generate SQL drop script for a domain entity notify trigger }}
+{{{sql_license}}}
+{{#domain_entity}}
+
+drop trigger if exists {{product}}_{{component}}_{{entity_plural}}_notify_trg on "{{product}}_{{component}}_{{entity_plural}}_tbl";
+drop function if exists {{product}}_{{component}}_{{entity_plural}}_notify_fn;
+{{/domain_entity}}

--- a/projects/ores.codegen/models/refdata/deposit_convention_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/deposit_convention_domain_entity.json
@@ -1,0 +1,162 @@
+{
+  "domain_entity": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
+    "has_tenant_id": true,
+    "entity_singular": "deposit_convention",
+    "entity_plural": "deposit_conventions",
+    "entity_title": "Deposit Convention",
+    "brief": "Conventions for a money-market deposit or IBOR index fixing.",
+    "description": "Specifies the settlement lag, calendar, and day count for short-term\ndeposits used as the near-end instruments when bootstrapping a yield\ncurve. Corresponds to the <Deposit> element in ORE conventions.xml.\nWhen index_based is true the remaining fields may be omitted and are\ninstead inherited from the referenced IBOR index convention.",
+
+    "primary_key": {
+      "column": "id",
+      "type": "text",
+      "cpp_type": "std::string",
+      "description": "Unique convention identifier.",
+      "detail": "Examples: 'USD-LIBOR-CONVENTIONS', 'EUR-EURIBOR-CONVENTIONS'.",
+      "generator_expr": "std::string(\"USD-LIBOR-CONVENTIONS\")"
+    },
+
+    "natural_keys": [],
+
+    "columns": [
+      {
+        "name": "index_based",
+        "type": "boolean",
+        "cpp_type": "bool",
+        "nullable": false,
+        "description": "Whether the deposit conventions are derived from an IBOR index. When true, index must be set and the remaining fields are optional.",
+        "generator_expr": "true"
+      },
+      {
+        "name": "index",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "IBOR index identifier (e.g. 'USD-LIBOR') used when index_based.",
+        "generator_expr": "std::string(\"USD-LIBOR\")"
+      },
+      {
+        "name": "calendar",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "Settlement calendar (e.g. 'TARGET', 'US-FED').",
+        "generator_expr": "std::nullopt"
+      },
+      {
+        "name": "convention",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "Business day convention applied to settlement dates (canonical FpML).",
+        "generator_expr": "std::nullopt"
+      },
+      {
+        "name": "end_of_month",
+        "type": "boolean",
+        "cpp_type": "std::optional<bool>",
+        "nullable": true,
+        "description": "Whether end-of-month convention applies.",
+        "generator_expr": "std::nullopt"
+      },
+      {
+        "name": "day_count_fraction",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "Day count fraction code (canonical FpML, e.g. 'ACT/360').",
+        "generator_expr": "std::nullopt"
+      },
+      {
+        "name": "settlement_days",
+        "type": "integer",
+        "cpp_type": "std::optional<int>",
+        "nullable": true,
+        "description": "Number of business days from trade date to settlement.",
+        "generator_expr": "std::nullopt"
+      }
+    ],
+
+    "sql": {
+      "tablename": "ores_refdata_deposit_conventions_tbl"
+    },
+
+    "repository": {
+      "entity_singular_short": "deposit_convention",
+      "entity_plural_short": "deposit_conventions",
+      "entity_singular_words": "deposit convention",
+      "entity_plural_words": "deposit conventions"
+    },
+
+    "cpp": {
+      "includes": {
+        "domain": ["<chrono>", "<string>", "<optional>"],
+        "entity": ["<string>", "<optional>", "\"sqlgen/Timestamp.hpp\""]
+      },
+      "iterator_var": "dc",
+      "table_display": [
+        {"column": "id", "header": "Id"},
+        {"column": "index_based", "header": "Index Based"},
+        {"column": "index", "header": "Index"},
+        {"column": "calendar", "header": "Calendar"},
+        {"column": "day_count_fraction", "header": "DCF"},
+        {"column": "modified_by", "header": "Modified By"},
+        {"column": "version", "header": "Version"}
+      ]
+    },
+
+    "qt": {
+      "collection_name": "deposit_conventions",
+      "item_var": "dc",
+      "key_field": "id",
+      "has_uuid_primary_key": false,
+
+      "get_request_class": "refdata::messaging::get_deposit_conventions_request",
+      "get_response_class": "refdata::messaging::get_deposit_conventions_response",
+      "get_message_type": "get_deposit_conventions_request",
+      "save_request_class": "refdata::messaging::save_deposit_convention_request",
+      "save_response_class": "refdata::messaging::save_deposit_convention_response",
+      "save_message_type": "save_deposit_convention_request",
+      "save_request_item_field": "deposit_convention",
+      "delete_request_class": "refdata::messaging::delete_deposit_convention_request",
+      "delete_response_class": "refdata::messaging::delete_deposit_convention_response",
+      "delete_message_type": "delete_deposit_convention_request",
+      "history_request_class": "refdata::messaging::get_deposit_convention_history_request",
+      "history_response_class": "refdata::messaging::get_deposit_convention_history_response",
+      "history_message_type": "get_deposit_convention_history_request",
+
+      "detail_fields": [
+        {"field": "id", "label": "Id", "widget": "idEdit", "type": "line_edit",
+         "is_key": true, "is_required": true, "placeholder": "Enter convention id"},
+        {"field": "index", "label": "Index", "widget": "indexEdit",
+         "type": "line_edit", "placeholder": "e.g. USD-LIBOR"},
+        {"field": "calendar", "label": "Calendar", "widget": "calendarEdit",
+         "type": "line_edit", "placeholder": "e.g. TARGET"},
+        {"field": "convention", "label": "Convention", "widget": "conventionEdit",
+         "type": "line_edit", "placeholder": "e.g. Following"},
+        {"field": "day_count_fraction", "label": "Day Count Fraction", "widget": "dayCountFractionEdit",
+         "type": "line_edit", "placeholder": "e.g. ACT/360"}
+      ],
+
+      "columns": [
+        {"enum_name": "Id", "field": "id", "header": "Id", "is_string": true, "width": 200},
+        {"enum_name": "IndexBased", "field": "index_based", "header": "Index Based", "is_bool": true, "width": 100},
+        {"enum_name": "Index", "field": "index", "header": "Index", "is_string": true, "width": 140},
+        {"enum_name": "Calendar", "field": "calendar", "header": "Calendar", "is_string": true, "width": 120},
+        {"enum_name": "DayCountFraction", "field": "day_count_fraction", "header": "DCF", "is_string": true, "width": 100},
+        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
+        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
+        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+      ],
+
+      "settings_group": "DepositConventionListWindow",
+      "window_title": "Deposit Conventions",
+      "icon": "Chart"
+    }
+  }
+}

--- a/projects/ores.codegen/models/refdata/deposit_convention_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/deposit_convention_domain_entity.json
@@ -133,6 +133,8 @@
       "detail_fields": [
         {"field": "id", "label": "Id", "widget": "idEdit", "type": "line_edit",
          "is_key": true, "is_required": true, "placeholder": "Enter convention id"},
+        {"field": "index_based", "label": "Index Based", "widget": "indexBasedEdit",
+         "type": "check_box"},
         {"field": "index", "label": "Index", "widget": "indexEdit",
          "type": "line_edit", "placeholder": "e.g. USD-LIBOR"},
         {"field": "calendar", "label": "Calendar", "widget": "calendarEdit",
@@ -140,7 +142,11 @@
         {"field": "convention", "label": "Convention", "widget": "conventionEdit",
          "type": "line_edit", "placeholder": "e.g. Following"},
         {"field": "day_count_fraction", "label": "Day Count Fraction", "widget": "dayCountFractionEdit",
-         "type": "line_edit", "placeholder": "e.g. ACT/360"}
+         "type": "line_edit", "placeholder": "e.g. ACT/360"},
+        {"field": "end_of_month", "label": "End Of Month", "widget": "endOfMonthEdit",
+         "type": "check_box"},
+        {"field": "settlement_days", "label": "Settlement Days", "widget": "settlementDaysEdit",
+         "type": "spin_box", "spin_min": -1, "spin_max": 30}
       ],
 
       "columns": [

--- a/projects/ores.codegen/src/generator.py
+++ b/projects/ores.codegen/src/generator.py
@@ -1251,6 +1251,17 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
                     and not is_uuid_type
                     and not is_already_optional
                 )
+                # Supply a safe default for non-nullable scalar types that
+                # would otherwise leave the domain struct with an
+                # indeterminate value. Nullable fields wrap in optional so
+                # they default to nullopt; only bool/int need an explicit
+                # default. The model may override via default_value.
+                if not col.get('default_value') and col['is_simple']:
+                    cpp_type = col.get('cpp_type', '')
+                    if cpp_type == 'bool':
+                        col['default_value'] = 'false'
+                    elif cpp_type == 'int':
+                        col['default_value'] = '0'
                 col['iter_var'] = iter_var
         if 'natural_keys' in domain_entity:
             _mark_last_item(domain_entity['natural_keys'])
@@ -1403,11 +1414,27 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
                 f['is_text_edit'] = f.get('type') == 'text_edit'
                 f['is_static_combo'] = f.get('type') == 'static_combo'
                 f['is_dynamic_combo'] = f.get('type') == 'dynamic_combo'
+                f['is_check_box'] = f.get('type') == 'check_box'
+                f['is_spin_box'] = f.get('type') == 'spin_box'
                 field_cpp = domain_col_types.get(f.get('field'), '')
                 f['is_optional_string'] = (
                     field_cpp.startswith('std::optional<std::string>')
                     and (f['is_line_edit'] or f['is_text_edit'])
                 )
+                # Tri-state checkbox for optional<bool>; normal two-state
+                # for plain bool. Nullable spin box uses minimum as sentinel.
+                f['is_tristate'] = (
+                    f['is_check_box']
+                    and field_cpp.startswith('std::optional<bool>')
+                )
+                f['is_nullable_int'] = (
+                    f['is_spin_box']
+                    and field_cpp.startswith('std::optional<int>')
+                )
+                # Default spin box range (overridable via model)
+                if f['is_spin_box']:
+                    f.setdefault('spin_min', -1 if f['is_nullable_int'] else 0)
+                    f.setdefault('spin_max', 9999)
                 f['_is_first'] = (i == 0)
                 f['_is_last'] = (i == len(detail_fields) - 1)
                 f['_row_index'] = i

--- a/projects/ores.qt.refdata/include/ores.qt/ClientDepositConventionModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientDepositConventionModel.hpp
@@ -1,0 +1,156 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CLIENT_DEPOSIT_CONVENTION_MODEL_HPP
+#define ORES_QT_CLIENT_DEPOSIT_CONVENTION_MODEL_HPP
+
+#include <vector>
+#include <QFutureWatcher>
+#include <QAbstractTableModel>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/RecencyPulseManager.hpp"
+#include "ores.qt/RecencyTracker.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/deposit_convention.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief Model for displaying deposit conventions fetched from the server.
+ *
+ * This model extends QAbstractTableModel and fetches deposit convention
+ * data asynchronously using the ores.comms client.
+ */
+class ClientDepositConventionModel final : public QAbstractTableModel {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.client_deposit_convention_model";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    /**
+     * @brief Enumeration of table columns for type-safe column access.
+     */
+    enum Column {
+        Id,
+        IndexBased,
+        Index,
+        Calendar,
+        DayCountFraction,
+        Version,
+        ModifiedBy,
+        RecordedAt,
+        ColumnCount
+    };
+
+    explicit ClientDepositConventionModel(ClientManager* clientManager,
+                                       QObject* parent = nullptr);
+    ~ClientDepositConventionModel() override = default;
+
+    // QAbstractTableModel interface
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+        int role = Qt::DisplayRole) const override;
+
+    /**
+     * @brief Refresh deposit convention data from server asynchronously.
+     */
+    void refresh();
+
+    /**
+     * @brief Get deposit convention at the specified row.
+     *
+     * @param row The row index.
+     * @return The deposit convention, or nullptr if row is invalid.
+     */
+    const refdata::domain::deposit_convention* getConvention(int row) const;
+
+    /**
+     * @brief Load a specific page of data.
+     */
+    void load_page(std::uint32_t offset, std::uint32_t limit);
+
+    /**
+     * @brief Get the page size used for pagination.
+     */
+    std::uint32_t page_size() const { return page_size_; }
+
+    /**
+     * @brief Set the page size for pagination.
+     */
+    void set_page_size(std::uint32_t size);
+
+    /**
+     * @brief Get the total number of records available on the server.
+     */
+    std::uint32_t total_available_count() const { return total_available_count_; }
+
+signals:
+    /**
+     * @brief Emitted when data has been successfully loaded.
+     */
+    void dataLoaded();
+
+    /**
+     * @brief Emitted when an error occurs during data loading.
+     */
+    void loadError(const QString& error_message, const QString& details = {});
+
+private slots:
+    void onConventionsLoaded();
+    void onPulseStateChanged(bool isOn);
+    void onPulsingComplete();
+
+private:
+    QVariant recency_foreground_color(const std::string& code) const;
+
+    struct FetchResult {
+        bool success;
+        std::vector<refdata::domain::deposit_convention> deposit_conventions;
+        std::uint32_t total_available_count;
+        QString error_message;
+        QString error_details;
+    };
+
+    void fetch_deposit_conventions(std::uint32_t offset, std::uint32_t limit);
+
+    ClientManager* clientManager_;
+    std::vector<refdata::domain::deposit_convention> deposit_conventions_;
+    QFutureWatcher<FetchResult>* watcher_;
+    std::uint32_t page_size_{100};
+    std::uint32_t total_available_count_{0};
+    bool is_fetching_{false};
+
+    using DepositConventionKeyExtractor = std::string(*)(const refdata::domain::deposit_convention&);
+    RecencyTracker<refdata::domain::deposit_convention, DepositConventionKeyExtractor> recencyTracker_;
+    RecencyPulseManager* pulseManager_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/DepositConventionController.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/DepositConventionController.hpp
@@ -1,0 +1,93 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_DEPOSIT_CONVENTION_CONTROLLER_HPP
+#define ORES_QT_DEPOSIT_CONVENTION_CONTROLLER_HPP
+
+#include <QMdiArea>
+#include <QMainWindow>
+#include "ores.qt/EntityController.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/deposit_convention.hpp"
+#include "ores.qt/EntityListMdiWindow.hpp"
+
+namespace ores::qt {
+
+class DepositConventionMdiWindow;
+class DetachableMdiSubWindow;
+
+/**
+ * @brief Controller for managing deposit convention windows and operations.
+ *
+ * Manages the lifecycle of deposit convention list, detail, and history windows.
+ * Handles event subscriptions and coordinates between windows.
+ */
+class DepositConventionController final : public EntityController {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.deposit_convention_controller";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    DepositConventionController(
+        QMainWindow* mainWindow,
+        QMdiArea* mdiArea,
+        ClientManager* clientManager,
+        const QString& username,
+        QObject* parent = nullptr);
+
+    void showListWindow() override;
+    void closeAllWindows() override;
+    void reloadListWindow() override;
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& error);
+
+protected:
+    EntityListMdiWindow* listWindow() const override;
+
+private slots:
+    void onShowDetails(const refdata::domain::deposit_convention& dc);
+    void onAddNewRequested();
+    void onShowHistory(const refdata::domain::deposit_convention& dc);
+    void onRevertVersion(const refdata::domain::deposit_convention& dc);
+    void onOpenVersion(const refdata::domain::deposit_convention& dc,
+                       int versionNumber);
+
+private:
+    void showAddWindow();
+    void showDetailWindow(const refdata::domain::deposit_convention& dc);
+    void showHistoryWindow(const QString& code);
+
+    DepositConventionMdiWindow* listWindow_;
+    DetachableMdiSubWindow* listMdiSubWindow_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/DepositConventionDetailDialog.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/DepositConventionDetailDialog.hpp
@@ -1,0 +1,104 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_DEPOSIT_CONVENTION_DETAIL_DIALOG_HPP
+#define ORES_QT_DEPOSIT_CONVENTION_DETAIL_DIALOG_HPP
+
+#include <vector>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/DetailDialogBase.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/deposit_convention.hpp"
+
+
+namespace Ui {
+class DepositConventionDetailDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Detail dialog for viewing and editing deposit convention records.
+ *
+ * This dialog allows viewing, creating, and editing deposit conventions.
+ * It supports both create mode (for new records) and edit mode (for
+ * existing records).
+ */
+class DepositConventionDetailDialog final : public DetailDialogBase {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.deposit_convention_detail_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit DepositConventionDetailDialog(QWidget* parent = nullptr);
+    ~DepositConventionDetailDialog() override;
+
+    void setClientManager(ClientManager* clientManager);
+    void setUsername(const std::string& username);
+    void setConvention(const refdata::domain::deposit_convention& dc);
+    void setCreateMode(bool createMode);
+    void setReadOnly(bool readOnly);
+
+
+signals:
+    void dcSaved(const QString& code);
+    void dcDeleted(const QString& code);
+
+private slots:
+    void onSaveClicked();
+    void onDeleteClicked();
+    void onCodeChanged(const QString& text);
+    void onFieldChanged();
+
+protected:
+    QTabWidget* tabWidget() const override;
+    QWidget* provenanceTab() const override;
+    ProvenanceWidget* provenanceWidget() const override;
+    bool hasUnsavedChanges() const override { return hasChanges_; }
+
+private:
+    void setupUi();
+    void setupConnections();
+    void updateUiFromConvention();
+    void updateConventionFromUi();
+    void updateSaveButtonState();
+    bool validateInput();
+
+
+    Ui::DepositConventionDetailDialog* ui_;
+    ClientManager* clientManager_;
+    std::string username_;
+    refdata::domain::deposit_convention dc_;
+    bool createMode_{true};
+    bool readOnly_{false};
+    bool hasChanges_{false};
+
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/DepositConventionHistoryDialog.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/DepositConventionHistoryDialog.hpp
@@ -1,0 +1,97 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_DEPOSIT_CONVENTION_HISTORY_DIALOG_HPP
+#define ORES_QT_DEPOSIT_CONVENTION_HISTORY_DIALOG_HPP
+
+#include <QWidget>
+#include <QToolBar>
+#include <QTableWidget>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/deposit_convention.hpp"
+
+namespace Ui {
+class DepositConventionHistoryDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Dialog for viewing the version history of a deposit convention.
+ *
+ * Shows all historical versions of a deposit convention with ability
+ * to view details or revert to a previous version.
+ */
+class DepositConventionHistoryDialog final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.deposit_convention_history_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit DepositConventionHistoryDialog(
+        const QString& code,
+        ClientManager* clientManager,
+        QWidget* parent = nullptr);
+    ~DepositConventionHistoryDialog() override;
+
+    void loadHistory();
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void openVersionRequested(const refdata::domain::deposit_convention& dc,
+                              int versionNumber);
+    void revertVersionRequested(const refdata::domain::deposit_convention& dc);
+
+private slots:
+    void onVersionSelected();
+    void onOpenVersionClicked();
+    void onRevertClicked();
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupConnections();
+    void updateVersionList();
+    void updateChangesTable(int currentVersionIndex);
+    void updateFullDetails(int versionIndex);
+    void updateActionStates();
+
+    Ui::DepositConventionHistoryDialog* ui_;
+    QString code_;
+    ClientManager* clientManager_;
+    std::vector<refdata::domain::deposit_convention> versions_;
+
+    QToolBar* toolbar_;
+    QAction* openVersionAction_;
+    QAction* revertAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/DepositConventionMdiWindow.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/DepositConventionMdiWindow.hpp
@@ -1,0 +1,115 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_DEPOSIT_CONVENTION_MDI_WINDOW_HPP
+#define ORES_QT_DEPOSIT_CONVENTION_MDI_WINDOW_HPP
+
+#include <QToolBar>
+#include <QTableView>
+#include <QSortFilterProxyModel>
+#include "ores.qt/EntityListMdiWindow.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ClientDepositConventionModel.hpp"
+#include "ores.qt/PaginationWidget.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/deposit_convention.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief MDI window for displaying and managing deposit conventions.
+ *
+ * Provides a table view of deposit conventions with toolbar actions
+ * for reload, add, edit, delete, and viewing history.
+ */
+class DepositConventionMdiWindow final : public EntityListMdiWindow {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.deposit_convention_mdi_window";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit DepositConventionMdiWindow(
+        ClientManager* clientManager,
+        const QString& username,
+        QWidget* parent = nullptr);
+    ~DepositConventionMdiWindow() override = default;
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void showConventionDetails(const refdata::domain::deposit_convention& dc);
+    void addNewRequested();
+    void dcDeleted(const QString& code);
+    void showConventionHistory(const refdata::domain::deposit_convention& dc);
+
+public slots:
+    void addNew();
+    void editSelected();
+    void deleteSelected();
+    void viewHistorySelected();
+
+protected:
+    void doReload() override;
+
+private slots:
+    void onDataLoaded();
+    void onLoadError(const QString& error_message, const QString& details = {});
+    void onSelectionChanged();
+    void onDoubleClicked(const QModelIndex& index);
+
+protected:
+    QString normalRefreshTooltip() const override {
+        return tr("Refresh deposit conventions");
+    }
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupTable();
+    void setupConnections();
+    void updateActionStates();
+
+    ClientManager* clientManager_;
+    QString username_;
+
+    QToolBar* toolbar_;
+    QTableView* tableView_;
+    ClientDepositConventionModel* model_;
+    QSortFilterProxyModel* proxyModel_;
+    PaginationWidget* paginationWidget_;
+
+    // Toolbar actions
+    QAction* reloadAction_;
+    QAction* addAction_;
+    QAction* editAction_;
+    QAction* deleteAction_;
+    QAction* historyAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/RefdataPlugin.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/RefdataPlugin.hpp
@@ -46,6 +46,7 @@ class MonetaryNatureController;
 class RoundingTypeController;
 class PurposeTypeController;
 class ZeroConventionController;
+class DepositConventionController;
 
 /**
  * @brief Reference data plugin: currencies, countries, dimensions, coding
@@ -107,6 +108,7 @@ private:
     std::unique_ptr<RoundingTypeController>                roundingTypeController_;
     std::unique_ptr<PurposeTypeController>                 purposeTypeController_;
     std::unique_ptr<ZeroConventionController>              zeroConventionController_;
+    std::unique_ptr<DepositConventionController>           depositConventionController_;
 };
 
 }

--- a/projects/ores.qt.refdata/src/ClientDepositConventionModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientDepositConventionModel.cpp
@@ -1,0 +1,309 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/ClientDepositConventionModel.hpp"
+
+#include <QtConcurrent>
+#include "ores.refdata.api/messaging/deposit_convention_protocol.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/ExceptionHelper.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+namespace {
+    std::string deposit_convention_key_extractor(const refdata::domain::deposit_convention& e) {
+        return e.id;
+    }
+}
+
+ClientDepositConventionModel::ClientDepositConventionModel(
+    ClientManager* clientManager, QObject* parent)
+    : QAbstractTableModel(parent),
+      clientManager_(clientManager),
+      watcher_(new QFutureWatcher<FetchResult>(this)),
+      recencyTracker_(deposit_convention_key_extractor),
+      pulseManager_(new RecencyPulseManager(this)) {
+
+    connect(watcher_, &QFutureWatcher<FetchResult>::finished,
+            this, &ClientDepositConventionModel::onConventionsLoaded);
+
+    connect(pulseManager_, &RecencyPulseManager::pulse_state_changed,
+            this, &ClientDepositConventionModel::onPulseStateChanged);
+    connect(pulseManager_, &RecencyPulseManager::pulsing_complete,
+            this, &ClientDepositConventionModel::onPulsingComplete);
+}
+
+int ClientDepositConventionModel::rowCount(const QModelIndex& parent) const {
+    if (parent.isValid())
+        return 0;
+    return static_cast<int>(deposit_conventions_.size());
+}
+
+int ClientDepositConventionModel::columnCount(const QModelIndex& parent) const {
+    if (parent.isValid())
+        return 0;
+    return ColumnCount;
+}
+
+QVariant ClientDepositConventionModel::data(
+    const QModelIndex& index, int role) const {
+    if (!index.isValid())
+        return {};
+
+    const auto row = static_cast<std::size_t>(index.row());
+    if (row >= deposit_conventions_.size())
+        return {};
+
+    const auto& dc = deposit_conventions_[row];
+
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case Id:
+            return QString::fromStdString(dc.id);
+        case IndexBased:
+        case Index:
+            return dc.index
+                ? QString::fromStdString(*dc.index)
+                : QString{};
+        case Calendar:
+            return dc.calendar
+                ? QString::fromStdString(*dc.calendar)
+                : QString{};
+        case DayCountFraction:
+            return dc.day_count_fraction
+                ? QString::fromStdString(*dc.day_count_fraction)
+                : QString{};
+        case Version:
+            return static_cast<qlonglong>(dc.version);
+        case ModifiedBy:
+            return QString::fromStdString(dc.modified_by);
+        case RecordedAt:
+            return relative_time_helper::format(dc.recorded_at);
+        default:
+            return {};
+        }
+    }
+
+    if (role == Qt::ForegroundRole) {
+        return recency_foreground_color(dc.id);
+    }
+
+    return {};
+}
+
+QVariant ClientDepositConventionModel::headerData(
+    int section, Qt::Orientation orientation, int role) const {
+    if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
+        return {};
+
+    switch (section) {
+    case Id:
+        return tr("Id");
+    case IndexBased:
+        return tr("Index Based");
+    case Index:
+        return tr("Index");
+    case Calendar:
+        return tr("Calendar");
+    case DayCountFraction:
+        return tr("DCF");
+    case Version:
+        return tr("Version");
+    case ModifiedBy:
+        return tr("Modified By");
+    case RecordedAt:
+        return tr("Recorded At");
+    default:
+        return {};
+    }
+}
+
+void ClientDepositConventionModel::refresh() {
+    BOOST_LOG_SEV(lg(), debug) << "Calling refresh.";
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress, ignoring refresh request.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Cannot refresh deposit convention model: disconnected.";
+        emit loadError("Not connected to server");
+        return;
+    }
+
+    if (!deposit_conventions_.empty()) {
+        beginResetModel();
+        deposit_conventions_.clear();
+        recencyTracker_.clear();
+        pulseManager_->stop_pulsing();
+        total_available_count_ = 0;
+        endResetModel();
+    }
+
+    fetch_deposit_conventions(0, page_size_);
+}
+
+void ClientDepositConventionModel::load_page(std::uint32_t offset,
+                                          std::uint32_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "load_page: offset=" << offset << ", limit=" << limit;
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress, ignoring load_page request.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Cannot load page: disconnected.";
+        return;
+    }
+
+    if (!deposit_conventions_.empty()) {
+        beginResetModel();
+        deposit_conventions_.clear();
+        recencyTracker_.clear();
+        pulseManager_->stop_pulsing();
+        endResetModel();
+    }
+
+    fetch_deposit_conventions(offset, limit);
+}
+
+void ClientDepositConventionModel::fetch_deposit_conventions(
+    std::uint32_t offset, std::uint32_t limit) {
+    is_fetching_ = true;
+    QPointer<ClientDepositConventionModel> self = this;
+
+    QFuture<FetchResult> future =
+        QtConcurrent::run([self, offset, limit]() -> FetchResult {
+            return exception_helper::wrap_async_fetch<FetchResult>([&]() -> FetchResult {
+                BOOST_LOG_SEV(lg(), debug) << "Making deposit conventions request with offset="
+                                           << offset << ", limit=" << limit;
+                if (!self || !self->clientManager_) {
+                    return {.success = false, .deposit_conventions = {},
+                            .total_available_count = 0,
+                            .error_message = "Model was destroyed",
+                            .error_details = {}};
+                }
+
+                refdata::messaging::get_deposit_conventions_request request;
+
+                auto result = self->clientManager_->
+                    process_authenticated_request(std::move(request));
+
+                if (!result) {
+                    BOOST_LOG_SEV(lg(), error) << "Failed to send request: " << result.error();
+                    return {.success = false, .deposit_conventions = {},
+                            .total_available_count = 0,
+                            .error_message = QString::fromStdString(result.error()),
+                            .error_details = {}};
+                }
+
+                BOOST_LOG_SEV(lg(), debug) << "Fetched " << result->deposit_conventions.size()
+                                           << " deposit conventions";
+                const std::uint32_t count =
+                    static_cast<std::uint32_t>(result->deposit_conventions.size());
+                return {.success = true,
+                        .deposit_conventions = std::move(result->deposit_conventions),
+                        .total_available_count = count,
+                        .error_message = {}, .error_details = {}};
+            }, "deposit conventions");
+        });
+
+    watcher_->setFuture(future);
+}
+
+void ClientDepositConventionModel::onConventionsLoaded() {
+    is_fetching_ = false;
+
+    const auto result = watcher_->result();
+
+    if (!result.success) {
+        BOOST_LOG_SEV(lg(), error) << "Failed to fetch deposit conventions: "
+                                   << result.error_message.toStdString();
+        emit loadError(result.error_message, result.error_details);
+        return;
+    }
+
+    total_available_count_ = result.total_available_count;
+
+    const int new_count = static_cast<int>(result.deposit_conventions.size());
+
+    if (new_count > 0) {
+        beginResetModel();
+        deposit_conventions_ = std::move(result.deposit_conventions);
+        endResetModel();
+
+        const bool has_recent = recencyTracker_.update(deposit_conventions_);
+        if (has_recent && !pulseManager_->is_pulsing()) {
+            pulseManager_->start_pulsing();
+            BOOST_LOG_SEV(lg(), debug) << "Found " << recencyTracker_.recent_count()
+                                       << " deposit conventions newer than last reload";
+        }
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Loaded " << new_count << " deposit conventions."
+                              << " Total available: " << total_available_count_;
+
+    emit dataLoaded();
+}
+
+void ClientDepositConventionModel::set_page_size(std::uint32_t size) {
+    if (size == 0 || size > 1000) {
+        BOOST_LOG_SEV(lg(), warn) << "Invalid page size: " << size
+                                  << ". Must be between 1 and 1000. Using default: 100";
+        page_size_ = 100;
+    } else {
+        page_size_ = size;
+        BOOST_LOG_SEV(lg(), info) << "Page size set to: " << page_size_;
+    }
+}
+
+const refdata::domain::deposit_convention*
+ClientDepositConventionModel::getConvention(int row) const {
+    const auto idx = static_cast<std::size_t>(row);
+    if (idx >= deposit_conventions_.size())
+        return nullptr;
+    return &deposit_conventions_[idx];
+}
+
+QVariant ClientDepositConventionModel::recency_foreground_color(
+    const std::string& code) const {
+    if (recencyTracker_.is_recent(code) && pulseManager_->is_pulse_on()) {
+        return color_constants::stale_indicator;
+    }
+    return {};
+}
+
+void ClientDepositConventionModel::onPulseStateChanged(bool /*isOn*/) {
+    if (!deposit_conventions_.empty()) {
+        emit dataChanged(index(0, 0), index(rowCount() - 1, columnCount() - 1),
+            {Qt::ForegroundRole});
+    }
+}
+
+void ClientDepositConventionModel::onPulsingComplete() {
+    BOOST_LOG_SEV(lg(), debug) << "Recency highlight pulsing complete";
+    recencyTracker_.clear();
+}
+
+}

--- a/projects/ores.qt.refdata/src/ClientDepositConventionModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientDepositConventionModel.cpp
@@ -80,6 +80,7 @@ QVariant ClientDepositConventionModel::data(
         case Id:
             return QString::fromStdString(dc.id);
         case IndexBased:
+            return dc.index_based ? tr("true") : tr("false");
         case Index:
             return dc.index
                 ? QString::fromStdString(*dc.index)

--- a/projects/ores.qt.refdata/src/ClientZeroConventionModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientZeroConventionModel.cpp
@@ -80,6 +80,7 @@ QVariant ClientZeroConventionModel::data(
         case Id:
             return QString::fromStdString(zc.id);
         case TenorBased:
+            return zc.tenor_based ? tr("true") : tr("false");
         case DayCountFraction:
             return QString::fromStdString(zc.day_count_fraction);
         case Compounding:

--- a/projects/ores.qt.refdata/src/DepositConventionController.cpp
+++ b/projects/ores.qt.refdata/src/DepositConventionController.cpp
@@ -1,0 +1,385 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/DepositConventionController.hpp"
+
+#include <QMdiSubWindow>
+#include <QMessageBox>
+#include <QPointer>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/DepositConventionMdiWindow.hpp"
+#include "ores.qt/DepositConventionDetailDialog.hpp"
+#include "ores.qt/DepositConventionHistoryDialog.hpp"
+#include "ores.qt/DetachableMdiSubWindow.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+DepositConventionController::DepositConventionController(
+    QMainWindow* mainWindow,
+    QMdiArea* mdiArea,
+    ClientManager* clientManager,
+    const QString& username,
+    QObject* parent)
+    : EntityController(mainWindow, mdiArea, clientManager, username,
+          std::string_view{}, parent),
+      listWindow_(nullptr),
+      listMdiSubWindow_(nullptr) {
+
+    BOOST_LOG_SEV(lg(), debug) << "DepositConventionController created";
+}
+
+void DepositConventionController::showListWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "showListWindow called";
+
+    const QString key = build_window_key("list", "deposit_conventions");
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing list window";
+        return;
+    }
+
+    // Create new window
+    listWindow_ = new DepositConventionMdiWindow(clientManager_, username_);
+
+    // Connect signals
+    connect(listWindow_, &DepositConventionMdiWindow::statusChanged,
+            this, &DepositConventionController::statusMessage);
+    connect(listWindow_, &DepositConventionMdiWindow::errorOccurred,
+            this, &DepositConventionController::errorMessage);
+    connect(listWindow_, &DepositConventionMdiWindow::showConventionDetails,
+            this, &DepositConventionController::onShowDetails);
+    connect(listWindow_, &DepositConventionMdiWindow::addNewRequested,
+            this, &DepositConventionController::onAddNewRequested);
+    connect(listWindow_, &DepositConventionMdiWindow::showConventionHistory,
+            this, &DepositConventionController::onShowHistory);
+
+    // Create MDI subwindow
+    listMdiSubWindow_ = new DetachableMdiSubWindow(mainWindow_);
+    listMdiSubWindow_->setWidget(listWindow_);
+    listMdiSubWindow_->setWindowTitle("Deposit Conventions");
+    listMdiSubWindow_->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+    listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
+    listMdiSubWindow_->resize(listWindow_->sizeHint());
+
+    mdiArea_->addSubWindow(listMdiSubWindow_);
+    listMdiSubWindow_->show();
+
+    // Track window
+    track_window(key, listMdiSubWindow_);
+    register_detachable_window(listMdiSubWindow_);
+
+    // Cleanup when closed
+    connect(listMdiSubWindow_, &QObject::destroyed, this, [self = QPointer<DepositConventionController>(this), key]() {
+        if (!self) return;
+        self->untrack_window(key);
+        self->listWindow_ = nullptr;
+        self->listMdiSubWindow_ = nullptr;
+    });
+
+    BOOST_LOG_SEV(lg(), debug) << "Deposit Convention list window created";
+}
+
+void DepositConventionController::closeAllWindows() {
+    BOOST_LOG_SEV(lg(), debug) << "closeAllWindows called";
+
+    // Close all managed windows
+    QList<QString> keys = managed_windows_.keys();
+    for (const QString& key : keys) {
+        if (auto* window = managed_windows_.value(key)) {
+            window->close();
+        }
+    }
+    managed_windows_.clear();
+
+    listWindow_ = nullptr;
+    listMdiSubWindow_ = nullptr;
+}
+
+void DepositConventionController::reloadListWindow() {
+    if (listWindow_) {
+        listWindow_->reload();
+    }
+}
+
+void DepositConventionController::onShowDetails(
+    const refdata::domain::deposit_convention& dc) {
+    BOOST_LOG_SEV(lg(), debug) << "Show details for: " << dc.id;
+    showDetailWindow(dc);
+}
+
+void DepositConventionController::onAddNewRequested() {
+    BOOST_LOG_SEV(lg(), info) << "Add new deposit convention requested";
+    showAddWindow();
+}
+
+void DepositConventionController::onShowHistory(
+    const refdata::domain::deposit_convention& dc) {
+    BOOST_LOG_SEV(lg(), debug) << "Show history requested for: " << dc.id;
+    showHistoryWindow(QString::fromStdString(dc.id));
+}
+
+void DepositConventionController::showAddWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "Creating add window for new deposit convention";
+
+    auto* detailDialog = new DepositConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(true);
+
+    connect(detailDialog, &DepositConventionDetailDialog::statusMessage,
+            this, &DepositConventionController::statusMessage);
+    connect(detailDialog, &DepositConventionDetailDialog::errorMessage,
+            this, &DepositConventionController::errorMessage);
+    connect(detailDialog, &DepositConventionDetailDialog::dcSaved,
+            this, [self = QPointer<DepositConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "Deposit Convention saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle("New Deposit Convention");
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void DepositConventionController::showDetailWindow(
+    const refdata::domain::deposit_convention& dc) {
+
+    const QString identifier = QString::fromStdString(dc.id);
+    const QString key = build_window_key("details", identifier);
+
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing detail window";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Creating detail window for: " << dc.id;
+
+    auto* detailDialog = new DepositConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(false);
+    detailDialog->setConvention(dc);
+
+    connect(detailDialog, &DepositConventionDetailDialog::statusMessage,
+            this, &DepositConventionController::statusMessage);
+    connect(detailDialog, &DepositConventionDetailDialog::errorMessage,
+            this, &DepositConventionController::errorMessage);
+    connect(detailDialog, &DepositConventionDetailDialog::dcSaved,
+            this, [self = QPointer<DepositConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "Deposit Convention saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+    connect(detailDialog, &DepositConventionDetailDialog::dcDeleted,
+            this, [self = QPointer<DepositConventionController>(this), key](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "Deposit Convention deleted: " << code.toStdString();
+        self->handleEntityDeleted();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Deposit Convention: %1").arg(identifier));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+
+    // Track window
+    track_window(key, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<DepositConventionController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, key]() {
+        if (self) {
+            self->untrack_window(key);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void DepositConventionController::showHistoryWindow(const QString& code) {
+    BOOST_LOG_SEV(lg(), info) << "Opening history window for deposit convention: "
+                              << code.toStdString();
+
+    const QString windowKey = build_window_key("history", code);
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing history window for: "
+                                  << code.toStdString();
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Creating new history window for: "
+                              << code.toStdString();
+
+    auto* historyDialog = new DepositConventionHistoryDialog(code, clientManager_, mainWindow_);
+
+    connect(historyDialog, &DepositConventionHistoryDialog::statusChanged,
+            this, [self = QPointer<DepositConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(historyDialog, &DepositConventionHistoryDialog::errorOccurred,
+            this, [self = QPointer<DepositConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+    connect(historyDialog, &DepositConventionHistoryDialog::revertVersionRequested,
+            this, &DepositConventionController::onRevertVersion);
+    connect(historyDialog, &DepositConventionHistoryDialog::openVersionRequested,
+            this, &DepositConventionController::onOpenVersion);
+
+    // Load history data
+    historyDialog->loadHistory();
+
+    auto* historyWindow = new DetachableMdiSubWindow(mainWindow_);
+    historyWindow->setAttribute(Qt::WA_DeleteOnClose);
+    historyWindow->setWidget(historyDialog);
+    historyWindow->setWindowTitle(QString("Deposit Convention History: %1").arg(code));
+    historyWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    // Track this history window
+    track_window(windowKey, historyWindow);
+    register_detachable_window(historyWindow);
+
+    QPointer<DepositConventionController> self = this;
+    connect(historyWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    show_managed_window(historyWindow, listMdiSubWindow_);
+}
+
+void DepositConventionController::onOpenVersion(
+    const refdata::domain::deposit_convention& dc, int versionNumber) {
+    BOOST_LOG_SEV(lg(), info) << "Opening historical version " << versionNumber
+                              << " for deposit convention: " << dc.id;
+
+    const QString code = QString::fromStdString(dc.id);
+    const QString windowKey = build_window_key("version", QString("%1_v%2")
+        .arg(code).arg(versionNumber));
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing version window";
+        return;
+    }
+
+    auto* detailDialog = new DepositConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setConvention(dc);
+    detailDialog->setReadOnly(true);
+
+    connect(detailDialog, &DepositConventionDetailDialog::statusMessage,
+            this, [self = QPointer<DepositConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(detailDialog, &DepositConventionDetailDialog::errorMessage,
+            this, [self = QPointer<DepositConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Deposit Convention: %1 (Version %2)")
+        .arg(code).arg(versionNumber));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    track_window(windowKey, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<DepositConventionController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_, QPoint(60, 60));
+}
+
+void DepositConventionController::onRevertVersion(
+    const refdata::domain::deposit_convention& dc) {
+    BOOST_LOG_SEV(lg(), info) << "Reverting deposit convention to version: "
+                              << dc.version;
+
+    // Open detail dialog with the old version data for editing
+    auto* detailDialog = new DepositConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setConvention(dc);
+    detailDialog->setCreateMode(false);
+
+    connect(detailDialog, &DepositConventionDetailDialog::statusMessage,
+            this, &DepositConventionController::statusMessage);
+    connect(detailDialog, &DepositConventionDetailDialog::errorMessage,
+            this, &DepositConventionController::errorMessage);
+    connect(detailDialog, &DepositConventionDetailDialog::dcSaved,
+            this, [self = QPointer<DepositConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "Deposit Convention reverted: " << code.toStdString();
+        emit self->statusMessage(QString("Deposit Convention '%1' reverted successfully").arg(code));
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Revert Deposit Convention: %1")
+        .arg(QString::fromStdString(dc.id)));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+EntityListMdiWindow* DepositConventionController::listWindow() const {
+    return listWindow_;
+}
+
+}

--- a/projects/ores.qt.refdata/src/DepositConventionDetailDialog.cpp
+++ b/projects/ores.qt.refdata/src/DepositConventionDetailDialog.cpp
@@ -1,0 +1,338 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/DepositConventionDetailDialog.hpp"
+
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_DepositConventionDetailDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.refdata.api/messaging/deposit_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+DepositConventionDetailDialog::DepositConventionDetailDialog(QWidget* parent)
+    : DetailDialogBase(parent),
+      ui_(new Ui::DepositConventionDetailDialog),
+      clientManager_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupConnections();
+}
+
+DepositConventionDetailDialog::~DepositConventionDetailDialog() {
+    delete ui_;
+}
+
+QTabWidget* DepositConventionDetailDialog::tabWidget() const {
+    return ui_->tabWidget;
+}
+
+QWidget* DepositConventionDetailDialog::provenanceTab() const {
+    return ui_->provenanceTab;
+}
+
+ProvenanceWidget* DepositConventionDetailDialog::provenanceWidget() const {
+    return ui_->provenanceWidget;
+}
+
+void DepositConventionDetailDialog::setupUi() {
+    ui_->saveButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Save, IconUtils::DefaultIconColor));
+    ui_->saveButton->setEnabled(false);
+
+    ui_->deleteButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Delete, IconUtils::DefaultIconColor));
+
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+}
+
+void DepositConventionDetailDialog::setupConnections() {
+    connect(ui_->saveButton, &QPushButton::clicked, this,
+            &DepositConventionDetailDialog::onSaveClicked);
+    connect(ui_->deleteButton, &QPushButton::clicked, this,
+            &DepositConventionDetailDialog::onDeleteClicked);
+    connect(ui_->closeButton, &QPushButton::clicked, this,
+            &DepositConventionDetailDialog::onCloseClicked);
+
+    connect(ui_->idEdit, &QLineEdit::textChanged, this,
+            &DepositConventionDetailDialog::onCodeChanged);
+    connect(ui_->indexEdit, &QLineEdit::textChanged, this,
+            &DepositConventionDetailDialog::onFieldChanged);
+    connect(ui_->calendarEdit, &QLineEdit::textChanged, this,
+            &DepositConventionDetailDialog::onFieldChanged);
+    connect(ui_->conventionEdit, &QLineEdit::textChanged, this,
+            &DepositConventionDetailDialog::onFieldChanged);
+    connect(ui_->dayCountFractionEdit, &QLineEdit::textChanged, this,
+            &DepositConventionDetailDialog::onFieldChanged);
+}
+
+void DepositConventionDetailDialog::setClientManager(ClientManager* clientManager) {
+    clientManager_ = clientManager;
+}
+
+void DepositConventionDetailDialog::setUsername(const std::string& username) {
+    username_ = username;
+}
+
+void DepositConventionDetailDialog::setConvention(
+    const refdata::domain::deposit_convention& dc) {
+    dc_ = dc;
+    updateUiFromConvention();
+}
+
+void DepositConventionDetailDialog::setCreateMode(bool createMode) {
+    createMode_ = createMode;
+    ui_->idEdit->setReadOnly(!createMode);
+    ui_->deleteButton->setVisible(!createMode);
+    setProvenanceEnabled(!createMode);
+    hasChanges_ = false;
+    updateSaveButtonState();
+}
+
+void DepositConventionDetailDialog::setReadOnly(bool readOnly) {
+    readOnly_ = readOnly;
+    ui_->idEdit->setReadOnly(true);
+    ui_->indexEdit->setReadOnly(readOnly);
+    ui_->calendarEdit->setReadOnly(readOnly);
+    ui_->conventionEdit->setReadOnly(readOnly);
+    ui_->dayCountFractionEdit->setReadOnly(readOnly);
+    ui_->saveButton->setVisible(!readOnly);
+    ui_->deleteButton->setVisible(!readOnly);
+}
+
+void DepositConventionDetailDialog::updateUiFromConvention() {
+    ui_->idEdit->setText(QString::fromStdString(dc_.id));
+    ui_->indexEdit->setText(dc_.index
+        ? QString::fromStdString(*dc_.index)
+        : QString{});
+    ui_->calendarEdit->setText(dc_.calendar
+        ? QString::fromStdString(*dc_.calendar)
+        : QString{});
+    ui_->conventionEdit->setText(dc_.convention
+        ? QString::fromStdString(*dc_.convention)
+        : QString{});
+    ui_->dayCountFractionEdit->setText(dc_.day_count_fraction
+        ? QString::fromStdString(*dc_.day_count_fraction)
+        : QString{});
+
+    populateProvenance(dc_.version,
+                       dc_.modified_by,
+                       dc_.performed_by,
+                       dc_.recorded_at,
+                       dc_.change_reason_code,
+                       dc_.change_commentary);
+
+    hasChanges_ = false;
+    updateSaveButtonState();
+}
+
+void DepositConventionDetailDialog::updateConventionFromUi() {
+    if (createMode_) {
+        dc_.id = ui_->idEdit->text().trimmed().toStdString();
+    }
+    {
+        const auto index_str = ui_->indexEdit->text().trimmed().toStdString();
+        dc_.index =
+            index_str.empty() ? std::nullopt : std::optional<std::string>(index_str);
+    }
+    {
+        const auto calendar_str = ui_->calendarEdit->text().trimmed().toStdString();
+        dc_.calendar =
+            calendar_str.empty() ? std::nullopt : std::optional<std::string>(calendar_str);
+    }
+    {
+        const auto convention_str = ui_->conventionEdit->text().trimmed().toStdString();
+        dc_.convention =
+            convention_str.empty() ? std::nullopt : std::optional<std::string>(convention_str);
+    }
+    {
+        const auto day_count_fraction_str = ui_->dayCountFractionEdit->text().trimmed().toStdString();
+        dc_.day_count_fraction =
+            day_count_fraction_str.empty() ? std::nullopt : std::optional<std::string>(day_count_fraction_str);
+    }
+    dc_.modified_by = username_;
+}
+
+void DepositConventionDetailDialog::onCodeChanged(const QString& /* text */) {
+    hasChanges_ = true;
+    updateSaveButtonState();
+}
+
+void DepositConventionDetailDialog::onFieldChanged() {
+    hasChanges_ = true;
+    updateSaveButtonState();
+}
+
+void DepositConventionDetailDialog::updateSaveButtonState() {
+    bool canSave = hasChanges_ && validateInput() && !readOnly_;
+    ui_->saveButton->setEnabled(canSave);
+}
+
+bool DepositConventionDetailDialog::validateInput() {
+    const QString id_val = ui_->idEdit->text().trimmed();
+
+    return true
+        && !id_val.isEmpty()
+    ;
+}
+
+void DepositConventionDetailDialog::onSaveClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot save deposit convention while disconnected from server.");
+        return;
+    }
+
+    if (!validateInput()) {
+        MessageBoxHelper::warning(this, "Invalid Input",
+            "Please fill in all required fields.");
+        return;
+    }
+
+    updateConventionFromUi();
+
+    BOOST_LOG_SEV(lg(), info) << "Saving deposit convention: "
+        << dc_.id;
+
+    QPointer<DepositConventionDetailDialog> self = this;
+
+    struct SaveResult {
+        bool success;
+        std::string message;
+    };
+
+    auto task = [self, dc = dc_]() -> SaveResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed"};
+        }
+
+        refdata::messaging::save_deposit_convention_request request;
+        request.data = dc;
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server"};
+        }
+
+        return {response_result->success, response_result->message};
+    };
+
+    auto* watcher = new QFutureWatcher<SaveResult>(self);
+    connect(watcher, &QFutureWatcher<SaveResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "Deposit Convention saved successfully";
+            QString code = QString::fromStdString(
+                self->dc_.id);
+            self->hasChanges_ = false;
+            self->updateSaveButtonState();
+            emit self->dcSaved(code);
+            self->notifySaveSuccess(tr("Deposit Convention '%1' saved").arg(code));
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Save failed: " << result.message;
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Save Failed", errorMsg);
+        }
+    });
+
+    QFuture<SaveResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+void DepositConventionDetailDialog::onDeleteClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete deposit convention while disconnected from server.");
+        return;
+    }
+
+    QString code = QString::fromStdString(
+        dc_.id);
+    auto reply = MessageBoxHelper::question(this, "Delete Deposit Convention",
+        QString("Are you sure you want to delete deposit convention '%1'?").arg(code),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Deleting deposit convention: "
+        << dc_.id;
+
+    QPointer<DepositConventionDetailDialog> self = this;
+
+    struct DeleteResult {
+        bool success;
+        std::string message;
+    };
+
+    auto task = [self, code = dc_.id]() -> DeleteResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed"};
+        }
+
+        refdata::messaging::delete_deposit_convention_request request;
+        request.codes = {code};
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server"};
+        }
+
+        return {response_result->success, response_result->message};
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, code, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "Deposit Convention deleted successfully";
+            emit self->statusMessage(
+                QString("Deposit Convention '%1' deleted").arg(code));
+            emit self->dcDeleted(code);
+            self->requestClose();
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Delete failed: " << result.message;
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Delete Failed", errorMsg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt.refdata/src/DepositConventionDetailDialog.cpp
+++ b/projects/ores.qt.refdata/src/DepositConventionDetailDialog.cpp
@@ -125,6 +125,7 @@ void DepositConventionDetailDialog::setReadOnly(bool readOnly) {
 
 void DepositConventionDetailDialog::updateUiFromConvention() {
     ui_->idEdit->setText(QString::fromStdString(dc_.id));
+    ui_->indexBasedEdit->setChecked(dc_.index_based);
     ui_->indexEdit->setText(dc_.index
         ? QString::fromStdString(*dc_.index)
         : QString{});
@@ -137,6 +138,11 @@ void DepositConventionDetailDialog::updateUiFromConvention() {
     ui_->dayCountFractionEdit->setText(dc_.day_count_fraction
         ? QString::fromStdString(*dc_.day_count_fraction)
         : QString{});
+    ui_->endOfMonthEdit->setCheckState(dc_.end_of_month
+        ? (*dc_.end_of_month ? Qt::Checked : Qt::Unchecked)
+        : Qt::PartiallyChecked);
+    ui_->settlementDaysEdit->setValue(dc_.settlement_days.value_or(
+        ui_->settlementDaysEdit->minimum()));
 
     populateProvenance(dc_.version,
                        dc_.modified_by,
@@ -153,6 +159,7 @@ void DepositConventionDetailDialog::updateConventionFromUi() {
     if (createMode_) {
         dc_.id = ui_->idEdit->text().trimmed().toStdString();
     }
+    dc_.index_based = ui_->indexBasedEdit->isChecked();
     {
         const auto index_str = ui_->indexEdit->text().trimmed().toStdString();
         dc_.index =
@@ -173,6 +180,21 @@ void DepositConventionDetailDialog::updateConventionFromUi() {
         dc_.day_count_fraction =
             day_count_fraction_str.empty() ? std::nullopt : std::optional<std::string>(day_count_fraction_str);
     }
+    switch (ui_->endOfMonthEdit->checkState()) {
+    case Qt::Checked:
+        dc_.end_of_month = std::optional<bool>(true);
+        break;
+    case Qt::Unchecked:
+        dc_.end_of_month = std::optional<bool>(false);
+        break;
+    default:
+        dc_.end_of_month = std::nullopt;
+        break;
+    }
+    if (ui_->settlementDaysEdit->value() == ui_->settlementDaysEdit->minimum())
+        dc_.settlement_days = std::nullopt;
+    else
+        dc_.settlement_days = ui_->settlementDaysEdit->value();
     dc_.modified_by = username_;
 }
 

--- a/projects/ores.qt.refdata/src/DepositConventionHistoryDialog.cpp
+++ b/projects/ores.qt.refdata/src/DepositConventionHistoryDialog.cpp
@@ -1,0 +1,338 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/DepositConventionHistoryDialog.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_DepositConventionHistoryDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.refdata.api/messaging/deposit_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+DepositConventionHistoryDialog::DepositConventionHistoryDialog(
+    const QString& code,
+    ClientManager* clientManager,
+    QWidget* parent)
+    : QWidget(parent),
+      ui_(new Ui::DepositConventionHistoryDialog),
+      code_(code),
+      clientManager_(clientManager),
+      toolbar_(nullptr),
+      openVersionAction_(nullptr),
+      revertAction_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupToolbar();
+    setupConnections();
+}
+
+DepositConventionHistoryDialog::~DepositConventionHistoryDialog() {
+    delete ui_;
+}
+
+void DepositConventionHistoryDialog::setupUi() {
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+
+    ui_->titleLabel->setText(QString("History for: %1").arg(code_));
+
+    // Setup version list table
+    ui_->versionListWidget->setColumnCount(5);
+    ui_->versionListWidget->setHorizontalHeaderLabels(
+        {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
+    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
+    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    // Setup changes table
+    ui_->changesTableWidget->setColumnCount(3);
+    ui_->changesTableWidget->setHorizontalHeaderLabels(
+        {"Field", "Old Value", "New Value"});
+    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+}
+
+void DepositConventionHistoryDialog::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    openVersionAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor),
+        tr("Open"));
+    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
+    openVersionAction_->setEnabled(false);
+
+    revertAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor),
+        tr("Revert"));
+    revertAction_->setToolTip(tr("Revert to this version"));
+    revertAction_->setEnabled(false);
+
+    // Insert toolbar at the top of the layout
+    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
+    if (layout) {
+        layout->insertWidget(0, toolbar_);
+    }
+}
+
+void DepositConventionHistoryDialog::setupConnections() {
+    connect(ui_->versionListWidget, &QTableWidget::itemSelectionChanged,
+            this, &DepositConventionHistoryDialog::onVersionSelected);
+    connect(openVersionAction_, &QAction::triggered,
+            this, &DepositConventionHistoryDialog::onOpenVersionClicked);
+    connect(revertAction_, &QAction::triggered,
+            this, &DepositConventionHistoryDialog::onRevertClicked);
+    connect(ui_->closeButton, &QPushButton::clicked,
+            this, [this]() { if (window()) window()->close(); });
+}
+
+void DepositConventionHistoryDialog::loadHistory() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        emit errorOccurred("Not connected to server");
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for deposit convention: " << code_.toStdString();
+    emit statusChanged(tr("Loading history..."));
+
+    QPointer<DepositConventionHistoryDialog> self = this;
+
+    using HistoryResult = std::expected<refdata::messaging::get_deposit_convention_history_response, std::string>;
+
+    QFuture<HistoryResult> future =
+        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
+        if (!self || !self->clientManager_)
+            return std::unexpected("Dialog closed");
+        refdata::messaging::get_deposit_convention_history_request request;
+        request.id = code;
+        auto result = self->clientManager_->process_authenticated_request(std::move(request));
+        if (!result) return std::unexpected(result.error());
+        return std::move(*result);
+    });
+
+    auto* watcher = new QFutureWatcher<HistoryResult>(self);
+    connect(watcher, &QFutureWatcher<HistoryResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (!result) {
+            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
+            emit self->errorOccurred(QString::fromStdString(result.error()));
+            return;
+        }
+        if (!result->success) {
+            emit self->errorOccurred(QString::fromStdString(result->message));
+            return;
+        }
+        self->versions_ = std::move(result->deposit_conventions);
+        self->updateVersionList();
+        emit self->statusChanged(
+            QString("Loaded %1 versions").arg(self->versions_.size()));
+    });
+    watcher->setFuture(future);
+}
+
+void DepositConventionHistoryDialog::updateVersionList() {
+    ui_->versionListWidget->setRowCount(0);
+
+    for (const auto& version : versions_) {
+        int row = ui_->versionListWidget->rowCount();
+        ui_->versionListWidget->insertRow(row);
+
+        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
+        versionItem->setTextAlignment(Qt::AlignCenter);
+        ui_->versionListWidget->setItem(row, 0, versionItem);
+
+        auto* recordedAtItem = new QTableWidgetItem(
+            relative_time_helper::format(version.recorded_at));
+        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
+
+        auto* modifiedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.modified_by));
+        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
+
+        auto* performedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.performed_by));
+        ui_->versionListWidget->setItem(row, 3, performedByItem);
+
+        auto* commentaryItem = new QTableWidgetItem(
+            QString::fromStdString(version.change_commentary));
+        ui_->versionListWidget->setItem(row, 4, commentaryItem);
+    }
+
+    // Select the first (most recent) version
+    if (!versions_.empty()) {
+        ui_->versionListWidget->selectRow(0);
+    }
+}
+
+void DepositConventionHistoryDialog::onVersionSelected() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) {
+        updateActionStates();
+        return;
+    }
+
+    int row = selected.first()->row();
+    updateChangesTable(row);
+    updateFullDetails(row);
+    updateActionStates();
+}
+
+void DepositConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
+    ui_->changesTableWidget->setRowCount(0);
+
+    if (currentVersionIndex < 0 ||
+        static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
+        return;
+    }
+
+    // Get the next older version to compare against
+    int previousVersionIndex = currentVersionIndex + 1;
+    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
+        // This is the first version, no changes to show
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(Initial version)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+        return;
+    }
+
+    const auto& current = versions_[currentVersionIndex];
+    const auto& previous = versions_[previousVersionIndex];
+
+    auto addChange = [this](const QString& field,
+                            const QString& oldVal, const QString& newVal) {
+        int row = ui_->changesTableWidget->rowCount();
+        ui_->changesTableWidget->insertRow(row);
+        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
+        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
+        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
+    };
+
+    if (current.id != previous.id) {
+        addChange("Id",
+                  QString::fromStdString(previous.id),
+                  QString::fromStdString(current.id));
+    }
+
+    if (current.index != previous.index) {
+        addChange("Index",
+                  previous.index ? QString::fromStdString(*previous.index) : QString{},
+                  current.index ? QString::fromStdString(*current.index) : QString{});
+    }
+
+    if (current.calendar != previous.calendar) {
+        addChange("Calendar",
+                  previous.calendar ? QString::fromStdString(*previous.calendar) : QString{},
+                  current.calendar ? QString::fromStdString(*current.calendar) : QString{});
+    }
+
+    if (current.convention != previous.convention) {
+        addChange("Convention",
+                  previous.convention ? QString::fromStdString(*previous.convention) : QString{},
+                  current.convention ? QString::fromStdString(*current.convention) : QString{});
+    }
+
+    if (current.day_count_fraction != previous.day_count_fraction) {
+        addChange("Day Count Fraction",
+                  previous.day_count_fraction ? QString::fromStdString(*previous.day_count_fraction) : QString{},
+                  current.day_count_fraction ? QString::fromStdString(*current.day_count_fraction) : QString{});
+    }
+
+
+    if (ui_->changesTableWidget->rowCount() == 0) {
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(No field changes)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+    }
+}
+
+void DepositConventionHistoryDialog::updateFullDetails(int versionIndex) {
+    if (versionIndex < 0 ||
+        static_cast<size_t>(versionIndex) >= versions_.size()) {
+        return;
+    }
+
+    const auto& version = versions_[versionIndex];
+
+    ui_->idValue->setText(QString::fromStdString(version.id));
+    ui_->indexValue->setText(version.index
+        ? QString::fromStdString(*version.index)
+        : QString{});
+    ui_->calendarValue->setText(version.calendar
+        ? QString::fromStdString(*version.calendar)
+        : QString{});
+    ui_->conventionValue->setText(version.convention
+        ? QString::fromStdString(*version.convention)
+        : QString{});
+    ui_->dayCountFractionValue->setText(version.day_count_fraction
+        ? QString::fromStdString(*version.day_count_fraction)
+        : QString{});
+    ui_->versionNumberValue->setText(QString::number(version.version));
+    ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
+}
+
+void DepositConventionHistoryDialog::updateActionStates() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    bool hasSelection = !selected.isEmpty();
+    bool isNotLatest = hasSelection && selected.first()->row() > 0;
+
+    openVersionAction_->setEnabled(hasSelection);
+    revertAction_->setEnabled(isNotLatest);
+}
+
+void DepositConventionHistoryDialog::onOpenVersionClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit openVersionRequested(versions_[row], versions_[row].version);
+}
+
+void DepositConventionHistoryDialog::onRevertClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit revertVersionRequested(versions_[row]);
+}
+
+}

--- a/projects/ores.qt.refdata/src/DepositConventionHistoryDialog.cpp
+++ b/projects/ores.qt.refdata/src/DepositConventionHistoryDialog.cpp
@@ -244,6 +244,12 @@ void DepositConventionHistoryDialog::updateChangesTable(int currentVersionIndex)
                   QString::fromStdString(current.id));
     }
 
+    if (current.index_based != previous.index_based) {
+        addChange("Index Based",
+                  previous.index_based ? tr("true") : tr("false"),
+                  current.index_based ? tr("true") : tr("false"));
+    }
+
     if (current.index != previous.index) {
         addChange("Index",
                   previous.index ? QString::fromStdString(*previous.index) : QString{},
@@ -268,6 +274,18 @@ void DepositConventionHistoryDialog::updateChangesTable(int currentVersionIndex)
                   current.day_count_fraction ? QString::fromStdString(*current.day_count_fraction) : QString{});
     }
 
+    if (current.end_of_month != previous.end_of_month) {
+        addChange("End Of Month",
+                  previous.end_of_month ? (*previous.end_of_month ? tr("true") : tr("false")) : tr("(unset)"),
+                  current.end_of_month ? (*current.end_of_month ? tr("true") : tr("false")) : tr("(unset)"));
+    }
+
+    if (current.settlement_days != previous.settlement_days) {
+        addChange("Settlement Days",
+                  previous.settlement_days ? QString::number(*previous.settlement_days) : tr("(unset)"),
+                  current.settlement_days ? QString::number(*current.settlement_days) : tr("(unset)"));
+    }
+
 
     if (ui_->changesTableWidget->rowCount() == 0) {
         ui_->changesTableWidget->insertRow(0);
@@ -287,6 +305,7 @@ void DepositConventionHistoryDialog::updateFullDetails(int versionIndex) {
     const auto& version = versions_[versionIndex];
 
     ui_->idValue->setText(QString::fromStdString(version.id));
+    ui_->indexBasedValue->setText(version.index_based ? tr("true") : tr("false"));
     ui_->indexValue->setText(version.index
         ? QString::fromStdString(*version.index)
         : QString{});
@@ -299,6 +318,12 @@ void DepositConventionHistoryDialog::updateFullDetails(int versionIndex) {
     ui_->dayCountFractionValue->setText(version.day_count_fraction
         ? QString::fromStdString(*version.day_count_fraction)
         : QString{});
+    ui_->endOfMonthValue->setText(version.end_of_month
+        ? (*version.end_of_month ? tr("true") : tr("false"))
+        : tr("(unset)"));
+    ui_->settlementDaysValue->setText(version.settlement_days
+        ? QString::number(*version.settlement_days)
+        : tr("(unset)"));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
     ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));

--- a/projects/ores.qt.refdata/src/DepositConventionMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/DepositConventionMdiWindow.cpp
@@ -1,0 +1,385 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/DepositConventionMdiWindow.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.refdata.api/messaging/deposit_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+DepositConventionMdiWindow::DepositConventionMdiWindow(
+    ClientManager* clientManager,
+    const QString& username,
+    QWidget* parent)
+    : EntityListMdiWindow(parent),
+      clientManager_(clientManager),
+      username_(username),
+      toolbar_(nullptr),
+      tableView_(nullptr),
+      model_(nullptr),
+      proxyModel_(nullptr),
+      paginationWidget_(nullptr),
+      reloadAction_(nullptr),
+      addAction_(nullptr),
+      editAction_(nullptr),
+      deleteAction_(nullptr),
+      historyAction_(nullptr) {
+
+    setupUi();
+    setupConnections();
+
+    // Initial load
+    doReload();
+}
+
+void DepositConventionMdiWindow::setupUi() {
+    auto* layout = new QVBoxLayout(this);
+
+    setupToolbar();
+    layout->addWidget(toolbar_);
+
+    setupTable();
+    layout->addWidget(tableView_);
+
+    paginationWidget_ = new PaginationWidget(this);
+    layout->addWidget(paginationWidget_);
+}
+
+void DepositConventionMdiWindow::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    reloadAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowClockwise, IconUtils::DefaultIconColor),
+        tr("Reload"));
+    connect(reloadAction_, &QAction::triggered, this,
+            &DepositConventionMdiWindow::doReload);
+
+    initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
+
+    toolbar_->addSeparator();
+
+    addAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Add, IconUtils::DefaultIconColor),
+        tr("Add"));
+    addAction_->setToolTip(tr("Add new deposit convention"));
+    connect(addAction_, &QAction::triggered, this,
+            &DepositConventionMdiWindow::addNew);
+
+    editAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Edit, IconUtils::DefaultIconColor),
+        tr("Edit"));
+    editAction_->setToolTip(tr("Edit selected deposit convention"));
+    editAction_->setEnabled(false);
+    connect(editAction_, &QAction::triggered, this,
+            &DepositConventionMdiWindow::editSelected);
+
+    deleteAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Delete, IconUtils::DefaultIconColor),
+        tr("Delete"));
+    deleteAction_->setToolTip(tr("Delete selected deposit convention"));
+    deleteAction_->setEnabled(false);
+    connect(deleteAction_, &QAction::triggered, this,
+            &DepositConventionMdiWindow::deleteSelected);
+
+    historyAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::History, IconUtils::DefaultIconColor),
+        tr("History"));
+    historyAction_->setToolTip(tr("View deposit convention history"));
+    historyAction_->setEnabled(false);
+    connect(historyAction_, &QAction::triggered, this,
+            &DepositConventionMdiWindow::viewHistorySelected);
+}
+
+void DepositConventionMdiWindow::setupTable() {
+    model_ = new ClientDepositConventionModel(clientManager_, this);
+    proxyModel_ = new QSortFilterProxyModel(this);
+    proxyModel_->setSourceModel(model_);
+    proxyModel_->setSortCaseSensitivity(Qt::CaseInsensitive);
+
+    tableView_ = new QTableView(this);
+    tableView_->setModel(proxyModel_);
+    tableView_->setSelectionBehavior(QAbstractItemView::SelectRows);
+    tableView_->setSelectionMode(QAbstractItemView::SingleSelection);
+    tableView_->setSortingEnabled(true);
+    tableView_->setAlternatingRowColors(true);
+    tableView_->verticalHeader()->setVisible(false);
+
+    initializeTableSettings(tableView_, model_,
+        "DepositConventionListWindow",
+        {},
+        {900, 400}, 1);
+}
+
+void DepositConventionMdiWindow::setupConnections() {
+    connect(model_, &ClientDepositConventionModel::dataLoaded,
+            this, &DepositConventionMdiWindow::onDataLoaded);
+    connect(model_, &ClientDepositConventionModel::loadError,
+            this, &DepositConventionMdiWindow::onLoadError);
+
+    connect(tableView_->selectionModel(), &QItemSelectionModel::selectionChanged,
+            this, &DepositConventionMdiWindow::onSelectionChanged);
+    connect(tableView_, &QTableView::doubleClicked,
+            this, &DepositConventionMdiWindow::onDoubleClicked);
+
+    connect(paginationWidget_, &PaginationWidget::page_size_changed,
+            this, [this](std::uint32_t size) {
+        model_->set_page_size(size);
+        model_->refresh();
+    });
+
+    connect(paginationWidget_, &PaginationWidget::load_all_requested,
+            this, [this]() {
+        const auto total = model_->total_available_count();
+        if (total > 0 && total <= 1000) {
+            model_->set_page_size(total);
+            model_->refresh();
+        }
+    });
+
+    connect(paginationWidget_, &PaginationWidget::page_requested,
+            this, [this](std::uint32_t offset, std::uint32_t limit) {
+        model_->load_page(offset, limit);
+    });
+}
+
+void DepositConventionMdiWindow::doReload() {
+    BOOST_LOG_SEV(lg(), debug) << "Reloading deposit conventions";
+    clearStaleIndicator();
+    emit statusChanged(tr("Loading deposit conventions..."));
+    model_->refresh();
+}
+
+void DepositConventionMdiWindow::onDataLoaded() {
+    const auto loaded = model_->rowCount();
+    const auto total = model_->total_available_count();
+    emit statusChanged(tr("Loaded %1 of %2 deposit conventions").arg(loaded).arg(total));
+
+    paginationWidget_->update_state(loaded, total);
+    paginationWidget_->set_load_all_enabled(
+        loaded < static_cast<int>(total) && total > 0 && total <= 1000);
+}
+
+void DepositConventionMdiWindow::onLoadError(const QString& error_message,
+                                          const QString& details) {
+    BOOST_LOG_SEV(lg(), error) << "Load error: " << error_message.toStdString();
+    emit errorOccurred(error_message);
+    MessageBoxHelper::critical(this, tr("Load Error"), error_message, details);
+}
+
+void DepositConventionMdiWindow::onSelectionChanged() {
+    updateActionStates();
+}
+
+void DepositConventionMdiWindow::onDoubleClicked(const QModelIndex& index) {
+    if (!index.isValid())
+        return;
+
+    auto sourceIndex = proxyModel_->mapToSource(index);
+    if (auto* dc = model_->getConvention(sourceIndex.row())) {
+        emit showConventionDetails(*dc);
+    }
+}
+
+void DepositConventionMdiWindow::updateActionStates() {
+    const bool hasSelection = tableView_->selectionModel()->hasSelection();
+    editAction_->setEnabled(hasSelection);
+    deleteAction_->setEnabled(hasSelection);
+    historyAction_->setEnabled(hasSelection);
+}
+
+void DepositConventionMdiWindow::addNew() {
+    BOOST_LOG_SEV(lg(), debug) << "Add new deposit convention requested";
+    emit addNewRequested();
+}
+
+void DepositConventionMdiWindow::editSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Edit requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* dc = model_->getConvention(sourceIndex.row())) {
+        emit showConventionDetails(*dc);
+    }
+}
+
+void DepositConventionMdiWindow::viewHistorySelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "View history requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* dc = model_->getConvention(sourceIndex.row())) {
+        BOOST_LOG_SEV(lg(), debug) << "Emitting showConventionHistory for code: "
+                                   << dc->id;
+        emit showConventionHistory(*dc);
+    }
+}
+
+void DepositConventionMdiWindow::deleteSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Delete requested but no row selected";
+        return;
+    }
+
+    if (!clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete deposit convention while disconnected.");
+        return;
+    }
+
+    std::vector<std::string> codes;
+    for (const auto& index : selected) {
+        auto sourceIndex = proxyModel_->mapToSource(index);
+        if (auto* dc = model_->getConvention(sourceIndex.row())) {
+            codes.push_back(dc->id);
+        }
+    }
+
+    if (codes.empty()) {
+        BOOST_LOG_SEV(lg(), warn) << "No valid deposit conventions to delete";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Delete requested for " << codes.size()
+                               << " deposit conventions";
+
+    QString confirmMessage;
+    if (codes.size() == 1) {
+        confirmMessage = QString("Are you sure you want to delete deposit convention '%1'?")
+            .arg(QString::fromStdString(codes.front()));
+    } else {
+        confirmMessage = QString("Are you sure you want to delete %1 deposit conventions?")
+            .arg(codes.size());
+    }
+
+    auto reply = MessageBoxHelper::question(this, "Delete Deposit Convention",
+        confirmMessage, QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        BOOST_LOG_SEV(lg(), debug) << "Delete cancelled by user";
+        return;
+    }
+
+    QPointer<DepositConventionMdiWindow> self = this;
+    using DeleteResult = std::vector<std::pair<std::string, std::pair<bool, std::string>>>;
+
+    auto task = [self, codes]() -> DeleteResult {
+        DeleteResult results;
+        if (!self) return {};
+
+        BOOST_LOG_SEV(lg(), debug) << "Making batch delete request for "
+                                   << codes.size() << " deposit conventions";
+
+        refdata::messaging::delete_deposit_convention_request request;
+        request.codes = codes;
+        auto response_result = self->clientManager_->process_authenticated_request(
+            std::move(request));
+
+        if (!response_result) {
+            BOOST_LOG_SEV(lg(), error) << "Failed to send batch delete request";
+            for (const auto& code : codes) {
+                results.push_back({code, {false, "Failed to communicate with server"}});
+            }
+            return results;
+        }
+
+        for (const auto& code : codes) {
+            results.push_back({code, {response_result->success, response_result->message}});
+        }
+
+        return results;
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, watcher]() {
+        auto results = watcher->result();
+        watcher->deleteLater();
+
+        int success_count = 0;
+        int failure_count = 0;
+        QString first_error;
+
+        for (const auto& [code, result] : results) {
+            if (result.first) {
+                BOOST_LOG_SEV(lg(), debug) << "Deposit Convention deleted: " << code;
+                success_count++;
+                emit self->dcDeleted(QString::fromStdString(code));
+            } else {
+                BOOST_LOG_SEV(lg(), error) << "Deposit Convention deletion failed: "
+                                           << code << " - " << result.second;
+                failure_count++;
+                if (first_error.isEmpty()) {
+                    first_error = QString::fromStdString(result.second);
+                }
+            }
+        }
+
+        self->model_->refresh();
+
+        if (failure_count == 0) {
+            QString msg = success_count == 1
+                ? "Successfully deleted 1 deposit convention"
+                : QString("Successfully deleted %1 deposit conventions").arg(success_count);
+            emit self->statusChanged(msg);
+        } else if (success_count == 0) {
+            QString msg = QString("Failed to delete %1 %2: %3")
+                .arg(failure_count)
+                .arg(failure_count == 1 ? "deposit convention" : "deposit conventions")
+                .arg(first_error);
+            emit self->errorOccurred(msg);
+            MessageBoxHelper::critical(self, "Delete Failed", msg);
+        } else {
+            QString msg = QString("Deleted %1, failed to delete %2")
+                .arg(success_count)
+                .arg(failure_count);
+            emit self->statusChanged(msg);
+            MessageBoxHelper::warning(self, "Partial Success", msg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt.refdata/src/RefdataPlugin.cpp
+++ b/projects/ores.qt.refdata/src/RefdataPlugin.cpp
@@ -45,6 +45,7 @@
 #include "ores.qt/RoundingTypeController.hpp"
 #include "ores.qt/PurposeTypeController.hpp"
 #include "ores.qt/ZeroConventionController.hpp"
+#include "ores.qt/DepositConventionController.hpp"
 
 namespace ores::qt {
 
@@ -162,6 +163,11 @@ void RefdataPlugin::on_login(const plugin_context& ctx) {
         ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
         ctx_.username, this);
     connectControllerSignals(zeroConventionController_.get());
+
+    depositConventionController_ = std::make_unique<DepositConventionController>(
+        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
+        ctx_.username, this);
+    connectControllerSignals(depositConventionController_.get());
 }
 
 // ---------------------------------------------------------------------------
@@ -223,6 +229,11 @@ void RefdataPlugin::setup_menus(const shared_menus_context& smc) {
             ico(Icon::Tag), tr("&Zero Conventions"));
         connect(actZeroConventions, &QAction::triggered, this, [this]() {
             if (zeroConventionController_) zeroConventionController_->showListWindow();
+        });
+        auto* actDepositConventions = menuOreConventions->addAction(
+            ico(Icon::Tag), tr("&Deposit Conventions"));
+        connect(actDepositConventions, &QAction::triggered, this, [this]() {
+            if (depositConventionController_) depositConventionController_->showListWindow();
         });
 
         ref->addSeparator();

--- a/projects/ores.qt.refdata/ui/DepositConventionDetailDialog.ui
+++ b/projects/ores.qt.refdata/ui/DepositConventionDetailDialog.ui
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DepositConventionDetailDialog</class>
+ <widget class="QWidget" name="DepositConventionDetailDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>500</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>600</width>
+    <height>500</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Deposit Convention Details</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex"><number>0</number></property>
+     <widget class="QWidget" name="generalTab">
+      <attribute name="title"><string>General</string></attribute>
+      <layout class="QVBoxLayout" name="generalLayout">
+       <item>
+        <widget class="QGroupBox" name="basicInfoGroup">
+         <property name="title">
+          <string>Basic Information</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelId">
+            <property name="text">
+             <string>Id:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="idEdit">
+            <property name="placeholderText">
+             <string>Enter convention id</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelIndex">
+            <property name="text">
+             <string>Index:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="indexEdit">
+            <property name="placeholderText">
+             <string>e.g. USD-LIBOR</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelCalendar">
+            <property name="text">
+             <string>Calendar:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="calendarEdit">
+            <property name="placeholderText">
+             <string>e.g. TARGET</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelConvention">
+            <property name="text">
+             <string>Convention:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="conventionEdit">
+            <property name="placeholderText">
+             <string>e.g. Following</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelDayCountFraction">
+            <property name="text">
+             <string>Day Count Fraction:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="dayCountFractionEdit">
+            <property name="placeholderText">
+             <string>e.g. ACT/360</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="provenanceTab">
+      <attribute name="title"><string>Provenance</string></attribute>
+      <layout class="QVBoxLayout" name="provenanceTabLayout">
+       <item>
+        <widget class="ores::qt::ProvenanceWidget" name="provenanceWidget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="deleteButton">
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveButton">
+       <property name="text">
+        <string>Save</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ores::qt::ProvenanceWidget</class>
+   <extends>QWidget</extends>
+   <header>ores.qt/ProvenanceWidget.hpp</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt.refdata/ui/DepositConventionDetailDialog.ui
+++ b/projects/ores.qt.refdata/ui/DepositConventionDetailDialog.ui
@@ -53,58 +53,109 @@
            </widget>
           </item>
           <item row="1" column="0">
+           <widget class="QLabel" name="labelIndexBased">
+            <property name="text">
+             <string>Index Based:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="indexBasedEdit">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
            <widget class="QLabel" name="labelIndex">
             <property name="text">
              <string>Index:</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="2" column="1">
            <widget class="QLineEdit" name="indexEdit">
             <property name="placeholderText">
              <string>e.g. USD-LIBOR</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="labelCalendar">
             <property name="text">
              <string>Calendar:</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QLineEdit" name="calendarEdit">
             <property name="placeholderText">
              <string>e.g. TARGET</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="labelConvention">
             <property name="text">
              <string>Convention:</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="4" column="1">
            <widget class="QLineEdit" name="conventionEdit">
             <property name="placeholderText">
              <string>e.g. Following</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="5" column="0">
            <widget class="QLabel" name="labelDayCountFraction">
             <property name="text">
              <string>Day Count Fraction:</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="5" column="1">
            <widget class="QLineEdit" name="dayCountFractionEdit">
             <property name="placeholderText">
              <string>e.g. ACT/360</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="labelEndOfMonth">
+            <property name="text">
+             <string>End Of Month:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QCheckBox" name="endOfMonthEdit">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="tristate">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="labelSettlementDays">
+            <property name="text">
+             <string>Settlement Days:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QSpinBox" name="settlementDaysEdit">
+            <property name="minimum">
+             <number>-1</number>
+            </property>
+            <property name="maximum">
+             <number>30</number>
+            </property>
+            <property name="specialValueText">
+             <string>(unset)</string>
             </property>
            </widget>
           </item>

--- a/projects/ores.qt.refdata/ui/DepositConventionHistoryDialog.ui
+++ b/projects/ores.qt.refdata/ui/DepositConventionHistoryDialog.ui
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DepositConventionHistoryDialog</class>
+ <widget class="QWidget" name="DepositConventionHistoryDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>900</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Deposit Convention History</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Deposit Convention History</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QTableWidget" name="versionListWidget">
+      <property name="minimumHeight">
+       <number>150</number>
+      </property>
+      <property name="maximumHeight">
+       <number>250</number>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="editTriggers">
+       <set>QAbstractItemView::NoEditTriggers</set>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+      <column>
+       <property name="text">
+        <string>Version</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Recorded At</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Modified By</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Commentary</string>
+       </property>
+      </column>
+     </widget>
+     <widget class="QWidget" name="detailWidget">
+      <layout class="QVBoxLayout" name="detailLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTabWidget" name="tabWidget">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="changesTab">
+          <attribute name="title">
+           <string>Changes</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="changesTabLayout">
+           <item>
+            <widget class="QTableWidget" name="changesTableWidget">
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="alternatingRowColors">
+              <bool>true</bool>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::SingleSelection</enum>
+             </property>
+             <property name="selectionBehavior">
+              <enum>QAbstractItemView::SelectRows</enum>
+             </property>
+             <column>
+              <property name="text">
+               <string>Field</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Old Value</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>New Value</string>
+              </property>
+             </column>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="fullDetailsTab">
+          <attribute name="title">
+           <string>Full Details</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="fullDetailsTabLayout">
+           <item>
+            <widget class="QScrollArea" name="scrollArea">
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>560</width>
+                <height>450</height>
+               </rect>
+              </property>
+              <layout class="QFormLayout" name="formLayout">
+               <item row="0" column="0">
+                <widget class="QLabel" name="idLabel">
+                 <property name="text">
+                  <string>Id:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="idValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="indexLabel">
+                 <property name="text">
+                  <string>Index:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="indexValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="calendarLabel">
+                 <property name="text">
+                  <string>Calendar:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLabel" name="calendarValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="conventionLabel">
+                 <property name="text">
+                  <string>Convention:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="conventionValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="day_count_fractionLabel">
+                 <property name="text">
+                  <string>Day Count Fraction:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLabel" name="dayCountFractionValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="versionNumberLabel">
+                 <property name="text">
+                  <string>Version:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QLabel" name="versionNumberValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="modifiedByLabel">
+                 <property name="text">
+                  <string>Modified By:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QLabel" name="modifiedByValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="recordedAtLabel">
+                 <property name="text">
+                  <string>Recorded At:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QLabel" name="recordedAtValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="0">
+                <widget class="QLabel" name="changeCommentaryLabel">
+                 <property name="text">
+                  <string>Change Commentary:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QLabel" name="changeCommentaryValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size><width>40</width><height>20</height></size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt.refdata/ui/DepositConventionHistoryDialog.ui
+++ b/projects/ores.qt.refdata/ui/DepositConventionHistoryDialog.ui
@@ -164,111 +164,153 @@
                 </widget>
                </item>
                <item row="1" column="0">
-                <widget class="QLabel" name="indexLabel">
+                <widget class="QLabel" name="index_basedLabel">
                  <property name="text">
-                  <string>Index:</string>
+                  <string>Index Based:</string>
                  </property>
                 </widget>
                </item>
                <item row="1" column="1">
-                <widget class="QLabel" name="indexValue">
+                <widget class="QLabel" name="indexBasedValue">
                  <property name="text">
                   <string/>
                  </property>
                 </widget>
                </item>
                <item row="2" column="0">
-                <widget class="QLabel" name="calendarLabel">
+                <widget class="QLabel" name="indexLabel">
                  <property name="text">
-                  <string>Calendar:</string>
+                  <string>Index:</string>
                  </property>
                 </widget>
                </item>
                <item row="2" column="1">
-                <widget class="QLabel" name="calendarValue">
+                <widget class="QLabel" name="indexValue">
                  <property name="text">
                   <string/>
                  </property>
                 </widget>
                </item>
                <item row="3" column="0">
-                <widget class="QLabel" name="conventionLabel">
+                <widget class="QLabel" name="calendarLabel">
                  <property name="text">
-                  <string>Convention:</string>
+                  <string>Calendar:</string>
                  </property>
                 </widget>
                </item>
                <item row="3" column="1">
-                <widget class="QLabel" name="conventionValue">
+                <widget class="QLabel" name="calendarValue">
                  <property name="text">
                   <string/>
                  </property>
                 </widget>
                </item>
                <item row="4" column="0">
-                <widget class="QLabel" name="day_count_fractionLabel">
+                <widget class="QLabel" name="conventionLabel">
                  <property name="text">
-                  <string>Day Count Fraction:</string>
+                  <string>Convention:</string>
                  </property>
                 </widget>
                </item>
                <item row="4" column="1">
-                <widget class="QLabel" name="dayCountFractionValue">
+                <widget class="QLabel" name="conventionValue">
                  <property name="text">
                   <string/>
                  </property>
                 </widget>
                </item>
                <item row="5" column="0">
-                <widget class="QLabel" name="versionNumberLabel">
+                <widget class="QLabel" name="day_count_fractionLabel">
                  <property name="text">
-                  <string>Version:</string>
+                  <string>Day Count Fraction:</string>
                  </property>
                 </widget>
                </item>
                <item row="5" column="1">
-                <widget class="QLabel" name="versionNumberValue">
+                <widget class="QLabel" name="dayCountFractionValue">
                  <property name="text">
                   <string/>
                  </property>
                 </widget>
                </item>
                <item row="6" column="0">
-                <widget class="QLabel" name="modifiedByLabel">
+                <widget class="QLabel" name="end_of_monthLabel">
                  <property name="text">
-                  <string>Modified By:</string>
+                  <string>End Of Month:</string>
                  </property>
                 </widget>
                </item>
                <item row="6" column="1">
-                <widget class="QLabel" name="modifiedByValue">
+                <widget class="QLabel" name="endOfMonthValue">
                  <property name="text">
                   <string/>
                  </property>
                 </widget>
                </item>
                <item row="7" column="0">
-                <widget class="QLabel" name="recordedAtLabel">
+                <widget class="QLabel" name="settlement_daysLabel">
                  <property name="text">
-                  <string>Recorded At:</string>
+                  <string>Settlement Days:</string>
                  </property>
                 </widget>
                </item>
                <item row="7" column="1">
-                <widget class="QLabel" name="recordedAtValue">
+                <widget class="QLabel" name="settlementDaysValue">
                  <property name="text">
                   <string/>
                  </property>
                 </widget>
                </item>
                <item row="8" column="0">
+                <widget class="QLabel" name="versionNumberLabel">
+                 <property name="text">
+                  <string>Version:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QLabel" name="versionNumberValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0">
+                <widget class="QLabel" name="modifiedByLabel">
+                 <property name="text">
+                  <string>Modified By:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QLabel" name="modifiedByValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="0">
+                <widget class="QLabel" name="recordedAtLabel">
+                 <property name="text">
+                  <string>Recorded At:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="1">
+                <widget class="QLabel" name="recordedAtValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="0">
                 <widget class="QLabel" name="changeCommentaryLabel">
                  <property name="text">
                   <string>Change Commentary:</string>
                  </property>
                 </widget>
                </item>
-               <item row="8" column="1">
+               <item row="11" column="1">
                 <widget class="QLabel" name="changeCommentaryValue">
                  <property name="text">
                   <string/>

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/deposit_convention.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/deposit_convention.hpp
@@ -17,8 +17,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_API_DOMAIN_DEPOSIT_CONVENTION_HPP
-#define ORES_REFDATA_API_DOMAIN_DEPOSIT_CONVENTION_HPP
+#ifndef ORES_REFDATA_DOMAIN_DEPOSIT_CONVENTION_HPP
+#define ORES_REFDATA_DOMAIN_DEPOSIT_CONVENTION_HPP
 
 #include <chrono>
 #include <string>
@@ -31,10 +31,9 @@ namespace ores::refdata::domain {
  * @brief Conventions for a money-market deposit or IBOR index fixing.
  *
  * Specifies the settlement lag, calendar, and day count for short-term
- * deposits used as the near-end instruments when bootstrapping a yield curve.
- * Corresponds to the @c <Deposit> element in @c conventions.xml.
- *
- * When @c index_based is @c true the remaining fields may be omitted and are
+ * deposits used as the near-end instruments when bootstrapping a yield
+ * curve. Corresponds to the <Deposit> element in ORE conventions.xml.
+ * When index_based is true the remaining fields may be omitted and are
  * instead inherited from the referenced IBOR index convention.
  */
 struct deposit_convention final {
@@ -49,24 +48,24 @@ struct deposit_convention final {
     utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
-     * @brief Unique convention identifier (e.g. "USD-LIBOR-CONVENTIONS").
+     * @brief Unique convention identifier.
+     *
+     * Examples: 'USD-LIBOR-CONVENTIONS', 'EUR-EURIBOR-CONVENTIONS'.
      */
     std::string id;
 
     /**
-     * @brief Whether the deposit conventions are derived from an IBOR index.
-     *
-     * When @c true, @c index must be set and the remaining fields are optional.
+     * @brief Whether the deposit conventions are derived from an IBOR index. When true, index must be set and the remaining fields are optional.
      */
-    bool index_based = false;
+    bool index_based;
 
     /**
-     * @brief IBOR index identifier (e.g. "USD-LIBOR") used when @c index_based.
+     * @brief IBOR index identifier (e.g. 'USD-LIBOR') used when index_based.
      */
     std::optional<std::string> index;
 
     /**
-     * @brief Settlement calendar (e.g. "TARGET", "US-FED").
+     * @brief Settlement calendar (e.g. 'TARGET', 'US-FED').
      */
     std::optional<std::string> calendar;
 
@@ -81,7 +80,7 @@ struct deposit_convention final {
     std::optional<bool> end_of_month;
 
     /**
-     * @brief Day count fraction code (canonical FpML, e.g. "ACT/360").
+     * @brief Day count fraction code (canonical FpML, e.g. 'ACT/360').
      */
     std::optional<std::string> day_count_fraction;
 
@@ -91,12 +90,19 @@ struct deposit_convention final {
     std::optional<int> settlement_days;
 
     /**
-     * @brief Username of the person who recorded this version.
+     * @brief Username of the person who last modified this deposit convention.
      */
     std::string modified_by;
 
     /**
+     * @brief Username of the account that performed this action.
+     */
+    std::string performed_by;
+
+    /**
      * @brief Code identifying the reason for the change.
+     *
+     * References change_reasons table (soft FK).
      */
     std::string change_reason_code;
 
@@ -104,11 +110,6 @@ struct deposit_convention final {
      * @brief Free-text commentary explaining the change.
      */
     std::string change_commentary;
-
-    /**
-     * @brief Username of the account that performed this operation.
-     */
-    std::string performed_by;
 
     /**
      * @brief Timestamp when this version of the record was recorded.

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/deposit_convention.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/deposit_convention.hpp
@@ -57,7 +57,7 @@ struct deposit_convention final {
     /**
      * @brief Whether the deposit conventions are derived from an IBOR index. When true, index must be set and the remaining fields are optional.
      */
-    bool index_based;
+    bool index_based = false;
 
     /**
      * @brief IBOR index identifier (e.g. 'USD-LIBOR') used when index_based.

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/deposit_convention_json_io.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/deposit_convention_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_DEPOSIT_CONVENTION_JSON_IO_HPP
+#define ORES_REFDATA_DOMAIN_DEPOSIT_CONVENTION_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.refdata.api/domain/deposit_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the deposit_convention to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const deposit_convention& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/deposit_convention_table.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/deposit_convention_table.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_DEPOSIT_CONVENTION_TABLE_HPP
+#define ORES_REFDATA_DOMAIN_DEPOSIT_CONVENTION_TABLE_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata.api/domain/deposit_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Converts deposit_conventions to the table format.
+ */
+std::string convert_to_table(const std::vector<deposit_convention>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/deposit_convention_table_io.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/deposit_convention_table_io.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_DEPOSIT_CONVENTION_TABLE_IO_HPP
+#define ORES_REFDATA_DOMAIN_DEPOSIT_CONVENTION_TABLE_IO_HPP
+
+#include <iosfwd>
+#include <vector>
+#include "ores.refdata.api/domain/deposit_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the deposit_convention objects to a stream in table format.
+ */
+std::ostream& operator<<(std::ostream& s, const std::vector<deposit_convention>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/zero_convention.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/zero_convention.hpp
@@ -55,7 +55,7 @@ struct zero_convention final {
     /**
      * @brief Whether the curve is defined on a tenor grid (true) or on absolute dates (false).
      */
-    bool tenor_based;
+    bool tenor_based = false;
 
     /**
      * @brief Day count fraction code (canonical FpML, e.g. 'ACT/365.FIXED').

--- a/projects/ores.refdata.api/include/ores.refdata.api/generators/deposit_convention_generator.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/generators/deposit_convention_generator.hpp
@@ -1,0 +1,44 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_GENERATORS_DEPOSIT_CONVENTION_GENERATOR_HPP
+#define ORES_REFDATA_GENERATORS_DEPOSIT_CONVENTION_GENERATOR_HPP
+
+#include <vector>
+#include "ores.refdata.api/domain/deposit_convention.hpp"
+#include "ores.utility/generation/generation_context.hpp"
+
+namespace ores::refdata::generators {
+
+/**
+ * @brief Generates a synthetic deposit_convention.
+ */
+domain::deposit_convention generate_synthetic_deposit_convention(
+    utility::generation::generation_context& ctx);
+
+/**
+ * @brief Generates N synthetic deposit_conventions.
+ */
+std::vector<domain::deposit_convention>
+generate_synthetic_deposit_conventions(std::size_t n,
+    utility::generation::generation_context& ctx);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/messaging/deposit_convention_protocol.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/messaging/deposit_convention_protocol.hpp
@@ -1,0 +1,81 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_DEPOSIT_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_MESSAGING_DEPOSIT_CONVENTION_PROTOCOL_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata.api/domain/deposit_convention.hpp"
+
+namespace ores::refdata::messaging {
+
+struct get_deposit_conventions_request {
+    using response_type = struct get_deposit_conventions_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.deposit_conventions.list";
+};
+
+struct get_deposit_conventions_response {
+    std::vector<ores::refdata::domain::deposit_convention> deposit_conventions;
+    int total_available_count = 0;
+    bool success = true;
+    std::string message;
+};
+
+struct save_deposit_convention_request {
+    using response_type = struct save_deposit_convention_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.deposit_conventions.save";
+    ores::refdata::domain::deposit_convention data;
+};
+
+struct save_deposit_convention_response {
+    bool success = false;
+    std::string message;
+};
+
+struct delete_deposit_convention_request {
+    using response_type = struct delete_deposit_convention_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.deposit_conventions.delete";
+    std::vector<std::string> codes;
+};
+
+struct delete_deposit_convention_response {
+    bool success = false;
+    std::string message;
+};
+
+struct get_deposit_convention_history_request {
+    using response_type = struct get_deposit_convention_history_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.deposit_conventions.history";
+    std::string id;
+};
+
+struct get_deposit_convention_history_response {
+    std::vector<ores::refdata::domain::deposit_convention> deposit_conventions;
+    bool success = false;
+    std::string message;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.api/src/domain/deposit_convention_json_io.cpp
+++ b/projects/ores.refdata.api/src/domain/deposit_convention_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/deposit_convention_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::domain {
+
+std::ostream& operator<<(std::ostream& s, const deposit_convention& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/deposit_convention_table.cpp
+++ b/projects/ores.refdata.api/src/domain/deposit_convention_table.cpp
@@ -1,0 +1,52 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/deposit_convention_table.hpp"
+
+#include <sstream>
+#include <boost/uuid/uuid_io.hpp>
+#include <fort.hpp>
+
+namespace ores::refdata::domain {
+
+namespace {
+template <typename T>
+std::string opt_str(const std::optional<T>& o) {
+    if (!o) return {};
+    std::ostringstream s;
+    if constexpr (std::is_same_v<T, bool>)
+        s << std::boolalpha;
+    s << *o;
+    return s.str();
+}
+}
+
+std::string convert_to_table(const std::vector<deposit_convention>& v) {
+    fort::char_table table;
+    table.set_border_style(FT_BASIC_STYLE);
+
+    table << fort::header << "Id" << "Index Based" << "Index" << "Calendar" << "DCF" << "Modified By" << "Version" << fort::endr;
+
+    for (const auto& dc : v) {
+        table << dc.id << dc.index_based << opt_str(dc.index) << opt_str(dc.calendar) << opt_str(dc.day_count_fraction) << dc.modified_by << dc.version << fort::endr;
+    }
+    return table.to_string();
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/deposit_convention_table_io.cpp
+++ b/projects/ores.refdata.api/src/domain/deposit_convention_table_io.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/deposit_convention_table_io.hpp"
+
+#include <ostream>
+#include "ores.refdata.api/domain/deposit_convention_table.hpp"
+
+namespace ores::refdata::domain {
+
+namespace {
+
+void print_deposit_convention_table(std::ostream& s, const std::vector<deposit_convention>& v) {
+    s << std::endl << convert_to_table(v) << std::endl;
+}
+
+}
+
+std::ostream& operator<<(std::ostream& s, const std::vector<deposit_convention>& v) {
+    print_deposit_convention_table(s, v);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.api/src/generators/deposit_convention_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/deposit_convention_generator.cpp
@@ -20,6 +20,7 @@
 #include "ores.refdata.api/generators/deposit_convention_generator.hpp"
 
 #include <atomic>
+#include <string>
 #include <faker-cxx/faker.h> // IWYU pragma: keep.
 #include "ores.utility/generation/generation_keys.hpp"
 
@@ -35,7 +36,8 @@ domain::deposit_convention generate_synthetic_deposit_convention(
 
     domain::deposit_convention r;
     r.version = 1;
-    r.id = std::string("USD-LIBOR-CONVENTIONS");
+    r.id = std::string("USD-LIBOR-CONVENTIONS") + "-"
+        + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
     r.index_based = true;
     r.index = std::string("USD-LIBOR");
     r.calendar = std::nullopt;

--- a/projects/ores.refdata.api/src/generators/deposit_convention_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/deposit_convention_generator.cpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/generators/deposit_convention_generator.hpp"
+
+#include <atomic>
+#include <faker-cxx/faker.h> // IWYU pragma: keep.
+#include "ores.utility/generation/generation_keys.hpp"
+
+namespace ores::refdata::generators {
+
+using ores::utility::generation::generation_keys;
+
+domain::deposit_convention generate_synthetic_deposit_convention(
+    utility::generation::generation_context& ctx) {
+    static std::atomic<int> counter{0};
+    const auto modified_by = ctx.env().get_or(
+        std::string(generation_keys::modified_by), "system");
+
+    domain::deposit_convention r;
+    r.version = 1;
+    r.id = std::string("USD-LIBOR-CONVENTIONS");
+    r.index_based = true;
+    r.index = std::string("USD-LIBOR");
+    r.calendar = std::nullopt;
+    r.convention = std::nullopt;
+    r.end_of_month = std::nullopt;
+    r.day_count_fraction = std::nullopt;
+    r.settlement_days = std::nullopt;
+    r.modified_by = modified_by;
+    r.performed_by = modified_by;
+    r.change_reason_code = "system.new";
+    r.change_commentary = "Synthetic test data";
+    r.recorded_at = ctx.past_timepoint();
+    return r;
+}
+
+std::vector<domain::deposit_convention>
+generate_synthetic_deposit_conventions(std::size_t n,
+    utility::generation::generation_context& ctx) {
+    std::vector<domain::deposit_convention> r;
+    r.reserve(n);
+    while (r.size() < n)
+        r.push_back(generate_synthetic_deposit_convention(ctx));
+    return r;
+}
+
+}

--- a/projects/ores.refdata.api/src/generators/zero_convention_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/zero_convention_generator.cpp
@@ -20,6 +20,7 @@
 #include "ores.refdata.api/generators/zero_convention_generator.hpp"
 
 #include <atomic>
+#include <string>
 #include <faker-cxx/faker.h> // IWYU pragma: keep.
 #include "ores.utility/generation/generation_keys.hpp"
 
@@ -35,7 +36,8 @@ domain::zero_convention generate_synthetic_zero_convention(
 
     domain::zero_convention r;
     r.version = 1;
-    r.id = std::string("EUR-ZERO-CONVENTIONS");
+    r.id = std::string("EUR-ZERO-CONVENTIONS") + "-"
+        + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
     r.tenor_based = true;
     r.day_count_fraction = std::string("ACT/365.FIXED");
     r.compounding = std::string("Continuous");

--- a/projects/ores.refdata.core/include/ores.refdata.core/messaging/deposit_convention_handler.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/messaging/deposit_convention_handler.hpp
@@ -1,0 +1,197 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_DEPOSIT_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_MESSAGING_DEPOSIT_CONVENTION_HANDLER_HPP
+
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.refdata.api/messaging/deposit_convention_protocol.hpp"
+#include "ores.refdata.core/service/deposit_convention_service.hpp"
+
+namespace ores::refdata::messaging {
+
+namespace {
+inline auto& deposit_convention_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.deposit_convention_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using ores::service::messaging::has_permission;
+using namespace ores::logging;
+
+/**
+ * @brief NATS message handler for deposit convention operations.
+ */
+class deposit_convention_handler {
+public:
+    deposit_convention_handler(ores::nats::service::client& nats,
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
+
+    void list(ores::nats::message msg) {
+        BOOST_LOG_SEV(deposit_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::deposit_convention_service svc(req_ctx);
+        get_deposit_conventions_response resp;
+        try {
+            resp.deposit_conventions = svc.list_deposit_conventions();
+            resp.total_available_count =
+                static_cast<int>(resp.deposit_conventions.size());
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(deposit_convention_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            resp.success = false;
+            resp.message = e.what();
+        }
+        BOOST_LOG_SEV(deposit_convention_handler_lg(), debug)
+            << "Completed " << msg.subject;
+        reply(nats_, msg, resp);
+    }
+
+    void save(ores::nats::message msg) {
+        BOOST_LOG_SEV(deposit_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::deposit_conventions:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::deposit_convention_service svc(req_ctx);
+        if (auto req = decode<save_deposit_convention_request>(msg)) {
+            try {
+                svc.save_deposit_convention(req->data);
+                BOOST_LOG_SEV(deposit_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_deposit_convention_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(deposit_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_deposit_convention_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(deposit_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void history(ores::nats::message msg) {
+        BOOST_LOG_SEV(deposit_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::deposit_convention_service svc(req_ctx);
+        if (auto req = decode<get_deposit_convention_history_request>(msg)) {
+            try {
+                auto hist = svc.get_deposit_convention_history(req->id);
+                BOOST_LOG_SEV(deposit_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_deposit_convention_history_response{
+                    .deposit_conventions = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(deposit_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_deposit_convention_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(deposit_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(deposit_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::deposit_conventions:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::deposit_convention_service svc(req_ctx);
+        if (auto req = decode<delete_deposit_convention_request>(msg)) {
+            try {
+                for (const auto& code : req->codes)
+                    svc.remove_deposit_convention(code);
+                BOOST_LOG_SEV(deposit_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_deposit_convention_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(deposit_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_deposit_convention_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(deposit_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::refdata::messaging
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/deposit_convention_entity.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/deposit_convention_entity.hpp
@@ -38,7 +38,7 @@ struct deposit_convention_entity {
     sqlgen::PrimaryKey<std::string> id;
     std::string tenant_id;
     int version = 0;
-    bool index_based;
+    bool index_based = false;
     std::optional<std::string> index;
     std::optional<std::string> calendar;
     std::optional<std::string> convention;

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/deposit_convention_entity.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/deposit_convention_entity.hpp
@@ -1,0 +1,60 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_DEPOSIT_CONVENTION_ENTITY_HPP
+#define ORES_REFDATA_REPOSITORY_DEPOSIT_CONVENTION_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Represents a deposit convention in the database.
+ */
+struct deposit_convention_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_refdata_deposit_conventions_tbl";
+
+    sqlgen::PrimaryKey<std::string> id;
+    std::string tenant_id;
+    int version = 0;
+    bool index_based;
+    std::optional<std::string> index;
+    std::optional<std::string> calendar;
+    std::optional<std::string> convention;
+    std::optional<bool> end_of_month;
+    std::optional<std::string> day_count_fraction;
+    std::optional<int> settlement_days;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const deposit_convention_entity& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/deposit_convention_mapper.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/deposit_convention_mapper.hpp
@@ -1,0 +1,54 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_DEPOSIT_CONVENTION_MAPPER_HPP
+#define ORES_REFDATA_REPOSITORY_DEPOSIT_CONVENTION_MAPPER_HPP
+
+#include "ores.refdata.api/domain/deposit_convention.hpp"
+#include "ores.refdata.core/repository/deposit_convention_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Maps deposit_convention domain entities to data storage layer and vice-versa.
+ */
+class deposit_convention_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.deposit_convention_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::deposit_convention map(const deposit_convention_entity& v);
+    static deposit_convention_entity map(const domain::deposit_convention& v);
+
+    static std::vector<domain::deposit_convention>
+    map(const std::vector<deposit_convention_entity>& v);
+    static std::vector<deposit_convention_entity>
+    map(const std::vector<domain::deposit_convention>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/deposit_convention_repository.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/deposit_convention_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_DEPOSIT_CONVENTION_REPOSITORY_HPP
+#define ORES_REFDATA_REPOSITORY_DEPOSIT_CONVENTION_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata.api/domain/deposit_convention.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Reads and writes deposit conventions to data storage.
+ */
+class deposit_convention_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.deposit_convention_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::deposit_convention& v);
+    void write(context ctx, const std::vector<domain::deposit_convention>& v);
+
+    std::vector<domain::deposit_convention> read_latest(context ctx);
+    std::vector<domain::deposit_convention>
+    read_latest(context ctx, const std::string& id);
+    std::vector<domain::deposit_convention>
+    read_all(context ctx, const std::string& id);
+
+    void remove(context ctx, const std::string& id);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/zero_convention_entity.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/zero_convention_entity.hpp
@@ -38,7 +38,7 @@ struct zero_convention_entity {
     sqlgen::PrimaryKey<std::string> id;
     std::string tenant_id;
     int version = 0;
-    bool tenor_based;
+    bool tenor_based = false;
     std::string day_count_fraction;
     std::optional<std::string> compounding;
     std::optional<std::string> compounding_frequency;

--- a/projects/ores.refdata.core/include/ores.refdata.core/service/deposit_convention_service.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/service/deposit_convention_service.hpp
@@ -1,0 +1,71 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_SERVICE_DEPOSIT_CONVENTION_SERVICE_HPP
+#define ORES_REFDATA_SERVICE_DEPOSIT_CONVENTION_SERVICE_HPP
+
+#include <string>
+#include <vector>
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata.api/domain/deposit_convention.hpp"
+#include "ores.refdata.core/repository/deposit_convention_repository.hpp"
+
+namespace ores::refdata::service {
+
+/**
+ * @brief Service for managing deposit conventions.
+ */
+class deposit_convention_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.service.deposit_convention_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit deposit_convention_service(context ctx);
+
+    std::vector<domain::deposit_convention> list_deposit_conventions();
+
+    std::optional<domain::deposit_convention>
+    get_deposit_convention(const std::string& id);
+
+    void save_deposit_convention(const domain::deposit_convention& v);
+
+    void remove_deposit_convention(const std::string& id);
+
+    std::vector<domain::deposit_convention>
+    get_deposit_convention_history(const std::string& id);
+
+private:
+    context ctx_;
+    repository::deposit_convention_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/service/zero_convention_service.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/service/zero_convention_service.hpp
@@ -52,7 +52,7 @@ public:
     std::vector<domain::zero_convention> list_zero_conventions();
 
     std::optional<domain::zero_convention>
-    find_zero_convention(const std::string& id);
+    get_zero_convention(const std::string& id);
 
     void save_zero_convention(const domain::zero_convention& v);
 

--- a/projects/ores.refdata.core/src/messaging/registrar.cpp
+++ b/projects/ores.refdata.core/src/messaging/registrar.cpp
@@ -47,6 +47,7 @@
 #include "ores.refdata.core/messaging/purpose_type_handler.hpp"
 #include "ores.refdata.core/messaging/asset_class_handler.hpp"
 #include "ores.refdata.core/messaging/zero_convention_handler.hpp"
+#include "ores.refdata.core/messaging/deposit_convention_handler.hpp"
 #include "ores.refdata.api/messaging/country_protocol.hpp"
 #include "ores.refdata.api/messaging/currency_protocol.hpp"
 #include "ores.refdata.api/messaging/currency_history_protocol.hpp"
@@ -72,6 +73,7 @@
 #include "ores.refdata.api/messaging/purpose_type_protocol.hpp"
 #include "ores.refdata.api/messaging/asset_class_protocol.hpp"
 #include "ores.refdata.api/messaging/zero_convention_protocol.hpp"
+#include "ores.refdata.api/messaging/deposit_convention_protocol.hpp"
 
 namespace ores::refdata::messaging {
 
@@ -160,6 +162,26 @@ registrar::register_handlers(ores::nats::service::client& nats,
             [h](ores::nats::message msg) { h->remove(std::move(msg)); }));
         subs.push_back(nats.queue_subscribe(
             get_zero_convention_history_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->history(std::move(msg)); }));
+    }
+
+    // ----------------------------------------------------------------
+    // Deposit conventions
+    // ----------------------------------------------------------------
+    {
+        auto h = std::make_shared<deposit_convention_handler>(
+            nats, ctx, verifier);
+        subs.push_back(nats.queue_subscribe(
+            get_deposit_conventions_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->list(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            save_deposit_convention_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->save(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            delete_deposit_convention_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->remove(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            get_deposit_convention_history_request::nats_subject, queue_group,
             [h](ores::nats::message msg) { h->history(std::move(msg)); }));
     }
 

--- a/projects/ores.refdata.core/src/repository/deposit_convention_entity.cpp
+++ b/projects/ores.refdata.core/src/repository/deposit_convention_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/deposit_convention_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::refdata::repository {
+
+std::ostream& operator<<(std::ostream& s, const deposit_convention_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/deposit_convention_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/deposit_convention_mapper.cpp
@@ -1,0 +1,99 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/deposit_convention_mapper.hpp"
+
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.refdata.api/domain/deposit_convention_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::deposit_convention
+deposit_convention_mapper::map(const deposit_convention_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::deposit_convention r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.id = v.id.value();
+    r.index_based = v.index_based;
+    r.index = v.index;
+    r.calendar = v.calendar;
+    r.convention = v.convention;
+    r.end_of_month = v.end_of_month;
+    r.day_count_fraction = v.day_count_fraction;
+    r.settlement_days = v.settlement_days;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+deposit_convention_entity
+deposit_convention_mapper::map(const domain::deposit_convention& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    deposit_convention_entity r;
+    r.id = v.id;
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.index_based = v.index_based;
+    r.index = v.index;
+    r.calendar = v.calendar;
+    r.convention = v.convention;
+    r.end_of_month = v.end_of_month;
+    r.day_count_fraction = v.day_count_fraction;
+    r.settlement_days = v.settlement_days;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::deposit_convention>
+deposit_convention_mapper::map(const std::vector<deposit_convention_entity>& v) {
+    return map_vector<deposit_convention_entity, domain::deposit_convention>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<deposit_convention_entity>
+deposit_convention_mapper::map(const std::vector<domain::deposit_convention>& v) {
+    return map_vector<domain::deposit_convention, deposit_convention_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/deposit_convention_repository.cpp
+++ b/projects/ores.refdata.core/src/repository/deposit_convention_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/deposit_convention_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.refdata.api/domain/deposit_convention_json_io.hpp" // IWYU pragma: keep.
+#include "ores.refdata.core/repository/deposit_convention_entity.hpp"
+#include "ores.refdata.core/repository/deposit_convention_mapper.hpp"
+
+namespace ores::refdata::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string deposit_convention_repository::sql() {
+    return generate_create_table_sql<deposit_convention_entity>(lg());
+}
+
+void deposit_convention_repository::write(context ctx, const domain::deposit_convention& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing deposit convention: " << v.id;
+    execute_write_query(ctx, deposit_convention_mapper::map(v),
+        lg(), "Writing deposit convention to database.");
+}
+
+void deposit_convention_repository::write(
+    context ctx, const std::vector<domain::deposit_convention>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing deposit conventions. Count: " << v.size();
+    execute_write_query(ctx, deposit_convention_mapper::map(v),
+        lg(), "Writing deposit conventions to database.");
+}
+
+std::vector<domain::deposit_convention>
+deposit_convention_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<deposit_convention_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("id"_c);
+
+    return execute_read_query<deposit_convention_entity, domain::deposit_convention>(
+        ctx, query,
+        [](const auto& entities) { return deposit_convention_mapper::map(entities); },
+        lg(), "Reading latest deposit conventions");
+}
+
+std::vector<domain::deposit_convention>
+deposit_convention_repository::read_latest(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest deposit convention. id: " << id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<deposit_convention_entity>> |
+        where("tenant_id"_c == tid && "id"_c == id && "valid_to"_c == max.value());
+
+    return execute_read_query<deposit_convention_entity, domain::deposit_convention>(
+        ctx, query,
+        [](const auto& entities) { return deposit_convention_mapper::map(entities); },
+        lg(), "Reading latest deposit convention by id.");
+}
+
+std::vector<domain::deposit_convention>
+deposit_convention_repository::read_all(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all deposit convention versions. id: " << id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<deposit_convention_entity>> |
+        where("tenant_id"_c == tid && "id"_c == id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<deposit_convention_entity, domain::deposit_convention>(
+        ctx, query,
+        [](const auto& entities) { return deposit_convention_mapper::map(entities); },
+        lg(), "Reading all deposit convention versions by id.");
+}
+
+void deposit_convention_repository::remove(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing deposit convention: " << id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<deposit_convention_entity> |
+        where("tenant_id"_c == tid && "id"_c == id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing deposit convention from database.");
+}
+
+}

--- a/projects/ores.refdata.core/src/service/deposit_convention_service.cpp
+++ b/projects/ores.refdata.core/src/service/deposit_convention_service.cpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/service/deposit_convention_service.hpp"
+
+#include <stdexcept>
+
+namespace ores::refdata::service {
+
+using namespace ores::logging;
+
+deposit_convention_service::deposit_convention_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+std::vector<domain::deposit_convention> deposit_convention_service::list_deposit_conventions() {
+    BOOST_LOG_SEV(lg(), debug) << "Listing all deposit conventions";
+    return repo_.read_latest(ctx_);
+}
+
+std::optional<domain::deposit_convention>
+deposit_convention_service::get_deposit_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting deposit convention: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
+void deposit_convention_service::save_deposit_convention(const domain::deposit_convention& v) {
+    if (v.id.empty())
+        throw std::invalid_argument("Deposit Convention id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving deposit convention: " << v.id;
+    repo_.write(ctx_, v);
+    BOOST_LOG_SEV(lg(), info) << "Saved deposit convention: " << v.id;
+}
+
+void deposit_convention_service::remove_deposit_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing deposit convention: " << id;
+    repo_.remove(ctx_, id);
+    BOOST_LOG_SEV(lg(), info) << "Removed deposit convention: " << id;
+}
+
+std::vector<domain::deposit_convention>
+deposit_convention_service::get_deposit_convention_history(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting history for deposit convention: " << id;
+    return repo_.read_all(ctx_, id);
+}
+
+}

--- a/projects/ores.refdata.core/src/service/zero_convention_service.cpp
+++ b/projects/ores.refdata.core/src/service/zero_convention_service.cpp
@@ -34,8 +34,8 @@ std::vector<domain::zero_convention> zero_convention_service::list_zero_conventi
 }
 
 std::optional<domain::zero_convention>
-zero_convention_service::find_zero_convention(const std::string& id) {
-    BOOST_LOG_SEV(lg(), debug) << "Finding zero convention: " << id;
+zero_convention_service::get_zero_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting zero convention: " << id;
     auto results = repo_.read_latest(ctx_, id);
     if (results.empty()) return std::nullopt;
     return results.front();

--- a/projects/ores.sql/create/refdata/refdata_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_create.sql
@@ -122,3 +122,5 @@
 -- ORE conventions (curve-building conventions imported from conventions.xml)
 \ir ./refdata_zero_conventions_create.sql
 \ir ./refdata_zero_conventions_notify_trigger_create.sql
+\ir ./refdata_deposit_conventions_create.sql
+\ir ./refdata_deposit_conventions_notify_trigger_create.sql

--- a/projects/ores.sql/create/refdata/refdata_deposit_conventions_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_deposit_conventions_create.sql
@@ -1,0 +1,129 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+/**
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_domain_entity_create.mustache
+ * To modify, update the template and regenerate.
+ *
+ *  Table
+ *
+ * Specifies the settlement lag, calendar, and day count for short-term
+ * deposits used as the near-end instruments when bootstrapping a yield
+ * curve. Corresponds to the <Deposit> element in ORE conventions.xml.
+ * When index_based is true the remaining fields may be omitted and are
+ * instead inherited from the referenced IBOR index convention.
+ */
+
+create table if not exists "ores_refdata_deposit_conventions_tbl" (
+    "id" text not null,
+    "tenant_id" uuid not null,
+    "version" integer not null,
+    "index_based" boolean not null,
+    "index" text null,
+    "calendar" text null,
+    "convention" text null,
+    "end_of_month" boolean null,
+    "day_count_fraction" text null,
+    "settlement_days" integer null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("id" <> '')
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_refdata_deposit_conventions_version_uniq_idx
+on "ores_refdata_deposit_conventions_tbl" (tenant_id, id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create unique index if not exists ores_refdata_deposit_conventions_id_uniq_idx
+on "ores_refdata_deposit_conventions_tbl" (tenant_id, id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create index if not exists ores_refdata_deposit_conventions_tenant_idx
+on "ores_refdata_deposit_conventions_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create or replace function ores_refdata_deposit_conventions_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Version management
+    select version into current_version
+    from "ores_refdata_deposit_conventions_tbl"
+    where tenant_id = NEW.tenant_id
+      and id = NEW.id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_refdata_deposit_conventions_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and id = NEW.id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_actor_fn(), current_user);
+
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    return NEW;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_refdata_deposit_conventions_insert_trg
+before insert on "ores_refdata_deposit_conventions_tbl"
+for each row execute function ores_refdata_deposit_conventions_insert_fn();
+
+create or replace rule ores_refdata_deposit_conventions_delete_rule as
+on delete to "ores_refdata_deposit_conventions_tbl" do instead
+    update "ores_refdata_deposit_conventions_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and id = OLD.id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/refdata/refdata_deposit_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_deposit_conventions_notify_trigger_create.sql
@@ -1,0 +1,58 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+/*
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_notify_trigger.mustache
+ * To modify, update the template and regenerate.
+ */
+
+create or replace function ores_refdata_deposit_conventions_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.refdata.deposit_convention';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.id;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.id;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_deposit_conventions', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_refdata_deposit_conventions_notify_trg
+after insert or update or delete on ores_refdata_deposit_conventions_tbl
+for each row execute function ores_refdata_deposit_conventions_notify_fn();

--- a/projects/ores.sql/create/refdata/refdata_rls_policies_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_rls_policies_create.sql
@@ -66,6 +66,19 @@ with check (
 );
 
 -- -----------------------------------------------------------------------------
+-- Deposit Conventions
+-- -----------------------------------------------------------------------------
+alter table ores_refdata_deposit_conventions_tbl enable row level security;
+
+create policy ores_refdata_deposit_conventions_tenant_isolation_policy on ores_refdata_deposit_conventions_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+-- -----------------------------------------------------------------------------
 -- Currencies
 -- -----------------------------------------------------------------------------
 alter table ores_refdata_currencies_tbl enable row level security;

--- a/projects/ores.sql/create/refdata/refdata_zero_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_zero_conventions_notify_trigger_create.sql
@@ -17,6 +17,11 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
+/*
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_notify_trigger.mustache
+ * To modify, update the template and regenerate.
+ */
 
 create or replace function ores_refdata_zero_conventions_notify_fn()
 returns trigger as $$

--- a/projects/ores.sql/drop/refdata/refdata_deposit_conventions_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_deposit_conventions_drop.sql
@@ -1,0 +1,24 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop rule if exists ores_refdata_deposit_conventions_delete_rule on "ores_refdata_deposit_conventions_tbl";
+drop trigger if exists ores_refdata_deposit_conventions_insert_trg on "ores_refdata_deposit_conventions_tbl";
+drop function if exists ores_refdata_deposit_conventions_insert_fn;
+drop table if exists "ores_refdata_deposit_conventions_tbl";

--- a/projects/ores.sql/drop/refdata/refdata_deposit_conventions_notify_trigger_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_deposit_conventions_notify_trigger_drop.sql
@@ -1,0 +1,22 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_refdata_deposit_conventions_notify_trg on "ores_refdata_deposit_conventions_tbl";
+drop function if exists ores_refdata_deposit_conventions_notify_fn;

--- a/projects/ores.sql/drop/refdata/refdata_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_drop.sql
@@ -21,6 +21,8 @@
 -- ORE conventions (no dependants, drop first)
 \ir ./refdata_zero_conventions_notify_trigger_drop.sql
 \ir ./refdata_zero_conventions_drop.sql
+\ir ./refdata_deposit_conventions_notify_trigger_drop.sql
+\ir ./refdata_deposit_conventions_drop.sql
 
 -- Books, portfolios, and business units (drop first, depend on parties and lookup tables)
 \ir ./refdata_books_notify_trigger_drop.sql


### PR DESCRIPTION
## Summary

Second convention type in the ORE import Phase 2 roll-out (after
`zero_convention`). Follows the same five-commit shape established by
the pilot.

1. `[codegen]` Wire the notify-trigger template into the `sql` profile
   and fix it to use `{{#domain_entity}}` section syntax. Until now
   the template used old-style `{{entity.*}}` placeholders, so it only
   produced valid SQL for `_entity.json` models; new `_domain_entity`
   types had their trigger file hand-authored. Phase 2 types now get
   it from a single `--profile all` run.
2. `[refdata]` Generate the `deposit_convention` domain type — SQL,
   domain, JSON I/O, table I/O, generator, protocol, repository,
   mapper, service, NATS handler, Qt model/window/detail/history/
   controller/.ui. Fields: `id` (text PK), `index_based` (bool), plus
   optionals `index`, `calendar`, `convention`, `end_of_month`,
   `day_count_fraction`, `settlement_days`.
3. `[sql]` Load `refdata_deposit_conventions_create.sql` and its
   notify-trigger from `refdata_create.sql`, plus enable RLS with the
   standard tenant-isolation policy in `refdata_rls_policies_create.sql`.
4. `[refdata]` Register the NATS handler on
   `refdata.v1.deposit_conventions.{list,save,delete,history}`.
5. `[qt]` Register `DepositConventionController` in `RefdataPlugin`
   and add a "Deposit Conventions" entry under the existing
   Conventions submenu.

Part of `doc/plans/2026-04-21-ore-import-conventions.org` — Phase 2
(seven conventions remaining after this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)