### PR TITLE
[qt,trading] Currency combos with flag icons, date pickers, and dialog polish

### DIFF
--- a/external/ore/examples/Products/SupportedTrades/FX_Option_European.xml
+++ b/external/ore/examples/Products/SupportedTrades/FX_Option_European.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Portfolio>
+    <Trade id="FX_CALL_OPTION">
+        <TradeType>FxOption</TradeType>
+        <Envelope>
+            <CounterParty>CPTY</CounterParty>
+            <NettingSetId>NS</NettingSetId>
+            <AdditionalFields>
+                <party_id>party</party_id>
+                <valuation_date>2025-02-10</valuation_date>
+            </AdditionalFields>
+        </Envelope>
+        <FxOptionData>
+            <OptionData>
+                <LongShort>Long</LongShort>
+                <OptionType>Call</OptionType>
+                <Style>European</Style>
+                <Settlement>Cash</Settlement>
+                <PayOffAtExpiry>false</PayOffAtExpiry>
+                <ExerciseDates>
+                    <ExerciseDate>2033-02-20</ExerciseDate>
+                </ExerciseDates>
+                <Premiums>
+                    <Premium>
+                        <Amount>10900</Amount>
+                        <Currency>EUR</Currency>
+                        <PayDate>2025-02-20</PayDate>
+                    </Premium>
+                </Premiums>
+            </OptionData>
+            <BoughtCurrency>EUR</BoughtCurrency>
+            <BoughtAmount>1000000</BoughtAmount>
+            <SoldCurrency>USD</SoldCurrency>
+            <SoldAmount>1100000</SoldAmount>
+        </FxOptionData>
+    </Trade>
+</Portfolio>

