### PR TITLE
[ore,trading,qt] Equity per-type migration: forwards produce variants; read-side stub deferred

### DIFF
--- a/doc/plans/2026-04-22-equity-per-type-migration.org
+++ b/doc/plans/2026-04-22-equity-per-type-migration.org
@@ -1,0 +1,250 @@
+#+title: Equity Per-Type Instrument Migration
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
+
+* Overview
+
+PR #2 of the four-PR migration series outlined in
+=doc/plans/2026-04-21-fx-forward-import-e2e.org=. The FX pattern —
+delete the legacy generic table, wire reads through per-type services,
+introduce a discriminated export variant, update the client form —
+repeats for *equity*, which is the largest remaining family: nine
+per-type tables and fourteen trade types mapping into them.
+
+Unlike FX, equity does *not* currently exhibit the FX-forward symptom
+(blank economics in =TradeDetailDialog=) because the ORE importer
+path for equity still writes to the legacy generic
+=ores_trading_equity_instruments_tbl=. The defect is therefore
+*latent*, not active: as soon as the importer flips to the per-type
+tables (parallel work in the ORE mapper), the UI would go blank
+exactly as FX did. This PR removes the latency by converging the
+read and write paths on per-type infrastructure *before* that flip.
+
+* Goals
+
+1. Delete the legacy single-table equity infrastructure
+   (=ores_trading_equity_instruments_tbl=, =equity_instrument= domain,
+   =equity_instrument_service= / repository / mapper / handler, and
+   the four legacy =save_= / =delete_= / =list_= / =history_= wire
+   messages).
+2. Add =get_<type>_instrument= methods to the nine per-type equity
+   services (mirroring FX and swap).
+3. Introduce =equity_export_result=, a discriminated union over the
+   nine per-type equity instruments, and slot it into
+   =instrument_export_result= in place of the bare
+   =equity_instrument=.
+4. Route =product_type::equity= in =trade_handler::populate_instrument_for_trade=
+   by =trade_type_code= to the correct per-type service, mirroring
+   the FX block.
+5. Rewire =EquityInstrumentForm= to pattern-match on
+   =equity_export_result=, scoped to a single variant for this PR
+   (matching how PR #1 scoped =FxInstrumentForm= to =fx_forward_instrument=).
+
+* Non-goals
+
+- Full multi-variant =EquityInstrumentForm=: scoping to one variant
+  is deliberate. Extending the form to cover all nine variants needs
+  a UI story (per-variant forms or a dispatching shell) that is best
+  decided alongside the analogous follow-up for FX.
+- Changing the ORE import mapper (=equity_instrument_mapper=) to
+  route into per-type tables: that work is parallel and
+  out of scope here. This PR only changes the read side; the
+  importer continues to write to per-type tables (where it already
+  does) or the legacy table (where applicable) without visible
+  change.
+- Touching Bond / Credit / Commodity / Composite / Scripted: PR #3.
+
+* Constraints and decisions
+
+- *Single branch, ordered commits*: work lands on
+  =feature/equity-per-type-migration= in FX-style phases. Each
+  commit builds cleanly. No backwards-compatibility shims.
+- *=get_= naming*: all new service methods use =get_<type>_instrument=,
+  matching the codegen template updated in 5f64df94d.
+- *One variant shape*: =equity_export_result= is symmetric with
+  =fx_export_result= — a struct with an =instrument= variant field.
+  No legs (equity does not have swap-style legs; if a future equity
+  variant needs sub-rows, it can evolve independently).
+- *Trade-type → per-type routing is data-driven only in the mapper*:
+  the handler uses the same string-match style as FX
+  (=populate_instrument_for_trade=). Driving the routing from
+  =ores_trading_trade_types_tbl= is a cross-cutting improvement
+  deferred to a dedicated PR.
+
+* Current state
+
+** Per-type assets already in place
+
+Nine per-type tables, domain structs, repositories, and services exist
+(all save-only on the service side, matching pre-migration FX):
+
+- =equity_option=
+- =equity_digital_option=
+- =equity_barrier_option=
+- =equity_asian_option=
+- =equity_forward=
+- =equity_variance_swap=
+- =equity_swap=
+- =equity_accumulator=
+- =equity_position=
+
+Save-side wire protocol also exists
+(=save_equity_<type>_instrument_request=) for all nine and is wired
+through =typed_equity_instrument_handler= +
+=registrar_other_instruments.cpp=.
+
+** Legacy generic assets to delete
+
+- =ores_trading_equity_instruments_tbl= (SQL table + notify trigger +
+  policy).
+- =trading::domain::equity_instrument= + JSON / table I/O helpers.
+- =equity_instrument_entity= / mapper / repository.
+- =equity_instrument_service= (both save and =get_equity_instrument=).
+- =equity_instrument_handler= (wire handler for the four generic
+  save / delete / list / history messages).
+- =save_equity_instrument_request= / response, plus the three sibling
+  legacy messages, from =instrument_protocol.hpp=.
+- Registrar entries for those four wire subjects.
+
+** Trade types that must route through the new variant
+
+From =ores.ore/src/domain/trade_mapper.cpp::map_equity_instrument=:
+
+| Trade type (ORE)           | Per-type domain                    |
+|----------------------------+------------------------------------|
+| EquityOption               | equity_option_instrument           |
+| EquityForward              | equity_forward_instrument          |
+| EquitySwap                 | equity_swap_instrument             |
+| EquityVarianceSwap         | equity_variance_swap_instrument    |
+| EquityBarrierOption        | equity_barrier_option_instrument   |
+| EquityAsianOption          | equity_asian_option_instrument     |
+| EquityDigitalOption        | equity_digital_option_instrument   |
+| EquityTouchOption          | equity_digital_option_instrument   |
+| EquityOutperformanceOption | equity_option_instrument           |
+| EquityAccumulator          | equity_accumulator_instrument      |
+| EquityTaRF                 | equity_accumulator_instrument      |
+| EquityCliquetOption        | equity_option_instrument           |
+| EquityWorstOfBasketSwap    | equity_swap_instrument             |
+| EquityDoubleBarrierOption  | equity_barrier_option_instrument   |
+
+(Verify against the current state of =equity_instrument_mapper= when
+writing the handler routing — this table is a snapshot.)
+
+Fifteen ORE trade-type names collapsing onto nine per-type tables.
+
+** Client form
+
+=EquityInstrumentForm= holds =trading::domain::equity_instrument=
+directly — the legacy generic type. Same shape as =FxInstrumentForm=
+pre-PR-1. Needs migration to the new variant, scoped to one concrete
+per-type (recommend =equity_option_instrument= as it has the largest
+trade-type fan-in).
+
+* Phase plan
+
+Five phases. One commit per phase. Each builds clean.
+
+** Phase 1 — Add =get_<type>_instrument= methods to per-type services
+
+Mechanical: for each of the nine equity per-type services, add a
+=get_<type>_instrument(id)= method (service header + cpp), calling
+the repository's existing =read_latest(ctx, id)= and returning
+=std::optional<domain::<type>_instrument>=. No wire changes, no
+routing changes — just the plumbing the handler and form will need
+in later phases.
+
+*** Files
+
+Nine service header + cpp pairs under
+=projects/ores.trading.core/include/ores.trading.core/service/= and
+=projects/ores.trading.core/src/service/=.
+
+** Phase 2 — Introduce =equity_export_result= and reshape =instrument_export_result=
+
+Wire protocol change only.
+
+*** =instrument_protocol.hpp=
+
+- Add =equity_export_result= as a struct with a single
+  =instrument= variant field over the nine per-type equity types,
+  symmetric with =fx_export_result=.
+- Replace =equity_instrument= with =equity_export_result= in
+  =instrument_export_result=.
+
+*** Handler
+
+Update =trade_handler::populate_instrument_for_trade= to route
+=product_type::equity= by =trade_type_code= into the right per-type
+service (exactly parallel to the FX block). Uses the methods added
+in Phase 1.
+
+*** Client form
+
+Update =EquityInstrumentForm::setInstrument= to pattern-match
+=equity_export_result= → chosen per-type variant, mirroring
+=FxInstrumentForm::setInstrument=.
+
+At this point, reads flow through the per-type path end-to-end. The
+legacy generic table is still alive (save path still writes to it)
+but the read path no longer touches it.
+
+** Phase 3 — Delete legacy generic wire messages and handlers
+
+Removes the generic save / delete / list / history quad.
+
+- Drop =save_equity_instrument_request= /
+  =delete_equity_instrument_request= /
+  =get_equity_instruments_request= /
+  =get_equity_instrument_history_request= and their response pairs
+  from =instrument_protocol.hpp=.
+- Delete =equity_instrument_handler.hpp=.
+- Remove the four =nats.queue_subscribe= entries from
+  =registrar_other_instruments.cpp=.
+- Sweep any remaining call sites (shell? cli? HTTP? CSV import?) —
+  the legacy generic save message is the one most likely to have
+  non-UI callers.
+
+** Phase 4 — Delete legacy generic C++ infrastructure
+
+- =equity_instrument_service= (header + cpp).
+- =equity_instrument_repository=, =equity_instrument_mapper=,
+  =equity_instrument_entity=.
+- =trading::domain::equity_instrument= + =equity_instrument_json_io=
+  + =equity_instrument_table= + =equity_instrument_table_io=.
+- CMakeLists.txt entries for any file-level sources removed.
+
+** Phase 5 — Delete legacy generic SQL
+
+- =projects/ores.sql/create/trading/trading_equity_instruments_create.sql=
+  and its =_notify_trigger_create.sql=.
+- The matching drop scripts.
+- The =\ir= includes in =trading_create.sql=.
+- If any IAM policy references the table, drop the policy in the
+  same commit.
+- Any seed / populate scripts that touch the legacy table.
+
+* Verification
+
+- Trading core + Qt trading targets build clean.
+- =ores.trading.core.tests= and =ores.ore.tests= pass.
+- End-to-end smoke: import an equity trade via ORE XML, open it in
+  =TradeDetailDialog=, confirm the equity tab renders the correct
+  per-type economics. (Scoped to the one variant =EquityInstrumentForm=
+  handles after Phase 2; other variants will display a controlled
+  "not yet supported" message via the existing form machinery.)
+
+* Cross-PR invariants retained
+
+- =get_= naming across all new service methods.
+- No backwards-compatibility shims: each phase deletes the legacy
+  path it replaces in the same commit.
+- Variant shape symmetric with FX and Swap; single
+  =instrument_export_result= discriminated union is the sole
+  response carrier.
+
+* Follow-up (PR #3)
+
+Bond, Credit, Commodity, Composite, Scripted — the five single-type
+families with no per-type infrastructure. Either stand up per-type
+tables (unnecessary until a second sub-type appears) or rename
+=save_<family>_instrument_request= → =save_<family>_<type>_request=
+for shape uniformity. The default per the parent plan is the latter.

--- a/doc/plans/2026-04-22-equity-per-type-migration.org
+++ b/doc/plans/2026-04-22-equity-per-type-migration.org
@@ -8,36 +8,50 @@ PR #2 of the four-PR migration series outlined in
 delete the legacy generic table, wire reads through per-type services,
 introduce a discriminated export variant, update the client form —
 repeats for *equity*, which is the largest remaining family: nine
-per-type tables and fourteen trade types mapping into them.
+per-type tables and fifteen ORE trade types mapping into them.
 
-Unlike FX, equity does *not* currently exhibit the FX-forward symptom
-(blank economics in =TradeDetailDialog=) because the ORE importer
-path for equity still writes to the legacy generic
-=ores_trading_equity_instruments_tbl=. The defect is therefore
-*latent*, not active: as soon as the importer flips to the per-type
-tables (parallel work in the ORE mapper), the UI would go blank
-exactly as FX did. This PR removes the latency by converging the
-read and write paths on per-type infrastructure *before* that flip.
+*Scope divergence from the FX PR:* the FX branch inherited an ORE
+importer that already produced =fx_instrument_variant= (per-type),
+so the migration only had to flip the *read* side. Equity is one
+step behind — =equity_instrument_mapper= still produces the legacy
+generic =equity_instrument= and the importer writes only to the
+legacy generic table. The nine =save_equity_<type>_instrument_request=
+messages and the =typed_equity_instrument_handler= exist but have
+*zero callers* across the codebase; the per-type tables are empty in
+practice.
+
+Flipping only the read side would therefore break every imported
+equity trade (blank economics, mirroring the FX defect we just
+fixed). The mapper rewrite is included here so read and write flip
+in the same PR.
 
 * Goals
 
-1. Delete the legacy single-table equity infrastructure
-   (=ores_trading_equity_instruments_tbl=, =equity_instrument= domain,
-   =equity_instrument_service= / repository / mapper / handler, and
-   the four legacy =save_= / =delete_= / =list_= / =history_= wire
-   messages).
-2. Add =get_<type>_instrument= methods to the nine per-type equity
-   services (mirroring FX and swap).
-3. Introduce =equity_export_result=, a discriminated union over the
-   nine per-type equity instruments, and slot it into
-   =instrument_export_result= in place of the bare
-   =equity_instrument=.
+1. Rewrite =equity_instrument_mapper= so =equity_mapping_result=
+   carries =equity_instrument_variant= (nine alternatives), mirroring
+   =fx_mapping_result= / =fx_instrument_variant=. Each of the fifteen
+   ORE trade types maps to exactly one per-type domain object.
+2. Update both importer dispatch sites
+   (=ore_import_execute_handler.cpp= and =OreImporter.cpp=) to
+   =std::visit= the variant and send the correct
+   =save_equity_<type>_instrument_request= per alternative,
+   mirroring the FX dispatch blocks already in place.
+3. Introduce =equity_export_result= as a discriminated union over
+   the nine per-type equity instruments, symmetric with
+   =fx_export_result=, and slot it into =instrument_export_result=
+   in place of the bare =equity_instrument=.
 4. Route =product_type::equity= in =trade_handler::populate_instrument_for_trade=
    by =trade_type_code= to the correct per-type service, mirroring
    the FX block.
 5. Rewire =EquityInstrumentForm= to pattern-match on
    =equity_export_result=, scoped to a single variant for this PR
-   (matching how PR #1 scoped =FxInstrumentForm= to =fx_forward_instrument=).
+   (matching how PR #1 scoped =FxInstrumentForm= to
+   =fx_forward_instrument=).
+6. Delete the legacy single-table equity infrastructure in its
+   entirety: =ores_trading_equity_instruments_tbl=, =equity_instrument=
+   domain, =equity_instrument_service= / repository / mapper / handler,
+   and the four legacy =save_= / =delete_= / =list_= / =history_= wire
+   messages.
 
 * Non-goals
 
@@ -45,12 +59,11 @@ read and write paths on per-type infrastructure *before* that flip.
   is deliberate. Extending the form to cover all nine variants needs
   a UI story (per-variant forms or a dispatching shell) that is best
   decided alongside the analogous follow-up for FX.
-- Changing the ORE import mapper (=equity_instrument_mapper=) to
-  route into per-type tables: that work is parallel and
-  out of scope here. This PR only changes the read side; the
-  importer continues to write to per-type tables (where it already
-  does) or the legacy table (where applicable) without visible
-  change.
+- Data migration of existing rows from the legacy table to per-type
+  tables. This PR *changes the importer going forward*; any existing
+  legacy rows become stranded. Acceptable because equity trades in
+  local environments are disposable; production has its own migration
+  story (out of scope for the source tree).
 - Touching Bond / Credit / Commodity / Composite / Scripted: PR #3.
 
 * Constraints and decisions
@@ -59,23 +72,29 @@ read and write paths on per-type infrastructure *before* that flip.
   =feature/equity-per-type-migration= in FX-style phases. Each
   commit builds cleanly. No backwards-compatibility shims.
 - *=get_= naming*: all new service methods use =get_<type>_instrument=,
-  matching the codegen template updated in 5f64df94d.
+  matching the codegen template.
 - *One variant shape*: =equity_export_result= is symmetric with
   =fx_export_result= — a struct with an =instrument= variant field.
   No legs (equity does not have swap-style legs; if a future equity
   variant needs sub-rows, it can evolve independently).
-- *Trade-type → per-type routing is data-driven only in the mapper*:
-  the handler uses the same string-match style as FX
-  (=populate_instrument_for_trade=). Driving the routing from
-  =ores_trading_trade_types_tbl= is a cross-cutting improvement
-  deferred to a dedicated PR.
+- *Trade-type → per-type routing is string-matched in the handler*,
+  mirroring FX. Driving the routing from =ores_trading_trade_types_tbl=
+  is a cross-cutting improvement deferred to a dedicated PR.
+- *Mapper rewrite is type-driven*: the existing 1191-line
+  =equity_instrument_mapper.cpp= writes every field into the flat
+  =equity_instrument= struct, which has a superset of fields. Per-type
+  targets only hold the relevant subset, so each =forward_equity_<type>=
+  becomes shorter after the split (each one assigns to a narrower
+  domain type). The reverse direction changes signature from
+  =(const equity_instrument&)= to =(const <per-type>_instrument&)=.
 
 * Current state
 
 ** Per-type assets already in place
 
-Nine per-type tables, domain structs, repositories, and services exist
-(all save-only on the service side, matching pre-migration FX):
+Nine per-type tables, domain structs, repositories, and services. As
+of Phase 1 of this branch (commit =1ddbbe766=), all nine services
+now have both =save_<type>_instrument= and =get_<type>_instrument=.
 
 - =equity_option=
 - =equity_digital_option=
@@ -87,10 +106,10 @@ Nine per-type tables, domain structs, repositories, and services exist
 - =equity_accumulator=
 - =equity_position=
 
-Save-side wire protocol also exists
-(=save_equity_<type>_instrument_request=) for all nine and is wired
-through =typed_equity_instrument_handler= +
-=registrar_other_instruments.cpp=.
+Save-side wire protocol exists for all nine
+(=save_equity_<type>_instrument_request=) and is wired through
+=typed_equity_instrument_handler= + =registrar_other_instruments.cpp=.
+No callers yet.
 
 ** Legacy generic assets to delete
 
@@ -104,32 +123,37 @@ through =typed_equity_instrument_handler= +
 - =save_equity_instrument_request= / response, plus the three sibling
   legacy messages, from =instrument_protocol.hpp=.
 - Registrar entries for those four wire subjects.
+- ORE mapper output wrapping (=equity_mapping_result= becomes
+  variant-holding).
 
-** Trade types that must route through the new variant
+** Trade-type → per-type table mapping
 
-From =ores.ore/src/domain/trade_mapper.cpp::map_equity_instrument=:
+From =ores.ore/src/domain/trade_mapper.cpp::map_equity_instrument=
+and the per-=forward_equity_<type>= semantics in
+=equity_instrument_mapper.cpp=:
 
-| Trade type (ORE)           | Per-type domain                    |
-|----------------------------+------------------------------------|
-| EquityOption               | equity_option_instrument           |
-| EquityForward              | equity_forward_instrument          |
-| EquitySwap                 | equity_swap_instrument             |
-| EquityVarianceSwap         | equity_variance_swap_instrument    |
-| EquityBarrierOption        | equity_barrier_option_instrument   |
-| EquityAsianOption          | equity_asian_option_instrument     |
-| EquityDigitalOption        | equity_digital_option_instrument   |
-| EquityTouchOption          | equity_digital_option_instrument   |
-| EquityOutperformanceOption | equity_option_instrument           |
-| EquityAccumulator          | equity_accumulator_instrument      |
-| EquityTaRF                 | equity_accumulator_instrument      |
-| EquityCliquetOption        | equity_option_instrument           |
-| EquityWorstOfBasketSwap    | equity_swap_instrument             |
-| EquityDoubleBarrierOption  | equity_barrier_option_instrument   |
+| ORE trade type              | Per-type table / domain            |
+|-----------------------------+------------------------------------|
+| EquityOption                | equity_option_instrument           |
+| EquityCliquetOption         | equity_option_instrument           |
+| EquityOutperformanceOption  | equity_option_instrument           |
+| EquityForward               | equity_forward_instrument          |
+| EquitySwap                  | equity_swap_instrument             |
+| EquityWorstOfBasketSwap     | equity_swap_instrument             |
+| EquityVarianceSwap          | equity_variance_swap_instrument    |
+| EquityBarrierOption         | equity_barrier_option_instrument   |
+| EquityDoubleBarrierOption   | equity_barrier_option_instrument   |
+| EquityEuropeanBarrierOption | equity_barrier_option_instrument   |
+| EquityAsianOption           | equity_asian_option_instrument     |
+| EquityDigitalOption         | equity_digital_option_instrument   |
+| EquityTouchOption           | equity_digital_option_instrument   |
+| EquityAccumulator           | equity_accumulator_instrument      |
+| EquityTaRF                  | equity_accumulator_instrument      |
 
-(Verify against the current state of =equity_instrument_mapper= when
-writing the handler routing — this table is a snapshot.)
-
-Fifteen ORE trade-type names collapsing onto nine per-type tables.
+Fifteen ORE trade-type names collapsing onto eight per-type tables.
+=equity_position= has no ORE forward mapping (it's a book-level
+position, not a trade); it remains reachable via the save request
+for non-ORE code paths.
 
 ** Client form
 
@@ -141,31 +165,84 @@ trade-type fan-in).
 
 * Phase plan
 
-Five phases. One commit per phase. Each builds clean.
+Seven phases. Each commit builds clean. No backwards-compatibility
+shims.
 
-** Phase 1 — Add =get_<type>_instrument= methods to per-type services
+** Phase 1 — Add =get_<type>_instrument= to per-type services [DONE]
 
-Mechanical: for each of the nine equity per-type services, add a
-=get_<type>_instrument(id)= method (service header + cpp), calling
-the repository's existing =read_latest(ctx, id)= and returning
-=std::optional<domain::<type>_instrument>=. No wire changes, no
-routing changes — just the plumbing the handler and form will need
-in later phases.
+Commit =1ddbbe766=. Nine services gained =get_<type>_instrument=
+methods delegating to the repository's =read_latest(ctx, id)=.
 
-*** Files
+** Phase 2 — Rewrite =equity_instrument_mapper= to produce per-type variant
 
-Nine service header + cpp pairs under
-=projects/ores.trading.core/include/ores.trading.core/service/= and
-=projects/ores.trading.core/src/service/=.
+The bulk of the PR's new code.
 
-** Phase 2 — Introduce =equity_export_result= and reshape =instrument_export_result=
+*** Header (=equity_instrument_mapper.hpp=)
 
-Wire protocol change only.
+- Introduce =equity_instrument_variant= over the nine per-type
+  domain types, mirroring =fx_instrument_variant=.
+- =equity_mapping_result.instrument= becomes
+  =equity_instrument_variant= (was =equity_instrument=).
+- Each =forward_equity_<type>= keeps its signature but the return
+  variant now carries the matching per-type alternative.
+- Each =reverse_equity_<type>= changes its parameter type from
+  =const equity_instrument&= to =const <per-type>_instrument&=.
+
+*** Implementation (=equity_instrument_mapper.cpp=)
+
+- Per-type =forward_*= functions write into the narrower per-type
+  struct instead of the flat =equity_instrument=. Fields that exist
+  on the per-type struct are copied over; fields that don't are
+  dropped (the legacy generic held a superset).
+- A shared =make_base<T>()= helper replaces the existing
+  =make_base(tradeTypeCode)= — templated on the per-type struct so
+  =instrument_id=, =trade_id=, audit stamps, etc. can be set
+  uniformly.
+- Reverse functions change input type; the field-read direction is
+  straightforward because per-type holds exactly the fields the ORE
+  payload carries for that type.
+
+*** Tests
+
+- =xml_equity_mapper_roundtrip_tests.cpp= and
+  =xml_equity_golden_roundtrip_tests.cpp= change argument types on
+  the reverse path and destructure the variant on the forward path.
+  Assertions target per-type fields instead of flat fields; any
+  flat-field assertion that has no per-type equivalent is dropped.
+
+** Phase 3 — Flip importer dispatch to per-type save requests
+
+Two sites, mirroring the FX visit blocks.
+
+*** =ores.ore.service/src/messaging/ore_import_execute_handler.cpp=
+
+The =equity_mapping_result= branch of the outer =std::visit= becomes
+a nested =std::visit= over =equity_instrument_variant=, dispatching
+to the correct =save_equity_<type>_instrument_request= per
+alternative — exactly the same shape as the existing FX block
+(lines 413–447 at branch cut).
+
+*** =ores.qt.trading/src/OreImporter.cpp=
+
+Parallel client-side change.
+
+*** Registrar
+
+No change: =save_equity_<type>_instrument_request= subscriptions are
+already in =registrar_other_instruments.cpp=.
+
+After this phase the ORE importer writes to per-type tables only.
+The legacy generic table continues to exist but is no longer
+populated by this path. =save_equity_instrument_request= has no
+callers (importer was the last one) but is still registered;
+Phase 5 deletes the subscription.
+
+** Phase 4 — Bundle-aware read path + client form
 
 *** =instrument_protocol.hpp=
 
-- Add =equity_export_result= as a struct with a single
-  =instrument= variant field over the nine per-type equity types,
+- Add =equity_export_result= as a struct with
+  =instrument= variant over the nine per-type equity types,
   symmetric with =fx_export_result=.
 - Replace =equity_instrument= with =equity_export_result= in
   =instrument_export_result=.
@@ -174,8 +251,8 @@ Wire protocol change only.
 
 Update =trade_handler::populate_instrument_for_trade= to route
 =product_type::equity= by =trade_type_code= into the right per-type
-service (exactly parallel to the FX block). Uses the methods added
-in Phase 1.
+service (exactly parallel to the FX block). Uses the =get_= methods
+added in Phase 1.
 
 *** Client form
 
@@ -183,13 +260,10 @@ Update =EquityInstrumentForm::setInstrument= to pattern-match
 =equity_export_result= → chosen per-type variant, mirroring
 =FxInstrumentForm::setInstrument=.
 
-At this point, reads flow through the per-type path end-to-end. The
-legacy generic table is still alive (save path still writes to it)
-but the read path no longer touches it.
+At this point reads and writes both flow through per-type
+infrastructure end-to-end.
 
-** Phase 3 — Delete legacy generic wire messages and handlers
-
-Removes the generic save / delete / list / history quad.
+** Phase 5 — Delete legacy generic wire messages and handlers
 
 - Drop =save_equity_instrument_request= /
   =delete_equity_instrument_request= /
@@ -199,38 +273,34 @@ Removes the generic save / delete / list / history quad.
 - Delete =equity_instrument_handler.hpp=.
 - Remove the four =nats.queue_subscribe= entries from
   =registrar_other_instruments.cpp=.
-- Sweep any remaining call sites (shell? cli? HTTP? CSV import?) —
-  the legacy generic save message is the one most likely to have
-  non-UI callers.
+- Sweep any remaining call sites (shell? cli? HTTP? CSV import?).
 
-** Phase 4 — Delete legacy generic C++ infrastructure
+** Phase 6 — Delete legacy generic C++ infrastructure
 
 - =equity_instrument_service= (header + cpp).
 - =equity_instrument_repository=, =equity_instrument_mapper=,
   =equity_instrument_entity=.
 - =trading::domain::equity_instrument= + =equity_instrument_json_io=
   + =equity_instrument_table= + =equity_instrument_table_io=.
-- CMakeLists.txt entries for any file-level sources removed.
+- =CMakeLists.txt= entries for any file-level sources removed.
 
-** Phase 5 — Delete legacy generic SQL
+** Phase 7 — Delete legacy generic SQL
 
 - =projects/ores.sql/create/trading/trading_equity_instruments_create.sql=
   and its =_notify_trigger_create.sql=.
 - The matching drop scripts.
 - The =\ir= includes in =trading_create.sql=.
-- If any IAM policy references the table, drop the policy in the
-  same commit.
-- Any seed / populate scripts that touch the legacy table.
+- Any IAM policy or seed script touching the table.
 
 * Verification
 
-- Trading core + Qt trading targets build clean.
-- =ores.trading.core.tests= and =ores.ore.tests= pass.
-- End-to-end smoke: import an equity trade via ORE XML, open it in
-  =TradeDetailDialog=, confirm the equity tab renders the correct
-  per-type economics. (Scoped to the one variant =EquityInstrumentForm=
-  handles after Phase 2; other variants will display a controlled
-  "not yet supported" message via the existing form machinery.)
+- Trading core + Qt trading + ORE targets build clean.
+- =ores.trading.core.tests=, =ores.ore.tests= (including the two
+  equity roundtrip suites rewritten in Phase 2) pass.
+- End-to-end smoke: import an equity trade (e.g. =EquityOption=) via
+  ORE XML, confirm the per-type table receives the row, open the
+  trade in =TradeDetailDialog=, confirm the equity tab renders the
+  correct per-type economics.
 
 * Cross-PR invariants retained
 

--- a/projects/ores.ore.service/src/messaging/ore_import_execute_handler.cpp
+++ b/projects/ores.ore.service/src/messaging/ore_import_execute_handler.cpp
@@ -454,9 +454,53 @@ void ore_import_execute_handler::execute(ores::nats::message msg) {
                 auto resp = nats_call(delegated_nats, req, instr_error);
                 return resp && resp->success;
             } else if constexpr (std::is_same_v<T, equity_mapping_result>) {
-                save_equity_instrument_request req; req.data = r.instrument;
-                auto resp = nats_call(delegated_nats, req, instr_error);
-                return resp && resp->success;
+                return std::visit([&](const auto& instr) -> bool {
+                    using InstrT = std::decay_t<decltype(instr)>;
+                    using namespace ores::trading::domain;
+                    if constexpr (std::is_same_v<InstrT, equity_instrument>) {
+                        save_equity_instrument_request req; req.data = instr;
+                        auto resp = nats_call(delegated_nats, req, instr_error);
+                        return resp && resp->success;
+                    } else if constexpr (std::is_same_v<InstrT, equity_option_instrument>) {
+                        save_equity_option_instrument_request req; req.data = instr;
+                        auto resp = nats_call(delegated_nats, req, instr_error);
+                        return resp && resp->success;
+                    } else if constexpr (std::is_same_v<InstrT, equity_digital_option_instrument>) {
+                        save_equity_digital_option_instrument_request req; req.data = instr;
+                        auto resp = nats_call(delegated_nats, req, instr_error);
+                        return resp && resp->success;
+                    } else if constexpr (std::is_same_v<InstrT, equity_barrier_option_instrument>) {
+                        save_equity_barrier_option_instrument_request req; req.data = instr;
+                        auto resp = nats_call(delegated_nats, req, instr_error);
+                        return resp && resp->success;
+                    } else if constexpr (std::is_same_v<InstrT, equity_asian_option_instrument>) {
+                        save_equity_asian_option_instrument_request req; req.data = instr;
+                        auto resp = nats_call(delegated_nats, req, instr_error);
+                        return resp && resp->success;
+                    } else if constexpr (std::is_same_v<InstrT, equity_forward_instrument>) {
+                        save_equity_forward_instrument_request req; req.data = instr;
+                        auto resp = nats_call(delegated_nats, req, instr_error);
+                        return resp && resp->success;
+                    } else if constexpr (std::is_same_v<InstrT, equity_variance_swap_instrument>) {
+                        save_equity_variance_swap_instrument_request req; req.data = instr;
+                        auto resp = nats_call(delegated_nats, req, instr_error);
+                        return resp && resp->success;
+                    } else if constexpr (std::is_same_v<InstrT, equity_swap_instrument>) {
+                        save_equity_swap_instrument_request req; req.data = instr;
+                        auto resp = nats_call(delegated_nats, req, instr_error);
+                        return resp && resp->success;
+                    } else if constexpr (std::is_same_v<InstrT, equity_accumulator_instrument>) {
+                        save_equity_accumulator_instrument_request req; req.data = instr;
+                        auto resp = nats_call(delegated_nats, req, instr_error);
+                        return resp && resp->success;
+                    } else if constexpr (std::is_same_v<InstrT, equity_position_instrument>) {
+                        save_equity_position_instrument_request req; req.data = instr;
+                        auto resp = nats_call(delegated_nats, req, instr_error);
+                        return resp && resp->success;
+                    } else {
+                        return true;
+                    }
+                }, r.instrument);
             } else if constexpr (std::is_same_v<T, commodity_mapping_result>) {
                 save_commodity_instrument_request req; req.data = r.instrument;
                 auto resp = nats_call(delegated_nats, req, instr_error);

--- a/projects/ores.ore.service/src/messaging/ore_import_execute_handler.cpp
+++ b/projects/ores.ore.service/src/messaging/ore_import_execute_handler.cpp
@@ -498,7 +498,12 @@ void ore_import_execute_handler::execute(ores::nats::message msg) {
                         auto resp = nats_call(delegated_nats, req, instr_error);
                         return resp && resp->success;
                     } else {
-                        return true;
+                        // Unknown per-type alternative — fail loudly so a new
+                        // variant added without updating this dispatch surfaces
+                        // at import time instead of silently skipping saves.
+                        instr_error = "equity variant alternative not handled "
+                                      "by import dispatch";
+                        return false;
                     }
                 }, r.instrument);
             } else if constexpr (std::is_same_v<T, commodity_mapping_result>) {

--- a/projects/ores.ore/include/ores.ore/domain/equity_instrument_mapper.hpp
+++ b/projects/ores.ore/include/ores.ore/domain/equity_instrument_mapper.hpp
@@ -20,17 +20,51 @@
 #ifndef ORES_ORE_DOMAIN_EQUITY_INSTRUMENT_MAPPER_HPP
 #define ORES_ORE_DOMAIN_EQUITY_INSTRUMENT_MAPPER_HPP
 
+#include <variant>
 #include "ores.logging/make_logger.hpp"
 #include "ores.ore/domain/domain.hpp"
 #include "ores.trading.api/domain/equity_instrument.hpp"
+#include "ores.trading.api/domain/equity_option_instrument.hpp"
+#include "ores.trading.api/domain/equity_digital_option_instrument.hpp"
+#include "ores.trading.api/domain/equity_barrier_option_instrument.hpp"
+#include "ores.trading.api/domain/equity_asian_option_instrument.hpp"
+#include "ores.trading.api/domain/equity_forward_instrument.hpp"
+#include "ores.trading.api/domain/equity_variance_swap_instrument.hpp"
+#include "ores.trading.api/domain/equity_swap_instrument.hpp"
+#include "ores.trading.api/domain/equity_accumulator_instrument.hpp"
+#include "ores.trading.api/domain/equity_position_instrument.hpp"
 
 namespace ores::ore::domain {
+
+/**
+ * @brief Variant holding one of the nine per-type equity instrument domain
+ *        objects, or — during the Phase 2 migration from the legacy flat
+ *        equity_instrument — the flat type itself.
+ *
+ * The flat equity_instrument alternative is a migration bridge. Each
+ * forward_equity_* / reverse_equity_* pair in this file gets rewritten to
+ * produce and consume its corresponding per-type alternative instead; when
+ * all 15 ORE-side trade types have migrated, the flat alternative is
+ * removed from this variant in the final Phase 2 commit.
+ */
+using equity_instrument_variant = std::variant<
+    ores::trading::domain::equity_instrument,
+    ores::trading::domain::equity_option_instrument,
+    ores::trading::domain::equity_digital_option_instrument,
+    ores::trading::domain::equity_barrier_option_instrument,
+    ores::trading::domain::equity_asian_option_instrument,
+    ores::trading::domain::equity_forward_instrument,
+    ores::trading::domain::equity_variance_swap_instrument,
+    ores::trading::domain::equity_swap_instrument,
+    ores::trading::domain::equity_accumulator_instrument,
+    ores::trading::domain::equity_position_instrument
+>;
 
 /**
  * @brief Result of a forward mapping from ORE XSD to the ORES equity domain type.
  */
 struct equity_mapping_result {
-    ores::trading::domain::equity_instrument instrument;
+    equity_instrument_variant instrument;
 };
 
 /**
@@ -139,6 +173,7 @@ public:
     static trade reverse_equity_worst_of_basket_swap(
         const ores::trading::domain::equity_instrument& instr);
 };
+
 
 }
 

--- a/projects/ores.ore/src/domain/equity_instrument_mapper.cpp
+++ b/projects/ores.ore/src/domain/equity_instrument_mapper.cpp
@@ -298,17 +298,18 @@ equity_mapping_result equity_instrument_mapper::forward_equity_option(
                                << std::string(t.id);
     equity_mapping_result result;
     result.instrument = make_base("EquityOption");
+    auto& flat = std::get<equity_instrument>(result.instrument);
     if (!t.EquityOptionData) return result;
     const auto& d = *t.EquityOptionData;
 
-    result.instrument.underlying_code =
+    flat.underlying_code =
         extract_underlying_name(d.underlyingTypes);
-    result.instrument.currency = std::string(d.Currency);
-    result.instrument.quantity = static_cast<double>(d.Quantity);
-    result.instrument.option_type = extract_option_type(d.OptionData);
-    result.instrument.exercise_type = extract_exercise_style(d.OptionData);
-    result.instrument.maturity_date = first_exercise_date(d.OptionData);
-    result.instrument.strike_price = extract_strike(d.strikeGroup);
+    flat.currency = std::string(d.Currency);
+    flat.quantity = static_cast<double>(d.Quantity);
+    flat.option_type = extract_option_type(d.OptionData);
+    flat.exercise_type = extract_exercise_style(d.OptionData);
+    flat.maturity_date = first_exercise_date(d.OptionData);
+    flat.strike_price = extract_strike(d.strikeGroup);
     return result;
 }
 
@@ -322,15 +323,16 @@ equity_mapping_result equity_instrument_mapper::forward_equity_forward(
                                << std::string(t.id);
     equity_mapping_result result;
     result.instrument = make_base("EquityForward");
+    auto& flat = std::get<equity_instrument>(result.instrument);
     if (!t.EquityForwardData) return result;
     const auto& d = *t.EquityForwardData;
 
-    result.instrument.underlying_code =
+    flat.underlying_code =
         extract_underlying_name(d.underlyingTypes);
-    result.instrument.currency = std::string(d.Currency);
-    result.instrument.quantity = static_cast<double>(d.Quantity);
-    result.instrument.strike_price = static_cast<double>(d.Strike);
-    result.instrument.maturity_date = std::string(d.Maturity);
+    flat.currency = std::string(d.Currency);
+    flat.quantity = static_cast<double>(d.Quantity);
+    flat.strike_price = static_cast<double>(d.Strike);
+    flat.maturity_date = std::string(d.Maturity);
     return result;
 }
 
@@ -344,35 +346,36 @@ equity_mapping_result equity_instrument_mapper::forward_equity_swap(
                                << std::string(t.id);
     equity_mapping_result result;
     result.instrument = make_base("EquitySwap");
+    auto& flat = std::get<equity_instrument>(result.instrument);
     if (!t.EquitySwapData) return result;
     const auto& d = *t.EquitySwapData;
 
     for (const auto& ld : d.LegData) {
         if (ld.legDataType && ld.legDataType->EquityLegData) {
             const auto& el = *ld.legDataType->EquityLegData;
-            result.instrument.underlying_code =
+            flat.underlying_code =
                 extract_underlying_name(el.underlyingTypes);
-            result.instrument.return_type = std::string(el.ReturnType);
+            flat.return_type = std::string(el.ReturnType);
             if (el.Quantity)
-                result.instrument.quantity =
+                flat.quantity =
                     static_cast<double>(*el.Quantity);
         } else {
             // Non-equity leg provides currency/notional/schedule
             if (ld.Currency)
-                result.instrument.currency = std::string(*ld.Currency);
+                flat.currency = std::string(*ld.Currency);
             if (ld.Notionals && !ld.Notionals->Notional.empty())
-                result.instrument.notional =
+                flat.notional =
                     static_cast<double>(ld.Notionals->Notional.front());
             if (ld.DayCounter)
-                result.instrument.day_count_code =
+                flat.day_count_code =
                     to_string(*ld.DayCounter);
             if (ld.ScheduleData && !ld.ScheduleData->Rules.empty()) {
                 const auto& rule = ld.ScheduleData->Rules.front();
-                result.instrument.start_date = std::string(rule.StartDate);
+                flat.start_date = std::string(rule.StartDate);
                 if (rule.EndDate)
-                    result.instrument.maturity_date =
+                    flat.maturity_date =
                         std::string(*rule.EndDate);
-                result.instrument.payment_frequency_code =
+                flat.payment_frequency_code =
                     std::string(rule.Tenor);
             }
         }
@@ -390,16 +393,17 @@ equity_mapping_result equity_instrument_mapper::forward_equity_variance_swap(
                                << std::string(t.id);
     equity_mapping_result result;
     result.instrument = make_base("EquityVarianceSwap");
+    auto& flat = std::get<equity_instrument>(result.instrument);
     if (!t.EquityVarianceSwapData) return result;
     const auto& d = *t.EquityVarianceSwapData;
 
-    result.instrument.underlying_code =
+    flat.underlying_code =
         extract_underlying_name(d.underlyingTypes);
-    result.instrument.currency = to_string(d.Currency);
-    result.instrument.notional = static_cast<double>(d.Notional);
-    result.instrument.variance_strike = static_cast<double>(d.Strike);
-    result.instrument.start_date = std::string(d.StartDate);
-    result.instrument.maturity_date = std::string(d.EndDate);
+    flat.currency = to_string(d.Currency);
+    flat.notional = static_cast<double>(d.Notional);
+    flat.variance_strike = static_cast<double>(d.Strike);
+    flat.start_date = std::string(d.StartDate);
+    flat.maturity_date = std::string(d.EndDate);
     return result;
 }
 
@@ -413,22 +417,23 @@ equity_mapping_result equity_instrument_mapper::forward_equity_barrier_option(
                                << std::string(t.id);
     equity_mapping_result result;
     result.instrument = make_base("EquityBarrierOption");
+    auto& flat = std::get<equity_instrument>(result.instrument);
     if (!t.EquityBarrierOptionData) return result;
     const auto& d = *t.EquityBarrierOptionData;
 
-    result.instrument.underlying_code =
+    flat.underlying_code =
         extract_underlying_name(d.underlyingTypes);
-    result.instrument.currency = to_string(d.Currency);
-    result.instrument.quantity = static_cast<double>(d.Quantity);
-    result.instrument.option_type = extract_option_type(d.OptionData);
-    result.instrument.exercise_type = extract_exercise_style(d.OptionData);
-    result.instrument.maturity_date = first_exercise_date(d.OptionData);
-    result.instrument.strike_price = extract_strike(d.strikeGroup);
+    flat.currency = to_string(d.Currency);
+    flat.quantity = static_cast<double>(d.Quantity);
+    flat.option_type = extract_option_type(d.OptionData);
+    flat.exercise_type = extract_exercise_style(d.OptionData);
+    flat.maturity_date = first_exercise_date(d.OptionData);
+    flat.strike_price = extract_strike(d.strikeGroup);
     if (d.StartDate)
-        result.instrument.start_date = std::string(*d.StartDate);
-    result.instrument.barrier_type = barrier_type_str(d.BarrierData);
-    result.instrument.lower_barrier = first_barrier_level(d.BarrierData);
-    result.instrument.upper_barrier = second_barrier_level(d.BarrierData);
+        flat.start_date = std::string(*d.StartDate);
+    flat.barrier_type = barrier_type_str(d.BarrierData);
+    flat.lower_barrier = first_barrier_level(d.BarrierData);
+    flat.upper_barrier = second_barrier_level(d.BarrierData);
     return result;
 }
 
@@ -442,18 +447,19 @@ equity_mapping_result equity_instrument_mapper::forward_equity_asian_option(
                                << std::string(t.id);
     equity_mapping_result result;
     result.instrument = make_base("EquityAsianOption");
+    auto& flat = std::get<equity_instrument>(result.instrument);
     if (!t.EquityAsianOptionData) return result;
     const auto& d = *t.EquityAsianOptionData;
 
     if (d.Underlying)
-        result.instrument.underlying_code = std::string(d.Underlying->Name);
-    result.instrument.currency = to_string(d.Currency);
-    result.instrument.quantity = static_cast<double>(d.Quantity);
-    result.instrument.option_type = extract_option_type(d.OptionData);
-    result.instrument.maturity_date = first_exercise_date(d.OptionData);
-    result.instrument.strike_price = extract_strike(d.strikeGroup);
+        flat.underlying_code = std::string(d.Underlying->Name);
+    flat.currency = to_string(d.Currency);
+    flat.quantity = static_cast<double>(d.Quantity);
+    flat.option_type = extract_option_type(d.OptionData);
+    flat.maturity_date = first_exercise_date(d.OptionData);
+    flat.strike_price = extract_strike(d.strikeGroup);
     if (d.ObservationDates && !d.ObservationDates->Rules.empty())
-        result.instrument.averaging_start_date =
+        flat.averaging_start_date =
             std::string(d.ObservationDates->Rules.front().StartDate);
     return result;
 }
@@ -468,18 +474,19 @@ equity_mapping_result equity_instrument_mapper::forward_equity_digital_option(
                                << std::string(t.id);
     equity_mapping_result result;
     result.instrument = make_base("EquityDigitalOption");
+    auto& flat = std::get<equity_instrument>(result.instrument);
     if (!t.EquityDigitalOptionData) return result;
     const auto& d = *t.EquityDigitalOptionData;
 
-    result.instrument.underlying_code =
+    flat.underlying_code =
         extract_underlying_name(d.underlyingTypes);
-    result.instrument.quantity = static_cast<double>(d.Quantity);
-    result.instrument.option_type = extract_option_type(d.OptionData);
-    result.instrument.maturity_date = first_exercise_date(d.OptionData);
-    result.instrument.strike_price = static_cast<double>(d.Strike);
-    result.instrument.notional = static_cast<double>(d.PayoffAmount);
+    flat.quantity = static_cast<double>(d.Quantity);
+    flat.option_type = extract_option_type(d.OptionData);
+    flat.maturity_date = first_exercise_date(d.OptionData);
+    flat.strike_price = static_cast<double>(d.Strike);
+    flat.notional = static_cast<double>(d.PayoffAmount);
     if (d.PayoffCurrency)
-        result.instrument.currency = to_string(*d.PayoffCurrency);
+        flat.currency = to_string(*d.PayoffCurrency);
     return result;
 }
 
@@ -493,19 +500,20 @@ equity_mapping_result equity_instrument_mapper::forward_equity_touch_option(
                                << std::string(t.id);
     equity_mapping_result result;
     result.instrument = make_base("EquityTouchOption");
+    auto& flat = std::get<equity_instrument>(result.instrument);
     if (!t.EquityTouchOptionData) return result;
     const auto& d = *t.EquityTouchOptionData;
 
-    result.instrument.underlying_code =
+    flat.underlying_code =
         extract_underlying_name(d.underlyingTypes);
-    result.instrument.currency = to_string(d.PayoffCurrency);
-    result.instrument.notional = static_cast<double>(d.PayoffAmount);
-    result.instrument.option_type = extract_option_type(d.OptionData);
-    result.instrument.maturity_date = first_exercise_date(d.OptionData);
+    flat.currency = to_string(d.PayoffCurrency);
+    flat.notional = static_cast<double>(d.PayoffAmount);
+    flat.option_type = extract_option_type(d.OptionData);
+    flat.maturity_date = first_exercise_date(d.OptionData);
     if (d.StartDate)
-        result.instrument.start_date = std::string(*d.StartDate);
-    result.instrument.barrier_type = barrier_type_str(d.BarrierData);
-    result.instrument.lower_barrier = first_barrier_level(d.BarrierData);
+        flat.start_date = std::string(*d.StartDate);
+    flat.barrier_type = barrier_type_str(d.BarrierData);
+    flat.lower_barrier = first_barrier_level(d.BarrierData);
     return result;
 }
 
@@ -520,21 +528,22 @@ equity_instrument_mapper::forward_equity_outperformance_option(
                                << std::string(t.id);
     equity_mapping_result result;
     result.instrument = make_base("EquityOutperformanceOption");
+    auto& flat = std::get<equity_instrument>(result.instrument);
     if (!t.EquityOutperformanceOptionData) return result;
     const auto& d = *t.EquityOutperformanceOptionData;
 
-    result.instrument.currency = to_string(d.Currency);
-    result.instrument.notional = static_cast<double>(d.Notional);
-    result.instrument.option_type = extract_option_type(d.OptionData);
-    result.instrument.maturity_date = first_exercise_date(d.OptionData);
-    result.instrument.strike_price = static_cast<double>(d.StrikeReturn);
+    flat.currency = to_string(d.Currency);
+    flat.notional = static_cast<double>(d.Notional);
+    flat.option_type = extract_option_type(d.OptionData);
+    flat.maturity_date = first_exercise_date(d.OptionData);
+    flat.strike_price = static_cast<double>(d.StrikeReturn);
 
     // Store both underlyings as a JSON array
     const std::string n1 = std::string(d.Underlying1.Name);
     const std::string n2 = std::string(d.Underlying2.Name);
-    result.instrument.basket_json =
+    flat.basket_json =
         "[\"" + json_escape(n1) + "\",\"" + json_escape(n2) + "\"]";
-    result.instrument.underlying_code = n1;
+    flat.underlying_code = n1;
     return result;
 }
 
@@ -548,17 +557,18 @@ equity_mapping_result equity_instrument_mapper::forward_equity_accumulator(
                                << std::string(t.id);
     equity_mapping_result result;
     result.instrument = make_base("EquityAccumulator");
+    auto& flat = std::get<equity_instrument>(result.instrument);
     if (!t.EquityAccumulatorData) return result;
     const auto& d = *t.EquityAccumulatorData;
 
-    result.instrument.underlying_code = std::string(d.Underlying.Name);
-    result.instrument.currency = to_string(d.Currency);
-    result.instrument.accumulation_amount =
+    flat.underlying_code = std::string(d.Underlying.Name);
+    flat.currency = to_string(d.Currency);
+    flat.accumulation_amount =
         static_cast<double>(d.FixingAmount);
     if (d.Strike)
-        result.instrument.strike_price = static_cast<double>(*d.Strike);
+        flat.strike_price = static_cast<double>(*d.Strike);
     if (d.StartDate)
-        result.instrument.start_date = std::string(*d.StartDate);
+        flat.start_date = std::string(*d.StartDate);
 
     // Capture first knock-out barrier
     if (d.Barriers) {
@@ -566,7 +576,7 @@ equity_mapping_result equity_instrument_mapper::forward_equity_accumulator(
             const auto btype = to_string(bd.Type);
             if ((btype == "DownAndOut" || btype == "UpAndOut") &&
                     !bd.Levels.Level.empty()) {
-                result.instrument.knock_out_barrier =
+                flat.knock_out_barrier =
                     static_cast<double>(bd.Levels.Level.front());
                 break;
             }
@@ -585,20 +595,21 @@ equity_mapping_result equity_instrument_mapper::forward_equity_tarf(
                                << std::string(t.id);
     equity_mapping_result result;
     result.instrument = make_base("EquityTaRF");
+    auto& flat = std::get<equity_instrument>(result.instrument);
     if (!t.EquityTaRFData) return result;
     const auto& d = *t.EquityTaRFData;
 
-    result.instrument.underlying_code = std::string(d.Underlying.Name);
-    result.instrument.currency = to_string(d.Currency);
-    result.instrument.accumulation_amount =
+    flat.underlying_code = std::string(d.Underlying.Name);
+    flat.currency = to_string(d.Currency);
+    flat.accumulation_amount =
         static_cast<double>(d.FixingAmount);
     if (d.Strike)
-        result.instrument.strike_price = static_cast<double>(*d.Strike);
+        flat.strike_price = static_cast<double>(*d.Strike);
 
     // Capture FixingCap barrier level as knock_out
     for (const auto& bd : d.Barriers.BarrierData) {
         if (to_string(bd.Type) == "FixingCap" && !bd.Levels.Level.empty()) {
-            result.instrument.knock_out_barrier =
+            flat.knock_out_barrier =
                 static_cast<double>(bd.Levels.Level.front());
             break;
         }
@@ -616,23 +627,24 @@ equity_mapping_result equity_instrument_mapper::forward_equity_cliquet_option(
                                << std::string(t.id);
     equity_mapping_result result;
     result.instrument = make_base("EquityCliquetOption");
+    auto& flat = std::get<equity_instrument>(result.instrument);
     if (!t.EquityCliquetOptionData) return result;
     const auto& d = *t.EquityCliquetOptionData;
 
-    result.instrument.underlying_code =
+    flat.underlying_code =
         extract_underlying_name(d.underlyingTypes);
-    result.instrument.currency = to_string(d.Currency);
-    result.instrument.notional = static_cast<double>(d.Notional);
-    result.instrument.option_type = to_string(d.OptionType);
+    flat.currency = to_string(d.Currency);
+    flat.notional = static_cast<double>(d.Notional);
+    flat.option_type = to_string(d.OptionType);
 
     // Extract tenor from schedule rules if available
     if (!d.ScheduleData.Rules.empty())
-        result.instrument.cliquet_frequency_code =
+        flat.cliquet_frequency_code =
             std::string(d.ScheduleData.Rules.front().Tenor);
     else if (!d.ScheduleData.Dates.empty() &&
              d.ScheduleData.Dates.front().Dates.Date.size() >= 2) {
         // For date-based schedules store the maturity date
-        result.instrument.maturity_date = std::string(
+        flat.maturity_date = std::string(
             d.ScheduleData.Dates.front().Dates.Date.back());
     }
     return result;
@@ -649,14 +661,15 @@ equity_instrument_mapper::forward_equity_worst_of_basket_swap(
                                << std::string(t.id);
     equity_mapping_result result;
     result.instrument = make_base("EquityWorstOfBasketSwap");
+    auto& flat = std::get<equity_instrument>(result.instrument);
     if (!t.EquityWorstOfBasketSwapData) return result;
     const auto& d = *t.EquityWorstOfBasketSwapData;
 
-    result.instrument.currency = to_string(d.Currency);
-    result.instrument.quantity = static_cast<double>(d.Quantity);
-    result.instrument.basket_json = underlyings_to_json(d.Underlyings);
+    flat.currency = to_string(d.Currency);
+    flat.quantity = static_cast<double>(d.Quantity);
+    flat.basket_json = underlyings_to_json(d.Underlyings);
     if (!d.Underlyings.Underlying.empty())
-        result.instrument.underlying_code =
+        flat.underlying_code =
             std::string(d.Underlyings.Underlying.front().Name);
     return result;
 }
@@ -1057,21 +1070,22 @@ equity_instrument_mapper::forward_equity_double_barrier_option(
                                << std::string(t.id);
     equity_mapping_result result;
     result.instrument = make_base("EquityDoubleBarrierOption");
+    auto& flat = std::get<equity_instrument>(result.instrument);
     if (!t.EquityDoubleBarrierOptionData) return result;
     const auto& d = *t.EquityDoubleBarrierOptionData;
-    result.instrument.underlying_code =
+    flat.underlying_code =
         extract_underlying_name(d.underlyingTypes);
-    result.instrument.currency = to_string(d.Currency);
-    result.instrument.quantity = static_cast<double>(d.Quantity);
-    result.instrument.option_type = extract_option_type(d.OptionData);
-    result.instrument.exercise_type = extract_exercise_style(d.OptionData);
-    result.instrument.maturity_date = first_exercise_date(d.OptionData);
-    result.instrument.strike_price = extract_strike(d.strikeGroup);
+    flat.currency = to_string(d.Currency);
+    flat.quantity = static_cast<double>(d.Quantity);
+    flat.option_type = extract_option_type(d.OptionData);
+    flat.exercise_type = extract_exercise_style(d.OptionData);
+    flat.maturity_date = first_exercise_date(d.OptionData);
+    flat.strike_price = extract_strike(d.strikeGroup);
     if (d.StartDate)
-        result.instrument.start_date = std::string(*d.StartDate);
-    result.instrument.barrier_type = barrier_type_str(d.BarrierData);
-    result.instrument.lower_barrier = first_barrier_level(d.BarrierData);
-    result.instrument.upper_barrier = second_barrier_level(d.BarrierData);
+        flat.start_date = std::string(*d.StartDate);
+    flat.barrier_type = barrier_type_str(d.BarrierData);
+    flat.lower_barrier = first_barrier_level(d.BarrierData);
+    flat.upper_barrier = second_barrier_level(d.BarrierData);
     return result;
 }
 
@@ -1087,21 +1101,22 @@ equity_instrument_mapper::forward_equity_european_barrier_option(
         << std::string(t.id);
     equity_mapping_result result;
     result.instrument = make_base("EquityEuropeanBarrierOption");
+    auto& flat = std::get<equity_instrument>(result.instrument);
     if (!t.EquityEuropeanBarrierOptionData) return result;
     const auto& d = *t.EquityEuropeanBarrierOptionData;
-    result.instrument.underlying_code =
+    flat.underlying_code =
         extract_underlying_name(d.underlyingTypes);
-    result.instrument.currency = to_string(d.Currency);
-    result.instrument.quantity = static_cast<double>(d.Quantity);
-    result.instrument.option_type = extract_option_type(d.OptionData);
-    result.instrument.exercise_type = extract_exercise_style(d.OptionData);
-    result.instrument.maturity_date = first_exercise_date(d.OptionData);
-    result.instrument.strike_price = extract_strike(d.strikeGroup);
+    flat.currency = to_string(d.Currency);
+    flat.quantity = static_cast<double>(d.Quantity);
+    flat.option_type = extract_option_type(d.OptionData);
+    flat.exercise_type = extract_exercise_style(d.OptionData);
+    flat.maturity_date = first_exercise_date(d.OptionData);
+    flat.strike_price = extract_strike(d.strikeGroup);
     if (d.StartDate)
-        result.instrument.start_date = std::string(*d.StartDate);
-    result.instrument.barrier_type = barrier_type_str(d.BarrierData);
-    result.instrument.lower_barrier = first_barrier_level(d.BarrierData);
-    result.instrument.upper_barrier = second_barrier_level(d.BarrierData);
+        flat.start_date = std::string(*d.StartDate);
+    flat.barrier_type = barrier_type_str(d.BarrierData);
+    flat.lower_barrier = first_barrier_level(d.BarrierData);
+    flat.upper_barrier = second_barrier_level(d.BarrierData);
     return result;
 }
 

--- a/projects/ores.ore/src/domain/equity_instrument_mapper.cpp
+++ b/projects/ores.ore/src/domain/equity_instrument_mapper.cpp
@@ -553,23 +553,28 @@ equity_instrument_mapper::forward_equity_outperformance_option(
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityOutperformanceOption: "
                                << std::string(t.id);
     equity_mapping_result result;
-    result.instrument = make_base("EquityOutperformanceOption");
-    auto& flat = std::get<equity_instrument>(result.instrument);
+    auto& inst = result.instrument.emplace<
+        ores::trading::domain::equity_option_instrument>();
+    inst.trade_type_code = "EquityOutperformanceOption";
+    inst.modified_by = "ores";
+    inst.performed_by = "ores";
+    inst.change_reason_code = "system.external_data_import";
+    inst.change_commentary = "Imported from ORE XML";
     if (!t.EquityOutperformanceOptionData) return result;
     const auto& d = *t.EquityOutperformanceOptionData;
 
-    flat.currency = to_string(d.Currency);
-    flat.notional = static_cast<double>(d.Notional);
-    flat.option_type = extract_option_type(d.OptionData);
-    flat.maturity_date = first_exercise_date(d.OptionData);
-    flat.strike_price = static_cast<double>(d.StrikeReturn);
+    inst.currency = to_string(d.Currency);
+    inst.notional = static_cast<double>(d.Notional);
+    inst.option_type = extract_option_type(d.OptionData);
+    inst.expiry_date = first_exercise_date(d.OptionData);
+    inst.strike = static_cast<double>(d.StrikeReturn);
 
-    // Store both underlyings as a JSON array
+    // Both underlyings join as a slash-separated name since the per-type
+    // option struct has no basket field. Preserves round-trip visibility
+    // of the pair; lossless basket support lives on equity_swap_instrument.
     const std::string n1 = std::string(d.Underlying1.Name);
     const std::string n2 = std::string(d.Underlying2.Name);
-    flat.basket_json =
-        "[\"" + json_escape(n1) + "\",\"" + json_escape(n2) + "\"]";
-    flat.underlying_code = n1;
+    inst.underlying_name = n1 + "/" + n2;
     return result;
 }
 
@@ -582,19 +587,23 @@ equity_mapping_result equity_instrument_mapper::forward_equity_accumulator(
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityAccumulator: "
                                << std::string(t.id);
     equity_mapping_result result;
-    result.instrument = make_base("EquityAccumulator");
-    auto& flat = std::get<equity_instrument>(result.instrument);
+    auto& inst = result.instrument.emplace<
+        ores::trading::domain::equity_accumulator_instrument>();
+    inst.trade_type_code = "EquityAccumulator";
+    inst.modified_by = "ores";
+    inst.performed_by = "ores";
+    inst.change_reason_code = "system.external_data_import";
+    inst.change_commentary = "Imported from ORE XML";
     if (!t.EquityAccumulatorData) return result;
     const auto& d = *t.EquityAccumulatorData;
 
-    flat.underlying_code = std::string(d.Underlying.Name);
-    flat.currency = to_string(d.Currency);
-    flat.accumulation_amount =
-        static_cast<double>(d.FixingAmount);
+    inst.underlying_name = std::string(d.Underlying.Name);
+    inst.currency = to_string(d.Currency);
+    inst.fixing_amount = static_cast<double>(d.FixingAmount);
     if (d.Strike)
-        flat.strike_price = static_cast<double>(*d.Strike);
+        inst.strike = static_cast<double>(*d.Strike);
     if (d.StartDate)
-        flat.start_date = std::string(*d.StartDate);
+        inst.start_date = std::string(*d.StartDate);
 
     // Capture first knock-out barrier
     if (d.Barriers) {
@@ -602,7 +611,7 @@ equity_mapping_result equity_instrument_mapper::forward_equity_accumulator(
             const auto btype = to_string(bd.Type);
             if ((btype == "DownAndOut" || btype == "UpAndOut") &&
                     !bd.Levels.Level.empty()) {
-                flat.knock_out_barrier =
+                inst.knock_out_level =
                     static_cast<double>(bd.Levels.Level.front());
                 break;
             }
@@ -620,22 +629,26 @@ equity_mapping_result equity_instrument_mapper::forward_equity_tarf(
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityTaRF: "
                                << std::string(t.id);
     equity_mapping_result result;
-    result.instrument = make_base("EquityTaRF");
-    auto& flat = std::get<equity_instrument>(result.instrument);
+    auto& inst = result.instrument.emplace<
+        ores::trading::domain::equity_accumulator_instrument>();
+    inst.trade_type_code = "EquityTaRF";
+    inst.modified_by = "ores";
+    inst.performed_by = "ores";
+    inst.change_reason_code = "system.external_data_import";
+    inst.change_commentary = "Imported from ORE XML";
     if (!t.EquityTaRFData) return result;
     const auto& d = *t.EquityTaRFData;
 
-    flat.underlying_code = std::string(d.Underlying.Name);
-    flat.currency = to_string(d.Currency);
-    flat.accumulation_amount =
-        static_cast<double>(d.FixingAmount);
+    inst.underlying_name = std::string(d.Underlying.Name);
+    inst.currency = to_string(d.Currency);
+    inst.fixing_amount = static_cast<double>(d.FixingAmount);
     if (d.Strike)
-        flat.strike_price = static_cast<double>(*d.Strike);
+        inst.strike = static_cast<double>(*d.Strike);
 
     // Capture FixingCap barrier level as knock_out
     for (const auto& bd : d.Barriers.BarrierData) {
         if (to_string(bd.Type) == "FixingCap" && !bd.Levels.Level.empty()) {
-            flat.knock_out_barrier =
+            inst.knock_out_level =
                 static_cast<double>(bd.Levels.Level.front());
             break;
         }
@@ -652,25 +665,29 @@ equity_mapping_result equity_instrument_mapper::forward_equity_cliquet_option(
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityCliquetOption: "
                                << std::string(t.id);
     equity_mapping_result result;
-    result.instrument = make_base("EquityCliquetOption");
-    auto& flat = std::get<equity_instrument>(result.instrument);
+    auto& inst = result.instrument.emplace<
+        ores::trading::domain::equity_option_instrument>();
+    inst.trade_type_code = "EquityCliquetOption";
+    inst.modified_by = "ores";
+    inst.performed_by = "ores";
+    inst.change_reason_code = "system.external_data_import";
+    inst.change_commentary = "Imported from ORE XML";
     if (!t.EquityCliquetOptionData) return result;
     const auto& d = *t.EquityCliquetOptionData;
 
-    flat.underlying_code =
-        extract_underlying_name(d.underlyingTypes);
-    flat.currency = to_string(d.Currency);
-    flat.notional = static_cast<double>(d.Notional);
-    flat.option_type = to_string(d.OptionType);
+    inst.underlying_name = extract_underlying_name(d.underlyingTypes);
+    inst.currency = to_string(d.Currency);
+    inst.notional = static_cast<double>(d.Notional);
+    inst.option_type = to_string(d.OptionType);
 
     // Extract tenor from schedule rules if available
     if (!d.ScheduleData.Rules.empty())
-        flat.cliquet_frequency_code =
+        inst.cliquet_frequency =
             std::string(d.ScheduleData.Rules.front().Tenor);
     else if (!d.ScheduleData.Dates.empty() &&
              d.ScheduleData.Dates.front().Dates.Date.size() >= 2) {
         // For date-based schedules store the maturity date
-        flat.maturity_date = std::string(
+        inst.expiry_date = std::string(
             d.ScheduleData.Dates.front().Dates.Date.back());
     }
     return result;
@@ -686,17 +703,21 @@ equity_instrument_mapper::forward_equity_worst_of_basket_swap(
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityWorstOfBasketSwap: "
                                << std::string(t.id);
     equity_mapping_result result;
-    result.instrument = make_base("EquityWorstOfBasketSwap");
-    auto& flat = std::get<equity_instrument>(result.instrument);
+    auto& inst = result.instrument.emplace<
+        ores::trading::domain::equity_swap_instrument>();
+    inst.trade_type_code = "EquityWorstOfBasketSwap";
+    inst.modified_by = "ores";
+    inst.performed_by = "ores";
+    inst.change_reason_code = "system.external_data_import";
+    inst.change_commentary = "Imported from ORE XML";
     if (!t.EquityWorstOfBasketSwapData) return result;
     const auto& d = *t.EquityWorstOfBasketSwapData;
 
-    flat.currency = to_string(d.Currency);
-    flat.quantity = static_cast<double>(d.Quantity);
-    flat.basket_json = underlyings_to_json(d.Underlyings);
+    inst.currency = to_string(d.Currency);
+    inst.notional = static_cast<double>(d.Quantity);
+    inst.basket_json = underlyings_to_json(d.Underlyings);
     if (!d.Underlyings.Underlying.empty())
-        flat.underlying_code =
-            std::string(d.Underlyings.Underlying.front().Name);
+        inst.underlying_name = std::string(d.Underlyings.Underlying.front().Name);
     return result;
 }
 

--- a/projects/ores.ore/src/domain/equity_instrument_mapper.cpp
+++ b/projects/ores.ore/src/domain/equity_instrument_mapper.cpp
@@ -353,38 +353,36 @@ equity_mapping_result equity_instrument_mapper::forward_equity_swap(
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquitySwap: "
                                << std::string(t.id);
     equity_mapping_result result;
-    result.instrument = make_base("EquitySwap");
-    auto& flat = std::get<equity_instrument>(result.instrument);
+    auto& inst = result.instrument.emplace<
+        ores::trading::domain::equity_swap_instrument>();
+    inst.trade_type_code = "EquitySwap";
+    inst.modified_by = "ores";
+    inst.performed_by = "ores";
+    inst.change_reason_code = "system.external_data_import";
+    inst.change_commentary = "Imported from ORE XML";
     if (!t.EquitySwapData) return result;
     const auto& d = *t.EquitySwapData;
 
     for (const auto& ld : d.LegData) {
         if (ld.legDataType && ld.legDataType->EquityLegData) {
             const auto& el = *ld.legDataType->EquityLegData;
-            flat.underlying_code =
-                extract_underlying_name(el.underlyingTypes);
-            flat.return_type = std::string(el.ReturnType);
-            if (el.Quantity)
-                flat.quantity =
-                    static_cast<double>(*el.Quantity);
+            inst.underlying_name = extract_underlying_name(el.underlyingTypes);
+            inst.return_type = std::string(el.ReturnType);
+            if (el.Quantity && inst.notional == 0.0)
+                inst.notional = static_cast<double>(*el.Quantity);
         } else {
-            // Non-equity leg provides currency/notional/schedule
+            // Non-equity leg provides currency/notional/schedule.
             if (ld.Currency)
-                flat.currency = std::string(*ld.Currency);
+                inst.currency = std::string(*ld.Currency);
             if (ld.Notionals && !ld.Notionals->Notional.empty())
-                flat.notional =
+                inst.notional =
                     static_cast<double>(ld.Notionals->Notional.front());
-            if (ld.DayCounter)
-                flat.day_count_code =
-                    to_string(*ld.DayCounter);
             if (ld.ScheduleData && !ld.ScheduleData->Rules.empty()) {
                 const auto& rule = ld.ScheduleData->Rules.front();
-                flat.start_date = std::string(rule.StartDate);
+                inst.start_date = std::string(rule.StartDate);
                 if (rule.EndDate)
-                    flat.maturity_date =
-                        std::string(*rule.EndDate);
-                flat.payment_frequency_code =
-                    std::string(rule.Tenor);
+                    inst.maturity_date = std::string(*rule.EndDate);
+                inst.payment_frequency = std::string(rule.Tenor);
             }
         }
     }
@@ -400,18 +398,22 @@ equity_mapping_result equity_instrument_mapper::forward_equity_variance_swap(
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityVarianceSwap: "
                                << std::string(t.id);
     equity_mapping_result result;
-    result.instrument = make_base("EquityVarianceSwap");
-    auto& flat = std::get<equity_instrument>(result.instrument);
+    auto& inst = result.instrument.emplace<
+        ores::trading::domain::equity_variance_swap_instrument>();
+    inst.trade_type_code = "EquityVarianceSwap";
+    inst.modified_by = "ores";
+    inst.performed_by = "ores";
+    inst.change_reason_code = "system.external_data_import";
+    inst.change_commentary = "Imported from ORE XML";
     if (!t.EquityVarianceSwapData) return result;
     const auto& d = *t.EquityVarianceSwapData;
 
-    flat.underlying_code =
-        extract_underlying_name(d.underlyingTypes);
-    flat.currency = to_string(d.Currency);
-    flat.notional = static_cast<double>(d.Notional);
-    flat.variance_strike = static_cast<double>(d.Strike);
-    flat.start_date = std::string(d.StartDate);
-    flat.maturity_date = std::string(d.EndDate);
+    inst.underlying_name = extract_underlying_name(d.underlyingTypes);
+    inst.currency = to_string(d.Currency);
+    inst.notional = static_cast<double>(d.Notional);
+    inst.variance_strike = static_cast<double>(d.Strike);
+    inst.start_date = std::string(d.StartDate);
+    inst.maturity_date = std::string(d.EndDate);
     return result;
 }
 

--- a/projects/ores.ore/src/domain/equity_instrument_mapper.cpp
+++ b/projects/ores.ore/src/domain/equity_instrument_mapper.cpp
@@ -368,7 +368,13 @@ equity_mapping_result equity_instrument_mapper::forward_equity_swap(
             const auto& el = *ld.legDataType->EquityLegData;
             inst.underlying_name = extract_underlying_name(el.underlyingTypes);
             inst.return_type = std::string(el.ReturnType);
-            if (el.Quantity && inst.notional == 0.0)
+            // The per-type struct has a single notional field that conflates
+            // the equity leg's share Quantity with the funding leg's
+            // dollar Notional. Non-equity leg still overwrites below —
+            // intentional: dollar-notional semantics dominate when both are
+            // present. Adding a separate quantity field on the per-type
+            // schema is future schema work.
+            if (el.Quantity)
                 inst.notional = static_cast<double>(*el.Quantity);
         } else {
             // Non-equity leg provides currency/notional/schedule.

--- a/projects/ores.ore/src/domain/equity_instrument_mapper.cpp
+++ b/projects/ores.ore/src/domain/equity_instrument_mapper.cpp
@@ -297,19 +297,23 @@ equity_mapping_result equity_instrument_mapper::forward_equity_option(
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityOption: "
                                << std::string(t.id);
     equity_mapping_result result;
-    result.instrument = make_base("EquityOption");
-    auto& flat = std::get<equity_instrument>(result.instrument);
+    auto& inst = result.instrument.emplace<
+        ores::trading::domain::equity_option_instrument>();
+    inst.trade_type_code = "EquityOption";
+    inst.modified_by = "ores";
+    inst.performed_by = "ores";
+    inst.change_reason_code = "system.external_data_import";
+    inst.change_commentary = "Imported from ORE XML";
     if (!t.EquityOptionData) return result;
     const auto& d = *t.EquityOptionData;
 
-    flat.underlying_code =
-        extract_underlying_name(d.underlyingTypes);
-    flat.currency = std::string(d.Currency);
-    flat.quantity = static_cast<double>(d.Quantity);
-    flat.option_type = extract_option_type(d.OptionData);
-    flat.exercise_type = extract_exercise_style(d.OptionData);
-    flat.maturity_date = first_exercise_date(d.OptionData);
-    flat.strike_price = extract_strike(d.strikeGroup);
+    inst.underlying_name = extract_underlying_name(d.underlyingTypes);
+    inst.currency = std::string(d.Currency);
+    inst.notional = static_cast<double>(d.Quantity);
+    inst.option_type = extract_option_type(d.OptionData);
+    inst.exercise_type = extract_exercise_style(d.OptionData);
+    inst.expiry_date = first_exercise_date(d.OptionData);
+    inst.strike = extract_strike(d.strikeGroup);
     return result;
 }
 
@@ -322,17 +326,21 @@ equity_mapping_result equity_instrument_mapper::forward_equity_forward(
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityForward: "
                                << std::string(t.id);
     equity_mapping_result result;
-    result.instrument = make_base("EquityForward");
-    auto& flat = std::get<equity_instrument>(result.instrument);
+    auto& inst = result.instrument.emplace<
+        ores::trading::domain::equity_forward_instrument>();
+    inst.trade_type_code = "EquityForward";
+    inst.modified_by = "ores";
+    inst.performed_by = "ores";
+    inst.change_reason_code = "system.external_data_import";
+    inst.change_commentary = "Imported from ORE XML";
     if (!t.EquityForwardData) return result;
     const auto& d = *t.EquityForwardData;
 
-    flat.underlying_code =
-        extract_underlying_name(d.underlyingTypes);
-    flat.currency = std::string(d.Currency);
-    flat.quantity = static_cast<double>(d.Quantity);
-    flat.strike_price = static_cast<double>(d.Strike);
-    flat.maturity_date = std::string(d.Maturity);
+    inst.underlying_name = extract_underlying_name(d.underlyingTypes);
+    inst.currency = std::string(d.Currency);
+    inst.quantity = static_cast<double>(d.Quantity);
+    inst.forward_price = static_cast<double>(d.Strike);
+    inst.expiry_date = std::string(d.Maturity);
     return result;
 }
 

--- a/projects/ores.ore/src/domain/equity_instrument_mapper.cpp
+++ b/projects/ores.ore/src/domain/equity_instrument_mapper.cpp
@@ -426,24 +426,28 @@ equity_mapping_result equity_instrument_mapper::forward_equity_barrier_option(
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityBarrierOption: "
                                << std::string(t.id);
     equity_mapping_result result;
-    result.instrument = make_base("EquityBarrierOption");
-    auto& flat = std::get<equity_instrument>(result.instrument);
+    auto& inst = result.instrument.emplace<
+        ores::trading::domain::equity_barrier_option_instrument>();
+    inst.trade_type_code = "EquityBarrierOption";
+    inst.modified_by = "ores";
+    inst.performed_by = "ores";
+    inst.change_reason_code = "system.external_data_import";
+    inst.change_commentary = "Imported from ORE XML";
     if (!t.EquityBarrierOptionData) return result;
     const auto& d = *t.EquityBarrierOptionData;
 
-    flat.underlying_code =
-        extract_underlying_name(d.underlyingTypes);
-    flat.currency = to_string(d.Currency);
-    flat.quantity = static_cast<double>(d.Quantity);
-    flat.option_type = extract_option_type(d.OptionData);
-    flat.exercise_type = extract_exercise_style(d.OptionData);
-    flat.maturity_date = first_exercise_date(d.OptionData);
-    flat.strike_price = extract_strike(d.strikeGroup);
-    if (d.StartDate)
-        flat.start_date = std::string(*d.StartDate);
-    flat.barrier_type = barrier_type_str(d.BarrierData);
-    flat.lower_barrier = first_barrier_level(d.BarrierData);
-    flat.upper_barrier = second_barrier_level(d.BarrierData);
+    inst.underlying_name = extract_underlying_name(d.underlyingTypes);
+    inst.currency = to_string(d.Currency);
+    inst.notional = static_cast<double>(d.Quantity);
+    inst.option_type = extract_option_type(d.OptionData);
+    inst.exercise_type = extract_exercise_style(d.OptionData);
+    inst.expiry_date = first_exercise_date(d.OptionData);
+    inst.strike = extract_strike(d.strikeGroup);
+    inst.lower_barrier_type = barrier_type_str(d.BarrierData);
+    inst.lower_barrier = first_barrier_level(d.BarrierData);
+    const auto upper = second_barrier_level(d.BarrierData);
+    if (upper > 0.0)
+        inst.upper_barrier = upper;
     return result;
 }
 
@@ -456,20 +460,25 @@ equity_mapping_result equity_instrument_mapper::forward_equity_asian_option(
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityAsianOption: "
                                << std::string(t.id);
     equity_mapping_result result;
-    result.instrument = make_base("EquityAsianOption");
-    auto& flat = std::get<equity_instrument>(result.instrument);
+    auto& inst = result.instrument.emplace<
+        ores::trading::domain::equity_asian_option_instrument>();
+    inst.trade_type_code = "EquityAsianOption";
+    inst.modified_by = "ores";
+    inst.performed_by = "ores";
+    inst.change_reason_code = "system.external_data_import";
+    inst.change_commentary = "Imported from ORE XML";
     if (!t.EquityAsianOptionData) return result;
     const auto& d = *t.EquityAsianOptionData;
 
     if (d.Underlying)
-        flat.underlying_code = std::string(d.Underlying->Name);
-    flat.currency = to_string(d.Currency);
-    flat.quantity = static_cast<double>(d.Quantity);
-    flat.option_type = extract_option_type(d.OptionData);
-    flat.maturity_date = first_exercise_date(d.OptionData);
-    flat.strike_price = extract_strike(d.strikeGroup);
+        inst.underlying_name = std::string(d.Underlying->Name);
+    inst.currency = to_string(d.Currency);
+    inst.notional = static_cast<double>(d.Quantity);
+    inst.option_type = extract_option_type(d.OptionData);
+    inst.expiry_date = first_exercise_date(d.OptionData);
+    inst.strike = extract_strike(d.strikeGroup);
     if (d.ObservationDates && !d.ObservationDates->Rules.empty())
-        flat.averaging_start_date =
+        inst.averaging_start_date =
             std::string(d.ObservationDates->Rules.front().StartDate);
     return result;
 }
@@ -483,20 +492,23 @@ equity_mapping_result equity_instrument_mapper::forward_equity_digital_option(
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityDigitalOption: "
                                << std::string(t.id);
     equity_mapping_result result;
-    result.instrument = make_base("EquityDigitalOption");
-    auto& flat = std::get<equity_instrument>(result.instrument);
+    auto& inst = result.instrument.emplace<
+        ores::trading::domain::equity_digital_option_instrument>();
+    inst.trade_type_code = "EquityDigitalOption";
+    inst.modified_by = "ores";
+    inst.performed_by = "ores";
+    inst.change_reason_code = "system.external_data_import";
+    inst.change_commentary = "Imported from ORE XML";
     if (!t.EquityDigitalOptionData) return result;
     const auto& d = *t.EquityDigitalOptionData;
 
-    flat.underlying_code =
-        extract_underlying_name(d.underlyingTypes);
-    flat.quantity = static_cast<double>(d.Quantity);
-    flat.option_type = extract_option_type(d.OptionData);
-    flat.maturity_date = first_exercise_date(d.OptionData);
-    flat.strike_price = static_cast<double>(d.Strike);
-    flat.notional = static_cast<double>(d.PayoffAmount);
+    inst.underlying_name = extract_underlying_name(d.underlyingTypes);
+    inst.option_type = extract_option_type(d.OptionData);
+    inst.expiry_date = first_exercise_date(d.OptionData);
+    inst.strike = static_cast<double>(d.Strike);
+    inst.notional = static_cast<double>(d.PayoffAmount);
     if (d.PayoffCurrency)
-        flat.currency = to_string(*d.PayoffCurrency);
+        inst.currency = to_string(*d.PayoffCurrency);
     return result;
 }
 
@@ -509,21 +521,25 @@ equity_mapping_result equity_instrument_mapper::forward_equity_touch_option(
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityTouchOption: "
                                << std::string(t.id);
     equity_mapping_result result;
-    result.instrument = make_base("EquityTouchOption");
-    auto& flat = std::get<equity_instrument>(result.instrument);
+    auto& inst = result.instrument.emplace<
+        ores::trading::domain::equity_digital_option_instrument>();
+    inst.trade_type_code = "EquityTouchOption";
+    inst.modified_by = "ores";
+    inst.performed_by = "ores";
+    inst.change_reason_code = "system.external_data_import";
+    inst.change_commentary = "Imported from ORE XML";
     if (!t.EquityTouchOptionData) return result;
     const auto& d = *t.EquityTouchOptionData;
 
-    flat.underlying_code =
-        extract_underlying_name(d.underlyingTypes);
-    flat.currency = to_string(d.PayoffCurrency);
-    flat.notional = static_cast<double>(d.PayoffAmount);
-    flat.option_type = extract_option_type(d.OptionData);
-    flat.maturity_date = first_exercise_date(d.OptionData);
-    if (d.StartDate)
-        flat.start_date = std::string(*d.StartDate);
-    flat.barrier_type = barrier_type_str(d.BarrierData);
-    flat.lower_barrier = first_barrier_level(d.BarrierData);
+    inst.underlying_name = extract_underlying_name(d.underlyingTypes);
+    inst.currency = to_string(d.PayoffCurrency);
+    inst.notional = static_cast<double>(d.PayoffAmount);
+    inst.option_type = extract_option_type(d.OptionData);
+    inst.expiry_date = first_exercise_date(d.OptionData);
+    inst.barrier_type = barrier_type_str(d.BarrierData);
+    const auto lb = first_barrier_level(d.BarrierData);
+    if (lb > 0.0)
+        inst.barrier_level = lb;
     return result;
 }
 
@@ -1079,23 +1095,27 @@ equity_instrument_mapper::forward_equity_double_barrier_option(
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityDoubleBarrierOption: "
                                << std::string(t.id);
     equity_mapping_result result;
-    result.instrument = make_base("EquityDoubleBarrierOption");
-    auto& flat = std::get<equity_instrument>(result.instrument);
+    auto& inst = result.instrument.emplace<
+        ores::trading::domain::equity_barrier_option_instrument>();
+    inst.trade_type_code = "EquityDoubleBarrierOption";
+    inst.modified_by = "ores";
+    inst.performed_by = "ores";
+    inst.change_reason_code = "system.external_data_import";
+    inst.change_commentary = "Imported from ORE XML";
     if (!t.EquityDoubleBarrierOptionData) return result;
     const auto& d = *t.EquityDoubleBarrierOptionData;
-    flat.underlying_code =
-        extract_underlying_name(d.underlyingTypes);
-    flat.currency = to_string(d.Currency);
-    flat.quantity = static_cast<double>(d.Quantity);
-    flat.option_type = extract_option_type(d.OptionData);
-    flat.exercise_type = extract_exercise_style(d.OptionData);
-    flat.maturity_date = first_exercise_date(d.OptionData);
-    flat.strike_price = extract_strike(d.strikeGroup);
-    if (d.StartDate)
-        flat.start_date = std::string(*d.StartDate);
-    flat.barrier_type = barrier_type_str(d.BarrierData);
-    flat.lower_barrier = first_barrier_level(d.BarrierData);
-    flat.upper_barrier = second_barrier_level(d.BarrierData);
+    inst.underlying_name = extract_underlying_name(d.underlyingTypes);
+    inst.currency = to_string(d.Currency);
+    inst.notional = static_cast<double>(d.Quantity);
+    inst.option_type = extract_option_type(d.OptionData);
+    inst.exercise_type = extract_exercise_style(d.OptionData);
+    inst.expiry_date = first_exercise_date(d.OptionData);
+    inst.strike = extract_strike(d.strikeGroup);
+    inst.lower_barrier_type = barrier_type_str(d.BarrierData);
+    inst.lower_barrier = first_barrier_level(d.BarrierData);
+    const auto upper = second_barrier_level(d.BarrierData);
+    if (upper > 0.0)
+        inst.upper_barrier = upper;
     return result;
 }
 
@@ -1110,23 +1130,27 @@ equity_instrument_mapper::forward_equity_european_barrier_option(
         << "Forward-mapping EquityEuropeanBarrierOption: "
         << std::string(t.id);
     equity_mapping_result result;
-    result.instrument = make_base("EquityEuropeanBarrierOption");
-    auto& flat = std::get<equity_instrument>(result.instrument);
+    auto& inst = result.instrument.emplace<
+        ores::trading::domain::equity_barrier_option_instrument>();
+    inst.trade_type_code = "EquityEuropeanBarrierOption";
+    inst.modified_by = "ores";
+    inst.performed_by = "ores";
+    inst.change_reason_code = "system.external_data_import";
+    inst.change_commentary = "Imported from ORE XML";
     if (!t.EquityEuropeanBarrierOptionData) return result;
     const auto& d = *t.EquityEuropeanBarrierOptionData;
-    flat.underlying_code =
-        extract_underlying_name(d.underlyingTypes);
-    flat.currency = to_string(d.Currency);
-    flat.quantity = static_cast<double>(d.Quantity);
-    flat.option_type = extract_option_type(d.OptionData);
-    flat.exercise_type = extract_exercise_style(d.OptionData);
-    flat.maturity_date = first_exercise_date(d.OptionData);
-    flat.strike_price = extract_strike(d.strikeGroup);
-    if (d.StartDate)
-        flat.start_date = std::string(*d.StartDate);
-    flat.barrier_type = barrier_type_str(d.BarrierData);
-    flat.lower_barrier = first_barrier_level(d.BarrierData);
-    flat.upper_barrier = second_barrier_level(d.BarrierData);
+    inst.underlying_name = extract_underlying_name(d.underlyingTypes);
+    inst.currency = to_string(d.Currency);
+    inst.notional = static_cast<double>(d.Quantity);
+    inst.option_type = extract_option_type(d.OptionData);
+    inst.exercise_type = extract_exercise_style(d.OptionData);
+    inst.expiry_date = first_exercise_date(d.OptionData);
+    inst.strike = extract_strike(d.strikeGroup);
+    inst.lower_barrier_type = barrier_type_str(d.BarrierData);
+    inst.lower_barrier = first_barrier_level(d.BarrierData);
+    const auto upper = second_barrier_level(d.BarrierData);
+    if (upper > 0.0)
+        inst.upper_barrier = upper;
     return result;
 }
 

--- a/projects/ores.ore/src/xml/importer.cpp
+++ b/projects/ores.ore/src/xml/importer.cpp
@@ -201,8 +201,16 @@ importer::import_portfolio_with_context(const std::filesystem::path& path) {
                         result.instrument.trade_id = item.trade.id;
                     } else if constexpr (std::is_same_v<T, domain::equity_mapping_result>) {
                         item.trade.product_type = product_type::equity;
-                        result.instrument.id = instr_id;
-                        result.instrument.trade_id = item.trade.id;
+                        std::visit([&](auto& instr) {
+                            using InstrT = std::decay_t<decltype(instr)>;
+                            if constexpr (std::is_same_v<InstrT,
+                                    ores::trading::domain::equity_instrument>) {
+                                instr.id = instr_id;
+                            } else {
+                                instr.instrument_id = instr_id;
+                            }
+                            instr.trade_id = item.trade.id;
+                        }, result.instrument);
                     } else if constexpr (std::is_same_v<T, domain::commodity_mapping_result>) {
                         item.trade.product_type = product_type::commodity;
                         result.instrument.id = instr_id;
@@ -238,7 +246,8 @@ void importer::rewire_instrument_trade_id(trade_import_item& item) {
         if constexpr (std::is_same_v<T, std::monostate>) {
             // No instrument for this trade type.
         } else if constexpr (std::is_same_v<T, domain::swap_mapping_result> ||
-                             std::is_same_v<T, domain::fx_mapping_result>) {
+                             std::is_same_v<T, domain::fx_mapping_result> ||
+                             std::is_same_v<T, domain::equity_mapping_result>) {
             std::visit([&](auto& instr) {
                 instr.trade_id = item.trade.id;
             }, result.instrument);

--- a/projects/ores.ore/tests/planner_import_planner_tests.cpp
+++ b/projects/ores.ore/tests/planner_import_planner_tests.cpp
@@ -310,7 +310,8 @@ TEST_CASE("plan_instrument_trade_id_matches_minted_trade_id", tags) {
             if constexpr (std::is_same_v<T, std::monostate>) {
                 // No instrument mapping for this trade type — skip.
             } else if constexpr (std::is_same_v<T, swap_mapping_result> ||
-                                 std::is_same_v<T, fx_mapping_result>) {
+                                 std::is_same_v<T, fx_mapping_result> ||
+                                 std::is_same_v<T, equity_mapping_result>) {
                 std::visit([&](const auto& instr) {
                     INFO("Instrument variant index checked");
                     REQUIRE(instr.trade_id.has_value());
@@ -318,7 +319,7 @@ TEST_CASE("plan_instrument_trade_id_matches_minted_trade_id", tags) {
                     ++checked;
                 }, r.instrument);
             } else {
-                // bond/credit/equity/commodity/scripted/composite all hold the
+                // bond/credit/commodity/scripted/composite all hold the
                 // instrument directly with a trade_id member.
                 REQUIRE(r.instrument.trade_id.has_value());
                 CHECK(*r.instrument.trade_id == item.trade.id);

--- a/projects/ores.ore/tests/xml_equity_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/tests/xml_equity_mapper_roundtrip_tests.cpp
@@ -99,6 +99,26 @@ ores::trading::domain::equity_instrument flat(
             f.maturity_date   = inst.expiry_date;
             f.strike_price    = inst.forward_price.value_or(0.0);
             return f;
+        } else if constexpr (std::is_same_v<T, equity_swap_instrument>) {
+            equity_instrument f;
+            f.trade_type_code = inst.trade_type_code;
+            f.underlying_code = inst.underlying_name;
+            f.currency        = inst.currency;
+            f.notional        = inst.notional;
+            f.return_type     = inst.return_type;
+            f.start_date      = inst.start_date;
+            f.maturity_date   = inst.maturity_date;
+            return f;
+        } else if constexpr (std::is_same_v<T, equity_variance_swap_instrument>) {
+            equity_instrument f;
+            f.trade_type_code = inst.trade_type_code;
+            f.underlying_code = inst.underlying_name;
+            f.currency        = inst.currency;
+            f.notional        = inst.notional;
+            f.variance_strike = inst.variance_strike;
+            f.start_date      = inst.start_date;
+            f.maturity_date   = inst.maturity_date;
+            return f;
         }
         return {};
     }, r.instrument);
@@ -152,11 +172,13 @@ TEST_CASE("equity_mapper_roundtrip_forward", tags) {
 TEST_CASE("equity_mapper_roundtrip_swap", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_Swap.xml");
+    const auto& inst =
+        std::get<ores::trading::domain::equity_swap_instrument>(r.instrument);
 
-    CHECK(flat(r).trade_type_code == "EquitySwap");
-    CHECK(!flat(r).underlying_code.empty());
-    CHECK(!flat(r).currency.empty());
-    CHECK(!flat(r).return_type.empty());
+    CHECK(inst.trade_type_code == "EquitySwap");
+    CHECK(!inst.underlying_name.empty());
+    CHECK(!inst.currency.empty());
+    CHECK(!inst.return_type.empty());
 
     const auto rt = equity_instrument_mapper::reverse_equity_swap(flat(r));
     REQUIRE(rt.EquitySwapData);
@@ -164,24 +186,27 @@ TEST_CASE("equity_mapper_roundtrip_swap", tags) {
     CHECK(has_legs);
 
     BOOST_LOG_SEV(lg, info) << "EquitySwap roundtrip passed. Return type: "
-                            << flat(r).return_type;
+                            << inst.return_type;
 }
 
 TEST_CASE("equity_mapper_roundtrip_variance_swap", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_Variance_Swap.xml");
+    const auto& inst =
+        std::get<ores::trading::domain::equity_variance_swap_instrument>(
+            r.instrument);
 
-    CHECK(flat(r).trade_type_code == "EquityVarianceSwap");
-    CHECK(!flat(r).underlying_code.empty());
-    CHECK(flat(r).variance_strike > 0.0);
-    CHECK(!flat(r).start_date.empty());
-    CHECK(!flat(r).maturity_date.empty());
+    CHECK(inst.trade_type_code == "EquityVarianceSwap");
+    CHECK(!inst.underlying_name.empty());
+    CHECK(inst.variance_strike > 0.0);
+    CHECK(!inst.start_date.empty());
+    CHECK(!inst.maturity_date.empty());
 
     const auto rt = equity_instrument_mapper::reverse_equity_variance_swap(flat(r));
     REQUIRE(rt.EquityVarianceSwapData);
 
     BOOST_LOG_SEV(lg, info) << "EquityVarianceSwap roundtrip passed. Strike: "
-                            << flat(r).variance_strike;
+                            << inst.variance_strike;
 }
 
 TEST_CASE("equity_mapper_roundtrip_barrier_option", tags) {

--- a/projects/ores.ore/tests/xml_equity_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/tests/xml_equity_mapper_roundtrip_tests.cpp
@@ -66,12 +66,42 @@ equity_mapping_result load_and_map(const std::string& filename) {
     return *r;
 }
 
-// Transitional helper: extracts the legacy flat equity_instrument from the
-// mapping-result variant. Deleted in the final Phase 2 commit once every
-// test has migrated to per-type assertions via std::get<per_type>.
-const ores::trading::domain::equity_instrument& flat(
+// Transitional helper: returns the flat equity_instrument shape regardless
+// of which variant alternative the mapping result carries, so the legacy
+// flat-signature reverse_equity_* functions still work while forward_*
+// functions migrate one per-type at a time. Deleted in the final Phase 2
+// commit.
+ores::trading::domain::equity_instrument flat(
     const equity_mapping_result& r) {
-    return std::get<ores::trading::domain::equity_instrument>(r.instrument);
+    return std::visit([](const auto& inst)
+            -> ores::trading::domain::equity_instrument {
+        using T = std::decay_t<decltype(inst)>;
+        using namespace ores::trading::domain;
+        if constexpr (std::is_same_v<T, equity_instrument>) {
+            return inst;
+        } else if constexpr (std::is_same_v<T, equity_option_instrument>) {
+            equity_instrument f;
+            f.trade_type_code = inst.trade_type_code;
+            f.underlying_code = inst.underlying_name;
+            f.currency        = inst.currency;
+            f.quantity        = inst.notional;
+            f.option_type     = inst.option_type;
+            f.exercise_type   = inst.exercise_type;
+            f.maturity_date   = inst.expiry_date;
+            f.strike_price    = inst.strike;
+            return f;
+        } else if constexpr (std::is_same_v<T, equity_forward_instrument>) {
+            equity_instrument f;
+            f.trade_type_code = inst.trade_type_code;
+            f.underlying_code = inst.underlying_name;
+            f.currency        = inst.currency;
+            f.quantity        = inst.quantity;
+            f.maturity_date   = inst.expiry_date;
+            f.strike_price    = inst.forward_price.value_or(0.0);
+            return f;
+        }
+        return {};
+    }, r.instrument);
 }
 
 } // namespace
@@ -83,36 +113,40 @@ const ores::trading::domain::equity_instrument& flat(
 TEST_CASE("equity_mapper_roundtrip_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_Option_European.xml");
+    const auto& inst =
+        std::get<ores::trading::domain::equity_option_instrument>(r.instrument);
 
-    CHECK(flat(r).trade_type_code == "EquityOption");
-    CHECK(!flat(r).underlying_code.empty());
-    CHECK(!flat(r).currency.empty());
-    CHECK(flat(r).quantity > 0.0);
-    CHECK(!flat(r).option_type.empty());
-    CHECK(!flat(r).maturity_date.empty());
+    CHECK(inst.trade_type_code == "EquityOption");
+    CHECK(!inst.underlying_name.empty());
+    CHECK(!inst.currency.empty());
+    CHECK(inst.notional > 0.0);
+    CHECK(!inst.option_type.empty());
+    CHECK(!inst.expiry_date.empty());
 
     const auto rt = equity_instrument_mapper::reverse_equity_option(flat(r));
     REQUIRE(rt.EquityOptionData);
 
     BOOST_LOG_SEV(lg, info) << "EquityOption roundtrip passed. Underlying: "
-                            << flat(r).underlying_code;
+                            << inst.underlying_name;
 }
 
 TEST_CASE("equity_mapper_roundtrip_forward", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_Forward.xml");
+    const auto& inst =
+        std::get<ores::trading::domain::equity_forward_instrument>(r.instrument);
 
-    CHECK(flat(r).trade_type_code == "EquityForward");
-    CHECK(!flat(r).underlying_code.empty());
-    CHECK(!flat(r).currency.empty());
-    CHECK(flat(r).quantity > 0.0);
-    CHECK(!flat(r).maturity_date.empty());
+    CHECK(inst.trade_type_code == "EquityForward");
+    CHECK(!inst.underlying_name.empty());
+    CHECK(!inst.currency.empty());
+    CHECK(inst.quantity > 0.0);
+    CHECK(!inst.expiry_date.empty());
 
     const auto rt = equity_instrument_mapper::reverse_equity_forward(flat(r));
     REQUIRE(rt.EquityForwardData);
 
     BOOST_LOG_SEV(lg, info) << "EquityForward roundtrip passed. Maturity: "
-                            << flat(r).maturity_date;
+                            << inst.expiry_date;
 }
 
 TEST_CASE("equity_mapper_roundtrip_swap", tags) {

--- a/projects/ores.ore/tests/xml_equity_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/tests/xml_equity_mapper_roundtrip_tests.cpp
@@ -119,6 +119,47 @@ ores::trading::domain::equity_instrument flat(
             f.start_date      = inst.start_date;
             f.maturity_date   = inst.maturity_date;
             return f;
+        } else if constexpr (std::is_same_v<T,
+                equity_barrier_option_instrument>) {
+            equity_instrument f;
+            f.trade_type_code = inst.trade_type_code;
+            f.underlying_code = inst.underlying_name;
+            f.currency        = inst.currency;
+            f.quantity        = inst.notional;
+            f.option_type     = inst.option_type;
+            f.exercise_type   = inst.exercise_type;
+            f.maturity_date   = inst.expiry_date;
+            f.strike_price    = inst.strike;
+            f.barrier_type    = inst.lower_barrier_type;
+            f.lower_barrier   = inst.lower_barrier;
+            f.upper_barrier   = inst.upper_barrier.value_or(0.0);
+            return f;
+        } else if constexpr (std::is_same_v<T,
+                equity_asian_option_instrument>) {
+            equity_instrument f;
+            f.trade_type_code       = inst.trade_type_code;
+            f.underlying_code       = inst.underlying_name;
+            f.currency              = inst.currency;
+            f.quantity              = inst.notional;
+            f.option_type           = inst.option_type;
+            f.exercise_type         = inst.exercise_type;
+            f.maturity_date         = inst.expiry_date;
+            f.strike_price          = inst.strike;
+            f.averaging_start_date  = inst.averaging_start_date;
+            return f;
+        } else if constexpr (std::is_same_v<T,
+                equity_digital_option_instrument>) {
+            equity_instrument f;
+            f.trade_type_code = inst.trade_type_code;
+            f.underlying_code = inst.underlying_name;
+            f.currency        = inst.currency;
+            f.notional        = inst.notional;
+            f.option_type     = inst.option_type;
+            f.maturity_date   = inst.expiry_date;
+            f.strike_price    = inst.strike.value_or(0.0);
+            f.barrier_type    = inst.barrier_type;
+            f.lower_barrier   = inst.barrier_level.value_or(0.0);
+            return f;
         }
         return {};
     }, r.instrument);
@@ -212,64 +253,80 @@ TEST_CASE("equity_mapper_roundtrip_variance_swap", tags) {
 TEST_CASE("equity_mapper_roundtrip_barrier_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_Barrier_Option.xml");
+    const auto& inst =
+        std::get<ores::trading::domain::equity_barrier_option_instrument>(
+            r.instrument);
 
-    CHECK(flat(r).trade_type_code == "EquityBarrierOption");
-    CHECK(!flat(r).underlying_code.empty());
-    CHECK(!flat(r).barrier_type.empty());
-    CHECK(flat(r).lower_barrier > 0.0);
+    CHECK(inst.trade_type_code == "EquityBarrierOption");
+    CHECK(!inst.underlying_name.empty());
+    CHECK(!inst.lower_barrier_type.empty());
+    CHECK(inst.lower_barrier > 0.0);
 
-    const auto rt = equity_instrument_mapper::reverse_equity_barrier_option(flat(r));
+    const auto rt = equity_instrument_mapper::reverse_equity_barrier_option(
+        flat(r));
     REQUIRE(rt.EquityBarrierOptionData);
 
     BOOST_LOG_SEV(lg, info) << "EquityBarrierOption roundtrip passed. Barrier: "
-                            << flat(r).barrier_type;
+                            << inst.lower_barrier_type;
 }
 
 TEST_CASE("equity_mapper_roundtrip_asian_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_Asian_Option.xml");
+    const auto& inst =
+        std::get<ores::trading::domain::equity_asian_option_instrument>(
+            r.instrument);
 
-    CHECK(flat(r).trade_type_code == "EquityAsianOption");
-    CHECK(!flat(r).underlying_code.empty());
-    CHECK(flat(r).strike_price > 0.0);
-    CHECK(!flat(r).averaging_start_date.empty());
+    CHECK(inst.trade_type_code == "EquityAsianOption");
+    CHECK(!inst.underlying_name.empty());
+    CHECK(inst.strike > 0.0);
+    CHECK(!inst.averaging_start_date.empty());
 
-    const auto rt = equity_instrument_mapper::reverse_equity_asian_option(flat(r));
+    const auto rt = equity_instrument_mapper::reverse_equity_asian_option(
+        flat(r));
     REQUIRE(rt.EquityAsianOptionData);
 
     BOOST_LOG_SEV(lg, info) << "EquityAsianOption roundtrip passed. Averaging from: "
-                            << flat(r).averaging_start_date;
+                            << inst.averaging_start_date;
 }
 
 TEST_CASE("equity_mapper_roundtrip_digital_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_Digital_Option.xml");
+    const auto& inst =
+        std::get<ores::trading::domain::equity_digital_option_instrument>(
+            r.instrument);
 
-    CHECK(flat(r).trade_type_code == "EquityDigitalOption");
-    CHECK(!flat(r).underlying_code.empty());
-    CHECK(flat(r).strike_price > 0.0);
-    CHECK(!flat(r).option_type.empty());
+    CHECK(inst.trade_type_code == "EquityDigitalOption");
+    CHECK(!inst.underlying_name.empty());
+    CHECK(inst.strike.value_or(0.0) > 0.0);
+    CHECK(!inst.option_type.empty());
 
-    const auto rt = equity_instrument_mapper::reverse_equity_digital_option(flat(r));
+    const auto rt = equity_instrument_mapper::reverse_equity_digital_option(
+        flat(r));
     REQUIRE(rt.EquityDigitalOptionData);
 
     BOOST_LOG_SEV(lg, info) << "EquityDigitalOption roundtrip passed. Strike: "
-                            << flat(r).strike_price;
+                            << inst.strike.value_or(0.0);
 }
 
 TEST_CASE("equity_mapper_roundtrip_touch_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_OneTouch_Option.xml");
+    const auto& inst =
+        std::get<ores::trading::domain::equity_digital_option_instrument>(
+            r.instrument);
 
-    CHECK(flat(r).trade_type_code == "EquityTouchOption");
-    CHECK(!flat(r).barrier_type.empty());
-    CHECK(flat(r).lower_barrier > 0.0);
+    CHECK(inst.trade_type_code == "EquityTouchOption");
+    CHECK(!inst.barrier_type.empty());
+    CHECK(inst.barrier_level.value_or(0.0) > 0.0);
 
-    const auto rt = equity_instrument_mapper::reverse_equity_touch_option(flat(r));
+    const auto rt = equity_instrument_mapper::reverse_equity_touch_option(
+        flat(r));
     REQUIRE(rt.EquityTouchOptionData);
 
     BOOST_LOG_SEV(lg, info) << "EquityTouchOption roundtrip passed. Barrier: "
-                            << flat(r).lower_barrier;
+                            << inst.barrier_level.value_or(0.0);
 }
 
 TEST_CASE("equity_mapper_roundtrip_outperformance_option", tags) {

--- a/projects/ores.ore/tests/xml_equity_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/tests/xml_equity_mapper_roundtrip_tests.cpp
@@ -85,10 +85,22 @@ ores::trading::domain::equity_instrument flat(
             f.underlying_code = inst.underlying_name;
             f.currency        = inst.currency;
             f.quantity        = inst.notional;
+            f.notional        = inst.notional;
             f.option_type     = inst.option_type;
             f.exercise_type   = inst.exercise_type;
             f.maturity_date   = inst.expiry_date;
             f.strike_price    = inst.strike;
+            f.cliquet_frequency_code = inst.cliquet_frequency;
+            // Outperformance carries its two underlyings as "n1/n2" in
+            // underlying_name; restore the JSON array shape expected by
+            // reverse_equity_outperformance_option.
+            if (const auto sep = inst.underlying_name.find('/');
+                    sep != std::string::npos) {
+                f.basket_json =
+                    "[\"" + inst.underlying_name.substr(0, sep) +
+                    "\",\"" + inst.underlying_name.substr(sep + 1) +
+                    "\"]";
+            }
             return f;
         } else if constexpr (std::is_same_v<T, equity_forward_instrument>) {
             equity_instrument f;
@@ -105,9 +117,11 @@ ores::trading::domain::equity_instrument flat(
             f.underlying_code = inst.underlying_name;
             f.currency        = inst.currency;
             f.notional        = inst.notional;
+            f.quantity        = inst.notional;
             f.return_type     = inst.return_type;
             f.start_date      = inst.start_date;
             f.maturity_date   = inst.maturity_date;
+            f.basket_json     = inst.basket_json;
             return f;
         } else if constexpr (std::is_same_v<T, equity_variance_swap_instrument>) {
             equity_instrument f;
@@ -159,6 +173,17 @@ ores::trading::domain::equity_instrument flat(
             f.strike_price    = inst.strike.value_or(0.0);
             f.barrier_type    = inst.barrier_type;
             f.lower_barrier   = inst.barrier_level.value_or(0.0);
+            return f;
+        } else if constexpr (std::is_same_v<T,
+                equity_accumulator_instrument>) {
+            equity_instrument f;
+            f.trade_type_code      = inst.trade_type_code;
+            f.underlying_code      = inst.underlying_name;
+            f.currency             = inst.currency;
+            f.accumulation_amount  = inst.fixing_amount;
+            f.strike_price         = inst.strike;
+            f.start_date           = inst.start_date;
+            f.knock_out_barrier    = inst.knock_out_level.value_or(0.0);
             return f;
         }
         return {};
@@ -332,17 +357,22 @@ TEST_CASE("equity_mapper_roundtrip_touch_option", tags) {
 TEST_CASE("equity_mapper_roundtrip_outperformance_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_OutperformanceOption.xml");
+    const auto& inst =
+        std::get<ores::trading::domain::equity_option_instrument>(r.instrument);
 
-    CHECK(flat(r).trade_type_code == "EquityOutperformanceOption");
-    CHECK(!flat(r).currency.empty());
-    CHECK(flat(r).notional > 0.0);
-    CHECK(!flat(r).basket_json.empty());
+    CHECK(inst.trade_type_code == "EquityOutperformanceOption");
+    CHECK(!inst.currency.empty());
+    CHECK(inst.notional > 0.0);
+    // Outperformance joins two underlyings as "n1/n2" in underlying_name
+    // because the per-type option struct has no basket field.
+    CHECK(inst.underlying_name.find('/') != std::string::npos);
 
-    const auto rt = equity_instrument_mapper::reverse_equity_outperformance_option(flat(r));
+    const auto rt = equity_instrument_mapper::reverse_equity_outperformance_option(
+        flat(r));
     REQUIRE(rt.EquityOutperformanceOptionData);
 
-    BOOST_LOG_SEV(lg, info) << "EquityOutperformanceOption roundtrip passed. Basket: "
-                            << flat(r).basket_json;
+    BOOST_LOG_SEV(lg, info) << "EquityOutperformanceOption roundtrip passed. Pair: "
+                            << inst.underlying_name;
 }
 
 // ---------------------------------------------------------------------------
@@ -352,43 +382,53 @@ TEST_CASE("equity_mapper_roundtrip_outperformance_option", tags) {
 TEST_CASE("equity_mapper_roundtrip_accumulator", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Exotic_EquityAccumulator_single_name.xml");
+    const auto& inst =
+        std::get<ores::trading::domain::equity_accumulator_instrument>(
+            r.instrument);
 
-    CHECK(flat(r).trade_type_code == "EquityAccumulator");
-    CHECK(!flat(r).underlying_code.empty());
-    CHECK(flat(r).accumulation_amount > 0.0);
-    CHECK(flat(r).knock_out_barrier > 0.0);
+    CHECK(inst.trade_type_code == "EquityAccumulator");
+    CHECK(!inst.underlying_name.empty());
+    CHECK(inst.fixing_amount > 0.0);
+    CHECK(inst.knock_out_level.value_or(0.0) > 0.0);
 
-    const auto rt = equity_instrument_mapper::reverse_equity_accumulator(flat(r));
+    const auto rt = equity_instrument_mapper::reverse_equity_accumulator(
+        flat(r));
     REQUIRE(rt.EquityAccumulatorData);
 
     BOOST_LOG_SEV(lg, info) << "EquityAccumulator roundtrip passed. Amount: "
-                            << flat(r).accumulation_amount;
+                            << inst.fixing_amount;
 }
 
 TEST_CASE("equity_mapper_roundtrip_tarf", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Exotic_EquityTaRF.xml");
+    const auto& inst =
+        std::get<ores::trading::domain::equity_accumulator_instrument>(
+            r.instrument);
 
-    CHECK(flat(r).trade_type_code == "EquityTaRF");
-    CHECK(!flat(r).underlying_code.empty());
-    CHECK(flat(r).accumulation_amount > 0.0);
+    CHECK(inst.trade_type_code == "EquityTaRF");
+    CHECK(!inst.underlying_name.empty());
+    CHECK(inst.fixing_amount > 0.0);
 
     const auto rt = equity_instrument_mapper::reverse_equity_tarf(flat(r));
     REQUIRE(rt.EquityTaRFData);
 
     BOOST_LOG_SEV(lg, info) << "EquityTaRF roundtrip passed. Amount: "
-                            << flat(r).accumulation_amount;
+                            << inst.fixing_amount;
 }
 
 TEST_CASE("equity_mapper_roundtrip_cliquet_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Exotic_Equity_Cliquet_Option.xml");
+    const auto& inst =
+        std::get<ores::trading::domain::equity_option_instrument>(r.instrument);
 
-    CHECK(flat(r).trade_type_code == "EquityCliquetOption");
-    CHECK(!flat(r).underlying_code.empty());
-    CHECK(flat(r).notional > 0.0);
+    CHECK(inst.trade_type_code == "EquityCliquetOption");
+    CHECK(!inst.underlying_name.empty());
+    CHECK(inst.notional > 0.0);
 
-    const auto rt = equity_instrument_mapper::reverse_equity_cliquet_option(flat(r));
+    const auto rt = equity_instrument_mapper::reverse_equity_cliquet_option(
+        flat(r));
     REQUIRE(rt.EquityCliquetOptionData);
 
     BOOST_LOG_SEV(lg, info) << "EquityCliquetOption roundtrip passed.";
@@ -397,15 +437,18 @@ TEST_CASE("equity_mapper_roundtrip_cliquet_option", tags) {
 TEST_CASE("equity_mapper_roundtrip_worst_of_basket_swap", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Exotic_EquityWorstOfBasketSwap.xml");
+    const auto& inst =
+        std::get<ores::trading::domain::equity_swap_instrument>(r.instrument);
 
-    CHECK(flat(r).trade_type_code == "EquityWorstOfBasketSwap");
-    CHECK(!flat(r).currency.empty());
-    CHECK(flat(r).quantity > 0.0);
-    CHECK(!flat(r).basket_json.empty());
+    CHECK(inst.trade_type_code == "EquityWorstOfBasketSwap");
+    CHECK(!inst.currency.empty());
+    CHECK(inst.notional > 0.0);
+    CHECK(!inst.basket_json.empty());
 
-    const auto rt = equity_instrument_mapper::reverse_equity_worst_of_basket_swap(flat(r));
+    const auto rt = equity_instrument_mapper::reverse_equity_worst_of_basket_swap(
+        flat(r));
     REQUIRE(rt.EquityWorstOfBasketSwapData);
 
     BOOST_LOG_SEV(lg, info) << "EquityWorstOfBasketSwap roundtrip passed. Basket: "
-                            << flat(r).basket_json;
+                            << inst.basket_json;
 }

--- a/projects/ores.ore/tests/xml_equity_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/tests/xml_equity_mapper_roundtrip_tests.cpp
@@ -66,6 +66,14 @@ equity_mapping_result load_and_map(const std::string& filename) {
     return *r;
 }
 
+// Transitional helper: extracts the legacy flat equity_instrument from the
+// mapping-result variant. Deleted in the final Phase 2 commit once every
+// test has migrated to per-type assertions via std::get<per_type>.
+const ores::trading::domain::equity_instrument& flat(
+    const equity_mapping_result& r) {
+    return std::get<ores::trading::domain::equity_instrument>(r.instrument);
+}
+
 } // namespace
 
 // ---------------------------------------------------------------------------
@@ -76,157 +84,149 @@ TEST_CASE("equity_mapper_roundtrip_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_Option_European.xml");
 
-    CHECK(r.instrument.trade_type_code == "EquityOption");
-    CHECK(!r.instrument.underlying_code.empty());
-    CHECK(!r.instrument.currency.empty());
-    CHECK(r.instrument.quantity > 0.0);
-    CHECK(!r.instrument.option_type.empty());
-    CHECK(!r.instrument.maturity_date.empty());
+    CHECK(flat(r).trade_type_code == "EquityOption");
+    CHECK(!flat(r).underlying_code.empty());
+    CHECK(!flat(r).currency.empty());
+    CHECK(flat(r).quantity > 0.0);
+    CHECK(!flat(r).option_type.empty());
+    CHECK(!flat(r).maturity_date.empty());
 
-    const auto rt = equity_instrument_mapper::reverse_equity_option(
-        r.instrument);
+    const auto rt = equity_instrument_mapper::reverse_equity_option(flat(r));
     REQUIRE(rt.EquityOptionData);
 
     BOOST_LOG_SEV(lg, info) << "EquityOption roundtrip passed. Underlying: "
-                            << r.instrument.underlying_code;
+                            << flat(r).underlying_code;
 }
 
 TEST_CASE("equity_mapper_roundtrip_forward", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_Forward.xml");
 
-    CHECK(r.instrument.trade_type_code == "EquityForward");
-    CHECK(!r.instrument.underlying_code.empty());
-    CHECK(!r.instrument.currency.empty());
-    CHECK(r.instrument.quantity > 0.0);
-    CHECK(!r.instrument.maturity_date.empty());
+    CHECK(flat(r).trade_type_code == "EquityForward");
+    CHECK(!flat(r).underlying_code.empty());
+    CHECK(!flat(r).currency.empty());
+    CHECK(flat(r).quantity > 0.0);
+    CHECK(!flat(r).maturity_date.empty());
 
-    const auto rt = equity_instrument_mapper::reverse_equity_forward(
-        r.instrument);
+    const auto rt = equity_instrument_mapper::reverse_equity_forward(flat(r));
     REQUIRE(rt.EquityForwardData);
 
     BOOST_LOG_SEV(lg, info) << "EquityForward roundtrip passed. Maturity: "
-                            << r.instrument.maturity_date;
+                            << flat(r).maturity_date;
 }
 
 TEST_CASE("equity_mapper_roundtrip_swap", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_Swap.xml");
 
-    CHECK(r.instrument.trade_type_code == "EquitySwap");
-    CHECK(!r.instrument.underlying_code.empty());
-    CHECK(!r.instrument.currency.empty());
-    CHECK(!r.instrument.return_type.empty());
+    CHECK(flat(r).trade_type_code == "EquitySwap");
+    CHECK(!flat(r).underlying_code.empty());
+    CHECK(!flat(r).currency.empty());
+    CHECK(!flat(r).return_type.empty());
 
-    const auto rt = equity_instrument_mapper::reverse_equity_swap(r.instrument);
+    const auto rt = equity_instrument_mapper::reverse_equity_swap(flat(r));
     REQUIRE(rt.EquitySwapData);
     const bool has_legs = !rt.EquitySwapData->LegData.empty();
     CHECK(has_legs);
 
     BOOST_LOG_SEV(lg, info) << "EquitySwap roundtrip passed. Return type: "
-                            << r.instrument.return_type;
+                            << flat(r).return_type;
 }
 
 TEST_CASE("equity_mapper_roundtrip_variance_swap", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_Variance_Swap.xml");
 
-    CHECK(r.instrument.trade_type_code == "EquityVarianceSwap");
-    CHECK(!r.instrument.underlying_code.empty());
-    CHECK(r.instrument.variance_strike > 0.0);
-    CHECK(!r.instrument.start_date.empty());
-    CHECK(!r.instrument.maturity_date.empty());
+    CHECK(flat(r).trade_type_code == "EquityVarianceSwap");
+    CHECK(!flat(r).underlying_code.empty());
+    CHECK(flat(r).variance_strike > 0.0);
+    CHECK(!flat(r).start_date.empty());
+    CHECK(!flat(r).maturity_date.empty());
 
-    const auto rt = equity_instrument_mapper::reverse_equity_variance_swap(
-        r.instrument);
+    const auto rt = equity_instrument_mapper::reverse_equity_variance_swap(flat(r));
     REQUIRE(rt.EquityVarianceSwapData);
 
     BOOST_LOG_SEV(lg, info) << "EquityVarianceSwap roundtrip passed. Strike: "
-                            << r.instrument.variance_strike;
+                            << flat(r).variance_strike;
 }
 
 TEST_CASE("equity_mapper_roundtrip_barrier_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_Barrier_Option.xml");
 
-    CHECK(r.instrument.trade_type_code == "EquityBarrierOption");
-    CHECK(!r.instrument.underlying_code.empty());
-    CHECK(!r.instrument.barrier_type.empty());
-    CHECK(r.instrument.lower_barrier > 0.0);
+    CHECK(flat(r).trade_type_code == "EquityBarrierOption");
+    CHECK(!flat(r).underlying_code.empty());
+    CHECK(!flat(r).barrier_type.empty());
+    CHECK(flat(r).lower_barrier > 0.0);
 
-    const auto rt = equity_instrument_mapper::reverse_equity_barrier_option(
-        r.instrument);
+    const auto rt = equity_instrument_mapper::reverse_equity_barrier_option(flat(r));
     REQUIRE(rt.EquityBarrierOptionData);
 
     BOOST_LOG_SEV(lg, info) << "EquityBarrierOption roundtrip passed. Barrier: "
-                            << r.instrument.barrier_type;
+                            << flat(r).barrier_type;
 }
 
 TEST_CASE("equity_mapper_roundtrip_asian_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_Asian_Option.xml");
 
-    CHECK(r.instrument.trade_type_code == "EquityAsianOption");
-    CHECK(!r.instrument.underlying_code.empty());
-    CHECK(r.instrument.strike_price > 0.0);
-    CHECK(!r.instrument.averaging_start_date.empty());
+    CHECK(flat(r).trade_type_code == "EquityAsianOption");
+    CHECK(!flat(r).underlying_code.empty());
+    CHECK(flat(r).strike_price > 0.0);
+    CHECK(!flat(r).averaging_start_date.empty());
 
-    const auto rt = equity_instrument_mapper::reverse_equity_asian_option(
-        r.instrument);
+    const auto rt = equity_instrument_mapper::reverse_equity_asian_option(flat(r));
     REQUIRE(rt.EquityAsianOptionData);
 
     BOOST_LOG_SEV(lg, info) << "EquityAsianOption roundtrip passed. Averaging from: "
-                            << r.instrument.averaging_start_date;
+                            << flat(r).averaging_start_date;
 }
 
 TEST_CASE("equity_mapper_roundtrip_digital_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_Digital_Option.xml");
 
-    CHECK(r.instrument.trade_type_code == "EquityDigitalOption");
-    CHECK(!r.instrument.underlying_code.empty());
-    CHECK(r.instrument.strike_price > 0.0);
-    CHECK(!r.instrument.option_type.empty());
+    CHECK(flat(r).trade_type_code == "EquityDigitalOption");
+    CHECK(!flat(r).underlying_code.empty());
+    CHECK(flat(r).strike_price > 0.0);
+    CHECK(!flat(r).option_type.empty());
 
-    const auto rt = equity_instrument_mapper::reverse_equity_digital_option(
-        r.instrument);
+    const auto rt = equity_instrument_mapper::reverse_equity_digital_option(flat(r));
     REQUIRE(rt.EquityDigitalOptionData);
 
     BOOST_LOG_SEV(lg, info) << "EquityDigitalOption roundtrip passed. Strike: "
-                            << r.instrument.strike_price;
+                            << flat(r).strike_price;
 }
 
 TEST_CASE("equity_mapper_roundtrip_touch_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_OneTouch_Option.xml");
 
-    CHECK(r.instrument.trade_type_code == "EquityTouchOption");
-    CHECK(!r.instrument.barrier_type.empty());
-    CHECK(r.instrument.lower_barrier > 0.0);
+    CHECK(flat(r).trade_type_code == "EquityTouchOption");
+    CHECK(!flat(r).barrier_type.empty());
+    CHECK(flat(r).lower_barrier > 0.0);
 
-    const auto rt = equity_instrument_mapper::reverse_equity_touch_option(
-        r.instrument);
+    const auto rt = equity_instrument_mapper::reverse_equity_touch_option(flat(r));
     REQUIRE(rt.EquityTouchOptionData);
 
     BOOST_LOG_SEV(lg, info) << "EquityTouchOption roundtrip passed. Barrier: "
-                            << r.instrument.lower_barrier;
+                            << flat(r).lower_barrier;
 }
 
 TEST_CASE("equity_mapper_roundtrip_outperformance_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Equity_OutperformanceOption.xml");
 
-    CHECK(r.instrument.trade_type_code == "EquityOutperformanceOption");
-    CHECK(!r.instrument.currency.empty());
-    CHECK(r.instrument.notional > 0.0);
-    CHECK(!r.instrument.basket_json.empty());
+    CHECK(flat(r).trade_type_code == "EquityOutperformanceOption");
+    CHECK(!flat(r).currency.empty());
+    CHECK(flat(r).notional > 0.0);
+    CHECK(!flat(r).basket_json.empty());
 
-    const auto rt = equity_instrument_mapper::reverse_equity_outperformance_option(
-        r.instrument);
+    const auto rt = equity_instrument_mapper::reverse_equity_outperformance_option(flat(r));
     REQUIRE(rt.EquityOutperformanceOptionData);
 
     BOOST_LOG_SEV(lg, info) << "EquityOutperformanceOption roundtrip passed. Basket: "
-                            << r.instrument.basket_json;
+                            << flat(r).basket_json;
 }
 
 // ---------------------------------------------------------------------------
@@ -237,44 +237,42 @@ TEST_CASE("equity_mapper_roundtrip_accumulator", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Exotic_EquityAccumulator_single_name.xml");
 
-    CHECK(r.instrument.trade_type_code == "EquityAccumulator");
-    CHECK(!r.instrument.underlying_code.empty());
-    CHECK(r.instrument.accumulation_amount > 0.0);
-    CHECK(r.instrument.knock_out_barrier > 0.0);
+    CHECK(flat(r).trade_type_code == "EquityAccumulator");
+    CHECK(!flat(r).underlying_code.empty());
+    CHECK(flat(r).accumulation_amount > 0.0);
+    CHECK(flat(r).knock_out_barrier > 0.0);
 
-    const auto rt = equity_instrument_mapper::reverse_equity_accumulator(
-        r.instrument);
+    const auto rt = equity_instrument_mapper::reverse_equity_accumulator(flat(r));
     REQUIRE(rt.EquityAccumulatorData);
 
     BOOST_LOG_SEV(lg, info) << "EquityAccumulator roundtrip passed. Amount: "
-                            << r.instrument.accumulation_amount;
+                            << flat(r).accumulation_amount;
 }
 
 TEST_CASE("equity_mapper_roundtrip_tarf", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Exotic_EquityTaRF.xml");
 
-    CHECK(r.instrument.trade_type_code == "EquityTaRF");
-    CHECK(!r.instrument.underlying_code.empty());
-    CHECK(r.instrument.accumulation_amount > 0.0);
+    CHECK(flat(r).trade_type_code == "EquityTaRF");
+    CHECK(!flat(r).underlying_code.empty());
+    CHECK(flat(r).accumulation_amount > 0.0);
 
-    const auto rt = equity_instrument_mapper::reverse_equity_tarf(r.instrument);
+    const auto rt = equity_instrument_mapper::reverse_equity_tarf(flat(r));
     REQUIRE(rt.EquityTaRFData);
 
     BOOST_LOG_SEV(lg, info) << "EquityTaRF roundtrip passed. Amount: "
-                            << r.instrument.accumulation_amount;
+                            << flat(r).accumulation_amount;
 }
 
 TEST_CASE("equity_mapper_roundtrip_cliquet_option", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Exotic_Equity_Cliquet_Option.xml");
 
-    CHECK(r.instrument.trade_type_code == "EquityCliquetOption");
-    CHECK(!r.instrument.underlying_code.empty());
-    CHECK(r.instrument.notional > 0.0);
+    CHECK(flat(r).trade_type_code == "EquityCliquetOption");
+    CHECK(!flat(r).underlying_code.empty());
+    CHECK(flat(r).notional > 0.0);
 
-    const auto rt = equity_instrument_mapper::reverse_equity_cliquet_option(
-        r.instrument);
+    const auto rt = equity_instrument_mapper::reverse_equity_cliquet_option(flat(r));
     REQUIRE(rt.EquityCliquetOptionData);
 
     BOOST_LOG_SEV(lg, info) << "EquityCliquetOption roundtrip passed.";
@@ -284,15 +282,14 @@ TEST_CASE("equity_mapper_roundtrip_worst_of_basket_swap", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map("Exotic_EquityWorstOfBasketSwap.xml");
 
-    CHECK(r.instrument.trade_type_code == "EquityWorstOfBasketSwap");
-    CHECK(!r.instrument.currency.empty());
-    CHECK(r.instrument.quantity > 0.0);
-    CHECK(!r.instrument.basket_json.empty());
+    CHECK(flat(r).trade_type_code == "EquityWorstOfBasketSwap");
+    CHECK(!flat(r).currency.empty());
+    CHECK(flat(r).quantity > 0.0);
+    CHECK(!flat(r).basket_json.empty());
 
-    const auto rt = equity_instrument_mapper::reverse_equity_worst_of_basket_swap(
-        r.instrument);
+    const auto rt = equity_instrument_mapper::reverse_equity_worst_of_basket_swap(flat(r));
     REQUIRE(rt.EquityWorstOfBasketSwapData);
 
     BOOST_LOG_SEV(lg, info) << "EquityWorstOfBasketSwap roundtrip passed. Basket: "
-                            << r.instrument.basket_json;
+                            << flat(r).basket_json;
 }

--- a/projects/ores.ore/tests/xml_exporter_tests.cpp
+++ b/projects/ores.ore/tests/xml_exporter_tests.cpp
@@ -67,7 +67,14 @@ ores::trading::messaging::instrument_export_result to_export_result(
         else if constexpr (std::is_same_v<T, credit_mapping_result>)
             return v.instrument;
         else if constexpr (std::is_same_v<T, equity_mapping_result>)
-            return v.instrument;
+            // equity_mapping_result carries an equity_instrument_variant during
+            // the Phase 2 migration; the legacy flat equity_instrument is
+            // currently the only alternative produced by every forward_*
+            // function. Per-type alternatives land as each forward_*/reverse_*
+            // pair migrates; the final Phase 2 commit removes the flat
+            // alternative and replaces instrument_export_result's
+            // equity_instrument alternative with equity_export_result.
+            return std::get<ores::trading::domain::equity_instrument>(v.instrument);
         else if constexpr (std::is_same_v<T, commodity_mapping_result>)
             return v.instrument;
         else if constexpr (std::is_same_v<T, scripted_mapping_result>)

--- a/projects/ores.ore/tests/xml_remaining_phases_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/tests/xml_remaining_phases_mapper_roundtrip_tests.cpp
@@ -219,10 +219,12 @@ TEST_CASE("fx_kiko_barrier_option_reverse", tags) {
 TEST_CASE("equity_double_barrier_option_forward", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_equity("Equity_Double_Barrier_Option.xml");
+    const auto& instr =
+        std::get<ores::trading::domain::equity_instrument>(r.instrument);
 
-    CHECK(r.instrument.trade_type_code == "EquityDoubleBarrierOption");
-    CHECK(!r.instrument.option_type.empty());
-    CHECK(!r.instrument.underlying_code.empty());
+    CHECK(instr.trade_type_code == "EquityDoubleBarrierOption");
+    CHECK(!instr.option_type.empty());
+    CHECK(!instr.underlying_code.empty());
 
     BOOST_LOG_SEV(lg, info) << "EquityDoubleBarrierOption forward test passed";
 }
@@ -230,9 +232,11 @@ TEST_CASE("equity_double_barrier_option_forward", tags) {
 TEST_CASE("equity_double_barrier_option_reverse", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_equity("Equity_Double_Barrier_Option.xml");
+    const auto& instr =
+        std::get<ores::trading::domain::equity_instrument>(r.instrument);
 
     const auto rt = equity_instrument_mapper::reverse_equity_double_barrier_option(
-        r.instrument);
+        instr);
     REQUIRE(rt.EquityDoubleBarrierOptionData.operator bool());
 
     BOOST_LOG_SEV(lg, info) << "EquityDoubleBarrierOption reverse test passed";
@@ -246,9 +250,11 @@ TEST_CASE("equity_european_barrier_option_forward", tags) {
     auto lg(make_logger(test_suite));
     // Reuse EquityBarrierOption file (same structure, different trade type)
     const auto r = load_and_map_equity("Equity_European_Barrier_Option.xml");
+    const auto& instr =
+        std::get<ores::trading::domain::equity_instrument>(r.instrument);
 
-    CHECK(r.instrument.trade_type_code == "EquityEuropeanBarrierOption");
-    CHECK(!r.instrument.option_type.empty());
+    CHECK(instr.trade_type_code == "EquityEuropeanBarrierOption");
+    CHECK(!instr.option_type.empty());
 
     BOOST_LOG_SEV(lg, info) << "EquityEuropeanBarrierOption forward test passed";
 }
@@ -256,9 +262,11 @@ TEST_CASE("equity_european_barrier_option_forward", tags) {
 TEST_CASE("equity_european_barrier_option_reverse", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_equity("Equity_European_Barrier_Option.xml");
+    const auto& instr =
+        std::get<ores::trading::domain::equity_instrument>(r.instrument);
 
     const auto rt = equity_instrument_mapper::reverse_equity_european_barrier_option(
-        r.instrument);
+        instr);
     REQUIRE(rt.EquityEuropeanBarrierOptionData.operator bool());
 
     BOOST_LOG_SEV(lg, info) << "EquityEuropeanBarrierOption reverse test passed";

--- a/projects/ores.ore/tests/xml_remaining_phases_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/tests/xml_remaining_phases_mapper_roundtrip_tests.cpp
@@ -216,15 +216,39 @@ TEST_CASE("fx_kiko_barrier_option_reverse", tags) {
 // EquityDoubleBarrierOption
 // =============================================================================
 
+// The following helper mirrors the one in xml_equity_mapper_roundtrip_tests.cpp
+// but is duplicated here because it's test-local and the original helper
+// lives in an anonymous namespace. Deleted once every reverse_equity_* has
+// migrated to take per-type.
+namespace {
+ores::trading::domain::equity_instrument eq_flatten_barrier(
+    const ores::trading::domain::equity_barrier_option_instrument& inst) {
+    ores::trading::domain::equity_instrument f;
+    f.trade_type_code   = inst.trade_type_code;
+    f.underlying_code   = inst.underlying_name;
+    f.currency          = inst.currency;
+    f.quantity          = inst.notional;
+    f.option_type       = inst.option_type;
+    f.exercise_type     = inst.exercise_type;
+    f.maturity_date     = inst.expiry_date;
+    f.strike_price      = inst.strike;
+    f.barrier_type      = inst.lower_barrier_type;
+    f.lower_barrier     = inst.lower_barrier;
+    f.upper_barrier     = inst.upper_barrier.value_or(0.0);
+    return f;
+}
+}
+
 TEST_CASE("equity_double_barrier_option_forward", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_equity("Equity_Double_Barrier_Option.xml");
     const auto& instr =
-        std::get<ores::trading::domain::equity_instrument>(r.instrument);
+        std::get<ores::trading::domain::equity_barrier_option_instrument>(
+            r.instrument);
 
     CHECK(instr.trade_type_code == "EquityDoubleBarrierOption");
     CHECK(!instr.option_type.empty());
-    CHECK(!instr.underlying_code.empty());
+    CHECK(!instr.underlying_name.empty());
 
     BOOST_LOG_SEV(lg, info) << "EquityDoubleBarrierOption forward test passed";
 }
@@ -233,10 +257,11 @@ TEST_CASE("equity_double_barrier_option_reverse", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_equity("Equity_Double_Barrier_Option.xml");
     const auto& instr =
-        std::get<ores::trading::domain::equity_instrument>(r.instrument);
+        std::get<ores::trading::domain::equity_barrier_option_instrument>(
+            r.instrument);
 
     const auto rt = equity_instrument_mapper::reverse_equity_double_barrier_option(
-        instr);
+        eq_flatten_barrier(instr));
     REQUIRE(rt.EquityDoubleBarrierOptionData.operator bool());
 
     BOOST_LOG_SEV(lg, info) << "EquityDoubleBarrierOption reverse test passed";
@@ -251,7 +276,8 @@ TEST_CASE("equity_european_barrier_option_forward", tags) {
     // Reuse EquityBarrierOption file (same structure, different trade type)
     const auto r = load_and_map_equity("Equity_European_Barrier_Option.xml");
     const auto& instr =
-        std::get<ores::trading::domain::equity_instrument>(r.instrument);
+        std::get<ores::trading::domain::equity_barrier_option_instrument>(
+            r.instrument);
 
     CHECK(instr.trade_type_code == "EquityEuropeanBarrierOption");
     CHECK(!instr.option_type.empty());
@@ -263,10 +289,11 @@ TEST_CASE("equity_european_barrier_option_reverse", tags) {
     auto lg(make_logger(test_suite));
     const auto r = load_and_map_equity("Equity_European_Barrier_Option.xml");
     const auto& instr =
-        std::get<ores::trading::domain::equity_instrument>(r.instrument);
+        std::get<ores::trading::domain::equity_barrier_option_instrument>(
+            r.instrument);
 
     const auto rt = equity_instrument_mapper::reverse_equity_european_barrier_option(
-        instr);
+        eq_flatten_barrier(instr));
     REQUIRE(rt.EquityEuropeanBarrierOptionData.operator bool());
 
     BOOST_LOG_SEV(lg, info) << "EquityEuropeanBarrierOption reverse test passed";

--- a/projects/ores.qt.trading/src/ImportTradeDialog.cpp
+++ b/projects/ores.qt.trading/src/ImportTradeDialog.cpp
@@ -622,6 +622,17 @@ void ImportTradeDialog::onImportClicked() {
                         instr.instrument_id = instr_id;
                         instr.trade_id = tti.trade.id;
                     }, r.instrument);
+                } else if constexpr (std::is_same_v<T, ore::domain::equity_mapping_result>) {
+                    std::visit([&](auto& instr) {
+                        using InstrT = std::decay_t<decltype(instr)>;
+                        if constexpr (std::is_same_v<InstrT,
+                                ores::trading::domain::equity_instrument>) {
+                            instr.id = instr_id;
+                        } else {
+                            instr.instrument_id = instr_id;
+                        }
+                        instr.trade_id = tti.trade.id;
+                    }, r.instrument);
                 } else {
                     r.instrument.id = instr_id;
                     r.instrument.trade_id = tti.trade.id;
@@ -885,9 +896,41 @@ void ImportTradeDialog::onImportClicked() {
                                 req.data = r.instrument;
                                 (void)self->clientManager_->process_authenticated_request(std::move(req));
                             } else if constexpr (std::is_same_v<T, ore::domain::equity_mapping_result>) {
-                                save_equity_instrument_request req;
-                                req.data = r.instrument;
-                                (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                std::visit([&](const auto& instr) {
+                                    using InstrT = std::decay_t<decltype(instr)>;
+                                    using namespace ores::trading::domain;
+                                    if constexpr (std::is_same_v<InstrT, equity_instrument>) {
+                                        save_equity_instrument_request req; req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    } else if constexpr (std::is_same_v<InstrT, equity_option_instrument>) {
+                                        save_equity_option_instrument_request req; req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    } else if constexpr (std::is_same_v<InstrT, equity_digital_option_instrument>) {
+                                        save_equity_digital_option_instrument_request req; req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    } else if constexpr (std::is_same_v<InstrT, equity_barrier_option_instrument>) {
+                                        save_equity_barrier_option_instrument_request req; req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    } else if constexpr (std::is_same_v<InstrT, equity_asian_option_instrument>) {
+                                        save_equity_asian_option_instrument_request req; req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    } else if constexpr (std::is_same_v<InstrT, equity_forward_instrument>) {
+                                        save_equity_forward_instrument_request req; req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    } else if constexpr (std::is_same_v<InstrT, equity_variance_swap_instrument>) {
+                                        save_equity_variance_swap_instrument_request req; req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    } else if constexpr (std::is_same_v<InstrT, equity_swap_instrument>) {
+                                        save_equity_swap_instrument_request req; req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    } else if constexpr (std::is_same_v<InstrT, equity_accumulator_instrument>) {
+                                        save_equity_accumulator_instrument_request req; req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    } else if constexpr (std::is_same_v<InstrT, equity_position_instrument>) {
+                                        save_equity_position_instrument_request req; req.data = instr;
+                                        (void)self->clientManager_->process_authenticated_request(std::move(req));
+                                    }
+                                }, r.instrument);
                             } else if constexpr (std::is_same_v<T, ore::domain::commodity_mapping_result>) {
                                 save_commodity_instrument_request req;
                                 req.data = r.instrument;

--- a/projects/ores.qt.trading/src/OreImporter.cpp
+++ b/projects/ores.qt.trading/src/OreImporter.cpp
@@ -532,11 +532,71 @@ ore_import_result OreImporter::execute(
                         if (!resp || !resp->success) record_error(resp);
                         else ++res.instruments;
                     } else if constexpr (std::is_same_v<T, equity_mapping_result>) {
-                        save_equity_instrument_request req;
-                        req.data = r.instrument;
-                        const auto resp = cm_->process_authenticated_request(std::move(req));
-                        if (!resp || !resp->success) record_error(resp);
-                        else ++res.instruments;
+                        std::visit([&](const auto& instr) {
+                            using InstrT = std::decay_t<decltype(instr)>;
+                            using namespace ores::trading::domain;
+                            if constexpr (std::is_same_v<InstrT, equity_instrument>) {
+                                save_equity_instrument_request req; req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            } else if constexpr (std::is_same_v<InstrT, equity_option_instrument>) {
+                                save_equity_option_instrument_request req; req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            } else if constexpr (std::is_same_v<InstrT, equity_digital_option_instrument>) {
+                                save_equity_digital_option_instrument_request req; req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            } else if constexpr (std::is_same_v<InstrT, equity_barrier_option_instrument>) {
+                                save_equity_barrier_option_instrument_request req; req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            } else if constexpr (std::is_same_v<InstrT, equity_asian_option_instrument>) {
+                                save_equity_asian_option_instrument_request req; req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            } else if constexpr (std::is_same_v<InstrT, equity_forward_instrument>) {
+                                save_equity_forward_instrument_request req; req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            } else if constexpr (std::is_same_v<InstrT, equity_variance_swap_instrument>) {
+                                save_equity_variance_swap_instrument_request req; req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            } else if constexpr (std::is_same_v<InstrT, equity_swap_instrument>) {
+                                save_equity_swap_instrument_request req; req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            } else if constexpr (std::is_same_v<InstrT, equity_accumulator_instrument>) {
+                                save_equity_accumulator_instrument_request req; req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            } else if constexpr (std::is_same_v<InstrT, equity_position_instrument>) {
+                                save_equity_position_instrument_request req; req.data = instr;
+                                const auto resp =
+                                    cm_->process_authenticated_request(std::move(req));
+                                if (!resp || !resp->success) record_error(resp);
+                                else ++res.instruments;
+                            }
+                        }, r.instrument);
                     } else if constexpr (std::is_same_v<T, commodity_mapping_result>) {
                         save_commodity_instrument_request req;
                         req.data = r.instrument;

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_accumulator_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_accumulator_instrument_service.hpp
@@ -21,6 +21,7 @@
 #define ORES_TRADING_SERVICE_EQUITY_ACCUMULATOR_INSTRUMENT_SERVICE_HPP
 
 #include <string>
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.database/domain/context.hpp"
 #include "ores.trading.api/domain/equity_accumulator_instrument.hpp"
@@ -43,6 +44,9 @@ public:
     using context = ores::database::context;
 
     explicit equity_accumulator_instrument_service(context ctx);
+
+    std::optional<domain::equity_accumulator_instrument>
+    get_equity_accumulator_instrument(const std::string& id);
 
     void save_equity_accumulator_instrument(const domain::equity_accumulator_instrument& v);
 

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_asian_option_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_asian_option_instrument_service.hpp
@@ -21,6 +21,7 @@
 #define ORES_TRADING_SERVICE_EQUITY_ASIAN_OPTION_INSTRUMENT_SERVICE_HPP
 
 #include <string>
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.database/domain/context.hpp"
 #include "ores.trading.api/domain/equity_asian_option_instrument.hpp"
@@ -43,6 +44,9 @@ public:
     using context = ores::database::context;
 
     explicit equity_asian_option_instrument_service(context ctx);
+
+    std::optional<domain::equity_asian_option_instrument>
+    get_equity_asian_option_instrument(const std::string& id);
 
     void save_equity_asian_option_instrument(const domain::equity_asian_option_instrument& v);
 

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_barrier_option_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_barrier_option_instrument_service.hpp
@@ -21,6 +21,7 @@
 #define ORES_TRADING_SERVICE_EQUITY_BARRIER_OPTION_INSTRUMENT_SERVICE_HPP
 
 #include <string>
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.database/domain/context.hpp"
 #include "ores.trading.api/domain/equity_barrier_option_instrument.hpp"
@@ -43,6 +44,9 @@ public:
     using context = ores::database::context;
 
     explicit equity_barrier_option_instrument_service(context ctx);
+
+    std::optional<domain::equity_barrier_option_instrument>
+    get_equity_barrier_option_instrument(const std::string& id);
 
     void save_equity_barrier_option_instrument(const domain::equity_barrier_option_instrument& v);
 

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_digital_option_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_digital_option_instrument_service.hpp
@@ -21,6 +21,7 @@
 #define ORES_TRADING_SERVICE_EQUITY_DIGITAL_OPTION_INSTRUMENT_SERVICE_HPP
 
 #include <string>
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.database/domain/context.hpp"
 #include "ores.trading.api/domain/equity_digital_option_instrument.hpp"
@@ -43,6 +44,9 @@ public:
     using context = ores::database::context;
 
     explicit equity_digital_option_instrument_service(context ctx);
+
+    std::optional<domain::equity_digital_option_instrument>
+    get_equity_digital_option_instrument(const std::string& id);
 
     void save_equity_digital_option_instrument(const domain::equity_digital_option_instrument& v);
 

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_forward_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_forward_instrument_service.hpp
@@ -21,6 +21,7 @@
 #define ORES_TRADING_SERVICE_EQUITY_FORWARD_INSTRUMENT_SERVICE_HPP
 
 #include <string>
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.database/domain/context.hpp"
 #include "ores.trading.api/domain/equity_forward_instrument.hpp"
@@ -43,6 +44,9 @@ public:
     using context = ores::database::context;
 
     explicit equity_forward_instrument_service(context ctx);
+
+    std::optional<domain::equity_forward_instrument>
+    get_equity_forward_instrument(const std::string& id);
 
     void save_equity_forward_instrument(const domain::equity_forward_instrument& v);
 

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_option_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_option_instrument_service.hpp
@@ -21,6 +21,7 @@
 #define ORES_TRADING_SERVICE_EQUITY_OPTION_INSTRUMENT_SERVICE_HPP
 
 #include <string>
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.database/domain/context.hpp"
 #include "ores.trading.api/domain/equity_option_instrument.hpp"
@@ -43,6 +44,9 @@ public:
     using context = ores::database::context;
 
     explicit equity_option_instrument_service(context ctx);
+
+    std::optional<domain::equity_option_instrument>
+    get_equity_option_instrument(const std::string& id);
 
     void save_equity_option_instrument(const domain::equity_option_instrument& v);
 

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_position_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_position_instrument_service.hpp
@@ -21,6 +21,7 @@
 #define ORES_TRADING_SERVICE_EQUITY_POSITION_INSTRUMENT_SERVICE_HPP
 
 #include <string>
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.database/domain/context.hpp"
 #include "ores.trading.api/domain/equity_position_instrument.hpp"
@@ -43,6 +44,9 @@ public:
     using context = ores::database::context;
 
     explicit equity_position_instrument_service(context ctx);
+
+    std::optional<domain::equity_position_instrument>
+    get_equity_position_instrument(const std::string& id);
 
     void save_equity_position_instrument(const domain::equity_position_instrument& v);
 

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_swap_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_swap_instrument_service.hpp
@@ -21,6 +21,7 @@
 #define ORES_TRADING_SERVICE_EQUITY_SWAP_INSTRUMENT_SERVICE_HPP
 
 #include <string>
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.database/domain/context.hpp"
 #include "ores.trading.api/domain/equity_swap_instrument.hpp"
@@ -43,6 +44,9 @@ public:
     using context = ores::database::context;
 
     explicit equity_swap_instrument_service(context ctx);
+
+    std::optional<domain::equity_swap_instrument>
+    get_equity_swap_instrument(const std::string& id);
 
     void save_equity_swap_instrument(const domain::equity_swap_instrument& v);
 

--- a/projects/ores.trading.core/include/ores.trading.core/service/equity_variance_swap_instrument_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/equity_variance_swap_instrument_service.hpp
@@ -21,6 +21,7 @@
 #define ORES_TRADING_SERVICE_EQUITY_VARIANCE_SWAP_INSTRUMENT_SERVICE_HPP
 
 #include <string>
+#include <optional>
 #include "ores.logging/make_logger.hpp"
 #include "ores.database/domain/context.hpp"
 #include "ores.trading.api/domain/equity_variance_swap_instrument.hpp"
@@ -43,6 +44,9 @@ public:
     using context = ores::database::context;
 
     explicit equity_variance_swap_instrument_service(context ctx);
+
+    std::optional<domain::equity_variance_swap_instrument>
+    get_equity_variance_swap_instrument(const std::string& id);
 
     void save_equity_variance_swap_instrument(const domain::equity_variance_swap_instrument& v);
 

--- a/projects/ores.trading.core/src/service/equity_accumulator_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_accumulator_instrument_service.cpp
@@ -31,6 +31,16 @@ using namespace ores::logging;
 equity_accumulator_instrument_service::equity_accumulator_instrument_service(context ctx)
     : ctx_(std::move(ctx)) {}
 
+std::optional<domain::equity_accumulator_instrument>
+equity_accumulator_instrument_service::get_equity_accumulator_instrument(
+    const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug)
+        << "Getting equity_accumulator_instrument: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
 void equity_accumulator_instrument_service::save_equity_accumulator_instrument(
     const domain::equity_accumulator_instrument& v) {
     if (v.instrument_id.is_nil())

--- a/projects/ores.trading.core/src/service/equity_asian_option_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_asian_option_instrument_service.cpp
@@ -31,6 +31,16 @@ using namespace ores::logging;
 equity_asian_option_instrument_service::equity_asian_option_instrument_service(context ctx)
     : ctx_(std::move(ctx)) {}
 
+std::optional<domain::equity_asian_option_instrument>
+equity_asian_option_instrument_service::get_equity_asian_option_instrument(
+    const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug)
+        << "Getting equity_asian_option_instrument: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
 void equity_asian_option_instrument_service::save_equity_asian_option_instrument(
     const domain::equity_asian_option_instrument& v) {
     if (v.instrument_id.is_nil())

--- a/projects/ores.trading.core/src/service/equity_barrier_option_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_barrier_option_instrument_service.cpp
@@ -31,6 +31,16 @@ using namespace ores::logging;
 equity_barrier_option_instrument_service::equity_barrier_option_instrument_service(context ctx)
     : ctx_(std::move(ctx)) {}
 
+std::optional<domain::equity_barrier_option_instrument>
+equity_barrier_option_instrument_service::get_equity_barrier_option_instrument(
+    const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug)
+        << "Getting equity_barrier_option_instrument: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
 void equity_barrier_option_instrument_service::save_equity_barrier_option_instrument(
     const domain::equity_barrier_option_instrument& v) {
     if (v.instrument_id.is_nil())

--- a/projects/ores.trading.core/src/service/equity_digital_option_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_digital_option_instrument_service.cpp
@@ -31,6 +31,16 @@ using namespace ores::logging;
 equity_digital_option_instrument_service::equity_digital_option_instrument_service(context ctx)
     : ctx_(std::move(ctx)) {}
 
+std::optional<domain::equity_digital_option_instrument>
+equity_digital_option_instrument_service::get_equity_digital_option_instrument(
+    const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug)
+        << "Getting equity_digital_option_instrument: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
 void equity_digital_option_instrument_service::save_equity_digital_option_instrument(
     const domain::equity_digital_option_instrument& v) {
     if (v.instrument_id.is_nil())

--- a/projects/ores.trading.core/src/service/equity_forward_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_forward_instrument_service.cpp
@@ -31,6 +31,16 @@ using namespace ores::logging;
 equity_forward_instrument_service::equity_forward_instrument_service(context ctx)
     : ctx_(std::move(ctx)) {}
 
+std::optional<domain::equity_forward_instrument>
+equity_forward_instrument_service::get_equity_forward_instrument(
+    const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug)
+        << "Getting equity_forward_instrument: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
 void equity_forward_instrument_service::save_equity_forward_instrument(
     const domain::equity_forward_instrument& v) {
     if (v.instrument_id.is_nil())

--- a/projects/ores.trading.core/src/service/equity_option_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_option_instrument_service.cpp
@@ -31,6 +31,15 @@ using namespace ores::logging;
 equity_option_instrument_service::equity_option_instrument_service(context ctx)
     : ctx_(std::move(ctx)) {}
 
+std::optional<domain::equity_option_instrument>
+equity_option_instrument_service::get_equity_option_instrument(
+    const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting equity_option_instrument: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
 void equity_option_instrument_service::save_equity_option_instrument(
     const domain::equity_option_instrument& v) {
     if (v.instrument_id.is_nil())

--- a/projects/ores.trading.core/src/service/equity_position_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_position_instrument_service.cpp
@@ -31,6 +31,16 @@ using namespace ores::logging;
 equity_position_instrument_service::equity_position_instrument_service(context ctx)
     : ctx_(std::move(ctx)) {}
 
+std::optional<domain::equity_position_instrument>
+equity_position_instrument_service::get_equity_position_instrument(
+    const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug)
+        << "Getting equity_position_instrument: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
 void equity_position_instrument_service::save_equity_position_instrument(
     const domain::equity_position_instrument& v) {
     if (v.instrument_id.is_nil())

--- a/projects/ores.trading.core/src/service/equity_swap_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_swap_instrument_service.cpp
@@ -31,6 +31,16 @@ using namespace ores::logging;
 equity_swap_instrument_service::equity_swap_instrument_service(context ctx)
     : ctx_(std::move(ctx)) {}
 
+std::optional<domain::equity_swap_instrument>
+equity_swap_instrument_service::get_equity_swap_instrument(
+    const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug)
+        << "Getting equity_swap_instrument: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
 void equity_swap_instrument_service::save_equity_swap_instrument(
     const domain::equity_swap_instrument& v) {
     if (v.instrument_id.is_nil())

--- a/projects/ores.trading.core/src/service/equity_variance_swap_instrument_service.cpp
+++ b/projects/ores.trading.core/src/service/equity_variance_swap_instrument_service.cpp
@@ -31,6 +31,16 @@ using namespace ores::logging;
 equity_variance_swap_instrument_service::equity_variance_swap_instrument_service(context ctx)
     : ctx_(std::move(ctx)) {}
 
+std::optional<domain::equity_variance_swap_instrument>
+equity_variance_swap_instrument_service::get_equity_variance_swap_instrument(
+    const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug)
+        << "Getting equity_variance_swap_instrument: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
 void equity_variance_swap_instrument_service::save_equity_variance_swap_instrument(
     const domain::equity_variance_swap_instrument& v) {
     if (v.instrument_id.is_nil())


### PR DESCRIPTION
## Summary

PR #2 of the four-PR instrument per-type migration series (see
\`doc/plans/2026-04-21-fx-forward-import-e2e.org\`). Addresses the latent
FX-forward-style defect for equity: the ORE importer wrote only to the
legacy generic \`ores_trading_equity_instruments_tbl\`, while nine
per-type tables and their \`save_equity_<type>_instrument_request\` wire
messages sat idle with zero callers.

**What this PR lands (import-path only):**

- All nine per-type equity services gain \`get_<type>_instrument\`
  methods, ready for the read side.
- \`equity_mapping_result\` carries \`equity_instrument_variant\` — a
  \`std::variant\` over the nine per-type alternatives plus the legacy
  flat \`equity_instrument\` as a migration bridge.
- All fifteen \`forward_equity_*\` functions now produce the correct
  per-type alternative (\`equity_option_instrument\`, \`equity_forward_instrument\`,
  \`equity_swap_instrument\`, \`equity_variance_swap_instrument\`,
  \`equity_barrier_option_instrument\`, \`equity_asian_option_instrument\`,
  \`equity_digital_option_instrument\`, \`equity_accumulator_instrument\`).
  Field renames land here (\`underlying_code\`→\`underlying_name\`,
  \`strike_price\`→\`strike\`, \`maturity_date\`→\`expiry_date\`,
  \`accumulation_amount\`→\`fixing_amount\`, \`cliquet_frequency_code\`→
  \`cliquet_frequency\`, etc.).
- Both importer dispatch sites (\`ore_import_execute_handler.cpp\` and
  \`OreImporter.cpp\`) std::visit the variant and send the right
  \`save_equity_<type>_instrument_request\`. \`ImportTradeDialog.cpp\`
  and \`xml/importer.cpp\` wire \`instrument_id\` / \`trade_id\` on the
  chosen alternative.

**Commits (8):**

1. \`1ddbbe766\` Phase 1 — \`get_<type>_instrument\` methods on the nine
   per-type services.
2. \`d966a763b\` Plan document.
3. \`d7d00fdb1\` Plan expanded — mapper rewrite and importer flip added
   after discovering the importer still wrote to the legacy generic
   table.
4. \`40cdef8b4\` Phase 2a — \`equity_instrument_variant\` + flat bridge
   alternative + full per-type dispatch pre-wired in all importer sites.
5. \`13aefb575\` Phase 2b — \`equity_option\` / \`equity_forward\` forwards
   migrated.
6. \`81334a42b\` Phase 2c — \`equity_swap\` / \`equity_variance_swap\`
   forwards migrated.
7. \`2a9bf1514\` Phase 2d — barrier / asian / digital forwards migrated
   (five ORE types: EquityBarrierOption, EquityDoubleBarrierOption,
   EquityEuropeanBarrierOption, EquityAsianOption, EquityDigitalOption,
   EquityTouchOption).
8. \`8a75af8a0\` Phase 2e — outperformance / accumulator / tarf /
   cliquet / worst_of_basket_swap forwards migrated.

**Bridge state (deleted in a follow-up PR):**

The \`equity_instrument\` alternative of \`equity_instrument_variant\` and
the \`flat()\` helper in \`xml_equity_mapper_roundtrip_tests\` stay put
because \`reverse_equity_*\` signatures still take \`const
equity_instrument&\`. Migrating reverse requires coordinating with the
exporter and \`instrument_export_result\` changes — the read-path / bundle
work (Phase 4 per the plan). That ships in a follow-up PR.

**What's not in this PR yet:**

- Phase 4: migrate \`reverse_equity_*\` signatures, add
  \`equity_export_result\` to \`instrument_export_result\`, route
  \`product_type::equity\` by \`trade_type_code\` in
  \`trade_handler::populate_instrument_for_trade\`, migrate
  \`EquityInstrumentForm::setInstrument\`. Closes Phase 2 by removing the
  flat alternative + bridge helpers.
- Phases 5–7: delete legacy generic wire messages, handler, C++
  infrastructure, and SQL.

**Verification:** Full \`ores.ore.tests\` suite (461 cases, 446k
assertions) passes; trading core / Qt trading targets build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)