### PR TITLE
[trading,ore,qt] Wrap bond/credit/commodity/scripted in *_export_result structs

### DIFF
--- a/projects/ores.ore/src/xml/exporter.cpp
+++ b/projects/ores.ore/src/xml/exporter.cpp
@@ -38,12 +38,12 @@ using namespace ores::logging;
 using namespace ores::ore::domain;
 using trading::messaging::swap_export_result;
 using trading::messaging::fx_export_result;
+using trading::messaging::bond_export_result;
+using trading::messaging::credit_export_result;
 using trading::messaging::equity_export_result;
+using trading::messaging::commodity_export_result;
 using trading::messaging::composite_export_result;
-using trading::domain::bond_instrument;
-using trading::domain::credit_instrument;
-using trading::domain::commodity_instrument;
-using trading::domain::scripted_instrument;
+using trading::messaging::scripted_export_result;
 
 namespace {
 
@@ -196,39 +196,41 @@ std::string exporter::export_portfolio(
                         << "No reverse mapper for FX type: " << tt;
                     return;
                 }
-            } else if constexpr (std::is_same_v<T, bond_instrument>) {
+            } else if constexpr (std::is_same_v<T, bond_export_result>) {
+                const auto& instr = r.instrument;
                 if (tt == "Bond")
-                    xsd_t = bond_instrument_mapper::reverse_bond(r);
+                    xsd_t = bond_instrument_mapper::reverse_bond(instr);
                 else if (tt == "ForwardBond")
-                    xsd_t = bond_instrument_mapper::reverse_forward_bond(r);
+                    xsd_t = bond_instrument_mapper::reverse_forward_bond(instr);
                 else if (tt == "CallableBond")
-                    xsd_t = bond_instrument_mapper::reverse_callable_bond(r);
+                    xsd_t = bond_instrument_mapper::reverse_callable_bond(instr);
                 else if (tt == "ConvertibleBond")
-                    xsd_t = bond_instrument_mapper::reverse_convertible_bond(r);
+                    xsd_t = bond_instrument_mapper::reverse_convertible_bond(instr);
                 else if (tt == "BondOption")
-                    xsd_t = bond_instrument_mapper::reverse_bond_option(r);
+                    xsd_t = bond_instrument_mapper::reverse_bond_option(instr);
                 else if (tt == "BondTRS")
-                    xsd_t = bond_instrument_mapper::reverse_bond_trs(r);
+                    xsd_t = bond_instrument_mapper::reverse_bond_trs(instr);
                 else if (tt == "BondRepo")
-                    xsd_t = bond_instrument_mapper::reverse_bond_repo(r);
+                    xsd_t = bond_instrument_mapper::reverse_bond_repo(instr);
                 else {
                     BOOST_LOG_SEV(lg(), debug)
                         << "No reverse mapper for bond type: " << tt;
                     return;
                 }
-            } else if constexpr (std::is_same_v<T, credit_instrument>) {
+            } else if constexpr (std::is_same_v<T, credit_export_result>) {
+                const auto& instr = r.instrument;
                 if (tt == "CreditDefaultSwap")
-                    xsd_t = credit_instrument_mapper::reverse_cds(r);
+                    xsd_t = credit_instrument_mapper::reverse_cds(instr);
                 else if (tt == "IndexCreditDefaultSwap")
-                    xsd_t = credit_instrument_mapper::reverse_index_cds(r);
+                    xsd_t = credit_instrument_mapper::reverse_index_cds(instr);
                 else if (tt == "IndexCreditDefaultSwapOption")
-                    xsd_t = credit_instrument_mapper::reverse_index_cds_option(r);
+                    xsd_t = credit_instrument_mapper::reverse_index_cds_option(instr);
                 else if (tt == "CreditLinkedSwap")
-                    xsd_t = credit_instrument_mapper::reverse_credit_linked_swap(r);
+                    xsd_t = credit_instrument_mapper::reverse_credit_linked_swap(instr);
                 else if (tt == "SyntheticCDO")
-                    xsd_t = credit_instrument_mapper::reverse_synthetic_cdo(r);
+                    xsd_t = credit_instrument_mapper::reverse_synthetic_cdo(instr);
                 else if (tt == "RiskParticipationAgreement")
-                    xsd_t = credit_instrument_mapper::reverse_rpa(r);
+                    xsd_t = credit_instrument_mapper::reverse_rpa(instr);
                 else {
                     BOOST_LOG_SEV(lg(), debug)
                         << "No reverse mapper for credit type: " << tt;
@@ -314,35 +316,37 @@ std::string exporter::export_portfolio(
                         << "No reverse mapper for equity type: " << tt;
                     return;
                 }
-            } else if constexpr (std::is_same_v<T, commodity_instrument>) {
+            } else if constexpr (std::is_same_v<T, commodity_export_result>) {
+                const auto& instr = r.instrument;
                 if (tt == "CommodityForward")
-                    xsd_t = commodity_instrument_mapper::reverse_commodity_forward(r);
+                    xsd_t = commodity_instrument_mapper::reverse_commodity_forward(instr);
                 else if (tt == "CommodityOption")
-                    xsd_t = commodity_instrument_mapper::reverse_commodity_option(r);
+                    xsd_t = commodity_instrument_mapper::reverse_commodity_option(instr);
                 else if (tt == "CommoditySwap")
-                    xsd_t = commodity_instrument_mapper::reverse_commodity_swap(r);
+                    xsd_t = commodity_instrument_mapper::reverse_commodity_swap(instr);
                 else if (tt == "CommoditySwaption")
-                    xsd_t = commodity_instrument_mapper::reverse_commodity_swaption(r);
+                    xsd_t = commodity_instrument_mapper::reverse_commodity_swaption(instr);
                 else if (tt == "CommodityVarianceSwap")
-                    xsd_t = commodity_instrument_mapper::reverse_commodity_variance_swap(r);
+                    xsd_t = commodity_instrument_mapper::reverse_commodity_variance_swap(instr);
                 else if (tt == "CommodityAveragePriceOption")
-                    xsd_t = commodity_instrument_mapper::reverse_commodity_apo(r);
+                    xsd_t = commodity_instrument_mapper::reverse_commodity_apo(instr);
                 else if (tt == "CommodityOptionStrip")
-                    xsd_t = commodity_instrument_mapper::reverse_commodity_option_strip(r);
+                    xsd_t = commodity_instrument_mapper::reverse_commodity_option_strip(instr);
                 else {
                     BOOST_LOG_SEV(lg(), debug)
                         << "No reverse mapper for commodity type: " << tt;
                     return;
                 }
-            } else if constexpr (std::is_same_v<T, scripted_instrument>) {
+            } else if constexpr (std::is_same_v<T, scripted_export_result>) {
+                const auto& instr = r.instrument;
                 if (tt == "ScriptedTrade")
-                    xsd_t = scripted_instrument_mapper::reverse_scripted_trade(r);
+                    xsd_t = scripted_instrument_mapper::reverse_scripted_trade(instr);
                 else if (tt == "DoubleDigitalOption")
-                    xsd_t = scripted_instrument_mapper::reverse_double_digital_option(r);
+                    xsd_t = scripted_instrument_mapper::reverse_double_digital_option(instr);
                 else if (tt == "PerformanceOption_01")
-                    xsd_t = scripted_instrument_mapper::reverse_performance_option_01(r);
+                    xsd_t = scripted_instrument_mapper::reverse_performance_option_01(instr);
                 else if (tt == "KnockOutSwap")
-                    xsd_t = scripted_instrument_mapper::reverse_knock_out_swap(r);
+                    xsd_t = scripted_instrument_mapper::reverse_knock_out_swap(instr);
                 else {
                     BOOST_LOG_SEV(lg(), debug)
                         << "No reverse mapper for scripted type: " << tt;

--- a/projects/ores.ore/tests/xml_exporter_tests.cpp
+++ b/projects/ores.ore/tests/xml_exporter_tests.cpp
@@ -63,9 +63,9 @@ ores::trading::messaging::instrument_export_result to_export_result(
             return ex;
         }
         else if constexpr (std::is_same_v<T, bond_mapping_result>)
-            return v.instrument;
+            return bond_export_result{v.instrument};
         else if constexpr (std::is_same_v<T, credit_mapping_result>)
-            return v.instrument;
+            return credit_export_result{v.instrument};
         else if constexpr (std::is_same_v<T, equity_mapping_result>) {
             // equity_mapping_result::instrument (import-side variant) has the
             // same alternatives as equity_export_result::instrument; copy
@@ -77,9 +77,9 @@ ores::trading::messaging::instrument_export_result to_export_result(
             return ex;
         }
         else if constexpr (std::is_same_v<T, commodity_mapping_result>)
-            return v.instrument;
+            return commodity_export_result{v.instrument};
         else if constexpr (std::is_same_v<T, scripted_mapping_result>)
-            return v.instrument;
+            return scripted_export_result{v.instrument};
         else if constexpr (std::is_same_v<T, composite_mapping_result>)
             return composite_export_result{v.instrument, {}};
         return std::monostate{};

--- a/projects/ores.qt.trading/src/BondInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/BondInstrumentForm.cpp
@@ -178,9 +178,9 @@ void BondInstrumentForm::writeUiToInstrument() {
 void BondInstrumentForm::setInstrument(
     const trading::messaging::instrument_export_result& instrument) {
 
-    const auto* bond =
-        std::get_if<trading::domain::bond_instrument>(&instrument);
-    if (!bond) {
+    const auto* ex =
+        std::get_if<trading::messaging::bond_export_result>(&instrument);
+    if (!ex) {
         BOOST_LOG_SEV(lg(), warn)
             << "Non-bond instrument pushed to BondInstrumentForm";
         emit loadFailed(QStringLiteral(
@@ -188,7 +188,7 @@ void BondInstrumentForm::setInstrument(
         return;
     }
 
-    instrument_ = *bond;
+    instrument_ = ex->instrument;
     loaded_ = true;
     dirty_ = false;
     populateFromInstrument();

--- a/projects/ores.qt.trading/src/CommodityInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/CommodityInstrumentForm.cpp
@@ -242,9 +242,9 @@ void CommodityInstrumentForm::writeUiToInstrument() {
 void CommodityInstrumentForm::setInstrument(
     const trading::messaging::instrument_export_result& instrument) {
 
-    const auto* commodity =
-        std::get_if<trading::domain::commodity_instrument>(&instrument);
-    if (!commodity) {
+    const auto* ex =
+        std::get_if<trading::messaging::commodity_export_result>(&instrument);
+    if (!ex) {
         BOOST_LOG_SEV(lg(), warn)
             << "Non-commodity instrument pushed to CommodityInstrumentForm";
         emit loadFailed(QStringLiteral(
@@ -252,7 +252,7 @@ void CommodityInstrumentForm::setInstrument(
         return;
     }
 
-    instrument_ = *commodity;
+    instrument_ = ex->instrument;
     loaded_ = true;
     dirty_ = false;
     populateFromInstrument();

--- a/projects/ores.qt.trading/src/CreditInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/CreditInstrumentForm.cpp
@@ -196,9 +196,9 @@ void CreditInstrumentForm::writeUiToInstrument() {
 void CreditInstrumentForm::setInstrument(
     const trading::messaging::instrument_export_result& instrument) {
 
-    const auto* credit =
-        std::get_if<trading::domain::credit_instrument>(&instrument);
-    if (!credit) {
+    const auto* ex =
+        std::get_if<trading::messaging::credit_export_result>(&instrument);
+    if (!ex) {
         BOOST_LOG_SEV(lg(), warn)
             << "Non-credit instrument pushed to CreditInstrumentForm";
         emit loadFailed(QStringLiteral(
@@ -206,7 +206,7 @@ void CreditInstrumentForm::setInstrument(
         return;
     }
 
-    instrument_ = *credit;
+    instrument_ = ex->instrument;
     loaded_ = true;
     dirty_ = false;
     populateFromInstrument();

--- a/projects/ores.qt.trading/src/ScriptedInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/ScriptedInstrumentForm.cpp
@@ -112,9 +112,9 @@ void ScriptedInstrumentForm::writeUiToInstrument() {
 void ScriptedInstrumentForm::setInstrument(
     const trading::messaging::instrument_export_result& instrument) {
 
-    const auto* inst =
-        std::get_if<trading::domain::scripted_instrument>(&instrument);
-    if (!inst) {
+    const auto* ex =
+        std::get_if<trading::messaging::scripted_export_result>(&instrument);
+    if (!ex) {
         BOOST_LOG_SEV(lg(), warn)
             << "Non-scripted instrument pushed to ScriptedInstrumentForm";
         emit loadFailed(QStringLiteral(
@@ -122,7 +122,7 @@ void ScriptedInstrumentForm::setInstrument(
         return;
     }
 
-    instrument_ = *inst;
+    instrument_ = ex->instrument;
     loaded_ = true;
     dirty_ = false;
     populateFromInstrument();

--- a/projects/ores.trading.api/include/ores.trading.api/messaging/instrument_protocol.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/messaging/instrument_protocol.hpp
@@ -1107,11 +1107,39 @@ struct equity_export_result {
 };
 
 /**
+ * @brief Bond instrument, used in export/fetch results.
+ */
+struct bond_export_result {
+    ores::trading::domain::bond_instrument instrument;
+};
+
+/**
+ * @brief Credit instrument, used in export/fetch results.
+ */
+struct credit_export_result {
+    ores::trading::domain::credit_instrument instrument;
+};
+
+/**
+ * @brief Commodity instrument, used in export/fetch results.
+ */
+struct commodity_export_result {
+    ores::trading::domain::commodity_instrument instrument;
+};
+
+/**
  * @brief Composite instrument with its constituent legs.
  */
 struct composite_export_result {
     ores::trading::domain::composite_instrument instrument;
     std::vector<ores::trading::domain::composite_leg> legs;
+};
+
+/**
+ * @brief Scripted instrument, used in export/fetch results.
+ */
+struct scripted_export_result {
+    ores::trading::domain::scripted_instrument instrument;
 };
 
 /**
@@ -1125,12 +1153,12 @@ using instrument_export_result = std::variant<
     std::monostate,
     swap_export_result,
     fx_export_result,
-    ores::trading::domain::bond_instrument,
-    ores::trading::domain::credit_instrument,
+    bond_export_result,
+    credit_export_result,
     equity_export_result,
-    ores::trading::domain::commodity_instrument,
+    commodity_export_result,
     composite_export_result,
-    ores::trading::domain::scripted_instrument
+    scripted_export_result
 >;
 
 }

--- a/projects/ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp
@@ -255,14 +255,20 @@ private:
         }
         case product_type::bond: {
             service::bond_instrument_service isvc(ctx);
-            if (auto r = isvc.get_bond_instrument(id))
-                item.instrument = std::move(*r);
+            if (auto r = isvc.get_bond_instrument(id)) {
+                bond_export_result ex;
+                ex.instrument = std::move(*r);
+                item.instrument = std::move(ex);
+            }
             break;
         }
         case product_type::credit: {
             service::credit_instrument_service isvc(ctx);
-            if (auto r = isvc.get_credit_instrument(id))
-                item.instrument = std::move(*r);
+            if (auto r = isvc.get_credit_instrument(id)) {
+                credit_export_result ex;
+                ex.instrument = std::move(*r);
+                item.instrument = std::move(ex);
+            }
             break;
         }
         case product_type::equity: {
@@ -342,8 +348,11 @@ private:
         }
         case product_type::commodity: {
             service::commodity_instrument_service isvc(ctx);
-            if (auto r = isvc.get_commodity_instrument(id))
-                item.instrument = std::move(*r);
+            if (auto r = isvc.get_commodity_instrument(id)) {
+                commodity_export_result ex;
+                ex.instrument = std::move(*r);
+                item.instrument = std::move(ex);
+            }
             break;
         }
         case product_type::composite: {
@@ -358,8 +367,11 @@ private:
         }
         case product_type::scripted: {
             service::scripted_instrument_service isvc(ctx);
-            if (auto r = isvc.get_scripted_instrument(id))
-                item.instrument = std::move(*r);
+            if (auto r = isvc.get_scripted_instrument(id)) {
+                scripted_export_result ex;
+                ex.instrument = std::move(*r);
+                item.instrument = std::move(ex);
+            }
             break;
         }
         }

--- a/projects/ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp
@@ -255,20 +255,14 @@ private:
         }
         case product_type::bond: {
             service::bond_instrument_service isvc(ctx);
-            if (auto r = isvc.get_bond_instrument(id)) {
-                bond_export_result ex;
-                ex.instrument = std::move(*r);
-                item.instrument = std::move(ex);
-            }
+            if (auto r = isvc.get_bond_instrument(id))
+                item.instrument = bond_export_result{std::move(*r)};
             break;
         }
         case product_type::credit: {
             service::credit_instrument_service isvc(ctx);
-            if (auto r = isvc.get_credit_instrument(id)) {
-                credit_export_result ex;
-                ex.instrument = std::move(*r);
-                item.instrument = std::move(ex);
-            }
+            if (auto r = isvc.get_credit_instrument(id))
+                item.instrument = credit_export_result{std::move(*r)};
             break;
         }
         case product_type::equity: {
@@ -348,11 +342,8 @@ private:
         }
         case product_type::commodity: {
             service::commodity_instrument_service isvc(ctx);
-            if (auto r = isvc.get_commodity_instrument(id)) {
-                commodity_export_result ex;
-                ex.instrument = std::move(*r);
-                item.instrument = std::move(ex);
-            }
+            if (auto r = isvc.get_commodity_instrument(id))
+                item.instrument = commodity_export_result{std::move(*r)};
             break;
         }
         case product_type::composite: {
@@ -367,11 +358,8 @@ private:
         }
         case product_type::scripted: {
             service::scripted_instrument_service isvc(ctx);
-            if (auto r = isvc.get_scripted_instrument(id)) {
-                scripted_export_result ex;
-                ex.instrument = std::move(*r);
-                item.instrument = std::move(ex);
-            }
+            if (auto r = isvc.get_scripted_instrument(id))
+                item.instrument = scripted_export_result{std::move(*r)};
             break;
         }
         }


### PR DESCRIPTION
## Summary

- Introduces four new export-result wrappers — `bond_export_result`, `credit_export_result`, `commodity_export_result`, `scripted_export_result` — each holding the single per-family instrument, symmetric with the existing `swap_export_result`, `fx_export_result`, `equity_export_result`, and `composite_export_result`.
- Updates `instrument_export_result` (the top-level variant) to use the new wrappers instead of bare domain types.
- Updates `trade_handler::populate_instrument_for_trade` to populate the four new wrappers.
- Updates the ORE exporter's `std::visit` dispatch to unwrap `.instrument` from each result.
- Updates `BondInstrumentForm`, `CreditInstrumentForm`, `CommodityInstrumentForm`, and `ScriptedInstrumentForm` to pattern-match the new wrapper types in `setInstrument`.

This is PR #3 of the product-family migration series (plan: `doc/plans/2026-04-21-fx-forward-import-e2e.org`). All nine instrument families in `instrument_export_result` now follow a uniform named-wrapper shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)