### PR TITLE
[qt,compute] Mop-up: autogen leak, URI scheme, per-row Retry

### DIFF
--- a/projects/ores.compute.api/include/ores.compute.api/net/compute_storage.hpp
+++ b/projects/ores.compute.api/include/ores.compute.api/net/compute_storage.hpp
@@ -32,11 +32,14 @@ namespace ores::compute::net {
  * All compute artifacts live under a single "compute" bucket with
  * hierarchical keys:
  *
- *   packages/{app_version_id}[.ext]                   — single-platform bundle
- *   packages/{app_version_id}/{platform_code}[.ext]   — per-triplet bundle
- *   input/{workunit_id}[.ext]                         — workunit input archive
- *   config/{workunit_id}[.ext]                        — workunit configuration file
- *   output/{result_id}.tar.gz                         — result output archive
+ *   packages/{app_version_id}[.ext]
+ *       single-platform bundle (legacy, used by AppProvisionerWizard)
+ *   packages/{app_name}/{version}/{app_name}-{version}-{platform_code}[.ext]
+ *       per-triplet bundle; matches the SQL seed convention so blobs are
+ *       browseable by hand ("this is ORE 1.8.15.0 for x64-linux")
+ *   input/{workunit_id}[.ext]    — workunit input archive
+ *   config/{workunit_id}[.ext]   — workunit configuration file
+ *   output/{result_id}.tar.gz    — result output archive
  *
  * Use @c storage_paths::make_object_path / @c make_object_url to build
  * the full HTTP path or URL from the helpers below.
@@ -64,19 +67,28 @@ struct compute_storage {
     /**
      * @brief Key for a per-platform application package binary.
      *
-     * @param id             App version UUID as string.
-     * @param platform_code  vcpkg triplet code (e.g. "x64-linux").
+     * @param app_name       App name, e.g. "ore".
+     * @param version        Engine version, e.g. "1.8.15.0".
+     * @param platform_code  vcpkg triplet code, e.g. "x64-linux".
      * @param ext            File extension including the leading dot.
      *
-     * Per-platform bundles live one level deeper than the single-platform
-     * key so both layouts can coexist during migration.
+     * Uses a human-readable layout so admins browsing the storage bucket
+     * can identify blobs by sight, and the SQL seed (which hand-writes
+     * this path) round-trips through the same helper.
      */
-    static std::string package_key(std::string_view id,
+    static std::string package_key(std::string_view app_name,
+        std::string_view version,
         std::string_view platform_code,
         std::string_view ext) {
         std::string k = "packages/";
-        k += id;
+        k += app_name;
         k += '/';
+        k += version;
+        k += '/';
+        k += app_name;
+        k += '-';
+        k += version;
+        k += '-';
         k += platform_code;
         k += ext;
         return k;
@@ -137,11 +149,12 @@ struct compute_storage {
      * when populating ores_compute_app_version_platforms_tbl.package_uri so
      * clients don't have to synthesise the path inline.
      */
-    static std::string package_path(std::string_view id,
+    static std::string package_path(std::string_view app_name,
+        std::string_view version,
         std::string_view platform_code,
         std::string_view ext) {
         return ores::storage::net::storage_paths::make_object_path(
-            bucket, package_key(id, platform_code, ext));
+            bucket, package_key(app_name, version, platform_code, ext));
     }
 
     static std::string input_path(std::string_view workunit_id,

--- a/projects/ores.qt.compute/include/ores.qt/AppVersionDetailDialog.hpp
+++ b/projects/ores.qt.compute/include/ores.qt/AppVersionDetailDialog.hpp
@@ -83,6 +83,7 @@ private slots:
     void onAddPlatformClicked();
     void onRemovePlatformClicked();
     void onBrowsePackageRowClicked();
+    void onRetryPackageRowClicked();
 
 protected:
     QTabWidget* tabWidget() const override;

--- a/projects/ores.qt.compute/src/AppVersionDetailDialog.cpp
+++ b/projects/ores.qt.compute/src/AppVersionDetailDialog.cpp
@@ -686,7 +686,20 @@ void AppVersionDetailDialog::uploadPendingPackages(
     auto ctx = std::make_shared<Ctx>();
     ctx->remaining = static_cast<int>(pending.size());
 
-    const auto av_id = boost::uuids::to_string(app_version_.id);
+    // Resolve app name + engine version once — both feed the canonical
+    // human-readable URI layout produced by compute_storage::package_path,
+    // which matches the SQL seed so hand-seeded and UI-uploaded packages
+    // share a single convention.
+    const auto app_id_str = boost::uuids::to_string(app_version_.app_id);
+    const auto app_it = std::find_if(appEntries_.begin(), appEntries_.end(),
+        [&](const auto& e) { return e.id == app_id_str; });
+    if (app_it == appEntries_.end()) {
+        done(false, tr("Parent app metadata not loaded; cannot construct "
+            "package URI."));
+        return;
+    }
+    const std::string& app_name = app_it->name;
+    const std::string& version = app_version_.engine_version;
     QPointer<AppVersionDetailDialog> self = this;
 
     for (int row : pending) {
@@ -695,7 +708,7 @@ void AppVersionDetailDialog::uploadPendingPackages(
 
         const std::string uri_path =
             ores::compute::net::compute_storage::package_path(
-                av_id, pr.platform_code, ".tar.gz");
+                app_name, version, pr.platform_code, ".tar.gz");
         QUrl uploadUrl = httpBaseUrl_;
         uploadUrl.setPath(QString::fromStdString(uri_path));
 

--- a/projects/ores.qt.compute/src/AppVersionDetailDialog.cpp
+++ b/projects/ores.qt.compute/src/AppVersionDetailDialog.cpp
@@ -338,14 +338,23 @@ void AppVersionDetailDialog::updatePackagesTableRow(int row) {
     if (!pr.error.isEmpty()) status_item->setToolTip(pr.error);
     ui_->packagesTable->setItem(row, 2, status_item);
 
-    // Dedicated cell widget so we can attach a row-scoped Browse button with
-    // a dynamic property pointing at our row index; a simple onClick mapper
-    // keeps state consistent when table rows are rebuilt.
-    auto* btn = new QPushButton(tr("Browse…"), ui_->packagesTable);
-    btn->setProperty("package_row", row);
+    // Dedicated cell widget so we can attach a row-scoped Browse / Retry
+    // button with a dynamic property pointing at the platform_id; lookups
+    // at click time keep state consistent even when rows churn.
+    const bool show_retry = (pr.state == PackageRow::State::Failed);
+    auto* btn = new QPushButton(
+        show_retry ? tr("Retry") : tr("Browse…"),
+        ui_->packagesTable);
+    btn->setProperty("platform_id", QString::fromStdString(pr.platform_id));
     btn->setEnabled(!readOnly_ && !saveInProgress_);
-    connect(btn, &QPushButton::clicked, this,
-            &AppVersionDetailDialog::onBrowsePackageRowClicked);
+    if (show_retry) {
+        btn->setToolTip(tr("Re-upload the previously selected file"));
+        connect(btn, &QPushButton::clicked, this,
+                &AppVersionDetailDialog::onRetryPackageRowClicked);
+    } else {
+        connect(btn, &QPushButton::clicked, this,
+                &AppVersionDetailDialog::onBrowsePackageRowClicked);
+    }
     ui_->packagesTable->setCellWidget(row, 3, btn);
 }
 
@@ -578,8 +587,11 @@ bool AppVersionDetailDialog::validateInput() {
 void AppVersionDetailDialog::onBrowsePackageRowClicked() {
     auto* btn = qobject_cast<QPushButton*>(sender());
     if (!btn) return;
-    const int row = btn->property("package_row").toInt();
-    if (row < 0 || row >= static_cast<int>(package_rows_.size())) return;
+    const auto pid = btn->property("platform_id").toString().toStdString();
+    const auto it = std::find_if(package_rows_.begin(), package_rows_.end(),
+        [&](const auto& r) { return r.platform_id == pid; });
+    if (it == package_rows_.end()) return;
+    const int row = static_cast<int>(it - package_rows_.begin());
 
     const QString path = QFileDialog::getOpenFileName(
         this, tr("Select Package for %1").arg(
@@ -595,6 +607,53 @@ void AppVersionDetailDialog::onBrowsePackageRowClicked() {
 
     hasChanges_ = true;
     updateSaveButtonState();
+}
+
+void AppVersionDetailDialog::onRetryPackageRowClicked() {
+    auto* btn = qobject_cast<QPushButton*>(sender());
+    if (!btn) return;
+    const auto pid = btn->property("platform_id").toString().toStdString();
+    const auto it = std::find_if(package_rows_.begin(), package_rows_.end(),
+        [&](const auto& r) { return r.platform_id == pid; });
+    if (it == package_rows_.end()) return;
+    const int row = static_cast<int>(it - package_rows_.begin());
+
+    // Nothing to retry without a local file.
+    if (package_rows_[row].local_file.isEmpty()) return;
+    if (saveInProgress_) return; // Save is already retrying this row.
+
+    // Flip Failed → Selected so uploadPendingPackages picks up just this
+    // row (it skips Uploaded rows, so any previously-successful siblings
+    // aren't re-PUT). Disable the mutation buttons for the same reason as
+    // during a full Save.
+    package_rows_[row].error.clear();
+    setPackageRowState(row, PackageRow::State::Selected);
+
+    QPointer<AppVersionDetailDialog> self = this;
+    saveInProgress_ = true;
+    ui_->addPlatformButton->setEnabled(false);
+    ui_->removePlatformButton->setEnabled(false);
+    ui_->saveButton->setEnabled(false);
+    ui_->packagesProgressBar->setVisible(true);
+    ui_->packagesProgressBar->setValue(0);
+
+    uploadPendingPackages([self](bool ok, QString err) {
+        if (!self) return;
+        self->ui_->packagesProgressBar->setVisible(false);
+        self->saveInProgress_ = false;
+        if (!self->readOnly_) {
+            self->ui_->addPlatformButton->setEnabled(true);
+            self->ui_->removePlatformButton->setEnabled(true);
+        }
+        if (!ok) {
+            BOOST_LOG_SEV(lg(), error) << "Retry upload failed: "
+                                       << err.toStdString();
+            MessageBoxHelper::critical(self, tr("Upload Failed"), err);
+        } else {
+            emit self->statusMessage(tr("Package uploaded successfully"));
+        }
+        self->updateSaveButtonState();
+    });
 }
 
 void AppVersionDetailDialog::onSaveClicked() {

--- a/projects/ores.qt/include/ores.qt/AboutDialog.hpp
+++ b/projects/ores.qt/include/ores.qt/AboutDialog.hpp
@@ -22,9 +22,15 @@
 #define ORES_QT_ABOUT_DIALOG_HPP
 
 #include <QWidget>
-#include "ui_AboutDialog.h"
+#include <memory>
 #include "ores.qt/LogoLabel.hpp"
 #include "ores.logging/make_logger.hpp"
+
+namespace Ui {
+
+class AboutDialog;
+
+}
 
 namespace ores::qt {
 
@@ -68,7 +74,10 @@ private:
      * is available.
      */
     void populateSystemInfo();
-    Ui::AboutDialog ui_;
+    // Held by unique_ptr so the ui_AboutDialog.h include can live in the
+    // .cpp; keeps the generated header out of every consumer that links
+    // ores.qt.lib and would otherwise inherit it via PUBLIC autogen leak.
+    std::unique_ptr<Ui::AboutDialog> ui_;
     LogoLabel* logoLabel_;
     ClientManager* clientManager_;
 };

--- a/projects/ores.qt/include/ores.qt/MainWindow.hpp
+++ b/projects/ores.qt/include/ores.qt/MainWindow.hpp
@@ -35,7 +35,6 @@
 #include "ores.qt/MdiAreaWithBackground.hpp"
 #include "ores.eventing/service/event_bus.hpp"
 #include "ores.logging/make_logger.hpp"
-#include "ui_MainWindow.h"
 
 namespace Ui {
 

--- a/projects/ores.qt/src/AboutDialog.cpp
+++ b/projects/ores.qt/src/AboutDialog.cpp
@@ -23,6 +23,7 @@
 #include <QPixmap>
 #include <QTreeWidget>
 #include <QHeaderView>
+#include "ui_AboutDialog.h"
 #include "ores.utility/version/version.hpp"
 #include "ores.qt/ClientManager.hpp"
 
@@ -31,28 +32,32 @@ namespace ores::qt {
 using namespace ores::logging;
 
 AboutDialog::AboutDialog(ClientManager* clientManager, QWidget* parent)
-    : QWidget(parent), clientManager_(clientManager) {
+    : QWidget(parent),
+      ui_(std::make_unique<Ui::AboutDialog>()),
+      clientManager_(clientManager) {
 
     BOOST_LOG_SEV(lg(), debug) << "Creating about dialog.";
-    ui_.setupUi(this);
+    ui_->setupUi(this);
 
-    // Replace ui_.logoLabel with our custom LogoLabel in the layout
-    logoLabel_ = new LogoLabel(ui_.logoContainer);
-    logoLabel_->setAlignment(ui_.logoLabel->alignment());
-    logoLabel_->setScaledContents(ui_.logoLabel->hasScaledContents());
+    // Replace ui_->logoLabel with our custom LogoLabel in the layout
+    logoLabel_ = new LogoLabel(ui_->logoContainer);
+    logoLabel_->setAlignment(ui_->logoLabel->alignment());
+    logoLabel_->setScaledContents(ui_->logoLabel->hasScaledContents());
 
     // Replace the widget in the layout
-    QLayout* layout = ui_.logoLabel->parentWidget()->layout();
+    QLayout* layout = ui_->logoLabel->parentWidget()->layout();
     if (layout) {
-        layout->replaceWidget(ui_.logoLabel, logoLabel_);
-        ui_.logoLabel->deleteLater();
+        layout->replaceWidget(ui_->logoLabel, logoLabel_);
+        ui_->logoLabel->deleteLater();
     }
 
     // Component column auto-sizes; Version column takes the remaining space
-    ui_.systemInfoTree->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
-    ui_.systemInfoTree->header()->setSectionResizeMode(1, QHeaderView::Stretch);
+    ui_->systemInfoTree->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    ui_->systemInfoTree->header()->setSectionResizeMode(1, QHeaderView::Stretch);
 }
 
+// Out-of-line dtor so unique_ptr<Ui::AboutDialog> sees the full type when
+// destroying; the header only holds a forward declaration.
 AboutDialog::~AboutDialog() {
     BOOST_LOG_SEV(lg(), debug) << "Destroying about dialog.";
 }
@@ -86,18 +91,18 @@ void AboutDialog::showEvent(QShowEvent* e) {
 }
 
 void AboutDialog::populateSystemInfo() {
-    ui_.systemInfoTree->clear();
+    ui_->systemInfoTree->clear();
 
     // Database row
     {
-        auto* item = new QTreeWidgetItem(ui_.systemInfoTree);
+        auto* item = new QTreeWidgetItem(ui_->systemInfoTree);
         item->setText(0, "Database");
         item->setText(1, "(not connected)");
     }
 
     // Server row
     {
-        auto* item = new QTreeWidgetItem(ui_.systemInfoTree);
+        auto* item = new QTreeWidgetItem(ui_->systemInfoTree);
         item->setText(0, "Server");
         item->setText(1, clientManager_ && clientManager_->isConnected()
             ? QString::fromStdString(clientManager_->serverAddress())
@@ -106,7 +111,7 @@ void AboutDialog::populateSystemInfo() {
 
     // Client row — always available (compile-time constants)
     {
-        auto* item = new QTreeWidgetItem(ui_.systemInfoTree);
+        auto* item = new QTreeWidgetItem(ui_->systemInfoTree);
         item->setText(0, "Client");
         item->setText(1, QString("v%1 (%2)")
             .arg(ORES_VERSION)
@@ -114,7 +119,7 @@ void AboutDialog::populateSystemInfo() {
     }
 
     // Shrink the Component column to its content; Version gets the rest
-    ui_.systemInfoTree->resizeColumnToContents(0);
+    ui_->systemInfoTree->resizeColumnToContents(0);
 }
 
 }

--- a/projects/ores.qt/src/CMakeLists.txt
+++ b/projects/ores.qt/src/CMakeLists.txt
@@ -46,8 +46,13 @@ set_target_properties(${lib_target_name}
     PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 
 target_include_directories(${lib_target_name} PUBLIC
-    ${ORES_QT_DIR}/include
-    # Expose AUTOUIC-generated ui_*.h headers so consumers (exe) can find them.
+    ${ORES_QT_DIR}/include)
+# AUTOUIC headers are only consumed by .cpp files in ores.qt itself —
+# MainWindow and AboutDialog hold their Ui::* pimpl-style (forward-declared
+# in the .hpp, included in the .cpp). Keeping this dir PRIVATE stops stale
+# ui_*.h copies from leaking to plugin libs (and previously shadowing the
+# fresh ones at their own autogen dirs).
+target_include_directories(${lib_target_name} PRIVATE
     "${CMAKE_CURRENT_BINARY_DIR}/${lib_target_name}_autogen/include")
 target_link_libraries(${lib_target_name}
     PUBLIC


### PR DESCRIPTION
## Summary

Cleanup follow-ups surfaced during the per-platform package work (#714, #719). Three independent commits, each its own self-contained fix.

- **`9cd834751`** — Narrow `ores.qt.lib`'s AUTOUIC include from PUBLIC to PRIVATE. This was leaking stale `ui_*.h` copies of moved dialogs to every downstream plugin lib; it bit #719 mid-PR when a stale `ui_AppVersionDetailDialog.h` shadowed the fresh compute one. Enabled by PIMPLing `MainWindow` (straight delete of an unused `#include` from the header — the pointer member already used a forward decl) and `AboutDialog` (swap `Ui::AboutDialog` by-value to `std::unique_ptr<Ui::AboutDialog>` with an out-of-line dtor so the `#include` can live in the `.cpp`).
- **`0de3d0bb9`** — Unify the package URI scheme. The SQL seed wrote `/packages/{app_name}/{version}/{app_name}-{version}-{triplet}.tar.gz` (human-readable) while the Qt helper wrote `/packages/{uuid}/{triplet}.tar.gz` (UUID-based). Both worked because `storage_routes` is generic, but two schemes for the same blob was an unnecessary sharp edge. `compute_storage::package_key` (per-platform overload) now takes `(app_name, version, platform_code, ext)` so hand-seeded rows and UI uploads route to the same path. Qt dialog reads name from the already-loaded `appEntries_`.
- **`ea5b5c089`** — Per-row Retry. If one package failed mid-Save, the user had to re-Browse (unnecessary file picker) or click Save again. Now the row's action button shows "Retry" when in `Failed` state, reusing `uploadPendingPackages` with its existing skip-if-Uploaded semantics so successful siblings aren't re-PUT.

## Follow-ups (deferred)

- `AppProvisionerWizard` still uses the legacy single-URI-for-all-platforms path (`package_path(id, ext)` overload retained for that reason). Per-platform wizard rework is a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)