### PR TITLE
[cmake] Raise MSVC constexpr depth to 2048 for rfl trading types

### DIFF
--- a/projects/ores.trading.api/src/CMakeLists.txt
+++ b/projects/ores.trading.api/src/CMakeLists.txt
@@ -43,12 +43,14 @@ target_link_libraries(${lib_target_name}
         faker-cxx::faker-cxx
         libfort::fort)
 
-# fra_instrument has 18 fields; rfl's duplicate-field-names check performs an
-# O(N²) constexpr expansion that exhausts MSVC's default depth (512) and step
-# (100 000) budgets, producing C1202. PUBLIC propagates to all consumers that
-# include these headers and instantiate rfl reflection on the trading types.
+# Trading types have up to 18 fields; rfl's duplicate-field-names check performs
+# an O(N²) constexpr expansion that exhausts MSVC's default depth (512) and
+# step (100 000) budgets, producing C1202. Consumers like ores.qt.api instantiate
+# these types inside deeper template contexts (e.g. process_authenticated_request),
+# consuming extra depth budget before rfl evaluation starts, so depth must be
+# raised to 2048. PUBLIC propagates to all consumers automatically.
 target_compile_options(${lib_target_name} PUBLIC
-    $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<COMPILE_LANGUAGE:CXX>>:/constexpr:depth1024>
+    $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<COMPILE_LANGUAGE:CXX>>:/constexpr:depth2048>
     $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<COMPILE_LANGUAGE:CXX>>:/constexpr:steps10000000>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)


### PR DESCRIPTION
## Summary

- `ores.qt.api` was failing to compile `ClientManager.cpp` on Windows with C1202 ("recursive type or function dependency context too complex") — the same rfl `no_duplicate_field_names` O(N²) constexpr issue fixed in #727
- PR #727 raised `/constexpr:depth` to 1024 with `PUBLIC` visibility on `ores.trading.api`, which correctly propagated to `ores.qt.api` — but 1024 was not enough: `process_authenticated_request<get_trades_request>` adds extra template-context frames that consume constexpr depth before rfl's expansion starts
- Raising the depth limit from 1024 to 2048 gives the remaining budget needed; `PUBLIC` propagation covers all current and future consumers automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)