--- a/projects/ores.codegen/library/templates/cpp_qt_client_model.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_client_model.cpp.mustache
@@ -23,7 +23,7 @@ namespace {
 
 Client{{domain_entity.entity_pascal}}Model::Client{{domain_entity.entity_pascal}}Model(
     ClientManager* clientManager, QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager),
       watcher_(new QFutureWatcher<FetchResult>(this)),
       recencyTracker_({{domain_entity.entity_snake}}_key_extractor),

--- a/projects/ores.codegen/library/templates/cpp_qt_client_model.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_client_model.hpp.mustache
@@ -5,7 +5,6 @@
 
 #include <vector>
 #include <QFutureWatcher>
-#include <QAbstractTableModel>
 #include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"

--- a/projects/ores.codegen/library/templates/cpp_qt_client_model.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_client_model.hpp.mustache
@@ -6,6 +6,7 @@
 #include <vector>
 #include <QFutureWatcher>
 #include <QAbstractTableModel>
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"
 #include "ores.qt/RecencyTracker.hpp"
@@ -17,10 +18,10 @@ namespace ores::qt {
 /**
  * @brief Model for displaying {{domain_entity.entity_plural_words}} fetched from the server.
  *
- * This model extends QAbstractTableModel and fetches {{domain_entity.entity_singular_words}}
+ * This model extends AbstractClientModel and fetches {{domain_entity.entity_singular_words}}
  * data asynchronously using the ores.comms client.
  */
-class Client{{domain_entity.entity_pascal}}Model final : public QAbstractTableModel {
+class Client{{domain_entity.entity_pascal}}Model final : public AbstractClientModel {
     Q_OBJECT
 
 private:
@@ -87,17 +88,6 @@ public:
      * @brief Get the total number of records available on the server.
      */
     std::uint32_t total_available_count() const { return total_available_count_; }
-
-signals:
-    /**
-     * @brief Emitted when data has been successfully loaded.
-     */
-    void dataLoaded();
-
-    /**
-     * @brief Emitted when an error occurs during data loading.
-     */
-    void loadError(const QString& error_message, const QString& details = {});
 
 private slots:
     void on{{domain_entity.entity_pascal_short_plural}}Loaded();

--- a/projects/ores.codegen/library/templates/cpp_qt_mdi_window.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_mdi_window.cpp.mustache
@@ -39,9 +39,7 @@ using namespace ores::logging;
 
     setupUi();
     setupConnections();
-
-    // Initial load
-    doReload();
+    reload();
 }
 
 void {{domain_entity.entity_pascal}}MdiWindow::setupUi() {
@@ -49,6 +47,7 @@ void {{domain_entity.entity_pascal}}MdiWindow::setupUi() {
 
     setupToolbar();
     layout->addWidget(toolbar_);
+    layout->addWidget(loadingBar());
 
     setupTable();
     layout->addWidget(tableView_);
@@ -68,7 +67,7 @@ void {{domain_entity.entity_pascal}}MdiWindow::setupToolbar() {
             Icon::ArrowClockwise, IconUtils::DefaultIconColor),
         tr("Reload"));
     connect(reloadAction_, &QAction::triggered, this,
-            &{{domain_entity.entity_pascal}}MdiWindow::doReload);
+            &EntityListMdiWindow::reload);
 
     initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
 
@@ -165,6 +164,8 @@ void {{domain_entity.entity_pascal}}MdiWindow::setupConnections() {
             this, [this](std::uint32_t offset, std::uint32_t limit) {
         model_->load_page(offset, limit);
     });
+
+    connectModel(model_);
 }
 
 void {{domain_entity.entity_pascal}}MdiWindow::doReload() {

--- a/projects/ores.ore/include/ores.ore/xml/importer.hpp
+++ b/projects/ores.ore/include/ores.ore/xml/importer.hpp
@@ -169,6 +169,17 @@ public:
      * No-op for items whose trade type has no instrument mapping (monostate).
      */
     static void rewire_instrument_trade_id(trade_import_item& item);
+
+    /**
+     * @brief Assigns @p id as the instrument_id on both the instrument and
+     *        trade.instrument_id, establishing the forward FK from trade to
+     *        instrument so that populate_instrument_for_trade can find it.
+     *
+     * Call after rewire_instrument_trade_id once a stable UUID has been minted.
+     * No-op for items whose trade type has no instrument mapping (monostate).
+     */
+    static void assign_instrument_id(
+        trade_import_item& item, boost::uuids::uuid id);
 };
 
 }

--- a/projects/ores.ore/src/planner/ore_import_planner.cpp
+++ b/projects/ores.ore/src/planner/ore_import_planner.cpp
@@ -98,6 +98,7 @@ ore_import_plan ore_import_planner::plan() {
                 for (auto& item : items) {
                     item.trade.id           = uuid_gen();
                     xml::importer::rewire_instrument_trade_id(item);
+                    xml::importer::assign_instrument_id(item, uuid_gen());
                     item.trade.book_id      = target_book_id;
                     item.trade.portfolio_id = target_portfolio_id;
                     item.trade.party_id     = choices_.party_id;
@@ -215,6 +216,7 @@ ore_import_plan ore_import_planner::plan() {
             for (auto& item : items) {
                 item.trade.id = uuid_gen();
                 xml::importer::rewire_instrument_trade_id(item);
+                xml::importer::assign_instrument_id(item, uuid_gen());
                 item.trade.book_id = b.id;
                 item.trade.portfolio_id = book_parent_id;
                 item.trade.party_id = choices_.party_id;

--- a/projects/ores.ore/src/xml/importer.cpp
+++ b/projects/ores.ore/src/xml/importer.cpp
@@ -251,6 +251,29 @@ void importer::rewire_instrument_trade_id(trade_import_item& item) {
     }, item.instrument);
 }
 
+void importer::assign_instrument_id(
+    trade_import_item& item, boost::uuids::uuid id) {
+    bool has_instrument = false;
+    std::visit([&](auto& result) {
+        using T = std::decay_t<decltype(result)>;
+        if constexpr (std::is_same_v<T, std::monostate>) {
+            // No instrument for this trade type.
+        } else if constexpr (std::is_same_v<T, domain::swap_mapping_result> ||
+                             std::is_same_v<T, domain::fx_mapping_result> ||
+                             std::is_same_v<T, domain::equity_mapping_result>) {
+            std::visit([&](auto& instr) {
+                instr.instrument_id = id;
+            }, result.instrument);
+            has_instrument = true;
+        } else {
+            result.instrument.instrument_id = id;
+            has_instrument = true;
+        }
+    }, item.instrument);
+    if (has_instrument)
+        item.trade.instrument_id = id;
+}
+
 domain::mapped_conventions
 importer::import_conventions(const std::filesystem::path& path) {
     BOOST_LOG_SEV(lg(), debug) << "Started import: " << path.generic_string();

--- a/projects/ores.ore/src/xml/importer.cpp
+++ b/projects/ores.ore/src/xml/importer.cpp
@@ -261,12 +261,18 @@ void importer::assign_instrument_id(
         } else if constexpr (std::is_same_v<T, domain::swap_mapping_result> ||
                              std::is_same_v<T, domain::fx_mapping_result> ||
                              std::is_same_v<T, domain::equity_mapping_result>) {
+            // Nested variant: each inner instrument uses instrument_id
             std::visit([&](auto& instr) {
                 instr.instrument_id = id;
             }, result.instrument);
             has_instrument = true;
-        } else {
-            result.instrument.instrument_id = id;
+        } else if constexpr (std::is_same_v<T, domain::bond_mapping_result> ||
+                             std::is_same_v<T, domain::credit_mapping_result> ||
+                             std::is_same_v<T, domain::commodity_mapping_result> ||
+                             std::is_same_v<T, domain::scripted_mapping_result> ||
+                             std::is_same_v<T, domain::composite_mapping_result>) {
+            // Direct instrument: these types use id rather than instrument_id
+            result.instrument.id = id;
             has_instrument = true;
         }
     }, item.instrument);

--- a/projects/ores.qt.admin/include/ores.qt/ClientBadgeDefinitionModel.hpp
+++ b/projects/ores.qt.admin/include/ores.qt/ClientBadgeDefinitionModel.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <QFutureWatcher>
 #include <QAbstractTableModel>
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"
 #include "ores.qt/RecencyTracker.hpp"
@@ -34,10 +35,10 @@ namespace ores::qt {
 /**
  * @brief Model for displaying badge definitions fetched from the server.
  *
- * This model extends QAbstractTableModel and fetches badge definition
+ * This model extends AbstractClientModel and fetches badge definition
  * data asynchronously using the ores.comms client.
  */
-class ClientBadgeDefinitionModel final : public QAbstractTableModel {
+class ClientBadgeDefinitionModel final : public AbstractClientModel {
     Q_OBJECT
 
 private:
@@ -111,17 +112,6 @@ public:
      * @brief Get the total number of records available on the server.
      */
     std::uint32_t total_available_count() const { return total_available_count_; }
-
-signals:
-    /**
-     * @brief Emitted when data has been successfully loaded.
-     */
-    void dataLoaded();
-
-    /**
-     * @brief Emitted when an error occurs during data loading.
-     */
-    void loadError(const QString& error_message, const QString& details = {});
 
 private slots:
     void onDefinitionsLoaded();

--- a/projects/ores.qt.admin/include/ores.qt/ClientBadgeSeverityModel.hpp
+++ b/projects/ores.qt.admin/include/ores.qt/ClientBadgeSeverityModel.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <QFutureWatcher>
 #include <QAbstractTableModel>
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"
 #include "ores.qt/RecencyTracker.hpp"
@@ -34,10 +35,10 @@ namespace ores::qt {
 /**
  * @brief Model for displaying badge severities fetched from the server.
  *
- * This model extends QAbstractTableModel and fetches badge severity
+ * This model extends AbstractClientModel and fetches badge severity
  * data asynchronously using the ores.comms client.
  */
-class ClientBadgeSeverityModel final : public QAbstractTableModel {
+class ClientBadgeSeverityModel final : public AbstractClientModel {
     Q_OBJECT
 
 private:
@@ -108,17 +109,6 @@ public:
      * @brief Get the total number of records available on the server.
      */
     std::uint32_t total_available_count() const { return total_available_count_; }
-
-signals:
-    /**
-     * @brief Emitted when data has been successfully loaded.
-     */
-    void dataLoaded();
-
-    /**
-     * @brief Emitted when an error occurs during data loading.
-     */
-    void loadError(const QString& error_message, const QString& details = {});
 
 private slots:
     void onSeveritysLoaded();

--- a/projects/ores.qt.admin/src/BadgeDefinitionMdiWindow.cpp
+++ b/projects/ores.qt.admin/src/BadgeDefinitionMdiWindow.cpp
@@ -174,6 +174,8 @@ void BadgeDefinitionMdiWindow::setupConnections() {
             this, [this](std::uint32_t offset, std::uint32_t limit) {
         model_->load_page(offset, limit);
     });
+
+    connectModel(model_);
 }
 
 void BadgeDefinitionMdiWindow::doReload() {

--- a/projects/ores.qt.admin/src/BadgeSeverityMdiWindow.cpp
+++ b/projects/ores.qt.admin/src/BadgeSeverityMdiWindow.cpp
@@ -174,6 +174,8 @@ void BadgeSeverityMdiWindow::setupConnections() {
             this, [this](std::uint32_t offset, std::uint32_t limit) {
         model_->load_page(offset, limit);
     });
+
+    connectModel(model_);
 }
 
 void BadgeSeverityMdiWindow::doReload() {

--- a/projects/ores.qt.admin/src/ClientBadgeDefinitionModel.cpp
+++ b/projects/ores.qt.admin/src/ClientBadgeDefinitionModel.cpp
@@ -37,7 +37,7 @@ namespace {
 
 ClientBadgeDefinitionModel::ClientBadgeDefinitionModel(
     ClientManager* clientManager, QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager),
       watcher_(new QFutureWatcher<FetchResult>(this)),
       recencyTracker_(badge_definition_key_extractor),

--- a/projects/ores.qt.admin/src/ClientBadgeSeverityModel.cpp
+++ b/projects/ores.qt.admin/src/ClientBadgeSeverityModel.cpp
@@ -37,7 +37,7 @@ namespace {
 
 ClientBadgeSeverityModel::ClientBadgeSeverityModel(
     ClientManager* clientManager, QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager),
       watcher_(new QFutureWatcher<FetchResult>(this)),
       recencyTracker_(badge_severity_key_extractor),

--- a/projects/ores.qt.analytics/include/ores.qt/ClientPricingEngineTypeModel.hpp
+++ b/projects/ores.qt.analytics/include/ores.qt/ClientPricingEngineTypeModel.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <QFutureWatcher>
 #include <QAbstractTableModel>
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"
 #include "ores.qt/RecencyTracker.hpp"
@@ -34,10 +35,10 @@ namespace ores::qt {
 /**
  * @brief Model for displaying pricing engine types fetched from the server.
  *
- * This model extends QAbstractTableModel and fetches pricing engine type
+ * This model extends AbstractClientModel and fetches pricing engine type
  * data asynchronously using the ores.comms client.
  */
-class ClientPricingEngineTypeModel final : public QAbstractTableModel {
+class ClientPricingEngineTypeModel final : public AbstractClientModel {
     Q_OBJECT
 
 private:
@@ -107,17 +108,6 @@ public:
      * @brief Get the total number of records available on the server.
      */
     std::uint32_t total_available_count() const { return total_available_count_; }
-
-signals:
-    /**
-     * @brief Emitted when data has been successfully loaded.
-     */
-    void dataLoaded();
-
-    /**
-     * @brief Emitted when an error occurs during data loading.
-     */
-    void loadError(const QString& error_message, const QString& details = {});
 
 private slots:
     void onTypesLoaded();

--- a/projects/ores.qt.analytics/include/ores.qt/ClientPricingModelConfigModel.hpp
+++ b/projects/ores.qt.analytics/include/ores.qt/ClientPricingModelConfigModel.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <QFutureWatcher>
 #include <QAbstractTableModel>
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"
 #include "ores.qt/RecencyTracker.hpp"
@@ -34,10 +35,10 @@ namespace ores::qt {
 /**
  * @brief Model for displaying pricing model configurations fetched from the server.
  *
- * This model extends QAbstractTableModel and fetches pricing model configuration
+ * This model extends AbstractClientModel and fetches pricing model configuration
  * data asynchronously using the ores.comms client.
  */
-class ClientPricingModelConfigModel final : public QAbstractTableModel {
+class ClientPricingModelConfigModel final : public AbstractClientModel {
     Q_OBJECT
 
 private:
@@ -107,17 +108,6 @@ public:
      * @brief Get the total number of records available on the server.
      */
     std::uint32_t total_available_count() const { return total_available_count_; }
-
-signals:
-    /**
-     * @brief Emitted when data has been successfully loaded.
-     */
-    void dataLoaded();
-
-    /**
-     * @brief Emitted when an error occurs during data loading.
-     */
-    void loadError(const QString& error_message, const QString& details = {});
 
 private slots:
     void onConfigsLoaded();

--- a/projects/ores.qt.analytics/include/ores.qt/ClientPricingModelProductModel.hpp
+++ b/projects/ores.qt.analytics/include/ores.qt/ClientPricingModelProductModel.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <QFutureWatcher>
 #include <QAbstractTableModel>
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"
 #include "ores.qt/RecencyTracker.hpp"
@@ -34,10 +35,10 @@ namespace ores::qt {
 /**
  * @brief Model for displaying pricing model products fetched from the server.
  *
- * This model extends QAbstractTableModel and fetches pricing model product
+ * This model extends AbstractClientModel and fetches pricing model product
  * data asynchronously using the ores.comms client.
  */
-class ClientPricingModelProductModel final : public QAbstractTableModel {
+class ClientPricingModelProductModel final : public AbstractClientModel {
     Q_OBJECT
 
 private:
@@ -107,17 +108,6 @@ public:
      * @brief Get the total number of records available on the server.
      */
     std::uint32_t total_available_count() const { return total_available_count_; }
-
-signals:
-    /**
-     * @brief Emitted when data has been successfully loaded.
-     */
-    void dataLoaded();
-
-    /**
-     * @brief Emitted when an error occurs during data loading.
-     */
-    void loadError(const QString& error_message, const QString& details = {});
 
 private slots:
     void onProductsLoaded();

--- a/projects/ores.qt.analytics/include/ores.qt/ClientPricingModelProductParameterModel.hpp
+++ b/projects/ores.qt.analytics/include/ores.qt/ClientPricingModelProductParameterModel.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <QFutureWatcher>
 #include <QAbstractTableModel>
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"
 #include "ores.qt/RecencyTracker.hpp"
@@ -34,10 +35,10 @@ namespace ores::qt {
 /**
  * @brief Model for displaying pricing model product parameters fetched from the server.
  *
- * This model extends QAbstractTableModel and fetches pricing model product parameter
+ * This model extends AbstractClientModel and fetches pricing model product parameter
  * data asynchronously using the ores.comms client.
  */
-class ClientPricingModelProductParameterModel final : public QAbstractTableModel {
+class ClientPricingModelProductParameterModel final : public AbstractClientModel {
     Q_OBJECT
 
 private:
@@ -107,17 +108,6 @@ public:
      * @brief Get the total number of records available on the server.
      */
     std::uint32_t total_available_count() const { return total_available_count_; }
-
-signals:
-    /**
-     * @brief Emitted when data has been successfully loaded.
-     */
-    void dataLoaded();
-
-    /**
-     * @brief Emitted when an error occurs during data loading.
-     */
-    void loadError(const QString& error_message, const QString& details = {});
 
 private slots:
     void onParametersLoaded();

--- a/projects/ores.qt.analytics/src/ClientPricingEngineTypeModel.cpp
+++ b/projects/ores.qt.analytics/src/ClientPricingEngineTypeModel.cpp
@@ -37,7 +37,7 @@ namespace {
 
 ClientPricingEngineTypeModel::ClientPricingEngineTypeModel(
     ClientManager* clientManager, QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager),
       watcher_(new QFutureWatcher<FetchResult>(this)),
       recencyTracker_(pricing_engine_type_key_extractor),

--- a/projects/ores.qt.analytics/src/ClientPricingModelConfigModel.cpp
+++ b/projects/ores.qt.analytics/src/ClientPricingModelConfigModel.cpp
@@ -38,7 +38,7 @@ namespace {
 
 ClientPricingModelConfigModel::ClientPricingModelConfigModel(
     ClientManager* clientManager, QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager),
       watcher_(new QFutureWatcher<FetchResult>(this)),
       recencyTracker_(pricing_model_config_key_extractor),

--- a/projects/ores.qt.analytics/src/ClientPricingModelProductModel.cpp
+++ b/projects/ores.qt.analytics/src/ClientPricingModelProductModel.cpp
@@ -38,7 +38,7 @@ namespace {
 
 ClientPricingModelProductModel::ClientPricingModelProductModel(
     ClientManager* clientManager, QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager),
       watcher_(new QFutureWatcher<FetchResult>(this)),
       recencyTracker_(pricing_model_product_key_extractor),

--- a/projects/ores.qt.analytics/src/ClientPricingModelProductParameterModel.cpp
+++ b/projects/ores.qt.analytics/src/ClientPricingModelProductParameterModel.cpp
@@ -38,7 +38,7 @@ namespace {
 
 ClientPricingModelProductParameterModel::ClientPricingModelProductParameterModel(
     ClientManager* clientManager, QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager),
       watcher_(new QFutureWatcher<FetchResult>(this)),
       recencyTracker_(pricing_model_product_parameter_key_extractor),

--- a/projects/ores.qt.analytics/src/PricingEngineTypeMdiWindow.cpp
+++ b/projects/ores.qt.analytics/src/PricingEngineTypeMdiWindow.cpp
@@ -55,7 +55,7 @@ PricingEngineTypeMdiWindow::PricingEngineTypeMdiWindow(
     setupConnections();
 
     // Initial load
-    doReload();
+    reload();
 }
 
 void PricingEngineTypeMdiWindow::setupUi() {
@@ -82,7 +82,7 @@ void PricingEngineTypeMdiWindow::setupToolbar() {
             Icon::ArrowClockwise, IconUtils::DefaultIconColor),
         tr("Reload"));
     connect(reloadAction_, &QAction::triggered, this,
-            &PricingEngineTypeMdiWindow::doReload);
+            &EntityListMdiWindow::reload);
 
     initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
 
@@ -174,6 +174,8 @@ void PricingEngineTypeMdiWindow::setupConnections() {
             this, [this](std::uint32_t offset, std::uint32_t limit) {
         model_->load_page(offset, limit);
     });
+
+    connectModel(model_);
 }
 
 void PricingEngineTypeMdiWindow::doReload() {

--- a/projects/ores.qt.analytics/src/PricingModelConfigMdiWindow.cpp
+++ b/projects/ores.qt.analytics/src/PricingModelConfigMdiWindow.cpp
@@ -56,7 +56,7 @@ PricingModelConfigMdiWindow::PricingModelConfigMdiWindow(
     setupConnections();
 
     // Initial load
-    doReload();
+    reload();
 }
 
 void PricingModelConfigMdiWindow::setupUi() {
@@ -83,7 +83,7 @@ void PricingModelConfigMdiWindow::setupToolbar() {
             Icon::ArrowClockwise, IconUtils::DefaultIconColor),
         tr("Reload"));
     connect(reloadAction_, &QAction::triggered, this,
-            &PricingModelConfigMdiWindow::doReload);
+            &EntityListMdiWindow::reload);
 
     initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
 
@@ -175,6 +175,8 @@ void PricingModelConfigMdiWindow::setupConnections() {
             this, [this](std::uint32_t offset, std::uint32_t limit) {
         model_->load_page(offset, limit);
     });
+
+    connectModel(model_);
 }
 
 void PricingModelConfigMdiWindow::doReload() {

--- a/projects/ores.qt.analytics/src/PricingModelProductMdiWindow.cpp
+++ b/projects/ores.qt.analytics/src/PricingModelProductMdiWindow.cpp
@@ -56,7 +56,7 @@ PricingModelProductMdiWindow::PricingModelProductMdiWindow(
     setupConnections();
 
     // Initial load
-    doReload();
+    reload();
 }
 
 void PricingModelProductMdiWindow::setupUi() {
@@ -83,7 +83,7 @@ void PricingModelProductMdiWindow::setupToolbar() {
             Icon::ArrowClockwise, IconUtils::DefaultIconColor),
         tr("Reload"));
     connect(reloadAction_, &QAction::triggered, this,
-            &PricingModelProductMdiWindow::doReload);
+            &EntityListMdiWindow::reload);
 
     initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
 
@@ -175,6 +175,8 @@ void PricingModelProductMdiWindow::setupConnections() {
             this, [this](std::uint32_t offset, std::uint32_t limit) {
         model_->load_page(offset, limit);
     });
+
+    connectModel(model_);
 }
 
 void PricingModelProductMdiWindow::doReload() {

--- a/projects/ores.qt.analytics/src/PricingModelProductParameterMdiWindow.cpp
+++ b/projects/ores.qt.analytics/src/PricingModelProductParameterMdiWindow.cpp
@@ -56,7 +56,7 @@ PricingModelProductParameterMdiWindow::PricingModelProductParameterMdiWindow(
     setupConnections();
 
     // Initial load
-    doReload();
+    reload();
 }
 
 void PricingModelProductParameterMdiWindow::setupUi() {
@@ -83,7 +83,7 @@ void PricingModelProductParameterMdiWindow::setupToolbar() {
             Icon::ArrowClockwise, IconUtils::DefaultIconColor),
         tr("Reload"));
     connect(reloadAction_, &QAction::triggered, this,
-            &PricingModelProductParameterMdiWindow::doReload);
+            &EntityListMdiWindow::reload);
 
     initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
 
@@ -175,6 +175,8 @@ void PricingModelProductParameterMdiWindow::setupConnections() {
             this, [this](std::uint32_t offset, std::uint32_t limit) {
         model_->load_page(offset, limit);
     });
+
+    connectModel(model_);
 }
 
 void PricingModelProductParameterMdiWindow::doReload() {

--- a/projects/ores.qt.api/include/ores.qt/ClientManager.hpp
+++ b/projects/ores.qt.api/include/ores.qt/ClientManager.hpp
@@ -32,6 +32,7 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/random_generator.hpp>
 #include <rfl/json.hpp>
+#include <rfl/AddTagsToVariants.hpp>
 #include <QObject>
 #include <QTimer>
 #include "ores.utility/rfl/reflectors.hpp"
@@ -343,7 +344,7 @@ public:
             const std::string_view data(
                 reinterpret_cast<const char*>(msg.data.data()),
                 msg.data.size());
-            auto result = rfl::json::read<ResponseType>(data);
+            auto result = rfl::json::read<ResponseType, rfl::AddTagsToVariants>(data);
             if (!result) {
                 return std::unexpected(
                     std::string("Failed to deserialize response: ") +
@@ -387,7 +388,7 @@ public:
             const std::string_view data(
                 reinterpret_cast<const char*>(msg.data.data()),
                 msg.data.size());
-            auto result = rfl::json::read<ResponseType>(data);
+            auto result = rfl::json::read<ResponseType, rfl::AddTagsToVariants>(data);
             if (!result) {
                 return std::unexpected(
                     std::string("Failed to deserialize response: ") +

--- a/projects/ores.qt.api/include/ores.qt/UiPersistence.hpp
+++ b/projects/ores.qt.api/include/ores.qt/UiPersistence.hpp
@@ -27,6 +27,7 @@
 class QWidget;
 class QSplitter;
 class QHeaderView;
+class QMdiSubWindow;
 
 namespace ores::qt {
 
@@ -90,6 +91,19 @@ public:
      */
     static bool restoreHeader(const QString& group, QHeaderView* h,
                               int version = 1);
+
+    /**
+     * @brief Save MDI sub-window geometry (position and size within the MDI
+     *        area) to settings.
+     */
+    static void saveMdiGeometry(const QString& group, const QMdiSubWindow* w);
+
+    /**
+     * @brief Restore saved MDI sub-window geometry.
+     *
+     * @return true if saved state was applied; false if no saved state.
+     */
+    static bool restoreMdiGeometry(const QString& group, QMdiSubWindow* w);
 };
 
 }

--- a/projects/ores.qt.api/src/EntityController.cpp
+++ b/projects/ores.qt.api/src/EntityController.cpp
@@ -159,9 +159,12 @@ void EntityController::untrack_window(const QString& key) {
 
 void EntityController::show_managed_window(DetachableMdiSubWindow* window,
     DetachableMdiSubWindow* referenceWindow, QPoint offset) {
+    BOOST_LOG_SEV(lg(), info) << "DIAG: show_managed_window calling addSubWindow";
     mdiArea_->addSubWindow(window);
+    BOOST_LOG_SEV(lg(), info) << "DIAG: show_managed_window addSubWindow returned, calling adjustSize";
     window->setWindowFlags(window->windowFlags() & ~Qt::WindowMaximizeButtonHint);
     window->adjustSize();
+    BOOST_LOG_SEV(lg(), info) << "DIAG: show_managed_window adjustSize returned, calling show";
 
     if (referenceWindow && referenceWindow->isDetached()) {
         window->show();
@@ -171,6 +174,7 @@ void EntityController::show_managed_window(DetachableMdiSubWindow* window,
     } else {
         window->show();
     }
+    BOOST_LOG_SEV(lg(), info) << "DIAG: show_managed_window show returned";
 
     if (referenceWindow) {
         QPointer<EntityController> self = this;

--- a/projects/ores.qt.api/src/EntityListMdiWindow.cpp
+++ b/projects/ores.qt.api/src/EntityListMdiWindow.cpp
@@ -110,7 +110,7 @@ QProgressBar* EntityListMdiWindow::loadingBar() {
     if (!loadingBar_) {
         loadingBar_ = new QProgressBar(this);
         loadingBar_->setRange(0, 0);  // indeterminate (marquee) mode
-        loadingBar_->setFixedHeight(4);
+        loadingBar_->setFixedHeight(20);
         loadingBar_->setTextVisible(false);
         loadingBar_->hide();
     }

--- a/projects/ores.qt.api/src/UiPersistence.cpp
+++ b/projects/ores.qt.api/src/UiPersistence.cpp
@@ -23,6 +23,7 @@
 #include <QWidget>
 #include <QSplitter>
 #include <QHeaderView>
+#include <QMdiSubWindow>
 
 namespace ores::qt {
 
@@ -90,6 +91,27 @@ bool UiPersistence::restoreHeader(const QString& group, QHeaderView* h,
     s.setValue("settingsVersion", version);
     s.endGroup();
     return false;
+}
+
+void UiPersistence::saveMdiGeometry(const QString& group, const QMdiSubWindow* w) {
+    auto s = openSettings();
+    s.beginGroup(group);
+    s.setValue("mdiGeometry", w->geometry());
+    s.endGroup();
+}
+
+bool UiPersistence::restoreMdiGeometry(const QString& group, QMdiSubWindow* w) {
+    auto s = openSettings();
+    s.beginGroup(group);
+    if (!s.contains("mdiGeometry")) {
+        s.endGroup();
+        return false;
+    }
+    const QRect r = s.value("mdiGeometry").toRect();
+    s.endGroup();
+    if (!r.isValid()) return false;
+    w->setGeometry(r);
+    return true;
 }
 
 }

--- a/projects/ores.qt.mktdata/src/MarketFixingDetailMdiWindow.cpp
+++ b/projects/ores.qt.mktdata/src/MarketFixingDetailMdiWindow.cpp
@@ -90,6 +90,7 @@ void MarketFixingDetailMdiWindow::setupUi() {
     connect(model_.get(), &ClientMarketFixingModel::loadError,
             this, &MarketFixingDetailMdiWindow::onLoadError);
 
+    connectModel(model_.get());
     model_->refresh();
 }
 
@@ -101,7 +102,7 @@ void MarketFixingDetailMdiWindow::setupToolbar() {
         Icon::ArrowSync, color_constants::icon_color));
     reloadAction_->setToolTip(tr("Refresh fixings"));
     connect(reloadAction_, &QAction::triggered,
-            this, &MarketFixingDetailMdiWindow::doReload);
+            this, &EntityListMdiWindow::reload);
     toolBar_->addAction(reloadAction_);
     initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowSync));
 }

--- a/projects/ores.qt.mktdata/src/MarketFixingsMdiWindow.cpp
+++ b/projects/ores.qt.mktdata/src/MarketFixingsMdiWindow.cpp
@@ -79,6 +79,7 @@ void MarketFixingsMdiWindow::setupUi() {
             this, &MarketFixingsMdiWindow::onDataLoaded);
     connect(model_.get(), &ClientMarketSeriesModel::loadError,
             this, &MarketFixingsMdiWindow::onLoadError);
+    connectModel(model_.get());
     connect(tableView_, &QTableView::doubleClicked,
             this, &MarketFixingsMdiWindow::onRowDoubleClicked);
     connect(tableView_->selectionModel(),
@@ -125,7 +126,7 @@ void MarketFixingsMdiWindow::setupToolbar() {
         Icon::ArrowSync, iconColor));
     reloadAction_->setToolTip(tr("Refresh fixing series"));
     connect(reloadAction_, &QAction::triggered,
-            this, &MarketFixingsMdiWindow::doReload);
+            this, &EntityListMdiWindow::reload);
     toolBar_->addAction(reloadAction_);
     initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowSync));
 

--- a/projects/ores.qt.mktdata/src/MarketObservationMdiWindow.cpp
+++ b/projects/ores.qt.mktdata/src/MarketObservationMdiWindow.cpp
@@ -90,6 +90,7 @@ void MarketObservationMdiWindow::setupUi() {
     connect(model_.get(), &ClientMarketObservationModel::loadError,
             this, &MarketObservationMdiWindow::onLoadError);
 
+    connectModel(model_.get());
     model_->refresh();
 }
 
@@ -101,7 +102,7 @@ void MarketObservationMdiWindow::setupToolbar() {
         Icon::ArrowSync, color_constants::icon_color));
     reloadAction_->setToolTip(tr("Refresh observations"));
     connect(reloadAction_, &QAction::triggered,
-            this, &MarketObservationMdiWindow::doReload);
+            this, &EntityListMdiWindow::reload);
     toolBar_->addAction(reloadAction_);
     initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowSync));
 }

--- a/projects/ores.qt.mktdata/src/MarketSeriesMdiWindow.cpp
+++ b/projects/ores.qt.mktdata/src/MarketSeriesMdiWindow.cpp
@@ -87,6 +87,7 @@ void MarketSeriesMdiWindow::setupUi() {
             this, &MarketSeriesMdiWindow::onDataLoaded);
     connect(model_.get(), &ClientMarketSeriesModel::loadError,
             this, &MarketSeriesMdiWindow::onLoadError);
+    connectModel(model_.get());
     connect(tableView_, &QTableView::doubleClicked,
             this, &MarketSeriesMdiWindow::onRowDoubleClicked);
     connect(tableView_->selectionModel(),
@@ -138,7 +139,7 @@ void MarketSeriesMdiWindow::setupToolbar() {
         Icon::ArrowSync, iconColor));
     reloadAction_->setToolTip(tr("Refresh market series"));
     connect(reloadAction_, &QAction::triggered,
-            this, &MarketSeriesMdiWindow::doReload);
+            this, &EntityListMdiWindow::reload);
     toolBar_->addAction(reloadAction_);
     initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowSync));
 

--- a/projects/ores.qt.refdata/include/ores.qt/ClientBusinessDayConventionTypeModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientBusinessDayConventionTypeModel.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <QFutureWatcher>
 #include <QAbstractTableModel>
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"
 #include "ores.qt/RecencyTracker.hpp"
@@ -34,10 +35,10 @@ namespace ores::qt {
 /**
  * @brief Model for displaying business day convention types fetched from the server.
  *
- * This model extends QAbstractTableModel and fetches business day convention type
+ * This model extends AbstractClientModel and fetches business day convention type
  * data asynchronously using the ores.comms client.
  */
-class ClientBusinessDayConventionTypeModel final : public QAbstractTableModel {
+class ClientBusinessDayConventionTypeModel final : public AbstractClientModel {
     Q_OBJECT
 
 private:
@@ -106,17 +107,6 @@ public:
      * @brief Get the total number of records available on the server.
      */
     std::uint32_t total_available_count() const { return total_available_count_; }
-
-signals:
-    /**
-     * @brief Emitted when data has been successfully loaded.
-     */
-    void dataLoaded();
-
-    /**
-     * @brief Emitted when an error occurs during data loading.
-     */
-    void loadError(const QString& error_message, const QString& details = {});
 
 private slots:
     void onTypesLoaded();

--- a/projects/ores.qt.refdata/include/ores.qt/ClientCatalogModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientCatalogModel.hpp
@@ -24,6 +24,7 @@
 #include <QAbstractTableModel>
 #include <vector>
 #include "ores.dq.api/domain/catalog.hpp"
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/ColumnMetadata.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"
@@ -39,7 +40,7 @@ namespace ores::qt {
  * recently modified records. Records modified since the last reload
  * are highlighted with a pulsing color effect.
  */
-class ClientCatalogModel : public QAbstractTableModel {
+class ClientCatalogModel : public AbstractClientModel {
     Q_OBJECT
 
 private:

--- a/projects/ores.qt.refdata/include/ores.qt/ClientCodeDomainModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientCodeDomainModel.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <QFutureWatcher>
 #include <QAbstractTableModel>
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"
 #include "ores.qt/RecencyTracker.hpp"
@@ -34,10 +35,10 @@ namespace ores::qt {
 /**
  * @brief Model for displaying code domains fetched from the server.
  *
- * This model extends QAbstractTableModel and fetches code domain
+ * This model extends AbstractClientModel and fetches code domain
  * data asynchronously using the ores.comms client.
  */
-class ClientCodeDomainModel final : public QAbstractTableModel {
+class ClientCodeDomainModel final : public AbstractClientModel {
     Q_OBJECT
 
 private:
@@ -108,17 +109,6 @@ public:
      * @brief Get the total number of records available on the server.
      */
     std::uint32_t total_available_count() const { return total_available_count_; }
-
-signals:
-    /**
-     * @brief Emitted when data has been successfully loaded.
-     */
-    void dataLoaded();
-
-    /**
-     * @brief Emitted when an error occurs during data loading.
-     */
-    void loadError(const QString& error_message, const QString& details = {});
 
 private slots:
     void onDomainsLoaded();

--- a/projects/ores.qt.refdata/include/ores.qt/ClientDatasetDependencyModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientDatasetDependencyModel.hpp
@@ -23,6 +23,7 @@
 #include <QAbstractTableModel>
 #include <vector>
 #include "ores.dq.api/domain/dataset_dependency.hpp"
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.logging/make_logger.hpp"
 
@@ -34,7 +35,7 @@ namespace ores::qt {
  * Provides async loading from server. This is a read-only model
  * for viewing dependencies between datasets.
  */
-class ClientDatasetDependencyModel : public QAbstractTableModel {
+class ClientDatasetDependencyModel : public AbstractClientModel {
     Q_OBJECT
 
 private:

--- a/projects/ores.qt.refdata/include/ores.qt/ClientDayCountFractionTypeModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientDayCountFractionTypeModel.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <QFutureWatcher>
 #include <QAbstractTableModel>
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"
 #include "ores.qt/RecencyTracker.hpp"
@@ -34,10 +35,10 @@ namespace ores::qt {
 /**
  * @brief Model for displaying day count fraction types fetched from the server.
  *
- * This model extends QAbstractTableModel and fetches day count fraction type
+ * This model extends AbstractClientModel and fetches day count fraction type
  * data asynchronously using the ores.comms client.
  */
-class ClientDayCountFractionTypeModel final : public QAbstractTableModel {
+class ClientDayCountFractionTypeModel final : public AbstractClientModel {
     Q_OBJECT
 
 private:
@@ -106,17 +107,6 @@ public:
      * @brief Get the total number of records available on the server.
      */
     std::uint32_t total_available_count() const { return total_available_count_; }
-
-signals:
-    /**
-     * @brief Emitted when data has been successfully loaded.
-     */
-    void dataLoaded();
-
-    /**
-     * @brief Emitted when an error occurs during data loading.
-     */
-    void loadError(const QString& error_message, const QString& details = {});
 
 private slots:
     void onTypesLoaded();

--- a/projects/ores.qt.refdata/include/ores.qt/ClientDepositConventionModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientDepositConventionModel.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <QFutureWatcher>
 #include <QAbstractTableModel>
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"
 #include "ores.qt/RecencyTracker.hpp"
@@ -34,10 +35,10 @@ namespace ores::qt {
 /**
  * @brief Model for displaying deposit conventions fetched from the server.
  *
- * This model extends QAbstractTableModel and fetches deposit convention
+ * This model extends AbstractClientModel and fetches deposit convention
  * data asynchronously using the ores.comms client.
  */
-class ClientDepositConventionModel final : public QAbstractTableModel {
+class ClientDepositConventionModel final : public AbstractClientModel {
     Q_OBJECT
 
 private:
@@ -109,17 +110,6 @@ public:
      * @brief Get the total number of records available on the server.
      */
     std::uint32_t total_available_count() const { return total_available_count_; }
-
-signals:
-    /**
-     * @brief Emitted when data has been successfully loaded.
-     */
-    void dataLoaded();
-
-    /**
-     * @brief Emitted when an error occurs during data loading.
-     */
-    void loadError(const QString& error_message, const QString& details = {});
 
 private slots:
     void onConventionsLoaded();

--- a/projects/ores.qt.refdata/include/ores.qt/ClientFloatingIndexTypeModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientFloatingIndexTypeModel.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <QFutureWatcher>
 #include <QAbstractTableModel>
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"
 #include "ores.qt/RecencyTracker.hpp"
@@ -34,10 +35,10 @@ namespace ores::qt {
 /**
  * @brief Model for displaying floating index types fetched from the server.
  *
- * This model extends QAbstractTableModel and fetches floating index type
+ * This model extends AbstractClientModel and fetches floating index type
  * data asynchronously using the ores.comms client.
  */
-class ClientFloatingIndexTypeModel final : public QAbstractTableModel {
+class ClientFloatingIndexTypeModel final : public AbstractClientModel {
     Q_OBJECT
 
 private:
@@ -106,17 +107,6 @@ public:
      * @brief Get the total number of records available on the server.
      */
     std::uint32_t total_available_count() const { return total_available_count_; }
-
-signals:
-    /**
-     * @brief Emitted when data has been successfully loaded.
-     */
-    void dataLoaded();
-
-    /**
-     * @brief Emitted when an error occurs during data loading.
-     */
-    void loadError(const QString& error_message, const QString& details = {});
 
 private slots:
     void onTypesLoaded();

--- a/projects/ores.qt.refdata/include/ores.qt/ClientLegTypeModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientLegTypeModel.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <QFutureWatcher>
 #include <QAbstractTableModel>
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"
 #include "ores.qt/RecencyTracker.hpp"
@@ -34,10 +35,10 @@ namespace ores::qt {
 /**
  * @brief Model for displaying leg types fetched from the server.
  *
- * This model extends QAbstractTableModel and fetches leg type
+ * This model extends AbstractClientModel and fetches leg type
  * data asynchronously using the ores.comms client.
  */
-class ClientLegTypeModel final : public QAbstractTableModel {
+class ClientLegTypeModel final : public AbstractClientModel {
     Q_OBJECT
 
 private:
@@ -106,17 +107,6 @@ public:
      * @brief Get the total number of records available on the server.
      */
     std::uint32_t total_available_count() const { return total_available_count_; }
-
-signals:
-    /**
-     * @brief Emitted when data has been successfully loaded.
-     */
-    void dataLoaded();
-
-    /**
-     * @brief Emitted when an error occurs during data loading.
-     */
-    void loadError(const QString& error_message, const QString& details = {});
 
 private slots:
     void onTypesLoaded();

--- a/projects/ores.qt.refdata/include/ores.qt/ClientPaymentFrequencyTypeModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientPaymentFrequencyTypeModel.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <QFutureWatcher>
 #include <QAbstractTableModel>
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"
 #include "ores.qt/RecencyTracker.hpp"
@@ -34,10 +35,10 @@ namespace ores::qt {
 /**
  * @brief Model for displaying payment frequency types fetched from the server.
  *
- * This model extends QAbstractTableModel and fetches payment frequency type
+ * This model extends AbstractClientModel and fetches payment frequency type
  * data asynchronously using the ores.comms client.
  */
-class ClientPaymentFrequencyTypeModel final : public QAbstractTableModel {
+class ClientPaymentFrequencyTypeModel final : public AbstractClientModel {
     Q_OBJECT
 
 private:
@@ -106,17 +107,6 @@ public:
      * @brief Get the total number of records available on the server.
      */
     std::uint32_t total_available_count() const { return total_available_count_; }
-
-signals:
-    /**
-     * @brief Emitted when data has been successfully loaded.
-     */
-    void dataLoaded();
-
-    /**
-     * @brief Emitted when an error occurs during data loading.
-     */
-    void loadError(const QString& error_message, const QString& details = {});
 
 private slots:
     void onTypesLoaded();

--- a/projects/ores.qt.refdata/include/ores.qt/ClientZeroConventionModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientZeroConventionModel.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <QFutureWatcher>
 #include <QAbstractTableModel>
+#include "ores.qt/AbstractClientModel.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/RecencyPulseManager.hpp"
 #include "ores.qt/RecencyTracker.hpp"
@@ -34,10 +35,10 @@ namespace ores::qt {
 /**
  * @brief Model for displaying zero conventions fetched from the server.
  *
- * This model extends QAbstractTableModel and fetches zero convention
+ * This model extends AbstractClientModel and fetches zero convention
  * data asynchronously using the ores.comms client.
  */
-class ClientZeroConventionModel final : public QAbstractTableModel {
+class ClientZeroConventionModel final : public AbstractClientModel {
     Q_OBJECT
 
 private:
@@ -109,17 +110,6 @@ public:
      * @brief Get the total number of records available on the server.
      */
     std::uint32_t total_available_count() const { return total_available_count_; }
-
-signals:
-    /**
-     * @brief Emitted when data has been successfully loaded.
-     */
-    void dataLoaded();
-
-    /**
-     * @brief Emitted when an error occurs during data loading.
-     */
-    void loadError(const QString& error_message, const QString& details = {});
 
 private slots:
     void onConventionsLoaded();

--- a/projects/ores.qt.refdata/src/BusinessDayConventionTypeMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/BusinessDayConventionTypeMdiWindow.cpp
@@ -174,6 +174,8 @@ void BusinessDayConventionTypeMdiWindow::setupConnections() {
             this, [this](std::uint32_t offset, std::uint32_t limit) {
         model_->load_page(offset, limit);
     });
+
+    connectModel(model_);
 }
 
 void BusinessDayConventionTypeMdiWindow::doReload() {

--- a/projects/ores.qt.refdata/src/CatalogMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/CatalogMdiWindow.cpp
@@ -47,7 +47,7 @@ CatalogMdiWindow::CatalogMdiWindow(ClientManager* clientManager,
     setupUi();
     setupToolbar();
     setupConnections();
-    model_->loadData();
+    reload();
 }
 
 void CatalogMdiWindow::setupUi() {

--- a/projects/ores.qt.refdata/src/ClientBusinessDayConventionTypeModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientBusinessDayConventionTypeModel.cpp
@@ -37,7 +37,7 @@ namespace {
 
 ClientBusinessDayConventionTypeModel::ClientBusinessDayConventionTypeModel(
     ClientManager* clientManager, QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager),
       watcher_(new QFutureWatcher<FetchResult>(this)),
       recencyTracker_(business_day_convention_type_key_extractor),

--- a/projects/ores.qt.refdata/src/ClientCatalogModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientCatalogModel.cpp
@@ -38,7 +38,7 @@ namespace {
 
 ClientCatalogModel::ClientCatalogModel(ClientManager* clientManager,
                                        QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager),
       recencyTracker_(catalog_key_extractor),
       pulseManager_(new RecencyPulseManager(this)) {

--- a/projects/ores.qt.refdata/src/ClientCodeDomainModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientCodeDomainModel.cpp
@@ -37,7 +37,7 @@ namespace {
 
 ClientCodeDomainModel::ClientCodeDomainModel(
     ClientManager* clientManager, QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager),
       watcher_(new QFutureWatcher<FetchResult>(this)),
       recencyTracker_(code_domain_key_extractor),

--- a/projects/ores.qt.refdata/src/ClientDatasetDependencyModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientDatasetDependencyModel.cpp
@@ -31,7 +31,7 @@ using namespace ores::logging;
 
 ClientDatasetDependencyModel::ClientDatasetDependencyModel(
     ClientManager* clientManager, QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager) {
 }
 

--- a/projects/ores.qt.refdata/src/ClientDayCountFractionTypeModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientDayCountFractionTypeModel.cpp
@@ -37,7 +37,7 @@ namespace {
 
 ClientDayCountFractionTypeModel::ClientDayCountFractionTypeModel(
     ClientManager* clientManager, QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager),
       watcher_(new QFutureWatcher<FetchResult>(this)),
       recencyTracker_(day_count_fraction_type_key_extractor),

--- a/projects/ores.qt.refdata/src/ClientDepositConventionModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientDepositConventionModel.cpp
@@ -37,7 +37,7 @@ namespace {
 
 ClientDepositConventionModel::ClientDepositConventionModel(
     ClientManager* clientManager, QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager),
       watcher_(new QFutureWatcher<FetchResult>(this)),
       recencyTracker_(deposit_convention_key_extractor),

--- a/projects/ores.qt.refdata/src/ClientFloatingIndexTypeModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientFloatingIndexTypeModel.cpp
@@ -37,7 +37,7 @@ namespace {
 
 ClientFloatingIndexTypeModel::ClientFloatingIndexTypeModel(
     ClientManager* clientManager, QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager),
       watcher_(new QFutureWatcher<FetchResult>(this)),
       recencyTracker_(floating_index_type_key_extractor),

--- a/projects/ores.qt.refdata/src/ClientLegTypeModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientLegTypeModel.cpp
@@ -37,7 +37,7 @@ namespace {
 
 ClientLegTypeModel::ClientLegTypeModel(
     ClientManager* clientManager, QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager),
       watcher_(new QFutureWatcher<FetchResult>(this)),
       recencyTracker_(leg_type_key_extractor),

--- a/projects/ores.qt.refdata/src/ClientPaymentFrequencyTypeModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientPaymentFrequencyTypeModel.cpp
@@ -37,7 +37,7 @@ namespace {
 
 ClientPaymentFrequencyTypeModel::ClientPaymentFrequencyTypeModel(
     ClientManager* clientManager, QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager),
       watcher_(new QFutureWatcher<FetchResult>(this)),
       recencyTracker_(payment_frequency_type_key_extractor),

--- a/projects/ores.qt.refdata/src/ClientZeroConventionModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientZeroConventionModel.cpp
@@ -37,7 +37,7 @@ namespace {
 
 ClientZeroConventionModel::ClientZeroConventionModel(
     ClientManager* clientManager, QObject* parent)
-    : QAbstractTableModel(parent),
+    : AbstractClientModel(parent),
       clientManager_(clientManager),
       watcher_(new QFutureWatcher<FetchResult>(this)),
       recencyTracker_(zero_convention_key_extractor),

--- a/projects/ores.qt.refdata/src/CodeDomainMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/CodeDomainMdiWindow.cpp
@@ -174,6 +174,8 @@ void CodeDomainMdiWindow::setupConnections() {
             this, [this](std::uint32_t offset, std::uint32_t limit) {
         model_->load_page(offset, limit);
     });
+
+    connectModel(model_);
 }
 
 void CodeDomainMdiWindow::doReload() {

--- a/projects/ores.qt.refdata/src/DayCountFractionTypeMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/DayCountFractionTypeMdiWindow.cpp
@@ -174,6 +174,8 @@ void DayCountFractionTypeMdiWindow::setupConnections() {
             this, [this](std::uint32_t offset, std::uint32_t limit) {
         model_->load_page(offset, limit);
     });
+
+    connectModel(model_);
 }
 
 void DayCountFractionTypeMdiWindow::doReload() {

--- a/projects/ores.qt.refdata/src/DepositConventionMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/DepositConventionMdiWindow.cpp
@@ -55,7 +55,7 @@ DepositConventionMdiWindow::DepositConventionMdiWindow(
     setupConnections();
 
     // Initial load
-    doReload();
+    reload();
 }
 
 void DepositConventionMdiWindow::setupUi() {
@@ -82,7 +82,7 @@ void DepositConventionMdiWindow::setupToolbar() {
             Icon::ArrowClockwise, IconUtils::DefaultIconColor),
         tr("Reload"));
     connect(reloadAction_, &QAction::triggered, this,
-            &DepositConventionMdiWindow::doReload);
+            &EntityListMdiWindow::reload);
 
     initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
 
@@ -174,6 +174,8 @@ void DepositConventionMdiWindow::setupConnections() {
             this, [this](std::uint32_t offset, std::uint32_t limit) {
         model_->load_page(offset, limit);
     });
+
+    connectModel(model_);
 }
 
 void DepositConventionMdiWindow::doReload() {

--- a/projects/ores.qt.refdata/src/FloatingIndexTypeMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/FloatingIndexTypeMdiWindow.cpp
@@ -174,6 +174,8 @@ void FloatingIndexTypeMdiWindow::setupConnections() {
             this, [this](std::uint32_t offset, std::uint32_t limit) {
         model_->load_page(offset, limit);
     });
+
+    connectModel(model_);
 }
 
 void FloatingIndexTypeMdiWindow::doReload() {

--- a/projects/ores.qt.refdata/src/LegTypeMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/LegTypeMdiWindow.cpp
@@ -174,6 +174,8 @@ void LegTypeMdiWindow::setupConnections() {
             this, [this](std::uint32_t offset, std::uint32_t limit) {
         model_->load_page(offset, limit);
     });
+
+    connectModel(model_);
 }
 
 void LegTypeMdiWindow::doReload() {

--- a/projects/ores.qt.refdata/src/PaymentFrequencyTypeMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/PaymentFrequencyTypeMdiWindow.cpp
@@ -174,6 +174,8 @@ void PaymentFrequencyTypeMdiWindow::setupConnections() {
             this, [this](std::uint32_t offset, std::uint32_t limit) {
         model_->load_page(offset, limit);
     });
+
+    connectModel(model_);
 }
 
 void PaymentFrequencyTypeMdiWindow::doReload() {

--- a/projects/ores.qt.refdata/src/ZeroConventionMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/ZeroConventionMdiWindow.cpp
@@ -55,7 +55,7 @@ ZeroConventionMdiWindow::ZeroConventionMdiWindow(
     setupConnections();
 
     // Initial load
-    doReload();
+    reload();
 }
 
 void ZeroConventionMdiWindow::setupUi() {
@@ -82,7 +82,7 @@ void ZeroConventionMdiWindow::setupToolbar() {
             Icon::ArrowClockwise, IconUtils::DefaultIconColor),
         tr("Reload"));
     connect(reloadAction_, &QAction::triggered, this,
-            &ZeroConventionMdiWindow::doReload);
+            &EntityListMdiWindow::reload);
 
     initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
 
@@ -174,6 +174,8 @@ void ZeroConventionMdiWindow::setupConnections() {
             this, [this](std::uint32_t offset, std::uint32_t limit) {
         model_->load_page(offset, limit);
     });
+
+    connectModel(model_);
 }
 
 void ZeroConventionMdiWindow::doReload() {

--- a/projects/ores.qt.trading/include/ores.qt/AdaptiveStackedWidget.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/AdaptiveStackedWidget.hpp
@@ -1,0 +1,55 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_ADAPTIVE_STACKED_WIDGET_HPP
+#define ORES_QT_ADAPTIVE_STACKED_WIDGET_HPP
+
+#include <QStackedWidget>
+
+/**
+ * @brief QStackedWidget that reports the current page's size hints.
+ *
+ * The standard QStackedWidget::sizeHint() returns the maximum of all
+ * pages, which causes the containing dialog to be as tall as the largest
+ * form even when a compact form is shown. This subclass overrides
+ * sizeHint() and minimumSizeHint() to return the current page's values so
+ * that layouts and scroll areas can size themselves correctly.
+ *
+ * Must be in the global namespace so uic generates unqualified class names.
+ */
+class AdaptiveStackedWidget : public QStackedWidget {
+public:
+    explicit AdaptiveStackedWidget(QWidget* parent = nullptr)
+        : QStackedWidget(parent) {
+        connect(this, &QStackedWidget::currentChanged,
+                this, [this](int) { updateGeometry(); });
+    }
+
+    QSize sizeHint() const override {
+        if (const auto* w = currentWidget()) return w->sizeHint();
+        return QStackedWidget::sizeHint();
+    }
+
+    QSize minimumSizeHint() const override {
+        if (const auto* w = currentWidget()) return w->minimumSizeHint();
+        return QStackedWidget::minimumSizeHint();
+    }
+};
+
+#endif

--- a/projects/ores.qt.trading/include/ores.qt/BondInstrumentForm.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/BondInstrumentForm.hpp
@@ -56,6 +56,7 @@ public:
 
     void setClientManager(ClientManager* cm) override;
     void setUsername(const std::string& username) override;
+    void setImageCache(ImageCache* cache) override;
 
     void setInstrument(
         const trading::messaging::instrument_export_result& instrument) override;
@@ -78,12 +79,14 @@ public:
 
 private:
     void setupConnections();
+    void populateCurrencies();
     void populateFromInstrument();
     void emitProvenance();
     void onFieldChanged();
 
     Ui::BondInstrumentForm* ui_;
     ClientManager* clientManager_ = nullptr;
+    ImageCache* imageCache_ = nullptr;
     std::string username_;
     trading::domain::bond_instrument instrument_;
     bool dirty_ = false;

--- a/projects/ores.qt.trading/include/ores.qt/CommodityInstrumentForm.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/CommodityInstrumentForm.hpp
@@ -57,6 +57,7 @@ public:
 
     void setClientManager(ClientManager* cm) override;
     void setUsername(const std::string& username) override;
+    void setImageCache(ImageCache* cache) override;
 
     void setInstrument(
         const trading::messaging::instrument_export_result& instrument) override;
@@ -79,12 +80,14 @@ public:
 
 private:
     void setupConnections();
+    void populateCurrencies();
     void populateFromInstrument();
     void emitProvenance();
     void onFieldChanged();
 
     Ui::CommodityInstrumentForm* ui_;
     ClientManager* clientManager_ = nullptr;
+    ImageCache* imageCache_ = nullptr;
     std::string username_;
     trading::domain::commodity_instrument instrument_;
     bool dirty_ = false;

--- a/projects/ores.qt.trading/include/ores.qt/CreditInstrumentForm.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/CreditInstrumentForm.hpp
@@ -56,6 +56,7 @@ public:
 
     void setClientManager(ClientManager* cm) override;
     void setUsername(const std::string& username) override;
+    void setImageCache(ImageCache* cache) override;
 
     void setInstrument(
         const trading::messaging::instrument_export_result& instrument) override;
@@ -78,12 +79,14 @@ public:
 
 private:
     void setupConnections();
+    void populateCurrencies();
     void populateFromInstrument();
     void emitProvenance();
     void onFieldChanged();
 
     Ui::CreditInstrumentForm* ui_;
     ClientManager* clientManager_ = nullptr;
+    ImageCache* imageCache_ = nullptr;
     std::string username_;
     trading::domain::credit_instrument instrument_;
     bool dirty_ = false;

--- a/projects/ores.qt.trading/include/ores.qt/EquityInstrumentForm.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/EquityInstrumentForm.hpp
@@ -57,6 +57,7 @@ public:
 
     void setClientManager(ClientManager* cm) override;
     void setUsername(const std::string& username) override;
+    void setImageCache(ImageCache* cache) override;
 
     void setInstrument(
         const trading::messaging::instrument_export_result& instrument) override;
@@ -79,12 +80,14 @@ public:
 
 private:
     void setupConnections();
+    void populateCurrencies();
     void populateFromInstrument();
     void emitProvenance();
     void onFieldChanged();
 
     Ui::EquityInstrumentForm* ui_;
     ClientManager* clientManager_ = nullptr;
+    ImageCache* imageCache_ = nullptr;
     std::string username_;
     /// Per-type instrument state. Scoped to EquityOption for now; extending
     /// to other equity variants is follow-up work.

--- a/projects/ores.qt.trading/include/ores.qt/FxInstrumentForm.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/FxInstrumentForm.hpp
@@ -55,6 +55,7 @@ public:
 
     void setClientManager(ClientManager* cm) override;
     void setUsername(const std::string& username) override;
+    void setImageCache(ImageCache* cache) override;
 
     void setInstrument(
         const trading::messaging::instrument_export_result& instrument) override;
@@ -77,12 +78,14 @@ public:
 
 private:
     void setupConnections();
+    void populateCurrencies();
     void populateFromInstrument();
     void emitProvenance();
     void onFieldChanged();
 
     Ui::FxInstrumentForm* ui_;
     ClientManager* clientManager_ = nullptr;
+    ImageCache* imageCache_ = nullptr;
     std::string username_;
     /// Per-type instrument state. Scoped to FxForward for now; extending
     /// to other FX variants is follow-up work tracked in the per-type

--- a/projects/ores.qt.trading/include/ores.qt/FxVanillaOptionInstrumentForm.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/FxVanillaOptionInstrumentForm.hpp
@@ -1,0 +1,94 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_FX_VANILLA_OPTION_INSTRUMENT_FORM_HPP
+#define ORES_QT_FX_VANILLA_OPTION_INSTRUMENT_FORM_HPP
+
+#include "ores.qt/IInstrumentForm.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.trading.api/domain/fx_vanilla_option_instrument.hpp"
+
+namespace Ui {
+class FxVanillaOptionInstrumentForm;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief @c IInstrumentForm subclass for FX Vanilla Option (FxOption) trades.
+ *
+ * Handles European and American FX options. Registered in
+ * @c InstrumentFormRegistry under the trade type code @c "FxOption".
+ */
+class FxVanillaOptionInstrumentForm final : public IInstrumentForm {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.fx_vanilla_option_instrument_form";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit FxVanillaOptionInstrumentForm(QWidget* parent = nullptr);
+    ~FxVanillaOptionInstrumentForm() override;
+
+    void setClientManager(ClientManager* cm) override;
+    void setUsername(const std::string& username) override;
+
+    void setInstrument(
+        const trading::messaging::instrument_export_result& instrument) override;
+    void clear() override;
+
+    void setTradeType(const QString& code,
+        bool has_options, bool has_extension) override;
+
+    void setReadOnly(bool readOnly) override;
+    bool isDirty() const override;
+    bool isLoaded() const override;
+
+    void setChangeReason(
+        const std::string& code, const std::string& commentary) override;
+    void writeUiToInstrument() override;
+
+    void saveInstrument(
+        std::function<void(const std::string& id)> on_success,
+        std::function<void(const QString& error)> on_failure) override;
+
+private:
+    void setupConnections();
+    void populateFromInstrument();
+    void emitProvenance();
+    void onFieldChanged();
+
+    Ui::FxVanillaOptionInstrumentForm* ui_;
+    ClientManager* clientManager_ = nullptr;
+    std::string username_;
+    trading::domain::fx_vanilla_option_instrument instrument_;
+    bool dirty_ = false;
+    bool loaded_ = false;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.trading/include/ores.qt/FxVanillaOptionInstrumentForm.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/FxVanillaOptionInstrumentForm.hpp
@@ -55,6 +55,7 @@ public:
 
     void setClientManager(ClientManager* cm) override;
     void setUsername(const std::string& username) override;
+    void setImageCache(ImageCache* cache) override;
 
     void setInstrument(
         const trading::messaging::instrument_export_result& instrument) override;
@@ -77,12 +78,14 @@ public:
 
 private:
     void setupConnections();
+    void populateCurrencies();
     void populateFromInstrument();
     void emitProvenance();
     void onFieldChanged();
 
     Ui::FxVanillaOptionInstrumentForm* ui_;
     ClientManager* clientManager_ = nullptr;
+    ImageCache* imageCache_ = nullptr;
     std::string username_;
     trading::domain::fx_vanilla_option_instrument instrument_;
     bool dirty_ = false;

--- a/projects/ores.qt.trading/include/ores.qt/IInstrumentForm.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/IInstrumentForm.hpp
@@ -30,6 +30,7 @@
 namespace ores::qt {
 
 class ClientManager;
+class ImageCache;
 
 /**
  * @brief Audit metadata snapshot reported by an @c IInstrumentForm so the
@@ -80,6 +81,9 @@ public:
 
     /// Inject the username stamped on every saved instrument.
     virtual void setUsername(const std::string& username) = 0;
+
+    /// Inject the image cache for flag icons on currency combo boxes.
+    virtual void setImageCache(ImageCache* /*cache*/) {}
 
     /**
      * @brief Populate the form with the already-resolved instrument.

--- a/projects/ores.qt.trading/include/ores.qt/InstrumentFormRegistry.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/InstrumentFormRegistry.hpp
@@ -32,37 +32,45 @@ namespace ores::qt {
 class IInstrumentForm;
 
 /**
- * @brief Maps a @c product_type to its instrument form widget factory.
+ * @brief Maps instrument families and specific trade type codes to form
+ *        widget factories.
  *
- * Each registration carries the family's display name (used as the page
- * label in @c QStackedWidget bookkeeping and any future tab pickers) and
- * a factory closure that constructs a fresh form widget under the supplied
- * parent.
+ * Two registration tiers:
+ *  - Per product-family (product_type): one form handles all sub-types in
+ *    that family (e.g. BondInstrumentForm covers all bond variants).
+ *  - Per trade-type-code (QString): a dedicated form handles exactly one
+ *    sub-type (e.g. FxVanillaOptionInstrumentForm for "FxOption").
  *
- * Adding a ninth instrument family is one new @c IInstrumentForm subclass
- * plus one extra @ref registerForm call in @ref register_default_forms.
- * No file in @c TradeDetailDialog needs to change.
+ * @c TradeDetailDialog looks up by trade-type-code first, falling back to
+ * the family form when no type-specific registration exists.
  */
 class InstrumentFormRegistry final {
 public:
     using product_type = ores::trading::domain::product_type;
     using Factory = std::function<IInstrumentForm*(QWidget* parent)>;
 
+    // --- per-family registration ---
+
     void registerForm(product_type pt, QString displayName, Factory factory);
 
-    /// True when at least one form is registered for @p pt.
     [[nodiscard]] bool contains(product_type pt) const noexcept;
-
-    /// Construct a new form for @p pt parented at @p parent. Returns null
-    /// if no factory has been registered for that family.
     [[nodiscard]] IInstrumentForm* createForm(
         product_type pt, QWidget* parent) const;
-
-    /// Display name registered alongside the factory (for tab labels etc).
     [[nodiscard]] QString displayName(product_type pt) const;
-
-    /// All registered families, in registration order.
     [[nodiscard]] std::vector<product_type> registeredTypes() const;
+
+    // --- per-trade-type-code registration ---
+
+    /// Register a dedicated form for a single trade type code.
+    void registerTypeForm(const QString& trade_type_code, Factory factory);
+
+    [[nodiscard]] bool containsTypeForm(
+        const QString& trade_type_code) const noexcept;
+    [[nodiscard]] IInstrumentForm* createTypeForm(
+        const QString& trade_type_code, QWidget* parent) const;
+
+    /// All registered type codes, in registration order.
+    [[nodiscard]] std::vector<QString> registeredTypeCodes() const;
 
 private:
     struct Entry {
@@ -71,6 +79,10 @@ private:
     };
     std::vector<product_type> order_;
     std::map<product_type, Entry> entries_;
+
+    struct TypeEntry { Factory factory; };
+    std::vector<QString> typeOrder_;
+    std::map<QString, TypeEntry> typeEntries_;
 };
 
 /**

--- a/projects/ores.qt.trading/include/ores.qt/InstrumentFormUtils.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/InstrumentFormUtils.hpp
@@ -1,0 +1,99 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_INSTRUMENT_FORM_UTILS_HPP
+#define ORES_QT_INSTRUMENT_FORM_UTILS_HPP
+
+#include <string>
+
+class QComboBox;
+
+namespace ores::qt {
+
+/**
+ * @brief Static helpers for populating and reading instrument-form combo boxes.
+ *
+ * Each populate* method fills a QComboBox with the fixed vocabulary for that
+ * field. The first item is always an empty string so that optional fields can
+ * be left unset. All values match the canonical strings accepted by ORE/NATS
+ * handlers and stored in the database.
+ */
+class InstrumentFormUtils {
+public:
+    InstrumentFormUtils() = delete;
+
+    // ── Field-specific populators ──────────────────────────────────────────────
+
+    /** "", "Cash", "Physical" */
+    static void populateSettlement(QComboBox* cb);
+
+    /** "", "Call", "Put" */
+    static void populateOptionType(QComboBox* cb);
+
+    /** "", "European", "American" — FX vanilla options only (no Bermudan) */
+    static void populateExerciseStyle(QComboBox* cb);
+
+    /** "", "European", "American", "Bermudan" — equity / commodity */
+    static void populateExerciseType(QComboBox* cb);
+
+    /** "", A360, A365F, A365, ActAct(ISDA), ActAct(ISMA), ActAct(AFB),
+     *  30/360, 30E/360, 30E/360(ISDA), Business252, 1/1, Simple */
+    static void populateDayCount(QComboBox* cb);
+
+    /** "", Annual, Semiannual, EveryFourthMonth, Quarterly, Bimonthly,
+     *  Monthly, EveryFourthWeek, Biweekly, Weekly, Daily, Once */
+    static void populateFrequency(QComboBox* cb);
+
+    /** "", "UpIn", "UpOut", "DownIn", "DownOut" */
+    static void populateBarrierType(QComboBox* cb);
+
+    /** "", "Arithmetic", "Geometric" */
+    static void populateAverageType(QComboBox* cb);
+
+    /** "", "Senior", "Subordinated" */
+    static void populateSeniority(QComboBox* cb);
+
+    /** "", "MM", "MR", "CR", "XR" */
+    static void populateRestructuring(QComboBox* cb);
+
+    /** "", "TotalReturn", "PriceReturn" */
+    static void populateTrsReturnType(QComboBox* cb);
+
+    /** "", "Call", "Put" — ASCOT bond option type */
+    static void populateAscotOptionType(QComboBox* cb);
+
+    /** "", "TotalReturn", "PriceReturn" — equity swap / TRS return type */
+    static void populateReturnType(QComboBox* cb);
+
+    // ── Value accessors ────────────────────────────────────────────────────────
+
+    /**
+     * @brief Select the combo item whose text equals @p value.
+     *        Falls back to index 0 (the empty entry) if not found.
+     */
+    static void setComboValue(QComboBox* cb, const std::string& value);
+
+    /**
+     * @brief Return the currently selected item text as a std::string.
+     */
+    static std::string getComboValue(const QComboBox* cb);
+};
+
+} // namespace ores::qt
+
+#endif

--- a/projects/ores.qt.trading/include/ores.qt/OreCurrencyComboBox.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/OreCurrencyComboBox.hpp
@@ -1,0 +1,37 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_ORE_CURRENCY_COMBO_BOX_HPP
+#define ORES_QT_ORE_CURRENCY_COMBO_BOX_HPP
+
+#include <QComboBox>
+
+/**
+ * @brief QComboBox subclass for ISO currency selection with flag icons.
+ *
+ * Acts as a typed marker so uic generates the right widget class and
+ * includes the correct header. Currency codes are populated asynchronously
+ * by the owning form via LookupFetcher::fetch_currency_codes(); flag icons
+ * are applied via FlagIconHelper::setup_flag_combo().
+ */
+class OreCurrencyComboBox : public QComboBox {
+public:
+    explicit OreCurrencyComboBox(QWidget* parent = nullptr);
+};
+
+#endif

--- a/projects/ores.qt.trading/include/ores.qt/OreDateEdit.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/OreDateEdit.hpp
@@ -1,0 +1,42 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_ORE_DATE_EDIT_HPP
+#define ORES_QT_ORE_DATE_EDIT_HPP
+
+#include <string>
+#include <QDateEdit>
+
+class OreDateEdit : public QDateEdit {
+public:
+    explicit OreDateEdit(QWidget* parent = nullptr);
+
+    /**
+     * @brief Returns the selected date as "yyyy-MM-dd", or an empty string
+     *        when the widget is in the blank (unset) state.
+     */
+    std::string isoDate() const;
+
+    /**
+     * @brief Sets the widget to the date represented by @p iso ("yyyy-MM-dd").
+     *        An empty string resets the widget to the blank (unset) state.
+     */
+    void setIsoDate(const std::string& iso);
+};
+
+#endif

--- a/projects/ores.qt.trading/include/ores.qt/OreDoubleSpinBox.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/OreDoubleSpinBox.hpp
@@ -22,7 +22,6 @@
 #include <QDoubleSpinBox>
 
 class OreDoubleSpinBox : public QDoubleSpinBox {
-    Q_OBJECT
 public:
     explicit OreDoubleSpinBox(QWidget* parent = nullptr);
 };

--- a/projects/ores.qt.trading/include/ores.qt/OreDoubleSpinBox.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/OreDoubleSpinBox.hpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_ORE_DOUBLE_SPIN_BOX_HPP
+#define ORES_QT_ORE_DOUBLE_SPIN_BOX_HPP
+
+#include <QDoubleSpinBox>
+
+namespace ores::qt {
+
+class OreDoubleSpinBox : public QDoubleSpinBox {
+    Q_OBJECT
+public:
+    explicit OreDoubleSpinBox(QWidget* parent = nullptr);
+};
+
+} // namespace ores::qt
+
+#endif

--- a/projects/ores.qt.trading/include/ores.qt/OreDoubleSpinBox.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/OreDoubleSpinBox.hpp
@@ -21,14 +21,10 @@
 
 #include <QDoubleSpinBox>
 
-namespace ores::qt {
-
 class OreDoubleSpinBox : public QDoubleSpinBox {
     Q_OBJECT
 public:
     explicit OreDoubleSpinBox(QWidget* parent = nullptr);
 };
-
-} // namespace ores::qt
 
 #endif

--- a/projects/ores.qt.trading/include/ores.qt/SwapInstrumentForm.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/SwapInstrumentForm.hpp
@@ -116,6 +116,7 @@ public:
 
     void setClientManager(ClientManager* cm) override;
     void setUsername(const std::string& username) override;
+    void setImageCache(ImageCache* cache) override;
 
     void setInstrument(
         const trading::messaging::instrument_export_result& instrument) override;
@@ -138,12 +139,14 @@ public:
 
 private:
     void setupConnections();
+    void populateCurrencies();
     void populateFromState();
     void emitProvenance();
     void onFieldChanged();
 
     Ui::SwapInstrumentForm* ui_;
     ClientManager* clientManager_ = nullptr;
+    ImageCache* imageCache_ = nullptr;
     std::string username_;
     SwapFormState state_;
     std::vector<trading::domain::swap_leg> legs_;

--- a/projects/ores.qt.trading/include/ores.qt/TradeController.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/TradeController.hpp
@@ -24,6 +24,7 @@
 #include <QMainWindow>
 #include "ores.qt/EntityController.hpp"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ImageCache.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.trading.api/domain/trade.hpp"
 #include "ores.trading.api/messaging/trade_protocol.hpp"
@@ -60,6 +61,7 @@ public:
         QMdiArea* mdiArea,
         ClientManager* clientManager,
         ChangeReasonCache* changeReasonCache,
+        ImageCache* imageCache,
         const QString& username,
         QObject* parent = nullptr);
 
@@ -91,6 +93,7 @@ private:
     void showHistoryWindow(const trading::domain::trade& trade);
 
     ChangeReasonCache* changeReasonCache_{nullptr};
+    ImageCache* imageCache_{nullptr};
     TradeMdiWindow* listWindow_;
     DetachableMdiSubWindow* listMdiSubWindow_;
 };

--- a/projects/ores.qt.trading/include/ores.qt/TradeDetailDialog.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/TradeDetailDialog.hpp
@@ -120,7 +120,10 @@ private:
     void updateTradeFromUi();
     void updateSaveButtonState();
     bool validateInput();
+    void connectFormSignals(IInstrumentForm* form);
     void activateForm(IInstrumentForm* form, const std::string& tradeTypeCode);
+    IInstrumentForm* findForm(trading::domain::product_type pt,
+                              const std::string& trade_type_code);
     void applyCreateTradeType();
 
     void saveTrade(const trading::domain::trade& trade);
@@ -135,10 +138,13 @@ private:
     bool readOnly_{false};
     bool hasChanges_{false};
 
-    // All IInstrumentForm pages live in instrumentStack; formMap_ gives O(1)
-    // access by product_type without walking the stack at runtime.
+    // All IInstrumentForm pages live in instrumentStack. formMap_ gives O(1)
+    // access by product_type; typeFormMap_ gives O(1) access by trade_type_code
+    // for families that register dedicated per-sub-type forms.
+    // findForm() prefers typeFormMap_ over formMap_.
     InstrumentFormRegistry instrumentFormRegistry_;
     std::map<trading::domain::product_type, IInstrumentForm*> formMap_;
+    std::map<std::string, IInstrumentForm*> typeFormMap_;
     IInstrumentForm* activeForm_ = nullptr;
 
     // Trade-type reference data cached on connect for flag lookups.

--- a/projects/ores.qt.trading/include/ores.qt/TradeDetailDialog.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/TradeDetailDialog.hpp
@@ -25,6 +25,7 @@
 #include <QTabWidget>
 #include <QTimer>
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ImageCache.hpp"
 #include "ores.qt/DetailDialogBase.hpp"
 #include "ores.qt/ProvenanceWidget.hpp"
 #include "ores.qt/IInstrumentForm.hpp"
@@ -74,6 +75,7 @@ public:
 
     void setClientManager(ClientManager* clientManager);
     void setUsername(const std::string& username);
+    void setImageCache(ImageCache* cache);
 
     /**
      * @brief Populate the dialog with a trade bundle (trade + instrument).
@@ -130,6 +132,7 @@ private:
 
     Ui::TradeDetailDialog* ui_;
     ClientManager* clientManager_;
+    ImageCache* imageCache_ = nullptr;
     std::string username_;
     trading::domain::trade trade_;
     std::vector<refdata::domain::book> books_;

--- a/projects/ores.qt.trading/src/BondInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/BondInstrumentForm.cpp
@@ -26,6 +26,9 @@
 #include <boost/uuid/uuid_io.hpp>
 #include "ui_BondInstrumentForm.h"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ImageCache.hpp"
+#include "ores.qt/FlagIconHelper.hpp"
+#include "ores.qt/LookupFetcher.hpp"
 #include "ores.qt/InstrumentFormUtils.hpp"
 #include "ores.trading.api/messaging/instrument_protocol.hpp"
 
@@ -53,20 +56,24 @@ BondInstrumentForm::~BondInstrumentForm() = default;
 void BondInstrumentForm::setupConnections() {
     auto markChanged = [this]() { onFieldChanged(); };
     auto markChangedStr = [this](const QString&) { onFieldChanged(); };
+    auto markChangedDate = [this](const QDate&) { onFieldChanged(); };
     connect(ui_->issuerEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->currencyEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->issueDateEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->maturityDateEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->currencyCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->issueDateEdit, &QDateEdit::dateChanged, this, markChangedDate);
+    connect(ui_->maturityDateEdit, &QDateEdit::dateChanged, this, markChangedDate);
     connect(ui_->couponFrequencyCombo, &QComboBox::currentTextChanged,
             this, markChangedStr);
     connect(ui_->dayCountCombo, &QComboBox::currentTextChanged,
             this, markChangedStr);
-    connect(ui_->callDateEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->callDateEdit, &QDateEdit::dateChanged, this, markChangedDate);
     connect(ui_->descriptionEdit, &QPlainTextEdit::textChanged, this, markChanged);
-    connect(ui_->futureExpiryDateEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->futureExpiryDateEdit, &QDateEdit::dateChanged,
+            this, markChangedDate);
     connect(ui_->optionTypeCombo, &QComboBox::currentTextChanged,
             this, markChangedStr);
-    connect(ui_->optionExpiryDateEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->optionExpiryDateEdit, &QDateEdit::dateChanged,
+            this, markChangedDate);
     connect(ui_->trsReturnTypeCombo, &QComboBox::currentTextChanged,
             this, markChangedStr);
     connect(ui_->trsFundingLegCodeEdit, &QLineEdit::textChanged, this, markChanged);
@@ -91,6 +98,41 @@ void BondInstrumentForm::setupConnections() {
 
 void BondInstrumentForm::setClientManager(ClientManager* cm) {
     clientManager_ = cm;
+    populateCurrencies();
+}
+
+void BondInstrumentForm::setImageCache(ImageCache* cache) {
+    imageCache_ = cache;
+    setup_flag_combo(this, ui_->currencyCombo, imageCache_,
+                     FlagSource::Currency);
+}
+
+void BondInstrumentForm::populateCurrencies() {
+    if (!clientManager_) return;
+
+    QPointer<BondInstrumentForm> self = this;
+    auto* watcher = new QFutureWatcher<std::vector<std::string>>(self);
+    connect(watcher, &QFutureWatcher<std::vector<std::string>>::finished, self,
+        [self, watcher]() {
+        auto codes = watcher->result();
+        watcher->deleteLater();
+        if (!self) return;
+        auto* cb = self->ui_->currencyCombo;
+        cb->blockSignals(true);
+        cb->clear();
+        cb->addItem(QString());
+        for (const auto& c : codes)
+            cb->addItem(QString::fromStdString(c));
+        cb->blockSignals(false);
+        InstrumentFormUtils::setComboValue(cb, self->instrument_.currency);
+        if (self->imageCache_)
+            apply_flag_icons(cb, self->imageCache_, FlagSource::Currency);
+    });
+
+    auto* cm = clientManager_;
+    watcher->setFuture(QtConcurrent::run([cm]() {
+        return fetch_currency_codes(cm);
+    }));
 }
 
 void BondInstrumentForm::setUsername(const std::string& username) {
@@ -114,7 +156,7 @@ void BondInstrumentForm::setTradeType(const QString& code,
 
 void BondInstrumentForm::setReadOnly(bool readOnly) {
     ui_->issuerEdit->setReadOnly(readOnly);
-    ui_->currencyEdit->setReadOnly(readOnly);
+    ui_->currencyCombo->setEnabled(!readOnly);
     ui_->faceValueSpinBox->setReadOnly(readOnly);
     ui_->couponRateSpinBox->setReadOnly(readOnly);
     ui_->couponFrequencyCombo->setEnabled(!readOnly);
@@ -147,29 +189,24 @@ void BondInstrumentForm::writeUiToInstrument() {
     instrument_.issuer =
         ui_->issuerEdit->text().trimmed().toStdString();
     instrument_.currency =
-        ui_->currencyEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->currencyCombo);
     instrument_.face_value = ui_->faceValueSpinBox->value();
     instrument_.coupon_rate = ui_->couponRateSpinBox->value();
     instrument_.coupon_frequency_code =
         InstrumentFormUtils::getComboValue(ui_->couponFrequencyCombo);
     instrument_.day_count_code =
         InstrumentFormUtils::getComboValue(ui_->dayCountCombo);
-    instrument_.issue_date =
-        ui_->issueDateEdit->text().trimmed().toStdString();
-    instrument_.maturity_date =
-        ui_->maturityDateEdit->text().trimmed().toStdString();
+    instrument_.issue_date = ui_->issueDateEdit->isoDate();
+    instrument_.maturity_date = ui_->maturityDateEdit->isoDate();
     instrument_.settlement_days = ui_->settlementDaysSpinBox->value();
-    instrument_.call_date =
-        ui_->callDateEdit->text().trimmed().toStdString();
+    instrument_.call_date = ui_->callDateEdit->isoDate();
     instrument_.conversion_ratio = ui_->conversionRatioSpinBox->value();
     instrument_.description =
         ui_->descriptionEdit->toPlainText().trimmed().toStdString();
-    instrument_.future_expiry_date =
-        ui_->futureExpiryDateEdit->text().trimmed().toStdString();
+    instrument_.future_expiry_date = ui_->futureExpiryDateEdit->isoDate();
     instrument_.option_type =
         InstrumentFormUtils::getComboValue(ui_->optionTypeCombo);
-    instrument_.option_expiry_date =
-        ui_->optionExpiryDateEdit->text().trimmed().toStdString();
+    instrument_.option_expiry_date = ui_->optionExpiryDateEdit->isoDate();
     {
         const double s = ui_->optionStrikeSpinBox->value();
         instrument_.option_strike = (s > 0.0)
@@ -209,7 +246,7 @@ void BondInstrumentForm::setInstrument(
 void BondInstrumentForm::populateFromInstrument() {
     const auto block = [this](bool b) {
         ui_->issuerEdit->blockSignals(b);
-        ui_->currencyEdit->blockSignals(b);
+        ui_->currencyCombo->blockSignals(b);
         ui_->faceValueSpinBox->blockSignals(b);
         ui_->couponRateSpinBox->blockSignals(b);
         ui_->couponFrequencyCombo->blockSignals(b);
@@ -234,30 +271,25 @@ void BondInstrumentForm::populateFromInstrument() {
         QString::fromStdString(instrument_.trade_type_code));
     ui_->issuerEdit->setText(
         QString::fromStdString(instrument_.issuer));
-    ui_->currencyEdit->setText(
-        QString::fromStdString(instrument_.currency));
+    InstrumentFormUtils::setComboValue(
+        ui_->currencyCombo, instrument_.currency);
     ui_->faceValueSpinBox->setValue(instrument_.face_value);
     ui_->couponRateSpinBox->setValue(instrument_.coupon_rate);
     InstrumentFormUtils::setComboValue(
         ui_->couponFrequencyCombo, instrument_.coupon_frequency_code);
     InstrumentFormUtils::setComboValue(
         ui_->dayCountCombo, instrument_.day_count_code);
-    ui_->issueDateEdit->setText(
-        QString::fromStdString(instrument_.issue_date));
-    ui_->maturityDateEdit->setText(
-        QString::fromStdString(instrument_.maturity_date));
+    ui_->issueDateEdit->setIsoDate(instrument_.issue_date);
+    ui_->maturityDateEdit->setIsoDate(instrument_.maturity_date);
     ui_->settlementDaysSpinBox->setValue(instrument_.settlement_days);
-    ui_->callDateEdit->setText(
-        QString::fromStdString(instrument_.call_date));
+    ui_->callDateEdit->setIsoDate(instrument_.call_date);
     ui_->conversionRatioSpinBox->setValue(instrument_.conversion_ratio);
     ui_->descriptionEdit->setPlainText(
         QString::fromStdString(instrument_.description));
-    ui_->futureExpiryDateEdit->setText(
-        QString::fromStdString(instrument_.future_expiry_date));
+    ui_->futureExpiryDateEdit->setIsoDate(instrument_.future_expiry_date);
     InstrumentFormUtils::setComboValue(
         ui_->optionTypeCombo, instrument_.option_type);
-    ui_->optionExpiryDateEdit->setText(
-        QString::fromStdString(instrument_.option_expiry_date));
+    ui_->optionExpiryDateEdit->setIsoDate(instrument_.option_expiry_date);
     ui_->optionStrikeSpinBox->setValue(
         instrument_.option_strike.value_or(0.0));
     InstrumentFormUtils::setComboValue(

--- a/projects/ores.qt.trading/src/BondInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/BondInstrumentForm.cpp
@@ -19,12 +19,14 @@
  */
 #include "ores.qt/BondInstrumentForm.hpp"
 
+#include <QComboBox>
 #include <QPointer>
 #include <QtConcurrent>
 #include <QFutureWatcher>
 #include <boost/uuid/uuid_io.hpp>
 #include "ui_BondInstrumentForm.h"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/InstrumentFormUtils.hpp"
 #include "ores.trading.api/messaging/instrument_protocol.hpp"
 
 namespace ores::qt {
@@ -38,6 +40,11 @@ BondInstrumentForm::BondInstrumentForm(QWidget* parent)
     // Extensions tab is hidden until setTradeType() reveals it.
     ui_->subTabWidget->setTabVisible(
         ui_->subTabWidget->indexOf(ui_->extensionsTab), false);
+    InstrumentFormUtils::populateFrequency(ui_->couponFrequencyCombo);
+    InstrumentFormUtils::populateDayCount(ui_->dayCountCombo);
+    InstrumentFormUtils::populateOptionType(ui_->optionTypeCombo);
+    InstrumentFormUtils::populateTrsReturnType(ui_->trsReturnTypeCombo);
+    InstrumentFormUtils::populateAscotOptionType(ui_->ascotOptionTypeCombo);
     setupConnections();
 }
 
@@ -45,21 +52,26 @@ BondInstrumentForm::~BondInstrumentForm() = default;
 
 void BondInstrumentForm::setupConnections() {
     auto markChanged = [this]() { onFieldChanged(); };
-    connect(ui_->tradeTypeCodeEdit, &QLineEdit::textChanged, this, markChanged);
+    auto markChangedStr = [this](const QString&) { onFieldChanged(); };
     connect(ui_->issuerEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->currencyEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->issueDateEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->maturityDateEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->couponFrequencyCodeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->dayCountCodeEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->couponFrequencyCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->dayCountCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
     connect(ui_->callDateEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->descriptionEdit, &QPlainTextEdit::textChanged, this, markChanged);
     connect(ui_->futureExpiryDateEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->optionTypeEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->optionTypeCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
     connect(ui_->optionExpiryDateEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->trsReturnTypeEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->trsReturnTypeCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
     connect(ui_->trsFundingLegCodeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->ascotOptionTypeEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->ascotOptionTypeCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
     connect(ui_->faceValueSpinBox,
             QOverload<double>::of(&QDoubleSpinBox::valueChanged),
             this, markChanged);
@@ -95,18 +107,18 @@ void BondInstrumentForm::clear() {
 void BondInstrumentForm::setTradeType(const QString& code,
     bool /*has_options*/, bool has_extension) {
     instrument_.trade_type_code = code.trimmed().toStdString();
+    ui_->tradeTypeCodeEdit->setText(code.trimmed());
     ui_->subTabWidget->setTabVisible(
         ui_->subTabWidget->indexOf(ui_->extensionsTab), has_extension);
 }
 
 void BondInstrumentForm::setReadOnly(bool readOnly) {
-    ui_->tradeTypeCodeEdit->setReadOnly(readOnly);
     ui_->issuerEdit->setReadOnly(readOnly);
     ui_->currencyEdit->setReadOnly(readOnly);
     ui_->faceValueSpinBox->setReadOnly(readOnly);
     ui_->couponRateSpinBox->setReadOnly(readOnly);
-    ui_->couponFrequencyCodeEdit->setReadOnly(readOnly);
-    ui_->dayCountCodeEdit->setReadOnly(readOnly);
+    ui_->couponFrequencyCombo->setEnabled(!readOnly);
+    ui_->dayCountCombo->setEnabled(!readOnly);
     ui_->issueDateEdit->setReadOnly(readOnly);
     ui_->maturityDateEdit->setReadOnly(readOnly);
     ui_->settlementDaysSpinBox->setReadOnly(readOnly);
@@ -114,12 +126,12 @@ void BondInstrumentForm::setReadOnly(bool readOnly) {
     ui_->conversionRatioSpinBox->setReadOnly(readOnly);
     ui_->descriptionEdit->setReadOnly(readOnly);
     ui_->futureExpiryDateEdit->setReadOnly(readOnly);
-    ui_->optionTypeEdit->setReadOnly(readOnly);
+    ui_->optionTypeCombo->setEnabled(!readOnly);
     ui_->optionExpiryDateEdit->setReadOnly(readOnly);
     ui_->optionStrikeSpinBox->setReadOnly(readOnly);
-    ui_->trsReturnTypeEdit->setReadOnly(readOnly);
+    ui_->trsReturnTypeCombo->setEnabled(!readOnly);
     ui_->trsFundingLegCodeEdit->setReadOnly(readOnly);
-    ui_->ascotOptionTypeEdit->setReadOnly(readOnly);
+    ui_->ascotOptionTypeCombo->setEnabled(!readOnly);
 }
 
 bool BondInstrumentForm::isDirty() const { return dirty_; }
@@ -132,8 +144,6 @@ void BondInstrumentForm::setChangeReason(
 }
 
 void BondInstrumentForm::writeUiToInstrument() {
-    instrument_.trade_type_code =
-        ui_->tradeTypeCodeEdit->text().trimmed().toStdString();
     instrument_.issuer =
         ui_->issuerEdit->text().trimmed().toStdString();
     instrument_.currency =
@@ -141,9 +151,9 @@ void BondInstrumentForm::writeUiToInstrument() {
     instrument_.face_value = ui_->faceValueSpinBox->value();
     instrument_.coupon_rate = ui_->couponRateSpinBox->value();
     instrument_.coupon_frequency_code =
-        ui_->couponFrequencyCodeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->couponFrequencyCombo);
     instrument_.day_count_code =
-        ui_->dayCountCodeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->dayCountCombo);
     instrument_.issue_date =
         ui_->issueDateEdit->text().trimmed().toStdString();
     instrument_.maturity_date =
@@ -157,7 +167,7 @@ void BondInstrumentForm::writeUiToInstrument() {
     instrument_.future_expiry_date =
         ui_->futureExpiryDateEdit->text().trimmed().toStdString();
     instrument_.option_type =
-        ui_->optionTypeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->optionTypeCombo);
     instrument_.option_expiry_date =
         ui_->optionExpiryDateEdit->text().trimmed().toStdString();
     {
@@ -166,11 +176,11 @@ void BondInstrumentForm::writeUiToInstrument() {
             ? std::optional<double>(s) : std::nullopt;
     }
     instrument_.trs_return_type =
-        ui_->trsReturnTypeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->trsReturnTypeCombo);
     instrument_.trs_funding_leg_code =
         ui_->trsFundingLegCodeEdit->text().trimmed().toStdString();
     instrument_.ascot_option_type =
-        ui_->ascotOptionTypeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->ascotOptionTypeCombo);
     instrument_.modified_by = username_;
     instrument_.performed_by = username_;
 }
@@ -198,13 +208,12 @@ void BondInstrumentForm::setInstrument(
 
 void BondInstrumentForm::populateFromInstrument() {
     const auto block = [this](bool b) {
-        ui_->tradeTypeCodeEdit->blockSignals(b);
         ui_->issuerEdit->blockSignals(b);
         ui_->currencyEdit->blockSignals(b);
         ui_->faceValueSpinBox->blockSignals(b);
         ui_->couponRateSpinBox->blockSignals(b);
-        ui_->couponFrequencyCodeEdit->blockSignals(b);
-        ui_->dayCountCodeEdit->blockSignals(b);
+        ui_->couponFrequencyCombo->blockSignals(b);
+        ui_->dayCountCombo->blockSignals(b);
         ui_->issueDateEdit->blockSignals(b);
         ui_->maturityDateEdit->blockSignals(b);
         ui_->settlementDaysSpinBox->blockSignals(b);
@@ -212,12 +221,12 @@ void BondInstrumentForm::populateFromInstrument() {
         ui_->conversionRatioSpinBox->blockSignals(b);
         ui_->descriptionEdit->blockSignals(b);
         ui_->futureExpiryDateEdit->blockSignals(b);
-        ui_->optionTypeEdit->blockSignals(b);
+        ui_->optionTypeCombo->blockSignals(b);
         ui_->optionExpiryDateEdit->blockSignals(b);
         ui_->optionStrikeSpinBox->blockSignals(b);
-        ui_->trsReturnTypeEdit->blockSignals(b);
+        ui_->trsReturnTypeCombo->blockSignals(b);
         ui_->trsFundingLegCodeEdit->blockSignals(b);
-        ui_->ascotOptionTypeEdit->blockSignals(b);
+        ui_->ascotOptionTypeCombo->blockSignals(b);
     };
 
     block(true);
@@ -229,10 +238,10 @@ void BondInstrumentForm::populateFromInstrument() {
         QString::fromStdString(instrument_.currency));
     ui_->faceValueSpinBox->setValue(instrument_.face_value);
     ui_->couponRateSpinBox->setValue(instrument_.coupon_rate);
-    ui_->couponFrequencyCodeEdit->setText(
-        QString::fromStdString(instrument_.coupon_frequency_code));
-    ui_->dayCountCodeEdit->setText(
-        QString::fromStdString(instrument_.day_count_code));
+    InstrumentFormUtils::setComboValue(
+        ui_->couponFrequencyCombo, instrument_.coupon_frequency_code);
+    InstrumentFormUtils::setComboValue(
+        ui_->dayCountCombo, instrument_.day_count_code);
     ui_->issueDateEdit->setText(
         QString::fromStdString(instrument_.issue_date));
     ui_->maturityDateEdit->setText(
@@ -245,18 +254,18 @@ void BondInstrumentForm::populateFromInstrument() {
         QString::fromStdString(instrument_.description));
     ui_->futureExpiryDateEdit->setText(
         QString::fromStdString(instrument_.future_expiry_date));
-    ui_->optionTypeEdit->setText(
-        QString::fromStdString(instrument_.option_type));
+    InstrumentFormUtils::setComboValue(
+        ui_->optionTypeCombo, instrument_.option_type);
     ui_->optionExpiryDateEdit->setText(
         QString::fromStdString(instrument_.option_expiry_date));
     ui_->optionStrikeSpinBox->setValue(
         instrument_.option_strike.value_or(0.0));
-    ui_->trsReturnTypeEdit->setText(
-        QString::fromStdString(instrument_.trs_return_type));
+    InstrumentFormUtils::setComboValue(
+        ui_->trsReturnTypeCombo, instrument_.trs_return_type);
     ui_->trsFundingLegCodeEdit->setText(
         QString::fromStdString(instrument_.trs_funding_leg_code));
-    ui_->ascotOptionTypeEdit->setText(
-        QString::fromStdString(instrument_.ascot_option_type));
+    InstrumentFormUtils::setComboValue(
+        ui_->ascotOptionTypeCombo, instrument_.ascot_option_type);
     block(false);
 }
 

--- a/projects/ores.qt.trading/src/BondInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/BondInstrumentForm.cpp
@@ -123,8 +123,8 @@ void BondInstrumentForm::populateCurrencies() {
         cb->addItem(QString());
         for (const auto& c : codes)
             cb->addItem(QString::fromStdString(c));
-        cb->blockSignals(false);
         InstrumentFormUtils::setComboValue(cb, self->instrument_.currency);
+        cb->blockSignals(false);
         if (self->imageCache_)
             apply_flag_icons(cb, self->imageCache_, FlagSource::Currency);
     });

--- a/projects/ores.qt.trading/src/BookController.cpp
+++ b/projects/ores.qt.trading/src/BookController.cpp
@@ -88,11 +88,8 @@ void BookController::showListWindow() {
     listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
     listMdiSubWindow_->resize(listWindow_->sizeHint());
 
-    BOOST_LOG_SEV(lg(), info) << "DIAG: Books showListWindow calling addSubWindow";
     mdiArea_->addSubWindow(listMdiSubWindow_);
-    BOOST_LOG_SEV(lg(), info) << "DIAG: Books showListWindow addSubWindow returned, calling show";
     listMdiSubWindow_->show();
-    BOOST_LOG_SEV(lg(), info) << "DIAG: Books showListWindow show returned";
 
     // Track window
     track_window(key, listMdiSubWindow_);

--- a/projects/ores.qt.trading/src/BookController.cpp
+++ b/projects/ores.qt.trading/src/BookController.cpp
@@ -88,8 +88,11 @@ void BookController::showListWindow() {
     listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
     listMdiSubWindow_->resize(listWindow_->sizeHint());
 
+    BOOST_LOG_SEV(lg(), info) << "DIAG: Books showListWindow calling addSubWindow";
     mdiArea_->addSubWindow(listMdiSubWindow_);
+    BOOST_LOG_SEV(lg(), info) << "DIAG: Books showListWindow addSubWindow returned, calling show";
     listMdiSubWindow_->show();
+    BOOST_LOG_SEV(lg(), info) << "DIAG: Books showListWindow show returned";
 
     // Track window
     track_window(key, listMdiSubWindow_);

--- a/projects/ores.qt.trading/src/CommodityInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/CommodityInstrumentForm.cpp
@@ -19,12 +19,14 @@
  */
 #include "ores.qt/CommodityInstrumentForm.hpp"
 
+#include <QComboBox>
 #include <QPointer>
 #include <QtConcurrent>
 #include <QFutureWatcher>
 #include <boost/uuid/uuid_io.hpp>
 #include "ui_CommodityInstrumentForm.h"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/InstrumentFormUtils.hpp"
 #include "ores.trading.api/messaging/instrument_protocol.hpp"
 
 namespace ores::qt {
@@ -38,6 +40,13 @@ CommodityInstrumentForm::CommodityInstrumentForm(QWidget* parent)
     // Extensions tab hidden until setTradeType() reveals it.
     ui_->subTabWidget->setTabVisible(
         ui_->subTabWidget->indexOf(ui_->extensionsTab), false);
+    InstrumentFormUtils::populateOptionType(ui_->optionTypeCombo);
+    InstrumentFormUtils::populateExerciseType(ui_->exerciseTypeCombo);
+    InstrumentFormUtils::populateBarrierType(ui_->barrierTypeCombo);
+    InstrumentFormUtils::populateAverageType(ui_->averageTypeCombo);
+    InstrumentFormUtils::populateFrequency(ui_->stripFrequencyCombo);
+    InstrumentFormUtils::populateDayCount(ui_->dayCountCombo);
+    InstrumentFormUtils::populateFrequency(ui_->paymentFrequencyCombo);
     setupConnections();
 }
 
@@ -45,22 +54,29 @@ CommodityInstrumentForm::~CommodityInstrumentForm() = default;
 
 void CommodityInstrumentForm::setupConnections() {
     auto markChanged = [this]() { onFieldChanged(); };
-    connect(ui_->tradeTypeCodeEdit, &QLineEdit::textChanged, this, markChanged);
+    auto markChangedStr = [this](const QString&) { onFieldChanged(); };
     connect(ui_->commodityCodeEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->currencyEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->unitEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->startDateEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->maturityDateEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->optionTypeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->exerciseTypeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->barrierTypeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->averageTypeEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->optionTypeCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->exerciseTypeCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->barrierTypeCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->averageTypeCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
     connect(ui_->averagingStartDateEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->averagingEndDateEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->spreadCommodityCodeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->stripFrequencyCodeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->dayCountCodeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->paymentFrequencyCodeEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->stripFrequencyCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->dayCountCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->paymentFrequencyCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
     connect(ui_->swaptionExpiryDateEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->basketJsonEdit, &QPlainTextEdit::textChanged, this, markChanged);
     connect(ui_->descriptionEdit, &QPlainTextEdit::textChanged, this, markChanged);
@@ -111,12 +127,12 @@ void CommodityInstrumentForm::clear() {
 void CommodityInstrumentForm::setTradeType(const QString& code,
     bool /*has_options*/, bool has_extension) {
     instrument_.trade_type_code = code.trimmed().toStdString();
+    ui_->tradeTypeCodeEdit->setText(code.trimmed());
     ui_->subTabWidget->setTabVisible(
         ui_->subTabWidget->indexOf(ui_->extensionsTab), has_extension);
 }
 
 void CommodityInstrumentForm::setReadOnly(bool readOnly) {
-    ui_->tradeTypeCodeEdit->setReadOnly(readOnly);
     ui_->commodityCodeEdit->setReadOnly(readOnly);
     ui_->currencyEdit->setReadOnly(readOnly);
     ui_->quantitySpinBox->setReadOnly(readOnly);
@@ -124,23 +140,23 @@ void CommodityInstrumentForm::setReadOnly(bool readOnly) {
     ui_->startDateEdit->setReadOnly(readOnly);
     ui_->maturityDateEdit->setReadOnly(readOnly);
     ui_->fixedPriceSpinBox->setReadOnly(readOnly);
-    ui_->optionTypeEdit->setReadOnly(readOnly);
-    ui_->exerciseTypeEdit->setReadOnly(readOnly);
+    ui_->optionTypeCombo->setEnabled(!readOnly);
+    ui_->exerciseTypeCombo->setEnabled(!readOnly);
     ui_->strikePriceSpinBox->setReadOnly(readOnly);
-    ui_->barrierTypeEdit->setReadOnly(readOnly);
+    ui_->barrierTypeCombo->setEnabled(!readOnly);
     ui_->lowerBarrierSpinBox->setReadOnly(readOnly);
     ui_->upperBarrierSpinBox->setReadOnly(readOnly);
-    ui_->averageTypeEdit->setReadOnly(readOnly);
+    ui_->averageTypeCombo->setEnabled(!readOnly);
     ui_->averagingStartDateEdit->setReadOnly(readOnly);
     ui_->averagingEndDateEdit->setReadOnly(readOnly);
     ui_->spreadCommodityCodeEdit->setReadOnly(readOnly);
     ui_->spreadAmountSpinBox->setReadOnly(readOnly);
-    ui_->stripFrequencyCodeEdit->setReadOnly(readOnly);
+    ui_->stripFrequencyCombo->setEnabled(!readOnly);
     ui_->varianceStrikeSpinBox->setReadOnly(readOnly);
     ui_->accumulationAmountSpinBox->setReadOnly(readOnly);
     ui_->knockOutBarrierSpinBox->setReadOnly(readOnly);
-    ui_->dayCountCodeEdit->setReadOnly(readOnly);
-    ui_->paymentFrequencyCodeEdit->setReadOnly(readOnly);
+    ui_->dayCountCombo->setEnabled(!readOnly);
+    ui_->paymentFrequencyCombo->setEnabled(!readOnly);
     ui_->swaptionExpiryDateEdit->setReadOnly(readOnly);
     ui_->basketJsonEdit->setReadOnly(readOnly);
     ui_->descriptionEdit->setReadOnly(readOnly);
@@ -156,8 +172,6 @@ void CommodityInstrumentForm::setChangeReason(
 }
 
 void CommodityInstrumentForm::writeUiToInstrument() {
-    instrument_.trade_type_code =
-        ui_->tradeTypeCodeEdit->text().trimmed().toStdString();
     instrument_.commodity_code =
         ui_->commodityCodeEdit->text().trimmed().toStdString();
     instrument_.currency =
@@ -175,16 +189,16 @@ void CommodityInstrumentForm::writeUiToInstrument() {
             ? std::optional<double>(v) : std::nullopt;
     }
     instrument_.option_type =
-        ui_->optionTypeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->optionTypeCombo);
     {
         const double v = ui_->strikePriceSpinBox->value();
         instrument_.strike_price = (v > 0.0)
             ? std::optional<double>(v) : std::nullopt;
     }
     instrument_.exercise_type =
-        ui_->exerciseTypeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->exerciseTypeCombo);
     instrument_.average_type =
-        ui_->averageTypeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->averageTypeCombo);
     instrument_.averaging_start_date =
         ui_->averagingStartDateEdit->text().trimmed().toStdString();
     instrument_.averaging_end_date =
@@ -197,7 +211,7 @@ void CommodityInstrumentForm::writeUiToInstrument() {
             ? std::optional<double>(v) : std::nullopt;
     }
     instrument_.strip_frequency_code =
-        ui_->stripFrequencyCodeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->stripFrequencyCombo);
     {
         const double v = ui_->varianceStrikeSpinBox->value();
         instrument_.variance_strike = (v > 0.0)
@@ -214,7 +228,7 @@ void CommodityInstrumentForm::writeUiToInstrument() {
             ? std::optional<double>(v) : std::nullopt;
     }
     instrument_.barrier_type =
-        ui_->barrierTypeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->barrierTypeCombo);
     {
         const double v = ui_->lowerBarrierSpinBox->value();
         instrument_.lower_barrier = (v > 0.0)
@@ -228,9 +242,9 @@ void CommodityInstrumentForm::writeUiToInstrument() {
     instrument_.basket_json =
         ui_->basketJsonEdit->toPlainText().trimmed().toStdString();
     instrument_.day_count_code =
-        ui_->dayCountCodeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->dayCountCombo);
     instrument_.payment_frequency_code =
-        ui_->paymentFrequencyCodeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->paymentFrequencyCombo);
     instrument_.swaption_expiry_date =
         ui_->swaptionExpiryDateEdit->text().trimmed().toStdString();
     instrument_.description =
@@ -262,7 +276,6 @@ void CommodityInstrumentForm::setInstrument(
 
 void CommodityInstrumentForm::populateFromInstrument() {
     const auto block = [this](bool b) {
-        ui_->tradeTypeCodeEdit->blockSignals(b);
         ui_->commodityCodeEdit->blockSignals(b);
         ui_->currencyEdit->blockSignals(b);
         ui_->quantitySpinBox->blockSignals(b);
@@ -270,24 +283,24 @@ void CommodityInstrumentForm::populateFromInstrument() {
         ui_->startDateEdit->blockSignals(b);
         ui_->maturityDateEdit->blockSignals(b);
         ui_->fixedPriceSpinBox->blockSignals(b);
-        ui_->optionTypeEdit->blockSignals(b);
+        ui_->optionTypeCombo->blockSignals(b);
         ui_->strikePriceSpinBox->blockSignals(b);
-        ui_->exerciseTypeEdit->blockSignals(b);
-        ui_->averageTypeEdit->blockSignals(b);
+        ui_->exerciseTypeCombo->blockSignals(b);
+        ui_->averageTypeCombo->blockSignals(b);
         ui_->averagingStartDateEdit->blockSignals(b);
         ui_->averagingEndDateEdit->blockSignals(b);
         ui_->spreadCommodityCodeEdit->blockSignals(b);
         ui_->spreadAmountSpinBox->blockSignals(b);
-        ui_->stripFrequencyCodeEdit->blockSignals(b);
+        ui_->stripFrequencyCombo->blockSignals(b);
         ui_->varianceStrikeSpinBox->blockSignals(b);
         ui_->accumulationAmountSpinBox->blockSignals(b);
         ui_->knockOutBarrierSpinBox->blockSignals(b);
-        ui_->barrierTypeEdit->blockSignals(b);
+        ui_->barrierTypeCombo->blockSignals(b);
         ui_->lowerBarrierSpinBox->blockSignals(b);
         ui_->upperBarrierSpinBox->blockSignals(b);
         ui_->basketJsonEdit->blockSignals(b);
-        ui_->dayCountCodeEdit->blockSignals(b);
-        ui_->paymentFrequencyCodeEdit->blockSignals(b);
+        ui_->dayCountCombo->blockSignals(b);
+        ui_->paymentFrequencyCombo->blockSignals(b);
         ui_->swaptionExpiryDateEdit->blockSignals(b);
         ui_->descriptionEdit->blockSignals(b);
     };
@@ -307,13 +320,13 @@ void CommodityInstrumentForm::populateFromInstrument() {
     ui_->maturityDateEdit->setText(
         QString::fromStdString(instrument_.maturity_date));
     ui_->fixedPriceSpinBox->setValue(instrument_.fixed_price.value_or(0.0));
-    ui_->optionTypeEdit->setText(
-        QString::fromStdString(instrument_.option_type));
+    InstrumentFormUtils::setComboValue(
+        ui_->optionTypeCombo, instrument_.option_type);
     ui_->strikePriceSpinBox->setValue(instrument_.strike_price.value_or(0.0));
-    ui_->exerciseTypeEdit->setText(
-        QString::fromStdString(instrument_.exercise_type));
-    ui_->averageTypeEdit->setText(
-        QString::fromStdString(instrument_.average_type));
+    InstrumentFormUtils::setComboValue(
+        ui_->exerciseTypeCombo, instrument_.exercise_type);
+    InstrumentFormUtils::setComboValue(
+        ui_->averageTypeCombo, instrument_.average_type);
     ui_->averagingStartDateEdit->setText(
         QString::fromStdString(instrument_.averaging_start_date));
     ui_->averagingEndDateEdit->setText(
@@ -321,24 +334,24 @@ void CommodityInstrumentForm::populateFromInstrument() {
     ui_->spreadCommodityCodeEdit->setText(
         QString::fromStdString(instrument_.spread_commodity_code));
     ui_->spreadAmountSpinBox->setValue(instrument_.spread_amount.value_or(0.0));
-    ui_->stripFrequencyCodeEdit->setText(
-        QString::fromStdString(instrument_.strip_frequency_code));
+    InstrumentFormUtils::setComboValue(
+        ui_->stripFrequencyCombo, instrument_.strip_frequency_code);
     ui_->varianceStrikeSpinBox->setValue(
         instrument_.variance_strike.value_or(0.0));
     ui_->accumulationAmountSpinBox->setValue(
         instrument_.accumulation_amount.value_or(0.0));
     ui_->knockOutBarrierSpinBox->setValue(
         instrument_.knock_out_barrier.value_or(0.0));
-    ui_->barrierTypeEdit->setText(
-        QString::fromStdString(instrument_.barrier_type));
+    InstrumentFormUtils::setComboValue(
+        ui_->barrierTypeCombo, instrument_.barrier_type);
     ui_->lowerBarrierSpinBox->setValue(instrument_.lower_barrier.value_or(0.0));
     ui_->upperBarrierSpinBox->setValue(instrument_.upper_barrier.value_or(0.0));
     ui_->basketJsonEdit->setPlainText(
         QString::fromStdString(instrument_.basket_json));
-    ui_->dayCountCodeEdit->setText(
-        QString::fromStdString(instrument_.day_count_code));
-    ui_->paymentFrequencyCodeEdit->setText(
-        QString::fromStdString(instrument_.payment_frequency_code));
+    InstrumentFormUtils::setComboValue(
+        ui_->dayCountCombo, instrument_.day_count_code);
+    InstrumentFormUtils::setComboValue(
+        ui_->paymentFrequencyCombo, instrument_.payment_frequency_code);
     ui_->swaptionExpiryDateEdit->setText(
         QString::fromStdString(instrument_.swaption_expiry_date));
     ui_->descriptionEdit->setPlainText(

--- a/projects/ores.qt.trading/src/CommodityInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/CommodityInstrumentForm.cpp
@@ -26,6 +26,9 @@
 #include <boost/uuid/uuid_io.hpp>
 #include "ui_CommodityInstrumentForm.h"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ImageCache.hpp"
+#include "ores.qt/FlagIconHelper.hpp"
+#include "ores.qt/LookupFetcher.hpp"
 #include "ores.qt/InstrumentFormUtils.hpp"
 #include "ores.trading.api/messaging/instrument_protocol.hpp"
 
@@ -55,11 +58,13 @@ CommodityInstrumentForm::~CommodityInstrumentForm() = default;
 void CommodityInstrumentForm::setupConnections() {
     auto markChanged = [this]() { onFieldChanged(); };
     auto markChangedStr = [this](const QString&) { onFieldChanged(); };
+    auto markChangedDate = [this](const QDate&) { onFieldChanged(); };
     connect(ui_->commodityCodeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->currencyEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->currencyCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
     connect(ui_->unitEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->startDateEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->maturityDateEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->startDateEdit, &QDateEdit::dateChanged, this, markChangedDate);
+    connect(ui_->maturityDateEdit, &QDateEdit::dateChanged, this, markChangedDate);
     connect(ui_->optionTypeCombo, &QComboBox::currentTextChanged,
             this, markChangedStr);
     connect(ui_->exerciseTypeCombo, &QComboBox::currentTextChanged,
@@ -68,8 +73,10 @@ void CommodityInstrumentForm::setupConnections() {
             this, markChangedStr);
     connect(ui_->averageTypeCombo, &QComboBox::currentTextChanged,
             this, markChangedStr);
-    connect(ui_->averagingStartDateEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->averagingEndDateEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->averagingStartDateEdit, &QDateEdit::dateChanged,
+            this, markChangedDate);
+    connect(ui_->averagingEndDateEdit, &QDateEdit::dateChanged,
+            this, markChangedDate);
     connect(ui_->spreadCommodityCodeEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->stripFrequencyCombo, &QComboBox::currentTextChanged,
             this, markChangedStr);
@@ -77,7 +84,8 @@ void CommodityInstrumentForm::setupConnections() {
             this, markChangedStr);
     connect(ui_->paymentFrequencyCombo, &QComboBox::currentTextChanged,
             this, markChangedStr);
-    connect(ui_->swaptionExpiryDateEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->swaptionExpiryDateEdit, &QDateEdit::dateChanged,
+            this, markChangedDate);
     connect(ui_->basketJsonEdit, &QPlainTextEdit::textChanged, this, markChanged);
     connect(ui_->descriptionEdit, &QPlainTextEdit::textChanged, this, markChanged);
     connect(ui_->quantitySpinBox,
@@ -111,6 +119,41 @@ void CommodityInstrumentForm::setupConnections() {
 
 void CommodityInstrumentForm::setClientManager(ClientManager* cm) {
     clientManager_ = cm;
+    populateCurrencies();
+}
+
+void CommodityInstrumentForm::setImageCache(ImageCache* cache) {
+    imageCache_ = cache;
+    setup_flag_combo(this, ui_->currencyCombo, imageCache_,
+                     FlagSource::Currency);
+}
+
+void CommodityInstrumentForm::populateCurrencies() {
+    if (!clientManager_) return;
+
+    QPointer<CommodityInstrumentForm> self = this;
+    auto* watcher = new QFutureWatcher<std::vector<std::string>>(self);
+    connect(watcher, &QFutureWatcher<std::vector<std::string>>::finished, self,
+        [self, watcher]() {
+        auto codes = watcher->result();
+        watcher->deleteLater();
+        if (!self) return;
+        auto* cb = self->ui_->currencyCombo;
+        cb->blockSignals(true);
+        cb->clear();
+        cb->addItem(QString());
+        for (const auto& c : codes)
+            cb->addItem(QString::fromStdString(c));
+        InstrumentFormUtils::setComboValue(cb, self->instrument_.currency);
+        cb->blockSignals(false);
+        if (self->imageCache_)
+            apply_flag_icons(cb, self->imageCache_, FlagSource::Currency);
+    });
+
+    auto* cm = clientManager_;
+    watcher->setFuture(QtConcurrent::run([cm]() {
+        return fetch_currency_codes(cm);
+    }));
 }
 
 void CommodityInstrumentForm::setUsername(const std::string& username) {
@@ -134,7 +177,7 @@ void CommodityInstrumentForm::setTradeType(const QString& code,
 
 void CommodityInstrumentForm::setReadOnly(bool readOnly) {
     ui_->commodityCodeEdit->setReadOnly(readOnly);
-    ui_->currencyEdit->setReadOnly(readOnly);
+    ui_->currencyCombo->setEnabled(!readOnly);
     ui_->quantitySpinBox->setReadOnly(readOnly);
     ui_->unitEdit->setReadOnly(readOnly);
     ui_->startDateEdit->setReadOnly(readOnly);
@@ -175,14 +218,12 @@ void CommodityInstrumentForm::writeUiToInstrument() {
     instrument_.commodity_code =
         ui_->commodityCodeEdit->text().trimmed().toStdString();
     instrument_.currency =
-        ui_->currencyEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->currencyCombo);
     instrument_.quantity = ui_->quantitySpinBox->value();
     instrument_.unit =
         ui_->unitEdit->text().trimmed().toStdString();
-    instrument_.start_date =
-        ui_->startDateEdit->text().trimmed().toStdString();
-    instrument_.maturity_date =
-        ui_->maturityDateEdit->text().trimmed().toStdString();
+    instrument_.start_date = ui_->startDateEdit->isoDate();
+    instrument_.maturity_date = ui_->maturityDateEdit->isoDate();
     {
         const double v = ui_->fixedPriceSpinBox->value();
         instrument_.fixed_price = (v > 0.0)
@@ -199,10 +240,8 @@ void CommodityInstrumentForm::writeUiToInstrument() {
         InstrumentFormUtils::getComboValue(ui_->exerciseTypeCombo);
     instrument_.average_type =
         InstrumentFormUtils::getComboValue(ui_->averageTypeCombo);
-    instrument_.averaging_start_date =
-        ui_->averagingStartDateEdit->text().trimmed().toStdString();
-    instrument_.averaging_end_date =
-        ui_->averagingEndDateEdit->text().trimmed().toStdString();
+    instrument_.averaging_start_date = ui_->averagingStartDateEdit->isoDate();
+    instrument_.averaging_end_date = ui_->averagingEndDateEdit->isoDate();
     instrument_.spread_commodity_code =
         ui_->spreadCommodityCodeEdit->text().trimmed().toStdString();
     {
@@ -245,8 +284,7 @@ void CommodityInstrumentForm::writeUiToInstrument() {
         InstrumentFormUtils::getComboValue(ui_->dayCountCombo);
     instrument_.payment_frequency_code =
         InstrumentFormUtils::getComboValue(ui_->paymentFrequencyCombo);
-    instrument_.swaption_expiry_date =
-        ui_->swaptionExpiryDateEdit->text().trimmed().toStdString();
+    instrument_.swaption_expiry_date = ui_->swaptionExpiryDateEdit->isoDate();
     instrument_.description =
         ui_->descriptionEdit->toPlainText().trimmed().toStdString();
     instrument_.modified_by = username_;
@@ -277,7 +315,7 @@ void CommodityInstrumentForm::setInstrument(
 void CommodityInstrumentForm::populateFromInstrument() {
     const auto block = [this](bool b) {
         ui_->commodityCodeEdit->blockSignals(b);
-        ui_->currencyEdit->blockSignals(b);
+        ui_->currencyCombo->blockSignals(b);
         ui_->quantitySpinBox->blockSignals(b);
         ui_->unitEdit->blockSignals(b);
         ui_->startDateEdit->blockSignals(b);
@@ -310,15 +348,13 @@ void CommodityInstrumentForm::populateFromInstrument() {
         QString::fromStdString(instrument_.trade_type_code));
     ui_->commodityCodeEdit->setText(
         QString::fromStdString(instrument_.commodity_code));
-    ui_->currencyEdit->setText(
-        QString::fromStdString(instrument_.currency));
+    InstrumentFormUtils::setComboValue(
+        ui_->currencyCombo, instrument_.currency);
     ui_->quantitySpinBox->setValue(instrument_.quantity);
     ui_->unitEdit->setText(
         QString::fromStdString(instrument_.unit));
-    ui_->startDateEdit->setText(
-        QString::fromStdString(instrument_.start_date));
-    ui_->maturityDateEdit->setText(
-        QString::fromStdString(instrument_.maturity_date));
+    ui_->startDateEdit->setIsoDate(instrument_.start_date);
+    ui_->maturityDateEdit->setIsoDate(instrument_.maturity_date);
     ui_->fixedPriceSpinBox->setValue(instrument_.fixed_price.value_or(0.0));
     InstrumentFormUtils::setComboValue(
         ui_->optionTypeCombo, instrument_.option_type);
@@ -327,10 +363,8 @@ void CommodityInstrumentForm::populateFromInstrument() {
         ui_->exerciseTypeCombo, instrument_.exercise_type);
     InstrumentFormUtils::setComboValue(
         ui_->averageTypeCombo, instrument_.average_type);
-    ui_->averagingStartDateEdit->setText(
-        QString::fromStdString(instrument_.averaging_start_date));
-    ui_->averagingEndDateEdit->setText(
-        QString::fromStdString(instrument_.averaging_end_date));
+    ui_->averagingStartDateEdit->setIsoDate(instrument_.averaging_start_date);
+    ui_->averagingEndDateEdit->setIsoDate(instrument_.averaging_end_date);
     ui_->spreadCommodityCodeEdit->setText(
         QString::fromStdString(instrument_.spread_commodity_code));
     ui_->spreadAmountSpinBox->setValue(instrument_.spread_amount.value_or(0.0));
@@ -352,8 +386,7 @@ void CommodityInstrumentForm::populateFromInstrument() {
         ui_->dayCountCombo, instrument_.day_count_code);
     InstrumentFormUtils::setComboValue(
         ui_->paymentFrequencyCombo, instrument_.payment_frequency_code);
-    ui_->swaptionExpiryDateEdit->setText(
-        QString::fromStdString(instrument_.swaption_expiry_date));
+    ui_->swaptionExpiryDateEdit->setIsoDate(instrument_.swaption_expiry_date);
     ui_->descriptionEdit->setPlainText(
         QString::fromStdString(instrument_.description));
     block(false);

--- a/projects/ores.qt.trading/src/CreditInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/CreditInstrumentForm.cpp
@@ -19,12 +19,14 @@
  */
 #include "ores.qt/CreditInstrumentForm.hpp"
 
+#include <QComboBox>
 #include <QPointer>
 #include <QtConcurrent>
 #include <QFutureWatcher>
 #include <boost/uuid/uuid_io.hpp>
 #include "ui_CreditInstrumentForm.h"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/InstrumentFormUtils.hpp"
 #include "ores.trading.api/messaging/instrument_protocol.hpp"
 
 namespace ores::qt {
@@ -38,6 +40,11 @@ CreditInstrumentForm::CreditInstrumentForm(QWidget* parent)
     // Extensions tab hidden until setTradeType() reveals it.
     ui_->subTabWidget->setTabVisible(
         ui_->subTabWidget->indexOf(ui_->extensionsTab), false);
+    InstrumentFormUtils::populateDayCount(ui_->dayCountCombo);
+    InstrumentFormUtils::populateFrequency(ui_->paymentFrequencyCombo);
+    InstrumentFormUtils::populateSeniority(ui_->seniorityCombo);
+    InstrumentFormUtils::populateRestructuring(ui_->restructuringCombo);
+    InstrumentFormUtils::populateOptionType(ui_->optionTypeCombo);
     setupConnections();
 }
 
@@ -45,19 +52,24 @@ CreditInstrumentForm::~CreditInstrumentForm() = default;
 
 void CreditInstrumentForm::setupConnections() {
     auto markChanged = [this]() { onFieldChanged(); };
-    connect(ui_->tradeTypeCodeEdit, &QLineEdit::textChanged, this, markChanged);
+    auto markChangedStr = [this](const QString&) { onFieldChanged(); };
     connect(ui_->referenceEntityEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->currencyEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->tenorEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->startDateEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->maturityDateEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->dayCountCodeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->paymentFrequencyCodeEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->dayCountCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->paymentFrequencyCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
     connect(ui_->indexNameEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->seniorityEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->restructuringEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->seniorityCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->restructuringCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
     connect(ui_->descriptionEdit, &QPlainTextEdit::textChanged, this, markChanged);
-    connect(ui_->optionTypeEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->optionTypeCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
     connect(ui_->optionExpiryDateEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->linkedAssetCodeEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->notionalSpinBox,
@@ -101,12 +113,12 @@ void CreditInstrumentForm::clear() {
 void CreditInstrumentForm::setTradeType(const QString& code,
     bool /*has_options*/, bool has_extension) {
     instrument_.trade_type_code = code.trimmed().toStdString();
+    ui_->tradeTypeCodeEdit->setText(code.trimmed());
     ui_->subTabWidget->setTabVisible(
         ui_->subTabWidget->indexOf(ui_->extensionsTab), has_extension);
 }
 
 void CreditInstrumentForm::setReadOnly(bool readOnly) {
-    ui_->tradeTypeCodeEdit->setReadOnly(readOnly);
     ui_->referenceEntityEdit->setReadOnly(readOnly);
     ui_->currencyEdit->setReadOnly(readOnly);
     ui_->notionalSpinBox->setReadOnly(readOnly);
@@ -115,14 +127,14 @@ void CreditInstrumentForm::setReadOnly(bool readOnly) {
     ui_->tenorEdit->setReadOnly(readOnly);
     ui_->startDateEdit->setReadOnly(readOnly);
     ui_->maturityDateEdit->setReadOnly(readOnly);
-    ui_->dayCountCodeEdit->setReadOnly(readOnly);
-    ui_->paymentFrequencyCodeEdit->setReadOnly(readOnly);
+    ui_->dayCountCombo->setEnabled(!readOnly);
+    ui_->paymentFrequencyCombo->setEnabled(!readOnly);
     ui_->indexNameEdit->setReadOnly(readOnly);
     ui_->indexSeriesSpinBox->setReadOnly(readOnly);
-    ui_->seniorityEdit->setReadOnly(readOnly);
-    ui_->restructuringEdit->setReadOnly(readOnly);
+    ui_->seniorityCombo->setEnabled(!readOnly);
+    ui_->restructuringCombo->setEnabled(!readOnly);
     ui_->descriptionEdit->setReadOnly(readOnly);
-    ui_->optionTypeEdit->setReadOnly(readOnly);
+    ui_->optionTypeCombo->setEnabled(!readOnly);
     ui_->optionExpiryDateEdit->setReadOnly(readOnly);
     ui_->optionStrikeSpinBox->setReadOnly(readOnly);
     ui_->linkedAssetCodeEdit->setReadOnly(readOnly);
@@ -140,8 +152,6 @@ void CreditInstrumentForm::setChangeReason(
 }
 
 void CreditInstrumentForm::writeUiToInstrument() {
-    instrument_.trade_type_code =
-        ui_->tradeTypeCodeEdit->text().trimmed().toStdString();
     instrument_.reference_entity =
         ui_->referenceEntityEdit->text().trimmed().toStdString();
     instrument_.currency =
@@ -156,20 +166,20 @@ void CreditInstrumentForm::writeUiToInstrument() {
     instrument_.maturity_date =
         ui_->maturityDateEdit->text().trimmed().toStdString();
     instrument_.day_count_code =
-        ui_->dayCountCodeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->dayCountCombo);
     instrument_.payment_frequency_code =
-        ui_->paymentFrequencyCodeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->paymentFrequencyCombo);
     instrument_.index_name =
         ui_->indexNameEdit->text().trimmed().toStdString();
     instrument_.index_series = ui_->indexSeriesSpinBox->value();
     instrument_.seniority =
-        ui_->seniorityEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->seniorityCombo);
     instrument_.restructuring =
-        ui_->restructuringEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->restructuringCombo);
     instrument_.description =
         ui_->descriptionEdit->toPlainText().trimmed().toStdString();
     instrument_.option_type =
-        ui_->optionTypeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->optionTypeCombo);
     instrument_.option_expiry_date =
         ui_->optionExpiryDateEdit->text().trimmed().toStdString();
     {
@@ -216,7 +226,6 @@ void CreditInstrumentForm::setInstrument(
 
 void CreditInstrumentForm::populateFromInstrument() {
     const auto block = [this](bool b) {
-        ui_->tradeTypeCodeEdit->blockSignals(b);
         ui_->referenceEntityEdit->blockSignals(b);
         ui_->currencyEdit->blockSignals(b);
         ui_->notionalSpinBox->blockSignals(b);
@@ -225,14 +234,14 @@ void CreditInstrumentForm::populateFromInstrument() {
         ui_->tenorEdit->blockSignals(b);
         ui_->startDateEdit->blockSignals(b);
         ui_->maturityDateEdit->blockSignals(b);
-        ui_->dayCountCodeEdit->blockSignals(b);
-        ui_->paymentFrequencyCodeEdit->blockSignals(b);
+        ui_->dayCountCombo->blockSignals(b);
+        ui_->paymentFrequencyCombo->blockSignals(b);
         ui_->indexNameEdit->blockSignals(b);
         ui_->indexSeriesSpinBox->blockSignals(b);
-        ui_->seniorityEdit->blockSignals(b);
-        ui_->restructuringEdit->blockSignals(b);
+        ui_->seniorityCombo->blockSignals(b);
+        ui_->restructuringCombo->blockSignals(b);
         ui_->descriptionEdit->blockSignals(b);
-        ui_->optionTypeEdit->blockSignals(b);
+        ui_->optionTypeCombo->blockSignals(b);
         ui_->optionExpiryDateEdit->blockSignals(b);
         ui_->optionStrikeSpinBox->blockSignals(b);
         ui_->linkedAssetCodeEdit->blockSignals(b);
@@ -256,21 +265,21 @@ void CreditInstrumentForm::populateFromInstrument() {
         QString::fromStdString(instrument_.start_date));
     ui_->maturityDateEdit->setText(
         QString::fromStdString(instrument_.maturity_date));
-    ui_->dayCountCodeEdit->setText(
-        QString::fromStdString(instrument_.day_count_code));
-    ui_->paymentFrequencyCodeEdit->setText(
-        QString::fromStdString(instrument_.payment_frequency_code));
+    InstrumentFormUtils::setComboValue(
+        ui_->dayCountCombo, instrument_.day_count_code);
+    InstrumentFormUtils::setComboValue(
+        ui_->paymentFrequencyCombo, instrument_.payment_frequency_code);
     ui_->indexNameEdit->setText(
         QString::fromStdString(instrument_.index_name));
     ui_->indexSeriesSpinBox->setValue(instrument_.index_series);
-    ui_->seniorityEdit->setText(
-        QString::fromStdString(instrument_.seniority));
-    ui_->restructuringEdit->setText(
-        QString::fromStdString(instrument_.restructuring));
+    InstrumentFormUtils::setComboValue(
+        ui_->seniorityCombo, instrument_.seniority);
+    InstrumentFormUtils::setComboValue(
+        ui_->restructuringCombo, instrument_.restructuring);
     ui_->descriptionEdit->setPlainText(
         QString::fromStdString(instrument_.description));
-    ui_->optionTypeEdit->setText(
-        QString::fromStdString(instrument_.option_type));
+    InstrumentFormUtils::setComboValue(
+        ui_->optionTypeCombo, instrument_.option_type);
     ui_->optionExpiryDateEdit->setText(
         QString::fromStdString(instrument_.option_expiry_date));
     ui_->optionStrikeSpinBox->setValue(

--- a/projects/ores.qt.trading/src/CreditInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/CreditInstrumentForm.cpp
@@ -26,6 +26,9 @@
 #include <boost/uuid/uuid_io.hpp>
 #include "ui_CreditInstrumentForm.h"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ImageCache.hpp"
+#include "ores.qt/FlagIconHelper.hpp"
+#include "ores.qt/LookupFetcher.hpp"
 #include "ores.qt/InstrumentFormUtils.hpp"
 #include "ores.trading.api/messaging/instrument_protocol.hpp"
 
@@ -53,11 +56,13 @@ CreditInstrumentForm::~CreditInstrumentForm() = default;
 void CreditInstrumentForm::setupConnections() {
     auto markChanged = [this]() { onFieldChanged(); };
     auto markChangedStr = [this](const QString&) { onFieldChanged(); };
+    auto markChangedDate = [this](const QDate&) { onFieldChanged(); };
     connect(ui_->referenceEntityEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->currencyEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->currencyCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
     connect(ui_->tenorEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->startDateEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->maturityDateEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->startDateEdit, &QDateEdit::dateChanged, this, markChangedDate);
+    connect(ui_->maturityDateEdit, &QDateEdit::dateChanged, this, markChangedDate);
     connect(ui_->dayCountCombo, &QComboBox::currentTextChanged,
             this, markChangedStr);
     connect(ui_->paymentFrequencyCombo, &QComboBox::currentTextChanged,
@@ -70,7 +75,8 @@ void CreditInstrumentForm::setupConnections() {
     connect(ui_->descriptionEdit, &QPlainTextEdit::textChanged, this, markChanged);
     connect(ui_->optionTypeCombo, &QComboBox::currentTextChanged,
             this, markChangedStr);
-    connect(ui_->optionExpiryDateEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->optionExpiryDateEdit, &QDateEdit::dateChanged,
+            this, markChangedDate);
     connect(ui_->linkedAssetCodeEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->notionalSpinBox,
             QOverload<double>::of(&QDoubleSpinBox::valueChanged),
@@ -97,6 +103,41 @@ void CreditInstrumentForm::setupConnections() {
 
 void CreditInstrumentForm::setClientManager(ClientManager* cm) {
     clientManager_ = cm;
+    populateCurrencies();
+}
+
+void CreditInstrumentForm::setImageCache(ImageCache* cache) {
+    imageCache_ = cache;
+    setup_flag_combo(this, ui_->currencyCombo, imageCache_,
+                     FlagSource::Currency);
+}
+
+void CreditInstrumentForm::populateCurrencies() {
+    if (!clientManager_) return;
+
+    QPointer<CreditInstrumentForm> self = this;
+    auto* watcher = new QFutureWatcher<std::vector<std::string>>(self);
+    connect(watcher, &QFutureWatcher<std::vector<std::string>>::finished, self,
+        [self, watcher]() {
+        auto codes = watcher->result();
+        watcher->deleteLater();
+        if (!self) return;
+        auto* cb = self->ui_->currencyCombo;
+        cb->blockSignals(true);
+        cb->clear();
+        cb->addItem(QString());
+        for (const auto& c : codes)
+            cb->addItem(QString::fromStdString(c));
+        InstrumentFormUtils::setComboValue(cb, self->instrument_.currency);
+        cb->blockSignals(false);
+        if (self->imageCache_)
+            apply_flag_icons(cb, self->imageCache_, FlagSource::Currency);
+    });
+
+    auto* cm = clientManager_;
+    watcher->setFuture(QtConcurrent::run([cm]() {
+        return fetch_currency_codes(cm);
+    }));
 }
 
 void CreditInstrumentForm::setUsername(const std::string& username) {
@@ -120,7 +161,7 @@ void CreditInstrumentForm::setTradeType(const QString& code,
 
 void CreditInstrumentForm::setReadOnly(bool readOnly) {
     ui_->referenceEntityEdit->setReadOnly(readOnly);
-    ui_->currencyEdit->setReadOnly(readOnly);
+    ui_->currencyCombo->setEnabled(!readOnly);
     ui_->notionalSpinBox->setReadOnly(readOnly);
     ui_->spreadSpinBox->setReadOnly(readOnly);
     ui_->recoveryRateSpinBox->setReadOnly(readOnly);
@@ -155,16 +196,14 @@ void CreditInstrumentForm::writeUiToInstrument() {
     instrument_.reference_entity =
         ui_->referenceEntityEdit->text().trimmed().toStdString();
     instrument_.currency =
-        ui_->currencyEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->currencyCombo);
     instrument_.notional = ui_->notionalSpinBox->value();
     instrument_.spread = ui_->spreadSpinBox->value();
     instrument_.recovery_rate = ui_->recoveryRateSpinBox->value();
     instrument_.tenor =
         ui_->tenorEdit->text().trimmed().toStdString();
-    instrument_.start_date =
-        ui_->startDateEdit->text().trimmed().toStdString();
-    instrument_.maturity_date =
-        ui_->maturityDateEdit->text().trimmed().toStdString();
+    instrument_.start_date = ui_->startDateEdit->isoDate();
+    instrument_.maturity_date = ui_->maturityDateEdit->isoDate();
     instrument_.day_count_code =
         InstrumentFormUtils::getComboValue(ui_->dayCountCombo);
     instrument_.payment_frequency_code =
@@ -180,8 +219,7 @@ void CreditInstrumentForm::writeUiToInstrument() {
         ui_->descriptionEdit->toPlainText().trimmed().toStdString();
     instrument_.option_type =
         InstrumentFormUtils::getComboValue(ui_->optionTypeCombo);
-    instrument_.option_expiry_date =
-        ui_->optionExpiryDateEdit->text().trimmed().toStdString();
+    instrument_.option_expiry_date = ui_->optionExpiryDateEdit->isoDate();
     {
         const double s = ui_->optionStrikeSpinBox->value();
         instrument_.option_strike = (s > 0.0)
@@ -227,7 +265,7 @@ void CreditInstrumentForm::setInstrument(
 void CreditInstrumentForm::populateFromInstrument() {
     const auto block = [this](bool b) {
         ui_->referenceEntityEdit->blockSignals(b);
-        ui_->currencyEdit->blockSignals(b);
+        ui_->currencyCombo->blockSignals(b);
         ui_->notionalSpinBox->blockSignals(b);
         ui_->spreadSpinBox->blockSignals(b);
         ui_->recoveryRateSpinBox->blockSignals(b);
@@ -254,17 +292,15 @@ void CreditInstrumentForm::populateFromInstrument() {
         QString::fromStdString(instrument_.trade_type_code));
     ui_->referenceEntityEdit->setText(
         QString::fromStdString(instrument_.reference_entity));
-    ui_->currencyEdit->setText(
-        QString::fromStdString(instrument_.currency));
+    InstrumentFormUtils::setComboValue(
+        ui_->currencyCombo, instrument_.currency);
     ui_->notionalSpinBox->setValue(instrument_.notional);
     ui_->spreadSpinBox->setValue(instrument_.spread);
     ui_->recoveryRateSpinBox->setValue(instrument_.recovery_rate);
     ui_->tenorEdit->setText(
         QString::fromStdString(instrument_.tenor));
-    ui_->startDateEdit->setText(
-        QString::fromStdString(instrument_.start_date));
-    ui_->maturityDateEdit->setText(
-        QString::fromStdString(instrument_.maturity_date));
+    ui_->startDateEdit->setIsoDate(instrument_.start_date);
+    ui_->maturityDateEdit->setIsoDate(instrument_.maturity_date);
     InstrumentFormUtils::setComboValue(
         ui_->dayCountCombo, instrument_.day_count_code);
     InstrumentFormUtils::setComboValue(
@@ -280,8 +316,7 @@ void CreditInstrumentForm::populateFromInstrument() {
         QString::fromStdString(instrument_.description));
     InstrumentFormUtils::setComboValue(
         ui_->optionTypeCombo, instrument_.option_type);
-    ui_->optionExpiryDateEdit->setText(
-        QString::fromStdString(instrument_.option_expiry_date));
+    ui_->optionExpiryDateEdit->setIsoDate(instrument_.option_expiry_date);
     ui_->optionStrikeSpinBox->setValue(
         instrument_.option_strike.value_or(0.0));
     ui_->linkedAssetCodeEdit->setText(

--- a/projects/ores.qt.trading/src/EquityInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/EquityInstrumentForm.cpp
@@ -19,12 +19,14 @@
  */
 #include "ores.qt/EquityInstrumentForm.hpp"
 
+#include <QComboBox>
 #include <QPointer>
 #include <QtConcurrent>
 #include <QFutureWatcher>
 #include <boost/uuid/uuid_io.hpp>
 #include "ui_EquityInstrumentForm.h"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/InstrumentFormUtils.hpp"
 #include "ores.trading.api/messaging/instrument_protocol.hpp"
 
 namespace ores::qt {
@@ -40,6 +42,14 @@ EquityInstrumentForm::EquityInstrumentForm(QWidget* parent)
         ui_->subTabWidget->indexOf(ui_->optionsTab), false);
     ui_->subTabWidget->setTabVisible(
         ui_->subTabWidget->indexOf(ui_->extensionsTab), false);
+    InstrumentFormUtils::populateOptionType(ui_->optionTypeCombo);
+    InstrumentFormUtils::populateExerciseType(ui_->exerciseTypeCombo);
+    InstrumentFormUtils::populateBarrierType(ui_->barrierTypeCombo);
+    InstrumentFormUtils::populateAverageType(ui_->averageTypeCombo);
+    InstrumentFormUtils::populateFrequency(ui_->cliquetFrequencyCombo);
+    InstrumentFormUtils::populateDayCount(ui_->dayCountCombo);
+    InstrumentFormUtils::populateFrequency(ui_->paymentFrequencyCombo);
+    InstrumentFormUtils::populateReturnType(ui_->returnTypeCombo);
     setupConnections();
 }
 
@@ -47,21 +57,29 @@ EquityInstrumentForm::~EquityInstrumentForm() = default;
 
 void EquityInstrumentForm::setupConnections() {
     auto markChanged = [this]() { onFieldChanged(); };
-    connect(ui_->tradeTypeCodeEdit, &QLineEdit::textChanged, this, markChanged);
+    auto markChangedStr = [this](const QString&) { onFieldChanged(); };
     connect(ui_->underlyingCodeEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->currencyEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->startDateEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->maturityDateEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->descriptionEdit, &QPlainTextEdit::textChanged, this, markChanged);
-    connect(ui_->optionTypeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->exerciseTypeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->barrierTypeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->averageTypeEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->optionTypeCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->exerciseTypeCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->barrierTypeCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->averageTypeCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
     connect(ui_->averagingStartDateEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->cliquetFrequencyCodeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->dayCountCodeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->paymentFrequencyCodeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->returnTypeEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->cliquetFrequencyCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->dayCountCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->paymentFrequencyCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->returnTypeCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
     connect(ui_->basketJsonEdit, &QPlainTextEdit::textChanged, this, markChanged);
     connect(ui_->notionalSpinBox,
             QOverload<double>::of(&QDoubleSpinBox::valueChanged),
@@ -107,6 +125,7 @@ void EquityInstrumentForm::clear() {
 void EquityInstrumentForm::setTradeType(const QString& code,
     bool has_options, bool has_extension) {
     instrument_.trade_type_code = code.trimmed().toStdString();
+    ui_->tradeTypeCodeEdit->setText(code.trimmed());
     ui_->subTabWidget->setTabVisible(
         ui_->subTabWidget->indexOf(ui_->optionsTab), has_options);
     ui_->subTabWidget->setTabVisible(
@@ -114,7 +133,6 @@ void EquityInstrumentForm::setTradeType(const QString& code,
 }
 
 void EquityInstrumentForm::setReadOnly(bool readOnly) {
-    ui_->tradeTypeCodeEdit->setReadOnly(readOnly);
     ui_->underlyingCodeEdit->setReadOnly(readOnly);
     ui_->currencyEdit->setReadOnly(readOnly);
     ui_->notionalSpinBox->setReadOnly(readOnly);
@@ -122,21 +140,21 @@ void EquityInstrumentForm::setReadOnly(bool readOnly) {
     ui_->startDateEdit->setReadOnly(readOnly);
     ui_->maturityDateEdit->setReadOnly(readOnly);
     ui_->descriptionEdit->setReadOnly(readOnly);
-    ui_->optionTypeEdit->setReadOnly(readOnly);
-    ui_->exerciseTypeEdit->setReadOnly(readOnly);
+    ui_->optionTypeCombo->setEnabled(!readOnly);
+    ui_->exerciseTypeCombo->setEnabled(!readOnly);
     ui_->strikePriceSpinBox->setReadOnly(readOnly);
-    ui_->barrierTypeEdit->setReadOnly(readOnly);
+    ui_->barrierTypeCombo->setEnabled(!readOnly);
     ui_->lowerBarrierSpinBox->setReadOnly(readOnly);
     ui_->upperBarrierSpinBox->setReadOnly(readOnly);
-    ui_->averageTypeEdit->setReadOnly(readOnly);
+    ui_->averageTypeCombo->setEnabled(!readOnly);
     ui_->averagingStartDateEdit->setReadOnly(readOnly);
     ui_->varianceStrikeSpinBox->setReadOnly(readOnly);
-    ui_->cliquetFrequencyCodeEdit->setReadOnly(readOnly);
+    ui_->cliquetFrequencyCombo->setEnabled(!readOnly);
     ui_->accumulationAmountSpinBox->setReadOnly(readOnly);
     ui_->knockOutBarrierSpinBox->setReadOnly(readOnly);
-    ui_->dayCountCodeEdit->setReadOnly(readOnly);
-    ui_->paymentFrequencyCodeEdit->setReadOnly(readOnly);
-    ui_->returnTypeEdit->setReadOnly(readOnly);
+    ui_->dayCountCombo->setEnabled(!readOnly);
+    ui_->paymentFrequencyCombo->setEnabled(!readOnly);
+    ui_->returnTypeCombo->setEnabled(!readOnly);
     ui_->basketJsonEdit->setReadOnly(readOnly);
 }
 
@@ -150,12 +168,6 @@ void EquityInstrumentForm::setChangeReason(
 }
 
 void EquityInstrumentForm::writeUiToInstrument() {
-    // Scoped to equity_option_instrument. Widgets outside this struct's
-    // fields (barrier, averaging, variance, accumulation, return-type,
-    // day-count, basket) are left in place in the .ui for future variant
-    // coverage but are not read back here.
-    instrument_.trade_type_code =
-        ui_->tradeTypeCodeEdit->text().trimmed().toStdString();
     instrument_.underlying_name =
         ui_->underlyingCodeEdit->text().trimmed().toStdString();
     instrument_.currency =
@@ -166,12 +178,12 @@ void EquityInstrumentForm::writeUiToInstrument() {
     instrument_.description =
         ui_->descriptionEdit->toPlainText().trimmed().toStdString();
     instrument_.option_type =
-        ui_->optionTypeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->optionTypeCombo);
     instrument_.exercise_type =
-        ui_->exerciseTypeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->exerciseTypeCombo);
     instrument_.strike = ui_->strikePriceSpinBox->value();
     instrument_.cliquet_frequency =
-        ui_->cliquetFrequencyCodeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->cliquetFrequencyCombo);
     instrument_.modified_by = username_;
     instrument_.performed_by = username_;
 }
@@ -206,7 +218,6 @@ void EquityInstrumentForm::setInstrument(
 
 void EquityInstrumentForm::populateFromInstrument() {
     const auto block = [this](bool b) {
-        ui_->tradeTypeCodeEdit->blockSignals(b);
         ui_->underlyingCodeEdit->blockSignals(b);
         ui_->currencyEdit->blockSignals(b);
         ui_->notionalSpinBox->blockSignals(b);
@@ -214,21 +225,21 @@ void EquityInstrumentForm::populateFromInstrument() {
         ui_->startDateEdit->blockSignals(b);
         ui_->maturityDateEdit->blockSignals(b);
         ui_->descriptionEdit->blockSignals(b);
-        ui_->optionTypeEdit->blockSignals(b);
-        ui_->exerciseTypeEdit->blockSignals(b);
+        ui_->optionTypeCombo->blockSignals(b);
+        ui_->exerciseTypeCombo->blockSignals(b);
         ui_->strikePriceSpinBox->blockSignals(b);
-        ui_->barrierTypeEdit->blockSignals(b);
+        ui_->barrierTypeCombo->blockSignals(b);
         ui_->lowerBarrierSpinBox->blockSignals(b);
         ui_->upperBarrierSpinBox->blockSignals(b);
-        ui_->averageTypeEdit->blockSignals(b);
+        ui_->averageTypeCombo->blockSignals(b);
         ui_->averagingStartDateEdit->blockSignals(b);
         ui_->varianceStrikeSpinBox->blockSignals(b);
-        ui_->cliquetFrequencyCodeEdit->blockSignals(b);
+        ui_->cliquetFrequencyCombo->blockSignals(b);
         ui_->accumulationAmountSpinBox->blockSignals(b);
         ui_->knockOutBarrierSpinBox->blockSignals(b);
-        ui_->dayCountCodeEdit->blockSignals(b);
-        ui_->paymentFrequencyCodeEdit->blockSignals(b);
-        ui_->returnTypeEdit->blockSignals(b);
+        ui_->dayCountCombo->blockSignals(b);
+        ui_->paymentFrequencyCombo->blockSignals(b);
+        ui_->returnTypeCombo->blockSignals(b);
         ui_->basketJsonEdit->blockSignals(b);
     };
 
@@ -246,24 +257,24 @@ void EquityInstrumentForm::populateFromInstrument() {
         QString::fromStdString(instrument_.expiry_date));
     ui_->descriptionEdit->setPlainText(
         QString::fromStdString(instrument_.description));
-    ui_->optionTypeEdit->setText(
-        QString::fromStdString(instrument_.option_type));
-    ui_->exerciseTypeEdit->setText(
-        QString::fromStdString(instrument_.exercise_type));
+    InstrumentFormUtils::setComboValue(
+        ui_->optionTypeCombo, instrument_.option_type);
+    InstrumentFormUtils::setComboValue(
+        ui_->exerciseTypeCombo, instrument_.exercise_type);
     ui_->strikePriceSpinBox->setValue(instrument_.strike);
-    ui_->barrierTypeEdit->clear();
+    InstrumentFormUtils::setComboValue(ui_->barrierTypeCombo, "");
     ui_->lowerBarrierSpinBox->setValue(0.0);
     ui_->upperBarrierSpinBox->setValue(0.0);
-    ui_->averageTypeEdit->clear();
+    InstrumentFormUtils::setComboValue(ui_->averageTypeCombo, "");
     ui_->averagingStartDateEdit->clear();
     ui_->varianceStrikeSpinBox->setValue(0.0);
-    ui_->cliquetFrequencyCodeEdit->setText(
-        QString::fromStdString(instrument_.cliquet_frequency));
+    InstrumentFormUtils::setComboValue(
+        ui_->cliquetFrequencyCombo, instrument_.cliquet_frequency);
     ui_->accumulationAmountSpinBox->setValue(0.0);
     ui_->knockOutBarrierSpinBox->setValue(0.0);
-    ui_->dayCountCodeEdit->clear();
-    ui_->paymentFrequencyCodeEdit->clear();
-    ui_->returnTypeEdit->clear();
+    InstrumentFormUtils::setComboValue(ui_->dayCountCombo, "");
+    InstrumentFormUtils::setComboValue(ui_->paymentFrequencyCombo, "");
+    InstrumentFormUtils::setComboValue(ui_->returnTypeCombo, "");
     ui_->basketJsonEdit->clear();
     block(false);
 }

--- a/projects/ores.qt.trading/src/EquityInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/EquityInstrumentForm.cpp
@@ -26,6 +26,9 @@
 #include <boost/uuid/uuid_io.hpp>
 #include "ui_EquityInstrumentForm.h"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ImageCache.hpp"
+#include "ores.qt/FlagIconHelper.hpp"
+#include "ores.qt/LookupFetcher.hpp"
 #include "ores.qt/InstrumentFormUtils.hpp"
 #include "ores.trading.api/messaging/instrument_protocol.hpp"
 
@@ -58,10 +61,12 @@ EquityInstrumentForm::~EquityInstrumentForm() = default;
 void EquityInstrumentForm::setupConnections() {
     auto markChanged = [this]() { onFieldChanged(); };
     auto markChangedStr = [this](const QString&) { onFieldChanged(); };
+    auto markChangedDate = [this](const QDate&) { onFieldChanged(); };
     connect(ui_->underlyingCodeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->currencyEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->startDateEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->maturityDateEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->currencyCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->startDateEdit, &QDateEdit::dateChanged, this, markChangedDate);
+    connect(ui_->maturityDateEdit, &QDateEdit::dateChanged, this, markChangedDate);
     connect(ui_->descriptionEdit, &QPlainTextEdit::textChanged, this, markChanged);
     connect(ui_->optionTypeCombo, &QComboBox::currentTextChanged,
             this, markChangedStr);
@@ -71,7 +76,8 @@ void EquityInstrumentForm::setupConnections() {
             this, markChangedStr);
     connect(ui_->averageTypeCombo, &QComboBox::currentTextChanged,
             this, markChangedStr);
-    connect(ui_->averagingStartDateEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->averagingStartDateEdit, &QDateEdit::dateChanged,
+            this, markChangedDate);
     connect(ui_->cliquetFrequencyCombo, &QComboBox::currentTextChanged,
             this, markChangedStr);
     connect(ui_->dayCountCombo, &QComboBox::currentTextChanged,
@@ -109,6 +115,41 @@ void EquityInstrumentForm::setupConnections() {
 
 void EquityInstrumentForm::setClientManager(ClientManager* cm) {
     clientManager_ = cm;
+    populateCurrencies();
+}
+
+void EquityInstrumentForm::setImageCache(ImageCache* cache) {
+    imageCache_ = cache;
+    setup_flag_combo(this, ui_->currencyCombo, imageCache_,
+                     FlagSource::Currency);
+}
+
+void EquityInstrumentForm::populateCurrencies() {
+    if (!clientManager_) return;
+
+    QPointer<EquityInstrumentForm> self = this;
+    auto* watcher = new QFutureWatcher<std::vector<std::string>>(self);
+    connect(watcher, &QFutureWatcher<std::vector<std::string>>::finished, self,
+        [self, watcher]() {
+        auto codes = watcher->result();
+        watcher->deleteLater();
+        if (!self) return;
+        auto* cb = self->ui_->currencyCombo;
+        cb->blockSignals(true);
+        cb->clear();
+        cb->addItem(QString());
+        for (const auto& c : codes)
+            cb->addItem(QString::fromStdString(c));
+        InstrumentFormUtils::setComboValue(cb, self->instrument_.currency);
+        cb->blockSignals(false);
+        if (self->imageCache_)
+            apply_flag_icons(cb, self->imageCache_, FlagSource::Currency);
+    });
+
+    auto* cm = clientManager_;
+    watcher->setFuture(QtConcurrent::run([cm]() {
+        return fetch_currency_codes(cm);
+    }));
 }
 
 void EquityInstrumentForm::setUsername(const std::string& username) {
@@ -134,7 +175,7 @@ void EquityInstrumentForm::setTradeType(const QString& code,
 
 void EquityInstrumentForm::setReadOnly(bool readOnly) {
     ui_->underlyingCodeEdit->setReadOnly(readOnly);
-    ui_->currencyEdit->setReadOnly(readOnly);
+    ui_->currencyCombo->setEnabled(!readOnly);
     ui_->notionalSpinBox->setReadOnly(readOnly);
     ui_->quantitySpinBox->setReadOnly(readOnly);
     ui_->startDateEdit->setReadOnly(readOnly);
@@ -171,10 +212,9 @@ void EquityInstrumentForm::writeUiToInstrument() {
     instrument_.underlying_name =
         ui_->underlyingCodeEdit->text().trimmed().toStdString();
     instrument_.currency =
-        ui_->currencyEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->currencyCombo);
     instrument_.notional = ui_->notionalSpinBox->value();
-    instrument_.expiry_date =
-        ui_->maturityDateEdit->text().trimmed().toStdString();
+    instrument_.expiry_date = ui_->maturityDateEdit->isoDate();
     instrument_.description =
         ui_->descriptionEdit->toPlainText().trimmed().toStdString();
     instrument_.option_type =
@@ -219,7 +259,7 @@ void EquityInstrumentForm::setInstrument(
 void EquityInstrumentForm::populateFromInstrument() {
     const auto block = [this](bool b) {
         ui_->underlyingCodeEdit->blockSignals(b);
-        ui_->currencyEdit->blockSignals(b);
+        ui_->currencyCombo->blockSignals(b);
         ui_->notionalSpinBox->blockSignals(b);
         ui_->quantitySpinBox->blockSignals(b);
         ui_->startDateEdit->blockSignals(b);
@@ -248,13 +288,11 @@ void EquityInstrumentForm::populateFromInstrument() {
         QString::fromStdString(instrument_.trade_type_code));
     ui_->underlyingCodeEdit->setText(
         QString::fromStdString(instrument_.underlying_name));
-    ui_->currencyEdit->setText(
-        QString::fromStdString(instrument_.currency));
+    InstrumentFormUtils::setComboValue(ui_->currencyCombo, instrument_.currency);
     ui_->notionalSpinBox->setValue(instrument_.notional);
     ui_->quantitySpinBox->setValue(0.0);
-    ui_->startDateEdit->clear();
-    ui_->maturityDateEdit->setText(
-        QString::fromStdString(instrument_.expiry_date));
+    ui_->startDateEdit->setIsoDate("");
+    ui_->maturityDateEdit->setIsoDate(instrument_.expiry_date);
     ui_->descriptionEdit->setPlainText(
         QString::fromStdString(instrument_.description));
     InstrumentFormUtils::setComboValue(
@@ -266,7 +304,7 @@ void EquityInstrumentForm::populateFromInstrument() {
     ui_->lowerBarrierSpinBox->setValue(0.0);
     ui_->upperBarrierSpinBox->setValue(0.0);
     InstrumentFormUtils::setComboValue(ui_->averageTypeCombo, "");
-    ui_->averagingStartDateEdit->clear();
+    ui_->averagingStartDateEdit->setIsoDate("");
     ui_->varianceStrikeSpinBox->setValue(0.0);
     InstrumentFormUtils::setComboValue(
         ui_->cliquetFrequencyCombo, instrument_.cliquet_frequency);

--- a/projects/ores.qt.trading/src/FxInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/FxInstrumentForm.cpp
@@ -19,11 +19,13 @@
  */
 #include "ores.qt/FxInstrumentForm.hpp"
 
+#include <QComboBox>
 #include <QPointer>
 #include <QtConcurrent>
 #include <QFutureWatcher>
 #include "ui_FxInstrumentForm.h"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/InstrumentFormUtils.hpp"
 
 namespace ores::qt {
 
@@ -36,6 +38,8 @@ FxInstrumentForm::FxInstrumentForm(QWidget* parent)
     // Options sub-tab is hidden until setTradeType() reveals it.
     ui_->subTabWidget->setTabVisible(
         ui_->subTabWidget->indexOf(ui_->optionsTab), false);
+    InstrumentFormUtils::populateSettlement(ui_->settlementCombo);
+    InstrumentFormUtils::populateOptionType(ui_->optionTypeCombo);
     setupConnections();
 }
 
@@ -43,16 +47,17 @@ FxInstrumentForm::~FxInstrumentForm() = default;
 
 void FxInstrumentForm::setupConnections() {
     auto markChanged = [this]() { onFieldChanged(); };
-    connect(ui_->tradeTypeCodeEdit, &QLineEdit::textChanged,
-            this, markChanged);
+    auto markChangedStr = [this](const QString&) { onFieldChanged(); };
     connect(ui_->boughtCurrencyEdit, &QLineEdit::textChanged,
             this, markChanged);
     connect(ui_->soldCurrencyEdit, &QLineEdit::textChanged,
             this, markChanged);
     connect(ui_->valueDateEdit, &QLineEdit::textChanged,
             this, markChanged);
-    connect(ui_->settlementEdit, &QLineEdit::textChanged,
-            this, markChanged);
+    connect(ui_->settlementCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->optionTypeCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
     connect(ui_->descriptionEdit, &QPlainTextEdit::textChanged,
             this, markChanged);
     connect(ui_->boughtAmountSpinBox,
@@ -81,19 +86,20 @@ void FxInstrumentForm::clear() {
 void FxInstrumentForm::setTradeType(const QString& code,
     bool has_options, bool /*has_extension*/) {
     instrument_.trade_type_code = code.trimmed().toStdString();
+    ui_->tradeTypeCodeEdit->setText(code.trimmed());
     // FX has only an options sub-section; the extension flag is unused.
     ui_->subTabWidget->setTabVisible(
         ui_->subTabWidget->indexOf(ui_->optionsTab), has_options);
 }
 
 void FxInstrumentForm::setReadOnly(bool readOnly) {
-    ui_->tradeTypeCodeEdit->setReadOnly(readOnly);
     ui_->boughtCurrencyEdit->setReadOnly(readOnly);
     ui_->boughtAmountSpinBox->setReadOnly(readOnly);
     ui_->soldCurrencyEdit->setReadOnly(readOnly);
     ui_->soldAmountSpinBox->setReadOnly(readOnly);
     ui_->valueDateEdit->setReadOnly(readOnly);
-    ui_->settlementEdit->setReadOnly(readOnly);
+    ui_->settlementCombo->setEnabled(!readOnly);
+    ui_->optionTypeCombo->setEnabled(!readOnly);
     ui_->descriptionEdit->setReadOnly(readOnly);
 }
 
@@ -112,8 +118,6 @@ void FxInstrumentForm::setChangeReason(
 }
 
 void FxInstrumentForm::writeUiToInstrument() {
-    instrument_.trade_type_code =
-        ui_->tradeTypeCodeEdit->text().trimmed().toStdString();
     instrument_.bought_currency =
         ui_->boughtCurrencyEdit->text().trimmed().toStdString();
     instrument_.bought_amount = ui_->boughtAmountSpinBox->value();
@@ -123,7 +127,7 @@ void FxInstrumentForm::writeUiToInstrument() {
     instrument_.value_date =
         ui_->valueDateEdit->text().trimmed().toStdString();
     instrument_.settlement =
-        ui_->settlementEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->settlementCombo);
     instrument_.description =
         ui_->descriptionEdit->toPlainText().trimmed().toStdString();
     instrument_.modified_by = username_;
@@ -171,13 +175,13 @@ void FxInstrumentForm::setInstrument(
 void FxInstrumentForm::populateFromInstrument() {
     // Block signals while setting values so dirty_ stays untouched.
     const auto block = [this](bool b) {
-        ui_->tradeTypeCodeEdit->blockSignals(b);
         ui_->boughtCurrencyEdit->blockSignals(b);
         ui_->boughtAmountSpinBox->blockSignals(b);
         ui_->soldCurrencyEdit->blockSignals(b);
         ui_->soldAmountSpinBox->blockSignals(b);
         ui_->valueDateEdit->blockSignals(b);
-        ui_->settlementEdit->blockSignals(b);
+        ui_->settlementCombo->blockSignals(b);
+        ui_->optionTypeCombo->blockSignals(b);
         ui_->descriptionEdit->blockSignals(b);
     };
 
@@ -192,8 +196,7 @@ void FxInstrumentForm::populateFromInstrument() {
     ui_->soldAmountSpinBox->setValue(instrument_.sold_amount);
     ui_->valueDateEdit->setText(
         QString::fromStdString(instrument_.value_date));
-    ui_->settlementEdit->setText(
-        QString::fromStdString(instrument_.settlement));
+    InstrumentFormUtils::setComboValue(ui_->settlementCombo, instrument_.settlement);
     ui_->descriptionEdit->setPlainText(
         QString::fromStdString(instrument_.description));
     block(false);

--- a/projects/ores.qt.trading/src/FxInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/FxInstrumentForm.cpp
@@ -137,7 +137,8 @@ void FxInstrumentForm::setInstrument(
         std::get_if<trading::messaging::fx_export_result>(&instrument);
     if (!ex) {
         BOOST_LOG_SEV(lg(), warn)
-            << "Non-FX instrument pushed to FxInstrumentForm";
+            << "Non-FX instrument pushed to FxInstrumentForm"
+            << " (variant index=" << instrument.index() << ")";
         emit loadFailed(QStringLiteral(
             "Unexpected instrument type for FX form"));
         return;
@@ -146,6 +147,10 @@ void FxInstrumentForm::setInstrument(
         std::get_if<trading::domain::fx_forward_instrument>(&ex->instrument);
     if (!fwd) {
         const auto ttc = ui_->tradeTypeCodeEdit->text().trimmed().toStdString();
+        BOOST_LOG_SEV(lg(), warn)
+            << "Non-forward FX instrument in FxInstrumentForm"
+            << " trade_type_code=" << ttc
+            << " fx variant index=" << ex->instrument.index();
         emit loadFailed(QString::fromStdString(
             "Non-forward FX type not yet supported in this "
             "dialog (trade_type_code=" + ttc + ")"));
@@ -157,6 +162,9 @@ void FxInstrumentForm::setInstrument(
     dirty_ = false;
     populateFromInstrument();
     emitProvenance();
+    BOOST_LOG_SEV(lg(), debug)
+        << "FxInstrumentForm: instrument loaded trade_type_code="
+        << instrument_.trade_type_code;
     emit instrumentLoaded();
 }
 

--- a/projects/ores.qt.trading/src/FxInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/FxInstrumentForm.cpp
@@ -23,8 +23,12 @@
 #include <QPointer>
 #include <QtConcurrent>
 #include <QFutureWatcher>
+#include <boost/uuid/uuid_io.hpp>
 #include "ui_FxInstrumentForm.h"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ImageCache.hpp"
+#include "ores.qt/FlagIconHelper.hpp"
+#include "ores.qt/LookupFetcher.hpp"
 #include "ores.qt/InstrumentFormUtils.hpp"
 
 namespace ores::qt {
@@ -48,12 +52,12 @@ FxInstrumentForm::~FxInstrumentForm() = default;
 void FxInstrumentForm::setupConnections() {
     auto markChanged = [this]() { onFieldChanged(); };
     auto markChangedStr = [this](const QString&) { onFieldChanged(); };
-    connect(ui_->boughtCurrencyEdit, &QLineEdit::textChanged,
-            this, markChanged);
-    connect(ui_->soldCurrencyEdit, &QLineEdit::textChanged,
-            this, markChanged);
-    connect(ui_->valueDateEdit, &QLineEdit::textChanged,
-            this, markChanged);
+    auto markChangedDate = [this](const QDate&) { onFieldChanged(); };
+    connect(ui_->boughtCurrencyCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->soldCurrencyCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->valueDateEdit, &QDateEdit::dateChanged, this, markChangedDate);
     connect(ui_->settlementCombo, &QComboBox::currentTextChanged,
             this, markChangedStr);
     connect(ui_->optionTypeCombo, &QComboBox::currentTextChanged,
@@ -70,6 +74,53 @@ void FxInstrumentForm::setupConnections() {
 
 void FxInstrumentForm::setClientManager(ClientManager* cm) {
     clientManager_ = cm;
+    populateCurrencies();
+}
+
+void FxInstrumentForm::setImageCache(ImageCache* cache) {
+    imageCache_ = cache;
+    setup_flag_combo(this, ui_->boughtCurrencyCombo, imageCache_,
+                     FlagSource::Currency);
+    setup_flag_combo(this, ui_->soldCurrencyCombo, imageCache_,
+                     FlagSource::Currency);
+}
+
+void FxInstrumentForm::populateCurrencies() {
+    if (!clientManager_) return;
+
+    QPointer<FxInstrumentForm> self = this;
+    auto* watcher = new QFutureWatcher<std::vector<std::string>>(self);
+    connect(watcher, &QFutureWatcher<std::vector<std::string>>::finished, self,
+        [self, watcher]() {
+        auto codes = watcher->result();
+        watcher->deleteLater();
+        if (!self) return;
+
+        auto populate = [&codes](QComboBox* cb, const std::string& value) {
+            cb->blockSignals(true);
+            cb->clear();
+            cb->addItem(QString());
+            for (const auto& c : codes)
+                cb->addItem(QString::fromStdString(c));
+            InstrumentFormUtils::setComboValue(cb, value);
+            cb->blockSignals(false);
+        };
+
+        populate(self->ui_->boughtCurrencyCombo, self->instrument_.bought_currency);
+        populate(self->ui_->soldCurrencyCombo, self->instrument_.sold_currency);
+
+        if (self->imageCache_) {
+            apply_flag_icons(self->ui_->boughtCurrencyCombo,
+                             self->imageCache_, FlagSource::Currency);
+            apply_flag_icons(self->ui_->soldCurrencyCombo,
+                             self->imageCache_, FlagSource::Currency);
+        }
+    });
+
+    auto* cm = clientManager_;
+    watcher->setFuture(QtConcurrent::run([cm]() {
+        return fetch_currency_codes(cm);
+    }));
 }
 
 void FxInstrumentForm::setUsername(const std::string& username) {
@@ -93,9 +144,9 @@ void FxInstrumentForm::setTradeType(const QString& code,
 }
 
 void FxInstrumentForm::setReadOnly(bool readOnly) {
-    ui_->boughtCurrencyEdit->setReadOnly(readOnly);
+    ui_->boughtCurrencyCombo->setEnabled(!readOnly);
     ui_->boughtAmountSpinBox->setReadOnly(readOnly);
-    ui_->soldCurrencyEdit->setReadOnly(readOnly);
+    ui_->soldCurrencyCombo->setEnabled(!readOnly);
     ui_->soldAmountSpinBox->setReadOnly(readOnly);
     ui_->valueDateEdit->setReadOnly(readOnly);
     ui_->settlementCombo->setEnabled(!readOnly);
@@ -119,13 +170,12 @@ void FxInstrumentForm::setChangeReason(
 
 void FxInstrumentForm::writeUiToInstrument() {
     instrument_.bought_currency =
-        ui_->boughtCurrencyEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->boughtCurrencyCombo);
     instrument_.bought_amount = ui_->boughtAmountSpinBox->value();
     instrument_.sold_currency =
-        ui_->soldCurrencyEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->soldCurrencyCombo);
     instrument_.sold_amount = ui_->soldAmountSpinBox->value();
-    instrument_.value_date =
-        ui_->valueDateEdit->text().trimmed().toStdString();
+    instrument_.value_date = ui_->valueDateEdit->isoDate();
     instrument_.settlement =
         InstrumentFormUtils::getComboValue(ui_->settlementCombo);
     instrument_.description =
@@ -175,9 +225,9 @@ void FxInstrumentForm::setInstrument(
 void FxInstrumentForm::populateFromInstrument() {
     // Block signals while setting values so dirty_ stays untouched.
     const auto block = [this](bool b) {
-        ui_->boughtCurrencyEdit->blockSignals(b);
+        ui_->boughtCurrencyCombo->blockSignals(b);
         ui_->boughtAmountSpinBox->blockSignals(b);
-        ui_->soldCurrencyEdit->blockSignals(b);
+        ui_->soldCurrencyCombo->blockSignals(b);
         ui_->soldAmountSpinBox->blockSignals(b);
         ui_->valueDateEdit->blockSignals(b);
         ui_->settlementCombo->blockSignals(b);
@@ -188,14 +238,13 @@ void FxInstrumentForm::populateFromInstrument() {
     block(true);
     ui_->tradeTypeCodeEdit->setText(
         QString::fromStdString(instrument_.trade_type_code));
-    ui_->boughtCurrencyEdit->setText(
-        QString::fromStdString(instrument_.bought_currency));
+    InstrumentFormUtils::setComboValue(ui_->boughtCurrencyCombo,
+        instrument_.bought_currency);
     ui_->boughtAmountSpinBox->setValue(instrument_.bought_amount);
-    ui_->soldCurrencyEdit->setText(
-        QString::fromStdString(instrument_.sold_currency));
+    InstrumentFormUtils::setComboValue(ui_->soldCurrencyCombo,
+        instrument_.sold_currency);
     ui_->soldAmountSpinBox->setValue(instrument_.sold_amount);
-    ui_->valueDateEdit->setText(
-        QString::fromStdString(instrument_.value_date));
+    ui_->valueDateEdit->setIsoDate(instrument_.value_date);
     InstrumentFormUtils::setComboValue(ui_->settlementCombo, instrument_.settlement);
     ui_->descriptionEdit->setPlainText(
         QString::fromStdString(instrument_.description));

--- a/projects/ores.qt.trading/src/FxVanillaOptionInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/FxVanillaOptionInstrumentForm.cpp
@@ -1,0 +1,257 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/FxVanillaOptionInstrumentForm.hpp"
+
+#include <QPointer>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include <boost/uuid/uuid_io.hpp>
+#include "ui_FxVanillaOptionInstrumentForm.h"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.trading.api/messaging/instrument_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+FxVanillaOptionInstrumentForm::FxVanillaOptionInstrumentForm(QWidget* parent)
+    : IInstrumentForm(parent),
+      ui_(new Ui::FxVanillaOptionInstrumentForm) {
+    ui_->setupUi(this);
+    setupConnections();
+}
+
+FxVanillaOptionInstrumentForm::~FxVanillaOptionInstrumentForm() = default;
+
+void FxVanillaOptionInstrumentForm::setupConnections() {
+    auto markChanged = [this]() { onFieldChanged(); };
+    connect(ui_->tradeTypeCodeEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->boughtCurrencyEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->soldCurrencyEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->optionTypeEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->expiryDateEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->exerciseStyleEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->settlementEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->descriptionEdit, &QPlainTextEdit::textChanged, this, markChanged);
+    connect(ui_->boughtAmountSpinBox,
+            QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+            this, markChanged);
+    connect(ui_->soldAmountSpinBox,
+            QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+            this, markChanged);
+}
+
+void FxVanillaOptionInstrumentForm::setClientManager(ClientManager* cm) {
+    clientManager_ = cm;
+}
+
+void FxVanillaOptionInstrumentForm::setUsername(const std::string& username) {
+    username_ = username;
+}
+
+void FxVanillaOptionInstrumentForm::clear() {
+    instrument_ = trading::domain::fx_vanilla_option_instrument{};
+    loaded_ = false;
+    dirty_ = false;
+    populateFromInstrument();
+}
+
+void FxVanillaOptionInstrumentForm::setTradeType(const QString& code,
+    bool /*has_options*/, bool /*has_extension*/) {
+    instrument_.trade_type_code = code.trimmed().toStdString();
+}
+
+void FxVanillaOptionInstrumentForm::setReadOnly(bool readOnly) {
+    ui_->tradeTypeCodeEdit->setReadOnly(readOnly);
+    ui_->boughtCurrencyEdit->setReadOnly(readOnly);
+    ui_->boughtAmountSpinBox->setReadOnly(readOnly);
+    ui_->soldCurrencyEdit->setReadOnly(readOnly);
+    ui_->soldAmountSpinBox->setReadOnly(readOnly);
+    ui_->optionTypeEdit->setReadOnly(readOnly);
+    ui_->expiryDateEdit->setReadOnly(readOnly);
+    ui_->exerciseStyleEdit->setReadOnly(readOnly);
+    ui_->settlementEdit->setReadOnly(readOnly);
+    ui_->descriptionEdit->setReadOnly(readOnly);
+}
+
+bool FxVanillaOptionInstrumentForm::isDirty() const { return dirty_; }
+bool FxVanillaOptionInstrumentForm::isLoaded() const { return loaded_; }
+
+void FxVanillaOptionInstrumentForm::setChangeReason(
+    const std::string& code, const std::string& commentary) {
+    instrument_.change_reason_code = code;
+    instrument_.change_commentary = commentary;
+}
+
+void FxVanillaOptionInstrumentForm::writeUiToInstrument() {
+    instrument_.trade_type_code =
+        ui_->tradeTypeCodeEdit->text().trimmed().toStdString();
+    instrument_.bought_currency =
+        ui_->boughtCurrencyEdit->text().trimmed().toStdString();
+    instrument_.bought_amount = ui_->boughtAmountSpinBox->value();
+    instrument_.sold_currency =
+        ui_->soldCurrencyEdit->text().trimmed().toStdString();
+    instrument_.sold_amount = ui_->soldAmountSpinBox->value();
+    instrument_.option_type =
+        ui_->optionTypeEdit->text().trimmed().toStdString();
+    instrument_.expiry_date =
+        ui_->expiryDateEdit->text().trimmed().toStdString();
+    instrument_.exercise_style =
+        ui_->exerciseStyleEdit->text().trimmed().toStdString();
+    instrument_.settlement =
+        ui_->settlementEdit->text().trimmed().toStdString();
+    instrument_.description =
+        ui_->descriptionEdit->toPlainText().trimmed().toStdString();
+    instrument_.modified_by = username_;
+    instrument_.performed_by = username_;
+}
+
+void FxVanillaOptionInstrumentForm::setInstrument(
+    const trading::messaging::instrument_export_result& instrument) {
+
+    const auto* ex =
+        std::get_if<trading::messaging::fx_export_result>(&instrument);
+    if (!ex) {
+        BOOST_LOG_SEV(lg(), warn)
+            << "Non-FX instrument pushed to FxVanillaOptionInstrumentForm";
+        emit loadFailed(QStringLiteral(
+            "Unexpected instrument type for FX vanilla option form"));
+        return;
+    }
+    const auto* opt =
+        std::get_if<trading::domain::fx_vanilla_option_instrument>(&ex->instrument);
+    if (!opt) {
+        BOOST_LOG_SEV(lg(), warn)
+            << "Non-vanilla-option FX type pushed to FxVanillaOptionInstrumentForm";
+        emit loadFailed(QStringLiteral(
+            "Unexpected FX sub-type for vanilla option form"));
+        return;
+    }
+
+    instrument_ = *opt;
+    loaded_ = true;
+    dirty_ = false;
+    populateFromInstrument();
+    emitProvenance();
+    emit instrumentLoaded();
+}
+
+void FxVanillaOptionInstrumentForm::populateFromInstrument() {
+    const auto block = [this](bool b) {
+        ui_->tradeTypeCodeEdit->blockSignals(b);
+        ui_->boughtCurrencyEdit->blockSignals(b);
+        ui_->boughtAmountSpinBox->blockSignals(b);
+        ui_->soldCurrencyEdit->blockSignals(b);
+        ui_->soldAmountSpinBox->blockSignals(b);
+        ui_->optionTypeEdit->blockSignals(b);
+        ui_->expiryDateEdit->blockSignals(b);
+        ui_->exerciseStyleEdit->blockSignals(b);
+        ui_->settlementEdit->blockSignals(b);
+        ui_->descriptionEdit->blockSignals(b);
+    };
+
+    block(true);
+    ui_->tradeTypeCodeEdit->setText(
+        QString::fromStdString(instrument_.trade_type_code));
+    ui_->boughtCurrencyEdit->setText(
+        QString::fromStdString(instrument_.bought_currency));
+    ui_->boughtAmountSpinBox->setValue(instrument_.bought_amount);
+    ui_->soldCurrencyEdit->setText(
+        QString::fromStdString(instrument_.sold_currency));
+    ui_->soldAmountSpinBox->setValue(instrument_.sold_amount);
+    ui_->optionTypeEdit->setText(
+        QString::fromStdString(instrument_.option_type));
+    ui_->expiryDateEdit->setText(
+        QString::fromStdString(instrument_.expiry_date));
+    ui_->exerciseStyleEdit->setText(
+        QString::fromStdString(instrument_.exercise_style));
+    ui_->settlementEdit->setText(
+        QString::fromStdString(instrument_.settlement));
+    ui_->descriptionEdit->setPlainText(
+        QString::fromStdString(instrument_.description));
+    block(false);
+}
+
+void FxVanillaOptionInstrumentForm::emitProvenance() {
+    InstrumentProvenance p;
+    p.version = instrument_.version;
+    p.modified_by = instrument_.modified_by;
+    p.performed_by = instrument_.performed_by;
+    p.recorded_at = instrument_.recorded_at;
+    p.change_reason_code = instrument_.change_reason_code;
+    p.change_commentary = instrument_.change_commentary;
+    emit provenanceChanged(p);
+}
+
+void FxVanillaOptionInstrumentForm::onFieldChanged() {
+    if (!loaded_) return;
+    dirty_ = true;
+    emit changed();
+}
+
+void FxVanillaOptionInstrumentForm::saveInstrument(
+    std::function<void(const std::string&)> on_success,
+    std::function<void(const QString&)> on_failure) {
+
+    if (!clientManager_) {
+        on_failure(QStringLiteral("Dialog closed"));
+        return;
+    }
+
+    struct SaveResult { bool success; std::string message; };
+
+    QPointer<FxVanillaOptionInstrumentForm> self = this;
+    auto* watcher = new QFutureWatcher<SaveResult>(self);
+    connect(watcher, &QFutureWatcher<SaveResult>::finished, self,
+        [self, watcher,
+         on_success = std::move(on_success),
+         on_failure = std::move(on_failure)]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+        if (!self) return;
+
+        if (!result.success) {
+            BOOST_LOG_SEV(lg(), error)
+                << "FX vanilla option save failed: " << result.message;
+            on_failure(QString::fromStdString(result.message));
+            return;
+        }
+
+        BOOST_LOG_SEV(lg(), info) << "FX vanilla option instrument saved";
+        self->dirty_ = false;
+        self->emitProvenance();
+        on_success(boost::uuids::to_string(self->instrument_.instrument_id));
+    });
+
+    auto* cm = clientManager_;
+    auto instrument = instrument_;
+    watcher->setFuture(QtConcurrent::run(
+        [cm, instrument = std::move(instrument)]() -> SaveResult {
+        if (!cm)
+            return {false, "Dialog closed"};
+        trading::messaging::save_fx_vanilla_option_instrument_request req;
+        req.data = instrument;
+        auto r = cm->process_authenticated_request(std::move(req));
+        if (!r) return {false, "Failed to communicate with server"};
+        return {r->success, r->message};
+    }));
+}
+
+}

--- a/projects/ores.qt.trading/src/FxVanillaOptionInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/FxVanillaOptionInstrumentForm.cpp
@@ -127,8 +127,10 @@ void FxVanillaOptionInstrumentForm::setUsername(const std::string& username) {
 }
 
 void FxVanillaOptionInstrumentForm::clear() {
+    const std::string ttc = instrument_.trade_type_code;
     instrument_ = trading::domain::fx_vanilla_option_instrument{};
-    loaded_ = false;
+    instrument_.trade_type_code = ttc;
+    loaded_ = true;
     dirty_ = false;
     populateFromInstrument();
 }

--- a/projects/ores.qt.trading/src/FxVanillaOptionInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/FxVanillaOptionInstrumentForm.cpp
@@ -9,22 +9,23 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with
- * this program; if not, write to the Free Software Foundation, Inc., 51
- * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
 #include "ores.qt/FxVanillaOptionInstrumentForm.hpp"
 
+#include <QComboBox>
 #include <QPointer>
 #include <QtConcurrent>
 #include <QFutureWatcher>
 #include <boost/uuid/uuid_io.hpp>
 #include "ui_FxVanillaOptionInstrumentForm.h"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/InstrumentFormUtils.hpp"
 #include "ores.trading.api/messaging/instrument_protocol.hpp"
 
 namespace ores::qt {
@@ -35,6 +36,9 @@ FxVanillaOptionInstrumentForm::FxVanillaOptionInstrumentForm(QWidget* parent)
     : IInstrumentForm(parent),
       ui_(new Ui::FxVanillaOptionInstrumentForm) {
     ui_->setupUi(this);
+    InstrumentFormUtils::populateOptionType(ui_->optionTypeCombo);
+    InstrumentFormUtils::populateExerciseStyle(ui_->exerciseStyleCombo);
+    InstrumentFormUtils::populateSettlement(ui_->settlementCombo);
     setupConnections();
 }
 
@@ -42,13 +46,13 @@ FxVanillaOptionInstrumentForm::~FxVanillaOptionInstrumentForm() = default;
 
 void FxVanillaOptionInstrumentForm::setupConnections() {
     auto markChanged = [this]() { onFieldChanged(); };
-    connect(ui_->tradeTypeCodeEdit, &QLineEdit::textChanged, this, markChanged);
+    auto markChangedStr = [this](const QString&) { onFieldChanged(); };
     connect(ui_->boughtCurrencyEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->soldCurrencyEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->optionTypeEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->optionTypeCombo, &QComboBox::currentTextChanged, this, markChangedStr);
     connect(ui_->expiryDateEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->exerciseStyleEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->settlementEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->exerciseStyleCombo, &QComboBox::currentTextChanged, this, markChangedStr);
+    connect(ui_->settlementCombo, &QComboBox::currentTextChanged, this, markChangedStr);
     connect(ui_->descriptionEdit, &QPlainTextEdit::textChanged, this, markChanged);
     connect(ui_->boughtAmountSpinBox,
             QOverload<double>::of(&QDoubleSpinBox::valueChanged),
@@ -76,18 +80,18 @@ void FxVanillaOptionInstrumentForm::clear() {
 void FxVanillaOptionInstrumentForm::setTradeType(const QString& code,
     bool /*has_options*/, bool /*has_extension*/) {
     instrument_.trade_type_code = code.trimmed().toStdString();
+    ui_->tradeTypeCodeEdit->setText(code.trimmed());
 }
 
 void FxVanillaOptionInstrumentForm::setReadOnly(bool readOnly) {
-    ui_->tradeTypeCodeEdit->setReadOnly(readOnly);
     ui_->boughtCurrencyEdit->setReadOnly(readOnly);
     ui_->boughtAmountSpinBox->setReadOnly(readOnly);
     ui_->soldCurrencyEdit->setReadOnly(readOnly);
     ui_->soldAmountSpinBox->setReadOnly(readOnly);
-    ui_->optionTypeEdit->setReadOnly(readOnly);
+    ui_->optionTypeCombo->setEnabled(!readOnly);
     ui_->expiryDateEdit->setReadOnly(readOnly);
-    ui_->exerciseStyleEdit->setReadOnly(readOnly);
-    ui_->settlementEdit->setReadOnly(readOnly);
+    ui_->exerciseStyleCombo->setEnabled(!readOnly);
+    ui_->settlementCombo->setEnabled(!readOnly);
     ui_->descriptionEdit->setReadOnly(readOnly);
 }
 
@@ -101,8 +105,6 @@ void FxVanillaOptionInstrumentForm::setChangeReason(
 }
 
 void FxVanillaOptionInstrumentForm::writeUiToInstrument() {
-    instrument_.trade_type_code =
-        ui_->tradeTypeCodeEdit->text().trimmed().toStdString();
     instrument_.bought_currency =
         ui_->boughtCurrencyEdit->text().trimmed().toStdString();
     instrument_.bought_amount = ui_->boughtAmountSpinBox->value();
@@ -110,13 +112,13 @@ void FxVanillaOptionInstrumentForm::writeUiToInstrument() {
         ui_->soldCurrencyEdit->text().trimmed().toStdString();
     instrument_.sold_amount = ui_->soldAmountSpinBox->value();
     instrument_.option_type =
-        ui_->optionTypeEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->optionTypeCombo);
     instrument_.expiry_date =
         ui_->expiryDateEdit->text().trimmed().toStdString();
     instrument_.exercise_style =
-        ui_->exerciseStyleEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->exerciseStyleCombo);
     instrument_.settlement =
-        ui_->settlementEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->settlementCombo);
     instrument_.description =
         ui_->descriptionEdit->toPlainText().trimmed().toStdString();
     instrument_.modified_by = username_;
@@ -155,15 +157,14 @@ void FxVanillaOptionInstrumentForm::setInstrument(
 
 void FxVanillaOptionInstrumentForm::populateFromInstrument() {
     const auto block = [this](bool b) {
-        ui_->tradeTypeCodeEdit->blockSignals(b);
         ui_->boughtCurrencyEdit->blockSignals(b);
         ui_->boughtAmountSpinBox->blockSignals(b);
         ui_->soldCurrencyEdit->blockSignals(b);
         ui_->soldAmountSpinBox->blockSignals(b);
-        ui_->optionTypeEdit->blockSignals(b);
+        ui_->optionTypeCombo->blockSignals(b);
         ui_->expiryDateEdit->blockSignals(b);
-        ui_->exerciseStyleEdit->blockSignals(b);
-        ui_->settlementEdit->blockSignals(b);
+        ui_->exerciseStyleCombo->blockSignals(b);
+        ui_->settlementCombo->blockSignals(b);
         ui_->descriptionEdit->blockSignals(b);
     };
 
@@ -176,14 +177,11 @@ void FxVanillaOptionInstrumentForm::populateFromInstrument() {
     ui_->soldCurrencyEdit->setText(
         QString::fromStdString(instrument_.sold_currency));
     ui_->soldAmountSpinBox->setValue(instrument_.sold_amount);
-    ui_->optionTypeEdit->setText(
-        QString::fromStdString(instrument_.option_type));
+    InstrumentFormUtils::setComboValue(ui_->optionTypeCombo, instrument_.option_type);
     ui_->expiryDateEdit->setText(
         QString::fromStdString(instrument_.expiry_date));
-    ui_->exerciseStyleEdit->setText(
-        QString::fromStdString(instrument_.exercise_style));
-    ui_->settlementEdit->setText(
-        QString::fromStdString(instrument_.settlement));
+    InstrumentFormUtils::setComboValue(ui_->exerciseStyleCombo, instrument_.exercise_style);
+    InstrumentFormUtils::setComboValue(ui_->settlementCombo, instrument_.settlement);
     ui_->descriptionEdit->setPlainText(
         QString::fromStdString(instrument_.description));
     block(false);

--- a/projects/ores.qt.trading/src/FxVanillaOptionInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/FxVanillaOptionInstrumentForm.cpp
@@ -25,6 +25,9 @@
 #include <boost/uuid/uuid_io.hpp>
 #include "ui_FxVanillaOptionInstrumentForm.h"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ImageCache.hpp"
+#include "ores.qt/FlagIconHelper.hpp"
+#include "ores.qt/LookupFetcher.hpp"
 #include "ores.qt/InstrumentFormUtils.hpp"
 #include "ores.trading.api/messaging/instrument_protocol.hpp"
 
@@ -47,12 +50,18 @@ FxVanillaOptionInstrumentForm::~FxVanillaOptionInstrumentForm() = default;
 void FxVanillaOptionInstrumentForm::setupConnections() {
     auto markChanged = [this]() { onFieldChanged(); };
     auto markChangedStr = [this](const QString&) { onFieldChanged(); };
-    connect(ui_->boughtCurrencyEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->soldCurrencyEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->optionTypeCombo, &QComboBox::currentTextChanged, this, markChangedStr);
-    connect(ui_->expiryDateEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->exerciseStyleCombo, &QComboBox::currentTextChanged, this, markChangedStr);
-    connect(ui_->settlementCombo, &QComboBox::currentTextChanged, this, markChangedStr);
+    auto markChangedDate = [this](const QDate&) { onFieldChanged(); };
+    connect(ui_->boughtCurrencyCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->soldCurrencyCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->optionTypeCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->expiryDateEdit, &QDateEdit::dateChanged, this, markChangedDate);
+    connect(ui_->exerciseStyleCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->settlementCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
     connect(ui_->descriptionEdit, &QPlainTextEdit::textChanged, this, markChanged);
     connect(ui_->boughtAmountSpinBox,
             QOverload<double>::of(&QDoubleSpinBox::valueChanged),
@@ -64,6 +73,53 @@ void FxVanillaOptionInstrumentForm::setupConnections() {
 
 void FxVanillaOptionInstrumentForm::setClientManager(ClientManager* cm) {
     clientManager_ = cm;
+    populateCurrencies();
+}
+
+void FxVanillaOptionInstrumentForm::setImageCache(ImageCache* cache) {
+    imageCache_ = cache;
+    setup_flag_combo(this, ui_->boughtCurrencyCombo, imageCache_,
+                     FlagSource::Currency);
+    setup_flag_combo(this, ui_->soldCurrencyCombo, imageCache_,
+                     FlagSource::Currency);
+}
+
+void FxVanillaOptionInstrumentForm::populateCurrencies() {
+    if (!clientManager_) return;
+
+    QPointer<FxVanillaOptionInstrumentForm> self = this;
+    auto* watcher = new QFutureWatcher<std::vector<std::string>>(self);
+    connect(watcher, &QFutureWatcher<std::vector<std::string>>::finished, self,
+        [self, watcher]() {
+        auto codes = watcher->result();
+        watcher->deleteLater();
+        if (!self) return;
+
+        auto populate = [&codes](QComboBox* cb, const std::string& value) {
+            cb->blockSignals(true);
+            cb->clear();
+            cb->addItem(QString());
+            for (const auto& c : codes)
+                cb->addItem(QString::fromStdString(c));
+            InstrumentFormUtils::setComboValue(cb, value);
+            cb->blockSignals(false);
+        };
+
+        populate(self->ui_->boughtCurrencyCombo, self->instrument_.bought_currency);
+        populate(self->ui_->soldCurrencyCombo, self->instrument_.sold_currency);
+
+        if (self->imageCache_) {
+            apply_flag_icons(self->ui_->boughtCurrencyCombo,
+                             self->imageCache_, FlagSource::Currency);
+            apply_flag_icons(self->ui_->soldCurrencyCombo,
+                             self->imageCache_, FlagSource::Currency);
+        }
+    });
+
+    auto* cm = clientManager_;
+    watcher->setFuture(QtConcurrent::run([cm]() {
+        return fetch_currency_codes(cm);
+    }));
 }
 
 void FxVanillaOptionInstrumentForm::setUsername(const std::string& username) {
@@ -84,9 +140,9 @@ void FxVanillaOptionInstrumentForm::setTradeType(const QString& code,
 }
 
 void FxVanillaOptionInstrumentForm::setReadOnly(bool readOnly) {
-    ui_->boughtCurrencyEdit->setReadOnly(readOnly);
+    ui_->boughtCurrencyCombo->setEnabled(!readOnly);
     ui_->boughtAmountSpinBox->setReadOnly(readOnly);
-    ui_->soldCurrencyEdit->setReadOnly(readOnly);
+    ui_->soldCurrencyCombo->setEnabled(!readOnly);
     ui_->soldAmountSpinBox->setReadOnly(readOnly);
     ui_->optionTypeCombo->setEnabled(!readOnly);
     ui_->expiryDateEdit->setReadOnly(readOnly);
@@ -106,15 +162,14 @@ void FxVanillaOptionInstrumentForm::setChangeReason(
 
 void FxVanillaOptionInstrumentForm::writeUiToInstrument() {
     instrument_.bought_currency =
-        ui_->boughtCurrencyEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->boughtCurrencyCombo);
     instrument_.bought_amount = ui_->boughtAmountSpinBox->value();
     instrument_.sold_currency =
-        ui_->soldCurrencyEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->soldCurrencyCombo);
     instrument_.sold_amount = ui_->soldAmountSpinBox->value();
     instrument_.option_type =
         InstrumentFormUtils::getComboValue(ui_->optionTypeCombo);
-    instrument_.expiry_date =
-        ui_->expiryDateEdit->text().trimmed().toStdString();
+    instrument_.expiry_date = ui_->expiryDateEdit->isoDate();
     instrument_.exercise_style =
         InstrumentFormUtils::getComboValue(ui_->exerciseStyleCombo);
     instrument_.settlement =
@@ -157,9 +212,9 @@ void FxVanillaOptionInstrumentForm::setInstrument(
 
 void FxVanillaOptionInstrumentForm::populateFromInstrument() {
     const auto block = [this](bool b) {
-        ui_->boughtCurrencyEdit->blockSignals(b);
+        ui_->boughtCurrencyCombo->blockSignals(b);
         ui_->boughtAmountSpinBox->blockSignals(b);
-        ui_->soldCurrencyEdit->blockSignals(b);
+        ui_->soldCurrencyCombo->blockSignals(b);
         ui_->soldAmountSpinBox->blockSignals(b);
         ui_->optionTypeCombo->blockSignals(b);
         ui_->expiryDateEdit->blockSignals(b);
@@ -171,15 +226,14 @@ void FxVanillaOptionInstrumentForm::populateFromInstrument() {
     block(true);
     ui_->tradeTypeCodeEdit->setText(
         QString::fromStdString(instrument_.trade_type_code));
-    ui_->boughtCurrencyEdit->setText(
-        QString::fromStdString(instrument_.bought_currency));
+    InstrumentFormUtils::setComboValue(ui_->boughtCurrencyCombo,
+        instrument_.bought_currency);
     ui_->boughtAmountSpinBox->setValue(instrument_.bought_amount);
-    ui_->soldCurrencyEdit->setText(
-        QString::fromStdString(instrument_.sold_currency));
+    InstrumentFormUtils::setComboValue(ui_->soldCurrencyCombo,
+        instrument_.sold_currency);
     ui_->soldAmountSpinBox->setValue(instrument_.sold_amount);
     InstrumentFormUtils::setComboValue(ui_->optionTypeCombo, instrument_.option_type);
-    ui_->expiryDateEdit->setText(
-        QString::fromStdString(instrument_.expiry_date));
+    ui_->expiryDateEdit->setIsoDate(instrument_.expiry_date);
     InstrumentFormUtils::setComboValue(ui_->exerciseStyleCombo, instrument_.exercise_style);
     InstrumentFormUtils::setComboValue(ui_->settlementCombo, instrument_.settlement);
     ui_->descriptionEdit->setPlainText(

--- a/projects/ores.qt.trading/src/InstrumentFormRegistry.cpp
+++ b/projects/ores.qt.trading/src/InstrumentFormRegistry.cpp
@@ -26,6 +26,7 @@
 #include "ores.qt/CreditInstrumentForm.hpp"
 #include "ores.qt/EquityInstrumentForm.hpp"
 #include "ores.qt/FxInstrumentForm.hpp"
+#include "ores.qt/FxVanillaOptionInstrumentForm.hpp"
 #include "ores.qt/ScriptedInstrumentForm.hpp"
 #include "ores.qt/SwapInstrumentForm.hpp"
 
@@ -59,6 +60,29 @@ QString InstrumentFormRegistry::displayName(product_type pt) const {
 std::vector<InstrumentFormRegistry::product_type>
 InstrumentFormRegistry::registeredTypes() const {
     return order_;
+}
+
+void InstrumentFormRegistry::registerTypeForm(
+    const QString& trade_type_code, Factory factory) {
+    if (typeEntries_.find(trade_type_code) == typeEntries_.end())
+        typeOrder_.push_back(trade_type_code);
+    typeEntries_[trade_type_code] = TypeEntry{std::move(factory)};
+}
+
+bool InstrumentFormRegistry::containsTypeForm(
+    const QString& trade_type_code) const noexcept {
+    return typeEntries_.find(trade_type_code) != typeEntries_.end();
+}
+
+IInstrumentForm* InstrumentFormRegistry::createTypeForm(
+    const QString& trade_type_code, QWidget* parent) const {
+    auto it = typeEntries_.find(trade_type_code);
+    if (it == typeEntries_.end()) return nullptr;
+    return it->second.factory(parent);
+}
+
+std::vector<QString> InstrumentFormRegistry::registeredTypeCodes() const {
+    return typeOrder_;
 }
 
 void register_default_forms(InstrumentFormRegistry& registry) {
@@ -98,6 +122,14 @@ void register_default_forms(InstrumentFormRegistry& registry) {
     registry.registerForm(PT::fx, QStringLiteral("FX"),
         [](QWidget* parent) -> IInstrumentForm* {
             return new FxInstrumentForm(parent);
+        });
+
+    // Per-trade-type-code forms: each registered code gets its own dedicated
+    // form widget on the instrument stack. TradeDetailDialog prefers these
+    // over the family-level form when the trade_type_code matches.
+    registry.registerTypeForm(QStringLiteral("FxOption"),
+        [](QWidget* parent) -> IInstrumentForm* {
+            return new FxVanillaOptionInstrumentForm(parent);
         });
 }
 

--- a/projects/ores.qt.trading/src/InstrumentFormUtils.cpp
+++ b/projects/ores.qt.trading/src/InstrumentFormUtils.cpp
@@ -1,0 +1,127 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/InstrumentFormUtils.hpp"
+
+#include <QComboBox>
+
+namespace ores::qt {
+
+void InstrumentFormUtils::populateSettlement(QComboBox* cb) {
+    cb->clear();
+    cb->addItems({"", "Cash", "Physical"});
+}
+
+void InstrumentFormUtils::populateOptionType(QComboBox* cb) {
+    cb->clear();
+    cb->addItems({"", "Call", "Put"});
+}
+
+void InstrumentFormUtils::populateExerciseStyle(QComboBox* cb) {
+    cb->clear();
+    cb->addItems({"", "European", "American"});
+}
+
+void InstrumentFormUtils::populateExerciseType(QComboBox* cb) {
+    cb->clear();
+    cb->addItems({"", "European", "American", "Bermudan"});
+}
+
+void InstrumentFormUtils::populateDayCount(QComboBox* cb) {
+    cb->clear();
+    cb->addItems({
+        "",
+        "A360",
+        "A365F",
+        "A365",
+        "ActAct(ISDA)",
+        "ActAct(ISMA)",
+        "ActAct(AFB)",
+        "30/360",
+        "30E/360",
+        "30E/360(ISDA)",
+        "Business252",
+        "1/1",
+        "Simple",
+    });
+}
+
+void InstrumentFormUtils::populateFrequency(QComboBox* cb) {
+    cb->clear();
+    cb->addItems({
+        "",
+        "Annual",
+        "Semiannual",
+        "EveryFourthMonth",
+        "Quarterly",
+        "Bimonthly",
+        "Monthly",
+        "EveryFourthWeek",
+        "Biweekly",
+        "Weekly",
+        "Daily",
+        "Once",
+    });
+}
+
+void InstrumentFormUtils::populateBarrierType(QComboBox* cb) {
+    cb->clear();
+    cb->addItems({"", "UpIn", "UpOut", "DownIn", "DownOut"});
+}
+
+void InstrumentFormUtils::populateAverageType(QComboBox* cb) {
+    cb->clear();
+    cb->addItems({"", "Arithmetic", "Geometric"});
+}
+
+void InstrumentFormUtils::populateSeniority(QComboBox* cb) {
+    cb->clear();
+    cb->addItems({"", "Senior", "Subordinated"});
+}
+
+void InstrumentFormUtils::populateRestructuring(QComboBox* cb) {
+    cb->clear();
+    cb->addItems({"", "MM", "MR", "CR", "XR"});
+}
+
+void InstrumentFormUtils::populateTrsReturnType(QComboBox* cb) {
+    cb->clear();
+    cb->addItems({"", "TotalReturn", "PriceReturn"});
+}
+
+void InstrumentFormUtils::populateAscotOptionType(QComboBox* cb) {
+    cb->clear();
+    cb->addItems({"", "Call", "Put"});
+}
+
+void InstrumentFormUtils::populateReturnType(QComboBox* cb) {
+    cb->clear();
+    cb->addItems({"", "TotalReturn", "PriceReturn"});
+}
+
+void InstrumentFormUtils::setComboValue(QComboBox* cb, const std::string& value) {
+    const QString qv = QString::fromStdString(value);
+    const int idx = cb->findText(qv);
+    cb->setCurrentIndex(idx >= 0 ? idx : 0);
+}
+
+std::string InstrumentFormUtils::getComboValue(const QComboBox* cb) {
+    return cb->currentText().toStdString();
+}
+
+} // namespace ores::qt

--- a/projects/ores.qt.trading/src/OreCurrencyComboBox.cpp
+++ b/projects/ores.qt.trading/src/OreCurrencyComboBox.cpp
@@ -1,0 +1,22 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/OreCurrencyComboBox.hpp"
+
+OreCurrencyComboBox::OreCurrencyComboBox(QWidget* parent)
+    : QComboBox(parent) {}

--- a/projects/ores.qt.trading/src/OreDateEdit.cpp
+++ b/projects/ores.qt.trading/src/OreDateEdit.cpp
@@ -1,0 +1,45 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/OreDateEdit.hpp"
+
+OreDateEdit::OreDateEdit(QWidget* parent)
+    : QDateEdit(parent) {
+    setCalendarPopup(true);
+    setDisplayFormat(QStringLiteral("yyyy-MM-dd"));
+    setMinimumDate(QDate(1900, 1, 1));
+    // A single space signals the blank/unset state visually.
+    setSpecialValueText(QStringLiteral(" "));
+    setDate(minimumDate());
+}
+
+std::string OreDateEdit::isoDate() const {
+    if (date() == minimumDate())
+        return {};
+    return date().toString(QStringLiteral("yyyy-MM-dd")).toStdString();
+}
+
+void OreDateEdit::setIsoDate(const std::string& iso) {
+    if (iso.empty()) {
+        setDate(minimumDate());
+        return;
+    }
+    const QDate d = QDate::fromString(
+        QString::fromStdString(iso), QStringLiteral("yyyy-MM-dd"));
+    setDate(d.isValid() ? d : minimumDate());
+}

--- a/projects/ores.qt.trading/src/OreDoubleSpinBox.cpp
+++ b/projects/ores.qt.trading/src/OreDoubleSpinBox.cpp
@@ -1,0 +1,28 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/OreDoubleSpinBox.hpp"
+
+namespace ores::qt {
+
+OreDoubleSpinBox::OreDoubleSpinBox(QWidget* parent)
+    : QDoubleSpinBox(parent) {
+    setGroupSeparatorShown(true);
+}
+
+} // namespace ores::qt

--- a/projects/ores.qt.trading/src/OreDoubleSpinBox.cpp
+++ b/projects/ores.qt.trading/src/OreDoubleSpinBox.cpp
@@ -22,5 +22,3 @@ OreDoubleSpinBox::OreDoubleSpinBox(QWidget* parent)
     : QDoubleSpinBox(parent) {
     setGroupSeparatorShown(true);
 }
-
-#include "moc_OreDoubleSpinBox.cpp"

--- a/projects/ores.qt.trading/src/OreDoubleSpinBox.cpp
+++ b/projects/ores.qt.trading/src/OreDoubleSpinBox.cpp
@@ -18,11 +18,7 @@
  */
 #include "ores.qt/OreDoubleSpinBox.hpp"
 
-namespace ores::qt {
-
 OreDoubleSpinBox::OreDoubleSpinBox(QWidget* parent)
     : QDoubleSpinBox(parent) {
     setGroupSeparatorShown(true);
 }
-
-} // namespace ores::qt

--- a/projects/ores.qt.trading/src/OreDoubleSpinBox.cpp
+++ b/projects/ores.qt.trading/src/OreDoubleSpinBox.cpp
@@ -22,3 +22,5 @@ OreDoubleSpinBox::OreDoubleSpinBox(QWidget* parent)
     : QDoubleSpinBox(parent) {
     setGroupSeparatorShown(true);
 }
+
+#include "moc_OreDoubleSpinBox.cpp"

--- a/projects/ores.qt.trading/src/PortfolioExplorerMdiWindow.cpp
+++ b/projects/ores.qt.trading/src/PortfolioExplorerMdiWindow.cpp
@@ -21,6 +21,7 @@
 
 #include <QtConcurrent>
 #include <QApplication>
+#include <QThreadPool>
 #include <QDialog>
 #include <QDrag>
 #include <QLabel>
@@ -303,10 +304,15 @@ void PortfolioExplorerMdiWindow::doReload() {
     portfolios_loaded_ = false;
     books_loaded_ = false;
 
+    BOOST_LOG_SEV(lg(), info) << "doReload: submitting tasks. Thread pool: "
+        << QThreadPool::globalInstance()->activeThreadCount() << " active / "
+        << QThreadPool::globalInstance()->maxThreadCount() << " max";
+
     // Fetch portfolios
     QPointer<PortfolioExplorerMdiWindow> self = this;
     portfolioWatcher_->setFuture(
         QtConcurrent::run([self]() -> PortfolioFetchResult {
+            BOOST_LOG_SEV(lg(), info) << "DIAG: portfolio task started on worker thread";
             return exception_helper::wrap_async_fetch<PortfolioFetchResult>(
                 [&]() -> PortfolioFetchResult {
                     if (!self || !self->clientManager_)
@@ -315,8 +321,10 @@ void PortfolioExplorerMdiWindow::doReload() {
 
                     refdata::messaging::get_portfolios_request req;
                     req.limit = 1000;
+                    BOOST_LOG_SEV(lg(), info) << "DIAG: portfolio sending NATS request";
                     auto result = self->clientManager_->
                         process_authenticated_request(std::move(req));
+                    BOOST_LOG_SEV(lg(), info) << "DIAG: portfolio NATS response received";
                     if (!result)
                         return {.success = false, .portfolios = {},
                                 .error_message = QString::fromStdString(
@@ -332,6 +340,7 @@ void PortfolioExplorerMdiWindow::doReload() {
     // Fetch books
     bookWatcher_->setFuture(
         QtConcurrent::run([self]() -> BookFetchResult {
+            BOOST_LOG_SEV(lg(), info) << "DIAG: book task started on worker thread";
             return exception_helper::wrap_async_fetch<BookFetchResult>(
                 [&]() -> BookFetchResult {
                     if (!self || !self->clientManager_)
@@ -340,8 +349,10 @@ void PortfolioExplorerMdiWindow::doReload() {
 
                     refdata::messaging::get_books_request req;
                     req.limit = 1000;
+                    BOOST_LOG_SEV(lg(), info) << "DIAG: books sending NATS request";
                     auto result = self->clientManager_->
                         process_authenticated_request(std::move(req));
+                    BOOST_LOG_SEV(lg(), info) << "DIAG: books NATS response received";
                     if (!result)
                         return {.success = false, .books = {},
                                 .error_message = QString::fromStdString(
@@ -357,6 +368,7 @@ void PortfolioExplorerMdiWindow::doReload() {
     // Fetch counterparties for display
     counterpartyWatcher_->setFuture(
         QtConcurrent::run([self]() -> CounterpartyFetchResult {
+            BOOST_LOG_SEV(lg(), info) << "DIAG: counterparty task started on worker thread";
             return exception_helper::wrap_async_fetch<CounterpartyFetchResult>(
                 [&]() -> CounterpartyFetchResult {
                     if (!self || !self->clientManager_)
@@ -365,8 +377,10 @@ void PortfolioExplorerMdiWindow::doReload() {
 
                     refdata::messaging::get_counterparties_request req;
                     req.limit = 1000;
+                    BOOST_LOG_SEV(lg(), info) << "DIAG: counterparties sending NATS request";
                     auto result = self->clientManager_->
                         process_authenticated_request(std::move(req));
+                    BOOST_LOG_SEV(lg(), info) << "DIAG: counterparties NATS response received";
                     if (!result)
                         return {.success = false, .cpty_map = {},
                                 .error_message = QString::fromStdString(
@@ -384,6 +398,8 @@ void PortfolioExplorerMdiWindow::doReload() {
                             .error_message = {}};
                 }, "counterparties");
         }));
+
+    BOOST_LOG_SEV(lg(), info) << "doReload: all tasks submitted";
 }
 
 void PortfolioExplorerMdiWindow::onPortfoliosLoaded() {

--- a/projects/ores.qt.trading/src/PortfolioExplorerMdiWindow.cpp
+++ b/projects/ores.qt.trading/src/PortfolioExplorerMdiWindow.cpp
@@ -230,10 +230,13 @@ void PortfolioExplorerMdiWindow::setupConnections() {
     // Trade model signals
     connect(tradeModel_, &PortfolioExplorerTradeModel::dataLoaded,
             this, [this]() {
+        endLoading();
         paginationWidget_->update_state(
             static_cast<std::uint32_t>(tradeModel_->rowCount()),
             tradeModel_->total_available_count());
     });
+    connect(tradeModel_, &PortfolioExplorerTradeModel::loadError,
+            this, [this](const QString&, const QString&) { endLoading(); });
 
     // Pagination signals
     connect(paginationWidget_, &PaginationWidget::page_requested,
@@ -513,6 +516,7 @@ void PortfolioExplorerMdiWindow::onTreeSelectionChanged(
     if (selected.isEmpty()) {
         tradeModel_->set_filter(std::nullopt, std::nullopt);
         updateBreadcrumb(nullptr);
+        beginLoading();
         tradeModel_->refresh();
         updateActionStates();
         return;
@@ -524,6 +528,7 @@ void PortfolioExplorerMdiWindow::onTreeSelectionChanged(
 
     tradeModel_->set_filter(filter.book_id, filter.portfolio_id);
     updateBreadcrumb(node);
+    beginLoading();
     tradeModel_->refresh();
     updateActionStates();
 }

--- a/projects/ores.qt.trading/src/SwapInstrumentForm.cpp
+++ b/projects/ores.qt.trading/src/SwapInstrumentForm.cpp
@@ -19,12 +19,17 @@
  */
 #include "ores.qt/SwapInstrumentForm.hpp"
 
+#include <QComboBox>
 #include <QPointer>
 #include <QtConcurrent>
 #include <QFutureWatcher>
 #include <boost/uuid/uuid_io.hpp>
 #include "ui_SwapInstrumentForm.h"
 #include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ImageCache.hpp"
+#include "ores.qt/FlagIconHelper.hpp"
+#include "ores.qt/LookupFetcher.hpp"
+#include "ores.qt/InstrumentFormUtils.hpp"
 #include "ores.trading.api/messaging/instrument_protocol.hpp"
 #include "ores.trading.api/domain/fra_instrument.hpp"
 #include "ores.trading.api/domain/vanilla_swap_instrument.hpp"
@@ -323,13 +328,17 @@ SwapInstrumentForm::~SwapInstrumentForm() = default;
 
 void SwapInstrumentForm::setupConnections() {
     auto markChanged = [this]() { onFieldChanged(); };
+    auto markChangedStr = [this](const QString&) { onFieldChanged(); };
+    auto markChangedDate = [this](const QDate&) { onFieldChanged(); };
     connect(ui_->tradeTypeCodeEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->currencyEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->startDateEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->maturityDateEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->currencyCombo, &QComboBox::currentTextChanged,
+            this, markChangedStr);
+    connect(ui_->startDateEdit, &QDateEdit::dateChanged, this, markChangedDate);
+    connect(ui_->maturityDateEdit, &QDateEdit::dateChanged, this, markChangedDate);
     connect(ui_->descriptionEdit, &QPlainTextEdit::textChanged, this, markChanged);
-    connect(ui_->fraFixingDateEdit, &QLineEdit::textChanged, this, markChanged);
-    connect(ui_->fraSettlementDateEdit, &QLineEdit::textChanged, this, markChanged);
+    connect(ui_->fraFixingDateEdit, &QDateEdit::dateChanged, this, markChangedDate);
+    connect(ui_->fraSettlementDateEdit, &QDateEdit::dateChanged,
+            this, markChangedDate);
     connect(ui_->rpaCounterpartyEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->inflationIndexCodeEdit, &QLineEdit::textChanged, this, markChanged);
     connect(ui_->callableDatesJsonEdit, &QPlainTextEdit::textChanged, this, markChanged);
@@ -346,6 +355,41 @@ void SwapInstrumentForm::setupConnections() {
 
 void SwapInstrumentForm::setClientManager(ClientManager* cm) {
     clientManager_ = cm;
+    populateCurrencies();
+}
+
+void SwapInstrumentForm::setImageCache(ImageCache* cache) {
+    imageCache_ = cache;
+    setup_flag_combo(this, ui_->currencyCombo, imageCache_,
+                     FlagSource::Currency);
+}
+
+void SwapInstrumentForm::populateCurrencies() {
+    if (!clientManager_) return;
+
+    QPointer<SwapInstrumentForm> self = this;
+    auto* watcher = new QFutureWatcher<std::vector<std::string>>(self);
+    connect(watcher, &QFutureWatcher<std::vector<std::string>>::finished, self,
+        [self, watcher]() {
+        auto codes = watcher->result();
+        watcher->deleteLater();
+        if (!self) return;
+        auto* cb = self->ui_->currencyCombo;
+        cb->blockSignals(true);
+        cb->clear();
+        cb->addItem(QString());
+        for (const auto& c : codes)
+            cb->addItem(QString::fromStdString(c));
+        InstrumentFormUtils::setComboValue(cb, self->state_.currency);
+        cb->blockSignals(false);
+        if (self->imageCache_)
+            apply_flag_icons(cb, self->imageCache_, FlagSource::Currency);
+    });
+
+    auto* cm = clientManager_;
+    watcher->setFuture(QtConcurrent::run([cm]() {
+        return fetch_currency_codes(cm);
+    }));
 }
 
 void SwapInstrumentForm::setUsername(const std::string& username) {
@@ -372,7 +416,7 @@ void SwapInstrumentForm::setTradeType(const QString& code,
 void SwapInstrumentForm::setReadOnly(bool readOnly) {
     ui_->tradeTypeCodeEdit->setReadOnly(readOnly);
     ui_->notionalSpinBox->setReadOnly(readOnly);
-    ui_->currencyEdit->setReadOnly(readOnly);
+    ui_->currencyCombo->setEnabled(!readOnly);
     ui_->startDateEdit->setReadOnly(readOnly);
     ui_->maturityDateEdit->setReadOnly(readOnly);
     ui_->descriptionEdit->setReadOnly(readOnly);
@@ -395,16 +439,14 @@ void SwapInstrumentForm::setChangeReason(
 }
 
 void SwapInstrumentForm::writeUiToInstrument() {
-    state_.start_date =
-        ui_->startDateEdit->text().trimmed().toStdString();
-    state_.maturity_date =
-        ui_->maturityDateEdit->text().trimmed().toStdString();
+    state_.start_date = ui_->startDateEdit->isoDate();
+    state_.maturity_date = ui_->maturityDateEdit->isoDate();
     state_.description =
         ui_->descriptionEdit->toPlainText().trimmed().toStdString();
 
     // FRA-specific
     state_.currency =
-        ui_->currencyEdit->text().trimmed().toStdString();
+        InstrumentFormUtils::getComboValue(ui_->currencyCombo);
     state_.notional = ui_->notionalSpinBox->value();
 
     // Callable swap-specific
@@ -455,7 +497,7 @@ void SwapInstrumentForm::populateFromState() {
     const auto block = [this](bool b) {
         ui_->tradeTypeCodeEdit->blockSignals(b);
         ui_->notionalSpinBox->blockSignals(b);
-        ui_->currencyEdit->blockSignals(b);
+        ui_->currencyCombo->blockSignals(b);
         ui_->startDateEdit->blockSignals(b);
         ui_->maturityDateEdit->blockSignals(b);
         ui_->descriptionEdit->blockSignals(b);
@@ -472,18 +514,15 @@ void SwapInstrumentForm::populateFromState() {
     ui_->tradeTypeCodeEdit->setText(
         QString::fromStdString(state_.trade_type_code));
     ui_->notionalSpinBox->setValue(state_.notional);
-    ui_->currencyEdit->setText(
-        QString::fromStdString(state_.currency));
-    ui_->startDateEdit->setText(
-        QString::fromStdString(state_.start_date));
-    ui_->maturityDateEdit->setText(
-        QString::fromStdString(state_.maturity_date));
+    InstrumentFormUtils::setComboValue(ui_->currencyCombo, state_.currency);
+    ui_->startDateEdit->setIsoDate(state_.start_date);
+    ui_->maturityDateEdit->setIsoDate(state_.maturity_date);
     ui_->descriptionEdit->setPlainText(
         QString::fromStdString(state_.description));
     // FRA extension widgets — not populated from per-type domain objects
     // (these UI widgets will be repurposed in a future UI redesign).
-    ui_->fraFixingDateEdit->clear();
-    ui_->fraSettlementDateEdit->clear();
+    ui_->fraFixingDateEdit->setIsoDate("");
+    ui_->fraSettlementDateEdit->setIsoDate("");
     ui_->lockoutDaysSpinBox->setValue(state_.lockout_days.value_or(0));
     ui_->callableDatesJsonEdit->setPlainText(
         QString::fromStdString(state_.call_dates_json));

--- a/projects/ores.qt.trading/src/TradeController.cpp
+++ b/projects/ores.qt.trading/src/TradeController.cpp
@@ -19,6 +19,7 @@
  */
 #include "ores.qt/TradeController.hpp"
 #include "ores.qt/ChangeReasonCache.hpp"
+#include "ores.qt/ImageCache.hpp"
 
 #include <optional>
 #include <filesystem>
@@ -61,11 +62,13 @@ TradeController::TradeController(
     QMdiArea* mdiArea,
     ClientManager* clientManager,
     ChangeReasonCache* changeReasonCache,
+    ImageCache* imageCache,
     const QString& username,
     QObject* parent)
     : EntityController(mainWindow, mdiArea, clientManager, username,
           trade_event_name, parent),
       changeReasonCache_(changeReasonCache),
+      imageCache_(imageCache),
       listWindow_(nullptr),
       listMdiSubWindow_(nullptr) {
 
@@ -316,6 +319,8 @@ void TradeController::showAddWindow() {
         detailDialog->setChangeReasonCache(changeReasonCache_);
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
+    if (imageCache_)
+        detailDialog->setImageCache(imageCache_);
     detailDialog->setCreateMode(true);
 
     connect(detailDialog, &TradeDetailDialog::statusMessage,
@@ -361,6 +366,8 @@ void TradeController::showDetailWindow(
         detailDialog->setChangeReasonCache(changeReasonCache_);
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
+    if (imageCache_)
+        detailDialog->setImageCache(imageCache_);
     detailDialog->setCreateMode(false);
     detailDialog->setTradeBundle(bundle);
 
@@ -485,6 +492,8 @@ void TradeController::onOpenVersion(
         detailDialog->setChangeReasonCache(changeReasonCache_);
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
+    if (imageCache_)
+        detailDialog->setImageCache(imageCache_);
     // Historical versions don't carry an instrument bundle: the history
     // endpoint returns bare trades, and point-in-time instrument retrieval
     // is a separate concern. Pass monostate so the form clears rather than
@@ -538,6 +547,8 @@ void TradeController::onRevertVersion(
         detailDialog->setChangeReasonCache(changeReasonCache_);
     detailDialog->setClientManager(clientManager_);
     detailDialog->setUsername(username_.toStdString());
+    if (imageCache_)
+        detailDialog->setImageCache(imageCache_);
     trading::messaging::trade_export_item bundle{.trade = trade, .instrument = {}};
     detailDialog->setTradeBundle(bundle);
     detailDialog->setCreateMode(false);

--- a/projects/ores.qt.trading/src/TradeDetailDialog.cpp
+++ b/projects/ores.qt.trading/src/TradeDetailDialog.cpp
@@ -73,34 +73,22 @@ TradeDetailDialog::TradeDetailDialog(QWidget* parent)
         applyCreateTradeType();
     });
 
-    // Build a stack page per registered IInstrumentForm. formMap_ is
-    // populated here so setTradeBundle() can reach any form in O(1).
+    // Build a stack page per registered IInstrumentForm. formMap_ and
+    // typeFormMap_ are populated here so setTradeBundle() reaches any form O(1).
     register_default_forms(instrumentFormRegistry_);
     for (const auto pt : instrumentFormRegistry_.registeredTypes()) {
         IInstrumentForm* form =
             instrumentFormRegistry_.createForm(pt, ui_->instrumentStack);
         ui_->instrumentStack->addWidget(form);
         formMap_[pt] = form;
-
-        connect(form, &IInstrumentForm::changed, this,
-                &TradeDetailDialog::onInstrumentFieldChanged);
-        connect(form, &IInstrumentForm::instrumentLoaded, this, [this]() {
-            instrumentLoaded_ = true;
-            ui_->instrumentProvenanceGroup->setVisible(true);
-            updateSaveButtonState();
-        });
-        connect(form, &IInstrumentForm::loadFailed, this,
-                [](const QString& err) {
-            BOOST_LOG_SEV(lg(), warn)
-                << "Instrument load failed: " << err.toStdString();
-        });
-        connect(form, &IInstrumentForm::provenanceChanged, this,
-                [this](const InstrumentProvenance& p) {
-            ui_->instrumentProvenanceWidget->populate(
-                p.version, p.modified_by, p.performed_by,
-                p.recorded_at, p.change_reason_code, p.change_commentary);
-            ui_->instrumentProvenanceGroup->setVisible(true);
-        });
+        connectFormSignals(form);
+    }
+    for (const auto& code : instrumentFormRegistry_.registeredTypeCodes()) {
+        IInstrumentForm* form =
+            instrumentFormRegistry_.createTypeForm(code, ui_->instrumentStack);
+        ui_->instrumentStack->addWidget(form);
+        typeFormMap_[code.toStdString()] = form;
+        connectFormSignals(form);
     }
 }
 
@@ -339,6 +327,37 @@ void TradeDetailDialog::setUsername(const std::string& username) {
     username_ = username;
 }
 
+void TradeDetailDialog::connectFormSignals(IInstrumentForm* form) {
+    connect(form, &IInstrumentForm::changed, this,
+            &TradeDetailDialog::onInstrumentFieldChanged);
+    connect(form, &IInstrumentForm::instrumentLoaded, this, [this]() {
+        instrumentLoaded_ = true;
+        ui_->instrumentProvenanceGroup->setVisible(true);
+        updateSaveButtonState();
+    });
+    connect(form, &IInstrumentForm::loadFailed, this,
+            [](const QString& err) {
+        BOOST_LOG_SEV(lg(), warn)
+            << "Instrument load failed: " << err.toStdString();
+    });
+    connect(form, &IInstrumentForm::provenanceChanged, this,
+            [this](const InstrumentProvenance& p) {
+        ui_->instrumentProvenanceWidget->populate(
+            p.version, p.modified_by, p.performed_by,
+            p.recorded_at, p.change_reason_code, p.change_commentary);
+        ui_->instrumentProvenanceGroup->setVisible(true);
+    });
+}
+
+IInstrumentForm* TradeDetailDialog::findForm(
+    trading::domain::product_type pt, const std::string& trade_type_code) {
+    auto ttIt = typeFormMap_.find(trade_type_code);
+    if (ttIt != typeFormMap_.end()) return ttIt->second;
+    auto ptIt = formMap_.find(pt);
+    if (ptIt != formMap_.end()) return ptIt->second;
+    return nullptr;
+}
+
 // Selects @p form on the stack, sets client manager, username, and trade
 // type flags from the cache.  Does not trigger load or clear — caller does
 // that immediately after.
@@ -369,9 +388,9 @@ void TradeDetailDialog::setTradeBundle(
     selectCurrentBook();
     selectCurrentCounterparty();
 
-    auto it = formMap_.find(trade_.product_type);
-    if (it != formMap_.end()) {
-        activateForm(it->second, trade_.trade_type);
+    auto* form = findForm(trade_.product_type, trade_.trade_type);
+    if (form) {
+        activateForm(form, trade_.trade_type);
         if (std::holds_alternative<std::monostate>(bundle.instrument)) {
             activeForm_->clear();
         } else {
@@ -525,17 +544,17 @@ void TradeDetailDialog::applyCreateTradeType() {
         return;
     }
 
-    auto formIt = formMap_.find(ttIt->second.product_type);
-    if (formIt == formMap_.end()) {
+    auto* form = findForm(ttIt->second.product_type, code);
+    if (!form) {
         ui_->tabWidget->setTabVisible(
             ui_->tabWidget->indexOf(ui_->instrumentTab), false);
         activeForm_ = nullptr;
         return;
     }
 
-    // Only reset the form when the product family changes.
-    if (activeForm_ != formIt->second) {
-        activateForm(formIt->second, code);
+    // Only reset the form when the active form changes.
+    if (activeForm_ != form) {
+        activateForm(form, code);
         activeForm_->clear();
     }
 }

--- a/projects/ores.qt.trading/src/TradeDetailDialog.cpp
+++ b/projects/ores.qt.trading/src/TradeDetailDialog.cpp
@@ -336,9 +336,11 @@ void TradeDetailDialog::connectFormSignals(IInstrumentForm* form) {
         updateSaveButtonState();
     });
     connect(form, &IInstrumentForm::loadFailed, this,
-            [](const QString& err) {
-        BOOST_LOG_SEV(lg(), warn)
+            [this](const QString& err) {
+        BOOST_LOG_SEV(lg(), error)
             << "Instrument load failed: " << err.toStdString();
+        MessageBoxHelper::warning(this, tr("Instrument Load Failed"), err);
+        emit errorMessage(err);
     });
     connect(form, &IInstrumentForm::provenanceChanged, this,
             [this](const InstrumentProvenance& p) {
@@ -384,18 +386,70 @@ void TradeDetailDialog::activateForm(IInstrumentForm* form,
 void TradeDetailDialog::setTradeBundle(
     const trading::messaging::trade_export_item& bundle) {
     trade_ = bundle.trade;
+
+    const bool has_instrument = !std::holds_alternative<std::monostate>(bundle.instrument);
+    const std::string instrument_id_str = bundle.trade.instrument_id
+        ? boost::uuids::to_string(*bundle.trade.instrument_id) : "<none>";
+
+    BOOST_LOG_SEV(lg(), debug)
+        << "setTradeBundle: trade=" << bundle.trade.external_id
+        << " product_type=" << std::string(
+            ores::trading::domain::to_string(bundle.trade.product_type))
+        << " trade_type=" << bundle.trade.trade_type
+        << " instrument_id=" << instrument_id_str
+        << " instrument=" << (has_instrument
+            ? ("present (index=" + std::to_string(bundle.instrument.index()) + ")")
+            : "monostate");
+
     updateUiFromTrade();
     selectCurrentBook();
     selectCurrentCounterparty();
 
     auto* form = findForm(trade_.product_type, trade_.trade_type);
-    if (form) {
-        activateForm(form, trade_.trade_type);
-        if (std::holds_alternative<std::monostate>(bundle.instrument)) {
-            activeForm_->clear();
+    if (!form) {
+        const QString msg = tr("No instrument form registered for trade '%1' "
+            "(product_type=%2, trade_type=%3). "
+            "Check that the instrument form plugin is loaded.")
+            .arg(QString::fromStdString(bundle.trade.external_id))
+            .arg(QString::fromStdString(std::string(
+                ores::trading::domain::to_string(bundle.trade.product_type))))
+            .arg(QString::fromStdString(bundle.trade.trade_type));
+        BOOST_LOG_SEV(lg(), warn)
+            << "setTradeBundle: " << msg.toStdString();
+        MessageBoxHelper::warning(this, tr("Instrument Form Missing"), msg);
+        emit errorMessage(msg);
+        return;
+    }
+
+    activateForm(form, trade_.trade_type);
+    if (!has_instrument) {
+        if (bundle.trade.instrument_id) {
+            // Server had an instrument_id but returned monostate — something
+            // went wrong during instrument lookup on the server side.
+            const QString msg = tr("Instrument data could not be loaded for trade '%1' "
+                "(instrument_id=%2, trade_type=%3). "
+                "The server returned no instrument data despite a linked instrument. "
+                "Check the trading service log for details.")
+                .arg(QString::fromStdString(bundle.trade.external_id))
+                .arg(QString::fromStdString(instrument_id_str))
+                .arg(QString::fromStdString(bundle.trade.trade_type));
+            BOOST_LOG_SEV(lg(), error)
+                << "setTradeBundle: instrument_id set but got monostate"
+                << " trade=" << bundle.trade.external_id
+                << " instrument_id=" << instrument_id_str;
+            MessageBoxHelper::warning(this, tr("Instrument Load Failed"), msg);
+            emit errorMessage(msg);
         } else {
-            activeForm_->setInstrument(bundle.instrument);
+            BOOST_LOG_SEV(lg(), debug)
+                << "setTradeBundle: no instrument linked, clearing form for trade="
+                << bundle.trade.external_id;
         }
+        activeForm_->clear();
+    } else {
+        BOOST_LOG_SEV(lg(), debug)
+            << "setTradeBundle: calling setInstrument for trade=" << bundle.trade.external_id
+            << " instrument_id=" << instrument_id_str;
+        activeForm_->setInstrument(bundle.instrument);
     }
 }
 

--- a/projects/ores.qt.trading/src/TradeDetailDialog.cpp
+++ b/projects/ores.qt.trading/src/TradeDetailDialog.cpp
@@ -327,6 +327,10 @@ void TradeDetailDialog::setUsername(const std::string& username) {
     username_ = username;
 }
 
+void TradeDetailDialog::setImageCache(ImageCache* cache) {
+    imageCache_ = cache;
+}
+
 void TradeDetailDialog::connectFormSignals(IInstrumentForm* form) {
     connect(form, &IInstrumentForm::changed, this,
             &TradeDetailDialog::onInstrumentFieldChanged);
@@ -372,6 +376,8 @@ void TradeDetailDialog::activateForm(IInstrumentForm* form,
 
     form->setClientManager(clientManager_);
     form->setUsername(username_);
+    if (imageCache_)
+        form->setImageCache(imageCache_);
 
     bool has_options = false, has_extension = false;
     auto it = tradeTypeCache_.find(tradeTypeCode);

--- a/projects/ores.qt.trading/src/TradingPlugin.cpp
+++ b/projects/ores.qt.trading/src/TradingPlugin.cpp
@@ -153,6 +153,7 @@ QList<QMenu*> TradingPlugin::create_menus() {
             return;
         }
 
+        BOOST_LOG_SEV(lg(), info) << "DIAG: creating PortfolioExplorerMdiWindow";
         auto* window = new PortfolioExplorerMdiWindow(
             ctx_.client_manager,
             bookController_.get(),
@@ -161,15 +162,21 @@ QList<QMenu*> TradingPlugin::create_menus() {
             oreImportController_.get(),
             ctx_.username,
             ctx_.main_window);
+        BOOST_LOG_SEV(lg(), info) << "DIAG: PortfolioExplorerMdiWindow constructor returned";
 
         connect(window, &PortfolioExplorerMdiWindow::statusChanged,
                 this, [this](const QString& msg) { emit statusMessage(msg); });
 
+        BOOST_LOG_SEV(lg(), info) << "DIAG: new DetachableMdiSubWindow";
         auto* subWindow = new DetachableMdiSubWindow(ctx_.main_window);
+        BOOST_LOG_SEV(lg(), info) << "DIAG: setWidget";
         subWindow->setWidget(window);
+        BOOST_LOG_SEV(lg(), info) << "DIAG: setWindowTitle";
         subWindow->setWindowTitle(tr("Portfolio Explorer"));
+        BOOST_LOG_SEV(lg(), info) << "DIAG: setWindowIcon";
         subWindow->setWindowIcon(
             IconUtils::createRecoloredIcon(Icon::BriefcaseFilled, IconUtils::DefaultIconColor));
+        BOOST_LOG_SEV(lg(), info) << "DIAG: setAttribute";
         subWindow->setAttribute(Qt::WA_DeleteOnClose);
 
         portfolio_explorer_sub_window_ = subWindow;
@@ -177,9 +184,15 @@ QList<QMenu*> TradingPlugin::create_menus() {
             portfolio_explorer_sub_window_ = nullptr;
         });
 
+        BOOST_LOG_SEV(lg(), info) << "DIAG: calling addSubWindow";
         ctx_.mdi_area->addSubWindow(subWindow);
-        subWindow->resize(window->sizeHint());
+        BOOST_LOG_SEV(lg(), info) << "DIAG: addSubWindow returned, calling sizeHint";
+        const auto hint = window->sizeHint();
+        BOOST_LOG_SEV(lg(), info) << "DIAG: sizeHint returned " << hint.width() << "x" << hint.height() << ", calling resize";
+        subWindow->resize(hint);
+        BOOST_LOG_SEV(lg(), info) << "DIAG: resize returned, calling show";
         subWindow->show();
+        BOOST_LOG_SEV(lg(), info) << "DIAG: subWindow->show() returned, action handler done";
     });
 
     act_org_explorer_ = menuTrading->addAction(ico(Icon::Organization), tr("&Org Explorer"));

--- a/projects/ores.qt.trading/src/TradingPlugin.cpp
+++ b/projects/ores.qt.trading/src/TradingPlugin.cpp
@@ -85,7 +85,7 @@ void TradingPlugin::on_login(const plugin_context& ctx) {
 
     tradeController_ = std::make_unique<TradeController>(
         ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
-        ctx_.change_reason_cache, ctx_.username, this);
+        ctx_.change_reason_cache, ctx_.image_cache, ctx_.username, this);
     connectControllerSignals(tradeController_.get());
 }
 

--- a/projects/ores.qt.trading/ui/BondInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/BondInstrumentForm.ui
@@ -55,7 +55,7 @@
            <widget class="QLabel"><property name="text"><string>Face Value:</string></property></widget>
           </item>
           <item row="3" column="1">
-           <widget class="QDoubleSpinBox" name="faceValueSpinBox">
+           <widget class="OreDoubleSpinBox" name="faceValueSpinBox">
             <property name="decimals"><number>2</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999999.000000000000000</double></property>
@@ -66,7 +66,7 @@
            <widget class="QLabel"><property name="text"><string>Coupon Rate:</string></property></widget>
           </item>
           <item row="4" column="1">
-           <widget class="QDoubleSpinBox" name="couponRateSpinBox">
+           <widget class="OreDoubleSpinBox" name="couponRateSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>1.000000000000000</double></property>
@@ -147,7 +147,7 @@
            <widget class="QLabel"><property name="text"><string>Conversion Ratio:</string></property></widget>
           </item>
           <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="conversionRatioSpinBox">
+           <widget class="OreDoubleSpinBox" name="conversionRatioSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>9999.000000000000000</double></property>
@@ -220,7 +220,7 @@
            <widget class="QLabel"><property name="text"><string>Option Strike:</string></property></widget>
           </item>
           <item row="3" column="1">
-           <widget class="QDoubleSpinBox" name="optionStrikeSpinBox">
+           <widget class="OreDoubleSpinBox" name="optionStrikeSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999.000000000000000</double></property>
@@ -264,6 +264,13 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <customwidgets>
+ <customwidget>
+  <class>OreDoubleSpinBox</class>
+  <extends>QDoubleSpinBox</extends>
+  <header>ores.qt/OreDoubleSpinBox.hpp</header>
+ </customwidget>
+</customwidgets>
+<resources/>
  <connections/>
 </ui>

--- a/projects/ores.qt.trading/ui/BondInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/BondInstrumentForm.ui
@@ -33,7 +33,9 @@
            <widget class="QLabel"><property name="text"><string>Trade Type:</string></property></widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="tradeTypeCodeEdit"/>
+           <widget class="QLineEdit" name="tradeTypeCodeEdit">
+            <property name="readOnly"><bool>true</bool></property>
+           </widget>
           </item>
           <item row="1" column="0">
            <widget class="QLabel"><property name="text"><string>Issuer:</string></property></widget>
@@ -76,17 +78,13 @@
            <widget class="QLabel"><property name="text"><string>Coupon Frequency:</string></property></widget>
           </item>
           <item row="5" column="1">
-           <widget class="QLineEdit" name="couponFrequencyCodeEdit">
-            <property name="placeholderText"><string>e.g. Annual, SemiAnnual</string></property>
-           </widget>
+           <widget class="QComboBox" name="couponFrequencyCombo"/>
           </item>
           <item row="6" column="0">
            <widget class="QLabel"><property name="text"><string>Day Count:</string></property></widget>
           </item>
           <item row="6" column="1">
-           <widget class="QLineEdit" name="dayCountCodeEdit">
-            <property name="placeholderText"><string>e.g. Actual365Fixed</string></property>
-           </widget>
+           <widget class="QComboBox" name="dayCountCombo"/>
           </item>
           <item row="7" column="0">
            <widget class="QLabel"><property name="text"><string>Issue Date:</string></property></widget>
@@ -208,9 +206,7 @@
            <widget class="QLabel"><property name="text"><string>Option Type:</string></property></widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLineEdit" name="optionTypeEdit">
-            <property name="placeholderText"><string>Call or Put (BondOption)</string></property>
-           </widget>
+           <widget class="QComboBox" name="optionTypeCombo"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel"><property name="text"><string>Option Expiry Date:</string></property></widget>
@@ -235,9 +231,7 @@
            <widget class="QLabel"><property name="text"><string>TRS Return Type:</string></property></widget>
           </item>
           <item row="4" column="1">
-           <widget class="QLineEdit" name="trsReturnTypeEdit">
-            <property name="placeholderText"><string>TotalReturn or PriceReturn (BondTRS)</string></property>
-           </widget>
+           <widget class="QComboBox" name="trsReturnTypeCombo"/>
           </item>
           <item row="5" column="0">
            <widget class="QLabel"><property name="text"><string>TRS Funding Leg:</string></property></widget>
@@ -251,9 +245,7 @@
            <widget class="QLabel"><property name="text"><string>ASCOT Option Type:</string></property></widget>
           </item>
           <item row="6" column="1">
-           <widget class="QLineEdit" name="ascotOptionTypeEdit">
-            <property name="placeholderText"><string>Ascot option type</string></property>
-           </widget>
+           <widget class="QComboBox" name="ascotOptionTypeCombo"/>
           </item>
          </layout>
         </widget>

--- a/projects/ores.qt.trading/ui/BondInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/BondInstrumentForm.ui
@@ -47,9 +47,7 @@
            <widget class="QLabel"><property name="text"><string>Currency:</string></property></widget>
           </item>
           <item row="2" column="1">
-           <widget class="QLineEdit" name="currencyEdit">
-            <property name="placeholderText"><string>ISO 4217 (e.g. USD)</string></property>
-           </widget>
+           <widget class="OreCurrencyComboBox" name="currencyCombo"/>
           </item>
           <item row="3" column="0">
            <widget class="QLabel"><property name="text"><string>Face Value:</string></property></widget>
@@ -90,17 +88,13 @@
            <widget class="QLabel"><property name="text"><string>Issue Date:</string></property></widget>
           </item>
           <item row="7" column="1">
-           <widget class="QLineEdit" name="issueDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="issueDateEdit"/>
           </item>
           <item row="8" column="0">
            <widget class="QLabel"><property name="text"><string>Maturity Date:</string></property></widget>
           </item>
           <item row="8" column="1">
-           <widget class="QLineEdit" name="maturityDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="maturityDateEdit"/>
           </item>
          </layout>
         </widget>
@@ -139,9 +133,7 @@
            <widget class="QLabel"><property name="text"><string>Call Date:</string></property></widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLineEdit" name="callDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date (CallableBond)</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="callDateEdit"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel"><property name="text"><string>Conversion Ratio:</string></property></widget>
@@ -198,9 +190,7 @@
            <widget class="QLabel"><property name="text"><string>Future Expiry Date:</string></property></widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="futureExpiryDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date (BondFuture)</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="futureExpiryDateEdit"/>
           </item>
           <item row="1" column="0">
            <widget class="QLabel"><property name="text"><string>Option Type:</string></property></widget>
@@ -212,9 +202,7 @@
            <widget class="QLabel"><property name="text"><string>Option Expiry Date:</string></property></widget>
           </item>
           <item row="2" column="1">
-           <widget class="QLineEdit" name="optionExpiryDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date (BondOption)</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="optionExpiryDateEdit"/>
           </item>
           <item row="3" column="0">
            <widget class="QLabel"><property name="text"><string>Option Strike:</string></property></widget>
@@ -269,6 +257,16 @@
   <class>OreDoubleSpinBox</class>
   <extends>QDoubleSpinBox</extends>
   <header>ores.qt/OreDoubleSpinBox.hpp</header>
+ </customwidget>
+ <customwidget>
+  <class>OreDateEdit</class>
+  <extends>QDateEdit</extends>
+  <header>ores.qt/OreDateEdit.hpp</header>
+ </customwidget>
+ <customwidget>
+  <class>OreCurrencyComboBox</class>
+  <extends>QComboBox</extends>
+  <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>
 </customwidgets>
 <resources/>

--- a/projects/ores.qt.trading/ui/CommodityInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/CommodityInstrumentForm.ui
@@ -33,7 +33,9 @@
            <widget class="QLabel"><property name="text"><string>Trade Type:</string></property></widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="tradeTypeCodeEdit"/>
+           <widget class="QLineEdit" name="tradeTypeCodeEdit">
+            <property name="readOnly"><bool>true</bool></property>
+           </widget>
           </item>
           <item row="1" column="0">
            <widget class="QLabel"><property name="text"><string>Commodity Code:</string></property></widget>
@@ -124,17 +126,13 @@
            <widget class="QLabel"><property name="text"><string>Option Type:</string></property></widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="optionTypeEdit">
-            <property name="placeholderText"><string>Call or Put</string></property>
-           </widget>
+           <widget class="QComboBox" name="optionTypeCombo"/>
           </item>
           <item row="1" column="0">
            <widget class="QLabel"><property name="text"><string>Exercise Type:</string></property></widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLineEdit" name="exerciseTypeEdit">
-            <property name="placeholderText"><string>European or American</string></property>
-           </widget>
+           <widget class="QComboBox" name="exerciseTypeCombo"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel"><property name="text"><string>Strike Price:</string></property></widget>
@@ -150,9 +148,7 @@
            <widget class="QLabel"><property name="text"><string>Barrier Type:</string></property></widget>
           </item>
           <item row="3" column="1">
-           <widget class="QLineEdit" name="barrierTypeEdit">
-            <property name="placeholderText"><string>e.g. UpIn, UpOut, DownIn, DownOut</string></property>
-           </widget>
+           <widget class="QComboBox" name="barrierTypeCombo"/>
           </item>
           <item row="4" column="0">
            <widget class="QLabel"><property name="text"><string>Lower Barrier:</string></property></widget>
@@ -178,9 +174,7 @@
            <widget class="QLabel"><property name="text"><string>Average Type:</string></property></widget>
           </item>
           <item row="6" column="1">
-           <widget class="QLineEdit" name="averageTypeEdit">
-            <property name="placeholderText"><string>Arithmetic or Geometric</string></property>
-           </widget>
+           <widget class="QComboBox" name="averageTypeCombo"/>
           </item>
           <item row="7" column="0">
            <widget class="QLabel"><property name="text"><string>Averaging Start Date:</string></property></widget>
@@ -220,9 +214,7 @@
            <widget class="QLabel"><property name="text"><string>Strip Frequency:</string></property></widget>
           </item>
           <item row="11" column="1">
-           <widget class="QLineEdit" name="stripFrequencyCodeEdit">
-            <property name="placeholderText"><string>e.g. Monthly, Quarterly</string></property>
-           </widget>
+           <widget class="QComboBox" name="stripFrequencyCombo"/>
           </item>
           <item row="12" column="0">
            <widget class="QLabel"><property name="text"><string>Variance Strike:</string></property></widget>
@@ -258,17 +250,13 @@
            <widget class="QLabel"><property name="text"><string>Day Count:</string></property></widget>
           </item>
           <item row="15" column="1">
-           <widget class="QLineEdit" name="dayCountCodeEdit">
-            <property name="placeholderText"><string>e.g. Actual365Fixed</string></property>
-           </widget>
+           <widget class="QComboBox" name="dayCountCombo"/>
           </item>
           <item row="16" column="0">
            <widget class="QLabel"><property name="text"><string>Payment Frequency:</string></property></widget>
           </item>
           <item row="16" column="1">
-           <widget class="QLineEdit" name="paymentFrequencyCodeEdit">
-            <property name="placeholderText"><string>e.g. Quarterly</string></property>
-           </widget>
+           <widget class="QComboBox" name="paymentFrequencyCombo"/>
           </item>
           <item row="17" column="0">
            <widget class="QLabel"><property name="text"><string>Swaption Expiry Date:</string></property></widget>

--- a/projects/ores.qt.trading/ui/CommodityInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/CommodityInstrumentForm.ui
@@ -57,7 +57,7 @@
            <widget class="QLabel"><property name="text"><string>Quantity:</string></property></widget>
           </item>
           <item row="3" column="1">
-           <widget class="QDoubleSpinBox" name="quantitySpinBox">
+           <widget class="OreDoubleSpinBox" name="quantitySpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999.000000000000000</double></property>
@@ -92,7 +92,7 @@
            <widget class="QLabel"><property name="text"><string>Fixed Price:</string></property></widget>
           </item>
           <item row="7" column="1">
-           <widget class="QDoubleSpinBox" name="fixedPriceSpinBox">
+           <widget class="OreDoubleSpinBox" name="fixedPriceSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999.000000000000000</double></property>
@@ -138,7 +138,7 @@
            <widget class="QLabel"><property name="text"><string>Strike Price:</string></property></widget>
           </item>
           <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="strikePriceSpinBox">
+           <widget class="OreDoubleSpinBox" name="strikePriceSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999.000000000000000</double></property>
@@ -154,7 +154,7 @@
            <widget class="QLabel"><property name="text"><string>Lower Barrier:</string></property></widget>
           </item>
           <item row="4" column="1">
-           <widget class="QDoubleSpinBox" name="lowerBarrierSpinBox">
+           <widget class="OreDoubleSpinBox" name="lowerBarrierSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999.000000000000000</double></property>
@@ -164,7 +164,7 @@
            <widget class="QLabel"><property name="text"><string>Upper Barrier:</string></property></widget>
           </item>
           <item row="5" column="1">
-           <widget class="QDoubleSpinBox" name="upperBarrierSpinBox">
+           <widget class="OreDoubleSpinBox" name="upperBarrierSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999.000000000000000</double></property>
@@ -204,7 +204,7 @@
            <widget class="QLabel"><property name="text"><string>Spread Amount:</string></property></widget>
           </item>
           <item row="10" column="1">
-           <widget class="QDoubleSpinBox" name="spreadAmountSpinBox">
+           <widget class="OreDoubleSpinBox" name="spreadAmountSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999.000000000000000</double></property>
@@ -220,7 +220,7 @@
            <widget class="QLabel"><property name="text"><string>Variance Strike:</string></property></widget>
           </item>
           <item row="12" column="1">
-           <widget class="QDoubleSpinBox" name="varianceStrikeSpinBox">
+           <widget class="OreDoubleSpinBox" name="varianceStrikeSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999.000000000000000</double></property>
@@ -230,7 +230,7 @@
            <widget class="QLabel"><property name="text"><string>Accumulation Amount:</string></property></widget>
           </item>
           <item row="13" column="1">
-           <widget class="QDoubleSpinBox" name="accumulationAmountSpinBox">
+           <widget class="OreDoubleSpinBox" name="accumulationAmountSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999.000000000000000</double></property>
@@ -240,7 +240,7 @@
            <widget class="QLabel"><property name="text"><string>Knock-Out Barrier:</string></property></widget>
           </item>
           <item row="14" column="1">
-           <widget class="QDoubleSpinBox" name="knockOutBarrierSpinBox">
+           <widget class="OreDoubleSpinBox" name="knockOutBarrierSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999.000000000000000</double></property>
@@ -315,6 +315,13 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <customwidgets>
+ <customwidget>
+  <class>OreDoubleSpinBox</class>
+  <extends>QDoubleSpinBox</extends>
+  <header>ores.qt/OreDoubleSpinBox.hpp</header>
+ </customwidget>
+</customwidgets>
+<resources/>
  <connections/>
 </ui>

--- a/projects/ores.qt.trading/ui/CommodityInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/CommodityInstrumentForm.ui
@@ -49,9 +49,7 @@
            <widget class="QLabel"><property name="text"><string>Currency:</string></property></widget>
           </item>
           <item row="2" column="1">
-           <widget class="QLineEdit" name="currencyEdit">
-            <property name="placeholderText"><string>ISO 4217 (e.g. USD)</string></property>
-           </widget>
+           <widget class="OreCurrencyComboBox" name="currencyCombo"/>
           </item>
           <item row="3" column="0">
            <widget class="QLabel"><property name="text"><string>Quantity:</string></property></widget>
@@ -76,17 +74,13 @@
            <widget class="QLabel"><property name="text"><string>Start Date:</string></property></widget>
           </item>
           <item row="5" column="1">
-           <widget class="QLineEdit" name="startDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="startDateEdit"/>
           </item>
           <item row="6" column="0">
            <widget class="QLabel"><property name="text"><string>Maturity Date:</string></property></widget>
           </item>
           <item row="6" column="1">
-           <widget class="QLineEdit" name="maturityDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="maturityDateEdit"/>
           </item>
           <item row="7" column="0">
            <widget class="QLabel"><property name="text"><string>Fixed Price:</string></property></widget>
@@ -180,17 +174,13 @@
            <widget class="QLabel"><property name="text"><string>Averaging Start Date:</string></property></widget>
           </item>
           <item row="7" column="1">
-           <widget class="QLineEdit" name="averagingStartDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="averagingStartDateEdit"/>
           </item>
           <item row="8" column="0">
            <widget class="QLabel"><property name="text"><string>Averaging End Date:</string></property></widget>
           </item>
           <item row="8" column="1">
-           <widget class="QLineEdit" name="averagingEndDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="averagingEndDateEdit"/>
           </item>
           <item row="9" column="0">
            <widget class="QLabel"><property name="text"><string>Spread Commodity:</string></property></widget>
@@ -262,9 +252,7 @@
            <widget class="QLabel"><property name="text"><string>Swaption Expiry Date:</string></property></widget>
           </item>
           <item row="17" column="1">
-           <widget class="QLineEdit" name="swaptionExpiryDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="swaptionExpiryDateEdit"/>
           </item>
           <item row="18" column="0">
            <widget class="QLabel"><property name="text"><string>Basket (JSON):</string></property></widget>
@@ -320,6 +308,16 @@
   <class>OreDoubleSpinBox</class>
   <extends>QDoubleSpinBox</extends>
   <header>ores.qt/OreDoubleSpinBox.hpp</header>
+ </customwidget>
+ <customwidget>
+  <class>OreDateEdit</class>
+  <extends>QDateEdit</extends>
+  <header>ores.qt/OreDateEdit.hpp</header>
+ </customwidget>
+ <customwidget>
+  <class>OreCurrencyComboBox</class>
+  <extends>QComboBox</extends>
+  <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>
 </customwidgets>
 <resources/>

--- a/projects/ores.qt.trading/ui/CreditInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/CreditInstrumentForm.ui
@@ -47,9 +47,7 @@
            <widget class="QLabel"><property name="text"><string>Currency:</string></property></widget>
           </item>
           <item row="2" column="1">
-           <widget class="QLineEdit" name="currencyEdit">
-            <property name="placeholderText"><string>ISO 4217 (e.g. USD)</string></property>
-           </widget>
+           <widget class="OreCurrencyComboBox" name="currencyCombo"/>
           </item>
           <item row="3" column="0">
            <widget class="QLabel"><property name="text"><string>Notional:</string></property></widget>
@@ -97,17 +95,13 @@
            <widget class="QLabel"><property name="text"><string>Start Date:</string></property></widget>
           </item>
           <item row="7" column="1">
-           <widget class="QLineEdit" name="startDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="startDateEdit"/>
           </item>
           <item row="8" column="0">
            <widget class="QLabel"><property name="text"><string>Maturity Date:</string></property></widget>
           </item>
           <item row="8" column="1">
-           <widget class="QLineEdit" name="maturityDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="maturityDateEdit"/>
           </item>
           <item row="9" column="0">
            <widget class="QLabel"><property name="text"><string>Day Count:</string></property></widget>
@@ -200,9 +194,7 @@
            <widget class="QLabel"><property name="text"><string>Option Expiry Date:</string></property></widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLineEdit" name="optionExpiryDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="optionExpiryDateEdit"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel"><property name="text"><string>Option Strike (bps):</string></property></widget>
@@ -267,6 +259,16 @@
   <class>OreDoubleSpinBox</class>
   <extends>QDoubleSpinBox</extends>
   <header>ores.qt/OreDoubleSpinBox.hpp</header>
+ </customwidget>
+ <customwidget>
+  <class>OreDateEdit</class>
+  <extends>QDateEdit</extends>
+  <header>ores.qt/OreDateEdit.hpp</header>
+ </customwidget>
+ <customwidget>
+  <class>OreCurrencyComboBox</class>
+  <extends>QComboBox</extends>
+  <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>
 </customwidgets>
 <resources/>

--- a/projects/ores.qt.trading/ui/CreditInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/CreditInstrumentForm.ui
@@ -33,7 +33,9 @@
            <widget class="QLabel"><property name="text"><string>Trade Type:</string></property></widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="tradeTypeCodeEdit"/>
+           <widget class="QLineEdit" name="tradeTypeCodeEdit">
+            <property name="readOnly"><bool>true</bool></property>
+           </widget>
           </item>
           <item row="1" column="0">
            <widget class="QLabel"><property name="text"><string>Reference Entity:</string></property></widget>
@@ -111,17 +113,13 @@
            <widget class="QLabel"><property name="text"><string>Day Count:</string></property></widget>
           </item>
           <item row="9" column="1">
-           <widget class="QLineEdit" name="dayCountCodeEdit">
-            <property name="placeholderText"><string>e.g. Actual365Fixed</string></property>
-           </widget>
+           <widget class="QComboBox" name="dayCountCombo"/>
           </item>
           <item row="10" column="0">
            <widget class="QLabel"><property name="text"><string>Payment Frequency:</string></property></widget>
           </item>
           <item row="10" column="1">
-           <widget class="QLineEdit" name="paymentFrequencyCodeEdit">
-            <property name="placeholderText"><string>e.g. Quarterly, SemiAnnual</string></property>
-           </widget>
+           <widget class="QComboBox" name="paymentFrequencyCombo"/>
           </item>
           <item row="11" column="0">
            <widget class="QLabel"><property name="text"><string>Index Name:</string></property></widget>
@@ -144,17 +142,13 @@
            <widget class="QLabel"><property name="text"><string>Seniority:</string></property></widget>
           </item>
           <item row="13" column="1">
-           <widget class="QLineEdit" name="seniorityEdit">
-            <property name="placeholderText"><string>e.g. Senior, Subordinated</string></property>
-           </widget>
+           <widget class="QComboBox" name="seniorityCombo"/>
           </item>
           <item row="14" column="0">
            <widget class="QLabel"><property name="text"><string>Restructuring:</string></property></widget>
           </item>
           <item row="14" column="1">
-           <widget class="QLineEdit" name="restructuringEdit">
-            <property name="placeholderText"><string>e.g. MM, MR, CR, XR</string></property>
-           </widget>
+           <widget class="QComboBox" name="restructuringCombo"/>
           </item>
           <item row="15" column="0">
            <widget class="QLabel"><property name="text"><string>Description:</string></property></widget>
@@ -200,9 +194,7 @@
            <widget class="QLabel"><property name="text"><string>Option Type:</string></property></widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="optionTypeEdit">
-            <property name="placeholderText"><string>Call or Put (CreditDefaultSwapOption)</string></property>
-           </widget>
+           <widget class="QComboBox" name="optionTypeCombo"/>
           </item>
           <item row="1" column="0">
            <widget class="QLabel"><property name="text"><string>Option Expiry Date:</string></property></widget>

--- a/projects/ores.qt.trading/ui/CreditInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/CreditInstrumentForm.ui
@@ -55,7 +55,7 @@
            <widget class="QLabel"><property name="text"><string>Notional:</string></property></widget>
           </item>
           <item row="3" column="1">
-           <widget class="QDoubleSpinBox" name="notionalSpinBox">
+           <widget class="OreDoubleSpinBox" name="notionalSpinBox">
             <property name="decimals"><number>2</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999999.000000000000000</double></property>
@@ -66,7 +66,7 @@
            <widget class="QLabel"><property name="text"><string>Spread (bps):</string></property></widget>
           </item>
           <item row="4" column="1">
-           <widget class="QDoubleSpinBox" name="spreadSpinBox">
+           <widget class="OreDoubleSpinBox" name="spreadSpinBox">
             <property name="decimals"><number>4</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>10000.000000000000000</double></property>
@@ -77,7 +77,7 @@
            <widget class="QLabel"><property name="text"><string>Recovery Rate:</string></property></widget>
           </item>
           <item row="5" column="1">
-           <widget class="QDoubleSpinBox" name="recoveryRateSpinBox">
+           <widget class="OreDoubleSpinBox" name="recoveryRateSpinBox">
             <property name="decimals"><number>4</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>1.000000000000000</double></property>
@@ -208,7 +208,7 @@
            <widget class="QLabel"><property name="text"><string>Option Strike (bps):</string></property></widget>
           </item>
           <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="optionStrikeSpinBox">
+           <widget class="OreDoubleSpinBox" name="optionStrikeSpinBox">
             <property name="decimals"><number>4</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>10000.000000000000000</double></property>
@@ -227,7 +227,7 @@
            <widget class="QLabel"><property name="text"><string>Tranche Attachment:</string></property></widget>
           </item>
           <item row="4" column="1">
-           <widget class="QDoubleSpinBox" name="trancheAttachmentSpinBox">
+           <widget class="OreDoubleSpinBox" name="trancheAttachmentSpinBox">
             <property name="decimals"><number>4</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>1.000000000000000</double></property>
@@ -238,7 +238,7 @@
            <widget class="QLabel"><property name="text"><string>Tranche Detachment:</string></property></widget>
           </item>
           <item row="5" column="1">
-           <widget class="QDoubleSpinBox" name="trancheDetachmentSpinBox">
+           <widget class="OreDoubleSpinBox" name="trancheDetachmentSpinBox">
             <property name="decimals"><number>4</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>1.000000000000000</double></property>
@@ -262,6 +262,13 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <customwidgets>
+ <customwidget>
+  <class>OreDoubleSpinBox</class>
+  <extends>QDoubleSpinBox</extends>
+  <header>ores.qt/OreDoubleSpinBox.hpp</header>
+ </customwidget>
+</customwidgets>
+<resources/>
  <connections/>
 </ui>

--- a/projects/ores.qt.trading/ui/EquityInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/EquityInstrumentForm.ui
@@ -33,7 +33,9 @@
            <widget class="QLabel"><property name="text"><string>Trade Type:</string></property></widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="tradeTypeCodeEdit"/>
+           <widget class="QLineEdit" name="tradeTypeCodeEdit">
+            <property name="readOnly"><bool>true</bool></property>
+           </widget>
           </item>
           <item row="1" column="0">
            <widget class="QLabel"><property name="text"><string>Underlying Code:</string></property></widget>
@@ -133,17 +135,13 @@
            <widget class="QLabel"><property name="text"><string>Option Type:</string></property></widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="optionTypeEdit">
-            <property name="placeholderText"><string>Call or Put</string></property>
-           </widget>
+           <widget class="QComboBox" name="optionTypeCombo"/>
           </item>
           <item row="1" column="0">
            <widget class="QLabel"><property name="text"><string>Exercise Type:</string></property></widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLineEdit" name="exerciseTypeEdit">
-            <property name="placeholderText"><string>European, American, Bermudan</string></property>
-           </widget>
+           <widget class="QComboBox" name="exerciseTypeCombo"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel"><property name="text"><string>Strike Price:</string></property></widget>
@@ -159,9 +157,7 @@
            <widget class="QLabel"><property name="text"><string>Barrier Type:</string></property></widget>
           </item>
           <item row="3" column="1">
-           <widget class="QLineEdit" name="barrierTypeEdit">
-            <property name="placeholderText"><string>e.g. UpIn, UpOut, DownIn, DownOut</string></property>
-           </widget>
+           <widget class="QComboBox" name="barrierTypeCombo"/>
           </item>
           <item row="4" column="0">
            <widget class="QLabel"><property name="text"><string>Lower Barrier:</string></property></widget>
@@ -211,9 +207,7 @@
            <widget class="QLabel"><property name="text"><string>Average Type:</string></property></widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="averageTypeEdit">
-            <property name="placeholderText"><string>Arithmetic or Geometric (Asian)</string></property>
-           </widget>
+           <widget class="QComboBox" name="averageTypeCombo"/>
           </item>
           <item row="1" column="0">
            <widget class="QLabel"><property name="text"><string>Averaging Start Date:</string></property></widget>
@@ -238,9 +232,7 @@
            <widget class="QLabel"><property name="text"><string>Cliquet Frequency:</string></property></widget>
           </item>
           <item row="3" column="1">
-           <widget class="QLineEdit" name="cliquetFrequencyCodeEdit">
-            <property name="placeholderText"><string>e.g. Annual, SemiAnnual (Cliquet)</string></property>
-           </widget>
+           <widget class="QComboBox" name="cliquetFrequencyCombo"/>
           </item>
           <item row="4" column="0">
            <widget class="QLabel"><property name="text"><string>Accumulation Amount:</string></property></widget>
@@ -268,25 +260,19 @@
            <widget class="QLabel"><property name="text"><string>Day Count:</string></property></widget>
           </item>
           <item row="6" column="1">
-           <widget class="QLineEdit" name="dayCountCodeEdit">
-            <property name="placeholderText"><string>e.g. Actual365Fixed (EquitySwap)</string></property>
-           </widget>
+           <widget class="QComboBox" name="dayCountCombo"/>
           </item>
           <item row="7" column="0">
            <widget class="QLabel"><property name="text"><string>Payment Frequency:</string></property></widget>
           </item>
           <item row="7" column="1">
-           <widget class="QLineEdit" name="paymentFrequencyCodeEdit">
-            <property name="placeholderText"><string>e.g. Quarterly (EquitySwap)</string></property>
-           </widget>
+           <widget class="QComboBox" name="paymentFrequencyCombo"/>
           </item>
           <item row="8" column="0">
            <widget class="QLabel"><property name="text"><string>Return Type:</string></property></widget>
           </item>
           <item row="8" column="1">
-           <widget class="QLineEdit" name="returnTypeEdit">
-            <property name="placeholderText"><string>TotalReturn or PriceReturn (EquityTRS)</string></property>
-           </widget>
+           <widget class="QComboBox" name="returnTypeCombo"/>
           </item>
           <item row="9" column="0">
            <widget class="QLabel"><property name="text"><string>Basket (JSON):</string></property></widget>

--- a/projects/ores.qt.trading/ui/EquityInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/EquityInstrumentForm.ui
@@ -57,7 +57,7 @@
            <widget class="QLabel"><property name="text"><string>Notional:</string></property></widget>
           </item>
           <item row="3" column="1">
-           <widget class="QDoubleSpinBox" name="notionalSpinBox">
+           <widget class="OreDoubleSpinBox" name="notionalSpinBox">
             <property name="decimals"><number>2</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999999.000000000000000</double></property>
@@ -68,7 +68,7 @@
            <widget class="QLabel"><property name="text"><string>Quantity:</string></property></widget>
           </item>
           <item row="4" column="1">
-           <widget class="QDoubleSpinBox" name="quantitySpinBox">
+           <widget class="OreDoubleSpinBox" name="quantitySpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999999.000000000000000</double></property>
@@ -147,7 +147,7 @@
            <widget class="QLabel"><property name="text"><string>Strike Price:</string></property></widget>
           </item>
           <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="strikePriceSpinBox">
+           <widget class="OreDoubleSpinBox" name="strikePriceSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999.000000000000000</double></property>
@@ -163,7 +163,7 @@
            <widget class="QLabel"><property name="text"><string>Lower Barrier:</string></property></widget>
           </item>
           <item row="4" column="1">
-           <widget class="QDoubleSpinBox" name="lowerBarrierSpinBox">
+           <widget class="OreDoubleSpinBox" name="lowerBarrierSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999.000000000000000</double></property>
@@ -173,7 +173,7 @@
            <widget class="QLabel"><property name="text"><string>Upper Barrier:</string></property></widget>
           </item>
           <item row="5" column="1">
-           <widget class="QDoubleSpinBox" name="upperBarrierSpinBox">
+           <widget class="OreDoubleSpinBox" name="upperBarrierSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999.000000000000000</double></property>
@@ -221,7 +221,7 @@
            <widget class="QLabel"><property name="text"><string>Variance Strike:</string></property></widget>
           </item>
           <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="varianceStrikeSpinBox">
+           <widget class="OreDoubleSpinBox" name="varianceStrikeSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999.000000000000000</double></property>
@@ -238,7 +238,7 @@
            <widget class="QLabel"><property name="text"><string>Accumulation Amount:</string></property></widget>
           </item>
           <item row="4" column="1">
-           <widget class="QDoubleSpinBox" name="accumulationAmountSpinBox">
+           <widget class="OreDoubleSpinBox" name="accumulationAmountSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999.000000000000000</double></property>
@@ -249,7 +249,7 @@
            <widget class="QLabel"><property name="text"><string>Knock-Out Barrier:</string></property></widget>
           </item>
           <item row="5" column="1">
-           <widget class="QDoubleSpinBox" name="knockOutBarrierSpinBox">
+           <widget class="OreDoubleSpinBox" name="knockOutBarrierSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999.000000000000000</double></property>
@@ -307,6 +307,13 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <customwidgets>
+ <customwidget>
+  <class>OreDoubleSpinBox</class>
+  <extends>QDoubleSpinBox</extends>
+  <header>ores.qt/OreDoubleSpinBox.hpp</header>
+ </customwidget>
+</customwidgets>
+<resources/>
  <connections/>
 </ui>

--- a/projects/ores.qt.trading/ui/EquityInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/EquityInstrumentForm.ui
@@ -49,9 +49,7 @@
            <widget class="QLabel"><property name="text"><string>Currency:</string></property></widget>
           </item>
           <item row="2" column="1">
-           <widget class="QLineEdit" name="currencyEdit">
-            <property name="placeholderText"><string>ISO 4217 (e.g. USD)</string></property>
-           </widget>
+           <widget class="OreCurrencyComboBox" name="currencyCombo"/>
           </item>
           <item row="3" column="0">
            <widget class="QLabel"><property name="text"><string>Notional:</string></property></widget>
@@ -79,17 +77,13 @@
            <widget class="QLabel"><property name="text"><string>Start Date:</string></property></widget>
           </item>
           <item row="5" column="1">
-           <widget class="QLineEdit" name="startDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="startDateEdit"/>
           </item>
           <item row="6" column="0">
            <widget class="QLabel"><property name="text"><string>Maturity Date:</string></property></widget>
           </item>
           <item row="6" column="1">
-           <widget class="QLineEdit" name="maturityDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="maturityDateEdit"/>
           </item>
           <item row="7" column="0">
            <widget class="QLabel"><property name="text"><string>Description:</string></property></widget>
@@ -213,9 +207,7 @@
            <widget class="QLabel"><property name="text"><string>Averaging Start Date:</string></property></widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLineEdit" name="averagingStartDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date (Asian)</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="averagingStartDateEdit"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel"><property name="text"><string>Variance Strike:</string></property></widget>
@@ -312,6 +304,16 @@
   <class>OreDoubleSpinBox</class>
   <extends>QDoubleSpinBox</extends>
   <header>ores.qt/OreDoubleSpinBox.hpp</header>
+ </customwidget>
+ <customwidget>
+  <class>OreDateEdit</class>
+  <extends>QDateEdit</extends>
+  <header>ores.qt/OreDateEdit.hpp</header>
+ </customwidget>
+ <customwidget>
+  <class>OreCurrencyComboBox</class>
+  <extends>QComboBox</extends>
+  <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>
 </customwidgets>
 <resources/>

--- a/projects/ores.qt.trading/ui/FxInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/FxInstrumentForm.ui
@@ -55,7 +55,7 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="boughtAmountSpinBox">
+           <widget class="OreDoubleSpinBox" name="boughtAmountSpinBox">
             <property name="decimals"><number>2</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999999.000000000000000</double></property>
@@ -78,7 +78,7 @@
            </widget>
           </item>
           <item row="4" column="1">
-           <widget class="QDoubleSpinBox" name="soldAmountSpinBox">
+           <widget class="OreDoubleSpinBox" name="soldAmountSpinBox">
             <property name="decimals"><number>2</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999999.000000000000000</double></property>
@@ -159,7 +159,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QDoubleSpinBox" name="strikePriceSpinBox">
+           <widget class="OreDoubleSpinBox" name="strikePriceSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999.000000000000000</double></property>
@@ -195,6 +195,13 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <customwidgets>
+ <customwidget>
+  <class>OreDoubleSpinBox</class>
+  <extends>QDoubleSpinBox</extends>
+  <header>ores.qt/OreDoubleSpinBox.hpp</header>
+ </customwidget>
+</customwidgets>
+<resources/>
  <connections/>
 </ui>

--- a/projects/ores.qt.trading/ui/FxInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/FxInstrumentForm.ui
@@ -45,9 +45,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLineEdit" name="boughtCurrencyEdit">
-            <property name="placeholderText"><string>ISO 4217 (e.g. EUR)</string></property>
-           </widget>
+           <widget class="OreCurrencyComboBox" name="boughtCurrencyCombo"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="labelBoughtAmount">
@@ -68,9 +66,7 @@
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="QLineEdit" name="soldCurrencyEdit">
-            <property name="placeholderText"><string>ISO 4217 (e.g. USD)</string></property>
-           </widget>
+           <widget class="OreCurrencyComboBox" name="soldCurrencyCombo"/>
           </item>
           <item row="4" column="0">
            <widget class="QLabel" name="labelSoldAmount">
@@ -91,9 +87,7 @@
            </widget>
           </item>
           <item row="5" column="1">
-           <widget class="QLineEdit" name="valueDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date (e.g. 2026-06-30)</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="valueDateEdit"/>
           </item>
           <item row="6" column="0">
            <widget class="QLabel" name="labelSettlement">
@@ -172,11 +166,7 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QLineEdit" name="expiryDateEdit">
-            <property name="placeholderText">
-             <string>ISO 8601 date</string>
-            </property>
-           </widget>
+           <widget class="OreDateEdit" name="expiryDateEdit"/>
           </item>
          </layout>
         </widget>
@@ -200,6 +190,16 @@
   <class>OreDoubleSpinBox</class>
   <extends>QDoubleSpinBox</extends>
   <header>ores.qt/OreDoubleSpinBox.hpp</header>
+ </customwidget>
+ <customwidget>
+  <class>OreDateEdit</class>
+  <extends>QDateEdit</extends>
+  <header>ores.qt/OreDateEdit.hpp</header>
+ </customwidget>
+ <customwidget>
+  <class>OreCurrencyComboBox</class>
+  <extends>QComboBox</extends>
+  <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>
 </customwidgets>
 <resources/>

--- a/projects/ores.qt.trading/ui/FxInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/FxInstrumentForm.ui
@@ -36,9 +36,7 @@
           </item>
           <item row="0" column="1">
            <widget class="QLineEdit" name="tradeTypeCodeEdit">
-            <property name="placeholderText">
-             <string>e.g. FxForward, FxSwap, FxOption</string>
-            </property>
+            <property name="readOnly"><bool>true</bool></property>
            </widget>
           </item>
           <item row="1" column="0">
@@ -103,9 +101,7 @@
            </widget>
           </item>
           <item row="6" column="1">
-           <widget class="QLineEdit" name="settlementEdit">
-            <property name="placeholderText"><string>e.g. Cash, Physical (optional)</string></property>
-           </widget>
+           <widget class="QComboBox" name="settlementCombo"/>
           </item>
           <item row="7" column="0">
            <widget class="QLabel" name="labelDescription">
@@ -155,11 +151,7 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="optionTypeEdit">
-            <property name="placeholderText">
-             <string>Call or Put</string>
-            </property>
-           </widget>
+           <widget class="QComboBox" name="optionTypeCombo"/>
           </item>
           <item row="1" column="0">
            <widget class="QLabel" name="labelStrikePrice">

--- a/projects/ores.qt.trading/ui/FxVanillaOptionInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/FxVanillaOptionInstrumentForm.ui
@@ -45,9 +45,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLineEdit" name="boughtCurrencyEdit">
-            <property name="placeholderText"><string>ISO 4217 (e.g. EUR)</string></property>
-           </widget>
+           <widget class="OreCurrencyComboBox" name="boughtCurrencyCombo"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="labelBoughtAmount">
@@ -68,9 +66,7 @@
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="QLineEdit" name="soldCurrencyEdit">
-            <property name="placeholderText"><string>ISO 4217 (e.g. USD)</string></property>
-           </widget>
+           <widget class="OreCurrencyComboBox" name="soldCurrencyCombo"/>
           </item>
           <item row="4" column="0">
            <widget class="QLabel" name="labelSoldAmount">
@@ -99,9 +95,7 @@
            </widget>
           </item>
           <item row="6" column="1">
-           <widget class="QLineEdit" name="expiryDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date (e.g. 2026-12-31)</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="expiryDateEdit"/>
           </item>
           <item row="7" column="0">
            <widget class="QLabel" name="labelExerciseStyle">
@@ -159,6 +153,16 @@
   <class>OreDoubleSpinBox</class>
   <extends>QDoubleSpinBox</extends>
   <header>ores.qt/OreDoubleSpinBox.hpp</header>
+ </customwidget>
+ <customwidget>
+  <class>OreDateEdit</class>
+  <extends>QDateEdit</extends>
+  <header>ores.qt/OreDateEdit.hpp</header>
+ </customwidget>
+ <customwidget>
+  <class>OreCurrencyComboBox</class>
+  <extends>QComboBox</extends>
+  <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>
 </customwidgets>
 <resources/>

--- a/projects/ores.qt.trading/ui/FxVanillaOptionInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/FxVanillaOptionInstrumentForm.ui
@@ -55,7 +55,7 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="boughtAmountSpinBox">
+           <widget class="OreDoubleSpinBox" name="boughtAmountSpinBox">
             <property name="decimals"><number>2</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999999.000000000000000</double></property>
@@ -78,7 +78,7 @@
            </widget>
           </item>
           <item row="4" column="1">
-           <widget class="QDoubleSpinBox" name="soldAmountSpinBox">
+           <widget class="OreDoubleSpinBox" name="soldAmountSpinBox">
             <property name="decimals"><number>2</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999999.000000000000000</double></property>
@@ -154,6 +154,13 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <customwidgets>
+ <customwidget>
+  <class>OreDoubleSpinBox</class>
+  <extends>QDoubleSpinBox</extends>
+  <header>ores.qt/OreDoubleSpinBox.hpp</header>
+ </customwidget>
+</customwidgets>
+<resources/>
  <connections/>
 </ui>

--- a/projects/ores.qt.trading/ui/FxVanillaOptionInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/FxVanillaOptionInstrumentForm.ui
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FxVanillaOptionInstrumentForm</class>
+ <widget class="QWidget" name="FxVanillaOptionInstrumentForm">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>500</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="rootLayout">
+   <property name="leftMargin"><number>0</number></property>
+   <property name="topMargin"><number>0</number></property>
+   <property name="rightMargin"><number>0</number></property>
+   <property name="bottomMargin"><number>0</number></property>
+   <item>
+    <widget class="QTabWidget" name="subTabWidget">
+     <property name="currentIndex"><number>0</number></property>
+     <widget class="QWidget" name="economicsTab">
+      <attribute name="title">
+       <string>Economics</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="economicsLayout">
+       <item>
+        <widget class="QGroupBox" name="economicsGroup">
+         <property name="title">
+          <string>FX Vanilla Option Economics</string>
+         </property>
+         <layout class="QFormLayout" name="economicsFormLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelTradeTypeCode">
+            <property name="text"><string>Trade Type:</string></property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="tradeTypeCodeEdit">
+            <property name="placeholderText"><string>e.g. FxOption</string></property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelBoughtCurrency">
+            <property name="text"><string>Bought Currency:</string></property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="boughtCurrencyEdit">
+            <property name="placeholderText"><string>ISO 4217 (e.g. EUR)</string></property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelBoughtAmount">
+            <property name="text"><string>Bought Amount:</string></property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="boughtAmountSpinBox">
+            <property name="decimals"><number>2</number></property>
+            <property name="minimum"><double>0.000000000000000</double></property>
+            <property name="maximum"><double>999999999999.000000000000000</double></property>
+            <property name="singleStep"><double>1000.000000000000000</double></property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelSoldCurrency">
+            <property name="text"><string>Sold Currency:</string></property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="soldCurrencyEdit">
+            <property name="placeholderText"><string>ISO 4217 (e.g. USD)</string></property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelSoldAmount">
+            <property name="text"><string>Sold Amount:</string></property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QDoubleSpinBox" name="soldAmountSpinBox">
+            <property name="decimals"><number>2</number></property>
+            <property name="minimum"><double>0.000000000000000</double></property>
+            <property name="maximum"><double>999999999999.000000000000000</double></property>
+            <property name="singleStep"><double>1000.000000000000000</double></property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="labelOptionType">
+            <property name="text"><string>Option Type:</string></property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLineEdit" name="optionTypeEdit">
+            <property name="placeholderText"><string>Call or Put</string></property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="labelExpiryDate">
+            <property name="text"><string>Expiry Date:</string></property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QLineEdit" name="expiryDateEdit">
+            <property name="placeholderText"><string>ISO 8601 date (e.g. 2026-12-31)</string></property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="labelExerciseStyle">
+            <property name="text"><string>Exercise Style:</string></property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QLineEdit" name="exerciseStyleEdit">
+            <property name="placeholderText"><string>European or American</string></property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="labelSettlement">
+            <property name="text"><string>Settlement:</string></property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="QLineEdit" name="settlementEdit">
+            <property name="placeholderText"><string>e.g. Cash, Physical (optional)</string></property>
+           </widget>
+          </item>
+          <item row="9" column="0">
+           <widget class="QLabel" name="labelDescription">
+            <property name="text"><string>Description:</string></property>
+           </widget>
+          </item>
+          <item row="9" column="1">
+           <widget class="QPlainTextEdit" name="descriptionEdit">
+            <property name="minimumSize">
+             <size><width>0</width><height>60</height></size>
+            </property>
+            <property name="maximumSize">
+             <size><width>16777215</width><height>120</height></size>
+            </property>
+            <property name="placeholderText">
+             <string>Enter a description (optional)</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="economicsSpacer">
+         <property name="orientation"><enum>Qt::Vertical</enum></property>
+         <property name="sizeHint" stdset="0">
+          <size><width>20</width><height>20</height></size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt.trading/ui/FxVanillaOptionInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/FxVanillaOptionInstrumentForm.ui
@@ -36,7 +36,7 @@
           </item>
           <item row="0" column="1">
            <widget class="QLineEdit" name="tradeTypeCodeEdit">
-            <property name="placeholderText"><string>e.g. FxOption</string></property>
+            <property name="readOnly"><bool>true</bool></property>
            </widget>
           </item>
           <item row="1" column="0">
@@ -91,9 +91,7 @@
            </widget>
           </item>
           <item row="5" column="1">
-           <widget class="QLineEdit" name="optionTypeEdit">
-            <property name="placeholderText"><string>Call or Put</string></property>
-           </widget>
+           <widget class="QComboBox" name="optionTypeCombo"/>
           </item>
           <item row="6" column="0">
            <widget class="QLabel" name="labelExpiryDate">
@@ -111,9 +109,7 @@
            </widget>
           </item>
           <item row="7" column="1">
-           <widget class="QLineEdit" name="exerciseStyleEdit">
-            <property name="placeholderText"><string>European or American</string></property>
-           </widget>
+           <widget class="QComboBox" name="exerciseStyleCombo"/>
           </item>
           <item row="8" column="0">
            <widget class="QLabel" name="labelSettlement">
@@ -121,9 +117,7 @@
            </widget>
           </item>
           <item row="8" column="1">
-           <widget class="QLineEdit" name="settlementEdit">
-            <property name="placeholderText"><string>e.g. Cash, Physical (optional)</string></property>
-           </widget>
+           <widget class="QComboBox" name="settlementCombo"/>
           </item>
           <item row="9" column="0">
            <widget class="QLabel" name="labelDescription">

--- a/projects/ores.qt.trading/ui/SwapInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/SwapInstrumentForm.ui
@@ -33,7 +33,7 @@
           </item>
           <item row="1" column="0"><widget class="QLabel" name="labelNotional"><property name="text"><string>Notional:</string></property></widget></item>
           <item row="1" column="1">
-           <widget class="QDoubleSpinBox" name="notionalSpinBox">
+           <widget class="OreDoubleSpinBox" name="notionalSpinBox">
             <property name="decimals"><number>2</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>999999999999.000000000000000</double></property>
@@ -121,7 +121,7 @@
           </item>
           <item row="6" column="0"><widget class="QLabel" name="labelBaseCpi"><property name="text"><string>Base CPI:</string></property></widget></item>
           <item row="6" column="1">
-           <widget class="QDoubleSpinBox" name="baseCpiSpinBox">
+           <widget class="OreDoubleSpinBox" name="baseCpiSpinBox">
             <property name="decimals"><number>6</number></property>
             <property name="minimum"><double>0.000000000000000</double></property>
             <property name="maximum"><double>9999.000000000000000</double></property>
@@ -139,6 +139,13 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <customwidgets>
+ <customwidget>
+  <class>OreDoubleSpinBox</class>
+  <extends>QDoubleSpinBox</extends>
+  <header>ores.qt/OreDoubleSpinBox.hpp</header>
+ </customwidget>
+</customwidgets>
+<resources/>
  <connections/>
 </ui>

--- a/projects/ores.qt.trading/ui/SwapInstrumentForm.ui
+++ b/projects/ores.qt.trading/ui/SwapInstrumentForm.ui
@@ -42,21 +42,15 @@
           </item>
           <item row="2" column="0"><widget class="QLabel" name="labelCurrency"><property name="text"><string>Currency:</string></property></widget></item>
           <item row="2" column="1">
-           <widget class="QLineEdit" name="currencyEdit">
-            <property name="placeholderText"><string>ISO 4217 (e.g. USD)</string></property>
-           </widget>
+           <widget class="OreCurrencyComboBox" name="currencyCombo"/>
           </item>
           <item row="3" column="0"><widget class="QLabel" name="labelStartDate"><property name="text"><string>Start Date:</string></property></widget></item>
           <item row="3" column="1">
-           <widget class="QLineEdit" name="startDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date (e.g. 2026-01-01)</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="startDateEdit"/>
           </item>
           <item row="4" column="0"><widget class="QLabel" name="labelMaturityDate"><property name="text"><string>Maturity Date:</string></property></widget></item>
           <item row="4" column="1">
-           <widget class="QLineEdit" name="maturityDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date (e.g. 2031-01-01)</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="maturityDateEdit"/>
           </item>
           <item row="5" column="0"><widget class="QLabel" name="labelDescription"><property name="text"><string>Description:</string></property></widget></item>
           <item row="5" column="1">
@@ -81,15 +75,11 @@
          <layout class="QFormLayout" name="ratesFormLayout">
           <item row="0" column="0"><widget class="QLabel" name="labelFraFixingDate"><property name="text"><string>FRA Fixing Date:</string></property></widget></item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="fraFixingDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date (ForwardRateAgreement)</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="fraFixingDateEdit"/>
           </item>
           <item row="1" column="0"><widget class="QLabel" name="labelFraSettlementDate"><property name="text"><string>FRA Settlement Date:</string></property></widget></item>
           <item row="1" column="1">
-           <widget class="QLineEdit" name="fraSettlementDateEdit">
-            <property name="placeholderText"><string>ISO 8601 date (ForwardRateAgreement)</string></property>
-           </widget>
+           <widget class="OreDateEdit" name="fraSettlementDateEdit"/>
           </item>
           <item row="2" column="0"><widget class="QLabel" name="labelLockoutDays"><property name="text"><string>Lockout Days:</string></property></widget></item>
           <item row="2" column="1">
@@ -144,6 +134,16 @@
   <class>OreDoubleSpinBox</class>
   <extends>QDoubleSpinBox</extends>
   <header>ores.qt/OreDoubleSpinBox.hpp</header>
+ </customwidget>
+ <customwidget>
+  <class>OreDateEdit</class>
+  <extends>QDateEdit</extends>
+  <header>ores.qt/OreDateEdit.hpp</header>
+ </customwidget>
+ <customwidget>
+  <class>OreCurrencyComboBox</class>
+  <extends>QComboBox</extends>
+  <header>ores.qt/OreCurrencyComboBox.hpp</header>
  </customwidget>
 </customwidgets>
 <resources/>

--- a/projects/ores.qt.trading/ui/TradeDetailDialog.ui
+++ b/projects/ores.qt.trading/ui/TradeDetailDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>680</width>
-    <height>600</height>
+    <height>480</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,7 +19,7 @@
   <property name="minimumSize">
    <size>
     <width>680</width>
-    <height>600</height>
+    <height>400</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -218,9 +218,13 @@
        </item>
       </layout>
      </widget>
-     <!-- Instrument tab: hosts a QStackedWidget. One page per registered
-          IInstrumentForm; the active page is selected from the trade's
-          product_type. Hidden when no form is registered for the family. -->
+     <!-- Instrument tab: hosts an AdaptiveStackedWidget inside a QScrollArea.
+          One page per registered IInstrumentForm; the active page is selected
+          from the trade's product_type. Hidden when no form is registered for
+          the family. AdaptiveStackedWidget reports the current page's size hint
+          so compact forms (FX) don't inherit the height of large ones
+          (Commodity). The scroll area lets large forms scroll rather than
+          forcing the dialog to grow. -->
      <widget class="QWidget" name="instrumentTab">
       <attribute name="title">
        <string>Instrument</string>
@@ -231,8 +235,34 @@
        <property name="rightMargin"><number>0</number></property>
        <property name="bottomMargin"><number>0</number></property>
        <item>
-        <widget class="QStackedWidget" name="instrumentStack">
-         <property name="currentIndex"><number>-1</number></property>
+        <widget class="QScrollArea" name="instrumentScrollArea">
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <widget class="QWidget" name="instrumentScrollContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>660</width>
+            <height>400</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="instrumentScrollLayout">
+           <property name="leftMargin"><number>0</number></property>
+           <property name="topMargin"><number>0</number></property>
+           <property name="rightMargin"><number>0</number></property>
+           <property name="bottomMargin"><number>0</number></property>
+           <item>
+            <widget class="AdaptiveStackedWidget" name="instrumentStack">
+             <property name="currentIndex"><number>-1</number></property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>
@@ -318,6 +348,12 @@
    <class>ores::qt::ProvenanceWidget</class>
    <extends>QWidget</extends>
    <header>ores.qt/ProvenanceWidget.hpp</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>AdaptiveStackedWidget</class>
+   <extends>QStackedWidget</extends>
+   <header>ores.qt/AdaptiveStackedWidget.hpp</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/projects/ores.qt.workflow/include/ores.qt/WorkflowController.hpp
+++ b/projects/ores.qt.workflow/include/ores.qt/WorkflowController.hpp
@@ -19,6 +19,7 @@
 #ifndef ORES_QT_WORKFLOW_CONTROLLER_HPP
 #define ORES_QT_WORKFLOW_CONTROLLER_HPP
 
+#include <QEvent>
 #include <QObject>
 #include <QPointer>
 #include <QMdiArea>
@@ -61,6 +62,8 @@ public:
     void showListWindow();
     void showDefinitionsWindow();
     void closeAllWindows();
+
+    bool eventFilter(QObject* obj, QEvent* event) override;
 
 signals:
     void statusMessage(const QString& message);

--- a/projects/ores.qt.workflow/src/WorkflowController.cpp
+++ b/projects/ores.qt.workflow/src/WorkflowController.cpp
@@ -18,7 +18,9 @@
  */
 #include "ores.qt/WorkflowController.hpp"
 
+#include <QEvent>
 #include "ores.qt/IconUtils.hpp"
+#include "ores.qt/UiPersistence.hpp"
 #include "ores.qt/WorkflowMdiWindow.hpp"
 #include "ores.qt/WorkflowDefinitionMdiWindow.hpp"
 #include "ores.qt/DetachableMdiSubWindow.hpp"
@@ -79,10 +81,13 @@ void WorkflowController::showListWindow() {
         self->listSubWindow_ = nullptr;
     });
 
+    listSubWindow_->installEventFilter(this);
+
     emit detachableWindowCreated(listSubWindow_);
 
     mdiArea_->addSubWindow(listSubWindow_);
-    listSubWindow_->adjustSize();
+    if (!UiPersistence::restoreMdiGeometry("WorkflowListSubWindow", listSubWindow_))
+        listSubWindow_->adjustSize();
     listSubWindow_->show();
 }
 
@@ -121,11 +126,24 @@ void WorkflowController::showDefinitionsWindow() {
         self->defsSubWindow_ = nullptr;
     });
 
+    defsSubWindow_->installEventFilter(this);
+
     emit detachableWindowCreated(defsSubWindow_);
 
     mdiArea_->addSubWindow(defsSubWindow_);
-    defsSubWindow_->adjustSize();
+    if (!UiPersistence::restoreMdiGeometry("WorkflowDefsSubWindow", defsSubWindow_))
+        defsSubWindow_->adjustSize();
     defsSubWindow_->show();
+}
+
+bool WorkflowController::eventFilter(QObject* obj, QEvent* event) {
+    if (event->type() == QEvent::Close) {
+        if (obj == listSubWindow_)
+            UiPersistence::saveMdiGeometry("WorkflowListSubWindow", listSubWindow_);
+        else if (obj == defsSubWindow_)
+            UiPersistence::saveMdiGeometry("WorkflowDefsSubWindow", defsSubWindow_);
+    }
+    return QObject::eventFilter(obj, event);
 }
 
 void WorkflowController::closeAllWindows() {

--- a/projects/ores.reporting.core/src/repository/risk_report_config_repository.cpp
+++ b/projects/ores.reporting.core/src/repository/risk_report_config_repository.cpp
@@ -77,7 +77,7 @@ risk_report_config_repository::resolve_book_ids(
     const auto tid = ctx.tenant_id().to_string();
     const std::string sql =
         "SELECT id::text FROM "
-        "ores_reporting_resolve_book_ids_for_config_fn($1::uuid, $2::uuid)";
+        "ores_reporting_resolve_book_ids_for_config_fn($1::uuid, $2::uuid) AS t(id)";
 
     return execute_parameterized_string_query(
         ctx, sql, {tid, config_id}, lg(),

--- a/projects/ores.service/include/ores.service/messaging/handler_helpers.hpp
+++ b/projects/ores.service/include/ores.service/messaging/handler_helpers.hpp
@@ -25,6 +25,7 @@
 #include <string_view>
 #include <boost/uuid/uuid.hpp>
 #include <rfl/json.hpp>
+#include <rfl/AddTagsToVariants.hpp>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/headers.hpp"
 #include "ores.nats/domain/message.hpp"
@@ -146,13 +147,16 @@ inline const std::string& delegated_actor(const ores::database::context& ctx) {
 }
 
 // Serialise resp to JSON and publish to the message's reply subject.
+// AddTagsToVariants ensures each std::variant alternative carries a type-name
+// discriminant so the client can unambiguously select the right alternative.
+// Without it, std::monostate (zero required fields) always matches first.
 // No-op if the message has no reply subject.
 template<typename Resp>
 void reply(ores::nats::service::client& nats,
     const ores::nats::message& msg,
     const Resp& resp) {
     if (msg.reply_subject.empty()) return;
-    const auto json = rfl::json::write(resp);
+    const auto json = rfl::json::write<rfl::AddTagsToVariants>(resp);
     const auto* p = reinterpret_cast<const std::byte*>(json.data());
     nats.publish(msg.reply_subject, std::span<const std::byte>(p, json.size()));
 }

--- a/projects/ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp
@@ -104,7 +104,19 @@ private:
         const ores::trading::domain::trade& t,
         trade_export_item& item) {
         using ores::trading::domain::product_type;
-        if (!t.instrument_id || t.product_type == product_type::unknown) return;
+        BOOST_LOG_SEV(trade_handler_lg(), debug)
+            << "populate_instrument: trade=" << t.external_id
+            << " product_type=" << ores::trading::domain::to_string(t.product_type)
+            << " trade_type=" << t.trade_type
+            << " instrument_id=" << (t.instrument_id
+                ? boost::uuids::to_string(*t.instrument_id) : "<none>");
+        if (!t.instrument_id || t.product_type == product_type::unknown) {
+            BOOST_LOG_SEV(trade_handler_lg(), warn)
+                << "populate_instrument: skipping trade=" << t.external_id
+                << " reason=" << (!t.instrument_id
+                    ? "no_instrument_id" : "unknown_product_type");
+            return;
+        }
         const auto id = boost::uuids::to_string(*t.instrument_id);
         switch (t.product_type) {
         case product_type::unknown:
@@ -186,7 +198,16 @@ private:
                     ex_opt = std::move(ex);
                 }
             }
-            if (ex_opt) item.instrument = std::move(*ex_opt);
+            if (ex_opt) {
+                item.instrument = std::move(*ex_opt);
+                BOOST_LOG_SEV(trade_handler_lg(), debug)
+                    << "populate_instrument: populated swap for trade=" << t.external_id
+                    << " trade_type=" << ttc;
+            } else {
+                BOOST_LOG_SEV(trade_handler_lg(), warn)
+                    << "populate_instrument: no swap instrument for trade=" << t.external_id
+                    << " trade_type=" << ttc << " instrument_id=" << id;
+            }
             break;
         }
         case product_type::fx: {
@@ -250,19 +271,42 @@ private:
                     ex_opt = std::move(ex);
                 }
             }
-            if (ex_opt) item.instrument = std::move(*ex_opt);
+            if (ex_opt) {
+                item.instrument = std::move(*ex_opt);
+                BOOST_LOG_SEV(trade_handler_lg(), debug)
+                    << "populate_instrument: populated fx for trade=" << t.external_id
+                    << " trade_type=" << ttc;
+            } else {
+                BOOST_LOG_SEV(trade_handler_lg(), warn)
+                    << "populate_instrument: no fx instrument for trade=" << t.external_id
+                    << " trade_type=" << ttc << " instrument_id=" << id;
+            }
             break;
         }
         case product_type::bond: {
             service::bond_instrument_service isvc(ctx);
-            if (auto r = isvc.get_bond_instrument(id))
+            if (auto r = isvc.get_bond_instrument(id)) {
                 item.instrument = bond_export_result{std::move(*r)};
+                BOOST_LOG_SEV(trade_handler_lg(), debug)
+                    << "populate_instrument: populated bond for trade=" << t.external_id;
+            } else {
+                BOOST_LOG_SEV(trade_handler_lg(), warn)
+                    << "populate_instrument: bond instrument not found for trade="
+                    << t.external_id << " instrument_id=" << id;
+            }
             break;
         }
         case product_type::credit: {
             service::credit_instrument_service isvc(ctx);
-            if (auto r = isvc.get_credit_instrument(id))
+            if (auto r = isvc.get_credit_instrument(id)) {
                 item.instrument = credit_export_result{std::move(*r)};
+                BOOST_LOG_SEV(trade_handler_lg(), debug)
+                    << "populate_instrument: populated credit for trade=" << t.external_id;
+            } else {
+                BOOST_LOG_SEV(trade_handler_lg(), warn)
+                    << "populate_instrument: credit instrument not found for trade="
+                    << t.external_id << " instrument_id=" << id;
+            }
             break;
         }
         case product_type::equity: {
@@ -337,13 +381,29 @@ private:
                     ex_opt = std::move(ex);
                 }
             }
-            if (ex_opt) item.instrument = std::move(*ex_opt);
+            if (ex_opt) {
+                item.instrument = std::move(*ex_opt);
+                BOOST_LOG_SEV(trade_handler_lg(), debug)
+                    << "populate_instrument: populated equity for trade=" << t.external_id
+                    << " trade_type=" << ttc;
+            } else {
+                BOOST_LOG_SEV(trade_handler_lg(), warn)
+                    << "populate_instrument: no equity instrument for trade=" << t.external_id
+                    << " trade_type=" << ttc << " instrument_id=" << id;
+            }
             break;
         }
         case product_type::commodity: {
             service::commodity_instrument_service isvc(ctx);
-            if (auto r = isvc.get_commodity_instrument(id))
+            if (auto r = isvc.get_commodity_instrument(id)) {
                 item.instrument = commodity_export_result{std::move(*r)};
+                BOOST_LOG_SEV(trade_handler_lg(), debug)
+                    << "populate_instrument: populated commodity for trade=" << t.external_id;
+            } else {
+                BOOST_LOG_SEV(trade_handler_lg(), warn)
+                    << "populate_instrument: commodity instrument not found for trade="
+                    << t.external_id << " instrument_id=" << id;
+            }
             break;
         }
         case product_type::composite: {
@@ -353,13 +413,26 @@ private:
                 ex.instrument = std::move(*r);
                 ex.legs = isvc.get_legs(id);
                 item.instrument = std::move(ex);
+                BOOST_LOG_SEV(trade_handler_lg(), debug)
+                    << "populate_instrument: populated composite for trade=" << t.external_id;
+            } else {
+                BOOST_LOG_SEV(trade_handler_lg(), warn)
+                    << "populate_instrument: composite instrument not found for trade="
+                    << t.external_id << " instrument_id=" << id;
             }
             break;
         }
         case product_type::scripted: {
             service::scripted_instrument_service isvc(ctx);
-            if (auto r = isvc.get_scripted_instrument(id))
+            if (auto r = isvc.get_scripted_instrument(id)) {
                 item.instrument = scripted_export_result{std::move(*r)};
+                BOOST_LOG_SEV(trade_handler_lg(), debug)
+                    << "populate_instrument: populated scripted for trade=" << t.external_id;
+            } else {
+                BOOST_LOG_SEV(trade_handler_lg(), warn)
+                    << "populate_instrument: scripted instrument not found for trade="
+                    << t.external_id << " instrument_id=" << id;
+            }
             break;
         }
         }

--- a/projects/ores.trading.core/src/repository/trade_repository.cpp
+++ b/projects/ores.trading.core/src/repository/trade_repository.cpp
@@ -45,7 +45,7 @@ std::vector<std::string> fetch_book_ids(
     const std::string& tid, const std::string& id,
     logging::logger_t& lg, const std::string& desc) {
     const std::string sql =
-        "SELECT id::text FROM " + fn + "($1::uuid, $2::uuid)";
+        "SELECT id::text FROM " + fn + "($1::uuid, $2::uuid) AS t(id)";
     return execute_parameterized_string_query(ctx, sql, {tid, id}, lg, desc);
 }
 


### PR DESCRIPTION
## Summary

- **OreCurrencyComboBox / OreDateEdit**: new global-namespace custom widgets for uic compatibility. `OreDateEdit` shows `yyyy-MM-dd`, opens a calendar popup, and uses `specialValueText` for the blank state. `OreCurrencyComboBox` is a marker subclass that triggers flag-icon wiring.
- **Flag icons on all currency combos**: `ImageCache` is now threaded from `TradingPlugin` → `TradeController` → `TradeDetailDialog` → `IInstrumentForm` via a new `setImageCache()` virtual. Every instrument form (FX forward, FX vanilla option, equity, credit, commodity, swap, bond) fetches currency codes async and wires flag icons through `setup_flag_combo` / `apply_flag_icons`.
- **Adaptive dialog height**: `AdaptiveStackedWidget` overrides `sizeHint`/`minimumSizeHint` to report the *current* page's values instead of the maximum across all pages. `TradeDetailDialog` wraps the instrument stack in a `QScrollArea` (`widgetResizable=true`, horizontal bar suppressed) so large forms (commodity) scroll rather than forcing the dialog to grow; dialog geometry reduced from 680×600 to 680×480 (minimum 680×400).
- **Fix spurious dirty state**: `setComboValue` in each form's async currency-population callback was called *after* `blockSignals(false)`, causing `currentTextChanged` to fire once the instrument was already loaded and setting the form dirty without any user interaction. Fixed in all six affected forms by moving `setComboValue` inside the signal-blocking scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)