### PR TITLE
Add full codegen stack for seven ORE convention types

### DIFF
--- a/projects/ores.codegen/models/refdata/cds_convention_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/cds_convention_domain_entity.json
@@ -1,0 +1,196 @@
+{
+  "domain_entity": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
+    "has_tenant_id": true,
+    "entity_singular": "cds_convention",
+    "entity_plural": "cds_conventions",
+    "entity_title": "CDS Convention",
+    "brief": "Conventions for a credit default swap (CDS).",
+    "description": "Defines the settlement lag, premium payment schedule, and accrual rules\nfor a vanilla CDS. Corresponds to the <CDS> element in ORE conventions.xml.\nThe rule field governs IMM dates and standard CDS roll dates.",
+
+    "primary_key": {
+      "column": "id",
+      "type": "text",
+      "cpp_type": "std::string",
+      "description": "Unique convention identifier.",
+      "detail": "Examples: 'CDS-STANDARD-CONVENTIONS', 'EUR-CDS-CONVENTIONS'.",
+      "generator_expr": "std::string(\"CDS-STANDARD-CONVENTIONS\")"
+    },
+
+    "natural_keys": [],
+
+    "columns": [
+      {
+        "name": "settlement_days",
+        "type": "integer",
+        "cpp_type": "int",
+        "nullable": false,
+        "description": "Number of business days from trade date to cash settlement.",
+        "generator_expr": "3"
+      },
+      {
+        "name": "calendar",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "Calendar used for premium payment date adjustment (e.g. 'WeekendsOnly').",
+        "generator_expr": "std::string(\"WeekendsOnly\")"
+      },
+      {
+        "name": "frequency",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "Premium payment frequency (canonical CDM, e.g. 'Quarterly').",
+        "generator_expr": "std::string(\"Quarterly\")"
+      },
+      {
+        "name": "payment_convention",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "Business day convention for premium payments (canonical FpML).",
+        "generator_expr": "std::string(\"Following\")"
+      },
+      {
+        "name": "rule",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "Date generation rule (e.g. 'CDS2015', 'Backward', 'TwentiethIMM').",
+        "generator_expr": "std::string(\"CDS2015\")"
+      },
+      {
+        "name": "day_count_fraction",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "Day count fraction for premium accrual (canonical FpML, e.g. 'ACT/360').",
+        "generator_expr": "std::string(\"ACT/360\")"
+      },
+      {
+        "name": "settles_accrual",
+        "type": "boolean",
+        "cpp_type": "bool",
+        "nullable": false,
+        "description": "Whether accrued interest is settled on default.",
+        "generator_expr": "true"
+      },
+      {
+        "name": "pays_at_default_time",
+        "type": "boolean",
+        "cpp_type": "bool",
+        "nullable": false,
+        "description": "Whether the protection payment is made at the time of default.",
+        "generator_expr": "true"
+      },
+      {
+        "name": "upfront_settlement_days",
+        "type": "integer",
+        "cpp_type": "std::optional<int>",
+        "nullable": true,
+        "description": "Override for the upfront cash settlement lag (business days).",
+        "generator_expr": "std::nullopt"
+      },
+      {
+        "name": "last_period_day_count_fraction",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "Day count fraction for the last coupon period (canonical FpML). When absent the same fraction as day_count_fraction is used.",
+        "generator_expr": "std::nullopt"
+      }
+    ],
+
+    "sql": {
+      "tablename": "ores_refdata_cds_conventions_tbl"
+    },
+
+    "repository": {
+      "entity_singular_short": "cds_convention",
+      "entity_plural_short": "cds_conventions",
+      "entity_singular_words": "CDS convention",
+      "entity_plural_words": "CDS conventions"
+    },
+
+    "cpp": {
+      "includes": {
+        "domain": ["<chrono>", "<string>", "<optional>"],
+        "entity": ["<string>", "<optional>", "\"sqlgen/Timestamp.hpp\""]
+      },
+      "iterator_var": "cc",
+      "table_display": [
+        {"column": "id", "header": "Id"},
+        {"column": "frequency", "header": "Frequency"},
+        {"column": "rule", "header": "Rule"},
+        {"column": "day_count_fraction", "header": "DCF"},
+        {"column": "modified_by", "header": "Modified By"},
+        {"column": "version", "header": "Version"}
+      ]
+    },
+
+    "qt": {
+      "collection_name": "cds_conventions",
+      "item_var": "cc",
+      "key_field": "id",
+      "has_uuid_primary_key": false,
+
+      "get_request_class": "refdata::messaging::get_cds_conventions_request",
+      "get_response_class": "refdata::messaging::get_cds_conventions_response",
+      "get_message_type": "get_cds_conventions_request",
+      "save_request_class": "refdata::messaging::save_cds_convention_request",
+      "save_response_class": "refdata::messaging::save_cds_convention_response",
+      "save_message_type": "save_cds_convention_request",
+      "save_request_item_field": "cds_convention",
+      "delete_request_class": "refdata::messaging::delete_cds_convention_request",
+      "delete_response_class": "refdata::messaging::delete_cds_convention_response",
+      "delete_message_type": "delete_cds_convention_request",
+      "history_request_class": "refdata::messaging::get_cds_convention_history_request",
+      "history_response_class": "refdata::messaging::get_cds_convention_history_response",
+      "history_message_type": "get_cds_convention_history_request",
+
+      "detail_fields": [
+        {"field": "id", "label": "Id", "widget": "idEdit", "type": "line_edit",
+         "is_key": true, "is_required": true, "placeholder": "Enter convention id"},
+        {"field": "calendar", "label": "Calendar", "widget": "calendarEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. WeekendsOnly"},
+        {"field": "frequency", "label": "Frequency", "widget": "frequencyEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. Quarterly"},
+        {"field": "payment_convention", "label": "Payment Convention", "widget": "paymentConventionEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. Following"},
+        {"field": "rule", "label": "Rule", "widget": "ruleEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. CDS2015"},
+        {"field": "day_count_fraction", "label": "Day Count Fraction", "widget": "dayCountFractionEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. ACT/360"},
+        {"field": "settlement_days", "label": "Settlement Days", "widget": "settlementDaysEdit",
+         "type": "spin_box", "spin_min": 0, "spin_max": 10},
+        {"field": "upfront_settlement_days", "label": "Upfront Settlement Days", "widget": "upfrontSettlementDaysEdit",
+         "type": "spin_box", "spin_min": -1, "spin_max": 10},
+        {"field": "last_period_day_count_fraction", "label": "Last Period DCF", "widget": "lastPeriodDayCountFractionEdit",
+         "type": "line_edit", "placeholder": "e.g. ACT/360"},
+        {"field": "settles_accrual", "label": "Settles Accrual", "widget": "settlesAccrualEdit",
+         "type": "check_box"},
+        {"field": "pays_at_default_time", "label": "Pays At Default Time", "widget": "paysAtDefaultTimeEdit",
+         "type": "check_box"}
+      ],
+
+      "columns": [
+        {"enum_name": "Id", "field": "id", "header": "Id", "is_string": true, "width": 220},
+        {"enum_name": "Frequency", "field": "frequency", "header": "Frequency", "is_string": true, "width": 100},
+        {"enum_name": "Rule", "field": "rule", "header": "Rule", "is_string": true, "width": 120},
+        {"enum_name": "DayCountFraction", "field": "day_count_fraction", "header": "DCF", "is_string": true, "width": 100},
+        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
+        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
+        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+      ],
+
+      "settings_group": "CdsConventionListWindow",
+      "window_title": "CDS Conventions",
+      "icon": "Chart"
+    }
+  }
+}

--- a/projects/ores.codegen/models/refdata/fra_convention_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/fra_convention_domain_entity.json
@@ -1,0 +1,102 @@
+{
+  "domain_entity": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
+    "has_tenant_id": true,
+    "entity_singular": "fra_convention",
+    "entity_plural": "fra_conventions",
+    "entity_title": "FRA Convention",
+    "brief": "Conventions for a forward rate agreement (FRA).",
+    "description": "A FRA convention ties a FRA instrument to an IBOR index whose own\nconventions (calendar, day count, settlement) govern the FRA.\nCorresponds to the <FRA> element in ORE conventions.xml.",
+
+    "primary_key": {
+      "column": "id",
+      "type": "text",
+      "cpp_type": "std::string",
+      "description": "Unique convention identifier.",
+      "detail": "Examples: 'EUR-6M-FRA-CONVENTIONS', 'USD-3M-FRA-CONVENTIONS'.",
+      "generator_expr": "std::string(\"EUR-6M-FRA-CONVENTIONS\")"
+    },
+
+    "natural_keys": [],
+
+    "columns": [
+      {
+        "name": "index",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "IBOR index identifier (e.g. 'EUR-EURIBOR-6M'). All settlement, calendar, and day count details are inherited from the referenced index convention.",
+        "generator_expr": "std::string(\"EUR-EURIBOR-6M\")"
+      }
+    ],
+
+    "sql": {
+      "tablename": "ores_refdata_fra_conventions_tbl"
+    },
+
+    "repository": {
+      "entity_singular_short": "fra_convention",
+      "entity_plural_short": "fra_conventions",
+      "entity_singular_words": "FRA convention",
+      "entity_plural_words": "FRA conventions"
+    },
+
+    "cpp": {
+      "includes": {
+        "domain": ["<chrono>", "<string>"],
+        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
+      },
+      "iterator_var": "fc",
+      "table_display": [
+        {"column": "id", "header": "Id"},
+        {"column": "index", "header": "Index"},
+        {"column": "modified_by", "header": "Modified By"},
+        {"column": "version", "header": "Version"}
+      ]
+    },
+
+    "qt": {
+      "collection_name": "fra_conventions",
+      "item_var": "fc",
+      "key_field": "id",
+      "has_uuid_primary_key": false,
+
+      "get_request_class": "refdata::messaging::get_fra_conventions_request",
+      "get_response_class": "refdata::messaging::get_fra_conventions_response",
+      "get_message_type": "get_fra_conventions_request",
+      "save_request_class": "refdata::messaging::save_fra_convention_request",
+      "save_response_class": "refdata::messaging::save_fra_convention_response",
+      "save_message_type": "save_fra_convention_request",
+      "save_request_item_field": "fra_convention",
+      "delete_request_class": "refdata::messaging::delete_fra_convention_request",
+      "delete_response_class": "refdata::messaging::delete_fra_convention_response",
+      "delete_message_type": "delete_fra_convention_request",
+      "history_request_class": "refdata::messaging::get_fra_convention_history_request",
+      "history_response_class": "refdata::messaging::get_fra_convention_history_response",
+      "history_message_type": "get_fra_convention_history_request",
+
+      "detail_fields": [
+        {"field": "id", "label": "Id", "widget": "idEdit", "type": "line_edit",
+         "is_key": true, "is_required": true, "placeholder": "Enter convention id"},
+        {"field": "index", "label": "Index", "widget": "indexEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. EUR-EURIBOR-6M"}
+      ],
+
+      "columns": [
+        {"enum_name": "Id", "field": "id", "header": "Id", "is_string": true, "width": 220},
+        {"enum_name": "Index", "field": "index", "header": "Index", "is_string": true, "width": 180},
+        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
+        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
+        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+      ],
+
+      "settings_group": "FraConventionListWindow",
+      "window_title": "FRA Conventions",
+      "icon": "Chart"
+    }
+  }
+}

--- a/projects/ores.codegen/models/refdata/fx_convention_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/fx_convention_domain_entity.json
@@ -1,0 +1,174 @@
+{
+  "domain_entity": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
+    "has_tenant_id": true,
+    "entity_singular": "fx_convention",
+    "entity_plural": "fx_conventions",
+    "entity_title": "FX Convention",
+    "brief": "Conventions for FX spot and forward contracts.",
+    "description": "Defines the spot settlement lag, pip factor, and adjustment conventions for\na currency pair. Corresponds to the <FX> element in ORE conventions.xml.\nThe id typically takes the form 'CCY1-CCY2-FX-CONVENTIONS'.",
+
+    "primary_key": {
+      "column": "id",
+      "type": "text",
+      "cpp_type": "std::string",
+      "description": "Unique convention identifier.",
+      "detail": "Examples: 'EUR-USD-FX-CONVENTIONS', 'GBP-USD-FX-CONVENTIONS'.",
+      "generator_expr": "std::string(\"EUR-USD-FX-CONVENTIONS\")"
+    },
+
+    "natural_keys": [],
+
+    "columns": [
+      {
+        "name": "spot_days",
+        "type": "integer",
+        "cpp_type": "int",
+        "nullable": false,
+        "description": "Number of business days from trade to spot settlement (usually 2).",
+        "generator_expr": "2"
+      },
+      {
+        "name": "source_currency",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "ISO 4217 code of the source (base) currency (e.g. 'EUR').",
+        "generator_expr": "std::string(\"EUR\")"
+      },
+      {
+        "name": "target_currency",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "ISO 4217 code of the target (quote) currency (e.g. 'USD').",
+        "generator_expr": "std::string(\"USD\")"
+      },
+      {
+        "name": "points_factor",
+        "type": "double precision",
+        "cpp_type": "double",
+        "nullable": false,
+        "description": "Divisor applied to quoted FX points to obtain the rate increment (e.g. 10000.0 for most pairs).",
+        "generator_expr": "10000.0"
+      },
+      {
+        "name": "advance_calendar",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "Calendar used when advancing from spot to forward dates.",
+        "generator_expr": "std::nullopt"
+      },
+      {
+        "name": "spot_relative",
+        "type": "boolean",
+        "cpp_type": "std::optional<bool>",
+        "nullable": true,
+        "description": "Whether forward dates are generated relative to the spot date.",
+        "generator_expr": "std::nullopt"
+      },
+      {
+        "name": "end_of_month",
+        "type": "boolean",
+        "cpp_type": "std::optional<bool>",
+        "nullable": true,
+        "description": "Whether end-of-month convention applies.",
+        "generator_expr": "std::nullopt"
+      },
+      {
+        "name": "convention",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "Business day convention for forward dates (canonical FpML).",
+        "generator_expr": "std::nullopt"
+      }
+    ],
+
+    "sql": {
+      "tablename": "ores_refdata_fx_conventions_tbl"
+    },
+
+    "repository": {
+      "entity_singular_short": "fx_convention",
+      "entity_plural_short": "fx_conventions",
+      "entity_singular_words": "FX convention",
+      "entity_plural_words": "FX conventions"
+    },
+
+    "cpp": {
+      "includes": {
+        "domain": ["<chrono>", "<string>", "<optional>"],
+        "entity": ["<string>", "<optional>", "\"sqlgen/Timestamp.hpp\""]
+      },
+      "iterator_var": "fxc",
+      "table_display": [
+        {"column": "id", "header": "Id"},
+        {"column": "source_currency", "header": "Source CCY"},
+        {"column": "target_currency", "header": "Target CCY"},
+        {"column": "spot_days", "header": "Spot Days"},
+        {"column": "modified_by", "header": "Modified By"},
+        {"column": "version", "header": "Version"}
+      ]
+    },
+
+    "qt": {
+      "collection_name": "fx_conventions",
+      "item_var": "fxc",
+      "key_field": "id",
+      "has_uuid_primary_key": false,
+
+      "get_request_class": "refdata::messaging::get_fx_conventions_request",
+      "get_response_class": "refdata::messaging::get_fx_conventions_response",
+      "get_message_type": "get_fx_conventions_request",
+      "save_request_class": "refdata::messaging::save_fx_convention_request",
+      "save_response_class": "refdata::messaging::save_fx_convention_response",
+      "save_message_type": "save_fx_convention_request",
+      "save_request_item_field": "fx_convention",
+      "delete_request_class": "refdata::messaging::delete_fx_convention_request",
+      "delete_response_class": "refdata::messaging::delete_fx_convention_response",
+      "delete_message_type": "delete_fx_convention_request",
+      "history_request_class": "refdata::messaging::get_fx_convention_history_request",
+      "history_response_class": "refdata::messaging::get_fx_convention_history_response",
+      "history_message_type": "get_fx_convention_history_request",
+
+      "detail_fields": [
+        {"field": "id", "label": "Id", "widget": "idEdit", "type": "line_edit",
+         "is_key": true, "is_required": true, "placeholder": "Enter convention id"},
+        {"field": "source_currency", "label": "Source Currency", "widget": "sourceCurrencyEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. EUR"},
+        {"field": "target_currency", "label": "Target Currency", "widget": "targetCurrencyEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. USD"},
+        {"field": "spot_days", "label": "Spot Days", "widget": "spotDaysEdit",
+         "type": "spin_box", "spin_min": 0, "spin_max": 10},
+        {"field": "advance_calendar", "label": "Advance Calendar", "widget": "advanceCalendarEdit",
+         "type": "line_edit", "placeholder": "e.g. TARGET"},
+        {"field": "convention", "label": "Convention", "widget": "conventionEdit",
+         "type": "line_edit", "placeholder": "e.g. ModifiedFollowing"},
+        {"field": "spot_relative", "label": "Spot Relative", "widget": "spotRelativeEdit",
+         "type": "check_box"},
+        {"field": "end_of_month", "label": "End Of Month", "widget": "endOfMonthEdit",
+         "type": "check_box"}
+      ],
+
+      "columns": [
+        {"enum_name": "Id", "field": "id", "header": "Id", "is_string": true, "width": 220},
+        {"enum_name": "SourceCurrency", "field": "source_currency", "header": "Source CCY", "is_string": true, "width": 90},
+        {"enum_name": "TargetCurrency", "field": "target_currency", "header": "Target CCY", "is_string": true, "width": 90},
+        {"enum_name": "SpotDays", "field": "spot_days", "header": "Spot Days", "is_int": true, "width": 80},
+        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
+        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
+        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+      ],
+
+      "settings_group": "FxConventionListWindow",
+      "window_title": "FX Conventions",
+      "icon": "Chart"
+    }
+  }
+}

--- a/projects/ores.codegen/models/refdata/ibor_index_convention_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/ibor_index_convention_domain_entity.json
@@ -1,0 +1,146 @@
+{
+  "domain_entity": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
+    "has_tenant_id": true,
+    "entity_singular": "ibor_index_convention",
+    "entity_plural": "ibor_index_conventions",
+    "entity_title": "IBOR Index Convention",
+    "brief": "Conventions for an interbank offered rate (IBOR) index.",
+    "description": "Defines the fixing calendar, day count, settlement lag, and business day\nconvention for a term IBOR index such as EURIBOR or USD LIBOR.\nCorresponds to the <IborIndex> element in ORE conventions.xml.",
+
+    "primary_key": {
+      "column": "id",
+      "type": "text",
+      "cpp_type": "std::string",
+      "description": "Unique index identifier.",
+      "detail": "Examples: 'EUR-EURIBOR', 'USD-LIBOR'.",
+      "generator_expr": "std::string(\"EUR-EURIBOR\")"
+    },
+
+    "natural_keys": [],
+
+    "columns": [
+      {
+        "name": "fixing_calendar",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "Calendar used to determine valid fixing dates (e.g. 'TARGET').",
+        "generator_expr": "std::string(\"TARGET\")"
+      },
+      {
+        "name": "day_count_fraction",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "Day count fraction for accrual (canonical FpML, e.g. 'ACT/360').",
+        "generator_expr": "std::string(\"ACT/360\")"
+      },
+      {
+        "name": "settlement_days",
+        "type": "integer",
+        "cpp_type": "int",
+        "nullable": false,
+        "description": "Number of business days from fixing to settlement.",
+        "generator_expr": "2"
+      },
+      {
+        "name": "business_day_convention",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "Business day convention for maturity dates (canonical FpML).",
+        "generator_expr": "std::string(\"ModifiedFollowing\")"
+      },
+      {
+        "name": "end_of_month",
+        "type": "boolean",
+        "cpp_type": "bool",
+        "nullable": false,
+        "description": "Whether end-of-month convention applies.",
+        "generator_expr": "false"
+      }
+    ],
+
+    "sql": {
+      "tablename": "ores_refdata_ibor_index_conventions_tbl"
+    },
+
+    "repository": {
+      "entity_singular_short": "ibor_index_convention",
+      "entity_plural_short": "ibor_index_conventions",
+      "entity_singular_words": "IBOR index convention",
+      "entity_plural_words": "IBOR index conventions"
+    },
+
+    "cpp": {
+      "includes": {
+        "domain": ["<chrono>", "<string>"],
+        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
+      },
+      "iterator_var": "ic",
+      "table_display": [
+        {"column": "id", "header": "Id"},
+        {"column": "fixing_calendar", "header": "Fixing Calendar"},
+        {"column": "day_count_fraction", "header": "DCF"},
+        {"column": "settlement_days", "header": "Settlement Days"},
+        {"column": "modified_by", "header": "Modified By"},
+        {"column": "version", "header": "Version"}
+      ]
+    },
+
+    "qt": {
+      "collection_name": "ibor_index_conventions",
+      "item_var": "ic",
+      "key_field": "id",
+      "has_uuid_primary_key": false,
+
+      "get_request_class": "refdata::messaging::get_ibor_index_conventions_request",
+      "get_response_class": "refdata::messaging::get_ibor_index_conventions_response",
+      "get_message_type": "get_ibor_index_conventions_request",
+      "save_request_class": "refdata::messaging::save_ibor_index_convention_request",
+      "save_response_class": "refdata::messaging::save_ibor_index_convention_response",
+      "save_message_type": "save_ibor_index_convention_request",
+      "save_request_item_field": "ibor_index_convention",
+      "delete_request_class": "refdata::messaging::delete_ibor_index_convention_request",
+      "delete_response_class": "refdata::messaging::delete_ibor_index_convention_response",
+      "delete_message_type": "delete_ibor_index_convention_request",
+      "history_request_class": "refdata::messaging::get_ibor_index_convention_history_request",
+      "history_response_class": "refdata::messaging::get_ibor_index_convention_history_response",
+      "history_message_type": "get_ibor_index_convention_history_request",
+
+      "detail_fields": [
+        {"field": "id", "label": "Id", "widget": "idEdit", "type": "line_edit",
+         "is_key": true, "is_required": true, "placeholder": "Enter index id"},
+        {"field": "fixing_calendar", "label": "Fixing Calendar", "widget": "fixingCalendarEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. TARGET"},
+        {"field": "day_count_fraction", "label": "Day Count Fraction", "widget": "dayCountFractionEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. ACT/360"},
+        {"field": "settlement_days", "label": "Settlement Days", "widget": "settlementDaysEdit",
+         "type": "spin_box", "spin_min": 0, "spin_max": 10},
+        {"field": "business_day_convention", "label": "Business Day Convention", "widget": "businessDayConventionEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. ModifiedFollowing"},
+        {"field": "end_of_month", "label": "End Of Month", "widget": "endOfMonthEdit",
+         "type": "check_box"}
+      ],
+
+      "columns": [
+        {"enum_name": "Id", "field": "id", "header": "Id", "is_string": true, "width": 180},
+        {"enum_name": "FixingCalendar", "field": "fixing_calendar", "header": "Fixing Calendar", "is_string": true, "width": 120},
+        {"enum_name": "DayCountFraction", "field": "day_count_fraction", "header": "DCF", "is_string": true, "width": 100},
+        {"enum_name": "SettlementDays", "field": "settlement_days", "header": "Settlement Days", "is_int": true, "width": 110},
+        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
+        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
+        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+      ],
+
+      "settings_group": "IborIndexConventionListWindow",
+      "window_title": "IBOR Index Conventions",
+      "icon": "Chart"
+    }
+  }
+}

--- a/projects/ores.codegen/models/refdata/ois_convention_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/ois_convention_domain_entity.json
@@ -1,0 +1,216 @@
+{
+  "domain_entity": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
+    "has_tenant_id": true,
+    "entity_singular": "ois_convention",
+    "entity_plural": "ois_conventions",
+    "entity_title": "OIS Convention",
+    "brief": "Conventions for an overnight index swap (OIS).",
+    "description": "Defines the fixed-leg and overnight floating-leg parameters for an OIS.\nOIS are used to bootstrap risk-free overnight discount curves (e.g. EONIA,\nSOFR, SONIA). Corresponds to the <OIS> element in ORE conventions.xml.",
+
+    "primary_key": {
+      "column": "id",
+      "type": "text",
+      "cpp_type": "std::string",
+      "description": "Unique convention identifier.",
+      "detail": "Examples: 'EUR-OIS-CONVENTIONS', 'USD-OIS-CONVENTIONS'.",
+      "generator_expr": "std::string(\"EUR-OIS-CONVENTIONS\")"
+    },
+
+    "natural_keys": [],
+
+    "columns": [
+      {
+        "name": "spot_lag",
+        "type": "integer",
+        "cpp_type": "int",
+        "nullable": false,
+        "description": "Number of business days from trade date to spot date.",
+        "generator_expr": "2"
+      },
+      {
+        "name": "index",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "Overnight index identifier (e.g. 'EUR-EONIA', 'USD-SOFR').",
+        "generator_expr": "std::string(\"EUR-EONIA\")"
+      },
+      {
+        "name": "fixed_day_count_fraction",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "Day count fraction for the fixed leg (canonical FpML).",
+        "generator_expr": "std::string(\"ACT/360\")"
+      },
+      {
+        "name": "fixed_calendar",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "Fixed-leg payment calendar (e.g. 'TARGET').",
+        "generator_expr": "std::string(\"TARGET\")"
+      },
+      {
+        "name": "payment_lag",
+        "type": "integer",
+        "cpp_type": "std::optional<int>",
+        "nullable": true,
+        "description": "Number of business days between period end and payment.",
+        "generator_expr": "std::nullopt"
+      },
+      {
+        "name": "end_of_month",
+        "type": "boolean",
+        "cpp_type": "std::optional<bool>",
+        "nullable": true,
+        "description": "Whether end-of-month convention applies.",
+        "generator_expr": "std::nullopt"
+      },
+      {
+        "name": "fixed_frequency",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "Fixed-leg payment frequency (canonical CDM, e.g. 'Annual').",
+        "generator_expr": "std::nullopt"
+      },
+      {
+        "name": "fixed_convention",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "Business day convention for fixed coupon dates (canonical FpML).",
+        "generator_expr": "std::nullopt"
+      },
+      {
+        "name": "fixed_payment_convention",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "Business day convention for fixed payment dates (canonical FpML).",
+        "generator_expr": "std::nullopt"
+      },
+      {
+        "name": "rule",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "Date generation rule for the schedule (e.g. 'Backward', 'CDS2015').",
+        "generator_expr": "std::nullopt"
+      },
+      {
+        "name": "payment_calendar",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "Payment calendar override (e.g. 'TARGET').",
+        "generator_expr": "std::nullopt"
+      },
+      {
+        "name": "rate_cutoff",
+        "type": "integer",
+        "cpp_type": "std::optional<int>",
+        "nullable": true,
+        "description": "Number of fixing days before period end that rate is locked.",
+        "generator_expr": "std::nullopt"
+      }
+    ],
+
+    "sql": {
+      "tablename": "ores_refdata_ois_conventions_tbl"
+    },
+
+    "repository": {
+      "entity_singular_short": "ois_convention",
+      "entity_plural_short": "ois_conventions",
+      "entity_singular_words": "OIS convention",
+      "entity_plural_words": "OIS conventions"
+    },
+
+    "cpp": {
+      "includes": {
+        "domain": ["<chrono>", "<string>", "<optional>"],
+        "entity": ["<string>", "<optional>", "\"sqlgen/Timestamp.hpp\""]
+      },
+      "iterator_var": "oc",
+      "table_display": [
+        {"column": "id", "header": "Id"},
+        {"column": "index", "header": "Index"},
+        {"column": "spot_lag", "header": "Spot Lag"},
+        {"column": "fixed_day_count_fraction", "header": "Fixed DCF"},
+        {"column": "modified_by", "header": "Modified By"},
+        {"column": "version", "header": "Version"}
+      ]
+    },
+
+    "qt": {
+      "collection_name": "ois_conventions",
+      "item_var": "oc",
+      "key_field": "id",
+      "has_uuid_primary_key": false,
+
+      "get_request_class": "refdata::messaging::get_ois_conventions_request",
+      "get_response_class": "refdata::messaging::get_ois_conventions_response",
+      "get_message_type": "get_ois_conventions_request",
+      "save_request_class": "refdata::messaging::save_ois_convention_request",
+      "save_response_class": "refdata::messaging::save_ois_convention_response",
+      "save_message_type": "save_ois_convention_request",
+      "save_request_item_field": "ois_convention",
+      "delete_request_class": "refdata::messaging::delete_ois_convention_request",
+      "delete_response_class": "refdata::messaging::delete_ois_convention_response",
+      "delete_message_type": "delete_ois_convention_request",
+      "history_request_class": "refdata::messaging::get_ois_convention_history_request",
+      "history_response_class": "refdata::messaging::get_ois_convention_history_response",
+      "history_message_type": "get_ois_convention_history_request",
+
+      "detail_fields": [
+        {"field": "id", "label": "Id", "widget": "idEdit", "type": "line_edit",
+         "is_key": true, "is_required": true, "placeholder": "Enter convention id"},
+        {"field": "index", "label": "Index", "widget": "indexEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. EUR-EONIA"},
+        {"field": "spot_lag", "label": "Spot Lag", "widget": "spotLagEdit",
+         "type": "spin_box", "spin_min": 0, "spin_max": 10},
+        {"field": "fixed_day_count_fraction", "label": "Fixed Day Count Fraction", "widget": "fixedDayCountFractionEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. ACT/360"},
+        {"field": "fixed_calendar", "label": "Fixed Calendar", "widget": "fixedCalendarEdit",
+         "type": "line_edit", "placeholder": "e.g. TARGET"},
+        {"field": "payment_lag", "label": "Payment Lag", "widget": "paymentLagEdit",
+         "type": "spin_box", "spin_min": -1, "spin_max": 30},
+        {"field": "fixed_frequency", "label": "Fixed Frequency", "widget": "fixedFrequencyEdit",
+         "type": "line_edit", "placeholder": "e.g. Annual"},
+        {"field": "fixed_convention", "label": "Fixed Convention", "widget": "fixedConventionEdit",
+         "type": "line_edit", "placeholder": "e.g. ModifiedFollowing"},
+        {"field": "fixed_payment_convention", "label": "Fixed Payment Convention", "widget": "fixedPaymentConventionEdit",
+         "type": "line_edit", "placeholder": "e.g. Following"},
+        {"field": "rule", "label": "Rule", "widget": "ruleEdit",
+         "type": "line_edit", "placeholder": "e.g. Backward"},
+        {"field": "payment_calendar", "label": "Payment Calendar", "widget": "paymentCalendarEdit",
+         "type": "line_edit", "placeholder": "e.g. TARGET"},
+        {"field": "rate_cutoff", "label": "Rate Cutoff", "widget": "rateCutoffEdit",
+         "type": "spin_box", "spin_min": -1, "spin_max": 30},
+        {"field": "end_of_month", "label": "End Of Month", "widget": "endOfMonthEdit",
+         "type": "check_box"}
+      ],
+
+      "columns": [
+        {"enum_name": "Id", "field": "id", "header": "Id", "is_string": true, "width": 200},
+        {"enum_name": "Index", "field": "index", "header": "Index", "is_string": true, "width": 140},
+        {"enum_name": "SpotLag", "field": "spot_lag", "header": "Spot Lag", "is_int": true, "width": 80},
+        {"enum_name": "FixedDayCountFraction", "field": "fixed_day_count_fraction", "header": "Fixed DCF", "is_string": true, "width": 100},
+        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
+        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
+        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+      ],
+
+      "settings_group": "OisConventionListWindow",
+      "window_title": "OIS Conventions",
+      "icon": "Chart"
+    }
+  }
+}

--- a/projects/ores.codegen/models/refdata/overnight_index_convention_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/overnight_index_convention_domain_entity.json
@@ -1,0 +1,126 @@
+{
+  "domain_entity": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
+    "has_tenant_id": true,
+    "entity_singular": "overnight_index_convention",
+    "entity_plural": "overnight_index_conventions",
+    "entity_title": "Overnight Index Convention",
+    "brief": "Conventions for an overnight index (e.g. EONIA, SONIA, SOFR).",
+    "description": "Defines the fixing calendar, day count, and settlement lag for a risk-free\novernight rate index. Corresponds to the <OvernightIndex> element in\nORE conventions.xml.",
+
+    "primary_key": {
+      "column": "id",
+      "type": "text",
+      "cpp_type": "std::string",
+      "description": "Unique index identifier.",
+      "detail": "Examples: 'EUR-EONIA', 'USD-SOFR', 'GBP-SONIA'.",
+      "generator_expr": "std::string(\"EUR-EONIA\")"
+    },
+
+    "natural_keys": [],
+
+    "columns": [
+      {
+        "name": "fixing_calendar",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "Calendar used to determine valid fixing dates (e.g. 'TARGET').",
+        "generator_expr": "std::string(\"TARGET\")"
+      },
+      {
+        "name": "day_count_fraction",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "Day count fraction for accrual (canonical FpML, e.g. 'ACT/360').",
+        "generator_expr": "std::string(\"ACT/360\")"
+      },
+      {
+        "name": "settlement_days",
+        "type": "integer",
+        "cpp_type": "int",
+        "nullable": false,
+        "description": "Number of business days from fixing to value date (usually 0 or 1).",
+        "generator_expr": "0"
+      }
+    ],
+
+    "sql": {
+      "tablename": "ores_refdata_overnight_index_conventions_tbl"
+    },
+
+    "repository": {
+      "entity_singular_short": "overnight_index_convention",
+      "entity_plural_short": "overnight_index_conventions",
+      "entity_singular_words": "overnight index convention",
+      "entity_plural_words": "overnight index conventions"
+    },
+
+    "cpp": {
+      "includes": {
+        "domain": ["<chrono>", "<string>"],
+        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
+      },
+      "iterator_var": "ni",
+      "table_display": [
+        {"column": "id", "header": "Id"},
+        {"column": "fixing_calendar", "header": "Fixing Calendar"},
+        {"column": "day_count_fraction", "header": "DCF"},
+        {"column": "settlement_days", "header": "Settlement Days"},
+        {"column": "modified_by", "header": "Modified By"},
+        {"column": "version", "header": "Version"}
+      ]
+    },
+
+    "qt": {
+      "collection_name": "overnight_index_conventions",
+      "item_var": "ni",
+      "key_field": "id",
+      "has_uuid_primary_key": false,
+
+      "get_request_class": "refdata::messaging::get_overnight_index_conventions_request",
+      "get_response_class": "refdata::messaging::get_overnight_index_conventions_response",
+      "get_message_type": "get_overnight_index_conventions_request",
+      "save_request_class": "refdata::messaging::save_overnight_index_convention_request",
+      "save_response_class": "refdata::messaging::save_overnight_index_convention_response",
+      "save_message_type": "save_overnight_index_convention_request",
+      "save_request_item_field": "overnight_index_convention",
+      "delete_request_class": "refdata::messaging::delete_overnight_index_convention_request",
+      "delete_response_class": "refdata::messaging::delete_overnight_index_convention_response",
+      "delete_message_type": "delete_overnight_index_convention_request",
+      "history_request_class": "refdata::messaging::get_overnight_index_convention_history_request",
+      "history_response_class": "refdata::messaging::get_overnight_index_convention_history_response",
+      "history_message_type": "get_overnight_index_convention_history_request",
+
+      "detail_fields": [
+        {"field": "id", "label": "Id", "widget": "idEdit", "type": "line_edit",
+         "is_key": true, "is_required": true, "placeholder": "Enter index id"},
+        {"field": "fixing_calendar", "label": "Fixing Calendar", "widget": "fixingCalendarEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. TARGET"},
+        {"field": "day_count_fraction", "label": "Day Count Fraction", "widget": "dayCountFractionEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. ACT/360"},
+        {"field": "settlement_days", "label": "Settlement Days", "widget": "settlementDaysEdit",
+         "type": "spin_box", "spin_min": 0, "spin_max": 5}
+      ],
+
+      "columns": [
+        {"enum_name": "Id", "field": "id", "header": "Id", "is_string": true, "width": 180},
+        {"enum_name": "FixingCalendar", "field": "fixing_calendar", "header": "Fixing Calendar", "is_string": true, "width": 130},
+        {"enum_name": "DayCountFraction", "field": "day_count_fraction", "header": "DCF", "is_string": true, "width": 100},
+        {"enum_name": "SettlementDays", "field": "settlement_days", "header": "Settlement Days", "is_int": true, "width": 110},
+        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
+        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
+        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+      ],
+
+      "settings_group": "OvernightIndexConventionListWindow",
+      "window_title": "Overnight Index Conventions",
+      "icon": "Chart"
+    }
+  }
+}

--- a/projects/ores.codegen/models/refdata/swap_convention_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/swap_convention_domain_entity.json
@@ -1,0 +1,166 @@
+{
+  "domain_entity": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
+    "has_tenant_id": true,
+    "entity_singular": "swap_convention",
+    "entity_plural": "swap_conventions",
+    "entity_title": "Swap Convention",
+    "brief": "Conventions for a vanilla interest rate swap.",
+    "description": "Defines the fixed-leg schedule and the floating-leg index for a standard\ninterest rate swap. Used by ORE to bootstrap par swap rates off a yield\ncurve. Corresponds to the <Swap> element in ORE conventions.xml.",
+
+    "primary_key": {
+      "column": "id",
+      "type": "text",
+      "cpp_type": "std::string",
+      "description": "Unique convention identifier.",
+      "detail": "Examples: 'EUR-6M-SWAP-CONVENTIONS', 'USD-3M-SWAP-CONVENTIONS'.",
+      "generator_expr": "std::string(\"EUR-6M-SWAP-CONVENTIONS\")"
+    },
+
+    "natural_keys": [],
+
+    "columns": [
+      {
+        "name": "fixed_calendar",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "Fixed-leg payment calendar (e.g. 'TARGET').",
+        "generator_expr": "std::string(\"TARGET\")"
+      },
+      {
+        "name": "fixed_frequency",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "Fixed-leg payment frequency (canonical CDM, e.g. 'Annual').",
+        "generator_expr": "std::string(\"Annual\")"
+      },
+      {
+        "name": "fixed_convention",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "Business day convention for the fixed leg (canonical FpML).",
+        "generator_expr": "std::string(\"ModifiedFollowing\")"
+      },
+      {
+        "name": "fixed_day_count_fraction",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "Day count fraction for the fixed leg (canonical FpML, e.g. '30/360').",
+        "generator_expr": "std::string(\"30/360\")"
+      },
+      {
+        "name": "index",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "Floating-leg index identifier (e.g. 'EUR-EURIBOR-6M').",
+        "generator_expr": "std::string(\"EUR-EURIBOR-6M\")"
+      },
+      {
+        "name": "float_frequency",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "Floating-leg payment frequency override (canonical CDM). When absent the frequency is derived from the index tenor.",
+        "generator_expr": "std::nullopt"
+      },
+      {
+        "name": "sub_periods_coupon_type",
+        "type": "text",
+        "cpp_type": "std::optional<std::string>",
+        "nullable": true,
+        "description": "Sub-period coupon type when the float leg uses sub-periods. Either 'Compounding' or 'Averaging'.",
+        "generator_expr": "std::nullopt"
+      }
+    ],
+
+    "sql": {
+      "tablename": "ores_refdata_swap_conventions_tbl"
+    },
+
+    "repository": {
+      "entity_singular_short": "swap_convention",
+      "entity_plural_short": "swap_conventions",
+      "entity_singular_words": "swap convention",
+      "entity_plural_words": "swap conventions"
+    },
+
+    "cpp": {
+      "includes": {
+        "domain": ["<chrono>", "<string>", "<optional>"],
+        "entity": ["<string>", "<optional>", "\"sqlgen/Timestamp.hpp\""]
+      },
+      "iterator_var": "sc",
+      "table_display": [
+        {"column": "id", "header": "Id"},
+        {"column": "fixed_frequency", "header": "Fixed Freq"},
+        {"column": "fixed_day_count_fraction", "header": "Fixed DCF"},
+        {"column": "index", "header": "Index"},
+        {"column": "modified_by", "header": "Modified By"},
+        {"column": "version", "header": "Version"}
+      ]
+    },
+
+    "qt": {
+      "collection_name": "swap_conventions",
+      "item_var": "sc",
+      "key_field": "id",
+      "has_uuid_primary_key": false,
+
+      "get_request_class": "refdata::messaging::get_swap_conventions_request",
+      "get_response_class": "refdata::messaging::get_swap_conventions_response",
+      "get_message_type": "get_swap_conventions_request",
+      "save_request_class": "refdata::messaging::save_swap_convention_request",
+      "save_response_class": "refdata::messaging::save_swap_convention_response",
+      "save_message_type": "save_swap_convention_request",
+      "save_request_item_field": "swap_convention",
+      "delete_request_class": "refdata::messaging::delete_swap_convention_request",
+      "delete_response_class": "refdata::messaging::delete_swap_convention_response",
+      "delete_message_type": "delete_swap_convention_request",
+      "history_request_class": "refdata::messaging::get_swap_convention_history_request",
+      "history_response_class": "refdata::messaging::get_swap_convention_history_response",
+      "history_message_type": "get_swap_convention_history_request",
+
+      "detail_fields": [
+        {"field": "id", "label": "Id", "widget": "idEdit", "type": "line_edit",
+         "is_key": true, "is_required": true, "placeholder": "Enter convention id"},
+        {"field": "fixed_frequency", "label": "Fixed Frequency", "widget": "fixedFrequencyEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. Annual"},
+        {"field": "fixed_day_count_fraction", "label": "Fixed Day Count Fraction", "widget": "fixedDayCountFractionEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. 30/360"},
+        {"field": "index", "label": "Index", "widget": "indexEdit",
+         "type": "line_edit", "is_required": true, "placeholder": "e.g. EUR-EURIBOR-6M"},
+        {"field": "fixed_calendar", "label": "Fixed Calendar", "widget": "fixedCalendarEdit",
+         "type": "line_edit", "placeholder": "e.g. TARGET"},
+        {"field": "fixed_convention", "label": "Fixed Convention", "widget": "fixedConventionEdit",
+         "type": "line_edit", "placeholder": "e.g. ModifiedFollowing"},
+        {"field": "float_frequency", "label": "Float Frequency", "widget": "floatFrequencyEdit",
+         "type": "line_edit", "placeholder": "e.g. Semiannual"},
+        {"field": "sub_periods_coupon_type", "label": "Sub-Periods Coupon Type", "widget": "subPeriodsCouponTypeEdit",
+         "type": "line_edit", "placeholder": "e.g. Compounding"}
+      ],
+
+      "columns": [
+        {"enum_name": "Id", "field": "id", "header": "Id", "is_string": true, "width": 220},
+        {"enum_name": "FixedFrequency", "field": "fixed_frequency", "header": "Fixed Freq", "is_string": true, "width": 100},
+        {"enum_name": "FixedDayCountFraction", "field": "fixed_day_count_fraction", "header": "Fixed DCF", "is_string": true, "width": 100},
+        {"enum_name": "Index", "field": "index", "header": "Index", "is_string": true, "width": 160},
+        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
+        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
+        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+      ],
+
+      "settings_group": "SwapConventionListWindow",
+      "window_title": "Swap Conventions",
+      "icon": "Chart"
+    }
+  }
+}

--- a/projects/ores.qt.refdata/include/ores.qt/CdsConventionController.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/CdsConventionController.hpp
@@ -1,0 +1,93 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CDS_CONVENTION_CONTROLLER_HPP
+#define ORES_QT_CDS_CONVENTION_CONTROLLER_HPP
+
+#include <QMdiArea>
+#include <QMainWindow>
+#include "ores.qt/EntityController.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/cds_convention.hpp"
+#include "ores.qt/EntityListMdiWindow.hpp"
+
+namespace ores::qt {
+
+class CdsConventionMdiWindow;
+class DetachableMdiSubWindow;
+
+/**
+ * @brief Controller for managing CDS convention windows and operations.
+ *
+ * Manages the lifecycle of CDS convention list, detail, and history windows.
+ * Handles event subscriptions and coordinates between windows.
+ */
+class CdsConventionController final : public EntityController {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.cds_convention_controller";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    CdsConventionController(
+        QMainWindow* mainWindow,
+        QMdiArea* mdiArea,
+        ClientManager* clientManager,
+        const QString& username,
+        QObject* parent = nullptr);
+
+    void showListWindow() override;
+    void closeAllWindows() override;
+    void reloadListWindow() override;
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& error);
+
+protected:
+    EntityListMdiWindow* listWindow() const override;
+
+private slots:
+    void onShowDetails(const refdata::domain::cds_convention& cc);
+    void onAddNewRequested();
+    void onShowHistory(const refdata::domain::cds_convention& cc);
+    void onRevertVersion(const refdata::domain::cds_convention& cc);
+    void onOpenVersion(const refdata::domain::cds_convention& cc,
+                       int versionNumber);
+
+private:
+    void showAddWindow();
+    void showDetailWindow(const refdata::domain::cds_convention& cc);
+    void showHistoryWindow(const QString& code);
+
+    CdsConventionMdiWindow* listWindow_;
+    DetachableMdiSubWindow* listMdiSubWindow_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/CdsConventionDetailDialog.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/CdsConventionDetailDialog.hpp
@@ -1,0 +1,104 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CDS_CONVENTION_DETAIL_DIALOG_HPP
+#define ORES_QT_CDS_CONVENTION_DETAIL_DIALOG_HPP
+
+#include <vector>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/DetailDialogBase.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/cds_convention.hpp"
+
+
+namespace Ui {
+class CdsConventionDetailDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Detail dialog for viewing and editing CDS convention records.
+ *
+ * This dialog allows viewing, creating, and editing CDS conventions.
+ * It supports both create mode (for new records) and edit mode (for
+ * existing records).
+ */
+class CdsConventionDetailDialog final : public DetailDialogBase {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.cds_convention_detail_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit CdsConventionDetailDialog(QWidget* parent = nullptr);
+    ~CdsConventionDetailDialog() override;
+
+    void setClientManager(ClientManager* clientManager);
+    void setUsername(const std::string& username);
+    void setConvention(const refdata::domain::cds_convention& cc);
+    void setCreateMode(bool createMode);
+    void setReadOnly(bool readOnly);
+
+
+signals:
+    void ccSaved(const QString& code);
+    void ccDeleted(const QString& code);
+
+private slots:
+    void onSaveClicked();
+    void onDeleteClicked();
+    void onCodeChanged(const QString& text);
+    void onFieldChanged();
+
+protected:
+    QTabWidget* tabWidget() const override;
+    QWidget* provenanceTab() const override;
+    ProvenanceWidget* provenanceWidget() const override;
+    bool hasUnsavedChanges() const override { return hasChanges_; }
+
+private:
+    void setupUi();
+    void setupConnections();
+    void updateUiFromConvention();
+    void updateConventionFromUi();
+    void updateSaveButtonState();
+    bool validateInput();
+
+
+    Ui::CdsConventionDetailDialog* ui_;
+    ClientManager* clientManager_;
+    std::string username_;
+    refdata::domain::cds_convention cc_;
+    bool createMode_{true};
+    bool readOnly_{false};
+    bool hasChanges_{false};
+
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/CdsConventionHistoryDialog.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/CdsConventionHistoryDialog.hpp
@@ -1,0 +1,97 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CDS_CONVENTION_HISTORY_DIALOG_HPP
+#define ORES_QT_CDS_CONVENTION_HISTORY_DIALOG_HPP
+
+#include <QWidget>
+#include <QToolBar>
+#include <QTableWidget>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/cds_convention.hpp"
+
+namespace Ui {
+class CdsConventionHistoryDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Dialog for viewing the version history of a CDS convention.
+ *
+ * Shows all historical versions of a CDS convention with ability
+ * to view details or revert to a previous version.
+ */
+class CdsConventionHistoryDialog final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.cds_convention_history_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit CdsConventionHistoryDialog(
+        const QString& code,
+        ClientManager* clientManager,
+        QWidget* parent = nullptr);
+    ~CdsConventionHistoryDialog() override;
+
+    void loadHistory();
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void openVersionRequested(const refdata::domain::cds_convention& cc,
+                              int versionNumber);
+    void revertVersionRequested(const refdata::domain::cds_convention& cc);
+
+private slots:
+    void onVersionSelected();
+    void onOpenVersionClicked();
+    void onRevertClicked();
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupConnections();
+    void updateVersionList();
+    void updateChangesTable(int currentVersionIndex);
+    void updateFullDetails(int versionIndex);
+    void updateActionStates();
+
+    Ui::CdsConventionHistoryDialog* ui_;
+    QString code_;
+    ClientManager* clientManager_;
+    std::vector<refdata::domain::cds_convention> versions_;
+
+    QToolBar* toolbar_;
+    QAction* openVersionAction_;
+    QAction* revertAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/CdsConventionMdiWindow.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/CdsConventionMdiWindow.hpp
@@ -1,0 +1,115 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CDS_CONVENTION_MDI_WINDOW_HPP
+#define ORES_QT_CDS_CONVENTION_MDI_WINDOW_HPP
+
+#include <QToolBar>
+#include <QTableView>
+#include <QSortFilterProxyModel>
+#include "ores.qt/EntityListMdiWindow.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ClientCdsConventionModel.hpp"
+#include "ores.qt/PaginationWidget.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/cds_convention.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief MDI window for displaying and managing CDS conventions.
+ *
+ * Provides a table view of CDS conventions with toolbar actions
+ * for reload, add, edit, delete, and viewing history.
+ */
+class CdsConventionMdiWindow final : public EntityListMdiWindow {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.cds_convention_mdi_window";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit CdsConventionMdiWindow(
+        ClientManager* clientManager,
+        const QString& username,
+        QWidget* parent = nullptr);
+    ~CdsConventionMdiWindow() override = default;
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void showConventionDetails(const refdata::domain::cds_convention& cc);
+    void addNewRequested();
+    void ccDeleted(const QString& code);
+    void showConventionHistory(const refdata::domain::cds_convention& cc);
+
+public slots:
+    void addNew();
+    void editSelected();
+    void deleteSelected();
+    void viewHistorySelected();
+
+protected:
+    void doReload() override;
+
+private slots:
+    void onDataLoaded();
+    void onLoadError(const QString& error_message, const QString& details = {});
+    void onSelectionChanged();
+    void onDoubleClicked(const QModelIndex& index);
+
+protected:
+    QString normalRefreshTooltip() const override {
+        return tr("Refresh CDS conventions");
+    }
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupTable();
+    void setupConnections();
+    void updateActionStates();
+
+    ClientManager* clientManager_;
+    QString username_;
+
+    QToolBar* toolbar_;
+    QTableView* tableView_;
+    ClientCdsConventionModel* model_;
+    QSortFilterProxyModel* proxyModel_;
+    PaginationWidget* paginationWidget_;
+
+    // Toolbar actions
+    QAction* reloadAction_;
+    QAction* addAction_;
+    QAction* editAction_;
+    QAction* deleteAction_;
+    QAction* historyAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/ClientCdsConventionModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientCdsConventionModel.hpp
@@ -1,0 +1,144 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CLIENT_CDS_CONVENTION_MODEL_HPP
+#define ORES_QT_CLIENT_CDS_CONVENTION_MODEL_HPP
+
+#include <vector>
+#include <QFutureWatcher>
+#include "ores.qt/AbstractClientModel.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/RecencyPulseManager.hpp"
+#include "ores.qt/RecencyTracker.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/cds_convention.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief Model for displaying CDS conventions fetched from the server.
+ *
+ * This model extends AbstractClientModel and fetches CDS convention
+ * data asynchronously using the ores.comms client.
+ */
+class ClientCdsConventionModel final : public AbstractClientModel {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.client_cds_convention_model";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    /**
+     * @brief Enumeration of table columns for type-safe column access.
+     */
+    enum Column {
+        Id,
+        Frequency,
+        Rule,
+        DayCountFraction,
+        Version,
+        ModifiedBy,
+        RecordedAt,
+        ColumnCount
+    };
+
+    explicit ClientCdsConventionModel(ClientManager* clientManager,
+                                       QObject* parent = nullptr);
+    ~ClientCdsConventionModel() override = default;
+
+    // QAbstractTableModel interface
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+        int role = Qt::DisplayRole) const override;
+
+    /**
+     * @brief Refresh CDS convention data from server asynchronously.
+     */
+    void refresh();
+
+    /**
+     * @brief Get CDS convention at the specified row.
+     *
+     * @param row The row index.
+     * @return The CDS convention, or nullptr if row is invalid.
+     */
+    const refdata::domain::cds_convention* getConvention(int row) const;
+
+    /**
+     * @brief Load a specific page of data.
+     */
+    void load_page(std::uint32_t offset, std::uint32_t limit);
+
+    /**
+     * @brief Get the page size used for pagination.
+     */
+    std::uint32_t page_size() const { return page_size_; }
+
+    /**
+     * @brief Set the page size for pagination.
+     */
+    void set_page_size(std::uint32_t size);
+
+    /**
+     * @brief Get the total number of records available on the server.
+     */
+    std::uint32_t total_available_count() const { return total_available_count_; }
+
+private slots:
+    void onConventionsLoaded();
+    void onPulseStateChanged(bool isOn);
+    void onPulsingComplete();
+
+private:
+    QVariant recency_foreground_color(const std::string& code) const;
+
+    struct FetchResult {
+        bool success;
+        std::vector<refdata::domain::cds_convention> cds_conventions;
+        std::uint32_t total_available_count;
+        QString error_message;
+        QString error_details;
+    };
+
+    void fetch_cds_conventions(std::uint32_t offset, std::uint32_t limit);
+
+    ClientManager* clientManager_;
+    std::vector<refdata::domain::cds_convention> cds_conventions_;
+    QFutureWatcher<FetchResult>* watcher_;
+    std::uint32_t page_size_{100};
+    std::uint32_t total_available_count_{0};
+    bool is_fetching_{false};
+
+    using CdsConventionKeyExtractor = std::string(*)(const refdata::domain::cds_convention&);
+    RecencyTracker<refdata::domain::cds_convention, CdsConventionKeyExtractor> recencyTracker_;
+    RecencyPulseManager* pulseManager_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/ClientFraConventionModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientFraConventionModel.hpp
@@ -1,0 +1,142 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CLIENT_FRA_CONVENTION_MODEL_HPP
+#define ORES_QT_CLIENT_FRA_CONVENTION_MODEL_HPP
+
+#include <vector>
+#include <QFutureWatcher>
+#include "ores.qt/AbstractClientModel.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/RecencyPulseManager.hpp"
+#include "ores.qt/RecencyTracker.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/fra_convention.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief Model for displaying FRA conventions fetched from the server.
+ *
+ * This model extends AbstractClientModel and fetches FRA convention
+ * data asynchronously using the ores.comms client.
+ */
+class ClientFraConventionModel final : public AbstractClientModel {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.client_fra_convention_model";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    /**
+     * @brief Enumeration of table columns for type-safe column access.
+     */
+    enum Column {
+        Id,
+        Index,
+        Version,
+        ModifiedBy,
+        RecordedAt,
+        ColumnCount
+    };
+
+    explicit ClientFraConventionModel(ClientManager* clientManager,
+                                       QObject* parent = nullptr);
+    ~ClientFraConventionModel() override = default;
+
+    // QAbstractTableModel interface
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+        int role = Qt::DisplayRole) const override;
+
+    /**
+     * @brief Refresh FRA convention data from server asynchronously.
+     */
+    void refresh();
+
+    /**
+     * @brief Get FRA convention at the specified row.
+     *
+     * @param row The row index.
+     * @return The FRA convention, or nullptr if row is invalid.
+     */
+    const refdata::domain::fra_convention* getConvention(int row) const;
+
+    /**
+     * @brief Load a specific page of data.
+     */
+    void load_page(std::uint32_t offset, std::uint32_t limit);
+
+    /**
+     * @brief Get the page size used for pagination.
+     */
+    std::uint32_t page_size() const { return page_size_; }
+
+    /**
+     * @brief Set the page size for pagination.
+     */
+    void set_page_size(std::uint32_t size);
+
+    /**
+     * @brief Get the total number of records available on the server.
+     */
+    std::uint32_t total_available_count() const { return total_available_count_; }
+
+private slots:
+    void onConventionsLoaded();
+    void onPulseStateChanged(bool isOn);
+    void onPulsingComplete();
+
+private:
+    QVariant recency_foreground_color(const std::string& code) const;
+
+    struct FetchResult {
+        bool success;
+        std::vector<refdata::domain::fra_convention> fra_conventions;
+        std::uint32_t total_available_count;
+        QString error_message;
+        QString error_details;
+    };
+
+    void fetch_fra_conventions(std::uint32_t offset, std::uint32_t limit);
+
+    ClientManager* clientManager_;
+    std::vector<refdata::domain::fra_convention> fra_conventions_;
+    QFutureWatcher<FetchResult>* watcher_;
+    std::uint32_t page_size_{100};
+    std::uint32_t total_available_count_{0};
+    bool is_fetching_{false};
+
+    using FraConventionKeyExtractor = std::string(*)(const refdata::domain::fra_convention&);
+    RecencyTracker<refdata::domain::fra_convention, FraConventionKeyExtractor> recencyTracker_;
+    RecencyPulseManager* pulseManager_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/ClientFxConventionModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientFxConventionModel.hpp
@@ -1,0 +1,144 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CLIENT_FX_CONVENTION_MODEL_HPP
+#define ORES_QT_CLIENT_FX_CONVENTION_MODEL_HPP
+
+#include <vector>
+#include <QFutureWatcher>
+#include "ores.qt/AbstractClientModel.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/RecencyPulseManager.hpp"
+#include "ores.qt/RecencyTracker.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/fx_convention.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief Model for displaying FX conventions fetched from the server.
+ *
+ * This model extends AbstractClientModel and fetches FX convention
+ * data asynchronously using the ores.comms client.
+ */
+class ClientFxConventionModel final : public AbstractClientModel {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.client_fx_convention_model";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    /**
+     * @brief Enumeration of table columns for type-safe column access.
+     */
+    enum Column {
+        Id,
+        SourceCurrency,
+        TargetCurrency,
+        SpotDays,
+        Version,
+        ModifiedBy,
+        RecordedAt,
+        ColumnCount
+    };
+
+    explicit ClientFxConventionModel(ClientManager* clientManager,
+                                       QObject* parent = nullptr);
+    ~ClientFxConventionModel() override = default;
+
+    // QAbstractTableModel interface
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+        int role = Qt::DisplayRole) const override;
+
+    /**
+     * @brief Refresh FX convention data from server asynchronously.
+     */
+    void refresh();
+
+    /**
+     * @brief Get FX convention at the specified row.
+     *
+     * @param row The row index.
+     * @return The FX convention, or nullptr if row is invalid.
+     */
+    const refdata::domain::fx_convention* getConvention(int row) const;
+
+    /**
+     * @brief Load a specific page of data.
+     */
+    void load_page(std::uint32_t offset, std::uint32_t limit);
+
+    /**
+     * @brief Get the page size used for pagination.
+     */
+    std::uint32_t page_size() const { return page_size_; }
+
+    /**
+     * @brief Set the page size for pagination.
+     */
+    void set_page_size(std::uint32_t size);
+
+    /**
+     * @brief Get the total number of records available on the server.
+     */
+    std::uint32_t total_available_count() const { return total_available_count_; }
+
+private slots:
+    void onConventionsLoaded();
+    void onPulseStateChanged(bool isOn);
+    void onPulsingComplete();
+
+private:
+    QVariant recency_foreground_color(const std::string& code) const;
+
+    struct FetchResult {
+        bool success;
+        std::vector<refdata::domain::fx_convention> fx_conventions;
+        std::uint32_t total_available_count;
+        QString error_message;
+        QString error_details;
+    };
+
+    void fetch_fx_conventions(std::uint32_t offset, std::uint32_t limit);
+
+    ClientManager* clientManager_;
+    std::vector<refdata::domain::fx_convention> fx_conventions_;
+    QFutureWatcher<FetchResult>* watcher_;
+    std::uint32_t page_size_{100};
+    std::uint32_t total_available_count_{0};
+    bool is_fetching_{false};
+
+    using FxConventionKeyExtractor = std::string(*)(const refdata::domain::fx_convention&);
+    RecencyTracker<refdata::domain::fx_convention, FxConventionKeyExtractor> recencyTracker_;
+    RecencyPulseManager* pulseManager_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/ClientIborIndexConventionModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientIborIndexConventionModel.hpp
@@ -1,0 +1,144 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CLIENT_IBOR_INDEX_CONVENTION_MODEL_HPP
+#define ORES_QT_CLIENT_IBOR_INDEX_CONVENTION_MODEL_HPP
+
+#include <vector>
+#include <QFutureWatcher>
+#include "ores.qt/AbstractClientModel.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/RecencyPulseManager.hpp"
+#include "ores.qt/RecencyTracker.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/ibor_index_convention.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief Model for displaying IBOR index conventions fetched from the server.
+ *
+ * This model extends AbstractClientModel and fetches IBOR index convention
+ * data asynchronously using the ores.comms client.
+ */
+class ClientIborIndexConventionModel final : public AbstractClientModel {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.client_ibor_index_convention_model";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    /**
+     * @brief Enumeration of table columns for type-safe column access.
+     */
+    enum Column {
+        Id,
+        FixingCalendar,
+        DayCountFraction,
+        SettlementDays,
+        Version,
+        ModifiedBy,
+        RecordedAt,
+        ColumnCount
+    };
+
+    explicit ClientIborIndexConventionModel(ClientManager* clientManager,
+                                       QObject* parent = nullptr);
+    ~ClientIborIndexConventionModel() override = default;
+
+    // QAbstractTableModel interface
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+        int role = Qt::DisplayRole) const override;
+
+    /**
+     * @brief Refresh IBOR index convention data from server asynchronously.
+     */
+    void refresh();
+
+    /**
+     * @brief Get IBOR index convention at the specified row.
+     *
+     * @param row The row index.
+     * @return The IBOR index convention, or nullptr if row is invalid.
+     */
+    const refdata::domain::ibor_index_convention* getConvention(int row) const;
+
+    /**
+     * @brief Load a specific page of data.
+     */
+    void load_page(std::uint32_t offset, std::uint32_t limit);
+
+    /**
+     * @brief Get the page size used for pagination.
+     */
+    std::uint32_t page_size() const { return page_size_; }
+
+    /**
+     * @brief Set the page size for pagination.
+     */
+    void set_page_size(std::uint32_t size);
+
+    /**
+     * @brief Get the total number of records available on the server.
+     */
+    std::uint32_t total_available_count() const { return total_available_count_; }
+
+private slots:
+    void onConventionsLoaded();
+    void onPulseStateChanged(bool isOn);
+    void onPulsingComplete();
+
+private:
+    QVariant recency_foreground_color(const std::string& code) const;
+
+    struct FetchResult {
+        bool success;
+        std::vector<refdata::domain::ibor_index_convention> ibor_index_conventions;
+        std::uint32_t total_available_count;
+        QString error_message;
+        QString error_details;
+    };
+
+    void fetch_ibor_index_conventions(std::uint32_t offset, std::uint32_t limit);
+
+    ClientManager* clientManager_;
+    std::vector<refdata::domain::ibor_index_convention> ibor_index_conventions_;
+    QFutureWatcher<FetchResult>* watcher_;
+    std::uint32_t page_size_{100};
+    std::uint32_t total_available_count_{0};
+    bool is_fetching_{false};
+
+    using IborIndexConventionKeyExtractor = std::string(*)(const refdata::domain::ibor_index_convention&);
+    RecencyTracker<refdata::domain::ibor_index_convention, IborIndexConventionKeyExtractor> recencyTracker_;
+    RecencyPulseManager* pulseManager_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/ClientOisConventionModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientOisConventionModel.hpp
@@ -1,0 +1,144 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CLIENT_OIS_CONVENTION_MODEL_HPP
+#define ORES_QT_CLIENT_OIS_CONVENTION_MODEL_HPP
+
+#include <vector>
+#include <QFutureWatcher>
+#include "ores.qt/AbstractClientModel.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/RecencyPulseManager.hpp"
+#include "ores.qt/RecencyTracker.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/ois_convention.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief Model for displaying OIS conventions fetched from the server.
+ *
+ * This model extends AbstractClientModel and fetches OIS convention
+ * data asynchronously using the ores.comms client.
+ */
+class ClientOisConventionModel final : public AbstractClientModel {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.client_ois_convention_model";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    /**
+     * @brief Enumeration of table columns for type-safe column access.
+     */
+    enum Column {
+        Id,
+        Index,
+        SpotLag,
+        FixedDayCountFraction,
+        Version,
+        ModifiedBy,
+        RecordedAt,
+        ColumnCount
+    };
+
+    explicit ClientOisConventionModel(ClientManager* clientManager,
+                                       QObject* parent = nullptr);
+    ~ClientOisConventionModel() override = default;
+
+    // QAbstractTableModel interface
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+        int role = Qt::DisplayRole) const override;
+
+    /**
+     * @brief Refresh OIS convention data from server asynchronously.
+     */
+    void refresh();
+
+    /**
+     * @brief Get OIS convention at the specified row.
+     *
+     * @param row The row index.
+     * @return The OIS convention, or nullptr if row is invalid.
+     */
+    const refdata::domain::ois_convention* getConvention(int row) const;
+
+    /**
+     * @brief Load a specific page of data.
+     */
+    void load_page(std::uint32_t offset, std::uint32_t limit);
+
+    /**
+     * @brief Get the page size used for pagination.
+     */
+    std::uint32_t page_size() const { return page_size_; }
+
+    /**
+     * @brief Set the page size for pagination.
+     */
+    void set_page_size(std::uint32_t size);
+
+    /**
+     * @brief Get the total number of records available on the server.
+     */
+    std::uint32_t total_available_count() const { return total_available_count_; }
+
+private slots:
+    void onConventionsLoaded();
+    void onPulseStateChanged(bool isOn);
+    void onPulsingComplete();
+
+private:
+    QVariant recency_foreground_color(const std::string& code) const;
+
+    struct FetchResult {
+        bool success;
+        std::vector<refdata::domain::ois_convention> ois_conventions;
+        std::uint32_t total_available_count;
+        QString error_message;
+        QString error_details;
+    };
+
+    void fetch_ois_conventions(std::uint32_t offset, std::uint32_t limit);
+
+    ClientManager* clientManager_;
+    std::vector<refdata::domain::ois_convention> ois_conventions_;
+    QFutureWatcher<FetchResult>* watcher_;
+    std::uint32_t page_size_{100};
+    std::uint32_t total_available_count_{0};
+    bool is_fetching_{false};
+
+    using OisConventionKeyExtractor = std::string(*)(const refdata::domain::ois_convention&);
+    RecencyTracker<refdata::domain::ois_convention, OisConventionKeyExtractor> recencyTracker_;
+    RecencyPulseManager* pulseManager_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/ClientOvernightIndexConventionModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientOvernightIndexConventionModel.hpp
@@ -1,0 +1,144 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CLIENT_OVERNIGHT_INDEX_CONVENTION_MODEL_HPP
+#define ORES_QT_CLIENT_OVERNIGHT_INDEX_CONVENTION_MODEL_HPP
+
+#include <vector>
+#include <QFutureWatcher>
+#include "ores.qt/AbstractClientModel.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/RecencyPulseManager.hpp"
+#include "ores.qt/RecencyTracker.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/overnight_index_convention.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief Model for displaying overnight index conventions fetched from the server.
+ *
+ * This model extends AbstractClientModel and fetches overnight index convention
+ * data asynchronously using the ores.comms client.
+ */
+class ClientOvernightIndexConventionModel final : public AbstractClientModel {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.client_overnight_index_convention_model";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    /**
+     * @brief Enumeration of table columns for type-safe column access.
+     */
+    enum Column {
+        Id,
+        FixingCalendar,
+        DayCountFraction,
+        SettlementDays,
+        Version,
+        ModifiedBy,
+        RecordedAt,
+        ColumnCount
+    };
+
+    explicit ClientOvernightIndexConventionModel(ClientManager* clientManager,
+                                       QObject* parent = nullptr);
+    ~ClientOvernightIndexConventionModel() override = default;
+
+    // QAbstractTableModel interface
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+        int role = Qt::DisplayRole) const override;
+
+    /**
+     * @brief Refresh overnight index convention data from server asynchronously.
+     */
+    void refresh();
+
+    /**
+     * @brief Get overnight index convention at the specified row.
+     *
+     * @param row The row index.
+     * @return The overnight index convention, or nullptr if row is invalid.
+     */
+    const refdata::domain::overnight_index_convention* getConvention(int row) const;
+
+    /**
+     * @brief Load a specific page of data.
+     */
+    void load_page(std::uint32_t offset, std::uint32_t limit);
+
+    /**
+     * @brief Get the page size used for pagination.
+     */
+    std::uint32_t page_size() const { return page_size_; }
+
+    /**
+     * @brief Set the page size for pagination.
+     */
+    void set_page_size(std::uint32_t size);
+
+    /**
+     * @brief Get the total number of records available on the server.
+     */
+    std::uint32_t total_available_count() const { return total_available_count_; }
+
+private slots:
+    void onConventionsLoaded();
+    void onPulseStateChanged(bool isOn);
+    void onPulsingComplete();
+
+private:
+    QVariant recency_foreground_color(const std::string& code) const;
+
+    struct FetchResult {
+        bool success;
+        std::vector<refdata::domain::overnight_index_convention> overnight_index_conventions;
+        std::uint32_t total_available_count;
+        QString error_message;
+        QString error_details;
+    };
+
+    void fetch_overnight_index_conventions(std::uint32_t offset, std::uint32_t limit);
+
+    ClientManager* clientManager_;
+    std::vector<refdata::domain::overnight_index_convention> overnight_index_conventions_;
+    QFutureWatcher<FetchResult>* watcher_;
+    std::uint32_t page_size_{100};
+    std::uint32_t total_available_count_{0};
+    bool is_fetching_{false};
+
+    using OvernightIndexConventionKeyExtractor = std::string(*)(const refdata::domain::overnight_index_convention&);
+    RecencyTracker<refdata::domain::overnight_index_convention, OvernightIndexConventionKeyExtractor> recencyTracker_;
+    RecencyPulseManager* pulseManager_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/ClientSwapConventionModel.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/ClientSwapConventionModel.hpp
@@ -1,0 +1,144 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_CLIENT_SWAP_CONVENTION_MODEL_HPP
+#define ORES_QT_CLIENT_SWAP_CONVENTION_MODEL_HPP
+
+#include <vector>
+#include <QFutureWatcher>
+#include "ores.qt/AbstractClientModel.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/RecencyPulseManager.hpp"
+#include "ores.qt/RecencyTracker.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/swap_convention.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief Model for displaying swap conventions fetched from the server.
+ *
+ * This model extends AbstractClientModel and fetches swap convention
+ * data asynchronously using the ores.comms client.
+ */
+class ClientSwapConventionModel final : public AbstractClientModel {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.client_swap_convention_model";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    /**
+     * @brief Enumeration of table columns for type-safe column access.
+     */
+    enum Column {
+        Id,
+        FixedFrequency,
+        FixedDayCountFraction,
+        Index,
+        Version,
+        ModifiedBy,
+        RecordedAt,
+        ColumnCount
+    };
+
+    explicit ClientSwapConventionModel(ClientManager* clientManager,
+                                       QObject* parent = nullptr);
+    ~ClientSwapConventionModel() override = default;
+
+    // QAbstractTableModel interface
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+        int role = Qt::DisplayRole) const override;
+
+    /**
+     * @brief Refresh swap convention data from server asynchronously.
+     */
+    void refresh();
+
+    /**
+     * @brief Get swap convention at the specified row.
+     *
+     * @param row The row index.
+     * @return The swap convention, or nullptr if row is invalid.
+     */
+    const refdata::domain::swap_convention* getConvention(int row) const;
+
+    /**
+     * @brief Load a specific page of data.
+     */
+    void load_page(std::uint32_t offset, std::uint32_t limit);
+
+    /**
+     * @brief Get the page size used for pagination.
+     */
+    std::uint32_t page_size() const { return page_size_; }
+
+    /**
+     * @brief Set the page size for pagination.
+     */
+    void set_page_size(std::uint32_t size);
+
+    /**
+     * @brief Get the total number of records available on the server.
+     */
+    std::uint32_t total_available_count() const { return total_available_count_; }
+
+private slots:
+    void onConventionsLoaded();
+    void onPulseStateChanged(bool isOn);
+    void onPulsingComplete();
+
+private:
+    QVariant recency_foreground_color(const std::string& code) const;
+
+    struct FetchResult {
+        bool success;
+        std::vector<refdata::domain::swap_convention> swap_conventions;
+        std::uint32_t total_available_count;
+        QString error_message;
+        QString error_details;
+    };
+
+    void fetch_swap_conventions(std::uint32_t offset, std::uint32_t limit);
+
+    ClientManager* clientManager_;
+    std::vector<refdata::domain::swap_convention> swap_conventions_;
+    QFutureWatcher<FetchResult>* watcher_;
+    std::uint32_t page_size_{100};
+    std::uint32_t total_available_count_{0};
+    bool is_fetching_{false};
+
+    using SwapConventionKeyExtractor = std::string(*)(const refdata::domain::swap_convention&);
+    RecencyTracker<refdata::domain::swap_convention, SwapConventionKeyExtractor> recencyTracker_;
+    RecencyPulseManager* pulseManager_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/FraConventionController.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/FraConventionController.hpp
@@ -1,0 +1,93 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_FRA_CONVENTION_CONTROLLER_HPP
+#define ORES_QT_FRA_CONVENTION_CONTROLLER_HPP
+
+#include <QMdiArea>
+#include <QMainWindow>
+#include "ores.qt/EntityController.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/fra_convention.hpp"
+#include "ores.qt/EntityListMdiWindow.hpp"
+
+namespace ores::qt {
+
+class FraConventionMdiWindow;
+class DetachableMdiSubWindow;
+
+/**
+ * @brief Controller for managing FRA convention windows and operations.
+ *
+ * Manages the lifecycle of FRA convention list, detail, and history windows.
+ * Handles event subscriptions and coordinates between windows.
+ */
+class FraConventionController final : public EntityController {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.fra_convention_controller";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    FraConventionController(
+        QMainWindow* mainWindow,
+        QMdiArea* mdiArea,
+        ClientManager* clientManager,
+        const QString& username,
+        QObject* parent = nullptr);
+
+    void showListWindow() override;
+    void closeAllWindows() override;
+    void reloadListWindow() override;
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& error);
+
+protected:
+    EntityListMdiWindow* listWindow() const override;
+
+private slots:
+    void onShowDetails(const refdata::domain::fra_convention& fc);
+    void onAddNewRequested();
+    void onShowHistory(const refdata::domain::fra_convention& fc);
+    void onRevertVersion(const refdata::domain::fra_convention& fc);
+    void onOpenVersion(const refdata::domain::fra_convention& fc,
+                       int versionNumber);
+
+private:
+    void showAddWindow();
+    void showDetailWindow(const refdata::domain::fra_convention& fc);
+    void showHistoryWindow(const QString& code);
+
+    FraConventionMdiWindow* listWindow_;
+    DetachableMdiSubWindow* listMdiSubWindow_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/FraConventionDetailDialog.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/FraConventionDetailDialog.hpp
@@ -1,0 +1,104 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_FRA_CONVENTION_DETAIL_DIALOG_HPP
+#define ORES_QT_FRA_CONVENTION_DETAIL_DIALOG_HPP
+
+#include <vector>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/DetailDialogBase.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/fra_convention.hpp"
+
+
+namespace Ui {
+class FraConventionDetailDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Detail dialog for viewing and editing FRA convention records.
+ *
+ * This dialog allows viewing, creating, and editing FRA conventions.
+ * It supports both create mode (for new records) and edit mode (for
+ * existing records).
+ */
+class FraConventionDetailDialog final : public DetailDialogBase {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.fra_convention_detail_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit FraConventionDetailDialog(QWidget* parent = nullptr);
+    ~FraConventionDetailDialog() override;
+
+    void setClientManager(ClientManager* clientManager);
+    void setUsername(const std::string& username);
+    void setConvention(const refdata::domain::fra_convention& fc);
+    void setCreateMode(bool createMode);
+    void setReadOnly(bool readOnly);
+
+
+signals:
+    void fcSaved(const QString& code);
+    void fcDeleted(const QString& code);
+
+private slots:
+    void onSaveClicked();
+    void onDeleteClicked();
+    void onCodeChanged(const QString& text);
+    void onFieldChanged();
+
+protected:
+    QTabWidget* tabWidget() const override;
+    QWidget* provenanceTab() const override;
+    ProvenanceWidget* provenanceWidget() const override;
+    bool hasUnsavedChanges() const override { return hasChanges_; }
+
+private:
+    void setupUi();
+    void setupConnections();
+    void updateUiFromConvention();
+    void updateConventionFromUi();
+    void updateSaveButtonState();
+    bool validateInput();
+
+
+    Ui::FraConventionDetailDialog* ui_;
+    ClientManager* clientManager_;
+    std::string username_;
+    refdata::domain::fra_convention fc_;
+    bool createMode_{true};
+    bool readOnly_{false};
+    bool hasChanges_{false};
+
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/FraConventionHistoryDialog.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/FraConventionHistoryDialog.hpp
@@ -1,0 +1,97 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_FRA_CONVENTION_HISTORY_DIALOG_HPP
+#define ORES_QT_FRA_CONVENTION_HISTORY_DIALOG_HPP
+
+#include <QWidget>
+#include <QToolBar>
+#include <QTableWidget>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/fra_convention.hpp"
+
+namespace Ui {
+class FraConventionHistoryDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Dialog for viewing the version history of a FRA convention.
+ *
+ * Shows all historical versions of a FRA convention with ability
+ * to view details or revert to a previous version.
+ */
+class FraConventionHistoryDialog final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.fra_convention_history_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit FraConventionHistoryDialog(
+        const QString& code,
+        ClientManager* clientManager,
+        QWidget* parent = nullptr);
+    ~FraConventionHistoryDialog() override;
+
+    void loadHistory();
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void openVersionRequested(const refdata::domain::fra_convention& fc,
+                              int versionNumber);
+    void revertVersionRequested(const refdata::domain::fra_convention& fc);
+
+private slots:
+    void onVersionSelected();
+    void onOpenVersionClicked();
+    void onRevertClicked();
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupConnections();
+    void updateVersionList();
+    void updateChangesTable(int currentVersionIndex);
+    void updateFullDetails(int versionIndex);
+    void updateActionStates();
+
+    Ui::FraConventionHistoryDialog* ui_;
+    QString code_;
+    ClientManager* clientManager_;
+    std::vector<refdata::domain::fra_convention> versions_;
+
+    QToolBar* toolbar_;
+    QAction* openVersionAction_;
+    QAction* revertAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/FraConventionMdiWindow.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/FraConventionMdiWindow.hpp
@@ -1,0 +1,115 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_FRA_CONVENTION_MDI_WINDOW_HPP
+#define ORES_QT_FRA_CONVENTION_MDI_WINDOW_HPP
+
+#include <QToolBar>
+#include <QTableView>
+#include <QSortFilterProxyModel>
+#include "ores.qt/EntityListMdiWindow.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ClientFraConventionModel.hpp"
+#include "ores.qt/PaginationWidget.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/fra_convention.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief MDI window for displaying and managing FRA conventions.
+ *
+ * Provides a table view of FRA conventions with toolbar actions
+ * for reload, add, edit, delete, and viewing history.
+ */
+class FraConventionMdiWindow final : public EntityListMdiWindow {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.fra_convention_mdi_window";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit FraConventionMdiWindow(
+        ClientManager* clientManager,
+        const QString& username,
+        QWidget* parent = nullptr);
+    ~FraConventionMdiWindow() override = default;
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void showConventionDetails(const refdata::domain::fra_convention& fc);
+    void addNewRequested();
+    void fcDeleted(const QString& code);
+    void showConventionHistory(const refdata::domain::fra_convention& fc);
+
+public slots:
+    void addNew();
+    void editSelected();
+    void deleteSelected();
+    void viewHistorySelected();
+
+protected:
+    void doReload() override;
+
+private slots:
+    void onDataLoaded();
+    void onLoadError(const QString& error_message, const QString& details = {});
+    void onSelectionChanged();
+    void onDoubleClicked(const QModelIndex& index);
+
+protected:
+    QString normalRefreshTooltip() const override {
+        return tr("Refresh FRA conventions");
+    }
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupTable();
+    void setupConnections();
+    void updateActionStates();
+
+    ClientManager* clientManager_;
+    QString username_;
+
+    QToolBar* toolbar_;
+    QTableView* tableView_;
+    ClientFraConventionModel* model_;
+    QSortFilterProxyModel* proxyModel_;
+    PaginationWidget* paginationWidget_;
+
+    // Toolbar actions
+    QAction* reloadAction_;
+    QAction* addAction_;
+    QAction* editAction_;
+    QAction* deleteAction_;
+    QAction* historyAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/FxConventionController.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/FxConventionController.hpp
@@ -1,0 +1,93 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_FX_CONVENTION_CONTROLLER_HPP
+#define ORES_QT_FX_CONVENTION_CONTROLLER_HPP
+
+#include <QMdiArea>
+#include <QMainWindow>
+#include "ores.qt/EntityController.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/fx_convention.hpp"
+#include "ores.qt/EntityListMdiWindow.hpp"
+
+namespace ores::qt {
+
+class FxConventionMdiWindow;
+class DetachableMdiSubWindow;
+
+/**
+ * @brief Controller for managing FX convention windows and operations.
+ *
+ * Manages the lifecycle of FX convention list, detail, and history windows.
+ * Handles event subscriptions and coordinates between windows.
+ */
+class FxConventionController final : public EntityController {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.fx_convention_controller";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    FxConventionController(
+        QMainWindow* mainWindow,
+        QMdiArea* mdiArea,
+        ClientManager* clientManager,
+        const QString& username,
+        QObject* parent = nullptr);
+
+    void showListWindow() override;
+    void closeAllWindows() override;
+    void reloadListWindow() override;
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& error);
+
+protected:
+    EntityListMdiWindow* listWindow() const override;
+
+private slots:
+    void onShowDetails(const refdata::domain::fx_convention& fxc);
+    void onAddNewRequested();
+    void onShowHistory(const refdata::domain::fx_convention& fxc);
+    void onRevertVersion(const refdata::domain::fx_convention& fxc);
+    void onOpenVersion(const refdata::domain::fx_convention& fxc,
+                       int versionNumber);
+
+private:
+    void showAddWindow();
+    void showDetailWindow(const refdata::domain::fx_convention& fxc);
+    void showHistoryWindow(const QString& code);
+
+    FxConventionMdiWindow* listWindow_;
+    DetachableMdiSubWindow* listMdiSubWindow_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/FxConventionDetailDialog.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/FxConventionDetailDialog.hpp
@@ -1,0 +1,104 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_FX_CONVENTION_DETAIL_DIALOG_HPP
+#define ORES_QT_FX_CONVENTION_DETAIL_DIALOG_HPP
+
+#include <vector>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/DetailDialogBase.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/fx_convention.hpp"
+
+
+namespace Ui {
+class FxConventionDetailDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Detail dialog for viewing and editing FX convention records.
+ *
+ * This dialog allows viewing, creating, and editing FX conventions.
+ * It supports both create mode (for new records) and edit mode (for
+ * existing records).
+ */
+class FxConventionDetailDialog final : public DetailDialogBase {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.fx_convention_detail_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit FxConventionDetailDialog(QWidget* parent = nullptr);
+    ~FxConventionDetailDialog() override;
+
+    void setClientManager(ClientManager* clientManager);
+    void setUsername(const std::string& username);
+    void setConvention(const refdata::domain::fx_convention& fxc);
+    void setCreateMode(bool createMode);
+    void setReadOnly(bool readOnly);
+
+
+signals:
+    void fxcSaved(const QString& code);
+    void fxcDeleted(const QString& code);
+
+private slots:
+    void onSaveClicked();
+    void onDeleteClicked();
+    void onCodeChanged(const QString& text);
+    void onFieldChanged();
+
+protected:
+    QTabWidget* tabWidget() const override;
+    QWidget* provenanceTab() const override;
+    ProvenanceWidget* provenanceWidget() const override;
+    bool hasUnsavedChanges() const override { return hasChanges_; }
+
+private:
+    void setupUi();
+    void setupConnections();
+    void updateUiFromConvention();
+    void updateConventionFromUi();
+    void updateSaveButtonState();
+    bool validateInput();
+
+
+    Ui::FxConventionDetailDialog* ui_;
+    ClientManager* clientManager_;
+    std::string username_;
+    refdata::domain::fx_convention fxc_;
+    bool createMode_{true};
+    bool readOnly_{false};
+    bool hasChanges_{false};
+
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/FxConventionHistoryDialog.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/FxConventionHistoryDialog.hpp
@@ -1,0 +1,97 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_FX_CONVENTION_HISTORY_DIALOG_HPP
+#define ORES_QT_FX_CONVENTION_HISTORY_DIALOG_HPP
+
+#include <QWidget>
+#include <QToolBar>
+#include <QTableWidget>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/fx_convention.hpp"
+
+namespace Ui {
+class FxConventionHistoryDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Dialog for viewing the version history of a FX convention.
+ *
+ * Shows all historical versions of a FX convention with ability
+ * to view details or revert to a previous version.
+ */
+class FxConventionHistoryDialog final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.fx_convention_history_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit FxConventionHistoryDialog(
+        const QString& code,
+        ClientManager* clientManager,
+        QWidget* parent = nullptr);
+    ~FxConventionHistoryDialog() override;
+
+    void loadHistory();
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void openVersionRequested(const refdata::domain::fx_convention& fxc,
+                              int versionNumber);
+    void revertVersionRequested(const refdata::domain::fx_convention& fxc);
+
+private slots:
+    void onVersionSelected();
+    void onOpenVersionClicked();
+    void onRevertClicked();
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupConnections();
+    void updateVersionList();
+    void updateChangesTable(int currentVersionIndex);
+    void updateFullDetails(int versionIndex);
+    void updateActionStates();
+
+    Ui::FxConventionHistoryDialog* ui_;
+    QString code_;
+    ClientManager* clientManager_;
+    std::vector<refdata::domain::fx_convention> versions_;
+
+    QToolBar* toolbar_;
+    QAction* openVersionAction_;
+    QAction* revertAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/FxConventionMdiWindow.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/FxConventionMdiWindow.hpp
@@ -1,0 +1,115 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_FX_CONVENTION_MDI_WINDOW_HPP
+#define ORES_QT_FX_CONVENTION_MDI_WINDOW_HPP
+
+#include <QToolBar>
+#include <QTableView>
+#include <QSortFilterProxyModel>
+#include "ores.qt/EntityListMdiWindow.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ClientFxConventionModel.hpp"
+#include "ores.qt/PaginationWidget.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/fx_convention.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief MDI window for displaying and managing FX conventions.
+ *
+ * Provides a table view of FX conventions with toolbar actions
+ * for reload, add, edit, delete, and viewing history.
+ */
+class FxConventionMdiWindow final : public EntityListMdiWindow {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.fx_convention_mdi_window";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit FxConventionMdiWindow(
+        ClientManager* clientManager,
+        const QString& username,
+        QWidget* parent = nullptr);
+    ~FxConventionMdiWindow() override = default;
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void showConventionDetails(const refdata::domain::fx_convention& fxc);
+    void addNewRequested();
+    void fxcDeleted(const QString& code);
+    void showConventionHistory(const refdata::domain::fx_convention& fxc);
+
+public slots:
+    void addNew();
+    void editSelected();
+    void deleteSelected();
+    void viewHistorySelected();
+
+protected:
+    void doReload() override;
+
+private slots:
+    void onDataLoaded();
+    void onLoadError(const QString& error_message, const QString& details = {});
+    void onSelectionChanged();
+    void onDoubleClicked(const QModelIndex& index);
+
+protected:
+    QString normalRefreshTooltip() const override {
+        return tr("Refresh FX conventions");
+    }
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupTable();
+    void setupConnections();
+    void updateActionStates();
+
+    ClientManager* clientManager_;
+    QString username_;
+
+    QToolBar* toolbar_;
+    QTableView* tableView_;
+    ClientFxConventionModel* model_;
+    QSortFilterProxyModel* proxyModel_;
+    PaginationWidget* paginationWidget_;
+
+    // Toolbar actions
+    QAction* reloadAction_;
+    QAction* addAction_;
+    QAction* editAction_;
+    QAction* deleteAction_;
+    QAction* historyAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/IborIndexConventionController.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/IborIndexConventionController.hpp
@@ -1,0 +1,93 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_IBOR_INDEX_CONVENTION_CONTROLLER_HPP
+#define ORES_QT_IBOR_INDEX_CONVENTION_CONTROLLER_HPP
+
+#include <QMdiArea>
+#include <QMainWindow>
+#include "ores.qt/EntityController.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/ibor_index_convention.hpp"
+#include "ores.qt/EntityListMdiWindow.hpp"
+
+namespace ores::qt {
+
+class IborIndexConventionMdiWindow;
+class DetachableMdiSubWindow;
+
+/**
+ * @brief Controller for managing IBOR index convention windows and operations.
+ *
+ * Manages the lifecycle of IBOR index convention list, detail, and history windows.
+ * Handles event subscriptions and coordinates between windows.
+ */
+class IborIndexConventionController final : public EntityController {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.ibor_index_convention_controller";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    IborIndexConventionController(
+        QMainWindow* mainWindow,
+        QMdiArea* mdiArea,
+        ClientManager* clientManager,
+        const QString& username,
+        QObject* parent = nullptr);
+
+    void showListWindow() override;
+    void closeAllWindows() override;
+    void reloadListWindow() override;
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& error);
+
+protected:
+    EntityListMdiWindow* listWindow() const override;
+
+private slots:
+    void onShowDetails(const refdata::domain::ibor_index_convention& ic);
+    void onAddNewRequested();
+    void onShowHistory(const refdata::domain::ibor_index_convention& ic);
+    void onRevertVersion(const refdata::domain::ibor_index_convention& ic);
+    void onOpenVersion(const refdata::domain::ibor_index_convention& ic,
+                       int versionNumber);
+
+private:
+    void showAddWindow();
+    void showDetailWindow(const refdata::domain::ibor_index_convention& ic);
+    void showHistoryWindow(const QString& code);
+
+    IborIndexConventionMdiWindow* listWindow_;
+    DetachableMdiSubWindow* listMdiSubWindow_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/IborIndexConventionDetailDialog.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/IborIndexConventionDetailDialog.hpp
@@ -1,0 +1,104 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_IBOR_INDEX_CONVENTION_DETAIL_DIALOG_HPP
+#define ORES_QT_IBOR_INDEX_CONVENTION_DETAIL_DIALOG_HPP
+
+#include <vector>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/DetailDialogBase.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/ibor_index_convention.hpp"
+
+
+namespace Ui {
+class IborIndexConventionDetailDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Detail dialog for viewing and editing IBOR index convention records.
+ *
+ * This dialog allows viewing, creating, and editing IBOR index conventions.
+ * It supports both create mode (for new records) and edit mode (for
+ * existing records).
+ */
+class IborIndexConventionDetailDialog final : public DetailDialogBase {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.ibor_index_convention_detail_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit IborIndexConventionDetailDialog(QWidget* parent = nullptr);
+    ~IborIndexConventionDetailDialog() override;
+
+    void setClientManager(ClientManager* clientManager);
+    void setUsername(const std::string& username);
+    void setConvention(const refdata::domain::ibor_index_convention& ic);
+    void setCreateMode(bool createMode);
+    void setReadOnly(bool readOnly);
+
+
+signals:
+    void icSaved(const QString& code);
+    void icDeleted(const QString& code);
+
+private slots:
+    void onSaveClicked();
+    void onDeleteClicked();
+    void onCodeChanged(const QString& text);
+    void onFieldChanged();
+
+protected:
+    QTabWidget* tabWidget() const override;
+    QWidget* provenanceTab() const override;
+    ProvenanceWidget* provenanceWidget() const override;
+    bool hasUnsavedChanges() const override { return hasChanges_; }
+
+private:
+    void setupUi();
+    void setupConnections();
+    void updateUiFromConvention();
+    void updateConventionFromUi();
+    void updateSaveButtonState();
+    bool validateInput();
+
+
+    Ui::IborIndexConventionDetailDialog* ui_;
+    ClientManager* clientManager_;
+    std::string username_;
+    refdata::domain::ibor_index_convention ic_;
+    bool createMode_{true};
+    bool readOnly_{false};
+    bool hasChanges_{false};
+
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/IborIndexConventionHistoryDialog.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/IborIndexConventionHistoryDialog.hpp
@@ -1,0 +1,97 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_IBOR_INDEX_CONVENTION_HISTORY_DIALOG_HPP
+#define ORES_QT_IBOR_INDEX_CONVENTION_HISTORY_DIALOG_HPP
+
+#include <QWidget>
+#include <QToolBar>
+#include <QTableWidget>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/ibor_index_convention.hpp"
+
+namespace Ui {
+class IborIndexConventionHistoryDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Dialog for viewing the version history of a IBOR index convention.
+ *
+ * Shows all historical versions of a IBOR index convention with ability
+ * to view details or revert to a previous version.
+ */
+class IborIndexConventionHistoryDialog final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.ibor_index_convention_history_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit IborIndexConventionHistoryDialog(
+        const QString& code,
+        ClientManager* clientManager,
+        QWidget* parent = nullptr);
+    ~IborIndexConventionHistoryDialog() override;
+
+    void loadHistory();
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void openVersionRequested(const refdata::domain::ibor_index_convention& ic,
+                              int versionNumber);
+    void revertVersionRequested(const refdata::domain::ibor_index_convention& ic);
+
+private slots:
+    void onVersionSelected();
+    void onOpenVersionClicked();
+    void onRevertClicked();
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupConnections();
+    void updateVersionList();
+    void updateChangesTable(int currentVersionIndex);
+    void updateFullDetails(int versionIndex);
+    void updateActionStates();
+
+    Ui::IborIndexConventionHistoryDialog* ui_;
+    QString code_;
+    ClientManager* clientManager_;
+    std::vector<refdata::domain::ibor_index_convention> versions_;
+
+    QToolBar* toolbar_;
+    QAction* openVersionAction_;
+    QAction* revertAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/IborIndexConventionMdiWindow.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/IborIndexConventionMdiWindow.hpp
@@ -1,0 +1,115 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_IBOR_INDEX_CONVENTION_MDI_WINDOW_HPP
+#define ORES_QT_IBOR_INDEX_CONVENTION_MDI_WINDOW_HPP
+
+#include <QToolBar>
+#include <QTableView>
+#include <QSortFilterProxyModel>
+#include "ores.qt/EntityListMdiWindow.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ClientIborIndexConventionModel.hpp"
+#include "ores.qt/PaginationWidget.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/ibor_index_convention.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief MDI window for displaying and managing IBOR index conventions.
+ *
+ * Provides a table view of IBOR index conventions with toolbar actions
+ * for reload, add, edit, delete, and viewing history.
+ */
+class IborIndexConventionMdiWindow final : public EntityListMdiWindow {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.ibor_index_convention_mdi_window";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit IborIndexConventionMdiWindow(
+        ClientManager* clientManager,
+        const QString& username,
+        QWidget* parent = nullptr);
+    ~IborIndexConventionMdiWindow() override = default;
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void showConventionDetails(const refdata::domain::ibor_index_convention& ic);
+    void addNewRequested();
+    void icDeleted(const QString& code);
+    void showConventionHistory(const refdata::domain::ibor_index_convention& ic);
+
+public slots:
+    void addNew();
+    void editSelected();
+    void deleteSelected();
+    void viewHistorySelected();
+
+protected:
+    void doReload() override;
+
+private slots:
+    void onDataLoaded();
+    void onLoadError(const QString& error_message, const QString& details = {});
+    void onSelectionChanged();
+    void onDoubleClicked(const QModelIndex& index);
+
+protected:
+    QString normalRefreshTooltip() const override {
+        return tr("Refresh IBOR index conventions");
+    }
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupTable();
+    void setupConnections();
+    void updateActionStates();
+
+    ClientManager* clientManager_;
+    QString username_;
+
+    QToolBar* toolbar_;
+    QTableView* tableView_;
+    ClientIborIndexConventionModel* model_;
+    QSortFilterProxyModel* proxyModel_;
+    PaginationWidget* paginationWidget_;
+
+    // Toolbar actions
+    QAction* reloadAction_;
+    QAction* addAction_;
+    QAction* editAction_;
+    QAction* deleteAction_;
+    QAction* historyAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/OisConventionController.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/OisConventionController.hpp
@@ -1,0 +1,93 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_OIS_CONVENTION_CONTROLLER_HPP
+#define ORES_QT_OIS_CONVENTION_CONTROLLER_HPP
+
+#include <QMdiArea>
+#include <QMainWindow>
+#include "ores.qt/EntityController.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/ois_convention.hpp"
+#include "ores.qt/EntityListMdiWindow.hpp"
+
+namespace ores::qt {
+
+class OisConventionMdiWindow;
+class DetachableMdiSubWindow;
+
+/**
+ * @brief Controller for managing OIS convention windows and operations.
+ *
+ * Manages the lifecycle of OIS convention list, detail, and history windows.
+ * Handles event subscriptions and coordinates between windows.
+ */
+class OisConventionController final : public EntityController {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.ois_convention_controller";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    OisConventionController(
+        QMainWindow* mainWindow,
+        QMdiArea* mdiArea,
+        ClientManager* clientManager,
+        const QString& username,
+        QObject* parent = nullptr);
+
+    void showListWindow() override;
+    void closeAllWindows() override;
+    void reloadListWindow() override;
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& error);
+
+protected:
+    EntityListMdiWindow* listWindow() const override;
+
+private slots:
+    void onShowDetails(const refdata::domain::ois_convention& oc);
+    void onAddNewRequested();
+    void onShowHistory(const refdata::domain::ois_convention& oc);
+    void onRevertVersion(const refdata::domain::ois_convention& oc);
+    void onOpenVersion(const refdata::domain::ois_convention& oc,
+                       int versionNumber);
+
+private:
+    void showAddWindow();
+    void showDetailWindow(const refdata::domain::ois_convention& oc);
+    void showHistoryWindow(const QString& code);
+
+    OisConventionMdiWindow* listWindow_;
+    DetachableMdiSubWindow* listMdiSubWindow_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/OisConventionDetailDialog.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/OisConventionDetailDialog.hpp
@@ -1,0 +1,104 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_OIS_CONVENTION_DETAIL_DIALOG_HPP
+#define ORES_QT_OIS_CONVENTION_DETAIL_DIALOG_HPP
+
+#include <vector>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/DetailDialogBase.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/ois_convention.hpp"
+
+
+namespace Ui {
+class OisConventionDetailDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Detail dialog for viewing and editing OIS convention records.
+ *
+ * This dialog allows viewing, creating, and editing OIS conventions.
+ * It supports both create mode (for new records) and edit mode (for
+ * existing records).
+ */
+class OisConventionDetailDialog final : public DetailDialogBase {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.ois_convention_detail_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit OisConventionDetailDialog(QWidget* parent = nullptr);
+    ~OisConventionDetailDialog() override;
+
+    void setClientManager(ClientManager* clientManager);
+    void setUsername(const std::string& username);
+    void setConvention(const refdata::domain::ois_convention& oc);
+    void setCreateMode(bool createMode);
+    void setReadOnly(bool readOnly);
+
+
+signals:
+    void ocSaved(const QString& code);
+    void ocDeleted(const QString& code);
+
+private slots:
+    void onSaveClicked();
+    void onDeleteClicked();
+    void onCodeChanged(const QString& text);
+    void onFieldChanged();
+
+protected:
+    QTabWidget* tabWidget() const override;
+    QWidget* provenanceTab() const override;
+    ProvenanceWidget* provenanceWidget() const override;
+    bool hasUnsavedChanges() const override { return hasChanges_; }
+
+private:
+    void setupUi();
+    void setupConnections();
+    void updateUiFromConvention();
+    void updateConventionFromUi();
+    void updateSaveButtonState();
+    bool validateInput();
+
+
+    Ui::OisConventionDetailDialog* ui_;
+    ClientManager* clientManager_;
+    std::string username_;
+    refdata::domain::ois_convention oc_;
+    bool createMode_{true};
+    bool readOnly_{false};
+    bool hasChanges_{false};
+
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/OisConventionHistoryDialog.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/OisConventionHistoryDialog.hpp
@@ -1,0 +1,97 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_OIS_CONVENTION_HISTORY_DIALOG_HPP
+#define ORES_QT_OIS_CONVENTION_HISTORY_DIALOG_HPP
+
+#include <QWidget>
+#include <QToolBar>
+#include <QTableWidget>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/ois_convention.hpp"
+
+namespace Ui {
+class OisConventionHistoryDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Dialog for viewing the version history of a OIS convention.
+ *
+ * Shows all historical versions of a OIS convention with ability
+ * to view details or revert to a previous version.
+ */
+class OisConventionHistoryDialog final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.ois_convention_history_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit OisConventionHistoryDialog(
+        const QString& code,
+        ClientManager* clientManager,
+        QWidget* parent = nullptr);
+    ~OisConventionHistoryDialog() override;
+
+    void loadHistory();
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void openVersionRequested(const refdata::domain::ois_convention& oc,
+                              int versionNumber);
+    void revertVersionRequested(const refdata::domain::ois_convention& oc);
+
+private slots:
+    void onVersionSelected();
+    void onOpenVersionClicked();
+    void onRevertClicked();
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupConnections();
+    void updateVersionList();
+    void updateChangesTable(int currentVersionIndex);
+    void updateFullDetails(int versionIndex);
+    void updateActionStates();
+
+    Ui::OisConventionHistoryDialog* ui_;
+    QString code_;
+    ClientManager* clientManager_;
+    std::vector<refdata::domain::ois_convention> versions_;
+
+    QToolBar* toolbar_;
+    QAction* openVersionAction_;
+    QAction* revertAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/OisConventionMdiWindow.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/OisConventionMdiWindow.hpp
@@ -1,0 +1,115 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_OIS_CONVENTION_MDI_WINDOW_HPP
+#define ORES_QT_OIS_CONVENTION_MDI_WINDOW_HPP
+
+#include <QToolBar>
+#include <QTableView>
+#include <QSortFilterProxyModel>
+#include "ores.qt/EntityListMdiWindow.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ClientOisConventionModel.hpp"
+#include "ores.qt/PaginationWidget.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/ois_convention.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief MDI window for displaying and managing OIS conventions.
+ *
+ * Provides a table view of OIS conventions with toolbar actions
+ * for reload, add, edit, delete, and viewing history.
+ */
+class OisConventionMdiWindow final : public EntityListMdiWindow {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.ois_convention_mdi_window";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit OisConventionMdiWindow(
+        ClientManager* clientManager,
+        const QString& username,
+        QWidget* parent = nullptr);
+    ~OisConventionMdiWindow() override = default;
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void showConventionDetails(const refdata::domain::ois_convention& oc);
+    void addNewRequested();
+    void ocDeleted(const QString& code);
+    void showConventionHistory(const refdata::domain::ois_convention& oc);
+
+public slots:
+    void addNew();
+    void editSelected();
+    void deleteSelected();
+    void viewHistorySelected();
+
+protected:
+    void doReload() override;
+
+private slots:
+    void onDataLoaded();
+    void onLoadError(const QString& error_message, const QString& details = {});
+    void onSelectionChanged();
+    void onDoubleClicked(const QModelIndex& index);
+
+protected:
+    QString normalRefreshTooltip() const override {
+        return tr("Refresh OIS conventions");
+    }
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupTable();
+    void setupConnections();
+    void updateActionStates();
+
+    ClientManager* clientManager_;
+    QString username_;
+
+    QToolBar* toolbar_;
+    QTableView* tableView_;
+    ClientOisConventionModel* model_;
+    QSortFilterProxyModel* proxyModel_;
+    PaginationWidget* paginationWidget_;
+
+    // Toolbar actions
+    QAction* reloadAction_;
+    QAction* addAction_;
+    QAction* editAction_;
+    QAction* deleteAction_;
+    QAction* historyAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/OvernightIndexConventionController.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/OvernightIndexConventionController.hpp
@@ -1,0 +1,93 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_OVERNIGHT_INDEX_CONVENTION_CONTROLLER_HPP
+#define ORES_QT_OVERNIGHT_INDEX_CONVENTION_CONTROLLER_HPP
+
+#include <QMdiArea>
+#include <QMainWindow>
+#include "ores.qt/EntityController.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/overnight_index_convention.hpp"
+#include "ores.qt/EntityListMdiWindow.hpp"
+
+namespace ores::qt {
+
+class OvernightIndexConventionMdiWindow;
+class DetachableMdiSubWindow;
+
+/**
+ * @brief Controller for managing overnight index convention windows and operations.
+ *
+ * Manages the lifecycle of overnight index convention list, detail, and history windows.
+ * Handles event subscriptions and coordinates between windows.
+ */
+class OvernightIndexConventionController final : public EntityController {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.overnight_index_convention_controller";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    OvernightIndexConventionController(
+        QMainWindow* mainWindow,
+        QMdiArea* mdiArea,
+        ClientManager* clientManager,
+        const QString& username,
+        QObject* parent = nullptr);
+
+    void showListWindow() override;
+    void closeAllWindows() override;
+    void reloadListWindow() override;
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& error);
+
+protected:
+    EntityListMdiWindow* listWindow() const override;
+
+private slots:
+    void onShowDetails(const refdata::domain::overnight_index_convention& ni);
+    void onAddNewRequested();
+    void onShowHistory(const refdata::domain::overnight_index_convention& ni);
+    void onRevertVersion(const refdata::domain::overnight_index_convention& ni);
+    void onOpenVersion(const refdata::domain::overnight_index_convention& ni,
+                       int versionNumber);
+
+private:
+    void showAddWindow();
+    void showDetailWindow(const refdata::domain::overnight_index_convention& ni);
+    void showHistoryWindow(const QString& code);
+
+    OvernightIndexConventionMdiWindow* listWindow_;
+    DetachableMdiSubWindow* listMdiSubWindow_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/OvernightIndexConventionDetailDialog.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/OvernightIndexConventionDetailDialog.hpp
@@ -1,0 +1,104 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_OVERNIGHT_INDEX_CONVENTION_DETAIL_DIALOG_HPP
+#define ORES_QT_OVERNIGHT_INDEX_CONVENTION_DETAIL_DIALOG_HPP
+
+#include <vector>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/DetailDialogBase.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/overnight_index_convention.hpp"
+
+
+namespace Ui {
+class OvernightIndexConventionDetailDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Detail dialog for viewing and editing overnight index convention records.
+ *
+ * This dialog allows viewing, creating, and editing overnight index conventions.
+ * It supports both create mode (for new records) and edit mode (for
+ * existing records).
+ */
+class OvernightIndexConventionDetailDialog final : public DetailDialogBase {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.overnight_index_convention_detail_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit OvernightIndexConventionDetailDialog(QWidget* parent = nullptr);
+    ~OvernightIndexConventionDetailDialog() override;
+
+    void setClientManager(ClientManager* clientManager);
+    void setUsername(const std::string& username);
+    void setConvention(const refdata::domain::overnight_index_convention& ni);
+    void setCreateMode(bool createMode);
+    void setReadOnly(bool readOnly);
+
+
+signals:
+    void niSaved(const QString& code);
+    void niDeleted(const QString& code);
+
+private slots:
+    void onSaveClicked();
+    void onDeleteClicked();
+    void onCodeChanged(const QString& text);
+    void onFieldChanged();
+
+protected:
+    QTabWidget* tabWidget() const override;
+    QWidget* provenanceTab() const override;
+    ProvenanceWidget* provenanceWidget() const override;
+    bool hasUnsavedChanges() const override { return hasChanges_; }
+
+private:
+    void setupUi();
+    void setupConnections();
+    void updateUiFromConvention();
+    void updateConventionFromUi();
+    void updateSaveButtonState();
+    bool validateInput();
+
+
+    Ui::OvernightIndexConventionDetailDialog* ui_;
+    ClientManager* clientManager_;
+    std::string username_;
+    refdata::domain::overnight_index_convention ni_;
+    bool createMode_{true};
+    bool readOnly_{false};
+    bool hasChanges_{false};
+
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/OvernightIndexConventionHistoryDialog.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/OvernightIndexConventionHistoryDialog.hpp
@@ -1,0 +1,97 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_OVERNIGHT_INDEX_CONVENTION_HISTORY_DIALOG_HPP
+#define ORES_QT_OVERNIGHT_INDEX_CONVENTION_HISTORY_DIALOG_HPP
+
+#include <QWidget>
+#include <QToolBar>
+#include <QTableWidget>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/overnight_index_convention.hpp"
+
+namespace Ui {
+class OvernightIndexConventionHistoryDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Dialog for viewing the version history of a overnight index convention.
+ *
+ * Shows all historical versions of a overnight index convention with ability
+ * to view details or revert to a previous version.
+ */
+class OvernightIndexConventionHistoryDialog final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.overnight_index_convention_history_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit OvernightIndexConventionHistoryDialog(
+        const QString& code,
+        ClientManager* clientManager,
+        QWidget* parent = nullptr);
+    ~OvernightIndexConventionHistoryDialog() override;
+
+    void loadHistory();
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void openVersionRequested(const refdata::domain::overnight_index_convention& ni,
+                              int versionNumber);
+    void revertVersionRequested(const refdata::domain::overnight_index_convention& ni);
+
+private slots:
+    void onVersionSelected();
+    void onOpenVersionClicked();
+    void onRevertClicked();
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupConnections();
+    void updateVersionList();
+    void updateChangesTable(int currentVersionIndex);
+    void updateFullDetails(int versionIndex);
+    void updateActionStates();
+
+    Ui::OvernightIndexConventionHistoryDialog* ui_;
+    QString code_;
+    ClientManager* clientManager_;
+    std::vector<refdata::domain::overnight_index_convention> versions_;
+
+    QToolBar* toolbar_;
+    QAction* openVersionAction_;
+    QAction* revertAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/OvernightIndexConventionMdiWindow.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/OvernightIndexConventionMdiWindow.hpp
@@ -1,0 +1,115 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_OVERNIGHT_INDEX_CONVENTION_MDI_WINDOW_HPP
+#define ORES_QT_OVERNIGHT_INDEX_CONVENTION_MDI_WINDOW_HPP
+
+#include <QToolBar>
+#include <QTableView>
+#include <QSortFilterProxyModel>
+#include "ores.qt/EntityListMdiWindow.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ClientOvernightIndexConventionModel.hpp"
+#include "ores.qt/PaginationWidget.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/overnight_index_convention.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief MDI window for displaying and managing overnight index conventions.
+ *
+ * Provides a table view of overnight index conventions with toolbar actions
+ * for reload, add, edit, delete, and viewing history.
+ */
+class OvernightIndexConventionMdiWindow final : public EntityListMdiWindow {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.overnight_index_convention_mdi_window";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit OvernightIndexConventionMdiWindow(
+        ClientManager* clientManager,
+        const QString& username,
+        QWidget* parent = nullptr);
+    ~OvernightIndexConventionMdiWindow() override = default;
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void showConventionDetails(const refdata::domain::overnight_index_convention& ni);
+    void addNewRequested();
+    void niDeleted(const QString& code);
+    void showConventionHistory(const refdata::domain::overnight_index_convention& ni);
+
+public slots:
+    void addNew();
+    void editSelected();
+    void deleteSelected();
+    void viewHistorySelected();
+
+protected:
+    void doReload() override;
+
+private slots:
+    void onDataLoaded();
+    void onLoadError(const QString& error_message, const QString& details = {});
+    void onSelectionChanged();
+    void onDoubleClicked(const QModelIndex& index);
+
+protected:
+    QString normalRefreshTooltip() const override {
+        return tr("Refresh overnight index conventions");
+    }
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupTable();
+    void setupConnections();
+    void updateActionStates();
+
+    ClientManager* clientManager_;
+    QString username_;
+
+    QToolBar* toolbar_;
+    QTableView* tableView_;
+    ClientOvernightIndexConventionModel* model_;
+    QSortFilterProxyModel* proxyModel_;
+    PaginationWidget* paginationWidget_;
+
+    // Toolbar actions
+    QAction* reloadAction_;
+    QAction* addAction_;
+    QAction* editAction_;
+    QAction* deleteAction_;
+    QAction* historyAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/SwapConventionController.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/SwapConventionController.hpp
@@ -1,0 +1,93 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_SWAP_CONVENTION_CONTROLLER_HPP
+#define ORES_QT_SWAP_CONVENTION_CONTROLLER_HPP
+
+#include <QMdiArea>
+#include <QMainWindow>
+#include "ores.qt/EntityController.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/swap_convention.hpp"
+#include "ores.qt/EntityListMdiWindow.hpp"
+
+namespace ores::qt {
+
+class SwapConventionMdiWindow;
+class DetachableMdiSubWindow;
+
+/**
+ * @brief Controller for managing swap convention windows and operations.
+ *
+ * Manages the lifecycle of swap convention list, detail, and history windows.
+ * Handles event subscriptions and coordinates between windows.
+ */
+class SwapConventionController final : public EntityController {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.swap_convention_controller";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    SwapConventionController(
+        QMainWindow* mainWindow,
+        QMdiArea* mdiArea,
+        ClientManager* clientManager,
+        const QString& username,
+        QObject* parent = nullptr);
+
+    void showListWindow() override;
+    void closeAllWindows() override;
+    void reloadListWindow() override;
+
+signals:
+    void statusMessage(const QString& message);
+    void errorMessage(const QString& error);
+
+protected:
+    EntityListMdiWindow* listWindow() const override;
+
+private slots:
+    void onShowDetails(const refdata::domain::swap_convention& sc);
+    void onAddNewRequested();
+    void onShowHistory(const refdata::domain::swap_convention& sc);
+    void onRevertVersion(const refdata::domain::swap_convention& sc);
+    void onOpenVersion(const refdata::domain::swap_convention& sc,
+                       int versionNumber);
+
+private:
+    void showAddWindow();
+    void showDetailWindow(const refdata::domain::swap_convention& sc);
+    void showHistoryWindow(const QString& code);
+
+    SwapConventionMdiWindow* listWindow_;
+    DetachableMdiSubWindow* listMdiSubWindow_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/SwapConventionDetailDialog.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/SwapConventionDetailDialog.hpp
@@ -1,0 +1,104 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_SWAP_CONVENTION_DETAIL_DIALOG_HPP
+#define ORES_QT_SWAP_CONVENTION_DETAIL_DIALOG_HPP
+
+#include <vector>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/DetailDialogBase.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/swap_convention.hpp"
+
+
+namespace Ui {
+class SwapConventionDetailDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Detail dialog for viewing and editing swap convention records.
+ *
+ * This dialog allows viewing, creating, and editing swap conventions.
+ * It supports both create mode (for new records) and edit mode (for
+ * existing records).
+ */
+class SwapConventionDetailDialog final : public DetailDialogBase {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.swap_convention_detail_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit SwapConventionDetailDialog(QWidget* parent = nullptr);
+    ~SwapConventionDetailDialog() override;
+
+    void setClientManager(ClientManager* clientManager);
+    void setUsername(const std::string& username);
+    void setConvention(const refdata::domain::swap_convention& sc);
+    void setCreateMode(bool createMode);
+    void setReadOnly(bool readOnly);
+
+
+signals:
+    void scSaved(const QString& code);
+    void scDeleted(const QString& code);
+
+private slots:
+    void onSaveClicked();
+    void onDeleteClicked();
+    void onCodeChanged(const QString& text);
+    void onFieldChanged();
+
+protected:
+    QTabWidget* tabWidget() const override;
+    QWidget* provenanceTab() const override;
+    ProvenanceWidget* provenanceWidget() const override;
+    bool hasUnsavedChanges() const override { return hasChanges_; }
+
+private:
+    void setupUi();
+    void setupConnections();
+    void updateUiFromConvention();
+    void updateConventionFromUi();
+    void updateSaveButtonState();
+    bool validateInput();
+
+
+    Ui::SwapConventionDetailDialog* ui_;
+    ClientManager* clientManager_;
+    std::string username_;
+    refdata::domain::swap_convention sc_;
+    bool createMode_{true};
+    bool readOnly_{false};
+    bool hasChanges_{false};
+
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/SwapConventionHistoryDialog.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/SwapConventionHistoryDialog.hpp
@@ -1,0 +1,97 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_SWAP_CONVENTION_HISTORY_DIALOG_HPP
+#define ORES_QT_SWAP_CONVENTION_HISTORY_DIALOG_HPP
+
+#include <QWidget>
+#include <QToolBar>
+#include <QTableWidget>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/swap_convention.hpp"
+
+namespace Ui {
+class SwapConventionHistoryDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Dialog for viewing the version history of a swap convention.
+ *
+ * Shows all historical versions of a swap convention with ability
+ * to view details or revert to a previous version.
+ */
+class SwapConventionHistoryDialog final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.swap_convention_history_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit SwapConventionHistoryDialog(
+        const QString& code,
+        ClientManager* clientManager,
+        QWidget* parent = nullptr);
+    ~SwapConventionHistoryDialog() override;
+
+    void loadHistory();
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void openVersionRequested(const refdata::domain::swap_convention& sc,
+                              int versionNumber);
+    void revertVersionRequested(const refdata::domain::swap_convention& sc);
+
+private slots:
+    void onVersionSelected();
+    void onOpenVersionClicked();
+    void onRevertClicked();
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupConnections();
+    void updateVersionList();
+    void updateChangesTable(int currentVersionIndex);
+    void updateFullDetails(int versionIndex);
+    void updateActionStates();
+
+    Ui::SwapConventionHistoryDialog* ui_;
+    QString code_;
+    ClientManager* clientManager_;
+    std::vector<refdata::domain::swap_convention> versions_;
+
+    QToolBar* toolbar_;
+    QAction* openVersionAction_;
+    QAction* revertAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/include/ores.qt/SwapConventionMdiWindow.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/SwapConventionMdiWindow.hpp
@@ -1,0 +1,115 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_SWAP_CONVENTION_MDI_WINDOW_HPP
+#define ORES_QT_SWAP_CONVENTION_MDI_WINDOW_HPP
+
+#include <QToolBar>
+#include <QTableView>
+#include <QSortFilterProxyModel>
+#include "ores.qt/EntityListMdiWindow.hpp"
+#include "ores.qt/ClientManager.hpp"
+#include "ores.qt/ClientSwapConventionModel.hpp"
+#include "ores.qt/PaginationWidget.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.refdata.api/domain/swap_convention.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief MDI window for displaying and managing swap conventions.
+ *
+ * Provides a table view of swap conventions with toolbar actions
+ * for reload, add, edit, delete, and viewing history.
+ */
+class SwapConventionMdiWindow final : public EntityListMdiWindow {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.swap_convention_mdi_window";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit SwapConventionMdiWindow(
+        ClientManager* clientManager,
+        const QString& username,
+        QWidget* parent = nullptr);
+    ~SwapConventionMdiWindow() override = default;
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void showConventionDetails(const refdata::domain::swap_convention& sc);
+    void addNewRequested();
+    void scDeleted(const QString& code);
+    void showConventionHistory(const refdata::domain::swap_convention& sc);
+
+public slots:
+    void addNew();
+    void editSelected();
+    void deleteSelected();
+    void viewHistorySelected();
+
+protected:
+    void doReload() override;
+
+private slots:
+    void onDataLoaded();
+    void onLoadError(const QString& error_message, const QString& details = {});
+    void onSelectionChanged();
+    void onDoubleClicked(const QModelIndex& index);
+
+protected:
+    QString normalRefreshTooltip() const override {
+        return tr("Refresh swap conventions");
+    }
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupTable();
+    void setupConnections();
+    void updateActionStates();
+
+    ClientManager* clientManager_;
+    QString username_;
+
+    QToolBar* toolbar_;
+    QTableView* tableView_;
+    ClientSwapConventionModel* model_;
+    QSortFilterProxyModel* proxyModel_;
+    PaginationWidget* paginationWidget_;
+
+    // Toolbar actions
+    QAction* reloadAction_;
+    QAction* addAction_;
+    QAction* editAction_;
+    QAction* deleteAction_;
+    QAction* historyAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.refdata/src/CdsConventionController.cpp
+++ b/projects/ores.qt.refdata/src/CdsConventionController.cpp
@@ -1,0 +1,385 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/CdsConventionController.hpp"
+
+#include <QMdiSubWindow>
+#include <QMessageBox>
+#include <QPointer>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/CdsConventionMdiWindow.hpp"
+#include "ores.qt/CdsConventionDetailDialog.hpp"
+#include "ores.qt/CdsConventionHistoryDialog.hpp"
+#include "ores.qt/DetachableMdiSubWindow.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+CdsConventionController::CdsConventionController(
+    QMainWindow* mainWindow,
+    QMdiArea* mdiArea,
+    ClientManager* clientManager,
+    const QString& username,
+    QObject* parent)
+    : EntityController(mainWindow, mdiArea, clientManager, username,
+          std::string_view{}, parent),
+      listWindow_(nullptr),
+      listMdiSubWindow_(nullptr) {
+
+    BOOST_LOG_SEV(lg(), debug) << "CdsConventionController created";
+}
+
+void CdsConventionController::showListWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "showListWindow called";
+
+    const QString key = build_window_key("list", "cds_conventions");
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing list window";
+        return;
+    }
+
+    // Create new window
+    listWindow_ = new CdsConventionMdiWindow(clientManager_, username_);
+
+    // Connect signals
+    connect(listWindow_, &CdsConventionMdiWindow::statusChanged,
+            this, &CdsConventionController::statusMessage);
+    connect(listWindow_, &CdsConventionMdiWindow::errorOccurred,
+            this, &CdsConventionController::errorMessage);
+    connect(listWindow_, &CdsConventionMdiWindow::showConventionDetails,
+            this, &CdsConventionController::onShowDetails);
+    connect(listWindow_, &CdsConventionMdiWindow::addNewRequested,
+            this, &CdsConventionController::onAddNewRequested);
+    connect(listWindow_, &CdsConventionMdiWindow::showConventionHistory,
+            this, &CdsConventionController::onShowHistory);
+
+    // Create MDI subwindow
+    listMdiSubWindow_ = new DetachableMdiSubWindow(mainWindow_);
+    listMdiSubWindow_->setWidget(listWindow_);
+    listMdiSubWindow_->setWindowTitle("CDS Conventions");
+    listMdiSubWindow_->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+    listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
+    listMdiSubWindow_->resize(listWindow_->sizeHint());
+
+    mdiArea_->addSubWindow(listMdiSubWindow_);
+    listMdiSubWindow_->show();
+
+    // Track window
+    track_window(key, listMdiSubWindow_);
+    register_detachable_window(listMdiSubWindow_);
+
+    // Cleanup when closed
+    connect(listMdiSubWindow_, &QObject::destroyed, this, [self = QPointer<CdsConventionController>(this), key]() {
+        if (!self) return;
+        self->untrack_window(key);
+        self->listWindow_ = nullptr;
+        self->listMdiSubWindow_ = nullptr;
+    });
+
+    BOOST_LOG_SEV(lg(), debug) << "CDS Convention list window created";
+}
+
+void CdsConventionController::closeAllWindows() {
+    BOOST_LOG_SEV(lg(), debug) << "closeAllWindows called";
+
+    // Close all managed windows
+    QList<QString> keys = managed_windows_.keys();
+    for (const QString& key : keys) {
+        if (auto* window = managed_windows_.value(key)) {
+            window->close();
+        }
+    }
+    managed_windows_.clear();
+
+    listWindow_ = nullptr;
+    listMdiSubWindow_ = nullptr;
+}
+
+void CdsConventionController::reloadListWindow() {
+    if (listWindow_) {
+        listWindow_->reload();
+    }
+}
+
+void CdsConventionController::onShowDetails(
+    const refdata::domain::cds_convention& cc) {
+    BOOST_LOG_SEV(lg(), debug) << "Show details for: " << cc.id;
+    showDetailWindow(cc);
+}
+
+void CdsConventionController::onAddNewRequested() {
+    BOOST_LOG_SEV(lg(), info) << "Add new CDS convention requested";
+    showAddWindow();
+}
+
+void CdsConventionController::onShowHistory(
+    const refdata::domain::cds_convention& cc) {
+    BOOST_LOG_SEV(lg(), debug) << "Show history requested for: " << cc.id;
+    showHistoryWindow(QString::fromStdString(cc.id));
+}
+
+void CdsConventionController::showAddWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "Creating add window for new CDS convention";
+
+    auto* detailDialog = new CdsConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(true);
+
+    connect(detailDialog, &CdsConventionDetailDialog::statusMessage,
+            this, &CdsConventionController::statusMessage);
+    connect(detailDialog, &CdsConventionDetailDialog::errorMessage,
+            this, &CdsConventionController::errorMessage);
+    connect(detailDialog, &CdsConventionDetailDialog::ccSaved,
+            this, [self = QPointer<CdsConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "CDS Convention saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle("New CDS Convention");
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void CdsConventionController::showDetailWindow(
+    const refdata::domain::cds_convention& cc) {
+
+    const QString identifier = QString::fromStdString(cc.id);
+    const QString key = build_window_key("details", identifier);
+
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing detail window";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Creating detail window for: " << cc.id;
+
+    auto* detailDialog = new CdsConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(false);
+    detailDialog->setConvention(cc);
+
+    connect(detailDialog, &CdsConventionDetailDialog::statusMessage,
+            this, &CdsConventionController::statusMessage);
+    connect(detailDialog, &CdsConventionDetailDialog::errorMessage,
+            this, &CdsConventionController::errorMessage);
+    connect(detailDialog, &CdsConventionDetailDialog::ccSaved,
+            this, [self = QPointer<CdsConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "CDS Convention saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+    connect(detailDialog, &CdsConventionDetailDialog::ccDeleted,
+            this, [self = QPointer<CdsConventionController>(this), key](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "CDS Convention deleted: " << code.toStdString();
+        self->handleEntityDeleted();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("CDS Convention: %1").arg(identifier));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+
+    // Track window
+    track_window(key, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<CdsConventionController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, key]() {
+        if (self) {
+            self->untrack_window(key);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void CdsConventionController::showHistoryWindow(const QString& code) {
+    BOOST_LOG_SEV(lg(), info) << "Opening history window for CDS convention: "
+                              << code.toStdString();
+
+    const QString windowKey = build_window_key("history", code);
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing history window for: "
+                                  << code.toStdString();
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Creating new history window for: "
+                              << code.toStdString();
+
+    auto* historyDialog = new CdsConventionHistoryDialog(code, clientManager_, mainWindow_);
+
+    connect(historyDialog, &CdsConventionHistoryDialog::statusChanged,
+            this, [self = QPointer<CdsConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(historyDialog, &CdsConventionHistoryDialog::errorOccurred,
+            this, [self = QPointer<CdsConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+    connect(historyDialog, &CdsConventionHistoryDialog::revertVersionRequested,
+            this, &CdsConventionController::onRevertVersion);
+    connect(historyDialog, &CdsConventionHistoryDialog::openVersionRequested,
+            this, &CdsConventionController::onOpenVersion);
+
+    // Load history data
+    historyDialog->loadHistory();
+
+    auto* historyWindow = new DetachableMdiSubWindow(mainWindow_);
+    historyWindow->setAttribute(Qt::WA_DeleteOnClose);
+    historyWindow->setWidget(historyDialog);
+    historyWindow->setWindowTitle(QString("CDS Convention History: %1").arg(code));
+    historyWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    // Track this history window
+    track_window(windowKey, historyWindow);
+    register_detachable_window(historyWindow);
+
+    QPointer<CdsConventionController> self = this;
+    connect(historyWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    show_managed_window(historyWindow, listMdiSubWindow_);
+}
+
+void CdsConventionController::onOpenVersion(
+    const refdata::domain::cds_convention& cc, int versionNumber) {
+    BOOST_LOG_SEV(lg(), info) << "Opening historical version " << versionNumber
+                              << " for CDS convention: " << cc.id;
+
+    const QString code = QString::fromStdString(cc.id);
+    const QString windowKey = build_window_key("version", QString("%1_v%2")
+        .arg(code).arg(versionNumber));
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing version window";
+        return;
+    }
+
+    auto* detailDialog = new CdsConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setConvention(cc);
+    detailDialog->setReadOnly(true);
+
+    connect(detailDialog, &CdsConventionDetailDialog::statusMessage,
+            this, [self = QPointer<CdsConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(detailDialog, &CdsConventionDetailDialog::errorMessage,
+            this, [self = QPointer<CdsConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("CDS Convention: %1 (Version %2)")
+        .arg(code).arg(versionNumber));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    track_window(windowKey, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<CdsConventionController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_, QPoint(60, 60));
+}
+
+void CdsConventionController::onRevertVersion(
+    const refdata::domain::cds_convention& cc) {
+    BOOST_LOG_SEV(lg(), info) << "Reverting CDS convention to version: "
+                              << cc.version;
+
+    // Open detail dialog with the old version data for editing
+    auto* detailDialog = new CdsConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setConvention(cc);
+    detailDialog->setCreateMode(false);
+
+    connect(detailDialog, &CdsConventionDetailDialog::statusMessage,
+            this, &CdsConventionController::statusMessage);
+    connect(detailDialog, &CdsConventionDetailDialog::errorMessage,
+            this, &CdsConventionController::errorMessage);
+    connect(detailDialog, &CdsConventionDetailDialog::ccSaved,
+            this, [self = QPointer<CdsConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "CDS Convention reverted: " << code.toStdString();
+        emit self->statusMessage(QString("CDS Convention '%1' reverted successfully").arg(code));
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Revert CDS Convention: %1")
+        .arg(QString::fromStdString(cc.id)));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+EntityListMdiWindow* CdsConventionController::listWindow() const {
+    return listWindow_;
+}
+
+}

--- a/projects/ores.qt.refdata/src/CdsConventionDetailDialog.cpp
+++ b/projects/ores.qt.refdata/src/CdsConventionDetailDialog.cpp
@@ -1,0 +1,352 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/CdsConventionDetailDialog.hpp"
+
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_CdsConventionDetailDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.refdata.api/messaging/cds_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+CdsConventionDetailDialog::CdsConventionDetailDialog(QWidget* parent)
+    : DetailDialogBase(parent),
+      ui_(new Ui::CdsConventionDetailDialog),
+      clientManager_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupConnections();
+}
+
+CdsConventionDetailDialog::~CdsConventionDetailDialog() {
+    delete ui_;
+}
+
+QTabWidget* CdsConventionDetailDialog::tabWidget() const {
+    return ui_->tabWidget;
+}
+
+QWidget* CdsConventionDetailDialog::provenanceTab() const {
+    return ui_->provenanceTab;
+}
+
+ProvenanceWidget* CdsConventionDetailDialog::provenanceWidget() const {
+    return ui_->provenanceWidget;
+}
+
+void CdsConventionDetailDialog::setupUi() {
+    ui_->saveButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Save, IconUtils::DefaultIconColor));
+    ui_->saveButton->setEnabled(false);
+
+    ui_->deleteButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Delete, IconUtils::DefaultIconColor));
+
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+}
+
+void CdsConventionDetailDialog::setupConnections() {
+    connect(ui_->saveButton, &QPushButton::clicked, this,
+            &CdsConventionDetailDialog::onSaveClicked);
+    connect(ui_->deleteButton, &QPushButton::clicked, this,
+            &CdsConventionDetailDialog::onDeleteClicked);
+    connect(ui_->closeButton, &QPushButton::clicked, this,
+            &CdsConventionDetailDialog::onCloseClicked);
+
+    connect(ui_->idEdit, &QLineEdit::textChanged, this,
+            &CdsConventionDetailDialog::onCodeChanged);
+    connect(ui_->calendarEdit, &QLineEdit::textChanged, this,
+            &CdsConventionDetailDialog::onFieldChanged);
+    connect(ui_->frequencyEdit, &QLineEdit::textChanged, this,
+            &CdsConventionDetailDialog::onFieldChanged);
+    connect(ui_->paymentConventionEdit, &QLineEdit::textChanged, this,
+            &CdsConventionDetailDialog::onFieldChanged);
+    connect(ui_->ruleEdit, &QLineEdit::textChanged, this,
+            &CdsConventionDetailDialog::onFieldChanged);
+    connect(ui_->dayCountFractionEdit, &QLineEdit::textChanged, this,
+            &CdsConventionDetailDialog::onFieldChanged);
+    connect(ui_->lastPeriodDayCountFractionEdit, &QLineEdit::textChanged, this,
+            &CdsConventionDetailDialog::onFieldChanged);
+}
+
+void CdsConventionDetailDialog::setClientManager(ClientManager* clientManager) {
+    clientManager_ = clientManager;
+}
+
+void CdsConventionDetailDialog::setUsername(const std::string& username) {
+    username_ = username;
+}
+
+void CdsConventionDetailDialog::setConvention(
+    const refdata::domain::cds_convention& cc) {
+    cc_ = cc;
+    updateUiFromConvention();
+}
+
+void CdsConventionDetailDialog::setCreateMode(bool createMode) {
+    createMode_ = createMode;
+    ui_->idEdit->setReadOnly(!createMode);
+    ui_->deleteButton->setVisible(!createMode);
+    setProvenanceEnabled(!createMode);
+    hasChanges_ = false;
+    updateSaveButtonState();
+}
+
+void CdsConventionDetailDialog::setReadOnly(bool readOnly) {
+    readOnly_ = readOnly;
+    ui_->idEdit->setReadOnly(true);
+    ui_->calendarEdit->setReadOnly(readOnly);
+    ui_->frequencyEdit->setReadOnly(readOnly);
+    ui_->paymentConventionEdit->setReadOnly(readOnly);
+    ui_->ruleEdit->setReadOnly(readOnly);
+    ui_->dayCountFractionEdit->setReadOnly(readOnly);
+    ui_->lastPeriodDayCountFractionEdit->setReadOnly(readOnly);
+    ui_->saveButton->setVisible(!readOnly);
+    ui_->deleteButton->setVisible(!readOnly);
+}
+
+void CdsConventionDetailDialog::updateUiFromConvention() {
+    ui_->idEdit->setText(QString::fromStdString(cc_.id));
+    ui_->calendarEdit->setText(QString::fromStdString(cc_.calendar));
+    ui_->frequencyEdit->setText(QString::fromStdString(cc_.frequency));
+    ui_->paymentConventionEdit->setText(QString::fromStdString(cc_.payment_convention));
+    ui_->ruleEdit->setText(QString::fromStdString(cc_.rule));
+    ui_->dayCountFractionEdit->setText(QString::fromStdString(cc_.day_count_fraction));
+    ui_->settlementDaysEdit->setValue(cc_.settlement_days);
+    ui_->upfrontSettlementDaysEdit->setValue(cc_.upfront_settlement_days.value_or(
+        ui_->upfrontSettlementDaysEdit->minimum()));
+    ui_->lastPeriodDayCountFractionEdit->setText(cc_.last_period_day_count_fraction
+        ? QString::fromStdString(*cc_.last_period_day_count_fraction)
+        : QString{});
+    ui_->settlesAccrualEdit->setChecked(cc_.settles_accrual);
+    ui_->paysAtDefaultTimeEdit->setChecked(cc_.pays_at_default_time);
+
+    populateProvenance(cc_.version,
+                       cc_.modified_by,
+                       cc_.performed_by,
+                       cc_.recorded_at,
+                       cc_.change_reason_code,
+                       cc_.change_commentary);
+
+    hasChanges_ = false;
+    updateSaveButtonState();
+}
+
+void CdsConventionDetailDialog::updateConventionFromUi() {
+    if (createMode_) {
+        cc_.id = ui_->idEdit->text().trimmed().toStdString();
+    }
+    cc_.calendar = ui_->calendarEdit->text().trimmed().toStdString();
+    cc_.frequency = ui_->frequencyEdit->text().trimmed().toStdString();
+    cc_.payment_convention = ui_->paymentConventionEdit->text().trimmed().toStdString();
+    cc_.rule = ui_->ruleEdit->text().trimmed().toStdString();
+    cc_.day_count_fraction = ui_->dayCountFractionEdit->text().trimmed().toStdString();
+    cc_.settlement_days = ui_->settlementDaysEdit->value();
+    if (ui_->upfrontSettlementDaysEdit->value() == ui_->upfrontSettlementDaysEdit->minimum())
+        cc_.upfront_settlement_days = std::nullopt;
+    else
+        cc_.upfront_settlement_days = ui_->upfrontSettlementDaysEdit->value();
+    {
+        const auto last_period_day_count_fraction_str = ui_->lastPeriodDayCountFractionEdit->text().trimmed().toStdString();
+        cc_.last_period_day_count_fraction =
+            last_period_day_count_fraction_str.empty() ? std::nullopt : std::optional<std::string>(last_period_day_count_fraction_str);
+    }
+    cc_.settles_accrual = ui_->settlesAccrualEdit->isChecked();
+    cc_.pays_at_default_time = ui_->paysAtDefaultTimeEdit->isChecked();
+    cc_.modified_by = username_;
+}
+
+void CdsConventionDetailDialog::onCodeChanged(const QString& /* text */) {
+    hasChanges_ = true;
+    updateSaveButtonState();
+}
+
+void CdsConventionDetailDialog::onFieldChanged() {
+    hasChanges_ = true;
+    updateSaveButtonState();
+}
+
+void CdsConventionDetailDialog::updateSaveButtonState() {
+    bool canSave = hasChanges_ && validateInput() && !readOnly_;
+    ui_->saveButton->setEnabled(canSave);
+}
+
+bool CdsConventionDetailDialog::validateInput() {
+    const QString id_val = ui_->idEdit->text().trimmed();
+    const QString calendar_val = ui_->calendarEdit->text().trimmed();
+    const QString frequency_val = ui_->frequencyEdit->text().trimmed();
+    const QString payment_convention_val = ui_->paymentConventionEdit->text().trimmed();
+    const QString rule_val = ui_->ruleEdit->text().trimmed();
+    const QString day_count_fraction_val = ui_->dayCountFractionEdit->text().trimmed();
+
+    return true
+        && !id_val.isEmpty()
+        && !calendar_val.isEmpty()
+        && !frequency_val.isEmpty()
+        && !payment_convention_val.isEmpty()
+        && !rule_val.isEmpty()
+        && !day_count_fraction_val.isEmpty()
+    ;
+}
+
+void CdsConventionDetailDialog::onSaveClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot save CDS convention while disconnected from server.");
+        return;
+    }
+
+    if (!validateInput()) {
+        MessageBoxHelper::warning(this, "Invalid Input",
+            "Please fill in all required fields.");
+        return;
+    }
+
+    updateConventionFromUi();
+
+    BOOST_LOG_SEV(lg(), info) << "Saving CDS convention: "
+        << cc_.id;
+
+    QPointer<CdsConventionDetailDialog> self = this;
+
+    struct SaveResult {
+        bool success;
+        std::string message;
+    };
+
+    auto task = [self, cc = cc_]() -> SaveResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed"};
+        }
+
+        refdata::messaging::save_cds_convention_request request;
+        request.data = cc;
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server"};
+        }
+
+        return {response_result->success, response_result->message};
+    };
+
+    auto* watcher = new QFutureWatcher<SaveResult>(self);
+    connect(watcher, &QFutureWatcher<SaveResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "CDS Convention saved successfully";
+            QString code = QString::fromStdString(
+                self->cc_.id);
+            self->hasChanges_ = false;
+            self->updateSaveButtonState();
+            emit self->ccSaved(code);
+            self->notifySaveSuccess(tr("CDS Convention '%1' saved").arg(code));
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Save failed: " << result.message;
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Save Failed", errorMsg);
+        }
+    });
+
+    QFuture<SaveResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+void CdsConventionDetailDialog::onDeleteClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete CDS convention while disconnected from server.");
+        return;
+    }
+
+    QString code = QString::fromStdString(
+        cc_.id);
+    auto reply = MessageBoxHelper::question(this, "Delete CDS Convention",
+        QString("Are you sure you want to delete CDS convention '%1'?").arg(code),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Deleting CDS convention: "
+        << cc_.id;
+
+    QPointer<CdsConventionDetailDialog> self = this;
+
+    struct DeleteResult {
+        bool success;
+        std::string message;
+    };
+
+    auto task = [self, code = cc_.id]() -> DeleteResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed"};
+        }
+
+        refdata::messaging::delete_cds_convention_request request;
+        request.codes = {code};
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server"};
+        }
+
+        return {response_result->success, response_result->message};
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, code, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "CDS Convention deleted successfully";
+            emit self->statusMessage(
+                QString("CDS Convention '%1' deleted").arg(code));
+            emit self->ccDeleted(code);
+            self->requestClose();
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Delete failed: " << result.message;
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Delete Failed", errorMsg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt.refdata/src/CdsConventionHistoryDialog.cpp
+++ b/projects/ores.qt.refdata/src/CdsConventionHistoryDialog.cpp
@@ -1,0 +1,376 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/CdsConventionHistoryDialog.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_CdsConventionHistoryDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.refdata.api/messaging/cds_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+CdsConventionHistoryDialog::CdsConventionHistoryDialog(
+    const QString& code,
+    ClientManager* clientManager,
+    QWidget* parent)
+    : QWidget(parent),
+      ui_(new Ui::CdsConventionHistoryDialog),
+      code_(code),
+      clientManager_(clientManager),
+      toolbar_(nullptr),
+      openVersionAction_(nullptr),
+      revertAction_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupToolbar();
+    setupConnections();
+}
+
+CdsConventionHistoryDialog::~CdsConventionHistoryDialog() {
+    delete ui_;
+}
+
+void CdsConventionHistoryDialog::setupUi() {
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+
+    ui_->titleLabel->setText(QString("History for: %1").arg(code_));
+
+    // Setup version list table
+    ui_->versionListWidget->setColumnCount(5);
+    ui_->versionListWidget->setHorizontalHeaderLabels(
+        {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
+    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
+    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    // Setup changes table
+    ui_->changesTableWidget->setColumnCount(3);
+    ui_->changesTableWidget->setHorizontalHeaderLabels(
+        {"Field", "Old Value", "New Value"});
+    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+}
+
+void CdsConventionHistoryDialog::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    openVersionAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor),
+        tr("Open"));
+    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
+    openVersionAction_->setEnabled(false);
+
+    revertAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor),
+        tr("Revert"));
+    revertAction_->setToolTip(tr("Revert to this version"));
+    revertAction_->setEnabled(false);
+
+    // Insert toolbar at the top of the layout
+    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
+    if (layout) {
+        layout->insertWidget(0, toolbar_);
+    }
+}
+
+void CdsConventionHistoryDialog::setupConnections() {
+    connect(ui_->versionListWidget, &QTableWidget::itemSelectionChanged,
+            this, &CdsConventionHistoryDialog::onVersionSelected);
+    connect(openVersionAction_, &QAction::triggered,
+            this, &CdsConventionHistoryDialog::onOpenVersionClicked);
+    connect(revertAction_, &QAction::triggered,
+            this, &CdsConventionHistoryDialog::onRevertClicked);
+    connect(ui_->closeButton, &QPushButton::clicked,
+            this, [this]() { if (window()) window()->close(); });
+}
+
+void CdsConventionHistoryDialog::loadHistory() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        emit errorOccurred("Not connected to server");
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for CDS convention: " << code_.toStdString();
+    emit statusChanged(tr("Loading history..."));
+
+    QPointer<CdsConventionHistoryDialog> self = this;
+
+    using HistoryResult = std::expected<refdata::messaging::get_cds_convention_history_response, std::string>;
+
+    QFuture<HistoryResult> future =
+        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
+        if (!self || !self->clientManager_)
+            return std::unexpected("Dialog closed");
+        refdata::messaging::get_cds_convention_history_request request;
+        request.id = code;
+        auto result = self->clientManager_->process_authenticated_request(std::move(request));
+        if (!result) return std::unexpected(result.error());
+        return std::move(*result);
+    });
+
+    auto* watcher = new QFutureWatcher<HistoryResult>(self);
+    connect(watcher, &QFutureWatcher<HistoryResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (!result) {
+            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
+            emit self->errorOccurred(QString::fromStdString(result.error()));
+            return;
+        }
+        if (!result->success) {
+            emit self->errorOccurred(QString::fromStdString(result->message));
+            return;
+        }
+        self->versions_ = std::move(result->cds_conventions);
+        self->updateVersionList();
+        emit self->statusChanged(
+            QString("Loaded %1 versions").arg(self->versions_.size()));
+    });
+    watcher->setFuture(future);
+}
+
+void CdsConventionHistoryDialog::updateVersionList() {
+    ui_->versionListWidget->setRowCount(0);
+
+    for (const auto& version : versions_) {
+        int row = ui_->versionListWidget->rowCount();
+        ui_->versionListWidget->insertRow(row);
+
+        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
+        versionItem->setTextAlignment(Qt::AlignCenter);
+        ui_->versionListWidget->setItem(row, 0, versionItem);
+
+        auto* recordedAtItem = new QTableWidgetItem(
+            relative_time_helper::format(version.recorded_at));
+        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
+
+        auto* modifiedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.modified_by));
+        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
+
+        auto* performedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.performed_by));
+        ui_->versionListWidget->setItem(row, 3, performedByItem);
+
+        auto* commentaryItem = new QTableWidgetItem(
+            QString::fromStdString(version.change_commentary));
+        ui_->versionListWidget->setItem(row, 4, commentaryItem);
+    }
+
+    // Select the first (most recent) version
+    if (!versions_.empty()) {
+        ui_->versionListWidget->selectRow(0);
+    }
+}
+
+void CdsConventionHistoryDialog::onVersionSelected() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) {
+        updateActionStates();
+        return;
+    }
+
+    int row = selected.first()->row();
+    updateChangesTable(row);
+    updateFullDetails(row);
+    updateActionStates();
+}
+
+void CdsConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
+    ui_->changesTableWidget->setRowCount(0);
+
+    if (currentVersionIndex < 0 ||
+        static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
+        return;
+    }
+
+    // Get the next older version to compare against
+    int previousVersionIndex = currentVersionIndex + 1;
+    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
+        // This is the first version, no changes to show
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(Initial version)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+        return;
+    }
+
+    const auto& current = versions_[currentVersionIndex];
+    const auto& previous = versions_[previousVersionIndex];
+
+    auto addChange = [this](const QString& field,
+                            const QString& oldVal, const QString& newVal) {
+        int row = ui_->changesTableWidget->rowCount();
+        ui_->changesTableWidget->insertRow(row);
+        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
+        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
+        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
+    };
+
+    if (current.id != previous.id) {
+        addChange("Id",
+                  QString::fromStdString(previous.id),
+                  QString::fromStdString(current.id));
+    }
+
+    if (current.calendar != previous.calendar) {
+        addChange("Calendar",
+                  QString::fromStdString(previous.calendar),
+                  QString::fromStdString(current.calendar));
+    }
+
+    if (current.frequency != previous.frequency) {
+        addChange("Frequency",
+                  QString::fromStdString(previous.frequency),
+                  QString::fromStdString(current.frequency));
+    }
+
+    if (current.payment_convention != previous.payment_convention) {
+        addChange("Payment Convention",
+                  QString::fromStdString(previous.payment_convention),
+                  QString::fromStdString(current.payment_convention));
+    }
+
+    if (current.rule != previous.rule) {
+        addChange("Rule",
+                  QString::fromStdString(previous.rule),
+                  QString::fromStdString(current.rule));
+    }
+
+    if (current.day_count_fraction != previous.day_count_fraction) {
+        addChange("Day Count Fraction",
+                  QString::fromStdString(previous.day_count_fraction),
+                  QString::fromStdString(current.day_count_fraction));
+    }
+
+    if (current.settlement_days != previous.settlement_days) {
+        addChange("Settlement Days",
+                  QString::number(previous.settlement_days),
+                  QString::number(current.settlement_days));
+    }
+
+    if (current.upfront_settlement_days != previous.upfront_settlement_days) {
+        addChange("Upfront Settlement Days",
+                  previous.upfront_settlement_days ? QString::number(*previous.upfront_settlement_days) : tr("(unset)"),
+                  current.upfront_settlement_days ? QString::number(*current.upfront_settlement_days) : tr("(unset)"));
+    }
+
+    if (current.last_period_day_count_fraction != previous.last_period_day_count_fraction) {
+        addChange("Last Period DCF",
+                  previous.last_period_day_count_fraction ? QString::fromStdString(*previous.last_period_day_count_fraction) : QString{},
+                  current.last_period_day_count_fraction ? QString::fromStdString(*current.last_period_day_count_fraction) : QString{});
+    }
+
+    if (current.settles_accrual != previous.settles_accrual) {
+        addChange("Settles Accrual",
+                  previous.settles_accrual ? tr("true") : tr("false"),
+                  current.settles_accrual ? tr("true") : tr("false"));
+    }
+
+    if (current.pays_at_default_time != previous.pays_at_default_time) {
+        addChange("Pays At Default Time",
+                  previous.pays_at_default_time ? tr("true") : tr("false"),
+                  current.pays_at_default_time ? tr("true") : tr("false"));
+    }
+
+
+    if (ui_->changesTableWidget->rowCount() == 0) {
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(No field changes)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+    }
+}
+
+void CdsConventionHistoryDialog::updateFullDetails(int versionIndex) {
+    if (versionIndex < 0 ||
+        static_cast<size_t>(versionIndex) >= versions_.size()) {
+        return;
+    }
+
+    const auto& version = versions_[versionIndex];
+
+    ui_->idValue->setText(QString::fromStdString(version.id));
+    ui_->calendarValue->setText(QString::fromStdString(version.calendar));
+    ui_->frequencyValue->setText(QString::fromStdString(version.frequency));
+    ui_->paymentConventionValue->setText(QString::fromStdString(version.payment_convention));
+    ui_->ruleValue->setText(QString::fromStdString(version.rule));
+    ui_->dayCountFractionValue->setText(QString::fromStdString(version.day_count_fraction));
+    ui_->settlementDaysValue->setText(QString::number(version.settlement_days));
+    ui_->upfrontSettlementDaysValue->setText(version.upfront_settlement_days
+        ? QString::number(*version.upfront_settlement_days)
+        : tr("(unset)"));
+    ui_->lastPeriodDayCountFractionValue->setText(version.last_period_day_count_fraction
+        ? QString::fromStdString(*version.last_period_day_count_fraction)
+        : QString{});
+    ui_->settlesAccrualValue->setText(version.settles_accrual ? tr("true") : tr("false"));
+    ui_->paysAtDefaultTimeValue->setText(version.pays_at_default_time ? tr("true") : tr("false"));
+    ui_->versionNumberValue->setText(QString::number(version.version));
+    ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
+}
+
+void CdsConventionHistoryDialog::updateActionStates() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    bool hasSelection = !selected.isEmpty();
+    bool isNotLatest = hasSelection && selected.first()->row() > 0;
+
+    openVersionAction_->setEnabled(hasSelection);
+    revertAction_->setEnabled(isNotLatest);
+}
+
+void CdsConventionHistoryDialog::onOpenVersionClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit openVersionRequested(versions_[row], versions_[row].version);
+}
+
+void CdsConventionHistoryDialog::onRevertClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit revertVersionRequested(versions_[row]);
+}
+
+}

--- a/projects/ores.qt.refdata/src/CdsConventionMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/CdsConventionMdiWindow.cpp
@@ -1,0 +1,386 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/CdsConventionMdiWindow.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.refdata.api/messaging/cds_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+CdsConventionMdiWindow::CdsConventionMdiWindow(
+    ClientManager* clientManager,
+    const QString& username,
+    QWidget* parent)
+    : EntityListMdiWindow(parent),
+      clientManager_(clientManager),
+      username_(username),
+      toolbar_(nullptr),
+      tableView_(nullptr),
+      model_(nullptr),
+      proxyModel_(nullptr),
+      paginationWidget_(nullptr),
+      reloadAction_(nullptr),
+      addAction_(nullptr),
+      editAction_(nullptr),
+      deleteAction_(nullptr),
+      historyAction_(nullptr) {
+
+    setupUi();
+    setupConnections();
+    reload();
+}
+
+void CdsConventionMdiWindow::setupUi() {
+    auto* layout = new QVBoxLayout(this);
+
+    setupToolbar();
+    layout->addWidget(toolbar_);
+    layout->addWidget(loadingBar());
+
+    setupTable();
+    layout->addWidget(tableView_);
+
+    paginationWidget_ = new PaginationWidget(this);
+    layout->addWidget(paginationWidget_);
+}
+
+void CdsConventionMdiWindow::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    reloadAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowClockwise, IconUtils::DefaultIconColor),
+        tr("Reload"));
+    connect(reloadAction_, &QAction::triggered, this,
+            &EntityListMdiWindow::reload);
+
+    initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
+
+    toolbar_->addSeparator();
+
+    addAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Add, IconUtils::DefaultIconColor),
+        tr("Add"));
+    addAction_->setToolTip(tr("Add new CDS convention"));
+    connect(addAction_, &QAction::triggered, this,
+            &CdsConventionMdiWindow::addNew);
+
+    editAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Edit, IconUtils::DefaultIconColor),
+        tr("Edit"));
+    editAction_->setToolTip(tr("Edit selected CDS convention"));
+    editAction_->setEnabled(false);
+    connect(editAction_, &QAction::triggered, this,
+            &CdsConventionMdiWindow::editSelected);
+
+    deleteAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Delete, IconUtils::DefaultIconColor),
+        tr("Delete"));
+    deleteAction_->setToolTip(tr("Delete selected CDS convention"));
+    deleteAction_->setEnabled(false);
+    connect(deleteAction_, &QAction::triggered, this,
+            &CdsConventionMdiWindow::deleteSelected);
+
+    historyAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::History, IconUtils::DefaultIconColor),
+        tr("History"));
+    historyAction_->setToolTip(tr("View CDS convention history"));
+    historyAction_->setEnabled(false);
+    connect(historyAction_, &QAction::triggered, this,
+            &CdsConventionMdiWindow::viewHistorySelected);
+}
+
+void CdsConventionMdiWindow::setupTable() {
+    model_ = new ClientCdsConventionModel(clientManager_, this);
+    proxyModel_ = new QSortFilterProxyModel(this);
+    proxyModel_->setSourceModel(model_);
+    proxyModel_->setSortCaseSensitivity(Qt::CaseInsensitive);
+
+    tableView_ = new QTableView(this);
+    tableView_->setModel(proxyModel_);
+    tableView_->setSelectionBehavior(QAbstractItemView::SelectRows);
+    tableView_->setSelectionMode(QAbstractItemView::SingleSelection);
+    tableView_->setSortingEnabled(true);
+    tableView_->setAlternatingRowColors(true);
+    tableView_->verticalHeader()->setVisible(false);
+
+    initializeTableSettings(tableView_, model_,
+        "CdsConventionListWindow",
+        {},
+        {900, 400}, 1);
+}
+
+void CdsConventionMdiWindow::setupConnections() {
+    connect(model_, &ClientCdsConventionModel::dataLoaded,
+            this, &CdsConventionMdiWindow::onDataLoaded);
+    connect(model_, &ClientCdsConventionModel::loadError,
+            this, &CdsConventionMdiWindow::onLoadError);
+
+    connect(tableView_->selectionModel(), &QItemSelectionModel::selectionChanged,
+            this, &CdsConventionMdiWindow::onSelectionChanged);
+    connect(tableView_, &QTableView::doubleClicked,
+            this, &CdsConventionMdiWindow::onDoubleClicked);
+
+    connect(paginationWidget_, &PaginationWidget::page_size_changed,
+            this, [this](std::uint32_t size) {
+        model_->set_page_size(size);
+        model_->refresh();
+    });
+
+    connect(paginationWidget_, &PaginationWidget::load_all_requested,
+            this, [this]() {
+        const auto total = model_->total_available_count();
+        if (total > 0 && total <= 1000) {
+            model_->set_page_size(total);
+            model_->refresh();
+        }
+    });
+
+    connect(paginationWidget_, &PaginationWidget::page_requested,
+            this, [this](std::uint32_t offset, std::uint32_t limit) {
+        model_->load_page(offset, limit);
+    });
+
+    connectModel(model_);
+}
+
+void CdsConventionMdiWindow::doReload() {
+    BOOST_LOG_SEV(lg(), debug) << "Reloading CDS conventions";
+    clearStaleIndicator();
+    emit statusChanged(tr("Loading CDS conventions..."));
+    model_->refresh();
+}
+
+void CdsConventionMdiWindow::onDataLoaded() {
+    const auto loaded = model_->rowCount();
+    const auto total = model_->total_available_count();
+    emit statusChanged(tr("Loaded %1 of %2 CDS conventions").arg(loaded).arg(total));
+
+    paginationWidget_->update_state(loaded, total);
+    paginationWidget_->set_load_all_enabled(
+        loaded < static_cast<int>(total) && total > 0 && total <= 1000);
+}
+
+void CdsConventionMdiWindow::onLoadError(const QString& error_message,
+                                          const QString& details) {
+    BOOST_LOG_SEV(lg(), error) << "Load error: " << error_message.toStdString();
+    emit errorOccurred(error_message);
+    MessageBoxHelper::critical(this, tr("Load Error"), error_message, details);
+}
+
+void CdsConventionMdiWindow::onSelectionChanged() {
+    updateActionStates();
+}
+
+void CdsConventionMdiWindow::onDoubleClicked(const QModelIndex& index) {
+    if (!index.isValid())
+        return;
+
+    auto sourceIndex = proxyModel_->mapToSource(index);
+    if (auto* cc = model_->getConvention(sourceIndex.row())) {
+        emit showConventionDetails(*cc);
+    }
+}
+
+void CdsConventionMdiWindow::updateActionStates() {
+    const bool hasSelection = tableView_->selectionModel()->hasSelection();
+    editAction_->setEnabled(hasSelection);
+    deleteAction_->setEnabled(hasSelection);
+    historyAction_->setEnabled(hasSelection);
+}
+
+void CdsConventionMdiWindow::addNew() {
+    BOOST_LOG_SEV(lg(), debug) << "Add new CDS convention requested";
+    emit addNewRequested();
+}
+
+void CdsConventionMdiWindow::editSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Edit requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* cc = model_->getConvention(sourceIndex.row())) {
+        emit showConventionDetails(*cc);
+    }
+}
+
+void CdsConventionMdiWindow::viewHistorySelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "View history requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* cc = model_->getConvention(sourceIndex.row())) {
+        BOOST_LOG_SEV(lg(), debug) << "Emitting showConventionHistory for code: "
+                                   << cc->id;
+        emit showConventionHistory(*cc);
+    }
+}
+
+void CdsConventionMdiWindow::deleteSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Delete requested but no row selected";
+        return;
+    }
+
+    if (!clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete CDS convention while disconnected.");
+        return;
+    }
+
+    std::vector<std::string> codes;
+    for (const auto& index : selected) {
+        auto sourceIndex = proxyModel_->mapToSource(index);
+        if (auto* cc = model_->getConvention(sourceIndex.row())) {
+            codes.push_back(cc->id);
+        }
+    }
+
+    if (codes.empty()) {
+        BOOST_LOG_SEV(lg(), warn) << "No valid CDS conventions to delete";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Delete requested for " << codes.size()
+                               << " CDS conventions";
+
+    QString confirmMessage;
+    if (codes.size() == 1) {
+        confirmMessage = QString("Are you sure you want to delete CDS convention '%1'?")
+            .arg(QString::fromStdString(codes.front()));
+    } else {
+        confirmMessage = QString("Are you sure you want to delete %1 CDS conventions?")
+            .arg(codes.size());
+    }
+
+    auto reply = MessageBoxHelper::question(this, "Delete CDS Convention",
+        confirmMessage, QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        BOOST_LOG_SEV(lg(), debug) << "Delete cancelled by user";
+        return;
+    }
+
+    QPointer<CdsConventionMdiWindow> self = this;
+    using DeleteResult = std::vector<std::pair<std::string, std::pair<bool, std::string>>>;
+
+    auto task = [self, codes]() -> DeleteResult {
+        DeleteResult results;
+        if (!self) return {};
+
+        BOOST_LOG_SEV(lg(), debug) << "Making batch delete request for "
+                                   << codes.size() << " CDS conventions";
+
+        refdata::messaging::delete_cds_convention_request request;
+        request.codes = codes;
+        auto response_result = self->clientManager_->process_authenticated_request(
+            std::move(request));
+
+        if (!response_result) {
+            BOOST_LOG_SEV(lg(), error) << "Failed to send batch delete request";
+            for (const auto& code : codes) {
+                results.push_back({code, {false, "Failed to communicate with server"}});
+            }
+            return results;
+        }
+
+        for (const auto& code : codes) {
+            results.push_back({code, {response_result->success, response_result->message}});
+        }
+
+        return results;
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, watcher]() {
+        auto results = watcher->result();
+        watcher->deleteLater();
+
+        int success_count = 0;
+        int failure_count = 0;
+        QString first_error;
+
+        for (const auto& [code, result] : results) {
+            if (result.first) {
+                BOOST_LOG_SEV(lg(), debug) << "CDS Convention deleted: " << code;
+                success_count++;
+                emit self->ccDeleted(QString::fromStdString(code));
+            } else {
+                BOOST_LOG_SEV(lg(), error) << "CDS Convention deletion failed: "
+                                           << code << " - " << result.second;
+                failure_count++;
+                if (first_error.isEmpty()) {
+                    first_error = QString::fromStdString(result.second);
+                }
+            }
+        }
+
+        self->model_->refresh();
+
+        if (failure_count == 0) {
+            QString msg = success_count == 1
+                ? "Successfully deleted 1 CDS convention"
+                : QString("Successfully deleted %1 CDS conventions").arg(success_count);
+            emit self->statusChanged(msg);
+        } else if (success_count == 0) {
+            QString msg = QString("Failed to delete %1 %2: %3")
+                .arg(failure_count)
+                .arg(failure_count == 1 ? "CDS convention" : "CDS conventions")
+                .arg(first_error);
+            emit self->errorOccurred(msg);
+            MessageBoxHelper::critical(self, "Delete Failed", msg);
+        } else {
+            QString msg = QString("Deleted %1, failed to delete %2")
+                .arg(success_count)
+                .arg(failure_count);
+            emit self->statusChanged(msg);
+            MessageBoxHelper::warning(self, "Partial Success", msg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt.refdata/src/ClientCdsConventionModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientCdsConventionModel.cpp
@@ -1,0 +1,300 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/ClientCdsConventionModel.hpp"
+
+#include <QtConcurrent>
+#include "ores.refdata.api/messaging/cds_convention_protocol.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/ExceptionHelper.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+namespace {
+    std::string cds_convention_key_extractor(const refdata::domain::cds_convention& e) {
+        return e.id;
+    }
+}
+
+ClientCdsConventionModel::ClientCdsConventionModel(
+    ClientManager* clientManager, QObject* parent)
+    : AbstractClientModel(parent),
+      clientManager_(clientManager),
+      watcher_(new QFutureWatcher<FetchResult>(this)),
+      recencyTracker_(cds_convention_key_extractor),
+      pulseManager_(new RecencyPulseManager(this)) {
+
+    connect(watcher_, &QFutureWatcher<FetchResult>::finished,
+            this, &ClientCdsConventionModel::onConventionsLoaded);
+
+    connect(pulseManager_, &RecencyPulseManager::pulse_state_changed,
+            this, &ClientCdsConventionModel::onPulseStateChanged);
+    connect(pulseManager_, &RecencyPulseManager::pulsing_complete,
+            this, &ClientCdsConventionModel::onPulsingComplete);
+}
+
+int ClientCdsConventionModel::rowCount(const QModelIndex& parent) const {
+    if (parent.isValid())
+        return 0;
+    return static_cast<int>(cds_conventions_.size());
+}
+
+int ClientCdsConventionModel::columnCount(const QModelIndex& parent) const {
+    if (parent.isValid())
+        return 0;
+    return ColumnCount;
+}
+
+QVariant ClientCdsConventionModel::data(
+    const QModelIndex& index, int role) const {
+    if (!index.isValid())
+        return {};
+
+    const auto row = static_cast<std::size_t>(index.row());
+    if (row >= cds_conventions_.size())
+        return {};
+
+    const auto& cc = cds_conventions_[row];
+
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case Id:
+            return QString::fromStdString(cc.id);
+        case Frequency:
+            return QString::fromStdString(cc.frequency);
+        case Rule:
+            return QString::fromStdString(cc.rule);
+        case DayCountFraction:
+            return QString::fromStdString(cc.day_count_fraction);
+        case Version:
+            return static_cast<qlonglong>(cc.version);
+        case ModifiedBy:
+            return QString::fromStdString(cc.modified_by);
+        case RecordedAt:
+            return relative_time_helper::format(cc.recorded_at);
+        default:
+            return {};
+        }
+    }
+
+    if (role == Qt::ForegroundRole) {
+        return recency_foreground_color(cc.id);
+    }
+
+    return {};
+}
+
+QVariant ClientCdsConventionModel::headerData(
+    int section, Qt::Orientation orientation, int role) const {
+    if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
+        return {};
+
+    switch (section) {
+    case Id:
+        return tr("Id");
+    case Frequency:
+        return tr("Frequency");
+    case Rule:
+        return tr("Rule");
+    case DayCountFraction:
+        return tr("DCF");
+    case Version:
+        return tr("Version");
+    case ModifiedBy:
+        return tr("Modified By");
+    case RecordedAt:
+        return tr("Recorded At");
+    default:
+        return {};
+    }
+}
+
+void ClientCdsConventionModel::refresh() {
+    BOOST_LOG_SEV(lg(), debug) << "Calling refresh.";
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress, ignoring refresh request.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Cannot refresh CDS convention model: disconnected.";
+        emit loadError("Not connected to server");
+        return;
+    }
+
+    if (!cds_conventions_.empty()) {
+        beginResetModel();
+        cds_conventions_.clear();
+        recencyTracker_.clear();
+        pulseManager_->stop_pulsing();
+        total_available_count_ = 0;
+        endResetModel();
+    }
+
+    fetch_cds_conventions(0, page_size_);
+}
+
+void ClientCdsConventionModel::load_page(std::uint32_t offset,
+                                          std::uint32_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "load_page: offset=" << offset << ", limit=" << limit;
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress, ignoring load_page request.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Cannot load page: disconnected.";
+        return;
+    }
+
+    if (!cds_conventions_.empty()) {
+        beginResetModel();
+        cds_conventions_.clear();
+        recencyTracker_.clear();
+        pulseManager_->stop_pulsing();
+        endResetModel();
+    }
+
+    fetch_cds_conventions(offset, limit);
+}
+
+void ClientCdsConventionModel::fetch_cds_conventions(
+    std::uint32_t offset, std::uint32_t limit) {
+    is_fetching_ = true;
+    QPointer<ClientCdsConventionModel> self = this;
+
+    QFuture<FetchResult> future =
+        QtConcurrent::run([self, offset, limit]() -> FetchResult {
+            return exception_helper::wrap_async_fetch<FetchResult>([&]() -> FetchResult {
+                BOOST_LOG_SEV(lg(), debug) << "Making CDS conventions request with offset="
+                                           << offset << ", limit=" << limit;
+                if (!self || !self->clientManager_) {
+                    return {.success = false, .cds_conventions = {},
+                            .total_available_count = 0,
+                            .error_message = "Model was destroyed",
+                            .error_details = {}};
+                }
+
+                refdata::messaging::get_cds_conventions_request request;
+
+                auto result = self->clientManager_->
+                    process_authenticated_request(std::move(request));
+
+                if (!result) {
+                    BOOST_LOG_SEV(lg(), error) << "Failed to send request: " << result.error();
+                    return {.success = false, .cds_conventions = {},
+                            .total_available_count = 0,
+                            .error_message = QString::fromStdString(result.error()),
+                            .error_details = {}};
+                }
+
+                BOOST_LOG_SEV(lg(), debug) << "Fetched " << result->cds_conventions.size()
+                                           << " CDS conventions";
+                const std::uint32_t count =
+                    static_cast<std::uint32_t>(result->cds_conventions.size());
+                return {.success = true,
+                        .cds_conventions = std::move(result->cds_conventions),
+                        .total_available_count = count,
+                        .error_message = {}, .error_details = {}};
+            }, "CDS conventions");
+        });
+
+    watcher_->setFuture(future);
+}
+
+void ClientCdsConventionModel::onConventionsLoaded() {
+    is_fetching_ = false;
+
+    const auto result = watcher_->result();
+
+    if (!result.success) {
+        BOOST_LOG_SEV(lg(), error) << "Failed to fetch CDS conventions: "
+                                   << result.error_message.toStdString();
+        emit loadError(result.error_message, result.error_details);
+        return;
+    }
+
+    total_available_count_ = result.total_available_count;
+
+    const int new_count = static_cast<int>(result.cds_conventions.size());
+
+    if (new_count > 0) {
+        beginResetModel();
+        cds_conventions_ = std::move(result.cds_conventions);
+        endResetModel();
+
+        const bool has_recent = recencyTracker_.update(cds_conventions_);
+        if (has_recent && !pulseManager_->is_pulsing()) {
+            pulseManager_->start_pulsing();
+            BOOST_LOG_SEV(lg(), debug) << "Found " << recencyTracker_.recent_count()
+                                       << " CDS conventions newer than last reload";
+        }
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Loaded " << new_count << " CDS conventions."
+                              << " Total available: " << total_available_count_;
+
+    emit dataLoaded();
+}
+
+void ClientCdsConventionModel::set_page_size(std::uint32_t size) {
+    if (size == 0 || size > 1000) {
+        BOOST_LOG_SEV(lg(), warn) << "Invalid page size: " << size
+                                  << ". Must be between 1 and 1000. Using default: 100";
+        page_size_ = 100;
+    } else {
+        page_size_ = size;
+        BOOST_LOG_SEV(lg(), info) << "Page size set to: " << page_size_;
+    }
+}
+
+const refdata::domain::cds_convention*
+ClientCdsConventionModel::getConvention(int row) const {
+    const auto idx = static_cast<std::size_t>(row);
+    if (idx >= cds_conventions_.size())
+        return nullptr;
+    return &cds_conventions_[idx];
+}
+
+QVariant ClientCdsConventionModel::recency_foreground_color(
+    const std::string& code) const {
+    if (recencyTracker_.is_recent(code) && pulseManager_->is_pulse_on()) {
+        return color_constants::stale_indicator;
+    }
+    return {};
+}
+
+void ClientCdsConventionModel::onPulseStateChanged(bool /*isOn*/) {
+    if (!cds_conventions_.empty()) {
+        emit dataChanged(index(0, 0), index(rowCount() - 1, columnCount() - 1),
+            {Qt::ForegroundRole});
+    }
+}
+
+void ClientCdsConventionModel::onPulsingComplete() {
+    BOOST_LOG_SEV(lg(), debug) << "Recency highlight pulsing complete";
+    recencyTracker_.clear();
+}
+
+}

--- a/projects/ores.qt.refdata/src/ClientFraConventionModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientFraConventionModel.cpp
@@ -1,0 +1,292 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/ClientFraConventionModel.hpp"
+
+#include <QtConcurrent>
+#include "ores.refdata.api/messaging/fra_convention_protocol.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/ExceptionHelper.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+namespace {
+    std::string fra_convention_key_extractor(const refdata::domain::fra_convention& e) {
+        return e.id;
+    }
+}
+
+ClientFraConventionModel::ClientFraConventionModel(
+    ClientManager* clientManager, QObject* parent)
+    : AbstractClientModel(parent),
+      clientManager_(clientManager),
+      watcher_(new QFutureWatcher<FetchResult>(this)),
+      recencyTracker_(fra_convention_key_extractor),
+      pulseManager_(new RecencyPulseManager(this)) {
+
+    connect(watcher_, &QFutureWatcher<FetchResult>::finished,
+            this, &ClientFraConventionModel::onConventionsLoaded);
+
+    connect(pulseManager_, &RecencyPulseManager::pulse_state_changed,
+            this, &ClientFraConventionModel::onPulseStateChanged);
+    connect(pulseManager_, &RecencyPulseManager::pulsing_complete,
+            this, &ClientFraConventionModel::onPulsingComplete);
+}
+
+int ClientFraConventionModel::rowCount(const QModelIndex& parent) const {
+    if (parent.isValid())
+        return 0;
+    return static_cast<int>(fra_conventions_.size());
+}
+
+int ClientFraConventionModel::columnCount(const QModelIndex& parent) const {
+    if (parent.isValid())
+        return 0;
+    return ColumnCount;
+}
+
+QVariant ClientFraConventionModel::data(
+    const QModelIndex& index, int role) const {
+    if (!index.isValid())
+        return {};
+
+    const auto row = static_cast<std::size_t>(index.row());
+    if (row >= fra_conventions_.size())
+        return {};
+
+    const auto& fc = fra_conventions_[row];
+
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case Id:
+            return QString::fromStdString(fc.id);
+        case Index:
+            return QString::fromStdString(fc.index);
+        case Version:
+            return static_cast<qlonglong>(fc.version);
+        case ModifiedBy:
+            return QString::fromStdString(fc.modified_by);
+        case RecordedAt:
+            return relative_time_helper::format(fc.recorded_at);
+        default:
+            return {};
+        }
+    }
+
+    if (role == Qt::ForegroundRole) {
+        return recency_foreground_color(fc.id);
+    }
+
+    return {};
+}
+
+QVariant ClientFraConventionModel::headerData(
+    int section, Qt::Orientation orientation, int role) const {
+    if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
+        return {};
+
+    switch (section) {
+    case Id:
+        return tr("Id");
+    case Index:
+        return tr("Index");
+    case Version:
+        return tr("Version");
+    case ModifiedBy:
+        return tr("Modified By");
+    case RecordedAt:
+        return tr("Recorded At");
+    default:
+        return {};
+    }
+}
+
+void ClientFraConventionModel::refresh() {
+    BOOST_LOG_SEV(lg(), debug) << "Calling refresh.";
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress, ignoring refresh request.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Cannot refresh FRA convention model: disconnected.";
+        emit loadError("Not connected to server");
+        return;
+    }
+
+    if (!fra_conventions_.empty()) {
+        beginResetModel();
+        fra_conventions_.clear();
+        recencyTracker_.clear();
+        pulseManager_->stop_pulsing();
+        total_available_count_ = 0;
+        endResetModel();
+    }
+
+    fetch_fra_conventions(0, page_size_);
+}
+
+void ClientFraConventionModel::load_page(std::uint32_t offset,
+                                          std::uint32_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "load_page: offset=" << offset << ", limit=" << limit;
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress, ignoring load_page request.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Cannot load page: disconnected.";
+        return;
+    }
+
+    if (!fra_conventions_.empty()) {
+        beginResetModel();
+        fra_conventions_.clear();
+        recencyTracker_.clear();
+        pulseManager_->stop_pulsing();
+        endResetModel();
+    }
+
+    fetch_fra_conventions(offset, limit);
+}
+
+void ClientFraConventionModel::fetch_fra_conventions(
+    std::uint32_t offset, std::uint32_t limit) {
+    is_fetching_ = true;
+    QPointer<ClientFraConventionModel> self = this;
+
+    QFuture<FetchResult> future =
+        QtConcurrent::run([self, offset, limit]() -> FetchResult {
+            return exception_helper::wrap_async_fetch<FetchResult>([&]() -> FetchResult {
+                BOOST_LOG_SEV(lg(), debug) << "Making FRA conventions request with offset="
+                                           << offset << ", limit=" << limit;
+                if (!self || !self->clientManager_) {
+                    return {.success = false, .fra_conventions = {},
+                            .total_available_count = 0,
+                            .error_message = "Model was destroyed",
+                            .error_details = {}};
+                }
+
+                refdata::messaging::get_fra_conventions_request request;
+
+                auto result = self->clientManager_->
+                    process_authenticated_request(std::move(request));
+
+                if (!result) {
+                    BOOST_LOG_SEV(lg(), error) << "Failed to send request: " << result.error();
+                    return {.success = false, .fra_conventions = {},
+                            .total_available_count = 0,
+                            .error_message = QString::fromStdString(result.error()),
+                            .error_details = {}};
+                }
+
+                BOOST_LOG_SEV(lg(), debug) << "Fetched " << result->fra_conventions.size()
+                                           << " FRA conventions";
+                const std::uint32_t count =
+                    static_cast<std::uint32_t>(result->fra_conventions.size());
+                return {.success = true,
+                        .fra_conventions = std::move(result->fra_conventions),
+                        .total_available_count = count,
+                        .error_message = {}, .error_details = {}};
+            }, "FRA conventions");
+        });
+
+    watcher_->setFuture(future);
+}
+
+void ClientFraConventionModel::onConventionsLoaded() {
+    is_fetching_ = false;
+
+    const auto result = watcher_->result();
+
+    if (!result.success) {
+        BOOST_LOG_SEV(lg(), error) << "Failed to fetch FRA conventions: "
+                                   << result.error_message.toStdString();
+        emit loadError(result.error_message, result.error_details);
+        return;
+    }
+
+    total_available_count_ = result.total_available_count;
+
+    const int new_count = static_cast<int>(result.fra_conventions.size());
+
+    if (new_count > 0) {
+        beginResetModel();
+        fra_conventions_ = std::move(result.fra_conventions);
+        endResetModel();
+
+        const bool has_recent = recencyTracker_.update(fra_conventions_);
+        if (has_recent && !pulseManager_->is_pulsing()) {
+            pulseManager_->start_pulsing();
+            BOOST_LOG_SEV(lg(), debug) << "Found " << recencyTracker_.recent_count()
+                                       << " FRA conventions newer than last reload";
+        }
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Loaded " << new_count << " FRA conventions."
+                              << " Total available: " << total_available_count_;
+
+    emit dataLoaded();
+}
+
+void ClientFraConventionModel::set_page_size(std::uint32_t size) {
+    if (size == 0 || size > 1000) {
+        BOOST_LOG_SEV(lg(), warn) << "Invalid page size: " << size
+                                  << ". Must be between 1 and 1000. Using default: 100";
+        page_size_ = 100;
+    } else {
+        page_size_ = size;
+        BOOST_LOG_SEV(lg(), info) << "Page size set to: " << page_size_;
+    }
+}
+
+const refdata::domain::fra_convention*
+ClientFraConventionModel::getConvention(int row) const {
+    const auto idx = static_cast<std::size_t>(row);
+    if (idx >= fra_conventions_.size())
+        return nullptr;
+    return &fra_conventions_[idx];
+}
+
+QVariant ClientFraConventionModel::recency_foreground_color(
+    const std::string& code) const {
+    if (recencyTracker_.is_recent(code) && pulseManager_->is_pulse_on()) {
+        return color_constants::stale_indicator;
+    }
+    return {};
+}
+
+void ClientFraConventionModel::onPulseStateChanged(bool /*isOn*/) {
+    if (!fra_conventions_.empty()) {
+        emit dataChanged(index(0, 0), index(rowCount() - 1, columnCount() - 1),
+            {Qt::ForegroundRole});
+    }
+}
+
+void ClientFraConventionModel::onPulsingComplete() {
+    BOOST_LOG_SEV(lg(), debug) << "Recency highlight pulsing complete";
+    recencyTracker_.clear();
+}
+
+}

--- a/projects/ores.qt.refdata/src/ClientFxConventionModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientFxConventionModel.cpp
@@ -1,0 +1,300 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/ClientFxConventionModel.hpp"
+
+#include <QtConcurrent>
+#include "ores.refdata.api/messaging/fx_convention_protocol.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/ExceptionHelper.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+namespace {
+    std::string fx_convention_key_extractor(const refdata::domain::fx_convention& e) {
+        return e.id;
+    }
+}
+
+ClientFxConventionModel::ClientFxConventionModel(
+    ClientManager* clientManager, QObject* parent)
+    : AbstractClientModel(parent),
+      clientManager_(clientManager),
+      watcher_(new QFutureWatcher<FetchResult>(this)),
+      recencyTracker_(fx_convention_key_extractor),
+      pulseManager_(new RecencyPulseManager(this)) {
+
+    connect(watcher_, &QFutureWatcher<FetchResult>::finished,
+            this, &ClientFxConventionModel::onConventionsLoaded);
+
+    connect(pulseManager_, &RecencyPulseManager::pulse_state_changed,
+            this, &ClientFxConventionModel::onPulseStateChanged);
+    connect(pulseManager_, &RecencyPulseManager::pulsing_complete,
+            this, &ClientFxConventionModel::onPulsingComplete);
+}
+
+int ClientFxConventionModel::rowCount(const QModelIndex& parent) const {
+    if (parent.isValid())
+        return 0;
+    return static_cast<int>(fx_conventions_.size());
+}
+
+int ClientFxConventionModel::columnCount(const QModelIndex& parent) const {
+    if (parent.isValid())
+        return 0;
+    return ColumnCount;
+}
+
+QVariant ClientFxConventionModel::data(
+    const QModelIndex& index, int role) const {
+    if (!index.isValid())
+        return {};
+
+    const auto row = static_cast<std::size_t>(index.row());
+    if (row >= fx_conventions_.size())
+        return {};
+
+    const auto& fxc = fx_conventions_[row];
+
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case Id:
+            return QString::fromStdString(fxc.id);
+        case SourceCurrency:
+            return QString::fromStdString(fxc.source_currency);
+        case TargetCurrency:
+            return QString::fromStdString(fxc.target_currency);
+        case SpotDays:
+            return static_cast<qlonglong>(fxc.spot_days);
+        case Version:
+            return static_cast<qlonglong>(fxc.version);
+        case ModifiedBy:
+            return QString::fromStdString(fxc.modified_by);
+        case RecordedAt:
+            return relative_time_helper::format(fxc.recorded_at);
+        default:
+            return {};
+        }
+    }
+
+    if (role == Qt::ForegroundRole) {
+        return recency_foreground_color(fxc.id);
+    }
+
+    return {};
+}
+
+QVariant ClientFxConventionModel::headerData(
+    int section, Qt::Orientation orientation, int role) const {
+    if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
+        return {};
+
+    switch (section) {
+    case Id:
+        return tr("Id");
+    case SourceCurrency:
+        return tr("Source CCY");
+    case TargetCurrency:
+        return tr("Target CCY");
+    case SpotDays:
+        return tr("Spot Days");
+    case Version:
+        return tr("Version");
+    case ModifiedBy:
+        return tr("Modified By");
+    case RecordedAt:
+        return tr("Recorded At");
+    default:
+        return {};
+    }
+}
+
+void ClientFxConventionModel::refresh() {
+    BOOST_LOG_SEV(lg(), debug) << "Calling refresh.";
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress, ignoring refresh request.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Cannot refresh FX convention model: disconnected.";
+        emit loadError("Not connected to server");
+        return;
+    }
+
+    if (!fx_conventions_.empty()) {
+        beginResetModel();
+        fx_conventions_.clear();
+        recencyTracker_.clear();
+        pulseManager_->stop_pulsing();
+        total_available_count_ = 0;
+        endResetModel();
+    }
+
+    fetch_fx_conventions(0, page_size_);
+}
+
+void ClientFxConventionModel::load_page(std::uint32_t offset,
+                                          std::uint32_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "load_page: offset=" << offset << ", limit=" << limit;
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress, ignoring load_page request.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Cannot load page: disconnected.";
+        return;
+    }
+
+    if (!fx_conventions_.empty()) {
+        beginResetModel();
+        fx_conventions_.clear();
+        recencyTracker_.clear();
+        pulseManager_->stop_pulsing();
+        endResetModel();
+    }
+
+    fetch_fx_conventions(offset, limit);
+}
+
+void ClientFxConventionModel::fetch_fx_conventions(
+    std::uint32_t offset, std::uint32_t limit) {
+    is_fetching_ = true;
+    QPointer<ClientFxConventionModel> self = this;
+
+    QFuture<FetchResult> future =
+        QtConcurrent::run([self, offset, limit]() -> FetchResult {
+            return exception_helper::wrap_async_fetch<FetchResult>([&]() -> FetchResult {
+                BOOST_LOG_SEV(lg(), debug) << "Making FX conventions request with offset="
+                                           << offset << ", limit=" << limit;
+                if (!self || !self->clientManager_) {
+                    return {.success = false, .fx_conventions = {},
+                            .total_available_count = 0,
+                            .error_message = "Model was destroyed",
+                            .error_details = {}};
+                }
+
+                refdata::messaging::get_fx_conventions_request request;
+
+                auto result = self->clientManager_->
+                    process_authenticated_request(std::move(request));
+
+                if (!result) {
+                    BOOST_LOG_SEV(lg(), error) << "Failed to send request: " << result.error();
+                    return {.success = false, .fx_conventions = {},
+                            .total_available_count = 0,
+                            .error_message = QString::fromStdString(result.error()),
+                            .error_details = {}};
+                }
+
+                BOOST_LOG_SEV(lg(), debug) << "Fetched " << result->fx_conventions.size()
+                                           << " FX conventions";
+                const std::uint32_t count =
+                    static_cast<std::uint32_t>(result->fx_conventions.size());
+                return {.success = true,
+                        .fx_conventions = std::move(result->fx_conventions),
+                        .total_available_count = count,
+                        .error_message = {}, .error_details = {}};
+            }, "FX conventions");
+        });
+
+    watcher_->setFuture(future);
+}
+
+void ClientFxConventionModel::onConventionsLoaded() {
+    is_fetching_ = false;
+
+    const auto result = watcher_->result();
+
+    if (!result.success) {
+        BOOST_LOG_SEV(lg(), error) << "Failed to fetch FX conventions: "
+                                   << result.error_message.toStdString();
+        emit loadError(result.error_message, result.error_details);
+        return;
+    }
+
+    total_available_count_ = result.total_available_count;
+
+    const int new_count = static_cast<int>(result.fx_conventions.size());
+
+    if (new_count > 0) {
+        beginResetModel();
+        fx_conventions_ = std::move(result.fx_conventions);
+        endResetModel();
+
+        const bool has_recent = recencyTracker_.update(fx_conventions_);
+        if (has_recent && !pulseManager_->is_pulsing()) {
+            pulseManager_->start_pulsing();
+            BOOST_LOG_SEV(lg(), debug) << "Found " << recencyTracker_.recent_count()
+                                       << " FX conventions newer than last reload";
+        }
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Loaded " << new_count << " FX conventions."
+                              << " Total available: " << total_available_count_;
+
+    emit dataLoaded();
+}
+
+void ClientFxConventionModel::set_page_size(std::uint32_t size) {
+    if (size == 0 || size > 1000) {
+        BOOST_LOG_SEV(lg(), warn) << "Invalid page size: " << size
+                                  << ". Must be between 1 and 1000. Using default: 100";
+        page_size_ = 100;
+    } else {
+        page_size_ = size;
+        BOOST_LOG_SEV(lg(), info) << "Page size set to: " << page_size_;
+    }
+}
+
+const refdata::domain::fx_convention*
+ClientFxConventionModel::getConvention(int row) const {
+    const auto idx = static_cast<std::size_t>(row);
+    if (idx >= fx_conventions_.size())
+        return nullptr;
+    return &fx_conventions_[idx];
+}
+
+QVariant ClientFxConventionModel::recency_foreground_color(
+    const std::string& code) const {
+    if (recencyTracker_.is_recent(code) && pulseManager_->is_pulse_on()) {
+        return color_constants::stale_indicator;
+    }
+    return {};
+}
+
+void ClientFxConventionModel::onPulseStateChanged(bool /*isOn*/) {
+    if (!fx_conventions_.empty()) {
+        emit dataChanged(index(0, 0), index(rowCount() - 1, columnCount() - 1),
+            {Qt::ForegroundRole});
+    }
+}
+
+void ClientFxConventionModel::onPulsingComplete() {
+    BOOST_LOG_SEV(lg(), debug) << "Recency highlight pulsing complete";
+    recencyTracker_.clear();
+}
+
+}

--- a/projects/ores.qt.refdata/src/ClientIborIndexConventionModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientIborIndexConventionModel.cpp
@@ -1,0 +1,300 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/ClientIborIndexConventionModel.hpp"
+
+#include <QtConcurrent>
+#include "ores.refdata.api/messaging/ibor_index_convention_protocol.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/ExceptionHelper.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+namespace {
+    std::string ibor_index_convention_key_extractor(const refdata::domain::ibor_index_convention& e) {
+        return e.id;
+    }
+}
+
+ClientIborIndexConventionModel::ClientIborIndexConventionModel(
+    ClientManager* clientManager, QObject* parent)
+    : AbstractClientModel(parent),
+      clientManager_(clientManager),
+      watcher_(new QFutureWatcher<FetchResult>(this)),
+      recencyTracker_(ibor_index_convention_key_extractor),
+      pulseManager_(new RecencyPulseManager(this)) {
+
+    connect(watcher_, &QFutureWatcher<FetchResult>::finished,
+            this, &ClientIborIndexConventionModel::onConventionsLoaded);
+
+    connect(pulseManager_, &RecencyPulseManager::pulse_state_changed,
+            this, &ClientIborIndexConventionModel::onPulseStateChanged);
+    connect(pulseManager_, &RecencyPulseManager::pulsing_complete,
+            this, &ClientIborIndexConventionModel::onPulsingComplete);
+}
+
+int ClientIborIndexConventionModel::rowCount(const QModelIndex& parent) const {
+    if (parent.isValid())
+        return 0;
+    return static_cast<int>(ibor_index_conventions_.size());
+}
+
+int ClientIborIndexConventionModel::columnCount(const QModelIndex& parent) const {
+    if (parent.isValid())
+        return 0;
+    return ColumnCount;
+}
+
+QVariant ClientIborIndexConventionModel::data(
+    const QModelIndex& index, int role) const {
+    if (!index.isValid())
+        return {};
+
+    const auto row = static_cast<std::size_t>(index.row());
+    if (row >= ibor_index_conventions_.size())
+        return {};
+
+    const auto& ic = ibor_index_conventions_[row];
+
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case Id:
+            return QString::fromStdString(ic.id);
+        case FixingCalendar:
+            return QString::fromStdString(ic.fixing_calendar);
+        case DayCountFraction:
+            return QString::fromStdString(ic.day_count_fraction);
+        case SettlementDays:
+            return static_cast<qlonglong>(ic.settlement_days);
+        case Version:
+            return static_cast<qlonglong>(ic.version);
+        case ModifiedBy:
+            return QString::fromStdString(ic.modified_by);
+        case RecordedAt:
+            return relative_time_helper::format(ic.recorded_at);
+        default:
+            return {};
+        }
+    }
+
+    if (role == Qt::ForegroundRole) {
+        return recency_foreground_color(ic.id);
+    }
+
+    return {};
+}
+
+QVariant ClientIborIndexConventionModel::headerData(
+    int section, Qt::Orientation orientation, int role) const {
+    if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
+        return {};
+
+    switch (section) {
+    case Id:
+        return tr("Id");
+    case FixingCalendar:
+        return tr("Fixing Calendar");
+    case DayCountFraction:
+        return tr("DCF");
+    case SettlementDays:
+        return tr("Settlement Days");
+    case Version:
+        return tr("Version");
+    case ModifiedBy:
+        return tr("Modified By");
+    case RecordedAt:
+        return tr("Recorded At");
+    default:
+        return {};
+    }
+}
+
+void ClientIborIndexConventionModel::refresh() {
+    BOOST_LOG_SEV(lg(), debug) << "Calling refresh.";
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress, ignoring refresh request.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Cannot refresh IBOR index convention model: disconnected.";
+        emit loadError("Not connected to server");
+        return;
+    }
+
+    if (!ibor_index_conventions_.empty()) {
+        beginResetModel();
+        ibor_index_conventions_.clear();
+        recencyTracker_.clear();
+        pulseManager_->stop_pulsing();
+        total_available_count_ = 0;
+        endResetModel();
+    }
+
+    fetch_ibor_index_conventions(0, page_size_);
+}
+
+void ClientIborIndexConventionModel::load_page(std::uint32_t offset,
+                                          std::uint32_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "load_page: offset=" << offset << ", limit=" << limit;
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress, ignoring load_page request.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Cannot load page: disconnected.";
+        return;
+    }
+
+    if (!ibor_index_conventions_.empty()) {
+        beginResetModel();
+        ibor_index_conventions_.clear();
+        recencyTracker_.clear();
+        pulseManager_->stop_pulsing();
+        endResetModel();
+    }
+
+    fetch_ibor_index_conventions(offset, limit);
+}
+
+void ClientIborIndexConventionModel::fetch_ibor_index_conventions(
+    std::uint32_t offset, std::uint32_t limit) {
+    is_fetching_ = true;
+    QPointer<ClientIborIndexConventionModel> self = this;
+
+    QFuture<FetchResult> future =
+        QtConcurrent::run([self, offset, limit]() -> FetchResult {
+            return exception_helper::wrap_async_fetch<FetchResult>([&]() -> FetchResult {
+                BOOST_LOG_SEV(lg(), debug) << "Making IBOR index conventions request with offset="
+                                           << offset << ", limit=" << limit;
+                if (!self || !self->clientManager_) {
+                    return {.success = false, .ibor_index_conventions = {},
+                            .total_available_count = 0,
+                            .error_message = "Model was destroyed",
+                            .error_details = {}};
+                }
+
+                refdata::messaging::get_ibor_index_conventions_request request;
+
+                auto result = self->clientManager_->
+                    process_authenticated_request(std::move(request));
+
+                if (!result) {
+                    BOOST_LOG_SEV(lg(), error) << "Failed to send request: " << result.error();
+                    return {.success = false, .ibor_index_conventions = {},
+                            .total_available_count = 0,
+                            .error_message = QString::fromStdString(result.error()),
+                            .error_details = {}};
+                }
+
+                BOOST_LOG_SEV(lg(), debug) << "Fetched " << result->ibor_index_conventions.size()
+                                           << " IBOR index conventions";
+                const std::uint32_t count =
+                    static_cast<std::uint32_t>(result->ibor_index_conventions.size());
+                return {.success = true,
+                        .ibor_index_conventions = std::move(result->ibor_index_conventions),
+                        .total_available_count = count,
+                        .error_message = {}, .error_details = {}};
+            }, "IBOR index conventions");
+        });
+
+    watcher_->setFuture(future);
+}
+
+void ClientIborIndexConventionModel::onConventionsLoaded() {
+    is_fetching_ = false;
+
+    const auto result = watcher_->result();
+
+    if (!result.success) {
+        BOOST_LOG_SEV(lg(), error) << "Failed to fetch IBOR index conventions: "
+                                   << result.error_message.toStdString();
+        emit loadError(result.error_message, result.error_details);
+        return;
+    }
+
+    total_available_count_ = result.total_available_count;
+
+    const int new_count = static_cast<int>(result.ibor_index_conventions.size());
+
+    if (new_count > 0) {
+        beginResetModel();
+        ibor_index_conventions_ = std::move(result.ibor_index_conventions);
+        endResetModel();
+
+        const bool has_recent = recencyTracker_.update(ibor_index_conventions_);
+        if (has_recent && !pulseManager_->is_pulsing()) {
+            pulseManager_->start_pulsing();
+            BOOST_LOG_SEV(lg(), debug) << "Found " << recencyTracker_.recent_count()
+                                       << " IBOR index conventions newer than last reload";
+        }
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Loaded " << new_count << " IBOR index conventions."
+                              << " Total available: " << total_available_count_;
+
+    emit dataLoaded();
+}
+
+void ClientIborIndexConventionModel::set_page_size(std::uint32_t size) {
+    if (size == 0 || size > 1000) {
+        BOOST_LOG_SEV(lg(), warn) << "Invalid page size: " << size
+                                  << ". Must be between 1 and 1000. Using default: 100";
+        page_size_ = 100;
+    } else {
+        page_size_ = size;
+        BOOST_LOG_SEV(lg(), info) << "Page size set to: " << page_size_;
+    }
+}
+
+const refdata::domain::ibor_index_convention*
+ClientIborIndexConventionModel::getConvention(int row) const {
+    const auto idx = static_cast<std::size_t>(row);
+    if (idx >= ibor_index_conventions_.size())
+        return nullptr;
+    return &ibor_index_conventions_[idx];
+}
+
+QVariant ClientIborIndexConventionModel::recency_foreground_color(
+    const std::string& code) const {
+    if (recencyTracker_.is_recent(code) && pulseManager_->is_pulse_on()) {
+        return color_constants::stale_indicator;
+    }
+    return {};
+}
+
+void ClientIborIndexConventionModel::onPulseStateChanged(bool /*isOn*/) {
+    if (!ibor_index_conventions_.empty()) {
+        emit dataChanged(index(0, 0), index(rowCount() - 1, columnCount() - 1),
+            {Qt::ForegroundRole});
+    }
+}
+
+void ClientIborIndexConventionModel::onPulsingComplete() {
+    BOOST_LOG_SEV(lg(), debug) << "Recency highlight pulsing complete";
+    recencyTracker_.clear();
+}
+
+}

--- a/projects/ores.qt.refdata/src/ClientOisConventionModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientOisConventionModel.cpp
@@ -1,0 +1,300 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/ClientOisConventionModel.hpp"
+
+#include <QtConcurrent>
+#include "ores.refdata.api/messaging/ois_convention_protocol.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/ExceptionHelper.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+namespace {
+    std::string ois_convention_key_extractor(const refdata::domain::ois_convention& e) {
+        return e.id;
+    }
+}
+
+ClientOisConventionModel::ClientOisConventionModel(
+    ClientManager* clientManager, QObject* parent)
+    : AbstractClientModel(parent),
+      clientManager_(clientManager),
+      watcher_(new QFutureWatcher<FetchResult>(this)),
+      recencyTracker_(ois_convention_key_extractor),
+      pulseManager_(new RecencyPulseManager(this)) {
+
+    connect(watcher_, &QFutureWatcher<FetchResult>::finished,
+            this, &ClientOisConventionModel::onConventionsLoaded);
+
+    connect(pulseManager_, &RecencyPulseManager::pulse_state_changed,
+            this, &ClientOisConventionModel::onPulseStateChanged);
+    connect(pulseManager_, &RecencyPulseManager::pulsing_complete,
+            this, &ClientOisConventionModel::onPulsingComplete);
+}
+
+int ClientOisConventionModel::rowCount(const QModelIndex& parent) const {
+    if (parent.isValid())
+        return 0;
+    return static_cast<int>(ois_conventions_.size());
+}
+
+int ClientOisConventionModel::columnCount(const QModelIndex& parent) const {
+    if (parent.isValid())
+        return 0;
+    return ColumnCount;
+}
+
+QVariant ClientOisConventionModel::data(
+    const QModelIndex& index, int role) const {
+    if (!index.isValid())
+        return {};
+
+    const auto row = static_cast<std::size_t>(index.row());
+    if (row >= ois_conventions_.size())
+        return {};
+
+    const auto& oc = ois_conventions_[row];
+
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case Id:
+            return QString::fromStdString(oc.id);
+        case Index:
+            return QString::fromStdString(oc.index);
+        case SpotLag:
+            return static_cast<qlonglong>(oc.spot_lag);
+        case FixedDayCountFraction:
+            return QString::fromStdString(oc.fixed_day_count_fraction);
+        case Version:
+            return static_cast<qlonglong>(oc.version);
+        case ModifiedBy:
+            return QString::fromStdString(oc.modified_by);
+        case RecordedAt:
+            return relative_time_helper::format(oc.recorded_at);
+        default:
+            return {};
+        }
+    }
+
+    if (role == Qt::ForegroundRole) {
+        return recency_foreground_color(oc.id);
+    }
+
+    return {};
+}
+
+QVariant ClientOisConventionModel::headerData(
+    int section, Qt::Orientation orientation, int role) const {
+    if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
+        return {};
+
+    switch (section) {
+    case Id:
+        return tr("Id");
+    case Index:
+        return tr("Index");
+    case SpotLag:
+        return tr("Spot Lag");
+    case FixedDayCountFraction:
+        return tr("Fixed DCF");
+    case Version:
+        return tr("Version");
+    case ModifiedBy:
+        return tr("Modified By");
+    case RecordedAt:
+        return tr("Recorded At");
+    default:
+        return {};
+    }
+}
+
+void ClientOisConventionModel::refresh() {
+    BOOST_LOG_SEV(lg(), debug) << "Calling refresh.";
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress, ignoring refresh request.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Cannot refresh OIS convention model: disconnected.";
+        emit loadError("Not connected to server");
+        return;
+    }
+
+    if (!ois_conventions_.empty()) {
+        beginResetModel();
+        ois_conventions_.clear();
+        recencyTracker_.clear();
+        pulseManager_->stop_pulsing();
+        total_available_count_ = 0;
+        endResetModel();
+    }
+
+    fetch_ois_conventions(0, page_size_);
+}
+
+void ClientOisConventionModel::load_page(std::uint32_t offset,
+                                          std::uint32_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "load_page: offset=" << offset << ", limit=" << limit;
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress, ignoring load_page request.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Cannot load page: disconnected.";
+        return;
+    }
+
+    if (!ois_conventions_.empty()) {
+        beginResetModel();
+        ois_conventions_.clear();
+        recencyTracker_.clear();
+        pulseManager_->stop_pulsing();
+        endResetModel();
+    }
+
+    fetch_ois_conventions(offset, limit);
+}
+
+void ClientOisConventionModel::fetch_ois_conventions(
+    std::uint32_t offset, std::uint32_t limit) {
+    is_fetching_ = true;
+    QPointer<ClientOisConventionModel> self = this;
+
+    QFuture<FetchResult> future =
+        QtConcurrent::run([self, offset, limit]() -> FetchResult {
+            return exception_helper::wrap_async_fetch<FetchResult>([&]() -> FetchResult {
+                BOOST_LOG_SEV(lg(), debug) << "Making OIS conventions request with offset="
+                                           << offset << ", limit=" << limit;
+                if (!self || !self->clientManager_) {
+                    return {.success = false, .ois_conventions = {},
+                            .total_available_count = 0,
+                            .error_message = "Model was destroyed",
+                            .error_details = {}};
+                }
+
+                refdata::messaging::get_ois_conventions_request request;
+
+                auto result = self->clientManager_->
+                    process_authenticated_request(std::move(request));
+
+                if (!result) {
+                    BOOST_LOG_SEV(lg(), error) << "Failed to send request: " << result.error();
+                    return {.success = false, .ois_conventions = {},
+                            .total_available_count = 0,
+                            .error_message = QString::fromStdString(result.error()),
+                            .error_details = {}};
+                }
+
+                BOOST_LOG_SEV(lg(), debug) << "Fetched " << result->ois_conventions.size()
+                                           << " OIS conventions";
+                const std::uint32_t count =
+                    static_cast<std::uint32_t>(result->ois_conventions.size());
+                return {.success = true,
+                        .ois_conventions = std::move(result->ois_conventions),
+                        .total_available_count = count,
+                        .error_message = {}, .error_details = {}};
+            }, "OIS conventions");
+        });
+
+    watcher_->setFuture(future);
+}
+
+void ClientOisConventionModel::onConventionsLoaded() {
+    is_fetching_ = false;
+
+    const auto result = watcher_->result();
+
+    if (!result.success) {
+        BOOST_LOG_SEV(lg(), error) << "Failed to fetch OIS conventions: "
+                                   << result.error_message.toStdString();
+        emit loadError(result.error_message, result.error_details);
+        return;
+    }
+
+    total_available_count_ = result.total_available_count;
+
+    const int new_count = static_cast<int>(result.ois_conventions.size());
+
+    if (new_count > 0) {
+        beginResetModel();
+        ois_conventions_ = std::move(result.ois_conventions);
+        endResetModel();
+
+        const bool has_recent = recencyTracker_.update(ois_conventions_);
+        if (has_recent && !pulseManager_->is_pulsing()) {
+            pulseManager_->start_pulsing();
+            BOOST_LOG_SEV(lg(), debug) << "Found " << recencyTracker_.recent_count()
+                                       << " OIS conventions newer than last reload";
+        }
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Loaded " << new_count << " OIS conventions."
+                              << " Total available: " << total_available_count_;
+
+    emit dataLoaded();
+}
+
+void ClientOisConventionModel::set_page_size(std::uint32_t size) {
+    if (size == 0 || size > 1000) {
+        BOOST_LOG_SEV(lg(), warn) << "Invalid page size: " << size
+                                  << ". Must be between 1 and 1000. Using default: 100";
+        page_size_ = 100;
+    } else {
+        page_size_ = size;
+        BOOST_LOG_SEV(lg(), info) << "Page size set to: " << page_size_;
+    }
+}
+
+const refdata::domain::ois_convention*
+ClientOisConventionModel::getConvention(int row) const {
+    const auto idx = static_cast<std::size_t>(row);
+    if (idx >= ois_conventions_.size())
+        return nullptr;
+    return &ois_conventions_[idx];
+}
+
+QVariant ClientOisConventionModel::recency_foreground_color(
+    const std::string& code) const {
+    if (recencyTracker_.is_recent(code) && pulseManager_->is_pulse_on()) {
+        return color_constants::stale_indicator;
+    }
+    return {};
+}
+
+void ClientOisConventionModel::onPulseStateChanged(bool /*isOn*/) {
+    if (!ois_conventions_.empty()) {
+        emit dataChanged(index(0, 0), index(rowCount() - 1, columnCount() - 1),
+            {Qt::ForegroundRole});
+    }
+}
+
+void ClientOisConventionModel::onPulsingComplete() {
+    BOOST_LOG_SEV(lg(), debug) << "Recency highlight pulsing complete";
+    recencyTracker_.clear();
+}
+
+}

--- a/projects/ores.qt.refdata/src/ClientOvernightIndexConventionModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientOvernightIndexConventionModel.cpp
@@ -1,0 +1,300 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/ClientOvernightIndexConventionModel.hpp"
+
+#include <QtConcurrent>
+#include "ores.refdata.api/messaging/overnight_index_convention_protocol.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/ExceptionHelper.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+namespace {
+    std::string overnight_index_convention_key_extractor(const refdata::domain::overnight_index_convention& e) {
+        return e.id;
+    }
+}
+
+ClientOvernightIndexConventionModel::ClientOvernightIndexConventionModel(
+    ClientManager* clientManager, QObject* parent)
+    : AbstractClientModel(parent),
+      clientManager_(clientManager),
+      watcher_(new QFutureWatcher<FetchResult>(this)),
+      recencyTracker_(overnight_index_convention_key_extractor),
+      pulseManager_(new RecencyPulseManager(this)) {
+
+    connect(watcher_, &QFutureWatcher<FetchResult>::finished,
+            this, &ClientOvernightIndexConventionModel::onConventionsLoaded);
+
+    connect(pulseManager_, &RecencyPulseManager::pulse_state_changed,
+            this, &ClientOvernightIndexConventionModel::onPulseStateChanged);
+    connect(pulseManager_, &RecencyPulseManager::pulsing_complete,
+            this, &ClientOvernightIndexConventionModel::onPulsingComplete);
+}
+
+int ClientOvernightIndexConventionModel::rowCount(const QModelIndex& parent) const {
+    if (parent.isValid())
+        return 0;
+    return static_cast<int>(overnight_index_conventions_.size());
+}
+
+int ClientOvernightIndexConventionModel::columnCount(const QModelIndex& parent) const {
+    if (parent.isValid())
+        return 0;
+    return ColumnCount;
+}
+
+QVariant ClientOvernightIndexConventionModel::data(
+    const QModelIndex& index, int role) const {
+    if (!index.isValid())
+        return {};
+
+    const auto row = static_cast<std::size_t>(index.row());
+    if (row >= overnight_index_conventions_.size())
+        return {};
+
+    const auto& ni = overnight_index_conventions_[row];
+
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case Id:
+            return QString::fromStdString(ni.id);
+        case FixingCalendar:
+            return QString::fromStdString(ni.fixing_calendar);
+        case DayCountFraction:
+            return QString::fromStdString(ni.day_count_fraction);
+        case SettlementDays:
+            return static_cast<qlonglong>(ni.settlement_days);
+        case Version:
+            return static_cast<qlonglong>(ni.version);
+        case ModifiedBy:
+            return QString::fromStdString(ni.modified_by);
+        case RecordedAt:
+            return relative_time_helper::format(ni.recorded_at);
+        default:
+            return {};
+        }
+    }
+
+    if (role == Qt::ForegroundRole) {
+        return recency_foreground_color(ni.id);
+    }
+
+    return {};
+}
+
+QVariant ClientOvernightIndexConventionModel::headerData(
+    int section, Qt::Orientation orientation, int role) const {
+    if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
+        return {};
+
+    switch (section) {
+    case Id:
+        return tr("Id");
+    case FixingCalendar:
+        return tr("Fixing Calendar");
+    case DayCountFraction:
+        return tr("DCF");
+    case SettlementDays:
+        return tr("Settlement Days");
+    case Version:
+        return tr("Version");
+    case ModifiedBy:
+        return tr("Modified By");
+    case RecordedAt:
+        return tr("Recorded At");
+    default:
+        return {};
+    }
+}
+
+void ClientOvernightIndexConventionModel::refresh() {
+    BOOST_LOG_SEV(lg(), debug) << "Calling refresh.";
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress, ignoring refresh request.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Cannot refresh overnight index convention model: disconnected.";
+        emit loadError("Not connected to server");
+        return;
+    }
+
+    if (!overnight_index_conventions_.empty()) {
+        beginResetModel();
+        overnight_index_conventions_.clear();
+        recencyTracker_.clear();
+        pulseManager_->stop_pulsing();
+        total_available_count_ = 0;
+        endResetModel();
+    }
+
+    fetch_overnight_index_conventions(0, page_size_);
+}
+
+void ClientOvernightIndexConventionModel::load_page(std::uint32_t offset,
+                                          std::uint32_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "load_page: offset=" << offset << ", limit=" << limit;
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress, ignoring load_page request.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Cannot load page: disconnected.";
+        return;
+    }
+
+    if (!overnight_index_conventions_.empty()) {
+        beginResetModel();
+        overnight_index_conventions_.clear();
+        recencyTracker_.clear();
+        pulseManager_->stop_pulsing();
+        endResetModel();
+    }
+
+    fetch_overnight_index_conventions(offset, limit);
+}
+
+void ClientOvernightIndexConventionModel::fetch_overnight_index_conventions(
+    std::uint32_t offset, std::uint32_t limit) {
+    is_fetching_ = true;
+    QPointer<ClientOvernightIndexConventionModel> self = this;
+
+    QFuture<FetchResult> future =
+        QtConcurrent::run([self, offset, limit]() -> FetchResult {
+            return exception_helper::wrap_async_fetch<FetchResult>([&]() -> FetchResult {
+                BOOST_LOG_SEV(lg(), debug) << "Making overnight index conventions request with offset="
+                                           << offset << ", limit=" << limit;
+                if (!self || !self->clientManager_) {
+                    return {.success = false, .overnight_index_conventions = {},
+                            .total_available_count = 0,
+                            .error_message = "Model was destroyed",
+                            .error_details = {}};
+                }
+
+                refdata::messaging::get_overnight_index_conventions_request request;
+
+                auto result = self->clientManager_->
+                    process_authenticated_request(std::move(request));
+
+                if (!result) {
+                    BOOST_LOG_SEV(lg(), error) << "Failed to send request: " << result.error();
+                    return {.success = false, .overnight_index_conventions = {},
+                            .total_available_count = 0,
+                            .error_message = QString::fromStdString(result.error()),
+                            .error_details = {}};
+                }
+
+                BOOST_LOG_SEV(lg(), debug) << "Fetched " << result->overnight_index_conventions.size()
+                                           << " overnight index conventions";
+                const std::uint32_t count =
+                    static_cast<std::uint32_t>(result->overnight_index_conventions.size());
+                return {.success = true,
+                        .overnight_index_conventions = std::move(result->overnight_index_conventions),
+                        .total_available_count = count,
+                        .error_message = {}, .error_details = {}};
+            }, "overnight index conventions");
+        });
+
+    watcher_->setFuture(future);
+}
+
+void ClientOvernightIndexConventionModel::onConventionsLoaded() {
+    is_fetching_ = false;
+
+    const auto result = watcher_->result();
+
+    if (!result.success) {
+        BOOST_LOG_SEV(lg(), error) << "Failed to fetch overnight index conventions: "
+                                   << result.error_message.toStdString();
+        emit loadError(result.error_message, result.error_details);
+        return;
+    }
+
+    total_available_count_ = result.total_available_count;
+
+    const int new_count = static_cast<int>(result.overnight_index_conventions.size());
+
+    if (new_count > 0) {
+        beginResetModel();
+        overnight_index_conventions_ = std::move(result.overnight_index_conventions);
+        endResetModel();
+
+        const bool has_recent = recencyTracker_.update(overnight_index_conventions_);
+        if (has_recent && !pulseManager_->is_pulsing()) {
+            pulseManager_->start_pulsing();
+            BOOST_LOG_SEV(lg(), debug) << "Found " << recencyTracker_.recent_count()
+                                       << " overnight index conventions newer than last reload";
+        }
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Loaded " << new_count << " overnight index conventions."
+                              << " Total available: " << total_available_count_;
+
+    emit dataLoaded();
+}
+
+void ClientOvernightIndexConventionModel::set_page_size(std::uint32_t size) {
+    if (size == 0 || size > 1000) {
+        BOOST_LOG_SEV(lg(), warn) << "Invalid page size: " << size
+                                  << ". Must be between 1 and 1000. Using default: 100";
+        page_size_ = 100;
+    } else {
+        page_size_ = size;
+        BOOST_LOG_SEV(lg(), info) << "Page size set to: " << page_size_;
+    }
+}
+
+const refdata::domain::overnight_index_convention*
+ClientOvernightIndexConventionModel::getConvention(int row) const {
+    const auto idx = static_cast<std::size_t>(row);
+    if (idx >= overnight_index_conventions_.size())
+        return nullptr;
+    return &overnight_index_conventions_[idx];
+}
+
+QVariant ClientOvernightIndexConventionModel::recency_foreground_color(
+    const std::string& code) const {
+    if (recencyTracker_.is_recent(code) && pulseManager_->is_pulse_on()) {
+        return color_constants::stale_indicator;
+    }
+    return {};
+}
+
+void ClientOvernightIndexConventionModel::onPulseStateChanged(bool /*isOn*/) {
+    if (!overnight_index_conventions_.empty()) {
+        emit dataChanged(index(0, 0), index(rowCount() - 1, columnCount() - 1),
+            {Qt::ForegroundRole});
+    }
+}
+
+void ClientOvernightIndexConventionModel::onPulsingComplete() {
+    BOOST_LOG_SEV(lg(), debug) << "Recency highlight pulsing complete";
+    recencyTracker_.clear();
+}
+
+}

--- a/projects/ores.qt.refdata/src/ClientSwapConventionModel.cpp
+++ b/projects/ores.qt.refdata/src/ClientSwapConventionModel.cpp
@@ -1,0 +1,300 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/ClientSwapConventionModel.hpp"
+
+#include <QtConcurrent>
+#include "ores.refdata.api/messaging/swap_convention_protocol.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/ExceptionHelper.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+namespace {
+    std::string swap_convention_key_extractor(const refdata::domain::swap_convention& e) {
+        return e.id;
+    }
+}
+
+ClientSwapConventionModel::ClientSwapConventionModel(
+    ClientManager* clientManager, QObject* parent)
+    : AbstractClientModel(parent),
+      clientManager_(clientManager),
+      watcher_(new QFutureWatcher<FetchResult>(this)),
+      recencyTracker_(swap_convention_key_extractor),
+      pulseManager_(new RecencyPulseManager(this)) {
+
+    connect(watcher_, &QFutureWatcher<FetchResult>::finished,
+            this, &ClientSwapConventionModel::onConventionsLoaded);
+
+    connect(pulseManager_, &RecencyPulseManager::pulse_state_changed,
+            this, &ClientSwapConventionModel::onPulseStateChanged);
+    connect(pulseManager_, &RecencyPulseManager::pulsing_complete,
+            this, &ClientSwapConventionModel::onPulsingComplete);
+}
+
+int ClientSwapConventionModel::rowCount(const QModelIndex& parent) const {
+    if (parent.isValid())
+        return 0;
+    return static_cast<int>(swap_conventions_.size());
+}
+
+int ClientSwapConventionModel::columnCount(const QModelIndex& parent) const {
+    if (parent.isValid())
+        return 0;
+    return ColumnCount;
+}
+
+QVariant ClientSwapConventionModel::data(
+    const QModelIndex& index, int role) const {
+    if (!index.isValid())
+        return {};
+
+    const auto row = static_cast<std::size_t>(index.row());
+    if (row >= swap_conventions_.size())
+        return {};
+
+    const auto& sc = swap_conventions_[row];
+
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case Id:
+            return QString::fromStdString(sc.id);
+        case FixedFrequency:
+            return QString::fromStdString(sc.fixed_frequency);
+        case FixedDayCountFraction:
+            return QString::fromStdString(sc.fixed_day_count_fraction);
+        case Index:
+            return QString::fromStdString(sc.index);
+        case Version:
+            return static_cast<qlonglong>(sc.version);
+        case ModifiedBy:
+            return QString::fromStdString(sc.modified_by);
+        case RecordedAt:
+            return relative_time_helper::format(sc.recorded_at);
+        default:
+            return {};
+        }
+    }
+
+    if (role == Qt::ForegroundRole) {
+        return recency_foreground_color(sc.id);
+    }
+
+    return {};
+}
+
+QVariant ClientSwapConventionModel::headerData(
+    int section, Qt::Orientation orientation, int role) const {
+    if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
+        return {};
+
+    switch (section) {
+    case Id:
+        return tr("Id");
+    case FixedFrequency:
+        return tr("Fixed Freq");
+    case FixedDayCountFraction:
+        return tr("Fixed DCF");
+    case Index:
+        return tr("Index");
+    case Version:
+        return tr("Version");
+    case ModifiedBy:
+        return tr("Modified By");
+    case RecordedAt:
+        return tr("Recorded At");
+    default:
+        return {};
+    }
+}
+
+void ClientSwapConventionModel::refresh() {
+    BOOST_LOG_SEV(lg(), debug) << "Calling refresh.";
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress, ignoring refresh request.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Cannot refresh swap convention model: disconnected.";
+        emit loadError("Not connected to server");
+        return;
+    }
+
+    if (!swap_conventions_.empty()) {
+        beginResetModel();
+        swap_conventions_.clear();
+        recencyTracker_.clear();
+        pulseManager_->stop_pulsing();
+        total_available_count_ = 0;
+        endResetModel();
+    }
+
+    fetch_swap_conventions(0, page_size_);
+}
+
+void ClientSwapConventionModel::load_page(std::uint32_t offset,
+                                          std::uint32_t limit) {
+    BOOST_LOG_SEV(lg(), debug) << "load_page: offset=" << offset << ", limit=" << limit;
+
+    if (is_fetching_) {
+        BOOST_LOG_SEV(lg(), warn) << "Fetch already in progress, ignoring load_page request.";
+        return;
+    }
+
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        BOOST_LOG_SEV(lg(), warn) << "Cannot load page: disconnected.";
+        return;
+    }
+
+    if (!swap_conventions_.empty()) {
+        beginResetModel();
+        swap_conventions_.clear();
+        recencyTracker_.clear();
+        pulseManager_->stop_pulsing();
+        endResetModel();
+    }
+
+    fetch_swap_conventions(offset, limit);
+}
+
+void ClientSwapConventionModel::fetch_swap_conventions(
+    std::uint32_t offset, std::uint32_t limit) {
+    is_fetching_ = true;
+    QPointer<ClientSwapConventionModel> self = this;
+
+    QFuture<FetchResult> future =
+        QtConcurrent::run([self, offset, limit]() -> FetchResult {
+            return exception_helper::wrap_async_fetch<FetchResult>([&]() -> FetchResult {
+                BOOST_LOG_SEV(lg(), debug) << "Making swap conventions request with offset="
+                                           << offset << ", limit=" << limit;
+                if (!self || !self->clientManager_) {
+                    return {.success = false, .swap_conventions = {},
+                            .total_available_count = 0,
+                            .error_message = "Model was destroyed",
+                            .error_details = {}};
+                }
+
+                refdata::messaging::get_swap_conventions_request request;
+
+                auto result = self->clientManager_->
+                    process_authenticated_request(std::move(request));
+
+                if (!result) {
+                    BOOST_LOG_SEV(lg(), error) << "Failed to send request: " << result.error();
+                    return {.success = false, .swap_conventions = {},
+                            .total_available_count = 0,
+                            .error_message = QString::fromStdString(result.error()),
+                            .error_details = {}};
+                }
+
+                BOOST_LOG_SEV(lg(), debug) << "Fetched " << result->swap_conventions.size()
+                                           << " swap conventions";
+                const std::uint32_t count =
+                    static_cast<std::uint32_t>(result->swap_conventions.size());
+                return {.success = true,
+                        .swap_conventions = std::move(result->swap_conventions),
+                        .total_available_count = count,
+                        .error_message = {}, .error_details = {}};
+            }, "swap conventions");
+        });
+
+    watcher_->setFuture(future);
+}
+
+void ClientSwapConventionModel::onConventionsLoaded() {
+    is_fetching_ = false;
+
+    const auto result = watcher_->result();
+
+    if (!result.success) {
+        BOOST_LOG_SEV(lg(), error) << "Failed to fetch swap conventions: "
+                                   << result.error_message.toStdString();
+        emit loadError(result.error_message, result.error_details);
+        return;
+    }
+
+    total_available_count_ = result.total_available_count;
+
+    const int new_count = static_cast<int>(result.swap_conventions.size());
+
+    if (new_count > 0) {
+        beginResetModel();
+        swap_conventions_ = std::move(result.swap_conventions);
+        endResetModel();
+
+        const bool has_recent = recencyTracker_.update(swap_conventions_);
+        if (has_recent && !pulseManager_->is_pulsing()) {
+            pulseManager_->start_pulsing();
+            BOOST_LOG_SEV(lg(), debug) << "Found " << recencyTracker_.recent_count()
+                                       << " swap conventions newer than last reload";
+        }
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Loaded " << new_count << " swap conventions."
+                              << " Total available: " << total_available_count_;
+
+    emit dataLoaded();
+}
+
+void ClientSwapConventionModel::set_page_size(std::uint32_t size) {
+    if (size == 0 || size > 1000) {
+        BOOST_LOG_SEV(lg(), warn) << "Invalid page size: " << size
+                                  << ". Must be between 1 and 1000. Using default: 100";
+        page_size_ = 100;
+    } else {
+        page_size_ = size;
+        BOOST_LOG_SEV(lg(), info) << "Page size set to: " << page_size_;
+    }
+}
+
+const refdata::domain::swap_convention*
+ClientSwapConventionModel::getConvention(int row) const {
+    const auto idx = static_cast<std::size_t>(row);
+    if (idx >= swap_conventions_.size())
+        return nullptr;
+    return &swap_conventions_[idx];
+}
+
+QVariant ClientSwapConventionModel::recency_foreground_color(
+    const std::string& code) const {
+    if (recencyTracker_.is_recent(code) && pulseManager_->is_pulse_on()) {
+        return color_constants::stale_indicator;
+    }
+    return {};
+}
+
+void ClientSwapConventionModel::onPulseStateChanged(bool /*isOn*/) {
+    if (!swap_conventions_.empty()) {
+        emit dataChanged(index(0, 0), index(rowCount() - 1, columnCount() - 1),
+            {Qt::ForegroundRole});
+    }
+}
+
+void ClientSwapConventionModel::onPulsingComplete() {
+    BOOST_LOG_SEV(lg(), debug) << "Recency highlight pulsing complete";
+    recencyTracker_.clear();
+}
+
+}

--- a/projects/ores.qt.refdata/src/FraConventionController.cpp
+++ b/projects/ores.qt.refdata/src/FraConventionController.cpp
@@ -1,0 +1,385 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/FraConventionController.hpp"
+
+#include <QMdiSubWindow>
+#include <QMessageBox>
+#include <QPointer>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/FraConventionMdiWindow.hpp"
+#include "ores.qt/FraConventionDetailDialog.hpp"
+#include "ores.qt/FraConventionHistoryDialog.hpp"
+#include "ores.qt/DetachableMdiSubWindow.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+FraConventionController::FraConventionController(
+    QMainWindow* mainWindow,
+    QMdiArea* mdiArea,
+    ClientManager* clientManager,
+    const QString& username,
+    QObject* parent)
+    : EntityController(mainWindow, mdiArea, clientManager, username,
+          std::string_view{}, parent),
+      listWindow_(nullptr),
+      listMdiSubWindow_(nullptr) {
+
+    BOOST_LOG_SEV(lg(), debug) << "FraConventionController created";
+}
+
+void FraConventionController::showListWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "showListWindow called";
+
+    const QString key = build_window_key("list", "fra_conventions");
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing list window";
+        return;
+    }
+
+    // Create new window
+    listWindow_ = new FraConventionMdiWindow(clientManager_, username_);
+
+    // Connect signals
+    connect(listWindow_, &FraConventionMdiWindow::statusChanged,
+            this, &FraConventionController::statusMessage);
+    connect(listWindow_, &FraConventionMdiWindow::errorOccurred,
+            this, &FraConventionController::errorMessage);
+    connect(listWindow_, &FraConventionMdiWindow::showConventionDetails,
+            this, &FraConventionController::onShowDetails);
+    connect(listWindow_, &FraConventionMdiWindow::addNewRequested,
+            this, &FraConventionController::onAddNewRequested);
+    connect(listWindow_, &FraConventionMdiWindow::showConventionHistory,
+            this, &FraConventionController::onShowHistory);
+
+    // Create MDI subwindow
+    listMdiSubWindow_ = new DetachableMdiSubWindow(mainWindow_);
+    listMdiSubWindow_->setWidget(listWindow_);
+    listMdiSubWindow_->setWindowTitle("FRA Conventions");
+    listMdiSubWindow_->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+    listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
+    listMdiSubWindow_->resize(listWindow_->sizeHint());
+
+    mdiArea_->addSubWindow(listMdiSubWindow_);
+    listMdiSubWindow_->show();
+
+    // Track window
+    track_window(key, listMdiSubWindow_);
+    register_detachable_window(listMdiSubWindow_);
+
+    // Cleanup when closed
+    connect(listMdiSubWindow_, &QObject::destroyed, this, [self = QPointer<FraConventionController>(this), key]() {
+        if (!self) return;
+        self->untrack_window(key);
+        self->listWindow_ = nullptr;
+        self->listMdiSubWindow_ = nullptr;
+    });
+
+    BOOST_LOG_SEV(lg(), debug) << "FRA Convention list window created";
+}
+
+void FraConventionController::closeAllWindows() {
+    BOOST_LOG_SEV(lg(), debug) << "closeAllWindows called";
+
+    // Close all managed windows
+    QList<QString> keys = managed_windows_.keys();
+    for (const QString& key : keys) {
+        if (auto* window = managed_windows_.value(key)) {
+            window->close();
+        }
+    }
+    managed_windows_.clear();
+
+    listWindow_ = nullptr;
+    listMdiSubWindow_ = nullptr;
+}
+
+void FraConventionController::reloadListWindow() {
+    if (listWindow_) {
+        listWindow_->reload();
+    }
+}
+
+void FraConventionController::onShowDetails(
+    const refdata::domain::fra_convention& fc) {
+    BOOST_LOG_SEV(lg(), debug) << "Show details for: " << fc.id;
+    showDetailWindow(fc);
+}
+
+void FraConventionController::onAddNewRequested() {
+    BOOST_LOG_SEV(lg(), info) << "Add new FRA convention requested";
+    showAddWindow();
+}
+
+void FraConventionController::onShowHistory(
+    const refdata::domain::fra_convention& fc) {
+    BOOST_LOG_SEV(lg(), debug) << "Show history requested for: " << fc.id;
+    showHistoryWindow(QString::fromStdString(fc.id));
+}
+
+void FraConventionController::showAddWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "Creating add window for new FRA convention";
+
+    auto* detailDialog = new FraConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(true);
+
+    connect(detailDialog, &FraConventionDetailDialog::statusMessage,
+            this, &FraConventionController::statusMessage);
+    connect(detailDialog, &FraConventionDetailDialog::errorMessage,
+            this, &FraConventionController::errorMessage);
+    connect(detailDialog, &FraConventionDetailDialog::fcSaved,
+            this, [self = QPointer<FraConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "FRA Convention saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle("New FRA Convention");
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void FraConventionController::showDetailWindow(
+    const refdata::domain::fra_convention& fc) {
+
+    const QString identifier = QString::fromStdString(fc.id);
+    const QString key = build_window_key("details", identifier);
+
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing detail window";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Creating detail window for: " << fc.id;
+
+    auto* detailDialog = new FraConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(false);
+    detailDialog->setConvention(fc);
+
+    connect(detailDialog, &FraConventionDetailDialog::statusMessage,
+            this, &FraConventionController::statusMessage);
+    connect(detailDialog, &FraConventionDetailDialog::errorMessage,
+            this, &FraConventionController::errorMessage);
+    connect(detailDialog, &FraConventionDetailDialog::fcSaved,
+            this, [self = QPointer<FraConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "FRA Convention saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+    connect(detailDialog, &FraConventionDetailDialog::fcDeleted,
+            this, [self = QPointer<FraConventionController>(this), key](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "FRA Convention deleted: " << code.toStdString();
+        self->handleEntityDeleted();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("FRA Convention: %1").arg(identifier));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+
+    // Track window
+    track_window(key, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<FraConventionController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, key]() {
+        if (self) {
+            self->untrack_window(key);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void FraConventionController::showHistoryWindow(const QString& code) {
+    BOOST_LOG_SEV(lg(), info) << "Opening history window for FRA convention: "
+                              << code.toStdString();
+
+    const QString windowKey = build_window_key("history", code);
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing history window for: "
+                                  << code.toStdString();
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Creating new history window for: "
+                              << code.toStdString();
+
+    auto* historyDialog = new FraConventionHistoryDialog(code, clientManager_, mainWindow_);
+
+    connect(historyDialog, &FraConventionHistoryDialog::statusChanged,
+            this, [self = QPointer<FraConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(historyDialog, &FraConventionHistoryDialog::errorOccurred,
+            this, [self = QPointer<FraConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+    connect(historyDialog, &FraConventionHistoryDialog::revertVersionRequested,
+            this, &FraConventionController::onRevertVersion);
+    connect(historyDialog, &FraConventionHistoryDialog::openVersionRequested,
+            this, &FraConventionController::onOpenVersion);
+
+    // Load history data
+    historyDialog->loadHistory();
+
+    auto* historyWindow = new DetachableMdiSubWindow(mainWindow_);
+    historyWindow->setAttribute(Qt::WA_DeleteOnClose);
+    historyWindow->setWidget(historyDialog);
+    historyWindow->setWindowTitle(QString("FRA Convention History: %1").arg(code));
+    historyWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    // Track this history window
+    track_window(windowKey, historyWindow);
+    register_detachable_window(historyWindow);
+
+    QPointer<FraConventionController> self = this;
+    connect(historyWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    show_managed_window(historyWindow, listMdiSubWindow_);
+}
+
+void FraConventionController::onOpenVersion(
+    const refdata::domain::fra_convention& fc, int versionNumber) {
+    BOOST_LOG_SEV(lg(), info) << "Opening historical version " << versionNumber
+                              << " for FRA convention: " << fc.id;
+
+    const QString code = QString::fromStdString(fc.id);
+    const QString windowKey = build_window_key("version", QString("%1_v%2")
+        .arg(code).arg(versionNumber));
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing version window";
+        return;
+    }
+
+    auto* detailDialog = new FraConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setConvention(fc);
+    detailDialog->setReadOnly(true);
+
+    connect(detailDialog, &FraConventionDetailDialog::statusMessage,
+            this, [self = QPointer<FraConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(detailDialog, &FraConventionDetailDialog::errorMessage,
+            this, [self = QPointer<FraConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("FRA Convention: %1 (Version %2)")
+        .arg(code).arg(versionNumber));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    track_window(windowKey, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<FraConventionController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_, QPoint(60, 60));
+}
+
+void FraConventionController::onRevertVersion(
+    const refdata::domain::fra_convention& fc) {
+    BOOST_LOG_SEV(lg(), info) << "Reverting FRA convention to version: "
+                              << fc.version;
+
+    // Open detail dialog with the old version data for editing
+    auto* detailDialog = new FraConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setConvention(fc);
+    detailDialog->setCreateMode(false);
+
+    connect(detailDialog, &FraConventionDetailDialog::statusMessage,
+            this, &FraConventionController::statusMessage);
+    connect(detailDialog, &FraConventionDetailDialog::errorMessage,
+            this, &FraConventionController::errorMessage);
+    connect(detailDialog, &FraConventionDetailDialog::fcSaved,
+            this, [self = QPointer<FraConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "FRA Convention reverted: " << code.toStdString();
+        emit self->statusMessage(QString("FRA Convention '%1' reverted successfully").arg(code));
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Revert FRA Convention: %1")
+        .arg(QString::fromStdString(fc.id)));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+EntityListMdiWindow* FraConventionController::listWindow() const {
+    return listWindow_;
+}
+
+}

--- a/projects/ores.qt.refdata/src/FraConventionDetailDialog.cpp
+++ b/projects/ores.qt.refdata/src/FraConventionDetailDialog.cpp
@@ -1,0 +1,301 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/FraConventionDetailDialog.hpp"
+
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_FraConventionDetailDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.refdata.api/messaging/fra_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+FraConventionDetailDialog::FraConventionDetailDialog(QWidget* parent)
+    : DetailDialogBase(parent),
+      ui_(new Ui::FraConventionDetailDialog),
+      clientManager_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupConnections();
+}
+
+FraConventionDetailDialog::~FraConventionDetailDialog() {
+    delete ui_;
+}
+
+QTabWidget* FraConventionDetailDialog::tabWidget() const {
+    return ui_->tabWidget;
+}
+
+QWidget* FraConventionDetailDialog::provenanceTab() const {
+    return ui_->provenanceTab;
+}
+
+ProvenanceWidget* FraConventionDetailDialog::provenanceWidget() const {
+    return ui_->provenanceWidget;
+}
+
+void FraConventionDetailDialog::setupUi() {
+    ui_->saveButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Save, IconUtils::DefaultIconColor));
+    ui_->saveButton->setEnabled(false);
+
+    ui_->deleteButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Delete, IconUtils::DefaultIconColor));
+
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+}
+
+void FraConventionDetailDialog::setupConnections() {
+    connect(ui_->saveButton, &QPushButton::clicked, this,
+            &FraConventionDetailDialog::onSaveClicked);
+    connect(ui_->deleteButton, &QPushButton::clicked, this,
+            &FraConventionDetailDialog::onDeleteClicked);
+    connect(ui_->closeButton, &QPushButton::clicked, this,
+            &FraConventionDetailDialog::onCloseClicked);
+
+    connect(ui_->idEdit, &QLineEdit::textChanged, this,
+            &FraConventionDetailDialog::onCodeChanged);
+    connect(ui_->indexEdit, &QLineEdit::textChanged, this,
+            &FraConventionDetailDialog::onFieldChanged);
+}
+
+void FraConventionDetailDialog::setClientManager(ClientManager* clientManager) {
+    clientManager_ = clientManager;
+}
+
+void FraConventionDetailDialog::setUsername(const std::string& username) {
+    username_ = username;
+}
+
+void FraConventionDetailDialog::setConvention(
+    const refdata::domain::fra_convention& fc) {
+    fc_ = fc;
+    updateUiFromConvention();
+}
+
+void FraConventionDetailDialog::setCreateMode(bool createMode) {
+    createMode_ = createMode;
+    ui_->idEdit->setReadOnly(!createMode);
+    ui_->deleteButton->setVisible(!createMode);
+    setProvenanceEnabled(!createMode);
+    hasChanges_ = false;
+    updateSaveButtonState();
+}
+
+void FraConventionDetailDialog::setReadOnly(bool readOnly) {
+    readOnly_ = readOnly;
+    ui_->idEdit->setReadOnly(true);
+    ui_->indexEdit->setReadOnly(readOnly);
+    ui_->saveButton->setVisible(!readOnly);
+    ui_->deleteButton->setVisible(!readOnly);
+}
+
+void FraConventionDetailDialog::updateUiFromConvention() {
+    ui_->idEdit->setText(QString::fromStdString(fc_.id));
+    ui_->indexEdit->setText(QString::fromStdString(fc_.index));
+
+    populateProvenance(fc_.version,
+                       fc_.modified_by,
+                       fc_.performed_by,
+                       fc_.recorded_at,
+                       fc_.change_reason_code,
+                       fc_.change_commentary);
+
+    hasChanges_ = false;
+    updateSaveButtonState();
+}
+
+void FraConventionDetailDialog::updateConventionFromUi() {
+    if (createMode_) {
+        fc_.id = ui_->idEdit->text().trimmed().toStdString();
+    }
+    fc_.index = ui_->indexEdit->text().trimmed().toStdString();
+    fc_.modified_by = username_;
+}
+
+void FraConventionDetailDialog::onCodeChanged(const QString& /* text */) {
+    hasChanges_ = true;
+    updateSaveButtonState();
+}
+
+void FraConventionDetailDialog::onFieldChanged() {
+    hasChanges_ = true;
+    updateSaveButtonState();
+}
+
+void FraConventionDetailDialog::updateSaveButtonState() {
+    bool canSave = hasChanges_ && validateInput() && !readOnly_;
+    ui_->saveButton->setEnabled(canSave);
+}
+
+bool FraConventionDetailDialog::validateInput() {
+    const QString id_val = ui_->idEdit->text().trimmed();
+    const QString index_val = ui_->indexEdit->text().trimmed();
+
+    return true
+        && !id_val.isEmpty()
+        && !index_val.isEmpty()
+    ;
+}
+
+void FraConventionDetailDialog::onSaveClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot save FRA convention while disconnected from server.");
+        return;
+    }
+
+    if (!validateInput()) {
+        MessageBoxHelper::warning(this, "Invalid Input",
+            "Please fill in all required fields.");
+        return;
+    }
+
+    updateConventionFromUi();
+
+    BOOST_LOG_SEV(lg(), info) << "Saving FRA convention: "
+        << fc_.id;
+
+    QPointer<FraConventionDetailDialog> self = this;
+
+    struct SaveResult {
+        bool success;
+        std::string message;
+    };
+
+    auto task = [self, fc = fc_]() -> SaveResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed"};
+        }
+
+        refdata::messaging::save_fra_convention_request request;
+        request.data = fc;
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server"};
+        }
+
+        return {response_result->success, response_result->message};
+    };
+
+    auto* watcher = new QFutureWatcher<SaveResult>(self);
+    connect(watcher, &QFutureWatcher<SaveResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "FRA Convention saved successfully";
+            QString code = QString::fromStdString(
+                self->fc_.id);
+            self->hasChanges_ = false;
+            self->updateSaveButtonState();
+            emit self->fcSaved(code);
+            self->notifySaveSuccess(tr("FRA Convention '%1' saved").arg(code));
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Save failed: " << result.message;
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Save Failed", errorMsg);
+        }
+    });
+
+    QFuture<SaveResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+void FraConventionDetailDialog::onDeleteClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete FRA convention while disconnected from server.");
+        return;
+    }
+
+    QString code = QString::fromStdString(
+        fc_.id);
+    auto reply = MessageBoxHelper::question(this, "Delete FRA Convention",
+        QString("Are you sure you want to delete FRA convention '%1'?").arg(code),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Deleting FRA convention: "
+        << fc_.id;
+
+    QPointer<FraConventionDetailDialog> self = this;
+
+    struct DeleteResult {
+        bool success;
+        std::string message;
+    };
+
+    auto task = [self, code = fc_.id]() -> DeleteResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed"};
+        }
+
+        refdata::messaging::delete_fra_convention_request request;
+        request.codes = {code};
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server"};
+        }
+
+        return {response_result->success, response_result->message};
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, code, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "FRA Convention deleted successfully";
+            emit self->statusMessage(
+                QString("FRA Convention '%1' deleted").arg(code));
+            emit self->fcDeleted(code);
+            self->requestClose();
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Delete failed: " << result.message;
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Delete Failed", errorMsg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt.refdata/src/FraConventionHistoryDialog.cpp
+++ b/projects/ores.qt.refdata/src/FraConventionHistoryDialog.cpp
@@ -1,0 +1,309 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/FraConventionHistoryDialog.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_FraConventionHistoryDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.refdata.api/messaging/fra_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+FraConventionHistoryDialog::FraConventionHistoryDialog(
+    const QString& code,
+    ClientManager* clientManager,
+    QWidget* parent)
+    : QWidget(parent),
+      ui_(new Ui::FraConventionHistoryDialog),
+      code_(code),
+      clientManager_(clientManager),
+      toolbar_(nullptr),
+      openVersionAction_(nullptr),
+      revertAction_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupToolbar();
+    setupConnections();
+}
+
+FraConventionHistoryDialog::~FraConventionHistoryDialog() {
+    delete ui_;
+}
+
+void FraConventionHistoryDialog::setupUi() {
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+
+    ui_->titleLabel->setText(QString("History for: %1").arg(code_));
+
+    // Setup version list table
+    ui_->versionListWidget->setColumnCount(5);
+    ui_->versionListWidget->setHorizontalHeaderLabels(
+        {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
+    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
+    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    // Setup changes table
+    ui_->changesTableWidget->setColumnCount(3);
+    ui_->changesTableWidget->setHorizontalHeaderLabels(
+        {"Field", "Old Value", "New Value"});
+    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+}
+
+void FraConventionHistoryDialog::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    openVersionAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor),
+        tr("Open"));
+    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
+    openVersionAction_->setEnabled(false);
+
+    revertAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor),
+        tr("Revert"));
+    revertAction_->setToolTip(tr("Revert to this version"));
+    revertAction_->setEnabled(false);
+
+    // Insert toolbar at the top of the layout
+    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
+    if (layout) {
+        layout->insertWidget(0, toolbar_);
+    }
+}
+
+void FraConventionHistoryDialog::setupConnections() {
+    connect(ui_->versionListWidget, &QTableWidget::itemSelectionChanged,
+            this, &FraConventionHistoryDialog::onVersionSelected);
+    connect(openVersionAction_, &QAction::triggered,
+            this, &FraConventionHistoryDialog::onOpenVersionClicked);
+    connect(revertAction_, &QAction::triggered,
+            this, &FraConventionHistoryDialog::onRevertClicked);
+    connect(ui_->closeButton, &QPushButton::clicked,
+            this, [this]() { if (window()) window()->close(); });
+}
+
+void FraConventionHistoryDialog::loadHistory() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        emit errorOccurred("Not connected to server");
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for FRA convention: " << code_.toStdString();
+    emit statusChanged(tr("Loading history..."));
+
+    QPointer<FraConventionHistoryDialog> self = this;
+
+    using HistoryResult = std::expected<refdata::messaging::get_fra_convention_history_response, std::string>;
+
+    QFuture<HistoryResult> future =
+        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
+        if (!self || !self->clientManager_)
+            return std::unexpected("Dialog closed");
+        refdata::messaging::get_fra_convention_history_request request;
+        request.id = code;
+        auto result = self->clientManager_->process_authenticated_request(std::move(request));
+        if (!result) return std::unexpected(result.error());
+        return std::move(*result);
+    });
+
+    auto* watcher = new QFutureWatcher<HistoryResult>(self);
+    connect(watcher, &QFutureWatcher<HistoryResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (!result) {
+            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
+            emit self->errorOccurred(QString::fromStdString(result.error()));
+            return;
+        }
+        if (!result->success) {
+            emit self->errorOccurred(QString::fromStdString(result->message));
+            return;
+        }
+        self->versions_ = std::move(result->fra_conventions);
+        self->updateVersionList();
+        emit self->statusChanged(
+            QString("Loaded %1 versions").arg(self->versions_.size()));
+    });
+    watcher->setFuture(future);
+}
+
+void FraConventionHistoryDialog::updateVersionList() {
+    ui_->versionListWidget->setRowCount(0);
+
+    for (const auto& version : versions_) {
+        int row = ui_->versionListWidget->rowCount();
+        ui_->versionListWidget->insertRow(row);
+
+        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
+        versionItem->setTextAlignment(Qt::AlignCenter);
+        ui_->versionListWidget->setItem(row, 0, versionItem);
+
+        auto* recordedAtItem = new QTableWidgetItem(
+            relative_time_helper::format(version.recorded_at));
+        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
+
+        auto* modifiedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.modified_by));
+        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
+
+        auto* performedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.performed_by));
+        ui_->versionListWidget->setItem(row, 3, performedByItem);
+
+        auto* commentaryItem = new QTableWidgetItem(
+            QString::fromStdString(version.change_commentary));
+        ui_->versionListWidget->setItem(row, 4, commentaryItem);
+    }
+
+    // Select the first (most recent) version
+    if (!versions_.empty()) {
+        ui_->versionListWidget->selectRow(0);
+    }
+}
+
+void FraConventionHistoryDialog::onVersionSelected() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) {
+        updateActionStates();
+        return;
+    }
+
+    int row = selected.first()->row();
+    updateChangesTable(row);
+    updateFullDetails(row);
+    updateActionStates();
+}
+
+void FraConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
+    ui_->changesTableWidget->setRowCount(0);
+
+    if (currentVersionIndex < 0 ||
+        static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
+        return;
+    }
+
+    // Get the next older version to compare against
+    int previousVersionIndex = currentVersionIndex + 1;
+    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
+        // This is the first version, no changes to show
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(Initial version)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+        return;
+    }
+
+    const auto& current = versions_[currentVersionIndex];
+    const auto& previous = versions_[previousVersionIndex];
+
+    auto addChange = [this](const QString& field,
+                            const QString& oldVal, const QString& newVal) {
+        int row = ui_->changesTableWidget->rowCount();
+        ui_->changesTableWidget->insertRow(row);
+        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
+        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
+        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
+    };
+
+    if (current.id != previous.id) {
+        addChange("Id",
+                  QString::fromStdString(previous.id),
+                  QString::fromStdString(current.id));
+    }
+
+    if (current.index != previous.index) {
+        addChange("Index",
+                  QString::fromStdString(previous.index),
+                  QString::fromStdString(current.index));
+    }
+
+
+    if (ui_->changesTableWidget->rowCount() == 0) {
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(No field changes)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+    }
+}
+
+void FraConventionHistoryDialog::updateFullDetails(int versionIndex) {
+    if (versionIndex < 0 ||
+        static_cast<size_t>(versionIndex) >= versions_.size()) {
+        return;
+    }
+
+    const auto& version = versions_[versionIndex];
+
+    ui_->idValue->setText(QString::fromStdString(version.id));
+    ui_->indexValue->setText(QString::fromStdString(version.index));
+    ui_->versionNumberValue->setText(QString::number(version.version));
+    ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
+}
+
+void FraConventionHistoryDialog::updateActionStates() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    bool hasSelection = !selected.isEmpty();
+    bool isNotLatest = hasSelection && selected.first()->row() > 0;
+
+    openVersionAction_->setEnabled(hasSelection);
+    revertAction_->setEnabled(isNotLatest);
+}
+
+void FraConventionHistoryDialog::onOpenVersionClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit openVersionRequested(versions_[row], versions_[row].version);
+}
+
+void FraConventionHistoryDialog::onRevertClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit revertVersionRequested(versions_[row]);
+}
+
+}

--- a/projects/ores.qt.refdata/src/FraConventionMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/FraConventionMdiWindow.cpp
@@ -1,0 +1,386 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/FraConventionMdiWindow.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.refdata.api/messaging/fra_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+FraConventionMdiWindow::FraConventionMdiWindow(
+    ClientManager* clientManager,
+    const QString& username,
+    QWidget* parent)
+    : EntityListMdiWindow(parent),
+      clientManager_(clientManager),
+      username_(username),
+      toolbar_(nullptr),
+      tableView_(nullptr),
+      model_(nullptr),
+      proxyModel_(nullptr),
+      paginationWidget_(nullptr),
+      reloadAction_(nullptr),
+      addAction_(nullptr),
+      editAction_(nullptr),
+      deleteAction_(nullptr),
+      historyAction_(nullptr) {
+
+    setupUi();
+    setupConnections();
+    reload();
+}
+
+void FraConventionMdiWindow::setupUi() {
+    auto* layout = new QVBoxLayout(this);
+
+    setupToolbar();
+    layout->addWidget(toolbar_);
+    layout->addWidget(loadingBar());
+
+    setupTable();
+    layout->addWidget(tableView_);
+
+    paginationWidget_ = new PaginationWidget(this);
+    layout->addWidget(paginationWidget_);
+}
+
+void FraConventionMdiWindow::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    reloadAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowClockwise, IconUtils::DefaultIconColor),
+        tr("Reload"));
+    connect(reloadAction_, &QAction::triggered, this,
+            &EntityListMdiWindow::reload);
+
+    initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
+
+    toolbar_->addSeparator();
+
+    addAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Add, IconUtils::DefaultIconColor),
+        tr("Add"));
+    addAction_->setToolTip(tr("Add new FRA convention"));
+    connect(addAction_, &QAction::triggered, this,
+            &FraConventionMdiWindow::addNew);
+
+    editAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Edit, IconUtils::DefaultIconColor),
+        tr("Edit"));
+    editAction_->setToolTip(tr("Edit selected FRA convention"));
+    editAction_->setEnabled(false);
+    connect(editAction_, &QAction::triggered, this,
+            &FraConventionMdiWindow::editSelected);
+
+    deleteAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Delete, IconUtils::DefaultIconColor),
+        tr("Delete"));
+    deleteAction_->setToolTip(tr("Delete selected FRA convention"));
+    deleteAction_->setEnabled(false);
+    connect(deleteAction_, &QAction::triggered, this,
+            &FraConventionMdiWindow::deleteSelected);
+
+    historyAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::History, IconUtils::DefaultIconColor),
+        tr("History"));
+    historyAction_->setToolTip(tr("View FRA convention history"));
+    historyAction_->setEnabled(false);
+    connect(historyAction_, &QAction::triggered, this,
+            &FraConventionMdiWindow::viewHistorySelected);
+}
+
+void FraConventionMdiWindow::setupTable() {
+    model_ = new ClientFraConventionModel(clientManager_, this);
+    proxyModel_ = new QSortFilterProxyModel(this);
+    proxyModel_->setSourceModel(model_);
+    proxyModel_->setSortCaseSensitivity(Qt::CaseInsensitive);
+
+    tableView_ = new QTableView(this);
+    tableView_->setModel(proxyModel_);
+    tableView_->setSelectionBehavior(QAbstractItemView::SelectRows);
+    tableView_->setSelectionMode(QAbstractItemView::SingleSelection);
+    tableView_->setSortingEnabled(true);
+    tableView_->setAlternatingRowColors(true);
+    tableView_->verticalHeader()->setVisible(false);
+
+    initializeTableSettings(tableView_, model_,
+        "FraConventionListWindow",
+        {},
+        {900, 400}, 1);
+}
+
+void FraConventionMdiWindow::setupConnections() {
+    connect(model_, &ClientFraConventionModel::dataLoaded,
+            this, &FraConventionMdiWindow::onDataLoaded);
+    connect(model_, &ClientFraConventionModel::loadError,
+            this, &FraConventionMdiWindow::onLoadError);
+
+    connect(tableView_->selectionModel(), &QItemSelectionModel::selectionChanged,
+            this, &FraConventionMdiWindow::onSelectionChanged);
+    connect(tableView_, &QTableView::doubleClicked,
+            this, &FraConventionMdiWindow::onDoubleClicked);
+
+    connect(paginationWidget_, &PaginationWidget::page_size_changed,
+            this, [this](std::uint32_t size) {
+        model_->set_page_size(size);
+        model_->refresh();
+    });
+
+    connect(paginationWidget_, &PaginationWidget::load_all_requested,
+            this, [this]() {
+        const auto total = model_->total_available_count();
+        if (total > 0 && total <= 1000) {
+            model_->set_page_size(total);
+            model_->refresh();
+        }
+    });
+
+    connect(paginationWidget_, &PaginationWidget::page_requested,
+            this, [this](std::uint32_t offset, std::uint32_t limit) {
+        model_->load_page(offset, limit);
+    });
+
+    connectModel(model_);
+}
+
+void FraConventionMdiWindow::doReload() {
+    BOOST_LOG_SEV(lg(), debug) << "Reloading FRA conventions";
+    clearStaleIndicator();
+    emit statusChanged(tr("Loading FRA conventions..."));
+    model_->refresh();
+}
+
+void FraConventionMdiWindow::onDataLoaded() {
+    const auto loaded = model_->rowCount();
+    const auto total = model_->total_available_count();
+    emit statusChanged(tr("Loaded %1 of %2 FRA conventions").arg(loaded).arg(total));
+
+    paginationWidget_->update_state(loaded, total);
+    paginationWidget_->set_load_all_enabled(
+        loaded < static_cast<int>(total) && total > 0 && total <= 1000);
+}
+
+void FraConventionMdiWindow::onLoadError(const QString& error_message,
+                                          const QString& details) {
+    BOOST_LOG_SEV(lg(), error) << "Load error: " << error_message.toStdString();
+    emit errorOccurred(error_message);
+    MessageBoxHelper::critical(this, tr("Load Error"), error_message, details);
+}
+
+void FraConventionMdiWindow::onSelectionChanged() {
+    updateActionStates();
+}
+
+void FraConventionMdiWindow::onDoubleClicked(const QModelIndex& index) {
+    if (!index.isValid())
+        return;
+
+    auto sourceIndex = proxyModel_->mapToSource(index);
+    if (auto* fc = model_->getConvention(sourceIndex.row())) {
+        emit showConventionDetails(*fc);
+    }
+}
+
+void FraConventionMdiWindow::updateActionStates() {
+    const bool hasSelection = tableView_->selectionModel()->hasSelection();
+    editAction_->setEnabled(hasSelection);
+    deleteAction_->setEnabled(hasSelection);
+    historyAction_->setEnabled(hasSelection);
+}
+
+void FraConventionMdiWindow::addNew() {
+    BOOST_LOG_SEV(lg(), debug) << "Add new FRA convention requested";
+    emit addNewRequested();
+}
+
+void FraConventionMdiWindow::editSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Edit requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* fc = model_->getConvention(sourceIndex.row())) {
+        emit showConventionDetails(*fc);
+    }
+}
+
+void FraConventionMdiWindow::viewHistorySelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "View history requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* fc = model_->getConvention(sourceIndex.row())) {
+        BOOST_LOG_SEV(lg(), debug) << "Emitting showConventionHistory for code: "
+                                   << fc->id;
+        emit showConventionHistory(*fc);
+    }
+}
+
+void FraConventionMdiWindow::deleteSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Delete requested but no row selected";
+        return;
+    }
+
+    if (!clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete FRA convention while disconnected.");
+        return;
+    }
+
+    std::vector<std::string> codes;
+    for (const auto& index : selected) {
+        auto sourceIndex = proxyModel_->mapToSource(index);
+        if (auto* fc = model_->getConvention(sourceIndex.row())) {
+            codes.push_back(fc->id);
+        }
+    }
+
+    if (codes.empty()) {
+        BOOST_LOG_SEV(lg(), warn) << "No valid FRA conventions to delete";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Delete requested for " << codes.size()
+                               << " FRA conventions";
+
+    QString confirmMessage;
+    if (codes.size() == 1) {
+        confirmMessage = QString("Are you sure you want to delete FRA convention '%1'?")
+            .arg(QString::fromStdString(codes.front()));
+    } else {
+        confirmMessage = QString("Are you sure you want to delete %1 FRA conventions?")
+            .arg(codes.size());
+    }
+
+    auto reply = MessageBoxHelper::question(this, "Delete FRA Convention",
+        confirmMessage, QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        BOOST_LOG_SEV(lg(), debug) << "Delete cancelled by user";
+        return;
+    }
+
+    QPointer<FraConventionMdiWindow> self = this;
+    using DeleteResult = std::vector<std::pair<std::string, std::pair<bool, std::string>>>;
+
+    auto task = [self, codes]() -> DeleteResult {
+        DeleteResult results;
+        if (!self) return {};
+
+        BOOST_LOG_SEV(lg(), debug) << "Making batch delete request for "
+                                   << codes.size() << " FRA conventions";
+
+        refdata::messaging::delete_fra_convention_request request;
+        request.codes = codes;
+        auto response_result = self->clientManager_->process_authenticated_request(
+            std::move(request));
+
+        if (!response_result) {
+            BOOST_LOG_SEV(lg(), error) << "Failed to send batch delete request";
+            for (const auto& code : codes) {
+                results.push_back({code, {false, "Failed to communicate with server"}});
+            }
+            return results;
+        }
+
+        for (const auto& code : codes) {
+            results.push_back({code, {response_result->success, response_result->message}});
+        }
+
+        return results;
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, watcher]() {
+        auto results = watcher->result();
+        watcher->deleteLater();
+
+        int success_count = 0;
+        int failure_count = 0;
+        QString first_error;
+
+        for (const auto& [code, result] : results) {
+            if (result.first) {
+                BOOST_LOG_SEV(lg(), debug) << "FRA Convention deleted: " << code;
+                success_count++;
+                emit self->fcDeleted(QString::fromStdString(code));
+            } else {
+                BOOST_LOG_SEV(lg(), error) << "FRA Convention deletion failed: "
+                                           << code << " - " << result.second;
+                failure_count++;
+                if (first_error.isEmpty()) {
+                    first_error = QString::fromStdString(result.second);
+                }
+            }
+        }
+
+        self->model_->refresh();
+
+        if (failure_count == 0) {
+            QString msg = success_count == 1
+                ? "Successfully deleted 1 FRA convention"
+                : QString("Successfully deleted %1 FRA conventions").arg(success_count);
+            emit self->statusChanged(msg);
+        } else if (success_count == 0) {
+            QString msg = QString("Failed to delete %1 %2: %3")
+                .arg(failure_count)
+                .arg(failure_count == 1 ? "FRA convention" : "FRA conventions")
+                .arg(first_error);
+            emit self->errorOccurred(msg);
+            MessageBoxHelper::critical(self, "Delete Failed", msg);
+        } else {
+            QString msg = QString("Deleted %1, failed to delete %2")
+                .arg(success_count)
+                .arg(failure_count);
+            emit self->statusChanged(msg);
+            MessageBoxHelper::warning(self, "Partial Success", msg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt.refdata/src/FxConventionController.cpp
+++ b/projects/ores.qt.refdata/src/FxConventionController.cpp
@@ -1,0 +1,385 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/FxConventionController.hpp"
+
+#include <QMdiSubWindow>
+#include <QMessageBox>
+#include <QPointer>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/FxConventionMdiWindow.hpp"
+#include "ores.qt/FxConventionDetailDialog.hpp"
+#include "ores.qt/FxConventionHistoryDialog.hpp"
+#include "ores.qt/DetachableMdiSubWindow.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+FxConventionController::FxConventionController(
+    QMainWindow* mainWindow,
+    QMdiArea* mdiArea,
+    ClientManager* clientManager,
+    const QString& username,
+    QObject* parent)
+    : EntityController(mainWindow, mdiArea, clientManager, username,
+          std::string_view{}, parent),
+      listWindow_(nullptr),
+      listMdiSubWindow_(nullptr) {
+
+    BOOST_LOG_SEV(lg(), debug) << "FxConventionController created";
+}
+
+void FxConventionController::showListWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "showListWindow called";
+
+    const QString key = build_window_key("list", "fx_conventions");
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing list window";
+        return;
+    }
+
+    // Create new window
+    listWindow_ = new FxConventionMdiWindow(clientManager_, username_);
+
+    // Connect signals
+    connect(listWindow_, &FxConventionMdiWindow::statusChanged,
+            this, &FxConventionController::statusMessage);
+    connect(listWindow_, &FxConventionMdiWindow::errorOccurred,
+            this, &FxConventionController::errorMessage);
+    connect(listWindow_, &FxConventionMdiWindow::showConventionDetails,
+            this, &FxConventionController::onShowDetails);
+    connect(listWindow_, &FxConventionMdiWindow::addNewRequested,
+            this, &FxConventionController::onAddNewRequested);
+    connect(listWindow_, &FxConventionMdiWindow::showConventionHistory,
+            this, &FxConventionController::onShowHistory);
+
+    // Create MDI subwindow
+    listMdiSubWindow_ = new DetachableMdiSubWindow(mainWindow_);
+    listMdiSubWindow_->setWidget(listWindow_);
+    listMdiSubWindow_->setWindowTitle("FX Conventions");
+    listMdiSubWindow_->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+    listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
+    listMdiSubWindow_->resize(listWindow_->sizeHint());
+
+    mdiArea_->addSubWindow(listMdiSubWindow_);
+    listMdiSubWindow_->show();
+
+    // Track window
+    track_window(key, listMdiSubWindow_);
+    register_detachable_window(listMdiSubWindow_);
+
+    // Cleanup when closed
+    connect(listMdiSubWindow_, &QObject::destroyed, this, [self = QPointer<FxConventionController>(this), key]() {
+        if (!self) return;
+        self->untrack_window(key);
+        self->listWindow_ = nullptr;
+        self->listMdiSubWindow_ = nullptr;
+    });
+
+    BOOST_LOG_SEV(lg(), debug) << "FX Convention list window created";
+}
+
+void FxConventionController::closeAllWindows() {
+    BOOST_LOG_SEV(lg(), debug) << "closeAllWindows called";
+
+    // Close all managed windows
+    QList<QString> keys = managed_windows_.keys();
+    for (const QString& key : keys) {
+        if (auto* window = managed_windows_.value(key)) {
+            window->close();
+        }
+    }
+    managed_windows_.clear();
+
+    listWindow_ = nullptr;
+    listMdiSubWindow_ = nullptr;
+}
+
+void FxConventionController::reloadListWindow() {
+    if (listWindow_) {
+        listWindow_->reload();
+    }
+}
+
+void FxConventionController::onShowDetails(
+    const refdata::domain::fx_convention& fxc) {
+    BOOST_LOG_SEV(lg(), debug) << "Show details for: " << fxc.id;
+    showDetailWindow(fxc);
+}
+
+void FxConventionController::onAddNewRequested() {
+    BOOST_LOG_SEV(lg(), info) << "Add new FX convention requested";
+    showAddWindow();
+}
+
+void FxConventionController::onShowHistory(
+    const refdata::domain::fx_convention& fxc) {
+    BOOST_LOG_SEV(lg(), debug) << "Show history requested for: " << fxc.id;
+    showHistoryWindow(QString::fromStdString(fxc.id));
+}
+
+void FxConventionController::showAddWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "Creating add window for new FX convention";
+
+    auto* detailDialog = new FxConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(true);
+
+    connect(detailDialog, &FxConventionDetailDialog::statusMessage,
+            this, &FxConventionController::statusMessage);
+    connect(detailDialog, &FxConventionDetailDialog::errorMessage,
+            this, &FxConventionController::errorMessage);
+    connect(detailDialog, &FxConventionDetailDialog::fxcSaved,
+            this, [self = QPointer<FxConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "FX Convention saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle("New FX Convention");
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void FxConventionController::showDetailWindow(
+    const refdata::domain::fx_convention& fxc) {
+
+    const QString identifier = QString::fromStdString(fxc.id);
+    const QString key = build_window_key("details", identifier);
+
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing detail window";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Creating detail window for: " << fxc.id;
+
+    auto* detailDialog = new FxConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(false);
+    detailDialog->setConvention(fxc);
+
+    connect(detailDialog, &FxConventionDetailDialog::statusMessage,
+            this, &FxConventionController::statusMessage);
+    connect(detailDialog, &FxConventionDetailDialog::errorMessage,
+            this, &FxConventionController::errorMessage);
+    connect(detailDialog, &FxConventionDetailDialog::fxcSaved,
+            this, [self = QPointer<FxConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "FX Convention saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+    connect(detailDialog, &FxConventionDetailDialog::fxcDeleted,
+            this, [self = QPointer<FxConventionController>(this), key](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "FX Convention deleted: " << code.toStdString();
+        self->handleEntityDeleted();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("FX Convention: %1").arg(identifier));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+
+    // Track window
+    track_window(key, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<FxConventionController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, key]() {
+        if (self) {
+            self->untrack_window(key);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void FxConventionController::showHistoryWindow(const QString& code) {
+    BOOST_LOG_SEV(lg(), info) << "Opening history window for FX convention: "
+                              << code.toStdString();
+
+    const QString windowKey = build_window_key("history", code);
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing history window for: "
+                                  << code.toStdString();
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Creating new history window for: "
+                              << code.toStdString();
+
+    auto* historyDialog = new FxConventionHistoryDialog(code, clientManager_, mainWindow_);
+
+    connect(historyDialog, &FxConventionHistoryDialog::statusChanged,
+            this, [self = QPointer<FxConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(historyDialog, &FxConventionHistoryDialog::errorOccurred,
+            this, [self = QPointer<FxConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+    connect(historyDialog, &FxConventionHistoryDialog::revertVersionRequested,
+            this, &FxConventionController::onRevertVersion);
+    connect(historyDialog, &FxConventionHistoryDialog::openVersionRequested,
+            this, &FxConventionController::onOpenVersion);
+
+    // Load history data
+    historyDialog->loadHistory();
+
+    auto* historyWindow = new DetachableMdiSubWindow(mainWindow_);
+    historyWindow->setAttribute(Qt::WA_DeleteOnClose);
+    historyWindow->setWidget(historyDialog);
+    historyWindow->setWindowTitle(QString("FX Convention History: %1").arg(code));
+    historyWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    // Track this history window
+    track_window(windowKey, historyWindow);
+    register_detachable_window(historyWindow);
+
+    QPointer<FxConventionController> self = this;
+    connect(historyWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    show_managed_window(historyWindow, listMdiSubWindow_);
+}
+
+void FxConventionController::onOpenVersion(
+    const refdata::domain::fx_convention& fxc, int versionNumber) {
+    BOOST_LOG_SEV(lg(), info) << "Opening historical version " << versionNumber
+                              << " for FX convention: " << fxc.id;
+
+    const QString code = QString::fromStdString(fxc.id);
+    const QString windowKey = build_window_key("version", QString("%1_v%2")
+        .arg(code).arg(versionNumber));
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing version window";
+        return;
+    }
+
+    auto* detailDialog = new FxConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setConvention(fxc);
+    detailDialog->setReadOnly(true);
+
+    connect(detailDialog, &FxConventionDetailDialog::statusMessage,
+            this, [self = QPointer<FxConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(detailDialog, &FxConventionDetailDialog::errorMessage,
+            this, [self = QPointer<FxConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("FX Convention: %1 (Version %2)")
+        .arg(code).arg(versionNumber));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    track_window(windowKey, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<FxConventionController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_, QPoint(60, 60));
+}
+
+void FxConventionController::onRevertVersion(
+    const refdata::domain::fx_convention& fxc) {
+    BOOST_LOG_SEV(lg(), info) << "Reverting FX convention to version: "
+                              << fxc.version;
+
+    // Open detail dialog with the old version data for editing
+    auto* detailDialog = new FxConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setConvention(fxc);
+    detailDialog->setCreateMode(false);
+
+    connect(detailDialog, &FxConventionDetailDialog::statusMessage,
+            this, &FxConventionController::statusMessage);
+    connect(detailDialog, &FxConventionDetailDialog::errorMessage,
+            this, &FxConventionController::errorMessage);
+    connect(detailDialog, &FxConventionDetailDialog::fxcSaved,
+            this, [self = QPointer<FxConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "FX Convention reverted: " << code.toStdString();
+        emit self->statusMessage(QString("FX Convention '%1' reverted successfully").arg(code));
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Revert FX Convention: %1")
+        .arg(QString::fromStdString(fxc.id)));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+EntityListMdiWindow* FxConventionController::listWindow() const {
+    return listWindow_;
+}
+
+}

--- a/projects/ores.qt.refdata/src/FxConventionDetailDialog.cpp
+++ b/projects/ores.qt.refdata/src/FxConventionDetailDialog.cpp
@@ -1,0 +1,360 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/FxConventionDetailDialog.hpp"
+
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_FxConventionDetailDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.refdata.api/messaging/fx_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+FxConventionDetailDialog::FxConventionDetailDialog(QWidget* parent)
+    : DetailDialogBase(parent),
+      ui_(new Ui::FxConventionDetailDialog),
+      clientManager_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupConnections();
+}
+
+FxConventionDetailDialog::~FxConventionDetailDialog() {
+    delete ui_;
+}
+
+QTabWidget* FxConventionDetailDialog::tabWidget() const {
+    return ui_->tabWidget;
+}
+
+QWidget* FxConventionDetailDialog::provenanceTab() const {
+    return ui_->provenanceTab;
+}
+
+ProvenanceWidget* FxConventionDetailDialog::provenanceWidget() const {
+    return ui_->provenanceWidget;
+}
+
+void FxConventionDetailDialog::setupUi() {
+    ui_->saveButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Save, IconUtils::DefaultIconColor));
+    ui_->saveButton->setEnabled(false);
+
+    ui_->deleteButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Delete, IconUtils::DefaultIconColor));
+
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+}
+
+void FxConventionDetailDialog::setupConnections() {
+    connect(ui_->saveButton, &QPushButton::clicked, this,
+            &FxConventionDetailDialog::onSaveClicked);
+    connect(ui_->deleteButton, &QPushButton::clicked, this,
+            &FxConventionDetailDialog::onDeleteClicked);
+    connect(ui_->closeButton, &QPushButton::clicked, this,
+            &FxConventionDetailDialog::onCloseClicked);
+
+    connect(ui_->idEdit, &QLineEdit::textChanged, this,
+            &FxConventionDetailDialog::onCodeChanged);
+    connect(ui_->sourceCurrencyEdit, &QLineEdit::textChanged, this,
+            &FxConventionDetailDialog::onFieldChanged);
+    connect(ui_->targetCurrencyEdit, &QLineEdit::textChanged, this,
+            &FxConventionDetailDialog::onFieldChanged);
+    connect(ui_->advanceCalendarEdit, &QLineEdit::textChanged, this,
+            &FxConventionDetailDialog::onFieldChanged);
+    connect(ui_->conventionEdit, &QLineEdit::textChanged, this,
+            &FxConventionDetailDialog::onFieldChanged);
+}
+
+void FxConventionDetailDialog::setClientManager(ClientManager* clientManager) {
+    clientManager_ = clientManager;
+}
+
+void FxConventionDetailDialog::setUsername(const std::string& username) {
+    username_ = username;
+}
+
+void FxConventionDetailDialog::setConvention(
+    const refdata::domain::fx_convention& fxc) {
+    fxc_ = fxc;
+    updateUiFromConvention();
+}
+
+void FxConventionDetailDialog::setCreateMode(bool createMode) {
+    createMode_ = createMode;
+    ui_->idEdit->setReadOnly(!createMode);
+    ui_->deleteButton->setVisible(!createMode);
+    setProvenanceEnabled(!createMode);
+    hasChanges_ = false;
+    updateSaveButtonState();
+}
+
+void FxConventionDetailDialog::setReadOnly(bool readOnly) {
+    readOnly_ = readOnly;
+    ui_->idEdit->setReadOnly(true);
+    ui_->sourceCurrencyEdit->setReadOnly(readOnly);
+    ui_->targetCurrencyEdit->setReadOnly(readOnly);
+    ui_->advanceCalendarEdit->setReadOnly(readOnly);
+    ui_->conventionEdit->setReadOnly(readOnly);
+    ui_->saveButton->setVisible(!readOnly);
+    ui_->deleteButton->setVisible(!readOnly);
+}
+
+void FxConventionDetailDialog::updateUiFromConvention() {
+    ui_->idEdit->setText(QString::fromStdString(fxc_.id));
+    ui_->sourceCurrencyEdit->setText(QString::fromStdString(fxc_.source_currency));
+    ui_->targetCurrencyEdit->setText(QString::fromStdString(fxc_.target_currency));
+    ui_->spotDaysEdit->setValue(fxc_.spot_days);
+    ui_->advanceCalendarEdit->setText(fxc_.advance_calendar
+        ? QString::fromStdString(*fxc_.advance_calendar)
+        : QString{});
+    ui_->conventionEdit->setText(fxc_.convention
+        ? QString::fromStdString(*fxc_.convention)
+        : QString{});
+    ui_->spotRelativeEdit->setCheckState(fxc_.spot_relative
+        ? (*fxc_.spot_relative ? Qt::Checked : Qt::Unchecked)
+        : Qt::PartiallyChecked);
+    ui_->endOfMonthEdit->setCheckState(fxc_.end_of_month
+        ? (*fxc_.end_of_month ? Qt::Checked : Qt::Unchecked)
+        : Qt::PartiallyChecked);
+
+    populateProvenance(fxc_.version,
+                       fxc_.modified_by,
+                       fxc_.performed_by,
+                       fxc_.recorded_at,
+                       fxc_.change_reason_code,
+                       fxc_.change_commentary);
+
+    hasChanges_ = false;
+    updateSaveButtonState();
+}
+
+void FxConventionDetailDialog::updateConventionFromUi() {
+    if (createMode_) {
+        fxc_.id = ui_->idEdit->text().trimmed().toStdString();
+    }
+    fxc_.source_currency = ui_->sourceCurrencyEdit->text().trimmed().toStdString();
+    fxc_.target_currency = ui_->targetCurrencyEdit->text().trimmed().toStdString();
+    fxc_.spot_days = ui_->spotDaysEdit->value();
+    {
+        const auto advance_calendar_str = ui_->advanceCalendarEdit->text().trimmed().toStdString();
+        fxc_.advance_calendar =
+            advance_calendar_str.empty() ? std::nullopt : std::optional<std::string>(advance_calendar_str);
+    }
+    {
+        const auto convention_str = ui_->conventionEdit->text().trimmed().toStdString();
+        fxc_.convention =
+            convention_str.empty() ? std::nullopt : std::optional<std::string>(convention_str);
+    }
+    switch (ui_->spotRelativeEdit->checkState()) {
+    case Qt::Checked:
+        fxc_.spot_relative = std::optional<bool>(true);
+        break;
+    case Qt::Unchecked:
+        fxc_.spot_relative = std::optional<bool>(false);
+        break;
+    default:
+        fxc_.spot_relative = std::nullopt;
+        break;
+    }
+    switch (ui_->endOfMonthEdit->checkState()) {
+    case Qt::Checked:
+        fxc_.end_of_month = std::optional<bool>(true);
+        break;
+    case Qt::Unchecked:
+        fxc_.end_of_month = std::optional<bool>(false);
+        break;
+    default:
+        fxc_.end_of_month = std::nullopt;
+        break;
+    }
+    fxc_.modified_by = username_;
+}
+
+void FxConventionDetailDialog::onCodeChanged(const QString& /* text */) {
+    hasChanges_ = true;
+    updateSaveButtonState();
+}
+
+void FxConventionDetailDialog::onFieldChanged() {
+    hasChanges_ = true;
+    updateSaveButtonState();
+}
+
+void FxConventionDetailDialog::updateSaveButtonState() {
+    bool canSave = hasChanges_ && validateInput() && !readOnly_;
+    ui_->saveButton->setEnabled(canSave);
+}
+
+bool FxConventionDetailDialog::validateInput() {
+    const QString id_val = ui_->idEdit->text().trimmed();
+    const QString source_currency_val = ui_->sourceCurrencyEdit->text().trimmed();
+    const QString target_currency_val = ui_->targetCurrencyEdit->text().trimmed();
+
+    return true
+        && !id_val.isEmpty()
+        && !source_currency_val.isEmpty()
+        && !target_currency_val.isEmpty()
+    ;
+}
+
+void FxConventionDetailDialog::onSaveClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot save FX convention while disconnected from server.");
+        return;
+    }
+
+    if (!validateInput()) {
+        MessageBoxHelper::warning(this, "Invalid Input",
+            "Please fill in all required fields.");
+        return;
+    }
+
+    updateConventionFromUi();
+
+    BOOST_LOG_SEV(lg(), info) << "Saving FX convention: "
+        << fxc_.id;
+
+    QPointer<FxConventionDetailDialog> self = this;
+
+    struct SaveResult {
+        bool success;
+        std::string message;
+    };
+
+    auto task = [self, fxc = fxc_]() -> SaveResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed"};
+        }
+
+        refdata::messaging::save_fx_convention_request request;
+        request.data = fxc;
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server"};
+        }
+
+        return {response_result->success, response_result->message};
+    };
+
+    auto* watcher = new QFutureWatcher<SaveResult>(self);
+    connect(watcher, &QFutureWatcher<SaveResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "FX Convention saved successfully";
+            QString code = QString::fromStdString(
+                self->fxc_.id);
+            self->hasChanges_ = false;
+            self->updateSaveButtonState();
+            emit self->fxcSaved(code);
+            self->notifySaveSuccess(tr("FX Convention '%1' saved").arg(code));
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Save failed: " << result.message;
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Save Failed", errorMsg);
+        }
+    });
+
+    QFuture<SaveResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+void FxConventionDetailDialog::onDeleteClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete FX convention while disconnected from server.");
+        return;
+    }
+
+    QString code = QString::fromStdString(
+        fxc_.id);
+    auto reply = MessageBoxHelper::question(this, "Delete FX Convention",
+        QString("Are you sure you want to delete FX convention '%1'?").arg(code),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Deleting FX convention: "
+        << fxc_.id;
+
+    QPointer<FxConventionDetailDialog> self = this;
+
+    struct DeleteResult {
+        bool success;
+        std::string message;
+    };
+
+    auto task = [self, code = fxc_.id]() -> DeleteResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed"};
+        }
+
+        refdata::messaging::delete_fx_convention_request request;
+        request.codes = {code};
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server"};
+        }
+
+        return {response_result->success, response_result->message};
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, code, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "FX Convention deleted successfully";
+            emit self->statusMessage(
+                QString("FX Convention '%1' deleted").arg(code));
+            emit self->fxcDeleted(code);
+            self->requestClose();
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Delete failed: " << result.message;
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Delete Failed", errorMsg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt.refdata/src/FxConventionHistoryDialog.cpp
+++ b/projects/ores.qt.refdata/src/FxConventionHistoryDialog.cpp
@@ -1,0 +1,359 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/FxConventionHistoryDialog.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_FxConventionHistoryDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.refdata.api/messaging/fx_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+FxConventionHistoryDialog::FxConventionHistoryDialog(
+    const QString& code,
+    ClientManager* clientManager,
+    QWidget* parent)
+    : QWidget(parent),
+      ui_(new Ui::FxConventionHistoryDialog),
+      code_(code),
+      clientManager_(clientManager),
+      toolbar_(nullptr),
+      openVersionAction_(nullptr),
+      revertAction_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupToolbar();
+    setupConnections();
+}
+
+FxConventionHistoryDialog::~FxConventionHistoryDialog() {
+    delete ui_;
+}
+
+void FxConventionHistoryDialog::setupUi() {
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+
+    ui_->titleLabel->setText(QString("History for: %1").arg(code_));
+
+    // Setup version list table
+    ui_->versionListWidget->setColumnCount(5);
+    ui_->versionListWidget->setHorizontalHeaderLabels(
+        {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
+    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
+    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    // Setup changes table
+    ui_->changesTableWidget->setColumnCount(3);
+    ui_->changesTableWidget->setHorizontalHeaderLabels(
+        {"Field", "Old Value", "New Value"});
+    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+}
+
+void FxConventionHistoryDialog::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    openVersionAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor),
+        tr("Open"));
+    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
+    openVersionAction_->setEnabled(false);
+
+    revertAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor),
+        tr("Revert"));
+    revertAction_->setToolTip(tr("Revert to this version"));
+    revertAction_->setEnabled(false);
+
+    // Insert toolbar at the top of the layout
+    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
+    if (layout) {
+        layout->insertWidget(0, toolbar_);
+    }
+}
+
+void FxConventionHistoryDialog::setupConnections() {
+    connect(ui_->versionListWidget, &QTableWidget::itemSelectionChanged,
+            this, &FxConventionHistoryDialog::onVersionSelected);
+    connect(openVersionAction_, &QAction::triggered,
+            this, &FxConventionHistoryDialog::onOpenVersionClicked);
+    connect(revertAction_, &QAction::triggered,
+            this, &FxConventionHistoryDialog::onRevertClicked);
+    connect(ui_->closeButton, &QPushButton::clicked,
+            this, [this]() { if (window()) window()->close(); });
+}
+
+void FxConventionHistoryDialog::loadHistory() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        emit errorOccurred("Not connected to server");
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for FX convention: " << code_.toStdString();
+    emit statusChanged(tr("Loading history..."));
+
+    QPointer<FxConventionHistoryDialog> self = this;
+
+    using HistoryResult = std::expected<refdata::messaging::get_fx_convention_history_response, std::string>;
+
+    QFuture<HistoryResult> future =
+        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
+        if (!self || !self->clientManager_)
+            return std::unexpected("Dialog closed");
+        refdata::messaging::get_fx_convention_history_request request;
+        request.id = code;
+        auto result = self->clientManager_->process_authenticated_request(std::move(request));
+        if (!result) return std::unexpected(result.error());
+        return std::move(*result);
+    });
+
+    auto* watcher = new QFutureWatcher<HistoryResult>(self);
+    connect(watcher, &QFutureWatcher<HistoryResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (!result) {
+            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
+            emit self->errorOccurred(QString::fromStdString(result.error()));
+            return;
+        }
+        if (!result->success) {
+            emit self->errorOccurred(QString::fromStdString(result->message));
+            return;
+        }
+        self->versions_ = std::move(result->fx_conventions);
+        self->updateVersionList();
+        emit self->statusChanged(
+            QString("Loaded %1 versions").arg(self->versions_.size()));
+    });
+    watcher->setFuture(future);
+}
+
+void FxConventionHistoryDialog::updateVersionList() {
+    ui_->versionListWidget->setRowCount(0);
+
+    for (const auto& version : versions_) {
+        int row = ui_->versionListWidget->rowCount();
+        ui_->versionListWidget->insertRow(row);
+
+        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
+        versionItem->setTextAlignment(Qt::AlignCenter);
+        ui_->versionListWidget->setItem(row, 0, versionItem);
+
+        auto* recordedAtItem = new QTableWidgetItem(
+            relative_time_helper::format(version.recorded_at));
+        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
+
+        auto* modifiedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.modified_by));
+        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
+
+        auto* performedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.performed_by));
+        ui_->versionListWidget->setItem(row, 3, performedByItem);
+
+        auto* commentaryItem = new QTableWidgetItem(
+            QString::fromStdString(version.change_commentary));
+        ui_->versionListWidget->setItem(row, 4, commentaryItem);
+    }
+
+    // Select the first (most recent) version
+    if (!versions_.empty()) {
+        ui_->versionListWidget->selectRow(0);
+    }
+}
+
+void FxConventionHistoryDialog::onVersionSelected() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) {
+        updateActionStates();
+        return;
+    }
+
+    int row = selected.first()->row();
+    updateChangesTable(row);
+    updateFullDetails(row);
+    updateActionStates();
+}
+
+void FxConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
+    ui_->changesTableWidget->setRowCount(0);
+
+    if (currentVersionIndex < 0 ||
+        static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
+        return;
+    }
+
+    // Get the next older version to compare against
+    int previousVersionIndex = currentVersionIndex + 1;
+    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
+        // This is the first version, no changes to show
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(Initial version)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+        return;
+    }
+
+    const auto& current = versions_[currentVersionIndex];
+    const auto& previous = versions_[previousVersionIndex];
+
+    auto addChange = [this](const QString& field,
+                            const QString& oldVal, const QString& newVal) {
+        int row = ui_->changesTableWidget->rowCount();
+        ui_->changesTableWidget->insertRow(row);
+        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
+        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
+        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
+    };
+
+    if (current.id != previous.id) {
+        addChange("Id",
+                  QString::fromStdString(previous.id),
+                  QString::fromStdString(current.id));
+    }
+
+    if (current.source_currency != previous.source_currency) {
+        addChange("Source Currency",
+                  QString::fromStdString(previous.source_currency),
+                  QString::fromStdString(current.source_currency));
+    }
+
+    if (current.target_currency != previous.target_currency) {
+        addChange("Target Currency",
+                  QString::fromStdString(previous.target_currency),
+                  QString::fromStdString(current.target_currency));
+    }
+
+    if (current.spot_days != previous.spot_days) {
+        addChange("Spot Days",
+                  QString::number(previous.spot_days),
+                  QString::number(current.spot_days));
+    }
+
+    if (current.advance_calendar != previous.advance_calendar) {
+        addChange("Advance Calendar",
+                  previous.advance_calendar ? QString::fromStdString(*previous.advance_calendar) : QString{},
+                  current.advance_calendar ? QString::fromStdString(*current.advance_calendar) : QString{});
+    }
+
+    if (current.convention != previous.convention) {
+        addChange("Convention",
+                  previous.convention ? QString::fromStdString(*previous.convention) : QString{},
+                  current.convention ? QString::fromStdString(*current.convention) : QString{});
+    }
+
+    if (current.spot_relative != previous.spot_relative) {
+        addChange("Spot Relative",
+                  previous.spot_relative ? (*previous.spot_relative ? tr("true") : tr("false")) : tr("(unset)"),
+                  current.spot_relative ? (*current.spot_relative ? tr("true") : tr("false")) : tr("(unset)"));
+    }
+
+    if (current.end_of_month != previous.end_of_month) {
+        addChange("End Of Month",
+                  previous.end_of_month ? (*previous.end_of_month ? tr("true") : tr("false")) : tr("(unset)"),
+                  current.end_of_month ? (*current.end_of_month ? tr("true") : tr("false")) : tr("(unset)"));
+    }
+
+
+    if (ui_->changesTableWidget->rowCount() == 0) {
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(No field changes)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+    }
+}
+
+void FxConventionHistoryDialog::updateFullDetails(int versionIndex) {
+    if (versionIndex < 0 ||
+        static_cast<size_t>(versionIndex) >= versions_.size()) {
+        return;
+    }
+
+    const auto& version = versions_[versionIndex];
+
+    ui_->idValue->setText(QString::fromStdString(version.id));
+    ui_->sourceCurrencyValue->setText(QString::fromStdString(version.source_currency));
+    ui_->targetCurrencyValue->setText(QString::fromStdString(version.target_currency));
+    ui_->spotDaysValue->setText(QString::number(version.spot_days));
+    ui_->advanceCalendarValue->setText(version.advance_calendar
+        ? QString::fromStdString(*version.advance_calendar)
+        : QString{});
+    ui_->conventionValue->setText(version.convention
+        ? QString::fromStdString(*version.convention)
+        : QString{});
+    ui_->spotRelativeValue->setText(version.spot_relative
+        ? (*version.spot_relative ? tr("true") : tr("false"))
+        : tr("(unset)"));
+    ui_->endOfMonthValue->setText(version.end_of_month
+        ? (*version.end_of_month ? tr("true") : tr("false"))
+        : tr("(unset)"));
+    ui_->versionNumberValue->setText(QString::number(version.version));
+    ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
+}
+
+void FxConventionHistoryDialog::updateActionStates() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    bool hasSelection = !selected.isEmpty();
+    bool isNotLatest = hasSelection && selected.first()->row() > 0;
+
+    openVersionAction_->setEnabled(hasSelection);
+    revertAction_->setEnabled(isNotLatest);
+}
+
+void FxConventionHistoryDialog::onOpenVersionClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit openVersionRequested(versions_[row], versions_[row].version);
+}
+
+void FxConventionHistoryDialog::onRevertClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit revertVersionRequested(versions_[row]);
+}
+
+}

--- a/projects/ores.qt.refdata/src/FxConventionMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/FxConventionMdiWindow.cpp
@@ -1,0 +1,386 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/FxConventionMdiWindow.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.refdata.api/messaging/fx_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+FxConventionMdiWindow::FxConventionMdiWindow(
+    ClientManager* clientManager,
+    const QString& username,
+    QWidget* parent)
+    : EntityListMdiWindow(parent),
+      clientManager_(clientManager),
+      username_(username),
+      toolbar_(nullptr),
+      tableView_(nullptr),
+      model_(nullptr),
+      proxyModel_(nullptr),
+      paginationWidget_(nullptr),
+      reloadAction_(nullptr),
+      addAction_(nullptr),
+      editAction_(nullptr),
+      deleteAction_(nullptr),
+      historyAction_(nullptr) {
+
+    setupUi();
+    setupConnections();
+    reload();
+}
+
+void FxConventionMdiWindow::setupUi() {
+    auto* layout = new QVBoxLayout(this);
+
+    setupToolbar();
+    layout->addWidget(toolbar_);
+    layout->addWidget(loadingBar());
+
+    setupTable();
+    layout->addWidget(tableView_);
+
+    paginationWidget_ = new PaginationWidget(this);
+    layout->addWidget(paginationWidget_);
+}
+
+void FxConventionMdiWindow::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    reloadAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowClockwise, IconUtils::DefaultIconColor),
+        tr("Reload"));
+    connect(reloadAction_, &QAction::triggered, this,
+            &EntityListMdiWindow::reload);
+
+    initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
+
+    toolbar_->addSeparator();
+
+    addAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Add, IconUtils::DefaultIconColor),
+        tr("Add"));
+    addAction_->setToolTip(tr("Add new FX convention"));
+    connect(addAction_, &QAction::triggered, this,
+            &FxConventionMdiWindow::addNew);
+
+    editAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Edit, IconUtils::DefaultIconColor),
+        tr("Edit"));
+    editAction_->setToolTip(tr("Edit selected FX convention"));
+    editAction_->setEnabled(false);
+    connect(editAction_, &QAction::triggered, this,
+            &FxConventionMdiWindow::editSelected);
+
+    deleteAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Delete, IconUtils::DefaultIconColor),
+        tr("Delete"));
+    deleteAction_->setToolTip(tr("Delete selected FX convention"));
+    deleteAction_->setEnabled(false);
+    connect(deleteAction_, &QAction::triggered, this,
+            &FxConventionMdiWindow::deleteSelected);
+
+    historyAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::History, IconUtils::DefaultIconColor),
+        tr("History"));
+    historyAction_->setToolTip(tr("View FX convention history"));
+    historyAction_->setEnabled(false);
+    connect(historyAction_, &QAction::triggered, this,
+            &FxConventionMdiWindow::viewHistorySelected);
+}
+
+void FxConventionMdiWindow::setupTable() {
+    model_ = new ClientFxConventionModel(clientManager_, this);
+    proxyModel_ = new QSortFilterProxyModel(this);
+    proxyModel_->setSourceModel(model_);
+    proxyModel_->setSortCaseSensitivity(Qt::CaseInsensitive);
+
+    tableView_ = new QTableView(this);
+    tableView_->setModel(proxyModel_);
+    tableView_->setSelectionBehavior(QAbstractItemView::SelectRows);
+    tableView_->setSelectionMode(QAbstractItemView::SingleSelection);
+    tableView_->setSortingEnabled(true);
+    tableView_->setAlternatingRowColors(true);
+    tableView_->verticalHeader()->setVisible(false);
+
+    initializeTableSettings(tableView_, model_,
+        "FxConventionListWindow",
+        {},
+        {900, 400}, 1);
+}
+
+void FxConventionMdiWindow::setupConnections() {
+    connect(model_, &ClientFxConventionModel::dataLoaded,
+            this, &FxConventionMdiWindow::onDataLoaded);
+    connect(model_, &ClientFxConventionModel::loadError,
+            this, &FxConventionMdiWindow::onLoadError);
+
+    connect(tableView_->selectionModel(), &QItemSelectionModel::selectionChanged,
+            this, &FxConventionMdiWindow::onSelectionChanged);
+    connect(tableView_, &QTableView::doubleClicked,
+            this, &FxConventionMdiWindow::onDoubleClicked);
+
+    connect(paginationWidget_, &PaginationWidget::page_size_changed,
+            this, [this](std::uint32_t size) {
+        model_->set_page_size(size);
+        model_->refresh();
+    });
+
+    connect(paginationWidget_, &PaginationWidget::load_all_requested,
+            this, [this]() {
+        const auto total = model_->total_available_count();
+        if (total > 0 && total <= 1000) {
+            model_->set_page_size(total);
+            model_->refresh();
+        }
+    });
+
+    connect(paginationWidget_, &PaginationWidget::page_requested,
+            this, [this](std::uint32_t offset, std::uint32_t limit) {
+        model_->load_page(offset, limit);
+    });
+
+    connectModel(model_);
+}
+
+void FxConventionMdiWindow::doReload() {
+    BOOST_LOG_SEV(lg(), debug) << "Reloading FX conventions";
+    clearStaleIndicator();
+    emit statusChanged(tr("Loading FX conventions..."));
+    model_->refresh();
+}
+
+void FxConventionMdiWindow::onDataLoaded() {
+    const auto loaded = model_->rowCount();
+    const auto total = model_->total_available_count();
+    emit statusChanged(tr("Loaded %1 of %2 FX conventions").arg(loaded).arg(total));
+
+    paginationWidget_->update_state(loaded, total);
+    paginationWidget_->set_load_all_enabled(
+        loaded < static_cast<int>(total) && total > 0 && total <= 1000);
+}
+
+void FxConventionMdiWindow::onLoadError(const QString& error_message,
+                                          const QString& details) {
+    BOOST_LOG_SEV(lg(), error) << "Load error: " << error_message.toStdString();
+    emit errorOccurred(error_message);
+    MessageBoxHelper::critical(this, tr("Load Error"), error_message, details);
+}
+
+void FxConventionMdiWindow::onSelectionChanged() {
+    updateActionStates();
+}
+
+void FxConventionMdiWindow::onDoubleClicked(const QModelIndex& index) {
+    if (!index.isValid())
+        return;
+
+    auto sourceIndex = proxyModel_->mapToSource(index);
+    if (auto* fxc = model_->getConvention(sourceIndex.row())) {
+        emit showConventionDetails(*fxc);
+    }
+}
+
+void FxConventionMdiWindow::updateActionStates() {
+    const bool hasSelection = tableView_->selectionModel()->hasSelection();
+    editAction_->setEnabled(hasSelection);
+    deleteAction_->setEnabled(hasSelection);
+    historyAction_->setEnabled(hasSelection);
+}
+
+void FxConventionMdiWindow::addNew() {
+    BOOST_LOG_SEV(lg(), debug) << "Add new FX convention requested";
+    emit addNewRequested();
+}
+
+void FxConventionMdiWindow::editSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Edit requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* fxc = model_->getConvention(sourceIndex.row())) {
+        emit showConventionDetails(*fxc);
+    }
+}
+
+void FxConventionMdiWindow::viewHistorySelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "View history requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* fxc = model_->getConvention(sourceIndex.row())) {
+        BOOST_LOG_SEV(lg(), debug) << "Emitting showConventionHistory for code: "
+                                   << fxc->id;
+        emit showConventionHistory(*fxc);
+    }
+}
+
+void FxConventionMdiWindow::deleteSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Delete requested but no row selected";
+        return;
+    }
+
+    if (!clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete FX convention while disconnected.");
+        return;
+    }
+
+    std::vector<std::string> codes;
+    for (const auto& index : selected) {
+        auto sourceIndex = proxyModel_->mapToSource(index);
+        if (auto* fxc = model_->getConvention(sourceIndex.row())) {
+            codes.push_back(fxc->id);
+        }
+    }
+
+    if (codes.empty()) {
+        BOOST_LOG_SEV(lg(), warn) << "No valid FX conventions to delete";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Delete requested for " << codes.size()
+                               << " FX conventions";
+
+    QString confirmMessage;
+    if (codes.size() == 1) {
+        confirmMessage = QString("Are you sure you want to delete FX convention '%1'?")
+            .arg(QString::fromStdString(codes.front()));
+    } else {
+        confirmMessage = QString("Are you sure you want to delete %1 FX conventions?")
+            .arg(codes.size());
+    }
+
+    auto reply = MessageBoxHelper::question(this, "Delete FX Convention",
+        confirmMessage, QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        BOOST_LOG_SEV(lg(), debug) << "Delete cancelled by user";
+        return;
+    }
+
+    QPointer<FxConventionMdiWindow> self = this;
+    using DeleteResult = std::vector<std::pair<std::string, std::pair<bool, std::string>>>;
+
+    auto task = [self, codes]() -> DeleteResult {
+        DeleteResult results;
+        if (!self) return {};
+
+        BOOST_LOG_SEV(lg(), debug) << "Making batch delete request for "
+                                   << codes.size() << " FX conventions";
+
+        refdata::messaging::delete_fx_convention_request request;
+        request.codes = codes;
+        auto response_result = self->clientManager_->process_authenticated_request(
+            std::move(request));
+
+        if (!response_result) {
+            BOOST_LOG_SEV(lg(), error) << "Failed to send batch delete request";
+            for (const auto& code : codes) {
+                results.push_back({code, {false, "Failed to communicate with server"}});
+            }
+            return results;
+        }
+
+        for (const auto& code : codes) {
+            results.push_back({code, {response_result->success, response_result->message}});
+        }
+
+        return results;
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, watcher]() {
+        auto results = watcher->result();
+        watcher->deleteLater();
+
+        int success_count = 0;
+        int failure_count = 0;
+        QString first_error;
+
+        for (const auto& [code, result] : results) {
+            if (result.first) {
+                BOOST_LOG_SEV(lg(), debug) << "FX Convention deleted: " << code;
+                success_count++;
+                emit self->fxcDeleted(QString::fromStdString(code));
+            } else {
+                BOOST_LOG_SEV(lg(), error) << "FX Convention deletion failed: "
+                                           << code << " - " << result.second;
+                failure_count++;
+                if (first_error.isEmpty()) {
+                    first_error = QString::fromStdString(result.second);
+                }
+            }
+        }
+
+        self->model_->refresh();
+
+        if (failure_count == 0) {
+            QString msg = success_count == 1
+                ? "Successfully deleted 1 FX convention"
+                : QString("Successfully deleted %1 FX conventions").arg(success_count);
+            emit self->statusChanged(msg);
+        } else if (success_count == 0) {
+            QString msg = QString("Failed to delete %1 %2: %3")
+                .arg(failure_count)
+                .arg(failure_count == 1 ? "FX convention" : "FX conventions")
+                .arg(first_error);
+            emit self->errorOccurred(msg);
+            MessageBoxHelper::critical(self, "Delete Failed", msg);
+        } else {
+            QString msg = QString("Deleted %1, failed to delete %2")
+                .arg(success_count)
+                .arg(failure_count);
+            emit self->statusChanged(msg);
+            MessageBoxHelper::warning(self, "Partial Success", msg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt.refdata/src/IborIndexConventionController.cpp
+++ b/projects/ores.qt.refdata/src/IborIndexConventionController.cpp
@@ -1,0 +1,385 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/IborIndexConventionController.hpp"
+
+#include <QMdiSubWindow>
+#include <QMessageBox>
+#include <QPointer>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/IborIndexConventionMdiWindow.hpp"
+#include "ores.qt/IborIndexConventionDetailDialog.hpp"
+#include "ores.qt/IborIndexConventionHistoryDialog.hpp"
+#include "ores.qt/DetachableMdiSubWindow.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+IborIndexConventionController::IborIndexConventionController(
+    QMainWindow* mainWindow,
+    QMdiArea* mdiArea,
+    ClientManager* clientManager,
+    const QString& username,
+    QObject* parent)
+    : EntityController(mainWindow, mdiArea, clientManager, username,
+          std::string_view{}, parent),
+      listWindow_(nullptr),
+      listMdiSubWindow_(nullptr) {
+
+    BOOST_LOG_SEV(lg(), debug) << "IborIndexConventionController created";
+}
+
+void IborIndexConventionController::showListWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "showListWindow called";
+
+    const QString key = build_window_key("list", "ibor_index_conventions");
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing list window";
+        return;
+    }
+
+    // Create new window
+    listWindow_ = new IborIndexConventionMdiWindow(clientManager_, username_);
+
+    // Connect signals
+    connect(listWindow_, &IborIndexConventionMdiWindow::statusChanged,
+            this, &IborIndexConventionController::statusMessage);
+    connect(listWindow_, &IborIndexConventionMdiWindow::errorOccurred,
+            this, &IborIndexConventionController::errorMessage);
+    connect(listWindow_, &IborIndexConventionMdiWindow::showConventionDetails,
+            this, &IborIndexConventionController::onShowDetails);
+    connect(listWindow_, &IborIndexConventionMdiWindow::addNewRequested,
+            this, &IborIndexConventionController::onAddNewRequested);
+    connect(listWindow_, &IborIndexConventionMdiWindow::showConventionHistory,
+            this, &IborIndexConventionController::onShowHistory);
+
+    // Create MDI subwindow
+    listMdiSubWindow_ = new DetachableMdiSubWindow(mainWindow_);
+    listMdiSubWindow_->setWidget(listWindow_);
+    listMdiSubWindow_->setWindowTitle("IBOR Index Conventions");
+    listMdiSubWindow_->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+    listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
+    listMdiSubWindow_->resize(listWindow_->sizeHint());
+
+    mdiArea_->addSubWindow(listMdiSubWindow_);
+    listMdiSubWindow_->show();
+
+    // Track window
+    track_window(key, listMdiSubWindow_);
+    register_detachable_window(listMdiSubWindow_);
+
+    // Cleanup when closed
+    connect(listMdiSubWindow_, &QObject::destroyed, this, [self = QPointer<IborIndexConventionController>(this), key]() {
+        if (!self) return;
+        self->untrack_window(key);
+        self->listWindow_ = nullptr;
+        self->listMdiSubWindow_ = nullptr;
+    });
+
+    BOOST_LOG_SEV(lg(), debug) << "IBOR Index Convention list window created";
+}
+
+void IborIndexConventionController::closeAllWindows() {
+    BOOST_LOG_SEV(lg(), debug) << "closeAllWindows called";
+
+    // Close all managed windows
+    QList<QString> keys = managed_windows_.keys();
+    for (const QString& key : keys) {
+        if (auto* window = managed_windows_.value(key)) {
+            window->close();
+        }
+    }
+    managed_windows_.clear();
+
+    listWindow_ = nullptr;
+    listMdiSubWindow_ = nullptr;
+}
+
+void IborIndexConventionController::reloadListWindow() {
+    if (listWindow_) {
+        listWindow_->reload();
+    }
+}
+
+void IborIndexConventionController::onShowDetails(
+    const refdata::domain::ibor_index_convention& ic) {
+    BOOST_LOG_SEV(lg(), debug) << "Show details for: " << ic.id;
+    showDetailWindow(ic);
+}
+
+void IborIndexConventionController::onAddNewRequested() {
+    BOOST_LOG_SEV(lg(), info) << "Add new IBOR index convention requested";
+    showAddWindow();
+}
+
+void IborIndexConventionController::onShowHistory(
+    const refdata::domain::ibor_index_convention& ic) {
+    BOOST_LOG_SEV(lg(), debug) << "Show history requested for: " << ic.id;
+    showHistoryWindow(QString::fromStdString(ic.id));
+}
+
+void IborIndexConventionController::showAddWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "Creating add window for new IBOR index convention";
+
+    auto* detailDialog = new IborIndexConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(true);
+
+    connect(detailDialog, &IborIndexConventionDetailDialog::statusMessage,
+            this, &IborIndexConventionController::statusMessage);
+    connect(detailDialog, &IborIndexConventionDetailDialog::errorMessage,
+            this, &IborIndexConventionController::errorMessage);
+    connect(detailDialog, &IborIndexConventionDetailDialog::icSaved,
+            this, [self = QPointer<IborIndexConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "IBOR Index Convention saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle("New IBOR Index Convention");
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void IborIndexConventionController::showDetailWindow(
+    const refdata::domain::ibor_index_convention& ic) {
+
+    const QString identifier = QString::fromStdString(ic.id);
+    const QString key = build_window_key("details", identifier);
+
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing detail window";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Creating detail window for: " << ic.id;
+
+    auto* detailDialog = new IborIndexConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(false);
+    detailDialog->setConvention(ic);
+
+    connect(detailDialog, &IborIndexConventionDetailDialog::statusMessage,
+            this, &IborIndexConventionController::statusMessage);
+    connect(detailDialog, &IborIndexConventionDetailDialog::errorMessage,
+            this, &IborIndexConventionController::errorMessage);
+    connect(detailDialog, &IborIndexConventionDetailDialog::icSaved,
+            this, [self = QPointer<IborIndexConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "IBOR Index Convention saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+    connect(detailDialog, &IborIndexConventionDetailDialog::icDeleted,
+            this, [self = QPointer<IborIndexConventionController>(this), key](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "IBOR Index Convention deleted: " << code.toStdString();
+        self->handleEntityDeleted();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("IBOR Index Convention: %1").arg(identifier));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+
+    // Track window
+    track_window(key, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<IborIndexConventionController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, key]() {
+        if (self) {
+            self->untrack_window(key);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void IborIndexConventionController::showHistoryWindow(const QString& code) {
+    BOOST_LOG_SEV(lg(), info) << "Opening history window for IBOR index convention: "
+                              << code.toStdString();
+
+    const QString windowKey = build_window_key("history", code);
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing history window for: "
+                                  << code.toStdString();
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Creating new history window for: "
+                              << code.toStdString();
+
+    auto* historyDialog = new IborIndexConventionHistoryDialog(code, clientManager_, mainWindow_);
+
+    connect(historyDialog, &IborIndexConventionHistoryDialog::statusChanged,
+            this, [self = QPointer<IborIndexConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(historyDialog, &IborIndexConventionHistoryDialog::errorOccurred,
+            this, [self = QPointer<IborIndexConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+    connect(historyDialog, &IborIndexConventionHistoryDialog::revertVersionRequested,
+            this, &IborIndexConventionController::onRevertVersion);
+    connect(historyDialog, &IborIndexConventionHistoryDialog::openVersionRequested,
+            this, &IborIndexConventionController::onOpenVersion);
+
+    // Load history data
+    historyDialog->loadHistory();
+
+    auto* historyWindow = new DetachableMdiSubWindow(mainWindow_);
+    historyWindow->setAttribute(Qt::WA_DeleteOnClose);
+    historyWindow->setWidget(historyDialog);
+    historyWindow->setWindowTitle(QString("IBOR Index Convention History: %1").arg(code));
+    historyWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    // Track this history window
+    track_window(windowKey, historyWindow);
+    register_detachable_window(historyWindow);
+
+    QPointer<IborIndexConventionController> self = this;
+    connect(historyWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    show_managed_window(historyWindow, listMdiSubWindow_);
+}
+
+void IborIndexConventionController::onOpenVersion(
+    const refdata::domain::ibor_index_convention& ic, int versionNumber) {
+    BOOST_LOG_SEV(lg(), info) << "Opening historical version " << versionNumber
+                              << " for IBOR index convention: " << ic.id;
+
+    const QString code = QString::fromStdString(ic.id);
+    const QString windowKey = build_window_key("version", QString("%1_v%2")
+        .arg(code).arg(versionNumber));
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing version window";
+        return;
+    }
+
+    auto* detailDialog = new IborIndexConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setConvention(ic);
+    detailDialog->setReadOnly(true);
+
+    connect(detailDialog, &IborIndexConventionDetailDialog::statusMessage,
+            this, [self = QPointer<IborIndexConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(detailDialog, &IborIndexConventionDetailDialog::errorMessage,
+            this, [self = QPointer<IborIndexConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("IBOR Index Convention: %1 (Version %2)")
+        .arg(code).arg(versionNumber));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    track_window(windowKey, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<IborIndexConventionController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_, QPoint(60, 60));
+}
+
+void IborIndexConventionController::onRevertVersion(
+    const refdata::domain::ibor_index_convention& ic) {
+    BOOST_LOG_SEV(lg(), info) << "Reverting IBOR index convention to version: "
+                              << ic.version;
+
+    // Open detail dialog with the old version data for editing
+    auto* detailDialog = new IborIndexConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setConvention(ic);
+    detailDialog->setCreateMode(false);
+
+    connect(detailDialog, &IborIndexConventionDetailDialog::statusMessage,
+            this, &IborIndexConventionController::statusMessage);
+    connect(detailDialog, &IborIndexConventionDetailDialog::errorMessage,
+            this, &IborIndexConventionController::errorMessage);
+    connect(detailDialog, &IborIndexConventionDetailDialog::icSaved,
+            this, [self = QPointer<IborIndexConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "IBOR Index Convention reverted: " << code.toStdString();
+        emit self->statusMessage(QString("IBOR Index Convention '%1' reverted successfully").arg(code));
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Revert IBOR Index Convention: %1")
+        .arg(QString::fromStdString(ic.id)));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+EntityListMdiWindow* IborIndexConventionController::listWindow() const {
+    return listWindow_;
+}
+
+}

--- a/projects/ores.qt.refdata/src/IborIndexConventionDetailDialog.cpp
+++ b/projects/ores.qt.refdata/src/IborIndexConventionDetailDialog.cpp
@@ -1,0 +1,319 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/IborIndexConventionDetailDialog.hpp"
+
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_IborIndexConventionDetailDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.refdata.api/messaging/ibor_index_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+IborIndexConventionDetailDialog::IborIndexConventionDetailDialog(QWidget* parent)
+    : DetailDialogBase(parent),
+      ui_(new Ui::IborIndexConventionDetailDialog),
+      clientManager_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupConnections();
+}
+
+IborIndexConventionDetailDialog::~IborIndexConventionDetailDialog() {
+    delete ui_;
+}
+
+QTabWidget* IborIndexConventionDetailDialog::tabWidget() const {
+    return ui_->tabWidget;
+}
+
+QWidget* IborIndexConventionDetailDialog::provenanceTab() const {
+    return ui_->provenanceTab;
+}
+
+ProvenanceWidget* IborIndexConventionDetailDialog::provenanceWidget() const {
+    return ui_->provenanceWidget;
+}
+
+void IborIndexConventionDetailDialog::setupUi() {
+    ui_->saveButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Save, IconUtils::DefaultIconColor));
+    ui_->saveButton->setEnabled(false);
+
+    ui_->deleteButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Delete, IconUtils::DefaultIconColor));
+
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+}
+
+void IborIndexConventionDetailDialog::setupConnections() {
+    connect(ui_->saveButton, &QPushButton::clicked, this,
+            &IborIndexConventionDetailDialog::onSaveClicked);
+    connect(ui_->deleteButton, &QPushButton::clicked, this,
+            &IborIndexConventionDetailDialog::onDeleteClicked);
+    connect(ui_->closeButton, &QPushButton::clicked, this,
+            &IborIndexConventionDetailDialog::onCloseClicked);
+
+    connect(ui_->idEdit, &QLineEdit::textChanged, this,
+            &IborIndexConventionDetailDialog::onCodeChanged);
+    connect(ui_->fixingCalendarEdit, &QLineEdit::textChanged, this,
+            &IborIndexConventionDetailDialog::onFieldChanged);
+    connect(ui_->dayCountFractionEdit, &QLineEdit::textChanged, this,
+            &IborIndexConventionDetailDialog::onFieldChanged);
+    connect(ui_->businessDayConventionEdit, &QLineEdit::textChanged, this,
+            &IborIndexConventionDetailDialog::onFieldChanged);
+}
+
+void IborIndexConventionDetailDialog::setClientManager(ClientManager* clientManager) {
+    clientManager_ = clientManager;
+}
+
+void IborIndexConventionDetailDialog::setUsername(const std::string& username) {
+    username_ = username;
+}
+
+void IborIndexConventionDetailDialog::setConvention(
+    const refdata::domain::ibor_index_convention& ic) {
+    ic_ = ic;
+    updateUiFromConvention();
+}
+
+void IborIndexConventionDetailDialog::setCreateMode(bool createMode) {
+    createMode_ = createMode;
+    ui_->idEdit->setReadOnly(!createMode);
+    ui_->deleteButton->setVisible(!createMode);
+    setProvenanceEnabled(!createMode);
+    hasChanges_ = false;
+    updateSaveButtonState();
+}
+
+void IborIndexConventionDetailDialog::setReadOnly(bool readOnly) {
+    readOnly_ = readOnly;
+    ui_->idEdit->setReadOnly(true);
+    ui_->fixingCalendarEdit->setReadOnly(readOnly);
+    ui_->dayCountFractionEdit->setReadOnly(readOnly);
+    ui_->businessDayConventionEdit->setReadOnly(readOnly);
+    ui_->saveButton->setVisible(!readOnly);
+    ui_->deleteButton->setVisible(!readOnly);
+}
+
+void IborIndexConventionDetailDialog::updateUiFromConvention() {
+    ui_->idEdit->setText(QString::fromStdString(ic_.id));
+    ui_->fixingCalendarEdit->setText(QString::fromStdString(ic_.fixing_calendar));
+    ui_->dayCountFractionEdit->setText(QString::fromStdString(ic_.day_count_fraction));
+    ui_->settlementDaysEdit->setValue(ic_.settlement_days);
+    ui_->businessDayConventionEdit->setText(QString::fromStdString(ic_.business_day_convention));
+    ui_->endOfMonthEdit->setChecked(ic_.end_of_month);
+
+    populateProvenance(ic_.version,
+                       ic_.modified_by,
+                       ic_.performed_by,
+                       ic_.recorded_at,
+                       ic_.change_reason_code,
+                       ic_.change_commentary);
+
+    hasChanges_ = false;
+    updateSaveButtonState();
+}
+
+void IborIndexConventionDetailDialog::updateConventionFromUi() {
+    if (createMode_) {
+        ic_.id = ui_->idEdit->text().trimmed().toStdString();
+    }
+    ic_.fixing_calendar = ui_->fixingCalendarEdit->text().trimmed().toStdString();
+    ic_.day_count_fraction = ui_->dayCountFractionEdit->text().trimmed().toStdString();
+    ic_.settlement_days = ui_->settlementDaysEdit->value();
+    ic_.business_day_convention = ui_->businessDayConventionEdit->text().trimmed().toStdString();
+    ic_.end_of_month = ui_->endOfMonthEdit->isChecked();
+    ic_.modified_by = username_;
+}
+
+void IborIndexConventionDetailDialog::onCodeChanged(const QString& /* text */) {
+    hasChanges_ = true;
+    updateSaveButtonState();
+}
+
+void IborIndexConventionDetailDialog::onFieldChanged() {
+    hasChanges_ = true;
+    updateSaveButtonState();
+}
+
+void IborIndexConventionDetailDialog::updateSaveButtonState() {
+    bool canSave = hasChanges_ && validateInput() && !readOnly_;
+    ui_->saveButton->setEnabled(canSave);
+}
+
+bool IborIndexConventionDetailDialog::validateInput() {
+    const QString id_val = ui_->idEdit->text().trimmed();
+    const QString fixing_calendar_val = ui_->fixingCalendarEdit->text().trimmed();
+    const QString day_count_fraction_val = ui_->dayCountFractionEdit->text().trimmed();
+    const QString business_day_convention_val = ui_->businessDayConventionEdit->text().trimmed();
+
+    return true
+        && !id_val.isEmpty()
+        && !fixing_calendar_val.isEmpty()
+        && !day_count_fraction_val.isEmpty()
+        && !business_day_convention_val.isEmpty()
+    ;
+}
+
+void IborIndexConventionDetailDialog::onSaveClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot save IBOR index convention while disconnected from server.");
+        return;
+    }
+
+    if (!validateInput()) {
+        MessageBoxHelper::warning(this, "Invalid Input",
+            "Please fill in all required fields.");
+        return;
+    }
+
+    updateConventionFromUi();
+
+    BOOST_LOG_SEV(lg(), info) << "Saving IBOR index convention: "
+        << ic_.id;
+
+    QPointer<IborIndexConventionDetailDialog> self = this;
+
+    struct SaveResult {
+        bool success;
+        std::string message;
+    };
+
+    auto task = [self, ic = ic_]() -> SaveResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed"};
+        }
+
+        refdata::messaging::save_ibor_index_convention_request request;
+        request.data = ic;
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server"};
+        }
+
+        return {response_result->success, response_result->message};
+    };
+
+    auto* watcher = new QFutureWatcher<SaveResult>(self);
+    connect(watcher, &QFutureWatcher<SaveResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "IBOR Index Convention saved successfully";
+            QString code = QString::fromStdString(
+                self->ic_.id);
+            self->hasChanges_ = false;
+            self->updateSaveButtonState();
+            emit self->icSaved(code);
+            self->notifySaveSuccess(tr("IBOR Index Convention '%1' saved").arg(code));
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Save failed: " << result.message;
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Save Failed", errorMsg);
+        }
+    });
+
+    QFuture<SaveResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+void IborIndexConventionDetailDialog::onDeleteClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete IBOR index convention while disconnected from server.");
+        return;
+    }
+
+    QString code = QString::fromStdString(
+        ic_.id);
+    auto reply = MessageBoxHelper::question(this, "Delete IBOR Index Convention",
+        QString("Are you sure you want to delete IBOR index convention '%1'?").arg(code),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Deleting IBOR index convention: "
+        << ic_.id;
+
+    QPointer<IborIndexConventionDetailDialog> self = this;
+
+    struct DeleteResult {
+        bool success;
+        std::string message;
+    };
+
+    auto task = [self, code = ic_.id]() -> DeleteResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed"};
+        }
+
+        refdata::messaging::delete_ibor_index_convention_request request;
+        request.codes = {code};
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server"};
+        }
+
+        return {response_result->success, response_result->message};
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, code, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "IBOR Index Convention deleted successfully";
+            emit self->statusMessage(
+                QString("IBOR Index Convention '%1' deleted").arg(code));
+            emit self->icDeleted(code);
+            self->requestClose();
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Delete failed: " << result.message;
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Delete Failed", errorMsg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt.refdata/src/IborIndexConventionHistoryDialog.cpp
+++ b/projects/ores.qt.refdata/src/IborIndexConventionHistoryDialog.cpp
@@ -1,0 +1,337 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/IborIndexConventionHistoryDialog.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_IborIndexConventionHistoryDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.refdata.api/messaging/ibor_index_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+IborIndexConventionHistoryDialog::IborIndexConventionHistoryDialog(
+    const QString& code,
+    ClientManager* clientManager,
+    QWidget* parent)
+    : QWidget(parent),
+      ui_(new Ui::IborIndexConventionHistoryDialog),
+      code_(code),
+      clientManager_(clientManager),
+      toolbar_(nullptr),
+      openVersionAction_(nullptr),
+      revertAction_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupToolbar();
+    setupConnections();
+}
+
+IborIndexConventionHistoryDialog::~IborIndexConventionHistoryDialog() {
+    delete ui_;
+}
+
+void IborIndexConventionHistoryDialog::setupUi() {
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+
+    ui_->titleLabel->setText(QString("History for: %1").arg(code_));
+
+    // Setup version list table
+    ui_->versionListWidget->setColumnCount(5);
+    ui_->versionListWidget->setHorizontalHeaderLabels(
+        {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
+    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
+    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    // Setup changes table
+    ui_->changesTableWidget->setColumnCount(3);
+    ui_->changesTableWidget->setHorizontalHeaderLabels(
+        {"Field", "Old Value", "New Value"});
+    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+}
+
+void IborIndexConventionHistoryDialog::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    openVersionAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor),
+        tr("Open"));
+    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
+    openVersionAction_->setEnabled(false);
+
+    revertAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor),
+        tr("Revert"));
+    revertAction_->setToolTip(tr("Revert to this version"));
+    revertAction_->setEnabled(false);
+
+    // Insert toolbar at the top of the layout
+    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
+    if (layout) {
+        layout->insertWidget(0, toolbar_);
+    }
+}
+
+void IborIndexConventionHistoryDialog::setupConnections() {
+    connect(ui_->versionListWidget, &QTableWidget::itemSelectionChanged,
+            this, &IborIndexConventionHistoryDialog::onVersionSelected);
+    connect(openVersionAction_, &QAction::triggered,
+            this, &IborIndexConventionHistoryDialog::onOpenVersionClicked);
+    connect(revertAction_, &QAction::triggered,
+            this, &IborIndexConventionHistoryDialog::onRevertClicked);
+    connect(ui_->closeButton, &QPushButton::clicked,
+            this, [this]() { if (window()) window()->close(); });
+}
+
+void IborIndexConventionHistoryDialog::loadHistory() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        emit errorOccurred("Not connected to server");
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for IBOR index convention: " << code_.toStdString();
+    emit statusChanged(tr("Loading history..."));
+
+    QPointer<IborIndexConventionHistoryDialog> self = this;
+
+    using HistoryResult = std::expected<refdata::messaging::get_ibor_index_convention_history_response, std::string>;
+
+    QFuture<HistoryResult> future =
+        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
+        if (!self || !self->clientManager_)
+            return std::unexpected("Dialog closed");
+        refdata::messaging::get_ibor_index_convention_history_request request;
+        request.id = code;
+        auto result = self->clientManager_->process_authenticated_request(std::move(request));
+        if (!result) return std::unexpected(result.error());
+        return std::move(*result);
+    });
+
+    auto* watcher = new QFutureWatcher<HistoryResult>(self);
+    connect(watcher, &QFutureWatcher<HistoryResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (!result) {
+            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
+            emit self->errorOccurred(QString::fromStdString(result.error()));
+            return;
+        }
+        if (!result->success) {
+            emit self->errorOccurred(QString::fromStdString(result->message));
+            return;
+        }
+        self->versions_ = std::move(result->ibor_index_conventions);
+        self->updateVersionList();
+        emit self->statusChanged(
+            QString("Loaded %1 versions").arg(self->versions_.size()));
+    });
+    watcher->setFuture(future);
+}
+
+void IborIndexConventionHistoryDialog::updateVersionList() {
+    ui_->versionListWidget->setRowCount(0);
+
+    for (const auto& version : versions_) {
+        int row = ui_->versionListWidget->rowCount();
+        ui_->versionListWidget->insertRow(row);
+
+        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
+        versionItem->setTextAlignment(Qt::AlignCenter);
+        ui_->versionListWidget->setItem(row, 0, versionItem);
+
+        auto* recordedAtItem = new QTableWidgetItem(
+            relative_time_helper::format(version.recorded_at));
+        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
+
+        auto* modifiedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.modified_by));
+        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
+
+        auto* performedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.performed_by));
+        ui_->versionListWidget->setItem(row, 3, performedByItem);
+
+        auto* commentaryItem = new QTableWidgetItem(
+            QString::fromStdString(version.change_commentary));
+        ui_->versionListWidget->setItem(row, 4, commentaryItem);
+    }
+
+    // Select the first (most recent) version
+    if (!versions_.empty()) {
+        ui_->versionListWidget->selectRow(0);
+    }
+}
+
+void IborIndexConventionHistoryDialog::onVersionSelected() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) {
+        updateActionStates();
+        return;
+    }
+
+    int row = selected.first()->row();
+    updateChangesTable(row);
+    updateFullDetails(row);
+    updateActionStates();
+}
+
+void IborIndexConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
+    ui_->changesTableWidget->setRowCount(0);
+
+    if (currentVersionIndex < 0 ||
+        static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
+        return;
+    }
+
+    // Get the next older version to compare against
+    int previousVersionIndex = currentVersionIndex + 1;
+    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
+        // This is the first version, no changes to show
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(Initial version)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+        return;
+    }
+
+    const auto& current = versions_[currentVersionIndex];
+    const auto& previous = versions_[previousVersionIndex];
+
+    auto addChange = [this](const QString& field,
+                            const QString& oldVal, const QString& newVal) {
+        int row = ui_->changesTableWidget->rowCount();
+        ui_->changesTableWidget->insertRow(row);
+        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
+        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
+        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
+    };
+
+    if (current.id != previous.id) {
+        addChange("Id",
+                  QString::fromStdString(previous.id),
+                  QString::fromStdString(current.id));
+    }
+
+    if (current.fixing_calendar != previous.fixing_calendar) {
+        addChange("Fixing Calendar",
+                  QString::fromStdString(previous.fixing_calendar),
+                  QString::fromStdString(current.fixing_calendar));
+    }
+
+    if (current.day_count_fraction != previous.day_count_fraction) {
+        addChange("Day Count Fraction",
+                  QString::fromStdString(previous.day_count_fraction),
+                  QString::fromStdString(current.day_count_fraction));
+    }
+
+    if (current.settlement_days != previous.settlement_days) {
+        addChange("Settlement Days",
+                  QString::number(previous.settlement_days),
+                  QString::number(current.settlement_days));
+    }
+
+    if (current.business_day_convention != previous.business_day_convention) {
+        addChange("Business Day Convention",
+                  QString::fromStdString(previous.business_day_convention),
+                  QString::fromStdString(current.business_day_convention));
+    }
+
+    if (current.end_of_month != previous.end_of_month) {
+        addChange("End Of Month",
+                  previous.end_of_month ? tr("true") : tr("false"),
+                  current.end_of_month ? tr("true") : tr("false"));
+    }
+
+
+    if (ui_->changesTableWidget->rowCount() == 0) {
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(No field changes)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+    }
+}
+
+void IborIndexConventionHistoryDialog::updateFullDetails(int versionIndex) {
+    if (versionIndex < 0 ||
+        static_cast<size_t>(versionIndex) >= versions_.size()) {
+        return;
+    }
+
+    const auto& version = versions_[versionIndex];
+
+    ui_->idValue->setText(QString::fromStdString(version.id));
+    ui_->fixingCalendarValue->setText(QString::fromStdString(version.fixing_calendar));
+    ui_->dayCountFractionValue->setText(QString::fromStdString(version.day_count_fraction));
+    ui_->settlementDaysValue->setText(QString::number(version.settlement_days));
+    ui_->businessDayConventionValue->setText(QString::fromStdString(version.business_day_convention));
+    ui_->endOfMonthValue->setText(version.end_of_month ? tr("true") : tr("false"));
+    ui_->versionNumberValue->setText(QString::number(version.version));
+    ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
+}
+
+void IborIndexConventionHistoryDialog::updateActionStates() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    bool hasSelection = !selected.isEmpty();
+    bool isNotLatest = hasSelection && selected.first()->row() > 0;
+
+    openVersionAction_->setEnabled(hasSelection);
+    revertAction_->setEnabled(isNotLatest);
+}
+
+void IborIndexConventionHistoryDialog::onOpenVersionClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit openVersionRequested(versions_[row], versions_[row].version);
+}
+
+void IborIndexConventionHistoryDialog::onRevertClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit revertVersionRequested(versions_[row]);
+}
+
+}

--- a/projects/ores.qt.refdata/src/IborIndexConventionMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/IborIndexConventionMdiWindow.cpp
@@ -1,0 +1,386 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/IborIndexConventionMdiWindow.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.refdata.api/messaging/ibor_index_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+IborIndexConventionMdiWindow::IborIndexConventionMdiWindow(
+    ClientManager* clientManager,
+    const QString& username,
+    QWidget* parent)
+    : EntityListMdiWindow(parent),
+      clientManager_(clientManager),
+      username_(username),
+      toolbar_(nullptr),
+      tableView_(nullptr),
+      model_(nullptr),
+      proxyModel_(nullptr),
+      paginationWidget_(nullptr),
+      reloadAction_(nullptr),
+      addAction_(nullptr),
+      editAction_(nullptr),
+      deleteAction_(nullptr),
+      historyAction_(nullptr) {
+
+    setupUi();
+    setupConnections();
+    reload();
+}
+
+void IborIndexConventionMdiWindow::setupUi() {
+    auto* layout = new QVBoxLayout(this);
+
+    setupToolbar();
+    layout->addWidget(toolbar_);
+    layout->addWidget(loadingBar());
+
+    setupTable();
+    layout->addWidget(tableView_);
+
+    paginationWidget_ = new PaginationWidget(this);
+    layout->addWidget(paginationWidget_);
+}
+
+void IborIndexConventionMdiWindow::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    reloadAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowClockwise, IconUtils::DefaultIconColor),
+        tr("Reload"));
+    connect(reloadAction_, &QAction::triggered, this,
+            &EntityListMdiWindow::reload);
+
+    initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
+
+    toolbar_->addSeparator();
+
+    addAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Add, IconUtils::DefaultIconColor),
+        tr("Add"));
+    addAction_->setToolTip(tr("Add new IBOR index convention"));
+    connect(addAction_, &QAction::triggered, this,
+            &IborIndexConventionMdiWindow::addNew);
+
+    editAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Edit, IconUtils::DefaultIconColor),
+        tr("Edit"));
+    editAction_->setToolTip(tr("Edit selected IBOR index convention"));
+    editAction_->setEnabled(false);
+    connect(editAction_, &QAction::triggered, this,
+            &IborIndexConventionMdiWindow::editSelected);
+
+    deleteAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Delete, IconUtils::DefaultIconColor),
+        tr("Delete"));
+    deleteAction_->setToolTip(tr("Delete selected IBOR index convention"));
+    deleteAction_->setEnabled(false);
+    connect(deleteAction_, &QAction::triggered, this,
+            &IborIndexConventionMdiWindow::deleteSelected);
+
+    historyAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::History, IconUtils::DefaultIconColor),
+        tr("History"));
+    historyAction_->setToolTip(tr("View IBOR index convention history"));
+    historyAction_->setEnabled(false);
+    connect(historyAction_, &QAction::triggered, this,
+            &IborIndexConventionMdiWindow::viewHistorySelected);
+}
+
+void IborIndexConventionMdiWindow::setupTable() {
+    model_ = new ClientIborIndexConventionModel(clientManager_, this);
+    proxyModel_ = new QSortFilterProxyModel(this);
+    proxyModel_->setSourceModel(model_);
+    proxyModel_->setSortCaseSensitivity(Qt::CaseInsensitive);
+
+    tableView_ = new QTableView(this);
+    tableView_->setModel(proxyModel_);
+    tableView_->setSelectionBehavior(QAbstractItemView::SelectRows);
+    tableView_->setSelectionMode(QAbstractItemView::SingleSelection);
+    tableView_->setSortingEnabled(true);
+    tableView_->setAlternatingRowColors(true);
+    tableView_->verticalHeader()->setVisible(false);
+
+    initializeTableSettings(tableView_, model_,
+        "IborIndexConventionListWindow",
+        {},
+        {900, 400}, 1);
+}
+
+void IborIndexConventionMdiWindow::setupConnections() {
+    connect(model_, &ClientIborIndexConventionModel::dataLoaded,
+            this, &IborIndexConventionMdiWindow::onDataLoaded);
+    connect(model_, &ClientIborIndexConventionModel::loadError,
+            this, &IborIndexConventionMdiWindow::onLoadError);
+
+    connect(tableView_->selectionModel(), &QItemSelectionModel::selectionChanged,
+            this, &IborIndexConventionMdiWindow::onSelectionChanged);
+    connect(tableView_, &QTableView::doubleClicked,
+            this, &IborIndexConventionMdiWindow::onDoubleClicked);
+
+    connect(paginationWidget_, &PaginationWidget::page_size_changed,
+            this, [this](std::uint32_t size) {
+        model_->set_page_size(size);
+        model_->refresh();
+    });
+
+    connect(paginationWidget_, &PaginationWidget::load_all_requested,
+            this, [this]() {
+        const auto total = model_->total_available_count();
+        if (total > 0 && total <= 1000) {
+            model_->set_page_size(total);
+            model_->refresh();
+        }
+    });
+
+    connect(paginationWidget_, &PaginationWidget::page_requested,
+            this, [this](std::uint32_t offset, std::uint32_t limit) {
+        model_->load_page(offset, limit);
+    });
+
+    connectModel(model_);
+}
+
+void IborIndexConventionMdiWindow::doReload() {
+    BOOST_LOG_SEV(lg(), debug) << "Reloading IBOR index conventions";
+    clearStaleIndicator();
+    emit statusChanged(tr("Loading IBOR index conventions..."));
+    model_->refresh();
+}
+
+void IborIndexConventionMdiWindow::onDataLoaded() {
+    const auto loaded = model_->rowCount();
+    const auto total = model_->total_available_count();
+    emit statusChanged(tr("Loaded %1 of %2 IBOR index conventions").arg(loaded).arg(total));
+
+    paginationWidget_->update_state(loaded, total);
+    paginationWidget_->set_load_all_enabled(
+        loaded < static_cast<int>(total) && total > 0 && total <= 1000);
+}
+
+void IborIndexConventionMdiWindow::onLoadError(const QString& error_message,
+                                          const QString& details) {
+    BOOST_LOG_SEV(lg(), error) << "Load error: " << error_message.toStdString();
+    emit errorOccurred(error_message);
+    MessageBoxHelper::critical(this, tr("Load Error"), error_message, details);
+}
+
+void IborIndexConventionMdiWindow::onSelectionChanged() {
+    updateActionStates();
+}
+
+void IborIndexConventionMdiWindow::onDoubleClicked(const QModelIndex& index) {
+    if (!index.isValid())
+        return;
+
+    auto sourceIndex = proxyModel_->mapToSource(index);
+    if (auto* ic = model_->getConvention(sourceIndex.row())) {
+        emit showConventionDetails(*ic);
+    }
+}
+
+void IborIndexConventionMdiWindow::updateActionStates() {
+    const bool hasSelection = tableView_->selectionModel()->hasSelection();
+    editAction_->setEnabled(hasSelection);
+    deleteAction_->setEnabled(hasSelection);
+    historyAction_->setEnabled(hasSelection);
+}
+
+void IborIndexConventionMdiWindow::addNew() {
+    BOOST_LOG_SEV(lg(), debug) << "Add new IBOR index convention requested";
+    emit addNewRequested();
+}
+
+void IborIndexConventionMdiWindow::editSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Edit requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* ic = model_->getConvention(sourceIndex.row())) {
+        emit showConventionDetails(*ic);
+    }
+}
+
+void IborIndexConventionMdiWindow::viewHistorySelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "View history requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* ic = model_->getConvention(sourceIndex.row())) {
+        BOOST_LOG_SEV(lg(), debug) << "Emitting showConventionHistory for code: "
+                                   << ic->id;
+        emit showConventionHistory(*ic);
+    }
+}
+
+void IborIndexConventionMdiWindow::deleteSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Delete requested but no row selected";
+        return;
+    }
+
+    if (!clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete IBOR index convention while disconnected.");
+        return;
+    }
+
+    std::vector<std::string> codes;
+    for (const auto& index : selected) {
+        auto sourceIndex = proxyModel_->mapToSource(index);
+        if (auto* ic = model_->getConvention(sourceIndex.row())) {
+            codes.push_back(ic->id);
+        }
+    }
+
+    if (codes.empty()) {
+        BOOST_LOG_SEV(lg(), warn) << "No valid IBOR index conventions to delete";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Delete requested for " << codes.size()
+                               << " IBOR index conventions";
+
+    QString confirmMessage;
+    if (codes.size() == 1) {
+        confirmMessage = QString("Are you sure you want to delete IBOR index convention '%1'?")
+            .arg(QString::fromStdString(codes.front()));
+    } else {
+        confirmMessage = QString("Are you sure you want to delete %1 IBOR index conventions?")
+            .arg(codes.size());
+    }
+
+    auto reply = MessageBoxHelper::question(this, "Delete IBOR Index Convention",
+        confirmMessage, QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        BOOST_LOG_SEV(lg(), debug) << "Delete cancelled by user";
+        return;
+    }
+
+    QPointer<IborIndexConventionMdiWindow> self = this;
+    using DeleteResult = std::vector<std::pair<std::string, std::pair<bool, std::string>>>;
+
+    auto task = [self, codes]() -> DeleteResult {
+        DeleteResult results;
+        if (!self) return {};
+
+        BOOST_LOG_SEV(lg(), debug) << "Making batch delete request for "
+                                   << codes.size() << " IBOR index conventions";
+
+        refdata::messaging::delete_ibor_index_convention_request request;
+        request.codes = codes;
+        auto response_result = self->clientManager_->process_authenticated_request(
+            std::move(request));
+
+        if (!response_result) {
+            BOOST_LOG_SEV(lg(), error) << "Failed to send batch delete request";
+            for (const auto& code : codes) {
+                results.push_back({code, {false, "Failed to communicate with server"}});
+            }
+            return results;
+        }
+
+        for (const auto& code : codes) {
+            results.push_back({code, {response_result->success, response_result->message}});
+        }
+
+        return results;
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, watcher]() {
+        auto results = watcher->result();
+        watcher->deleteLater();
+
+        int success_count = 0;
+        int failure_count = 0;
+        QString first_error;
+
+        for (const auto& [code, result] : results) {
+            if (result.first) {
+                BOOST_LOG_SEV(lg(), debug) << "IBOR Index Convention deleted: " << code;
+                success_count++;
+                emit self->icDeleted(QString::fromStdString(code));
+            } else {
+                BOOST_LOG_SEV(lg(), error) << "IBOR Index Convention deletion failed: "
+                                           << code << " - " << result.second;
+                failure_count++;
+                if (first_error.isEmpty()) {
+                    first_error = QString::fromStdString(result.second);
+                }
+            }
+        }
+
+        self->model_->refresh();
+
+        if (failure_count == 0) {
+            QString msg = success_count == 1
+                ? "Successfully deleted 1 IBOR index convention"
+                : QString("Successfully deleted %1 IBOR index conventions").arg(success_count);
+            emit self->statusChanged(msg);
+        } else if (success_count == 0) {
+            QString msg = QString("Failed to delete %1 %2: %3")
+                .arg(failure_count)
+                .arg(failure_count == 1 ? "IBOR index convention" : "IBOR index conventions")
+                .arg(first_error);
+            emit self->errorOccurred(msg);
+            MessageBoxHelper::critical(self, "Delete Failed", msg);
+        } else {
+            QString msg = QString("Deleted %1, failed to delete %2")
+                .arg(success_count)
+                .arg(failure_count);
+            emit self->statusChanged(msg);
+            MessageBoxHelper::warning(self, "Partial Success", msg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt.refdata/src/OisConventionController.cpp
+++ b/projects/ores.qt.refdata/src/OisConventionController.cpp
@@ -1,0 +1,385 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/OisConventionController.hpp"
+
+#include <QMdiSubWindow>
+#include <QMessageBox>
+#include <QPointer>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/OisConventionMdiWindow.hpp"
+#include "ores.qt/OisConventionDetailDialog.hpp"
+#include "ores.qt/OisConventionHistoryDialog.hpp"
+#include "ores.qt/DetachableMdiSubWindow.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+OisConventionController::OisConventionController(
+    QMainWindow* mainWindow,
+    QMdiArea* mdiArea,
+    ClientManager* clientManager,
+    const QString& username,
+    QObject* parent)
+    : EntityController(mainWindow, mdiArea, clientManager, username,
+          std::string_view{}, parent),
+      listWindow_(nullptr),
+      listMdiSubWindow_(nullptr) {
+
+    BOOST_LOG_SEV(lg(), debug) << "OisConventionController created";
+}
+
+void OisConventionController::showListWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "showListWindow called";
+
+    const QString key = build_window_key("list", "ois_conventions");
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing list window";
+        return;
+    }
+
+    // Create new window
+    listWindow_ = new OisConventionMdiWindow(clientManager_, username_);
+
+    // Connect signals
+    connect(listWindow_, &OisConventionMdiWindow::statusChanged,
+            this, &OisConventionController::statusMessage);
+    connect(listWindow_, &OisConventionMdiWindow::errorOccurred,
+            this, &OisConventionController::errorMessage);
+    connect(listWindow_, &OisConventionMdiWindow::showConventionDetails,
+            this, &OisConventionController::onShowDetails);
+    connect(listWindow_, &OisConventionMdiWindow::addNewRequested,
+            this, &OisConventionController::onAddNewRequested);
+    connect(listWindow_, &OisConventionMdiWindow::showConventionHistory,
+            this, &OisConventionController::onShowHistory);
+
+    // Create MDI subwindow
+    listMdiSubWindow_ = new DetachableMdiSubWindow(mainWindow_);
+    listMdiSubWindow_->setWidget(listWindow_);
+    listMdiSubWindow_->setWindowTitle("OIS Conventions");
+    listMdiSubWindow_->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+    listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
+    listMdiSubWindow_->resize(listWindow_->sizeHint());
+
+    mdiArea_->addSubWindow(listMdiSubWindow_);
+    listMdiSubWindow_->show();
+
+    // Track window
+    track_window(key, listMdiSubWindow_);
+    register_detachable_window(listMdiSubWindow_);
+
+    // Cleanup when closed
+    connect(listMdiSubWindow_, &QObject::destroyed, this, [self = QPointer<OisConventionController>(this), key]() {
+        if (!self) return;
+        self->untrack_window(key);
+        self->listWindow_ = nullptr;
+        self->listMdiSubWindow_ = nullptr;
+    });
+
+    BOOST_LOG_SEV(lg(), debug) << "OIS Convention list window created";
+}
+
+void OisConventionController::closeAllWindows() {
+    BOOST_LOG_SEV(lg(), debug) << "closeAllWindows called";
+
+    // Close all managed windows
+    QList<QString> keys = managed_windows_.keys();
+    for (const QString& key : keys) {
+        if (auto* window = managed_windows_.value(key)) {
+            window->close();
+        }
+    }
+    managed_windows_.clear();
+
+    listWindow_ = nullptr;
+    listMdiSubWindow_ = nullptr;
+}
+
+void OisConventionController::reloadListWindow() {
+    if (listWindow_) {
+        listWindow_->reload();
+    }
+}
+
+void OisConventionController::onShowDetails(
+    const refdata::domain::ois_convention& oc) {
+    BOOST_LOG_SEV(lg(), debug) << "Show details for: " << oc.id;
+    showDetailWindow(oc);
+}
+
+void OisConventionController::onAddNewRequested() {
+    BOOST_LOG_SEV(lg(), info) << "Add new OIS convention requested";
+    showAddWindow();
+}
+
+void OisConventionController::onShowHistory(
+    const refdata::domain::ois_convention& oc) {
+    BOOST_LOG_SEV(lg(), debug) << "Show history requested for: " << oc.id;
+    showHistoryWindow(QString::fromStdString(oc.id));
+}
+
+void OisConventionController::showAddWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "Creating add window for new OIS convention";
+
+    auto* detailDialog = new OisConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(true);
+
+    connect(detailDialog, &OisConventionDetailDialog::statusMessage,
+            this, &OisConventionController::statusMessage);
+    connect(detailDialog, &OisConventionDetailDialog::errorMessage,
+            this, &OisConventionController::errorMessage);
+    connect(detailDialog, &OisConventionDetailDialog::ocSaved,
+            this, [self = QPointer<OisConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "OIS Convention saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle("New OIS Convention");
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void OisConventionController::showDetailWindow(
+    const refdata::domain::ois_convention& oc) {
+
+    const QString identifier = QString::fromStdString(oc.id);
+    const QString key = build_window_key("details", identifier);
+
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing detail window";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Creating detail window for: " << oc.id;
+
+    auto* detailDialog = new OisConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(false);
+    detailDialog->setConvention(oc);
+
+    connect(detailDialog, &OisConventionDetailDialog::statusMessage,
+            this, &OisConventionController::statusMessage);
+    connect(detailDialog, &OisConventionDetailDialog::errorMessage,
+            this, &OisConventionController::errorMessage);
+    connect(detailDialog, &OisConventionDetailDialog::ocSaved,
+            this, [self = QPointer<OisConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "OIS Convention saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+    connect(detailDialog, &OisConventionDetailDialog::ocDeleted,
+            this, [self = QPointer<OisConventionController>(this), key](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "OIS Convention deleted: " << code.toStdString();
+        self->handleEntityDeleted();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("OIS Convention: %1").arg(identifier));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+
+    // Track window
+    track_window(key, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<OisConventionController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, key]() {
+        if (self) {
+            self->untrack_window(key);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void OisConventionController::showHistoryWindow(const QString& code) {
+    BOOST_LOG_SEV(lg(), info) << "Opening history window for OIS convention: "
+                              << code.toStdString();
+
+    const QString windowKey = build_window_key("history", code);
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing history window for: "
+                                  << code.toStdString();
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Creating new history window for: "
+                              << code.toStdString();
+
+    auto* historyDialog = new OisConventionHistoryDialog(code, clientManager_, mainWindow_);
+
+    connect(historyDialog, &OisConventionHistoryDialog::statusChanged,
+            this, [self = QPointer<OisConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(historyDialog, &OisConventionHistoryDialog::errorOccurred,
+            this, [self = QPointer<OisConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+    connect(historyDialog, &OisConventionHistoryDialog::revertVersionRequested,
+            this, &OisConventionController::onRevertVersion);
+    connect(historyDialog, &OisConventionHistoryDialog::openVersionRequested,
+            this, &OisConventionController::onOpenVersion);
+
+    // Load history data
+    historyDialog->loadHistory();
+
+    auto* historyWindow = new DetachableMdiSubWindow(mainWindow_);
+    historyWindow->setAttribute(Qt::WA_DeleteOnClose);
+    historyWindow->setWidget(historyDialog);
+    historyWindow->setWindowTitle(QString("OIS Convention History: %1").arg(code));
+    historyWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    // Track this history window
+    track_window(windowKey, historyWindow);
+    register_detachable_window(historyWindow);
+
+    QPointer<OisConventionController> self = this;
+    connect(historyWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    show_managed_window(historyWindow, listMdiSubWindow_);
+}
+
+void OisConventionController::onOpenVersion(
+    const refdata::domain::ois_convention& oc, int versionNumber) {
+    BOOST_LOG_SEV(lg(), info) << "Opening historical version " << versionNumber
+                              << " for OIS convention: " << oc.id;
+
+    const QString code = QString::fromStdString(oc.id);
+    const QString windowKey = build_window_key("version", QString("%1_v%2")
+        .arg(code).arg(versionNumber));
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing version window";
+        return;
+    }
+
+    auto* detailDialog = new OisConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setConvention(oc);
+    detailDialog->setReadOnly(true);
+
+    connect(detailDialog, &OisConventionDetailDialog::statusMessage,
+            this, [self = QPointer<OisConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(detailDialog, &OisConventionDetailDialog::errorMessage,
+            this, [self = QPointer<OisConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("OIS Convention: %1 (Version %2)")
+        .arg(code).arg(versionNumber));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    track_window(windowKey, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<OisConventionController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_, QPoint(60, 60));
+}
+
+void OisConventionController::onRevertVersion(
+    const refdata::domain::ois_convention& oc) {
+    BOOST_LOG_SEV(lg(), info) << "Reverting OIS convention to version: "
+                              << oc.version;
+
+    // Open detail dialog with the old version data for editing
+    auto* detailDialog = new OisConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setConvention(oc);
+    detailDialog->setCreateMode(false);
+
+    connect(detailDialog, &OisConventionDetailDialog::statusMessage,
+            this, &OisConventionController::statusMessage);
+    connect(detailDialog, &OisConventionDetailDialog::errorMessage,
+            this, &OisConventionController::errorMessage);
+    connect(detailDialog, &OisConventionDetailDialog::ocSaved,
+            this, [self = QPointer<OisConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "OIS Convention reverted: " << code.toStdString();
+        emit self->statusMessage(QString("OIS Convention '%1' reverted successfully").arg(code));
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Revert OIS Convention: %1")
+        .arg(QString::fromStdString(oc.id)));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+EntityListMdiWindow* OisConventionController::listWindow() const {
+    return listWindow_;
+}
+
+}

--- a/projects/ores.qt.refdata/src/OisConventionDetailDialog.cpp
+++ b/projects/ores.qt.refdata/src/OisConventionDetailDialog.cpp
@@ -1,0 +1,402 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/OisConventionDetailDialog.hpp"
+
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_OisConventionDetailDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.refdata.api/messaging/ois_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+OisConventionDetailDialog::OisConventionDetailDialog(QWidget* parent)
+    : DetailDialogBase(parent),
+      ui_(new Ui::OisConventionDetailDialog),
+      clientManager_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupConnections();
+}
+
+OisConventionDetailDialog::~OisConventionDetailDialog() {
+    delete ui_;
+}
+
+QTabWidget* OisConventionDetailDialog::tabWidget() const {
+    return ui_->tabWidget;
+}
+
+QWidget* OisConventionDetailDialog::provenanceTab() const {
+    return ui_->provenanceTab;
+}
+
+ProvenanceWidget* OisConventionDetailDialog::provenanceWidget() const {
+    return ui_->provenanceWidget;
+}
+
+void OisConventionDetailDialog::setupUi() {
+    ui_->saveButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Save, IconUtils::DefaultIconColor));
+    ui_->saveButton->setEnabled(false);
+
+    ui_->deleteButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Delete, IconUtils::DefaultIconColor));
+
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+}
+
+void OisConventionDetailDialog::setupConnections() {
+    connect(ui_->saveButton, &QPushButton::clicked, this,
+            &OisConventionDetailDialog::onSaveClicked);
+    connect(ui_->deleteButton, &QPushButton::clicked, this,
+            &OisConventionDetailDialog::onDeleteClicked);
+    connect(ui_->closeButton, &QPushButton::clicked, this,
+            &OisConventionDetailDialog::onCloseClicked);
+
+    connect(ui_->idEdit, &QLineEdit::textChanged, this,
+            &OisConventionDetailDialog::onCodeChanged);
+    connect(ui_->indexEdit, &QLineEdit::textChanged, this,
+            &OisConventionDetailDialog::onFieldChanged);
+    connect(ui_->fixedDayCountFractionEdit, &QLineEdit::textChanged, this,
+            &OisConventionDetailDialog::onFieldChanged);
+    connect(ui_->fixedCalendarEdit, &QLineEdit::textChanged, this,
+            &OisConventionDetailDialog::onFieldChanged);
+    connect(ui_->fixedFrequencyEdit, &QLineEdit::textChanged, this,
+            &OisConventionDetailDialog::onFieldChanged);
+    connect(ui_->fixedConventionEdit, &QLineEdit::textChanged, this,
+            &OisConventionDetailDialog::onFieldChanged);
+    connect(ui_->fixedPaymentConventionEdit, &QLineEdit::textChanged, this,
+            &OisConventionDetailDialog::onFieldChanged);
+    connect(ui_->ruleEdit, &QLineEdit::textChanged, this,
+            &OisConventionDetailDialog::onFieldChanged);
+    connect(ui_->paymentCalendarEdit, &QLineEdit::textChanged, this,
+            &OisConventionDetailDialog::onFieldChanged);
+}
+
+void OisConventionDetailDialog::setClientManager(ClientManager* clientManager) {
+    clientManager_ = clientManager;
+}
+
+void OisConventionDetailDialog::setUsername(const std::string& username) {
+    username_ = username;
+}
+
+void OisConventionDetailDialog::setConvention(
+    const refdata::domain::ois_convention& oc) {
+    oc_ = oc;
+    updateUiFromConvention();
+}
+
+void OisConventionDetailDialog::setCreateMode(bool createMode) {
+    createMode_ = createMode;
+    ui_->idEdit->setReadOnly(!createMode);
+    ui_->deleteButton->setVisible(!createMode);
+    setProvenanceEnabled(!createMode);
+    hasChanges_ = false;
+    updateSaveButtonState();
+}
+
+void OisConventionDetailDialog::setReadOnly(bool readOnly) {
+    readOnly_ = readOnly;
+    ui_->idEdit->setReadOnly(true);
+    ui_->indexEdit->setReadOnly(readOnly);
+    ui_->fixedDayCountFractionEdit->setReadOnly(readOnly);
+    ui_->fixedCalendarEdit->setReadOnly(readOnly);
+    ui_->fixedFrequencyEdit->setReadOnly(readOnly);
+    ui_->fixedConventionEdit->setReadOnly(readOnly);
+    ui_->fixedPaymentConventionEdit->setReadOnly(readOnly);
+    ui_->ruleEdit->setReadOnly(readOnly);
+    ui_->paymentCalendarEdit->setReadOnly(readOnly);
+    ui_->saveButton->setVisible(!readOnly);
+    ui_->deleteButton->setVisible(!readOnly);
+}
+
+void OisConventionDetailDialog::updateUiFromConvention() {
+    ui_->idEdit->setText(QString::fromStdString(oc_.id));
+    ui_->indexEdit->setText(QString::fromStdString(oc_.index));
+    ui_->spotLagEdit->setValue(oc_.spot_lag);
+    ui_->fixedDayCountFractionEdit->setText(QString::fromStdString(oc_.fixed_day_count_fraction));
+    ui_->fixedCalendarEdit->setText(oc_.fixed_calendar
+        ? QString::fromStdString(*oc_.fixed_calendar)
+        : QString{});
+    ui_->paymentLagEdit->setValue(oc_.payment_lag.value_or(
+        ui_->paymentLagEdit->minimum()));
+    ui_->fixedFrequencyEdit->setText(oc_.fixed_frequency
+        ? QString::fromStdString(*oc_.fixed_frequency)
+        : QString{});
+    ui_->fixedConventionEdit->setText(oc_.fixed_convention
+        ? QString::fromStdString(*oc_.fixed_convention)
+        : QString{});
+    ui_->fixedPaymentConventionEdit->setText(oc_.fixed_payment_convention
+        ? QString::fromStdString(*oc_.fixed_payment_convention)
+        : QString{});
+    ui_->ruleEdit->setText(oc_.rule
+        ? QString::fromStdString(*oc_.rule)
+        : QString{});
+    ui_->paymentCalendarEdit->setText(oc_.payment_calendar
+        ? QString::fromStdString(*oc_.payment_calendar)
+        : QString{});
+    ui_->rateCutoffEdit->setValue(oc_.rate_cutoff.value_or(
+        ui_->rateCutoffEdit->minimum()));
+    ui_->endOfMonthEdit->setCheckState(oc_.end_of_month
+        ? (*oc_.end_of_month ? Qt::Checked : Qt::Unchecked)
+        : Qt::PartiallyChecked);
+
+    populateProvenance(oc_.version,
+                       oc_.modified_by,
+                       oc_.performed_by,
+                       oc_.recorded_at,
+                       oc_.change_reason_code,
+                       oc_.change_commentary);
+
+    hasChanges_ = false;
+    updateSaveButtonState();
+}
+
+void OisConventionDetailDialog::updateConventionFromUi() {
+    if (createMode_) {
+        oc_.id = ui_->idEdit->text().trimmed().toStdString();
+    }
+    oc_.index = ui_->indexEdit->text().trimmed().toStdString();
+    oc_.spot_lag = ui_->spotLagEdit->value();
+    oc_.fixed_day_count_fraction = ui_->fixedDayCountFractionEdit->text().trimmed().toStdString();
+    {
+        const auto fixed_calendar_str = ui_->fixedCalendarEdit->text().trimmed().toStdString();
+        oc_.fixed_calendar =
+            fixed_calendar_str.empty() ? std::nullopt : std::optional<std::string>(fixed_calendar_str);
+    }
+    if (ui_->paymentLagEdit->value() == ui_->paymentLagEdit->minimum())
+        oc_.payment_lag = std::nullopt;
+    else
+        oc_.payment_lag = ui_->paymentLagEdit->value();
+    {
+        const auto fixed_frequency_str = ui_->fixedFrequencyEdit->text().trimmed().toStdString();
+        oc_.fixed_frequency =
+            fixed_frequency_str.empty() ? std::nullopt : std::optional<std::string>(fixed_frequency_str);
+    }
+    {
+        const auto fixed_convention_str = ui_->fixedConventionEdit->text().trimmed().toStdString();
+        oc_.fixed_convention =
+            fixed_convention_str.empty() ? std::nullopt : std::optional<std::string>(fixed_convention_str);
+    }
+    {
+        const auto fixed_payment_convention_str = ui_->fixedPaymentConventionEdit->text().trimmed().toStdString();
+        oc_.fixed_payment_convention =
+            fixed_payment_convention_str.empty() ? std::nullopt : std::optional<std::string>(fixed_payment_convention_str);
+    }
+    {
+        const auto rule_str = ui_->ruleEdit->text().trimmed().toStdString();
+        oc_.rule =
+            rule_str.empty() ? std::nullopt : std::optional<std::string>(rule_str);
+    }
+    {
+        const auto payment_calendar_str = ui_->paymentCalendarEdit->text().trimmed().toStdString();
+        oc_.payment_calendar =
+            payment_calendar_str.empty() ? std::nullopt : std::optional<std::string>(payment_calendar_str);
+    }
+    if (ui_->rateCutoffEdit->value() == ui_->rateCutoffEdit->minimum())
+        oc_.rate_cutoff = std::nullopt;
+    else
+        oc_.rate_cutoff = ui_->rateCutoffEdit->value();
+    switch (ui_->endOfMonthEdit->checkState()) {
+    case Qt::Checked:
+        oc_.end_of_month = std::optional<bool>(true);
+        break;
+    case Qt::Unchecked:
+        oc_.end_of_month = std::optional<bool>(false);
+        break;
+    default:
+        oc_.end_of_month = std::nullopt;
+        break;
+    }
+    oc_.modified_by = username_;
+}
+
+void OisConventionDetailDialog::onCodeChanged(const QString& /* text */) {
+    hasChanges_ = true;
+    updateSaveButtonState();
+}
+
+void OisConventionDetailDialog::onFieldChanged() {
+    hasChanges_ = true;
+    updateSaveButtonState();
+}
+
+void OisConventionDetailDialog::updateSaveButtonState() {
+    bool canSave = hasChanges_ && validateInput() && !readOnly_;
+    ui_->saveButton->setEnabled(canSave);
+}
+
+bool OisConventionDetailDialog::validateInput() {
+    const QString id_val = ui_->idEdit->text().trimmed();
+    const QString index_val = ui_->indexEdit->text().trimmed();
+    const QString fixed_day_count_fraction_val = ui_->fixedDayCountFractionEdit->text().trimmed();
+
+    return true
+        && !id_val.isEmpty()
+        && !index_val.isEmpty()
+        && !fixed_day_count_fraction_val.isEmpty()
+    ;
+}
+
+void OisConventionDetailDialog::onSaveClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot save OIS convention while disconnected from server.");
+        return;
+    }
+
+    if (!validateInput()) {
+        MessageBoxHelper::warning(this, "Invalid Input",
+            "Please fill in all required fields.");
+        return;
+    }
+
+    updateConventionFromUi();
+
+    BOOST_LOG_SEV(lg(), info) << "Saving OIS convention: "
+        << oc_.id;
+
+    QPointer<OisConventionDetailDialog> self = this;
+
+    struct SaveResult {
+        bool success;
+        std::string message;
+    };
+
+    auto task = [self, oc = oc_]() -> SaveResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed"};
+        }
+
+        refdata::messaging::save_ois_convention_request request;
+        request.data = oc;
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server"};
+        }
+
+        return {response_result->success, response_result->message};
+    };
+
+    auto* watcher = new QFutureWatcher<SaveResult>(self);
+    connect(watcher, &QFutureWatcher<SaveResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "OIS Convention saved successfully";
+            QString code = QString::fromStdString(
+                self->oc_.id);
+            self->hasChanges_ = false;
+            self->updateSaveButtonState();
+            emit self->ocSaved(code);
+            self->notifySaveSuccess(tr("OIS Convention '%1' saved").arg(code));
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Save failed: " << result.message;
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Save Failed", errorMsg);
+        }
+    });
+
+    QFuture<SaveResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+void OisConventionDetailDialog::onDeleteClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete OIS convention while disconnected from server.");
+        return;
+    }
+
+    QString code = QString::fromStdString(
+        oc_.id);
+    auto reply = MessageBoxHelper::question(this, "Delete OIS Convention",
+        QString("Are you sure you want to delete OIS convention '%1'?").arg(code),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Deleting OIS convention: "
+        << oc_.id;
+
+    QPointer<OisConventionDetailDialog> self = this;
+
+    struct DeleteResult {
+        bool success;
+        std::string message;
+    };
+
+    auto task = [self, code = oc_.id]() -> DeleteResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed"};
+        }
+
+        refdata::messaging::delete_ois_convention_request request;
+        request.codes = {code};
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server"};
+        }
+
+        return {response_result->success, response_result->message};
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, code, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "OIS Convention deleted successfully";
+            emit self->statusMessage(
+                QString("OIS Convention '%1' deleted").arg(code));
+            emit self->ocDeleted(code);
+            self->requestClose();
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Delete failed: " << result.message;
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Delete Failed", errorMsg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt.refdata/src/OisConventionHistoryDialog.cpp
+++ b/projects/ores.qt.refdata/src/OisConventionHistoryDialog.cpp
@@ -1,0 +1,404 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/OisConventionHistoryDialog.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_OisConventionHistoryDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.refdata.api/messaging/ois_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+OisConventionHistoryDialog::OisConventionHistoryDialog(
+    const QString& code,
+    ClientManager* clientManager,
+    QWidget* parent)
+    : QWidget(parent),
+      ui_(new Ui::OisConventionHistoryDialog),
+      code_(code),
+      clientManager_(clientManager),
+      toolbar_(nullptr),
+      openVersionAction_(nullptr),
+      revertAction_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupToolbar();
+    setupConnections();
+}
+
+OisConventionHistoryDialog::~OisConventionHistoryDialog() {
+    delete ui_;
+}
+
+void OisConventionHistoryDialog::setupUi() {
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+
+    ui_->titleLabel->setText(QString("History for: %1").arg(code_));
+
+    // Setup version list table
+    ui_->versionListWidget->setColumnCount(5);
+    ui_->versionListWidget->setHorizontalHeaderLabels(
+        {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
+    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
+    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    // Setup changes table
+    ui_->changesTableWidget->setColumnCount(3);
+    ui_->changesTableWidget->setHorizontalHeaderLabels(
+        {"Field", "Old Value", "New Value"});
+    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+}
+
+void OisConventionHistoryDialog::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    openVersionAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor),
+        tr("Open"));
+    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
+    openVersionAction_->setEnabled(false);
+
+    revertAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor),
+        tr("Revert"));
+    revertAction_->setToolTip(tr("Revert to this version"));
+    revertAction_->setEnabled(false);
+
+    // Insert toolbar at the top of the layout
+    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
+    if (layout) {
+        layout->insertWidget(0, toolbar_);
+    }
+}
+
+void OisConventionHistoryDialog::setupConnections() {
+    connect(ui_->versionListWidget, &QTableWidget::itemSelectionChanged,
+            this, &OisConventionHistoryDialog::onVersionSelected);
+    connect(openVersionAction_, &QAction::triggered,
+            this, &OisConventionHistoryDialog::onOpenVersionClicked);
+    connect(revertAction_, &QAction::triggered,
+            this, &OisConventionHistoryDialog::onRevertClicked);
+    connect(ui_->closeButton, &QPushButton::clicked,
+            this, [this]() { if (window()) window()->close(); });
+}
+
+void OisConventionHistoryDialog::loadHistory() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        emit errorOccurred("Not connected to server");
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for OIS convention: " << code_.toStdString();
+    emit statusChanged(tr("Loading history..."));
+
+    QPointer<OisConventionHistoryDialog> self = this;
+
+    using HistoryResult = std::expected<refdata::messaging::get_ois_convention_history_response, std::string>;
+
+    QFuture<HistoryResult> future =
+        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
+        if (!self || !self->clientManager_)
+            return std::unexpected("Dialog closed");
+        refdata::messaging::get_ois_convention_history_request request;
+        request.id = code;
+        auto result = self->clientManager_->process_authenticated_request(std::move(request));
+        if (!result) return std::unexpected(result.error());
+        return std::move(*result);
+    });
+
+    auto* watcher = new QFutureWatcher<HistoryResult>(self);
+    connect(watcher, &QFutureWatcher<HistoryResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (!result) {
+            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
+            emit self->errorOccurred(QString::fromStdString(result.error()));
+            return;
+        }
+        if (!result->success) {
+            emit self->errorOccurred(QString::fromStdString(result->message));
+            return;
+        }
+        self->versions_ = std::move(result->ois_conventions);
+        self->updateVersionList();
+        emit self->statusChanged(
+            QString("Loaded %1 versions").arg(self->versions_.size()));
+    });
+    watcher->setFuture(future);
+}
+
+void OisConventionHistoryDialog::updateVersionList() {
+    ui_->versionListWidget->setRowCount(0);
+
+    for (const auto& version : versions_) {
+        int row = ui_->versionListWidget->rowCount();
+        ui_->versionListWidget->insertRow(row);
+
+        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
+        versionItem->setTextAlignment(Qt::AlignCenter);
+        ui_->versionListWidget->setItem(row, 0, versionItem);
+
+        auto* recordedAtItem = new QTableWidgetItem(
+            relative_time_helper::format(version.recorded_at));
+        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
+
+        auto* modifiedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.modified_by));
+        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
+
+        auto* performedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.performed_by));
+        ui_->versionListWidget->setItem(row, 3, performedByItem);
+
+        auto* commentaryItem = new QTableWidgetItem(
+            QString::fromStdString(version.change_commentary));
+        ui_->versionListWidget->setItem(row, 4, commentaryItem);
+    }
+
+    // Select the first (most recent) version
+    if (!versions_.empty()) {
+        ui_->versionListWidget->selectRow(0);
+    }
+}
+
+void OisConventionHistoryDialog::onVersionSelected() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) {
+        updateActionStates();
+        return;
+    }
+
+    int row = selected.first()->row();
+    updateChangesTable(row);
+    updateFullDetails(row);
+    updateActionStates();
+}
+
+void OisConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
+    ui_->changesTableWidget->setRowCount(0);
+
+    if (currentVersionIndex < 0 ||
+        static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
+        return;
+    }
+
+    // Get the next older version to compare against
+    int previousVersionIndex = currentVersionIndex + 1;
+    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
+        // This is the first version, no changes to show
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(Initial version)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+        return;
+    }
+
+    const auto& current = versions_[currentVersionIndex];
+    const auto& previous = versions_[previousVersionIndex];
+
+    auto addChange = [this](const QString& field,
+                            const QString& oldVal, const QString& newVal) {
+        int row = ui_->changesTableWidget->rowCount();
+        ui_->changesTableWidget->insertRow(row);
+        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
+        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
+        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
+    };
+
+    if (current.id != previous.id) {
+        addChange("Id",
+                  QString::fromStdString(previous.id),
+                  QString::fromStdString(current.id));
+    }
+
+    if (current.index != previous.index) {
+        addChange("Index",
+                  QString::fromStdString(previous.index),
+                  QString::fromStdString(current.index));
+    }
+
+    if (current.spot_lag != previous.spot_lag) {
+        addChange("Spot Lag",
+                  QString::number(previous.spot_lag),
+                  QString::number(current.spot_lag));
+    }
+
+    if (current.fixed_day_count_fraction != previous.fixed_day_count_fraction) {
+        addChange("Fixed Day Count Fraction",
+                  QString::fromStdString(previous.fixed_day_count_fraction),
+                  QString::fromStdString(current.fixed_day_count_fraction));
+    }
+
+    if (current.fixed_calendar != previous.fixed_calendar) {
+        addChange("Fixed Calendar",
+                  previous.fixed_calendar ? QString::fromStdString(*previous.fixed_calendar) : QString{},
+                  current.fixed_calendar ? QString::fromStdString(*current.fixed_calendar) : QString{});
+    }
+
+    if (current.payment_lag != previous.payment_lag) {
+        addChange("Payment Lag",
+                  previous.payment_lag ? QString::number(*previous.payment_lag) : tr("(unset)"),
+                  current.payment_lag ? QString::number(*current.payment_lag) : tr("(unset)"));
+    }
+
+    if (current.fixed_frequency != previous.fixed_frequency) {
+        addChange("Fixed Frequency",
+                  previous.fixed_frequency ? QString::fromStdString(*previous.fixed_frequency) : QString{},
+                  current.fixed_frequency ? QString::fromStdString(*current.fixed_frequency) : QString{});
+    }
+
+    if (current.fixed_convention != previous.fixed_convention) {
+        addChange("Fixed Convention",
+                  previous.fixed_convention ? QString::fromStdString(*previous.fixed_convention) : QString{},
+                  current.fixed_convention ? QString::fromStdString(*current.fixed_convention) : QString{});
+    }
+
+    if (current.fixed_payment_convention != previous.fixed_payment_convention) {
+        addChange("Fixed Payment Convention",
+                  previous.fixed_payment_convention ? QString::fromStdString(*previous.fixed_payment_convention) : QString{},
+                  current.fixed_payment_convention ? QString::fromStdString(*current.fixed_payment_convention) : QString{});
+    }
+
+    if (current.rule != previous.rule) {
+        addChange("Rule",
+                  previous.rule ? QString::fromStdString(*previous.rule) : QString{},
+                  current.rule ? QString::fromStdString(*current.rule) : QString{});
+    }
+
+    if (current.payment_calendar != previous.payment_calendar) {
+        addChange("Payment Calendar",
+                  previous.payment_calendar ? QString::fromStdString(*previous.payment_calendar) : QString{},
+                  current.payment_calendar ? QString::fromStdString(*current.payment_calendar) : QString{});
+    }
+
+    if (current.rate_cutoff != previous.rate_cutoff) {
+        addChange("Rate Cutoff",
+                  previous.rate_cutoff ? QString::number(*previous.rate_cutoff) : tr("(unset)"),
+                  current.rate_cutoff ? QString::number(*current.rate_cutoff) : tr("(unset)"));
+    }
+
+    if (current.end_of_month != previous.end_of_month) {
+        addChange("End Of Month",
+                  previous.end_of_month ? (*previous.end_of_month ? tr("true") : tr("false")) : tr("(unset)"),
+                  current.end_of_month ? (*current.end_of_month ? tr("true") : tr("false")) : tr("(unset)"));
+    }
+
+
+    if (ui_->changesTableWidget->rowCount() == 0) {
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(No field changes)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+    }
+}
+
+void OisConventionHistoryDialog::updateFullDetails(int versionIndex) {
+    if (versionIndex < 0 ||
+        static_cast<size_t>(versionIndex) >= versions_.size()) {
+        return;
+    }
+
+    const auto& version = versions_[versionIndex];
+
+    ui_->idValue->setText(QString::fromStdString(version.id));
+    ui_->indexValue->setText(QString::fromStdString(version.index));
+    ui_->spotLagValue->setText(QString::number(version.spot_lag));
+    ui_->fixedDayCountFractionValue->setText(QString::fromStdString(version.fixed_day_count_fraction));
+    ui_->fixedCalendarValue->setText(version.fixed_calendar
+        ? QString::fromStdString(*version.fixed_calendar)
+        : QString{});
+    ui_->paymentLagValue->setText(version.payment_lag
+        ? QString::number(*version.payment_lag)
+        : tr("(unset)"));
+    ui_->fixedFrequencyValue->setText(version.fixed_frequency
+        ? QString::fromStdString(*version.fixed_frequency)
+        : QString{});
+    ui_->fixedConventionValue->setText(version.fixed_convention
+        ? QString::fromStdString(*version.fixed_convention)
+        : QString{});
+    ui_->fixedPaymentConventionValue->setText(version.fixed_payment_convention
+        ? QString::fromStdString(*version.fixed_payment_convention)
+        : QString{});
+    ui_->ruleValue->setText(version.rule
+        ? QString::fromStdString(*version.rule)
+        : QString{});
+    ui_->paymentCalendarValue->setText(version.payment_calendar
+        ? QString::fromStdString(*version.payment_calendar)
+        : QString{});
+    ui_->rateCutoffValue->setText(version.rate_cutoff
+        ? QString::number(*version.rate_cutoff)
+        : tr("(unset)"));
+    ui_->endOfMonthValue->setText(version.end_of_month
+        ? (*version.end_of_month ? tr("true") : tr("false"))
+        : tr("(unset)"));
+    ui_->versionNumberValue->setText(QString::number(version.version));
+    ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
+}
+
+void OisConventionHistoryDialog::updateActionStates() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    bool hasSelection = !selected.isEmpty();
+    bool isNotLatest = hasSelection && selected.first()->row() > 0;
+
+    openVersionAction_->setEnabled(hasSelection);
+    revertAction_->setEnabled(isNotLatest);
+}
+
+void OisConventionHistoryDialog::onOpenVersionClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit openVersionRequested(versions_[row], versions_[row].version);
+}
+
+void OisConventionHistoryDialog::onRevertClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit revertVersionRequested(versions_[row]);
+}
+
+}

--- a/projects/ores.qt.refdata/src/OisConventionMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/OisConventionMdiWindow.cpp
@@ -1,0 +1,386 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/OisConventionMdiWindow.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.refdata.api/messaging/ois_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+OisConventionMdiWindow::OisConventionMdiWindow(
+    ClientManager* clientManager,
+    const QString& username,
+    QWidget* parent)
+    : EntityListMdiWindow(parent),
+      clientManager_(clientManager),
+      username_(username),
+      toolbar_(nullptr),
+      tableView_(nullptr),
+      model_(nullptr),
+      proxyModel_(nullptr),
+      paginationWidget_(nullptr),
+      reloadAction_(nullptr),
+      addAction_(nullptr),
+      editAction_(nullptr),
+      deleteAction_(nullptr),
+      historyAction_(nullptr) {
+
+    setupUi();
+    setupConnections();
+    reload();
+}
+
+void OisConventionMdiWindow::setupUi() {
+    auto* layout = new QVBoxLayout(this);
+
+    setupToolbar();
+    layout->addWidget(toolbar_);
+    layout->addWidget(loadingBar());
+
+    setupTable();
+    layout->addWidget(tableView_);
+
+    paginationWidget_ = new PaginationWidget(this);
+    layout->addWidget(paginationWidget_);
+}
+
+void OisConventionMdiWindow::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    reloadAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowClockwise, IconUtils::DefaultIconColor),
+        tr("Reload"));
+    connect(reloadAction_, &QAction::triggered, this,
+            &EntityListMdiWindow::reload);
+
+    initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
+
+    toolbar_->addSeparator();
+
+    addAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Add, IconUtils::DefaultIconColor),
+        tr("Add"));
+    addAction_->setToolTip(tr("Add new OIS convention"));
+    connect(addAction_, &QAction::triggered, this,
+            &OisConventionMdiWindow::addNew);
+
+    editAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Edit, IconUtils::DefaultIconColor),
+        tr("Edit"));
+    editAction_->setToolTip(tr("Edit selected OIS convention"));
+    editAction_->setEnabled(false);
+    connect(editAction_, &QAction::triggered, this,
+            &OisConventionMdiWindow::editSelected);
+
+    deleteAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Delete, IconUtils::DefaultIconColor),
+        tr("Delete"));
+    deleteAction_->setToolTip(tr("Delete selected OIS convention"));
+    deleteAction_->setEnabled(false);
+    connect(deleteAction_, &QAction::triggered, this,
+            &OisConventionMdiWindow::deleteSelected);
+
+    historyAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::History, IconUtils::DefaultIconColor),
+        tr("History"));
+    historyAction_->setToolTip(tr("View OIS convention history"));
+    historyAction_->setEnabled(false);
+    connect(historyAction_, &QAction::triggered, this,
+            &OisConventionMdiWindow::viewHistorySelected);
+}
+
+void OisConventionMdiWindow::setupTable() {
+    model_ = new ClientOisConventionModel(clientManager_, this);
+    proxyModel_ = new QSortFilterProxyModel(this);
+    proxyModel_->setSourceModel(model_);
+    proxyModel_->setSortCaseSensitivity(Qt::CaseInsensitive);
+
+    tableView_ = new QTableView(this);
+    tableView_->setModel(proxyModel_);
+    tableView_->setSelectionBehavior(QAbstractItemView::SelectRows);
+    tableView_->setSelectionMode(QAbstractItemView::SingleSelection);
+    tableView_->setSortingEnabled(true);
+    tableView_->setAlternatingRowColors(true);
+    tableView_->verticalHeader()->setVisible(false);
+
+    initializeTableSettings(tableView_, model_,
+        "OisConventionListWindow",
+        {},
+        {900, 400}, 1);
+}
+
+void OisConventionMdiWindow::setupConnections() {
+    connect(model_, &ClientOisConventionModel::dataLoaded,
+            this, &OisConventionMdiWindow::onDataLoaded);
+    connect(model_, &ClientOisConventionModel::loadError,
+            this, &OisConventionMdiWindow::onLoadError);
+
+    connect(tableView_->selectionModel(), &QItemSelectionModel::selectionChanged,
+            this, &OisConventionMdiWindow::onSelectionChanged);
+    connect(tableView_, &QTableView::doubleClicked,
+            this, &OisConventionMdiWindow::onDoubleClicked);
+
+    connect(paginationWidget_, &PaginationWidget::page_size_changed,
+            this, [this](std::uint32_t size) {
+        model_->set_page_size(size);
+        model_->refresh();
+    });
+
+    connect(paginationWidget_, &PaginationWidget::load_all_requested,
+            this, [this]() {
+        const auto total = model_->total_available_count();
+        if (total > 0 && total <= 1000) {
+            model_->set_page_size(total);
+            model_->refresh();
+        }
+    });
+
+    connect(paginationWidget_, &PaginationWidget::page_requested,
+            this, [this](std::uint32_t offset, std::uint32_t limit) {
+        model_->load_page(offset, limit);
+    });
+
+    connectModel(model_);
+}
+
+void OisConventionMdiWindow::doReload() {
+    BOOST_LOG_SEV(lg(), debug) << "Reloading OIS conventions";
+    clearStaleIndicator();
+    emit statusChanged(tr("Loading OIS conventions..."));
+    model_->refresh();
+}
+
+void OisConventionMdiWindow::onDataLoaded() {
+    const auto loaded = model_->rowCount();
+    const auto total = model_->total_available_count();
+    emit statusChanged(tr("Loaded %1 of %2 OIS conventions").arg(loaded).arg(total));
+
+    paginationWidget_->update_state(loaded, total);
+    paginationWidget_->set_load_all_enabled(
+        loaded < static_cast<int>(total) && total > 0 && total <= 1000);
+}
+
+void OisConventionMdiWindow::onLoadError(const QString& error_message,
+                                          const QString& details) {
+    BOOST_LOG_SEV(lg(), error) << "Load error: " << error_message.toStdString();
+    emit errorOccurred(error_message);
+    MessageBoxHelper::critical(this, tr("Load Error"), error_message, details);
+}
+
+void OisConventionMdiWindow::onSelectionChanged() {
+    updateActionStates();
+}
+
+void OisConventionMdiWindow::onDoubleClicked(const QModelIndex& index) {
+    if (!index.isValid())
+        return;
+
+    auto sourceIndex = proxyModel_->mapToSource(index);
+    if (auto* oc = model_->getConvention(sourceIndex.row())) {
+        emit showConventionDetails(*oc);
+    }
+}
+
+void OisConventionMdiWindow::updateActionStates() {
+    const bool hasSelection = tableView_->selectionModel()->hasSelection();
+    editAction_->setEnabled(hasSelection);
+    deleteAction_->setEnabled(hasSelection);
+    historyAction_->setEnabled(hasSelection);
+}
+
+void OisConventionMdiWindow::addNew() {
+    BOOST_LOG_SEV(lg(), debug) << "Add new OIS convention requested";
+    emit addNewRequested();
+}
+
+void OisConventionMdiWindow::editSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Edit requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* oc = model_->getConvention(sourceIndex.row())) {
+        emit showConventionDetails(*oc);
+    }
+}
+
+void OisConventionMdiWindow::viewHistorySelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "View history requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* oc = model_->getConvention(sourceIndex.row())) {
+        BOOST_LOG_SEV(lg(), debug) << "Emitting showConventionHistory for code: "
+                                   << oc->id;
+        emit showConventionHistory(*oc);
+    }
+}
+
+void OisConventionMdiWindow::deleteSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Delete requested but no row selected";
+        return;
+    }
+
+    if (!clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete OIS convention while disconnected.");
+        return;
+    }
+
+    std::vector<std::string> codes;
+    for (const auto& index : selected) {
+        auto sourceIndex = proxyModel_->mapToSource(index);
+        if (auto* oc = model_->getConvention(sourceIndex.row())) {
+            codes.push_back(oc->id);
+        }
+    }
+
+    if (codes.empty()) {
+        BOOST_LOG_SEV(lg(), warn) << "No valid OIS conventions to delete";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Delete requested for " << codes.size()
+                               << " OIS conventions";
+
+    QString confirmMessage;
+    if (codes.size() == 1) {
+        confirmMessage = QString("Are you sure you want to delete OIS convention '%1'?")
+            .arg(QString::fromStdString(codes.front()));
+    } else {
+        confirmMessage = QString("Are you sure you want to delete %1 OIS conventions?")
+            .arg(codes.size());
+    }
+
+    auto reply = MessageBoxHelper::question(this, "Delete OIS Convention",
+        confirmMessage, QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        BOOST_LOG_SEV(lg(), debug) << "Delete cancelled by user";
+        return;
+    }
+
+    QPointer<OisConventionMdiWindow> self = this;
+    using DeleteResult = std::vector<std::pair<std::string, std::pair<bool, std::string>>>;
+
+    auto task = [self, codes]() -> DeleteResult {
+        DeleteResult results;
+        if (!self) return {};
+
+        BOOST_LOG_SEV(lg(), debug) << "Making batch delete request for "
+                                   << codes.size() << " OIS conventions";
+
+        refdata::messaging::delete_ois_convention_request request;
+        request.codes = codes;
+        auto response_result = self->clientManager_->process_authenticated_request(
+            std::move(request));
+
+        if (!response_result) {
+            BOOST_LOG_SEV(lg(), error) << "Failed to send batch delete request";
+            for (const auto& code : codes) {
+                results.push_back({code, {false, "Failed to communicate with server"}});
+            }
+            return results;
+        }
+
+        for (const auto& code : codes) {
+            results.push_back({code, {response_result->success, response_result->message}});
+        }
+
+        return results;
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, watcher]() {
+        auto results = watcher->result();
+        watcher->deleteLater();
+
+        int success_count = 0;
+        int failure_count = 0;
+        QString first_error;
+
+        for (const auto& [code, result] : results) {
+            if (result.first) {
+                BOOST_LOG_SEV(lg(), debug) << "OIS Convention deleted: " << code;
+                success_count++;
+                emit self->ocDeleted(QString::fromStdString(code));
+            } else {
+                BOOST_LOG_SEV(lg(), error) << "OIS Convention deletion failed: "
+                                           << code << " - " << result.second;
+                failure_count++;
+                if (first_error.isEmpty()) {
+                    first_error = QString::fromStdString(result.second);
+                }
+            }
+        }
+
+        self->model_->refresh();
+
+        if (failure_count == 0) {
+            QString msg = success_count == 1
+                ? "Successfully deleted 1 OIS convention"
+                : QString("Successfully deleted %1 OIS conventions").arg(success_count);
+            emit self->statusChanged(msg);
+        } else if (success_count == 0) {
+            QString msg = QString("Failed to delete %1 %2: %3")
+                .arg(failure_count)
+                .arg(failure_count == 1 ? "OIS convention" : "OIS conventions")
+                .arg(first_error);
+            emit self->errorOccurred(msg);
+            MessageBoxHelper::critical(self, "Delete Failed", msg);
+        } else {
+            QString msg = QString("Deleted %1, failed to delete %2")
+                .arg(success_count)
+                .arg(failure_count);
+            emit self->statusChanged(msg);
+            MessageBoxHelper::warning(self, "Partial Success", msg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt.refdata/src/OvernightIndexConventionController.cpp
+++ b/projects/ores.qt.refdata/src/OvernightIndexConventionController.cpp
@@ -1,0 +1,385 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/OvernightIndexConventionController.hpp"
+
+#include <QMdiSubWindow>
+#include <QMessageBox>
+#include <QPointer>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/OvernightIndexConventionMdiWindow.hpp"
+#include "ores.qt/OvernightIndexConventionDetailDialog.hpp"
+#include "ores.qt/OvernightIndexConventionHistoryDialog.hpp"
+#include "ores.qt/DetachableMdiSubWindow.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+OvernightIndexConventionController::OvernightIndexConventionController(
+    QMainWindow* mainWindow,
+    QMdiArea* mdiArea,
+    ClientManager* clientManager,
+    const QString& username,
+    QObject* parent)
+    : EntityController(mainWindow, mdiArea, clientManager, username,
+          std::string_view{}, parent),
+      listWindow_(nullptr),
+      listMdiSubWindow_(nullptr) {
+
+    BOOST_LOG_SEV(lg(), debug) << "OvernightIndexConventionController created";
+}
+
+void OvernightIndexConventionController::showListWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "showListWindow called";
+
+    const QString key = build_window_key("list", "overnight_index_conventions");
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing list window";
+        return;
+    }
+
+    // Create new window
+    listWindow_ = new OvernightIndexConventionMdiWindow(clientManager_, username_);
+
+    // Connect signals
+    connect(listWindow_, &OvernightIndexConventionMdiWindow::statusChanged,
+            this, &OvernightIndexConventionController::statusMessage);
+    connect(listWindow_, &OvernightIndexConventionMdiWindow::errorOccurred,
+            this, &OvernightIndexConventionController::errorMessage);
+    connect(listWindow_, &OvernightIndexConventionMdiWindow::showConventionDetails,
+            this, &OvernightIndexConventionController::onShowDetails);
+    connect(listWindow_, &OvernightIndexConventionMdiWindow::addNewRequested,
+            this, &OvernightIndexConventionController::onAddNewRequested);
+    connect(listWindow_, &OvernightIndexConventionMdiWindow::showConventionHistory,
+            this, &OvernightIndexConventionController::onShowHistory);
+
+    // Create MDI subwindow
+    listMdiSubWindow_ = new DetachableMdiSubWindow(mainWindow_);
+    listMdiSubWindow_->setWidget(listWindow_);
+    listMdiSubWindow_->setWindowTitle("Overnight Index Conventions");
+    listMdiSubWindow_->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+    listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
+    listMdiSubWindow_->resize(listWindow_->sizeHint());
+
+    mdiArea_->addSubWindow(listMdiSubWindow_);
+    listMdiSubWindow_->show();
+
+    // Track window
+    track_window(key, listMdiSubWindow_);
+    register_detachable_window(listMdiSubWindow_);
+
+    // Cleanup when closed
+    connect(listMdiSubWindow_, &QObject::destroyed, this, [self = QPointer<OvernightIndexConventionController>(this), key]() {
+        if (!self) return;
+        self->untrack_window(key);
+        self->listWindow_ = nullptr;
+        self->listMdiSubWindow_ = nullptr;
+    });
+
+    BOOST_LOG_SEV(lg(), debug) << "Overnight Index Convention list window created";
+}
+
+void OvernightIndexConventionController::closeAllWindows() {
+    BOOST_LOG_SEV(lg(), debug) << "closeAllWindows called";
+
+    // Close all managed windows
+    QList<QString> keys = managed_windows_.keys();
+    for (const QString& key : keys) {
+        if (auto* window = managed_windows_.value(key)) {
+            window->close();
+        }
+    }
+    managed_windows_.clear();
+
+    listWindow_ = nullptr;
+    listMdiSubWindow_ = nullptr;
+}
+
+void OvernightIndexConventionController::reloadListWindow() {
+    if (listWindow_) {
+        listWindow_->reload();
+    }
+}
+
+void OvernightIndexConventionController::onShowDetails(
+    const refdata::domain::overnight_index_convention& ni) {
+    BOOST_LOG_SEV(lg(), debug) << "Show details for: " << ni.id;
+    showDetailWindow(ni);
+}
+
+void OvernightIndexConventionController::onAddNewRequested() {
+    BOOST_LOG_SEV(lg(), info) << "Add new overnight index convention requested";
+    showAddWindow();
+}
+
+void OvernightIndexConventionController::onShowHistory(
+    const refdata::domain::overnight_index_convention& ni) {
+    BOOST_LOG_SEV(lg(), debug) << "Show history requested for: " << ni.id;
+    showHistoryWindow(QString::fromStdString(ni.id));
+}
+
+void OvernightIndexConventionController::showAddWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "Creating add window for new overnight index convention";
+
+    auto* detailDialog = new OvernightIndexConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(true);
+
+    connect(detailDialog, &OvernightIndexConventionDetailDialog::statusMessage,
+            this, &OvernightIndexConventionController::statusMessage);
+    connect(detailDialog, &OvernightIndexConventionDetailDialog::errorMessage,
+            this, &OvernightIndexConventionController::errorMessage);
+    connect(detailDialog, &OvernightIndexConventionDetailDialog::niSaved,
+            this, [self = QPointer<OvernightIndexConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "Overnight Index Convention saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle("New Overnight Index Convention");
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void OvernightIndexConventionController::showDetailWindow(
+    const refdata::domain::overnight_index_convention& ni) {
+
+    const QString identifier = QString::fromStdString(ni.id);
+    const QString key = build_window_key("details", identifier);
+
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing detail window";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Creating detail window for: " << ni.id;
+
+    auto* detailDialog = new OvernightIndexConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(false);
+    detailDialog->setConvention(ni);
+
+    connect(detailDialog, &OvernightIndexConventionDetailDialog::statusMessage,
+            this, &OvernightIndexConventionController::statusMessage);
+    connect(detailDialog, &OvernightIndexConventionDetailDialog::errorMessage,
+            this, &OvernightIndexConventionController::errorMessage);
+    connect(detailDialog, &OvernightIndexConventionDetailDialog::niSaved,
+            this, [self = QPointer<OvernightIndexConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "Overnight Index Convention saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+    connect(detailDialog, &OvernightIndexConventionDetailDialog::niDeleted,
+            this, [self = QPointer<OvernightIndexConventionController>(this), key](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "Overnight Index Convention deleted: " << code.toStdString();
+        self->handleEntityDeleted();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Overnight Index Convention: %1").arg(identifier));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+
+    // Track window
+    track_window(key, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<OvernightIndexConventionController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, key]() {
+        if (self) {
+            self->untrack_window(key);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void OvernightIndexConventionController::showHistoryWindow(const QString& code) {
+    BOOST_LOG_SEV(lg(), info) << "Opening history window for overnight index convention: "
+                              << code.toStdString();
+
+    const QString windowKey = build_window_key("history", code);
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing history window for: "
+                                  << code.toStdString();
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Creating new history window for: "
+                              << code.toStdString();
+
+    auto* historyDialog = new OvernightIndexConventionHistoryDialog(code, clientManager_, mainWindow_);
+
+    connect(historyDialog, &OvernightIndexConventionHistoryDialog::statusChanged,
+            this, [self = QPointer<OvernightIndexConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(historyDialog, &OvernightIndexConventionHistoryDialog::errorOccurred,
+            this, [self = QPointer<OvernightIndexConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+    connect(historyDialog, &OvernightIndexConventionHistoryDialog::revertVersionRequested,
+            this, &OvernightIndexConventionController::onRevertVersion);
+    connect(historyDialog, &OvernightIndexConventionHistoryDialog::openVersionRequested,
+            this, &OvernightIndexConventionController::onOpenVersion);
+
+    // Load history data
+    historyDialog->loadHistory();
+
+    auto* historyWindow = new DetachableMdiSubWindow(mainWindow_);
+    historyWindow->setAttribute(Qt::WA_DeleteOnClose);
+    historyWindow->setWidget(historyDialog);
+    historyWindow->setWindowTitle(QString("Overnight Index Convention History: %1").arg(code));
+    historyWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    // Track this history window
+    track_window(windowKey, historyWindow);
+    register_detachable_window(historyWindow);
+
+    QPointer<OvernightIndexConventionController> self = this;
+    connect(historyWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    show_managed_window(historyWindow, listMdiSubWindow_);
+}
+
+void OvernightIndexConventionController::onOpenVersion(
+    const refdata::domain::overnight_index_convention& ni, int versionNumber) {
+    BOOST_LOG_SEV(lg(), info) << "Opening historical version " << versionNumber
+                              << " for overnight index convention: " << ni.id;
+
+    const QString code = QString::fromStdString(ni.id);
+    const QString windowKey = build_window_key("version", QString("%1_v%2")
+        .arg(code).arg(versionNumber));
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing version window";
+        return;
+    }
+
+    auto* detailDialog = new OvernightIndexConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setConvention(ni);
+    detailDialog->setReadOnly(true);
+
+    connect(detailDialog, &OvernightIndexConventionDetailDialog::statusMessage,
+            this, [self = QPointer<OvernightIndexConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(detailDialog, &OvernightIndexConventionDetailDialog::errorMessage,
+            this, [self = QPointer<OvernightIndexConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Overnight Index Convention: %1 (Version %2)")
+        .arg(code).arg(versionNumber));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    track_window(windowKey, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<OvernightIndexConventionController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_, QPoint(60, 60));
+}
+
+void OvernightIndexConventionController::onRevertVersion(
+    const refdata::domain::overnight_index_convention& ni) {
+    BOOST_LOG_SEV(lg(), info) << "Reverting overnight index convention to version: "
+                              << ni.version;
+
+    // Open detail dialog with the old version data for editing
+    auto* detailDialog = new OvernightIndexConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setConvention(ni);
+    detailDialog->setCreateMode(false);
+
+    connect(detailDialog, &OvernightIndexConventionDetailDialog::statusMessage,
+            this, &OvernightIndexConventionController::statusMessage);
+    connect(detailDialog, &OvernightIndexConventionDetailDialog::errorMessage,
+            this, &OvernightIndexConventionController::errorMessage);
+    connect(detailDialog, &OvernightIndexConventionDetailDialog::niSaved,
+            this, [self = QPointer<OvernightIndexConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "Overnight Index Convention reverted: " << code.toStdString();
+        emit self->statusMessage(QString("Overnight Index Convention '%1' reverted successfully").arg(code));
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Revert Overnight Index Convention: %1")
+        .arg(QString::fromStdString(ni.id)));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+EntityListMdiWindow* OvernightIndexConventionController::listWindow() const {
+    return listWindow_;
+}
+
+}

--- a/projects/ores.qt.refdata/src/OvernightIndexConventionDetailDialog.cpp
+++ b/projects/ores.qt.refdata/src/OvernightIndexConventionDetailDialog.cpp
@@ -1,0 +1,310 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/OvernightIndexConventionDetailDialog.hpp"
+
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_OvernightIndexConventionDetailDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.refdata.api/messaging/overnight_index_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+OvernightIndexConventionDetailDialog::OvernightIndexConventionDetailDialog(QWidget* parent)
+    : DetailDialogBase(parent),
+      ui_(new Ui::OvernightIndexConventionDetailDialog),
+      clientManager_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupConnections();
+}
+
+OvernightIndexConventionDetailDialog::~OvernightIndexConventionDetailDialog() {
+    delete ui_;
+}
+
+QTabWidget* OvernightIndexConventionDetailDialog::tabWidget() const {
+    return ui_->tabWidget;
+}
+
+QWidget* OvernightIndexConventionDetailDialog::provenanceTab() const {
+    return ui_->provenanceTab;
+}
+
+ProvenanceWidget* OvernightIndexConventionDetailDialog::provenanceWidget() const {
+    return ui_->provenanceWidget;
+}
+
+void OvernightIndexConventionDetailDialog::setupUi() {
+    ui_->saveButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Save, IconUtils::DefaultIconColor));
+    ui_->saveButton->setEnabled(false);
+
+    ui_->deleteButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Delete, IconUtils::DefaultIconColor));
+
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+}
+
+void OvernightIndexConventionDetailDialog::setupConnections() {
+    connect(ui_->saveButton, &QPushButton::clicked, this,
+            &OvernightIndexConventionDetailDialog::onSaveClicked);
+    connect(ui_->deleteButton, &QPushButton::clicked, this,
+            &OvernightIndexConventionDetailDialog::onDeleteClicked);
+    connect(ui_->closeButton, &QPushButton::clicked, this,
+            &OvernightIndexConventionDetailDialog::onCloseClicked);
+
+    connect(ui_->idEdit, &QLineEdit::textChanged, this,
+            &OvernightIndexConventionDetailDialog::onCodeChanged);
+    connect(ui_->fixingCalendarEdit, &QLineEdit::textChanged, this,
+            &OvernightIndexConventionDetailDialog::onFieldChanged);
+    connect(ui_->dayCountFractionEdit, &QLineEdit::textChanged, this,
+            &OvernightIndexConventionDetailDialog::onFieldChanged);
+}
+
+void OvernightIndexConventionDetailDialog::setClientManager(ClientManager* clientManager) {
+    clientManager_ = clientManager;
+}
+
+void OvernightIndexConventionDetailDialog::setUsername(const std::string& username) {
+    username_ = username;
+}
+
+void OvernightIndexConventionDetailDialog::setConvention(
+    const refdata::domain::overnight_index_convention& ni) {
+    ni_ = ni;
+    updateUiFromConvention();
+}
+
+void OvernightIndexConventionDetailDialog::setCreateMode(bool createMode) {
+    createMode_ = createMode;
+    ui_->idEdit->setReadOnly(!createMode);
+    ui_->deleteButton->setVisible(!createMode);
+    setProvenanceEnabled(!createMode);
+    hasChanges_ = false;
+    updateSaveButtonState();
+}
+
+void OvernightIndexConventionDetailDialog::setReadOnly(bool readOnly) {
+    readOnly_ = readOnly;
+    ui_->idEdit->setReadOnly(true);
+    ui_->fixingCalendarEdit->setReadOnly(readOnly);
+    ui_->dayCountFractionEdit->setReadOnly(readOnly);
+    ui_->saveButton->setVisible(!readOnly);
+    ui_->deleteButton->setVisible(!readOnly);
+}
+
+void OvernightIndexConventionDetailDialog::updateUiFromConvention() {
+    ui_->idEdit->setText(QString::fromStdString(ni_.id));
+    ui_->fixingCalendarEdit->setText(QString::fromStdString(ni_.fixing_calendar));
+    ui_->dayCountFractionEdit->setText(QString::fromStdString(ni_.day_count_fraction));
+    ui_->settlementDaysEdit->setValue(ni_.settlement_days);
+
+    populateProvenance(ni_.version,
+                       ni_.modified_by,
+                       ni_.performed_by,
+                       ni_.recorded_at,
+                       ni_.change_reason_code,
+                       ni_.change_commentary);
+
+    hasChanges_ = false;
+    updateSaveButtonState();
+}
+
+void OvernightIndexConventionDetailDialog::updateConventionFromUi() {
+    if (createMode_) {
+        ni_.id = ui_->idEdit->text().trimmed().toStdString();
+    }
+    ni_.fixing_calendar = ui_->fixingCalendarEdit->text().trimmed().toStdString();
+    ni_.day_count_fraction = ui_->dayCountFractionEdit->text().trimmed().toStdString();
+    ni_.settlement_days = ui_->settlementDaysEdit->value();
+    ni_.modified_by = username_;
+}
+
+void OvernightIndexConventionDetailDialog::onCodeChanged(const QString& /* text */) {
+    hasChanges_ = true;
+    updateSaveButtonState();
+}
+
+void OvernightIndexConventionDetailDialog::onFieldChanged() {
+    hasChanges_ = true;
+    updateSaveButtonState();
+}
+
+void OvernightIndexConventionDetailDialog::updateSaveButtonState() {
+    bool canSave = hasChanges_ && validateInput() && !readOnly_;
+    ui_->saveButton->setEnabled(canSave);
+}
+
+bool OvernightIndexConventionDetailDialog::validateInput() {
+    const QString id_val = ui_->idEdit->text().trimmed();
+    const QString fixing_calendar_val = ui_->fixingCalendarEdit->text().trimmed();
+    const QString day_count_fraction_val = ui_->dayCountFractionEdit->text().trimmed();
+
+    return true
+        && !id_val.isEmpty()
+        && !fixing_calendar_val.isEmpty()
+        && !day_count_fraction_val.isEmpty()
+    ;
+}
+
+void OvernightIndexConventionDetailDialog::onSaveClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot save overnight index convention while disconnected from server.");
+        return;
+    }
+
+    if (!validateInput()) {
+        MessageBoxHelper::warning(this, "Invalid Input",
+            "Please fill in all required fields.");
+        return;
+    }
+
+    updateConventionFromUi();
+
+    BOOST_LOG_SEV(lg(), info) << "Saving overnight index convention: "
+        << ni_.id;
+
+    QPointer<OvernightIndexConventionDetailDialog> self = this;
+
+    struct SaveResult {
+        bool success;
+        std::string message;
+    };
+
+    auto task = [self, ni = ni_]() -> SaveResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed"};
+        }
+
+        refdata::messaging::save_overnight_index_convention_request request;
+        request.data = ni;
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server"};
+        }
+
+        return {response_result->success, response_result->message};
+    };
+
+    auto* watcher = new QFutureWatcher<SaveResult>(self);
+    connect(watcher, &QFutureWatcher<SaveResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "Overnight Index Convention saved successfully";
+            QString code = QString::fromStdString(
+                self->ni_.id);
+            self->hasChanges_ = false;
+            self->updateSaveButtonState();
+            emit self->niSaved(code);
+            self->notifySaveSuccess(tr("Overnight Index Convention '%1' saved").arg(code));
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Save failed: " << result.message;
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Save Failed", errorMsg);
+        }
+    });
+
+    QFuture<SaveResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+void OvernightIndexConventionDetailDialog::onDeleteClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete overnight index convention while disconnected from server.");
+        return;
+    }
+
+    QString code = QString::fromStdString(
+        ni_.id);
+    auto reply = MessageBoxHelper::question(this, "Delete Overnight Index Convention",
+        QString("Are you sure you want to delete overnight index convention '%1'?").arg(code),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Deleting overnight index convention: "
+        << ni_.id;
+
+    QPointer<OvernightIndexConventionDetailDialog> self = this;
+
+    struct DeleteResult {
+        bool success;
+        std::string message;
+    };
+
+    auto task = [self, code = ni_.id]() -> DeleteResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed"};
+        }
+
+        refdata::messaging::delete_overnight_index_convention_request request;
+        request.codes = {code};
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server"};
+        }
+
+        return {response_result->success, response_result->message};
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, code, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "Overnight Index Convention deleted successfully";
+            emit self->statusMessage(
+                QString("Overnight Index Convention '%1' deleted").arg(code));
+            emit self->niDeleted(code);
+            self->requestClose();
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Delete failed: " << result.message;
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Delete Failed", errorMsg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt.refdata/src/OvernightIndexConventionHistoryDialog.cpp
+++ b/projects/ores.qt.refdata/src/OvernightIndexConventionHistoryDialog.cpp
@@ -1,0 +1,323 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/OvernightIndexConventionHistoryDialog.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_OvernightIndexConventionHistoryDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.refdata.api/messaging/overnight_index_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+OvernightIndexConventionHistoryDialog::OvernightIndexConventionHistoryDialog(
+    const QString& code,
+    ClientManager* clientManager,
+    QWidget* parent)
+    : QWidget(parent),
+      ui_(new Ui::OvernightIndexConventionHistoryDialog),
+      code_(code),
+      clientManager_(clientManager),
+      toolbar_(nullptr),
+      openVersionAction_(nullptr),
+      revertAction_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupToolbar();
+    setupConnections();
+}
+
+OvernightIndexConventionHistoryDialog::~OvernightIndexConventionHistoryDialog() {
+    delete ui_;
+}
+
+void OvernightIndexConventionHistoryDialog::setupUi() {
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+
+    ui_->titleLabel->setText(QString("History for: %1").arg(code_));
+
+    // Setup version list table
+    ui_->versionListWidget->setColumnCount(5);
+    ui_->versionListWidget->setHorizontalHeaderLabels(
+        {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
+    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
+    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    // Setup changes table
+    ui_->changesTableWidget->setColumnCount(3);
+    ui_->changesTableWidget->setHorizontalHeaderLabels(
+        {"Field", "Old Value", "New Value"});
+    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+}
+
+void OvernightIndexConventionHistoryDialog::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    openVersionAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor),
+        tr("Open"));
+    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
+    openVersionAction_->setEnabled(false);
+
+    revertAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor),
+        tr("Revert"));
+    revertAction_->setToolTip(tr("Revert to this version"));
+    revertAction_->setEnabled(false);
+
+    // Insert toolbar at the top of the layout
+    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
+    if (layout) {
+        layout->insertWidget(0, toolbar_);
+    }
+}
+
+void OvernightIndexConventionHistoryDialog::setupConnections() {
+    connect(ui_->versionListWidget, &QTableWidget::itemSelectionChanged,
+            this, &OvernightIndexConventionHistoryDialog::onVersionSelected);
+    connect(openVersionAction_, &QAction::triggered,
+            this, &OvernightIndexConventionHistoryDialog::onOpenVersionClicked);
+    connect(revertAction_, &QAction::triggered,
+            this, &OvernightIndexConventionHistoryDialog::onRevertClicked);
+    connect(ui_->closeButton, &QPushButton::clicked,
+            this, [this]() { if (window()) window()->close(); });
+}
+
+void OvernightIndexConventionHistoryDialog::loadHistory() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        emit errorOccurred("Not connected to server");
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for overnight index convention: " << code_.toStdString();
+    emit statusChanged(tr("Loading history..."));
+
+    QPointer<OvernightIndexConventionHistoryDialog> self = this;
+
+    using HistoryResult = std::expected<refdata::messaging::get_overnight_index_convention_history_response, std::string>;
+
+    QFuture<HistoryResult> future =
+        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
+        if (!self || !self->clientManager_)
+            return std::unexpected("Dialog closed");
+        refdata::messaging::get_overnight_index_convention_history_request request;
+        request.id = code;
+        auto result = self->clientManager_->process_authenticated_request(std::move(request));
+        if (!result) return std::unexpected(result.error());
+        return std::move(*result);
+    });
+
+    auto* watcher = new QFutureWatcher<HistoryResult>(self);
+    connect(watcher, &QFutureWatcher<HistoryResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (!result) {
+            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
+            emit self->errorOccurred(QString::fromStdString(result.error()));
+            return;
+        }
+        if (!result->success) {
+            emit self->errorOccurred(QString::fromStdString(result->message));
+            return;
+        }
+        self->versions_ = std::move(result->overnight_index_conventions);
+        self->updateVersionList();
+        emit self->statusChanged(
+            QString("Loaded %1 versions").arg(self->versions_.size()));
+    });
+    watcher->setFuture(future);
+}
+
+void OvernightIndexConventionHistoryDialog::updateVersionList() {
+    ui_->versionListWidget->setRowCount(0);
+
+    for (const auto& version : versions_) {
+        int row = ui_->versionListWidget->rowCount();
+        ui_->versionListWidget->insertRow(row);
+
+        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
+        versionItem->setTextAlignment(Qt::AlignCenter);
+        ui_->versionListWidget->setItem(row, 0, versionItem);
+
+        auto* recordedAtItem = new QTableWidgetItem(
+            relative_time_helper::format(version.recorded_at));
+        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
+
+        auto* modifiedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.modified_by));
+        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
+
+        auto* performedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.performed_by));
+        ui_->versionListWidget->setItem(row, 3, performedByItem);
+
+        auto* commentaryItem = new QTableWidgetItem(
+            QString::fromStdString(version.change_commentary));
+        ui_->versionListWidget->setItem(row, 4, commentaryItem);
+    }
+
+    // Select the first (most recent) version
+    if (!versions_.empty()) {
+        ui_->versionListWidget->selectRow(0);
+    }
+}
+
+void OvernightIndexConventionHistoryDialog::onVersionSelected() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) {
+        updateActionStates();
+        return;
+    }
+
+    int row = selected.first()->row();
+    updateChangesTable(row);
+    updateFullDetails(row);
+    updateActionStates();
+}
+
+void OvernightIndexConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
+    ui_->changesTableWidget->setRowCount(0);
+
+    if (currentVersionIndex < 0 ||
+        static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
+        return;
+    }
+
+    // Get the next older version to compare against
+    int previousVersionIndex = currentVersionIndex + 1;
+    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
+        // This is the first version, no changes to show
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(Initial version)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+        return;
+    }
+
+    const auto& current = versions_[currentVersionIndex];
+    const auto& previous = versions_[previousVersionIndex];
+
+    auto addChange = [this](const QString& field,
+                            const QString& oldVal, const QString& newVal) {
+        int row = ui_->changesTableWidget->rowCount();
+        ui_->changesTableWidget->insertRow(row);
+        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
+        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
+        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
+    };
+
+    if (current.id != previous.id) {
+        addChange("Id",
+                  QString::fromStdString(previous.id),
+                  QString::fromStdString(current.id));
+    }
+
+    if (current.fixing_calendar != previous.fixing_calendar) {
+        addChange("Fixing Calendar",
+                  QString::fromStdString(previous.fixing_calendar),
+                  QString::fromStdString(current.fixing_calendar));
+    }
+
+    if (current.day_count_fraction != previous.day_count_fraction) {
+        addChange("Day Count Fraction",
+                  QString::fromStdString(previous.day_count_fraction),
+                  QString::fromStdString(current.day_count_fraction));
+    }
+
+    if (current.settlement_days != previous.settlement_days) {
+        addChange("Settlement Days",
+                  QString::number(previous.settlement_days),
+                  QString::number(current.settlement_days));
+    }
+
+
+    if (ui_->changesTableWidget->rowCount() == 0) {
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(No field changes)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+    }
+}
+
+void OvernightIndexConventionHistoryDialog::updateFullDetails(int versionIndex) {
+    if (versionIndex < 0 ||
+        static_cast<size_t>(versionIndex) >= versions_.size()) {
+        return;
+    }
+
+    const auto& version = versions_[versionIndex];
+
+    ui_->idValue->setText(QString::fromStdString(version.id));
+    ui_->fixingCalendarValue->setText(QString::fromStdString(version.fixing_calendar));
+    ui_->dayCountFractionValue->setText(QString::fromStdString(version.day_count_fraction));
+    ui_->settlementDaysValue->setText(QString::number(version.settlement_days));
+    ui_->versionNumberValue->setText(QString::number(version.version));
+    ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
+}
+
+void OvernightIndexConventionHistoryDialog::updateActionStates() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    bool hasSelection = !selected.isEmpty();
+    bool isNotLatest = hasSelection && selected.first()->row() > 0;
+
+    openVersionAction_->setEnabled(hasSelection);
+    revertAction_->setEnabled(isNotLatest);
+}
+
+void OvernightIndexConventionHistoryDialog::onOpenVersionClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit openVersionRequested(versions_[row], versions_[row].version);
+}
+
+void OvernightIndexConventionHistoryDialog::onRevertClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit revertVersionRequested(versions_[row]);
+}
+
+}

--- a/projects/ores.qt.refdata/src/OvernightIndexConventionMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/OvernightIndexConventionMdiWindow.cpp
@@ -1,0 +1,386 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/OvernightIndexConventionMdiWindow.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.refdata.api/messaging/overnight_index_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+OvernightIndexConventionMdiWindow::OvernightIndexConventionMdiWindow(
+    ClientManager* clientManager,
+    const QString& username,
+    QWidget* parent)
+    : EntityListMdiWindow(parent),
+      clientManager_(clientManager),
+      username_(username),
+      toolbar_(nullptr),
+      tableView_(nullptr),
+      model_(nullptr),
+      proxyModel_(nullptr),
+      paginationWidget_(nullptr),
+      reloadAction_(nullptr),
+      addAction_(nullptr),
+      editAction_(nullptr),
+      deleteAction_(nullptr),
+      historyAction_(nullptr) {
+
+    setupUi();
+    setupConnections();
+    reload();
+}
+
+void OvernightIndexConventionMdiWindow::setupUi() {
+    auto* layout = new QVBoxLayout(this);
+
+    setupToolbar();
+    layout->addWidget(toolbar_);
+    layout->addWidget(loadingBar());
+
+    setupTable();
+    layout->addWidget(tableView_);
+
+    paginationWidget_ = new PaginationWidget(this);
+    layout->addWidget(paginationWidget_);
+}
+
+void OvernightIndexConventionMdiWindow::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    reloadAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowClockwise, IconUtils::DefaultIconColor),
+        tr("Reload"));
+    connect(reloadAction_, &QAction::triggered, this,
+            &EntityListMdiWindow::reload);
+
+    initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
+
+    toolbar_->addSeparator();
+
+    addAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Add, IconUtils::DefaultIconColor),
+        tr("Add"));
+    addAction_->setToolTip(tr("Add new overnight index convention"));
+    connect(addAction_, &QAction::triggered, this,
+            &OvernightIndexConventionMdiWindow::addNew);
+
+    editAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Edit, IconUtils::DefaultIconColor),
+        tr("Edit"));
+    editAction_->setToolTip(tr("Edit selected overnight index convention"));
+    editAction_->setEnabled(false);
+    connect(editAction_, &QAction::triggered, this,
+            &OvernightIndexConventionMdiWindow::editSelected);
+
+    deleteAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Delete, IconUtils::DefaultIconColor),
+        tr("Delete"));
+    deleteAction_->setToolTip(tr("Delete selected overnight index convention"));
+    deleteAction_->setEnabled(false);
+    connect(deleteAction_, &QAction::triggered, this,
+            &OvernightIndexConventionMdiWindow::deleteSelected);
+
+    historyAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::History, IconUtils::DefaultIconColor),
+        tr("History"));
+    historyAction_->setToolTip(tr("View overnight index convention history"));
+    historyAction_->setEnabled(false);
+    connect(historyAction_, &QAction::triggered, this,
+            &OvernightIndexConventionMdiWindow::viewHistorySelected);
+}
+
+void OvernightIndexConventionMdiWindow::setupTable() {
+    model_ = new ClientOvernightIndexConventionModel(clientManager_, this);
+    proxyModel_ = new QSortFilterProxyModel(this);
+    proxyModel_->setSourceModel(model_);
+    proxyModel_->setSortCaseSensitivity(Qt::CaseInsensitive);
+
+    tableView_ = new QTableView(this);
+    tableView_->setModel(proxyModel_);
+    tableView_->setSelectionBehavior(QAbstractItemView::SelectRows);
+    tableView_->setSelectionMode(QAbstractItemView::SingleSelection);
+    tableView_->setSortingEnabled(true);
+    tableView_->setAlternatingRowColors(true);
+    tableView_->verticalHeader()->setVisible(false);
+
+    initializeTableSettings(tableView_, model_,
+        "OvernightIndexConventionListWindow",
+        {},
+        {900, 400}, 1);
+}
+
+void OvernightIndexConventionMdiWindow::setupConnections() {
+    connect(model_, &ClientOvernightIndexConventionModel::dataLoaded,
+            this, &OvernightIndexConventionMdiWindow::onDataLoaded);
+    connect(model_, &ClientOvernightIndexConventionModel::loadError,
+            this, &OvernightIndexConventionMdiWindow::onLoadError);
+
+    connect(tableView_->selectionModel(), &QItemSelectionModel::selectionChanged,
+            this, &OvernightIndexConventionMdiWindow::onSelectionChanged);
+    connect(tableView_, &QTableView::doubleClicked,
+            this, &OvernightIndexConventionMdiWindow::onDoubleClicked);
+
+    connect(paginationWidget_, &PaginationWidget::page_size_changed,
+            this, [this](std::uint32_t size) {
+        model_->set_page_size(size);
+        model_->refresh();
+    });
+
+    connect(paginationWidget_, &PaginationWidget::load_all_requested,
+            this, [this]() {
+        const auto total = model_->total_available_count();
+        if (total > 0 && total <= 1000) {
+            model_->set_page_size(total);
+            model_->refresh();
+        }
+    });
+
+    connect(paginationWidget_, &PaginationWidget::page_requested,
+            this, [this](std::uint32_t offset, std::uint32_t limit) {
+        model_->load_page(offset, limit);
+    });
+
+    connectModel(model_);
+}
+
+void OvernightIndexConventionMdiWindow::doReload() {
+    BOOST_LOG_SEV(lg(), debug) << "Reloading overnight index conventions";
+    clearStaleIndicator();
+    emit statusChanged(tr("Loading overnight index conventions..."));
+    model_->refresh();
+}
+
+void OvernightIndexConventionMdiWindow::onDataLoaded() {
+    const auto loaded = model_->rowCount();
+    const auto total = model_->total_available_count();
+    emit statusChanged(tr("Loaded %1 of %2 overnight index conventions").arg(loaded).arg(total));
+
+    paginationWidget_->update_state(loaded, total);
+    paginationWidget_->set_load_all_enabled(
+        loaded < static_cast<int>(total) && total > 0 && total <= 1000);
+}
+
+void OvernightIndexConventionMdiWindow::onLoadError(const QString& error_message,
+                                          const QString& details) {
+    BOOST_LOG_SEV(lg(), error) << "Load error: " << error_message.toStdString();
+    emit errorOccurred(error_message);
+    MessageBoxHelper::critical(this, tr("Load Error"), error_message, details);
+}
+
+void OvernightIndexConventionMdiWindow::onSelectionChanged() {
+    updateActionStates();
+}
+
+void OvernightIndexConventionMdiWindow::onDoubleClicked(const QModelIndex& index) {
+    if (!index.isValid())
+        return;
+
+    auto sourceIndex = proxyModel_->mapToSource(index);
+    if (auto* ni = model_->getConvention(sourceIndex.row())) {
+        emit showConventionDetails(*ni);
+    }
+}
+
+void OvernightIndexConventionMdiWindow::updateActionStates() {
+    const bool hasSelection = tableView_->selectionModel()->hasSelection();
+    editAction_->setEnabled(hasSelection);
+    deleteAction_->setEnabled(hasSelection);
+    historyAction_->setEnabled(hasSelection);
+}
+
+void OvernightIndexConventionMdiWindow::addNew() {
+    BOOST_LOG_SEV(lg(), debug) << "Add new overnight index convention requested";
+    emit addNewRequested();
+}
+
+void OvernightIndexConventionMdiWindow::editSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Edit requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* ni = model_->getConvention(sourceIndex.row())) {
+        emit showConventionDetails(*ni);
+    }
+}
+
+void OvernightIndexConventionMdiWindow::viewHistorySelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "View history requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* ni = model_->getConvention(sourceIndex.row())) {
+        BOOST_LOG_SEV(lg(), debug) << "Emitting showConventionHistory for code: "
+                                   << ni->id;
+        emit showConventionHistory(*ni);
+    }
+}
+
+void OvernightIndexConventionMdiWindow::deleteSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Delete requested but no row selected";
+        return;
+    }
+
+    if (!clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete overnight index convention while disconnected.");
+        return;
+    }
+
+    std::vector<std::string> codes;
+    for (const auto& index : selected) {
+        auto sourceIndex = proxyModel_->mapToSource(index);
+        if (auto* ni = model_->getConvention(sourceIndex.row())) {
+            codes.push_back(ni->id);
+        }
+    }
+
+    if (codes.empty()) {
+        BOOST_LOG_SEV(lg(), warn) << "No valid overnight index conventions to delete";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Delete requested for " << codes.size()
+                               << " overnight index conventions";
+
+    QString confirmMessage;
+    if (codes.size() == 1) {
+        confirmMessage = QString("Are you sure you want to delete overnight index convention '%1'?")
+            .arg(QString::fromStdString(codes.front()));
+    } else {
+        confirmMessage = QString("Are you sure you want to delete %1 overnight index conventions?")
+            .arg(codes.size());
+    }
+
+    auto reply = MessageBoxHelper::question(this, "Delete Overnight Index Convention",
+        confirmMessage, QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        BOOST_LOG_SEV(lg(), debug) << "Delete cancelled by user";
+        return;
+    }
+
+    QPointer<OvernightIndexConventionMdiWindow> self = this;
+    using DeleteResult = std::vector<std::pair<std::string, std::pair<bool, std::string>>>;
+
+    auto task = [self, codes]() -> DeleteResult {
+        DeleteResult results;
+        if (!self) return {};
+
+        BOOST_LOG_SEV(lg(), debug) << "Making batch delete request for "
+                                   << codes.size() << " overnight index conventions";
+
+        refdata::messaging::delete_overnight_index_convention_request request;
+        request.codes = codes;
+        auto response_result = self->clientManager_->process_authenticated_request(
+            std::move(request));
+
+        if (!response_result) {
+            BOOST_LOG_SEV(lg(), error) << "Failed to send batch delete request";
+            for (const auto& code : codes) {
+                results.push_back({code, {false, "Failed to communicate with server"}});
+            }
+            return results;
+        }
+
+        for (const auto& code : codes) {
+            results.push_back({code, {response_result->success, response_result->message}});
+        }
+
+        return results;
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, watcher]() {
+        auto results = watcher->result();
+        watcher->deleteLater();
+
+        int success_count = 0;
+        int failure_count = 0;
+        QString first_error;
+
+        for (const auto& [code, result] : results) {
+            if (result.first) {
+                BOOST_LOG_SEV(lg(), debug) << "Overnight Index Convention deleted: " << code;
+                success_count++;
+                emit self->niDeleted(QString::fromStdString(code));
+            } else {
+                BOOST_LOG_SEV(lg(), error) << "Overnight Index Convention deletion failed: "
+                                           << code << " - " << result.second;
+                failure_count++;
+                if (first_error.isEmpty()) {
+                    first_error = QString::fromStdString(result.second);
+                }
+            }
+        }
+
+        self->model_->refresh();
+
+        if (failure_count == 0) {
+            QString msg = success_count == 1
+                ? "Successfully deleted 1 overnight index convention"
+                : QString("Successfully deleted %1 overnight index conventions").arg(success_count);
+            emit self->statusChanged(msg);
+        } else if (success_count == 0) {
+            QString msg = QString("Failed to delete %1 %2: %3")
+                .arg(failure_count)
+                .arg(failure_count == 1 ? "overnight index convention" : "overnight index conventions")
+                .arg(first_error);
+            emit self->errorOccurred(msg);
+            MessageBoxHelper::critical(self, "Delete Failed", msg);
+        } else {
+            QString msg = QString("Deleted %1, failed to delete %2")
+                .arg(success_count)
+                .arg(failure_count);
+            emit self->statusChanged(msg);
+            MessageBoxHelper::warning(self, "Partial Success", msg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt.refdata/src/SwapConventionController.cpp
+++ b/projects/ores.qt.refdata/src/SwapConventionController.cpp
@@ -1,0 +1,385 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/SwapConventionController.hpp"
+
+#include <QMdiSubWindow>
+#include <QMessageBox>
+#include <QPointer>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/SwapConventionMdiWindow.hpp"
+#include "ores.qt/SwapConventionDetailDialog.hpp"
+#include "ores.qt/SwapConventionHistoryDialog.hpp"
+#include "ores.qt/DetachableMdiSubWindow.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+SwapConventionController::SwapConventionController(
+    QMainWindow* mainWindow,
+    QMdiArea* mdiArea,
+    ClientManager* clientManager,
+    const QString& username,
+    QObject* parent)
+    : EntityController(mainWindow, mdiArea, clientManager, username,
+          std::string_view{}, parent),
+      listWindow_(nullptr),
+      listMdiSubWindow_(nullptr) {
+
+    BOOST_LOG_SEV(lg(), debug) << "SwapConventionController created";
+}
+
+void SwapConventionController::showListWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "showListWindow called";
+
+    const QString key = build_window_key("list", "swap_conventions");
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing list window";
+        return;
+    }
+
+    // Create new window
+    listWindow_ = new SwapConventionMdiWindow(clientManager_, username_);
+
+    // Connect signals
+    connect(listWindow_, &SwapConventionMdiWindow::statusChanged,
+            this, &SwapConventionController::statusMessage);
+    connect(listWindow_, &SwapConventionMdiWindow::errorOccurred,
+            this, &SwapConventionController::errorMessage);
+    connect(listWindow_, &SwapConventionMdiWindow::showConventionDetails,
+            this, &SwapConventionController::onShowDetails);
+    connect(listWindow_, &SwapConventionMdiWindow::addNewRequested,
+            this, &SwapConventionController::onAddNewRequested);
+    connect(listWindow_, &SwapConventionMdiWindow::showConventionHistory,
+            this, &SwapConventionController::onShowHistory);
+
+    // Create MDI subwindow
+    listMdiSubWindow_ = new DetachableMdiSubWindow(mainWindow_);
+    listMdiSubWindow_->setWidget(listWindow_);
+    listMdiSubWindow_->setWindowTitle("Swap Conventions");
+    listMdiSubWindow_->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+    listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
+    listMdiSubWindow_->resize(listWindow_->sizeHint());
+
+    mdiArea_->addSubWindow(listMdiSubWindow_);
+    listMdiSubWindow_->show();
+
+    // Track window
+    track_window(key, listMdiSubWindow_);
+    register_detachable_window(listMdiSubWindow_);
+
+    // Cleanup when closed
+    connect(listMdiSubWindow_, &QObject::destroyed, this, [self = QPointer<SwapConventionController>(this), key]() {
+        if (!self) return;
+        self->untrack_window(key);
+        self->listWindow_ = nullptr;
+        self->listMdiSubWindow_ = nullptr;
+    });
+
+    BOOST_LOG_SEV(lg(), debug) << "Swap Convention list window created";
+}
+
+void SwapConventionController::closeAllWindows() {
+    BOOST_LOG_SEV(lg(), debug) << "closeAllWindows called";
+
+    // Close all managed windows
+    QList<QString> keys = managed_windows_.keys();
+    for (const QString& key : keys) {
+        if (auto* window = managed_windows_.value(key)) {
+            window->close();
+        }
+    }
+    managed_windows_.clear();
+
+    listWindow_ = nullptr;
+    listMdiSubWindow_ = nullptr;
+}
+
+void SwapConventionController::reloadListWindow() {
+    if (listWindow_) {
+        listWindow_->reload();
+    }
+}
+
+void SwapConventionController::onShowDetails(
+    const refdata::domain::swap_convention& sc) {
+    BOOST_LOG_SEV(lg(), debug) << "Show details for: " << sc.id;
+    showDetailWindow(sc);
+}
+
+void SwapConventionController::onAddNewRequested() {
+    BOOST_LOG_SEV(lg(), info) << "Add new swap convention requested";
+    showAddWindow();
+}
+
+void SwapConventionController::onShowHistory(
+    const refdata::domain::swap_convention& sc) {
+    BOOST_LOG_SEV(lg(), debug) << "Show history requested for: " << sc.id;
+    showHistoryWindow(QString::fromStdString(sc.id));
+}
+
+void SwapConventionController::showAddWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "Creating add window for new swap convention";
+
+    auto* detailDialog = new SwapConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(true);
+
+    connect(detailDialog, &SwapConventionDetailDialog::statusMessage,
+            this, &SwapConventionController::statusMessage);
+    connect(detailDialog, &SwapConventionDetailDialog::errorMessage,
+            this, &SwapConventionController::errorMessage);
+    connect(detailDialog, &SwapConventionDetailDialog::scSaved,
+            this, [self = QPointer<SwapConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "Swap Convention saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle("New Swap Convention");
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void SwapConventionController::showDetailWindow(
+    const refdata::domain::swap_convention& sc) {
+
+    const QString identifier = QString::fromStdString(sc.id);
+    const QString key = build_window_key("details", identifier);
+
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing detail window";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Creating detail window for: " << sc.id;
+
+    auto* detailDialog = new SwapConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(false);
+    detailDialog->setConvention(sc);
+
+    connect(detailDialog, &SwapConventionDetailDialog::statusMessage,
+            this, &SwapConventionController::statusMessage);
+    connect(detailDialog, &SwapConventionDetailDialog::errorMessage,
+            this, &SwapConventionController::errorMessage);
+    connect(detailDialog, &SwapConventionDetailDialog::scSaved,
+            this, [self = QPointer<SwapConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "Swap Convention saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+    connect(detailDialog, &SwapConventionDetailDialog::scDeleted,
+            this, [self = QPointer<SwapConventionController>(this), key](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "Swap Convention deleted: " << code.toStdString();
+        self->handleEntityDeleted();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Swap Convention: %1").arg(identifier));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Chart, IconUtils::DefaultIconColor));
+
+    // Track window
+    track_window(key, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<SwapConventionController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, key]() {
+        if (self) {
+            self->untrack_window(key);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void SwapConventionController::showHistoryWindow(const QString& code) {
+    BOOST_LOG_SEV(lg(), info) << "Opening history window for swap convention: "
+                              << code.toStdString();
+
+    const QString windowKey = build_window_key("history", code);
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing history window for: "
+                                  << code.toStdString();
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Creating new history window for: "
+                              << code.toStdString();
+
+    auto* historyDialog = new SwapConventionHistoryDialog(code, clientManager_, mainWindow_);
+
+    connect(historyDialog, &SwapConventionHistoryDialog::statusChanged,
+            this, [self = QPointer<SwapConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(historyDialog, &SwapConventionHistoryDialog::errorOccurred,
+            this, [self = QPointer<SwapConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+    connect(historyDialog, &SwapConventionHistoryDialog::revertVersionRequested,
+            this, &SwapConventionController::onRevertVersion);
+    connect(historyDialog, &SwapConventionHistoryDialog::openVersionRequested,
+            this, &SwapConventionController::onOpenVersion);
+
+    // Load history data
+    historyDialog->loadHistory();
+
+    auto* historyWindow = new DetachableMdiSubWindow(mainWindow_);
+    historyWindow->setAttribute(Qt::WA_DeleteOnClose);
+    historyWindow->setWidget(historyDialog);
+    historyWindow->setWindowTitle(QString("Swap Convention History: %1").arg(code));
+    historyWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    // Track this history window
+    track_window(windowKey, historyWindow);
+    register_detachable_window(historyWindow);
+
+    QPointer<SwapConventionController> self = this;
+    connect(historyWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    show_managed_window(historyWindow, listMdiSubWindow_);
+}
+
+void SwapConventionController::onOpenVersion(
+    const refdata::domain::swap_convention& sc, int versionNumber) {
+    BOOST_LOG_SEV(lg(), info) << "Opening historical version " << versionNumber
+                              << " for swap convention: " << sc.id;
+
+    const QString code = QString::fromStdString(sc.id);
+    const QString windowKey = build_window_key("version", QString("%1_v%2")
+        .arg(code).arg(versionNumber));
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing version window";
+        return;
+    }
+
+    auto* detailDialog = new SwapConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setConvention(sc);
+    detailDialog->setReadOnly(true);
+
+    connect(detailDialog, &SwapConventionDetailDialog::statusMessage,
+            this, [self = QPointer<SwapConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(detailDialog, &SwapConventionDetailDialog::errorMessage,
+            this, [self = QPointer<SwapConventionController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Swap Convention: %1 (Version %2)")
+        .arg(code).arg(versionNumber));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    track_window(windowKey, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<SwapConventionController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_, QPoint(60, 60));
+}
+
+void SwapConventionController::onRevertVersion(
+    const refdata::domain::swap_convention& sc) {
+    BOOST_LOG_SEV(lg(), info) << "Reverting swap convention to version: "
+                              << sc.version;
+
+    // Open detail dialog with the old version data for editing
+    auto* detailDialog = new SwapConventionDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setConvention(sc);
+    detailDialog->setCreateMode(false);
+
+    connect(detailDialog, &SwapConventionDetailDialog::statusMessage,
+            this, &SwapConventionController::statusMessage);
+    connect(detailDialog, &SwapConventionDetailDialog::errorMessage,
+            this, &SwapConventionController::errorMessage);
+    connect(detailDialog, &SwapConventionDetailDialog::scSaved,
+            this, [self = QPointer<SwapConventionController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "Swap Convention reverted: " << code.toStdString();
+        emit self->statusMessage(QString("Swap Convention '%1' reverted successfully").arg(code));
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Revert Swap Convention: %1")
+        .arg(QString::fromStdString(sc.id)));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+EntityListMdiWindow* SwapConventionController::listWindow() const {
+    return listWindow_;
+}
+
+}

--- a/projects/ores.qt.refdata/src/SwapConventionDetailDialog.cpp
+++ b/projects/ores.qt.refdata/src/SwapConventionDetailDialog.cpp
@@ -1,0 +1,359 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/SwapConventionDetailDialog.hpp"
+
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_SwapConventionDetailDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.refdata.api/messaging/swap_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+SwapConventionDetailDialog::SwapConventionDetailDialog(QWidget* parent)
+    : DetailDialogBase(parent),
+      ui_(new Ui::SwapConventionDetailDialog),
+      clientManager_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupConnections();
+}
+
+SwapConventionDetailDialog::~SwapConventionDetailDialog() {
+    delete ui_;
+}
+
+QTabWidget* SwapConventionDetailDialog::tabWidget() const {
+    return ui_->tabWidget;
+}
+
+QWidget* SwapConventionDetailDialog::provenanceTab() const {
+    return ui_->provenanceTab;
+}
+
+ProvenanceWidget* SwapConventionDetailDialog::provenanceWidget() const {
+    return ui_->provenanceWidget;
+}
+
+void SwapConventionDetailDialog::setupUi() {
+    ui_->saveButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Save, IconUtils::DefaultIconColor));
+    ui_->saveButton->setEnabled(false);
+
+    ui_->deleteButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Delete, IconUtils::DefaultIconColor));
+
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+}
+
+void SwapConventionDetailDialog::setupConnections() {
+    connect(ui_->saveButton, &QPushButton::clicked, this,
+            &SwapConventionDetailDialog::onSaveClicked);
+    connect(ui_->deleteButton, &QPushButton::clicked, this,
+            &SwapConventionDetailDialog::onDeleteClicked);
+    connect(ui_->closeButton, &QPushButton::clicked, this,
+            &SwapConventionDetailDialog::onCloseClicked);
+
+    connect(ui_->idEdit, &QLineEdit::textChanged, this,
+            &SwapConventionDetailDialog::onCodeChanged);
+    connect(ui_->fixedFrequencyEdit, &QLineEdit::textChanged, this,
+            &SwapConventionDetailDialog::onFieldChanged);
+    connect(ui_->fixedDayCountFractionEdit, &QLineEdit::textChanged, this,
+            &SwapConventionDetailDialog::onFieldChanged);
+    connect(ui_->indexEdit, &QLineEdit::textChanged, this,
+            &SwapConventionDetailDialog::onFieldChanged);
+    connect(ui_->fixedCalendarEdit, &QLineEdit::textChanged, this,
+            &SwapConventionDetailDialog::onFieldChanged);
+    connect(ui_->fixedConventionEdit, &QLineEdit::textChanged, this,
+            &SwapConventionDetailDialog::onFieldChanged);
+    connect(ui_->floatFrequencyEdit, &QLineEdit::textChanged, this,
+            &SwapConventionDetailDialog::onFieldChanged);
+    connect(ui_->subPeriodsCouponTypeEdit, &QLineEdit::textChanged, this,
+            &SwapConventionDetailDialog::onFieldChanged);
+}
+
+void SwapConventionDetailDialog::setClientManager(ClientManager* clientManager) {
+    clientManager_ = clientManager;
+}
+
+void SwapConventionDetailDialog::setUsername(const std::string& username) {
+    username_ = username;
+}
+
+void SwapConventionDetailDialog::setConvention(
+    const refdata::domain::swap_convention& sc) {
+    sc_ = sc;
+    updateUiFromConvention();
+}
+
+void SwapConventionDetailDialog::setCreateMode(bool createMode) {
+    createMode_ = createMode;
+    ui_->idEdit->setReadOnly(!createMode);
+    ui_->deleteButton->setVisible(!createMode);
+    setProvenanceEnabled(!createMode);
+    hasChanges_ = false;
+    updateSaveButtonState();
+}
+
+void SwapConventionDetailDialog::setReadOnly(bool readOnly) {
+    readOnly_ = readOnly;
+    ui_->idEdit->setReadOnly(true);
+    ui_->fixedFrequencyEdit->setReadOnly(readOnly);
+    ui_->fixedDayCountFractionEdit->setReadOnly(readOnly);
+    ui_->indexEdit->setReadOnly(readOnly);
+    ui_->fixedCalendarEdit->setReadOnly(readOnly);
+    ui_->fixedConventionEdit->setReadOnly(readOnly);
+    ui_->floatFrequencyEdit->setReadOnly(readOnly);
+    ui_->subPeriodsCouponTypeEdit->setReadOnly(readOnly);
+    ui_->saveButton->setVisible(!readOnly);
+    ui_->deleteButton->setVisible(!readOnly);
+}
+
+void SwapConventionDetailDialog::updateUiFromConvention() {
+    ui_->idEdit->setText(QString::fromStdString(sc_.id));
+    ui_->fixedFrequencyEdit->setText(QString::fromStdString(sc_.fixed_frequency));
+    ui_->fixedDayCountFractionEdit->setText(QString::fromStdString(sc_.fixed_day_count_fraction));
+    ui_->indexEdit->setText(QString::fromStdString(sc_.index));
+    ui_->fixedCalendarEdit->setText(sc_.fixed_calendar
+        ? QString::fromStdString(*sc_.fixed_calendar)
+        : QString{});
+    ui_->fixedConventionEdit->setText(sc_.fixed_convention
+        ? QString::fromStdString(*sc_.fixed_convention)
+        : QString{});
+    ui_->floatFrequencyEdit->setText(sc_.float_frequency
+        ? QString::fromStdString(*sc_.float_frequency)
+        : QString{});
+    ui_->subPeriodsCouponTypeEdit->setText(sc_.sub_periods_coupon_type
+        ? QString::fromStdString(*sc_.sub_periods_coupon_type)
+        : QString{});
+
+    populateProvenance(sc_.version,
+                       sc_.modified_by,
+                       sc_.performed_by,
+                       sc_.recorded_at,
+                       sc_.change_reason_code,
+                       sc_.change_commentary);
+
+    hasChanges_ = false;
+    updateSaveButtonState();
+}
+
+void SwapConventionDetailDialog::updateConventionFromUi() {
+    if (createMode_) {
+        sc_.id = ui_->idEdit->text().trimmed().toStdString();
+    }
+    sc_.fixed_frequency = ui_->fixedFrequencyEdit->text().trimmed().toStdString();
+    sc_.fixed_day_count_fraction = ui_->fixedDayCountFractionEdit->text().trimmed().toStdString();
+    sc_.index = ui_->indexEdit->text().trimmed().toStdString();
+    {
+        const auto fixed_calendar_str = ui_->fixedCalendarEdit->text().trimmed().toStdString();
+        sc_.fixed_calendar =
+            fixed_calendar_str.empty() ? std::nullopt : std::optional<std::string>(fixed_calendar_str);
+    }
+    {
+        const auto fixed_convention_str = ui_->fixedConventionEdit->text().trimmed().toStdString();
+        sc_.fixed_convention =
+            fixed_convention_str.empty() ? std::nullopt : std::optional<std::string>(fixed_convention_str);
+    }
+    {
+        const auto float_frequency_str = ui_->floatFrequencyEdit->text().trimmed().toStdString();
+        sc_.float_frequency =
+            float_frequency_str.empty() ? std::nullopt : std::optional<std::string>(float_frequency_str);
+    }
+    {
+        const auto sub_periods_coupon_type_str = ui_->subPeriodsCouponTypeEdit->text().trimmed().toStdString();
+        sc_.sub_periods_coupon_type =
+            sub_periods_coupon_type_str.empty() ? std::nullopt : std::optional<std::string>(sub_periods_coupon_type_str);
+    }
+    sc_.modified_by = username_;
+}
+
+void SwapConventionDetailDialog::onCodeChanged(const QString& /* text */) {
+    hasChanges_ = true;
+    updateSaveButtonState();
+}
+
+void SwapConventionDetailDialog::onFieldChanged() {
+    hasChanges_ = true;
+    updateSaveButtonState();
+}
+
+void SwapConventionDetailDialog::updateSaveButtonState() {
+    bool canSave = hasChanges_ && validateInput() && !readOnly_;
+    ui_->saveButton->setEnabled(canSave);
+}
+
+bool SwapConventionDetailDialog::validateInput() {
+    const QString id_val = ui_->idEdit->text().trimmed();
+    const QString fixed_frequency_val = ui_->fixedFrequencyEdit->text().trimmed();
+    const QString fixed_day_count_fraction_val = ui_->fixedDayCountFractionEdit->text().trimmed();
+    const QString index_val = ui_->indexEdit->text().trimmed();
+
+    return true
+        && !id_val.isEmpty()
+        && !fixed_frequency_val.isEmpty()
+        && !fixed_day_count_fraction_val.isEmpty()
+        && !index_val.isEmpty()
+    ;
+}
+
+void SwapConventionDetailDialog::onSaveClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot save swap convention while disconnected from server.");
+        return;
+    }
+
+    if (!validateInput()) {
+        MessageBoxHelper::warning(this, "Invalid Input",
+            "Please fill in all required fields.");
+        return;
+    }
+
+    updateConventionFromUi();
+
+    BOOST_LOG_SEV(lg(), info) << "Saving swap convention: "
+        << sc_.id;
+
+    QPointer<SwapConventionDetailDialog> self = this;
+
+    struct SaveResult {
+        bool success;
+        std::string message;
+    };
+
+    auto task = [self, sc = sc_]() -> SaveResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed"};
+        }
+
+        refdata::messaging::save_swap_convention_request request;
+        request.data = sc;
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server"};
+        }
+
+        return {response_result->success, response_result->message};
+    };
+
+    auto* watcher = new QFutureWatcher<SaveResult>(self);
+    connect(watcher, &QFutureWatcher<SaveResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "Swap Convention saved successfully";
+            QString code = QString::fromStdString(
+                self->sc_.id);
+            self->hasChanges_ = false;
+            self->updateSaveButtonState();
+            emit self->scSaved(code);
+            self->notifySaveSuccess(tr("Swap Convention '%1' saved").arg(code));
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Save failed: " << result.message;
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Save Failed", errorMsg);
+        }
+    });
+
+    QFuture<SaveResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+void SwapConventionDetailDialog::onDeleteClicked() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete swap convention while disconnected from server.");
+        return;
+    }
+
+    QString code = QString::fromStdString(
+        sc_.id);
+    auto reply = MessageBoxHelper::question(this, "Delete Swap Convention",
+        QString("Are you sure you want to delete swap convention '%1'?").arg(code),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Deleting swap convention: "
+        << sc_.id;
+
+    QPointer<SwapConventionDetailDialog> self = this;
+
+    struct DeleteResult {
+        bool success;
+        std::string message;
+    };
+
+    auto task = [self, code = sc_.id]() -> DeleteResult {
+        if (!self || !self->clientManager_) {
+            return {false, "Dialog closed"};
+        }
+
+        refdata::messaging::delete_swap_convention_request request;
+        request.codes = {code};
+        auto response_result = self->clientManager_->
+            process_authenticated_request(std::move(request));
+
+        if (!response_result) {
+            return {false, "Failed to communicate with server"};
+        }
+
+        return {response_result->success, response_result->message};
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, code, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (result.success) {
+            BOOST_LOG_SEV(lg(), info) << "Swap Convention deleted successfully";
+            emit self->statusMessage(
+                QString("Swap Convention '%1' deleted").arg(code));
+            emit self->scDeleted(code);
+            self->requestClose();
+        } else {
+            BOOST_LOG_SEV(lg(), error) << "Delete failed: " << result.message;
+            QString errorMsg = QString::fromStdString(result.message);
+            emit self->errorMessage(errorMsg);
+            MessageBoxHelper::critical(self, "Delete Failed", errorMsg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt.refdata/src/SwapConventionHistoryDialog.cpp
+++ b/projects/ores.qt.refdata/src/SwapConventionHistoryDialog.cpp
@@ -1,0 +1,359 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/SwapConventionHistoryDialog.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_SwapConventionHistoryDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.refdata.api/messaging/swap_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+SwapConventionHistoryDialog::SwapConventionHistoryDialog(
+    const QString& code,
+    ClientManager* clientManager,
+    QWidget* parent)
+    : QWidget(parent),
+      ui_(new Ui::SwapConventionHistoryDialog),
+      code_(code),
+      clientManager_(clientManager),
+      toolbar_(nullptr),
+      openVersionAction_(nullptr),
+      revertAction_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupToolbar();
+    setupConnections();
+}
+
+SwapConventionHistoryDialog::~SwapConventionHistoryDialog() {
+    delete ui_;
+}
+
+void SwapConventionHistoryDialog::setupUi() {
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+
+    ui_->titleLabel->setText(QString("History for: %1").arg(code_));
+
+    // Setup version list table
+    ui_->versionListWidget->setColumnCount(5);
+    ui_->versionListWidget->setHorizontalHeaderLabels(
+        {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
+    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
+    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    // Setup changes table
+    ui_->changesTableWidget->setColumnCount(3);
+    ui_->changesTableWidget->setHorizontalHeaderLabels(
+        {"Field", "Old Value", "New Value"});
+    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+}
+
+void SwapConventionHistoryDialog::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    openVersionAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor),
+        tr("Open"));
+    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
+    openVersionAction_->setEnabled(false);
+
+    revertAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor),
+        tr("Revert"));
+    revertAction_->setToolTip(tr("Revert to this version"));
+    revertAction_->setEnabled(false);
+
+    // Insert toolbar at the top of the layout
+    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
+    if (layout) {
+        layout->insertWidget(0, toolbar_);
+    }
+}
+
+void SwapConventionHistoryDialog::setupConnections() {
+    connect(ui_->versionListWidget, &QTableWidget::itemSelectionChanged,
+            this, &SwapConventionHistoryDialog::onVersionSelected);
+    connect(openVersionAction_, &QAction::triggered,
+            this, &SwapConventionHistoryDialog::onOpenVersionClicked);
+    connect(revertAction_, &QAction::triggered,
+            this, &SwapConventionHistoryDialog::onRevertClicked);
+    connect(ui_->closeButton, &QPushButton::clicked,
+            this, [this]() { if (window()) window()->close(); });
+}
+
+void SwapConventionHistoryDialog::loadHistory() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        emit errorOccurred("Not connected to server");
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for swap convention: " << code_.toStdString();
+    emit statusChanged(tr("Loading history..."));
+
+    QPointer<SwapConventionHistoryDialog> self = this;
+
+    using HistoryResult = std::expected<refdata::messaging::get_swap_convention_history_response, std::string>;
+
+    QFuture<HistoryResult> future =
+        QtConcurrent::run([self, code = code_.toStdString()]() -> HistoryResult {
+        if (!self || !self->clientManager_)
+            return std::unexpected("Dialog closed");
+        refdata::messaging::get_swap_convention_history_request request;
+        request.id = code;
+        auto result = self->clientManager_->process_authenticated_request(std::move(request));
+        if (!result) return std::unexpected(result.error());
+        return std::move(*result);
+    });
+
+    auto* watcher = new QFutureWatcher<HistoryResult>(self);
+    connect(watcher, &QFutureWatcher<HistoryResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (!result) {
+            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
+            emit self->errorOccurred(QString::fromStdString(result.error()));
+            return;
+        }
+        if (!result->success) {
+            emit self->errorOccurred(QString::fromStdString(result->message));
+            return;
+        }
+        self->versions_ = std::move(result->swap_conventions);
+        self->updateVersionList();
+        emit self->statusChanged(
+            QString("Loaded %1 versions").arg(self->versions_.size()));
+    });
+    watcher->setFuture(future);
+}
+
+void SwapConventionHistoryDialog::updateVersionList() {
+    ui_->versionListWidget->setRowCount(0);
+
+    for (const auto& version : versions_) {
+        int row = ui_->versionListWidget->rowCount();
+        ui_->versionListWidget->insertRow(row);
+
+        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
+        versionItem->setTextAlignment(Qt::AlignCenter);
+        ui_->versionListWidget->setItem(row, 0, versionItem);
+
+        auto* recordedAtItem = new QTableWidgetItem(
+            relative_time_helper::format(version.recorded_at));
+        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
+
+        auto* modifiedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.modified_by));
+        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
+
+        auto* performedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.performed_by));
+        ui_->versionListWidget->setItem(row, 3, performedByItem);
+
+        auto* commentaryItem = new QTableWidgetItem(
+            QString::fromStdString(version.change_commentary));
+        ui_->versionListWidget->setItem(row, 4, commentaryItem);
+    }
+
+    // Select the first (most recent) version
+    if (!versions_.empty()) {
+        ui_->versionListWidget->selectRow(0);
+    }
+}
+
+void SwapConventionHistoryDialog::onVersionSelected() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) {
+        updateActionStates();
+        return;
+    }
+
+    int row = selected.first()->row();
+    updateChangesTable(row);
+    updateFullDetails(row);
+    updateActionStates();
+}
+
+void SwapConventionHistoryDialog::updateChangesTable(int currentVersionIndex) {
+    ui_->changesTableWidget->setRowCount(0);
+
+    if (currentVersionIndex < 0 ||
+        static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
+        return;
+    }
+
+    // Get the next older version to compare against
+    int previousVersionIndex = currentVersionIndex + 1;
+    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
+        // This is the first version, no changes to show
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(Initial version)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+        return;
+    }
+
+    const auto& current = versions_[currentVersionIndex];
+    const auto& previous = versions_[previousVersionIndex];
+
+    auto addChange = [this](const QString& field,
+                            const QString& oldVal, const QString& newVal) {
+        int row = ui_->changesTableWidget->rowCount();
+        ui_->changesTableWidget->insertRow(row);
+        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
+        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
+        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
+    };
+
+    if (current.id != previous.id) {
+        addChange("Id",
+                  QString::fromStdString(previous.id),
+                  QString::fromStdString(current.id));
+    }
+
+    if (current.fixed_frequency != previous.fixed_frequency) {
+        addChange("Fixed Frequency",
+                  QString::fromStdString(previous.fixed_frequency),
+                  QString::fromStdString(current.fixed_frequency));
+    }
+
+    if (current.fixed_day_count_fraction != previous.fixed_day_count_fraction) {
+        addChange("Fixed Day Count Fraction",
+                  QString::fromStdString(previous.fixed_day_count_fraction),
+                  QString::fromStdString(current.fixed_day_count_fraction));
+    }
+
+    if (current.index != previous.index) {
+        addChange("Index",
+                  QString::fromStdString(previous.index),
+                  QString::fromStdString(current.index));
+    }
+
+    if (current.fixed_calendar != previous.fixed_calendar) {
+        addChange("Fixed Calendar",
+                  previous.fixed_calendar ? QString::fromStdString(*previous.fixed_calendar) : QString{},
+                  current.fixed_calendar ? QString::fromStdString(*current.fixed_calendar) : QString{});
+    }
+
+    if (current.fixed_convention != previous.fixed_convention) {
+        addChange("Fixed Convention",
+                  previous.fixed_convention ? QString::fromStdString(*previous.fixed_convention) : QString{},
+                  current.fixed_convention ? QString::fromStdString(*current.fixed_convention) : QString{});
+    }
+
+    if (current.float_frequency != previous.float_frequency) {
+        addChange("Float Frequency",
+                  previous.float_frequency ? QString::fromStdString(*previous.float_frequency) : QString{},
+                  current.float_frequency ? QString::fromStdString(*current.float_frequency) : QString{});
+    }
+
+    if (current.sub_periods_coupon_type != previous.sub_periods_coupon_type) {
+        addChange("Sub-Periods Coupon Type",
+                  previous.sub_periods_coupon_type ? QString::fromStdString(*previous.sub_periods_coupon_type) : QString{},
+                  current.sub_periods_coupon_type ? QString::fromStdString(*current.sub_periods_coupon_type) : QString{});
+    }
+
+
+    if (ui_->changesTableWidget->rowCount() == 0) {
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(No field changes)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+    }
+}
+
+void SwapConventionHistoryDialog::updateFullDetails(int versionIndex) {
+    if (versionIndex < 0 ||
+        static_cast<size_t>(versionIndex) >= versions_.size()) {
+        return;
+    }
+
+    const auto& version = versions_[versionIndex];
+
+    ui_->idValue->setText(QString::fromStdString(version.id));
+    ui_->fixedFrequencyValue->setText(QString::fromStdString(version.fixed_frequency));
+    ui_->fixedDayCountFractionValue->setText(QString::fromStdString(version.fixed_day_count_fraction));
+    ui_->indexValue->setText(QString::fromStdString(version.index));
+    ui_->fixedCalendarValue->setText(version.fixed_calendar
+        ? QString::fromStdString(*version.fixed_calendar)
+        : QString{});
+    ui_->fixedConventionValue->setText(version.fixed_convention
+        ? QString::fromStdString(*version.fixed_convention)
+        : QString{});
+    ui_->floatFrequencyValue->setText(version.float_frequency
+        ? QString::fromStdString(*version.float_frequency)
+        : QString{});
+    ui_->subPeriodsCouponTypeValue->setText(version.sub_periods_coupon_type
+        ? QString::fromStdString(*version.sub_periods_coupon_type)
+        : QString{});
+    ui_->versionNumberValue->setText(QString::number(version.version));
+    ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
+}
+
+void SwapConventionHistoryDialog::updateActionStates() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    bool hasSelection = !selected.isEmpty();
+    bool isNotLatest = hasSelection && selected.first()->row() > 0;
+
+    openVersionAction_->setEnabled(hasSelection);
+    revertAction_->setEnabled(isNotLatest);
+}
+
+void SwapConventionHistoryDialog::onOpenVersionClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit openVersionRequested(versions_[row], versions_[row].version);
+}
+
+void SwapConventionHistoryDialog::onRevertClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit revertVersionRequested(versions_[row]);
+}
+
+}

--- a/projects/ores.qt.refdata/src/SwapConventionMdiWindow.cpp
+++ b/projects/ores.qt.refdata/src/SwapConventionMdiWindow.cpp
@@ -1,0 +1,386 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/SwapConventionMdiWindow.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QMessageBox>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/MessageBoxHelper.hpp"
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.refdata.api/messaging/swap_convention_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+SwapConventionMdiWindow::SwapConventionMdiWindow(
+    ClientManager* clientManager,
+    const QString& username,
+    QWidget* parent)
+    : EntityListMdiWindow(parent),
+      clientManager_(clientManager),
+      username_(username),
+      toolbar_(nullptr),
+      tableView_(nullptr),
+      model_(nullptr),
+      proxyModel_(nullptr),
+      paginationWidget_(nullptr),
+      reloadAction_(nullptr),
+      addAction_(nullptr),
+      editAction_(nullptr),
+      deleteAction_(nullptr),
+      historyAction_(nullptr) {
+
+    setupUi();
+    setupConnections();
+    reload();
+}
+
+void SwapConventionMdiWindow::setupUi() {
+    auto* layout = new QVBoxLayout(this);
+
+    setupToolbar();
+    layout->addWidget(toolbar_);
+    layout->addWidget(loadingBar());
+
+    setupTable();
+    layout->addWidget(tableView_);
+
+    paginationWidget_ = new PaginationWidget(this);
+    layout->addWidget(paginationWidget_);
+}
+
+void SwapConventionMdiWindow::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    reloadAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowClockwise, IconUtils::DefaultIconColor),
+        tr("Reload"));
+    connect(reloadAction_, &QAction::triggered, this,
+            &EntityListMdiWindow::reload);
+
+    initializeStaleIndicator(reloadAction_, IconUtils::iconPath(Icon::ArrowClockwise));
+
+    toolbar_->addSeparator();
+
+    addAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Add, IconUtils::DefaultIconColor),
+        tr("Add"));
+    addAction_->setToolTip(tr("Add new swap convention"));
+    connect(addAction_, &QAction::triggered, this,
+            &SwapConventionMdiWindow::addNew);
+
+    editAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Edit, IconUtils::DefaultIconColor),
+        tr("Edit"));
+    editAction_->setToolTip(tr("Edit selected swap convention"));
+    editAction_->setEnabled(false);
+    connect(editAction_, &QAction::triggered, this,
+            &SwapConventionMdiWindow::editSelected);
+
+    deleteAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::Delete, IconUtils::DefaultIconColor),
+        tr("Delete"));
+    deleteAction_->setToolTip(tr("Delete selected swap convention"));
+    deleteAction_->setEnabled(false);
+    connect(deleteAction_, &QAction::triggered, this,
+            &SwapConventionMdiWindow::deleteSelected);
+
+    historyAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::History, IconUtils::DefaultIconColor),
+        tr("History"));
+    historyAction_->setToolTip(tr("View swap convention history"));
+    historyAction_->setEnabled(false);
+    connect(historyAction_, &QAction::triggered, this,
+            &SwapConventionMdiWindow::viewHistorySelected);
+}
+
+void SwapConventionMdiWindow::setupTable() {
+    model_ = new ClientSwapConventionModel(clientManager_, this);
+    proxyModel_ = new QSortFilterProxyModel(this);
+    proxyModel_->setSourceModel(model_);
+    proxyModel_->setSortCaseSensitivity(Qt::CaseInsensitive);
+
+    tableView_ = new QTableView(this);
+    tableView_->setModel(proxyModel_);
+    tableView_->setSelectionBehavior(QAbstractItemView::SelectRows);
+    tableView_->setSelectionMode(QAbstractItemView::SingleSelection);
+    tableView_->setSortingEnabled(true);
+    tableView_->setAlternatingRowColors(true);
+    tableView_->verticalHeader()->setVisible(false);
+
+    initializeTableSettings(tableView_, model_,
+        "SwapConventionListWindow",
+        {},
+        {900, 400}, 1);
+}
+
+void SwapConventionMdiWindow::setupConnections() {
+    connect(model_, &ClientSwapConventionModel::dataLoaded,
+            this, &SwapConventionMdiWindow::onDataLoaded);
+    connect(model_, &ClientSwapConventionModel::loadError,
+            this, &SwapConventionMdiWindow::onLoadError);
+
+    connect(tableView_->selectionModel(), &QItemSelectionModel::selectionChanged,
+            this, &SwapConventionMdiWindow::onSelectionChanged);
+    connect(tableView_, &QTableView::doubleClicked,
+            this, &SwapConventionMdiWindow::onDoubleClicked);
+
+    connect(paginationWidget_, &PaginationWidget::page_size_changed,
+            this, [this](std::uint32_t size) {
+        model_->set_page_size(size);
+        model_->refresh();
+    });
+
+    connect(paginationWidget_, &PaginationWidget::load_all_requested,
+            this, [this]() {
+        const auto total = model_->total_available_count();
+        if (total > 0 && total <= 1000) {
+            model_->set_page_size(total);
+            model_->refresh();
+        }
+    });
+
+    connect(paginationWidget_, &PaginationWidget::page_requested,
+            this, [this](std::uint32_t offset, std::uint32_t limit) {
+        model_->load_page(offset, limit);
+    });
+
+    connectModel(model_);
+}
+
+void SwapConventionMdiWindow::doReload() {
+    BOOST_LOG_SEV(lg(), debug) << "Reloading swap conventions";
+    clearStaleIndicator();
+    emit statusChanged(tr("Loading swap conventions..."));
+    model_->refresh();
+}
+
+void SwapConventionMdiWindow::onDataLoaded() {
+    const auto loaded = model_->rowCount();
+    const auto total = model_->total_available_count();
+    emit statusChanged(tr("Loaded %1 of %2 swap conventions").arg(loaded).arg(total));
+
+    paginationWidget_->update_state(loaded, total);
+    paginationWidget_->set_load_all_enabled(
+        loaded < static_cast<int>(total) && total > 0 && total <= 1000);
+}
+
+void SwapConventionMdiWindow::onLoadError(const QString& error_message,
+                                          const QString& details) {
+    BOOST_LOG_SEV(lg(), error) << "Load error: " << error_message.toStdString();
+    emit errorOccurred(error_message);
+    MessageBoxHelper::critical(this, tr("Load Error"), error_message, details);
+}
+
+void SwapConventionMdiWindow::onSelectionChanged() {
+    updateActionStates();
+}
+
+void SwapConventionMdiWindow::onDoubleClicked(const QModelIndex& index) {
+    if (!index.isValid())
+        return;
+
+    auto sourceIndex = proxyModel_->mapToSource(index);
+    if (auto* sc = model_->getConvention(sourceIndex.row())) {
+        emit showConventionDetails(*sc);
+    }
+}
+
+void SwapConventionMdiWindow::updateActionStates() {
+    const bool hasSelection = tableView_->selectionModel()->hasSelection();
+    editAction_->setEnabled(hasSelection);
+    deleteAction_->setEnabled(hasSelection);
+    historyAction_->setEnabled(hasSelection);
+}
+
+void SwapConventionMdiWindow::addNew() {
+    BOOST_LOG_SEV(lg(), debug) << "Add new swap convention requested";
+    emit addNewRequested();
+}
+
+void SwapConventionMdiWindow::editSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Edit requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* sc = model_->getConvention(sourceIndex.row())) {
+        emit showConventionDetails(*sc);
+    }
+}
+
+void SwapConventionMdiWindow::viewHistorySelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "View history requested but no row selected";
+        return;
+    }
+
+    auto sourceIndex = proxyModel_->mapToSource(selected.first());
+    if (auto* sc = model_->getConvention(sourceIndex.row())) {
+        BOOST_LOG_SEV(lg(), debug) << "Emitting showConventionHistory for code: "
+                                   << sc->id;
+        emit showConventionHistory(*sc);
+    }
+}
+
+void SwapConventionMdiWindow::deleteSelected() {
+    const auto selected = tableView_->selectionModel()->selectedRows();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Delete requested but no row selected";
+        return;
+    }
+
+    if (!clientManager_->isConnected()) {
+        MessageBoxHelper::warning(this, "Disconnected",
+            "Cannot delete swap convention while disconnected.");
+        return;
+    }
+
+    std::vector<std::string> codes;
+    for (const auto& index : selected) {
+        auto sourceIndex = proxyModel_->mapToSource(index);
+        if (auto* sc = model_->getConvention(sourceIndex.row())) {
+            codes.push_back(sc->id);
+        }
+    }
+
+    if (codes.empty()) {
+        BOOST_LOG_SEV(lg(), warn) << "No valid swap conventions to delete";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Delete requested for " << codes.size()
+                               << " swap conventions";
+
+    QString confirmMessage;
+    if (codes.size() == 1) {
+        confirmMessage = QString("Are you sure you want to delete swap convention '%1'?")
+            .arg(QString::fromStdString(codes.front()));
+    } else {
+        confirmMessage = QString("Are you sure you want to delete %1 swap conventions?")
+            .arg(codes.size());
+    }
+
+    auto reply = MessageBoxHelper::question(this, "Delete Swap Convention",
+        confirmMessage, QMessageBox::Yes | QMessageBox::No);
+
+    if (reply != QMessageBox::Yes) {
+        BOOST_LOG_SEV(lg(), debug) << "Delete cancelled by user";
+        return;
+    }
+
+    QPointer<SwapConventionMdiWindow> self = this;
+    using DeleteResult = std::vector<std::pair<std::string, std::pair<bool, std::string>>>;
+
+    auto task = [self, codes]() -> DeleteResult {
+        DeleteResult results;
+        if (!self) return {};
+
+        BOOST_LOG_SEV(lg(), debug) << "Making batch delete request for "
+                                   << codes.size() << " swap conventions";
+
+        refdata::messaging::delete_swap_convention_request request;
+        request.codes = codes;
+        auto response_result = self->clientManager_->process_authenticated_request(
+            std::move(request));
+
+        if (!response_result) {
+            BOOST_LOG_SEV(lg(), error) << "Failed to send batch delete request";
+            for (const auto& code : codes) {
+                results.push_back({code, {false, "Failed to communicate with server"}});
+            }
+            return results;
+        }
+
+        for (const auto& code : codes) {
+            results.push_back({code, {response_result->success, response_result->message}});
+        }
+
+        return results;
+    };
+
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, watcher]() {
+        auto results = watcher->result();
+        watcher->deleteLater();
+
+        int success_count = 0;
+        int failure_count = 0;
+        QString first_error;
+
+        for (const auto& [code, result] : results) {
+            if (result.first) {
+                BOOST_LOG_SEV(lg(), debug) << "Swap Convention deleted: " << code;
+                success_count++;
+                emit self->scDeleted(QString::fromStdString(code));
+            } else {
+                BOOST_LOG_SEV(lg(), error) << "Swap Convention deletion failed: "
+                                           << code << " - " << result.second;
+                failure_count++;
+                if (first_error.isEmpty()) {
+                    first_error = QString::fromStdString(result.second);
+                }
+            }
+        }
+
+        self->model_->refresh();
+
+        if (failure_count == 0) {
+            QString msg = success_count == 1
+                ? "Successfully deleted 1 swap convention"
+                : QString("Successfully deleted %1 swap conventions").arg(success_count);
+            emit self->statusChanged(msg);
+        } else if (success_count == 0) {
+            QString msg = QString("Failed to delete %1 %2: %3")
+                .arg(failure_count)
+                .arg(failure_count == 1 ? "swap convention" : "swap conventions")
+                .arg(first_error);
+            emit self->errorOccurred(msg);
+            MessageBoxHelper::critical(self, "Delete Failed", msg);
+        } else {
+            QString msg = QString("Deleted %1, failed to delete %2")
+                .arg(success_count)
+                .arg(failure_count);
+            emit self->statusChanged(msg);
+            MessageBoxHelper::warning(self, "Partial Success", msg);
+        }
+    });
+
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
+}
+
+}

--- a/projects/ores.qt.refdata/ui/CdsConventionDetailDialog.ui
+++ b/projects/ores.qt.refdata/ui/CdsConventionDetailDialog.ui
@@ -1,0 +1,284 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CdsConventionDetailDialog</class>
+ <widget class="QWidget" name="CdsConventionDetailDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>500</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>600</width>
+    <height>500</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>CDS Convention Details</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex"><number>0</number></property>
+     <widget class="QWidget" name="generalTab">
+      <attribute name="title"><string>General</string></attribute>
+      <layout class="QVBoxLayout" name="generalLayout">
+       <item>
+        <widget class="QGroupBox" name="basicInfoGroup">
+         <property name="title">
+          <string>Basic Information</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelId">
+            <property name="text">
+             <string>Id:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="idEdit">
+            <property name="placeholderText">
+             <string>Enter convention id</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelCalendar">
+            <property name="text">
+             <string>Calendar:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="calendarEdit">
+            <property name="placeholderText">
+             <string>e.g. WeekendsOnly</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelFrequency">
+            <property name="text">
+             <string>Frequency:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="frequencyEdit">
+            <property name="placeholderText">
+             <string>e.g. Quarterly</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelPaymentConvention">
+            <property name="text">
+             <string>Payment Convention:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="paymentConventionEdit">
+            <property name="placeholderText">
+             <string>e.g. Following</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelRule">
+            <property name="text">
+             <string>Rule:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="ruleEdit">
+            <property name="placeholderText">
+             <string>e.g. CDS2015</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="labelDayCountFraction">
+            <property name="text">
+             <string>Day Count Fraction:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLineEdit" name="dayCountFractionEdit">
+            <property name="placeholderText">
+             <string>e.g. ACT/360</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="labelSettlementDays">
+            <property name="text">
+             <string>Settlement Days:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QSpinBox" name="settlementDaysEdit">
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>10</number>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="labelUpfrontSettlementDays">
+            <property name="text">
+             <string>Upfront Settlement Days:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QSpinBox" name="upfrontSettlementDaysEdit">
+            <property name="minimum">
+             <number>-1</number>
+            </property>
+            <property name="maximum">
+             <number>10</number>
+            </property>
+            <property name="specialValueText">
+             <string>(unset)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="labelLastPeriodDayCountFraction">
+            <property name="text">
+             <string>Last Period DCF:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="QLineEdit" name="lastPeriodDayCountFractionEdit">
+            <property name="placeholderText">
+             <string>e.g. ACT/360</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
+           <widget class="QLabel" name="labelSettlesAccrual">
+            <property name="text">
+             <string>Settles Accrual:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1">
+           <widget class="QCheckBox" name="settlesAccrualEdit">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="0">
+           <widget class="QLabel" name="labelPaysAtDefaultTime">
+            <property name="text">
+             <string>Pays At Default Time:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="1">
+           <widget class="QCheckBox" name="paysAtDefaultTimeEdit">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="provenanceTab">
+      <attribute name="title"><string>Provenance</string></attribute>
+      <layout class="QVBoxLayout" name="provenanceTabLayout">
+       <item>
+        <widget class="ores::qt::ProvenanceWidget" name="provenanceWidget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="deleteButton">
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveButton">
+       <property name="text">
+        <string>Save</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ores::qt::ProvenanceWidget</class>
+   <extends>QWidget</extends>
+   <header>ores.qt/ProvenanceWidget.hpp</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt.refdata/ui/CdsConventionHistoryDialog.ui
+++ b/projects/ores.qt.refdata/ui/CdsConventionHistoryDialog.ui
@@ -1,0 +1,402 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CdsConventionHistoryDialog</class>
+ <widget class="QWidget" name="CdsConventionHistoryDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>900</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>CDS Convention History</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>CDS Convention History</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QTableWidget" name="versionListWidget">
+      <property name="minimumHeight">
+       <number>150</number>
+      </property>
+      <property name="maximumHeight">
+       <number>250</number>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="editTriggers">
+       <set>QAbstractItemView::NoEditTriggers</set>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+      <column>
+       <property name="text">
+        <string>Version</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Recorded At</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Modified By</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Commentary</string>
+       </property>
+      </column>
+     </widget>
+     <widget class="QWidget" name="detailWidget">
+      <layout class="QVBoxLayout" name="detailLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTabWidget" name="tabWidget">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="changesTab">
+          <attribute name="title">
+           <string>Changes</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="changesTabLayout">
+           <item>
+            <widget class="QTableWidget" name="changesTableWidget">
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="alternatingRowColors">
+              <bool>true</bool>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::SingleSelection</enum>
+             </property>
+             <property name="selectionBehavior">
+              <enum>QAbstractItemView::SelectRows</enum>
+             </property>
+             <column>
+              <property name="text">
+               <string>Field</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Old Value</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>New Value</string>
+              </property>
+             </column>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="fullDetailsTab">
+          <attribute name="title">
+           <string>Full Details</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="fullDetailsTabLayout">
+           <item>
+            <widget class="QScrollArea" name="scrollArea">
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>560</width>
+                <height>450</height>
+               </rect>
+              </property>
+              <layout class="QFormLayout" name="formLayout">
+               <item row="0" column="0">
+                <widget class="QLabel" name="idLabel">
+                 <property name="text">
+                  <string>Id:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="idValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="calendarLabel">
+                 <property name="text">
+                  <string>Calendar:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="calendarValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="frequencyLabel">
+                 <property name="text">
+                  <string>Frequency:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLabel" name="frequencyValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="payment_conventionLabel">
+                 <property name="text">
+                  <string>Payment Convention:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="paymentConventionValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="ruleLabel">
+                 <property name="text">
+                  <string>Rule:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLabel" name="ruleValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="day_count_fractionLabel">
+                 <property name="text">
+                  <string>Day Count Fraction:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QLabel" name="dayCountFractionValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="settlement_daysLabel">
+                 <property name="text">
+                  <string>Settlement Days:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QLabel" name="settlementDaysValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="upfront_settlement_daysLabel">
+                 <property name="text">
+                  <string>Upfront Settlement Days:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QLabel" name="upfrontSettlementDaysValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="0">
+                <widget class="QLabel" name="last_period_day_count_fractionLabel">
+                 <property name="text">
+                  <string>Last Period DCF:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QLabel" name="lastPeriodDayCountFractionValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0">
+                <widget class="QLabel" name="settles_accrualLabel">
+                 <property name="text">
+                  <string>Settles Accrual:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QLabel" name="settlesAccrualValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="0">
+                <widget class="QLabel" name="pays_at_default_timeLabel">
+                 <property name="text">
+                  <string>Pays At Default Time:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="1">
+                <widget class="QLabel" name="paysAtDefaultTimeValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="0">
+                <widget class="QLabel" name="versionNumberLabel">
+                 <property name="text">
+                  <string>Version:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="1">
+                <widget class="QLabel" name="versionNumberValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="0">
+                <widget class="QLabel" name="modifiedByLabel">
+                 <property name="text">
+                  <string>Modified By:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="1">
+                <widget class="QLabel" name="modifiedByValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="0">
+                <widget class="QLabel" name="recordedAtLabel">
+                 <property name="text">
+                  <string>Recorded At:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="1">
+                <widget class="QLabel" name="recordedAtValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="0">
+                <widget class="QLabel" name="changeCommentaryLabel">
+                 <property name="text">
+                  <string>Change Commentary:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="1">
+                <widget class="QLabel" name="changeCommentaryValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size><width>40</width><height>20</height></size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt.refdata/ui/FraConventionDetailDialog.ui
+++ b/projects/ores.qt.refdata/ui/FraConventionDetailDialog.ui
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FraConventionDetailDialog</class>
+ <widget class="QWidget" name="FraConventionDetailDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>500</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>600</width>
+    <height>500</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>FRA Convention Details</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex"><number>0</number></property>
+     <widget class="QWidget" name="generalTab">
+      <attribute name="title"><string>General</string></attribute>
+      <layout class="QVBoxLayout" name="generalLayout">
+       <item>
+        <widget class="QGroupBox" name="basicInfoGroup">
+         <property name="title">
+          <string>Basic Information</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelId">
+            <property name="text">
+             <string>Id:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="idEdit">
+            <property name="placeholderText">
+             <string>Enter convention id</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelIndex">
+            <property name="text">
+             <string>Index:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="indexEdit">
+            <property name="placeholderText">
+             <string>e.g. EUR-EURIBOR-6M</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="provenanceTab">
+      <attribute name="title"><string>Provenance</string></attribute>
+      <layout class="QVBoxLayout" name="provenanceTabLayout">
+       <item>
+        <widget class="ores::qt::ProvenanceWidget" name="provenanceWidget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="deleteButton">
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveButton">
+       <property name="text">
+        <string>Save</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ores::qt::ProvenanceWidget</class>
+   <extends>QWidget</extends>
+   <header>ores.qt/ProvenanceWidget.hpp</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt.refdata/ui/FraConventionHistoryDialog.ui
+++ b/projects/ores.qt.refdata/ui/FraConventionHistoryDialog.ui
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FraConventionHistoryDialog</class>
+ <widget class="QWidget" name="FraConventionHistoryDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>900</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>FRA Convention History</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>FRA Convention History</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QTableWidget" name="versionListWidget">
+      <property name="minimumHeight">
+       <number>150</number>
+      </property>
+      <property name="maximumHeight">
+       <number>250</number>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="editTriggers">
+       <set>QAbstractItemView::NoEditTriggers</set>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+      <column>
+       <property name="text">
+        <string>Version</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Recorded At</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Modified By</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Commentary</string>
+       </property>
+      </column>
+     </widget>
+     <widget class="QWidget" name="detailWidget">
+      <layout class="QVBoxLayout" name="detailLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTabWidget" name="tabWidget">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="changesTab">
+          <attribute name="title">
+           <string>Changes</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="changesTabLayout">
+           <item>
+            <widget class="QTableWidget" name="changesTableWidget">
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="alternatingRowColors">
+              <bool>true</bool>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::SingleSelection</enum>
+             </property>
+             <property name="selectionBehavior">
+              <enum>QAbstractItemView::SelectRows</enum>
+             </property>
+             <column>
+              <property name="text">
+               <string>Field</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Old Value</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>New Value</string>
+              </property>
+             </column>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="fullDetailsTab">
+          <attribute name="title">
+           <string>Full Details</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="fullDetailsTabLayout">
+           <item>
+            <widget class="QScrollArea" name="scrollArea">
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>560</width>
+                <height>450</height>
+               </rect>
+              </property>
+              <layout class="QFormLayout" name="formLayout">
+               <item row="0" column="0">
+                <widget class="QLabel" name="idLabel">
+                 <property name="text">
+                  <string>Id:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="idValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="indexLabel">
+                 <property name="text">
+                  <string>Index:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="indexValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="versionNumberLabel">
+                 <property name="text">
+                  <string>Version:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLabel" name="versionNumberValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="modifiedByLabel">
+                 <property name="text">
+                  <string>Modified By:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="modifiedByValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="recordedAtLabel">
+                 <property name="text">
+                  <string>Recorded At:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLabel" name="recordedAtValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="changeCommentaryLabel">
+                 <property name="text">
+                  <string>Change Commentary:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QLabel" name="changeCommentaryValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size><width>40</width><height>20</height></size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt.refdata/ui/FxConventionDetailDialog.ui
+++ b/projects/ores.qt.refdata/ui/FxConventionDetailDialog.ui
@@ -1,0 +1,242 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FxConventionDetailDialog</class>
+ <widget class="QWidget" name="FxConventionDetailDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>500</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>600</width>
+    <height>500</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>FX Convention Details</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex"><number>0</number></property>
+     <widget class="QWidget" name="generalTab">
+      <attribute name="title"><string>General</string></attribute>
+      <layout class="QVBoxLayout" name="generalLayout">
+       <item>
+        <widget class="QGroupBox" name="basicInfoGroup">
+         <property name="title">
+          <string>Basic Information</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelId">
+            <property name="text">
+             <string>Id:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="idEdit">
+            <property name="placeholderText">
+             <string>Enter convention id</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelSourceCurrency">
+            <property name="text">
+             <string>Source Currency:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="sourceCurrencyEdit">
+            <property name="placeholderText">
+             <string>e.g. EUR</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelTargetCurrency">
+            <property name="text">
+             <string>Target Currency:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="targetCurrencyEdit">
+            <property name="placeholderText">
+             <string>e.g. USD</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelSpotDays">
+            <property name="text">
+             <string>Spot Days:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QSpinBox" name="spotDaysEdit">
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>10</number>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelAdvanceCalendar">
+            <property name="text">
+             <string>Advance Calendar:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="advanceCalendarEdit">
+            <property name="placeholderText">
+             <string>e.g. TARGET</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="labelConvention">
+            <property name="text">
+             <string>Convention:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLineEdit" name="conventionEdit">
+            <property name="placeholderText">
+             <string>e.g. ModifiedFollowing</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="labelSpotRelative">
+            <property name="text">
+             <string>Spot Relative:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QCheckBox" name="spotRelativeEdit">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="tristate">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="labelEndOfMonth">
+            <property name="text">
+             <string>End Of Month:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QCheckBox" name="endOfMonthEdit">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="tristate">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="provenanceTab">
+      <attribute name="title"><string>Provenance</string></attribute>
+      <layout class="QVBoxLayout" name="provenanceTabLayout">
+       <item>
+        <widget class="ores::qt::ProvenanceWidget" name="provenanceWidget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="deleteButton">
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveButton">
+       <property name="text">
+        <string>Save</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ores::qt::ProvenanceWidget</class>
+   <extends>QWidget</extends>
+   <header>ores.qt/ProvenanceWidget.hpp</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt.refdata/ui/FxConventionHistoryDialog.ui
+++ b/projects/ores.qt.refdata/ui/FxConventionHistoryDialog.ui
@@ -1,0 +1,360 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FxConventionHistoryDialog</class>
+ <widget class="QWidget" name="FxConventionHistoryDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>900</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>FX Convention History</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>FX Convention History</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QTableWidget" name="versionListWidget">
+      <property name="minimumHeight">
+       <number>150</number>
+      </property>
+      <property name="maximumHeight">
+       <number>250</number>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="editTriggers">
+       <set>QAbstractItemView::NoEditTriggers</set>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+      <column>
+       <property name="text">
+        <string>Version</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Recorded At</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Modified By</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Commentary</string>
+       </property>
+      </column>
+     </widget>
+     <widget class="QWidget" name="detailWidget">
+      <layout class="QVBoxLayout" name="detailLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTabWidget" name="tabWidget">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="changesTab">
+          <attribute name="title">
+           <string>Changes</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="changesTabLayout">
+           <item>
+            <widget class="QTableWidget" name="changesTableWidget">
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="alternatingRowColors">
+              <bool>true</bool>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::SingleSelection</enum>
+             </property>
+             <property name="selectionBehavior">
+              <enum>QAbstractItemView::SelectRows</enum>
+             </property>
+             <column>
+              <property name="text">
+               <string>Field</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Old Value</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>New Value</string>
+              </property>
+             </column>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="fullDetailsTab">
+          <attribute name="title">
+           <string>Full Details</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="fullDetailsTabLayout">
+           <item>
+            <widget class="QScrollArea" name="scrollArea">
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>560</width>
+                <height>450</height>
+               </rect>
+              </property>
+              <layout class="QFormLayout" name="formLayout">
+               <item row="0" column="0">
+                <widget class="QLabel" name="idLabel">
+                 <property name="text">
+                  <string>Id:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="idValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="source_currencyLabel">
+                 <property name="text">
+                  <string>Source Currency:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="sourceCurrencyValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="target_currencyLabel">
+                 <property name="text">
+                  <string>Target Currency:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLabel" name="targetCurrencyValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="spot_daysLabel">
+                 <property name="text">
+                  <string>Spot Days:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="spotDaysValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="advance_calendarLabel">
+                 <property name="text">
+                  <string>Advance Calendar:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLabel" name="advanceCalendarValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="conventionLabel">
+                 <property name="text">
+                  <string>Convention:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QLabel" name="conventionValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="spot_relativeLabel">
+                 <property name="text">
+                  <string>Spot Relative:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QLabel" name="spotRelativeValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="end_of_monthLabel">
+                 <property name="text">
+                  <string>End Of Month:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QLabel" name="endOfMonthValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="0">
+                <widget class="QLabel" name="versionNumberLabel">
+                 <property name="text">
+                  <string>Version:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QLabel" name="versionNumberValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0">
+                <widget class="QLabel" name="modifiedByLabel">
+                 <property name="text">
+                  <string>Modified By:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QLabel" name="modifiedByValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="0">
+                <widget class="QLabel" name="recordedAtLabel">
+                 <property name="text">
+                  <string>Recorded At:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="1">
+                <widget class="QLabel" name="recordedAtValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="0">
+                <widget class="QLabel" name="changeCommentaryLabel">
+                 <property name="text">
+                  <string>Change Commentary:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="1">
+                <widget class="QLabel" name="changeCommentaryValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size><width>40</width><height>20</height></size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt.refdata/ui/IborIndexConventionDetailDialog.ui
+++ b/projects/ores.qt.refdata/ui/IborIndexConventionDetailDialog.ui
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>IborIndexConventionDetailDialog</class>
+ <widget class="QWidget" name="IborIndexConventionDetailDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>500</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>600</width>
+    <height>500</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>IBOR Index Convention Details</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex"><number>0</number></property>
+     <widget class="QWidget" name="generalTab">
+      <attribute name="title"><string>General</string></attribute>
+      <layout class="QVBoxLayout" name="generalLayout">
+       <item>
+        <widget class="QGroupBox" name="basicInfoGroup">
+         <property name="title">
+          <string>Basic Information</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelId">
+            <property name="text">
+             <string>Id:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="idEdit">
+            <property name="placeholderText">
+             <string>Enter index id</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelFixingCalendar">
+            <property name="text">
+             <string>Fixing Calendar:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="fixingCalendarEdit">
+            <property name="placeholderText">
+             <string>e.g. TARGET</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelDayCountFraction">
+            <property name="text">
+             <string>Day Count Fraction:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="dayCountFractionEdit">
+            <property name="placeholderText">
+             <string>e.g. ACT/360</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelSettlementDays">
+            <property name="text">
+             <string>Settlement Days:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QSpinBox" name="settlementDaysEdit">
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>10</number>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelBusinessDayConvention">
+            <property name="text">
+             <string>Business Day Convention:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="businessDayConventionEdit">
+            <property name="placeholderText">
+             <string>e.g. ModifiedFollowing</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="labelEndOfMonth">
+            <property name="text">
+             <string>End Of Month:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QCheckBox" name="endOfMonthEdit">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="provenanceTab">
+      <attribute name="title"><string>Provenance</string></attribute>
+      <layout class="QVBoxLayout" name="provenanceTabLayout">
+       <item>
+        <widget class="ores::qt::ProvenanceWidget" name="provenanceWidget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="deleteButton">
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveButton">
+       <property name="text">
+        <string>Save</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ores::qt::ProvenanceWidget</class>
+   <extends>QWidget</extends>
+   <header>ores.qt/ProvenanceWidget.hpp</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt.refdata/ui/IborIndexConventionHistoryDialog.ui
+++ b/projects/ores.qt.refdata/ui/IborIndexConventionHistoryDialog.ui
@@ -1,0 +1,332 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>IborIndexConventionHistoryDialog</class>
+ <widget class="QWidget" name="IborIndexConventionHistoryDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>900</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>IBOR Index Convention History</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>IBOR Index Convention History</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QTableWidget" name="versionListWidget">
+      <property name="minimumHeight">
+       <number>150</number>
+      </property>
+      <property name="maximumHeight">
+       <number>250</number>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="editTriggers">
+       <set>QAbstractItemView::NoEditTriggers</set>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+      <column>
+       <property name="text">
+        <string>Version</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Recorded At</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Modified By</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Commentary</string>
+       </property>
+      </column>
+     </widget>
+     <widget class="QWidget" name="detailWidget">
+      <layout class="QVBoxLayout" name="detailLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTabWidget" name="tabWidget">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="changesTab">
+          <attribute name="title">
+           <string>Changes</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="changesTabLayout">
+           <item>
+            <widget class="QTableWidget" name="changesTableWidget">
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="alternatingRowColors">
+              <bool>true</bool>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::SingleSelection</enum>
+             </property>
+             <property name="selectionBehavior">
+              <enum>QAbstractItemView::SelectRows</enum>
+             </property>
+             <column>
+              <property name="text">
+               <string>Field</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Old Value</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>New Value</string>
+              </property>
+             </column>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="fullDetailsTab">
+          <attribute name="title">
+           <string>Full Details</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="fullDetailsTabLayout">
+           <item>
+            <widget class="QScrollArea" name="scrollArea">
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>560</width>
+                <height>450</height>
+               </rect>
+              </property>
+              <layout class="QFormLayout" name="formLayout">
+               <item row="0" column="0">
+                <widget class="QLabel" name="idLabel">
+                 <property name="text">
+                  <string>Id:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="idValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="fixing_calendarLabel">
+                 <property name="text">
+                  <string>Fixing Calendar:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="fixingCalendarValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="day_count_fractionLabel">
+                 <property name="text">
+                  <string>Day Count Fraction:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLabel" name="dayCountFractionValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="settlement_daysLabel">
+                 <property name="text">
+                  <string>Settlement Days:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="settlementDaysValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="business_day_conventionLabel">
+                 <property name="text">
+                  <string>Business Day Convention:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLabel" name="businessDayConventionValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="end_of_monthLabel">
+                 <property name="text">
+                  <string>End Of Month:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QLabel" name="endOfMonthValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="versionNumberLabel">
+                 <property name="text">
+                  <string>Version:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QLabel" name="versionNumberValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="modifiedByLabel">
+                 <property name="text">
+                  <string>Modified By:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QLabel" name="modifiedByValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="0">
+                <widget class="QLabel" name="recordedAtLabel">
+                 <property name="text">
+                  <string>Recorded At:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QLabel" name="recordedAtValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0">
+                <widget class="QLabel" name="changeCommentaryLabel">
+                 <property name="text">
+                  <string>Change Commentary:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QLabel" name="changeCommentaryValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size><width>40</width><height>20</height></size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt.refdata/ui/OisConventionDetailDialog.ui
+++ b/projects/ores.qt.refdata/ui/OisConventionDetailDialog.ui
@@ -1,0 +1,321 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OisConventionDetailDialog</class>
+ <widget class="QWidget" name="OisConventionDetailDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>500</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>600</width>
+    <height>500</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>OIS Convention Details</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex"><number>0</number></property>
+     <widget class="QWidget" name="generalTab">
+      <attribute name="title"><string>General</string></attribute>
+      <layout class="QVBoxLayout" name="generalLayout">
+       <item>
+        <widget class="QGroupBox" name="basicInfoGroup">
+         <property name="title">
+          <string>Basic Information</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelId">
+            <property name="text">
+             <string>Id:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="idEdit">
+            <property name="placeholderText">
+             <string>Enter convention id</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelIndex">
+            <property name="text">
+             <string>Index:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="indexEdit">
+            <property name="placeholderText">
+             <string>e.g. EUR-EONIA</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelSpotLag">
+            <property name="text">
+             <string>Spot Lag:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="spotLagEdit">
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>10</number>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelFixedDayCountFraction">
+            <property name="text">
+             <string>Fixed Day Count Fraction:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="fixedDayCountFractionEdit">
+            <property name="placeholderText">
+             <string>e.g. ACT/360</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelFixedCalendar">
+            <property name="text">
+             <string>Fixed Calendar:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="fixedCalendarEdit">
+            <property name="placeholderText">
+             <string>e.g. TARGET</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="labelPaymentLag">
+            <property name="text">
+             <string>Payment Lag:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QSpinBox" name="paymentLagEdit">
+            <property name="minimum">
+             <number>-1</number>
+            </property>
+            <property name="maximum">
+             <number>30</number>
+            </property>
+            <property name="specialValueText">
+             <string>(unset)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="labelFixedFrequency">
+            <property name="text">
+             <string>Fixed Frequency:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QLineEdit" name="fixedFrequencyEdit">
+            <property name="placeholderText">
+             <string>e.g. Annual</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="labelFixedConvention">
+            <property name="text">
+             <string>Fixed Convention:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QLineEdit" name="fixedConventionEdit">
+            <property name="placeholderText">
+             <string>e.g. ModifiedFollowing</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="labelFixedPaymentConvention">
+            <property name="text">
+             <string>Fixed Payment Convention:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="QLineEdit" name="fixedPaymentConventionEdit">
+            <property name="placeholderText">
+             <string>e.g. Following</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
+           <widget class="QLabel" name="labelRule">
+            <property name="text">
+             <string>Rule:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1">
+           <widget class="QLineEdit" name="ruleEdit">
+            <property name="placeholderText">
+             <string>e.g. Backward</string>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="0">
+           <widget class="QLabel" name="labelPaymentCalendar">
+            <property name="text">
+             <string>Payment Calendar:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="1">
+           <widget class="QLineEdit" name="paymentCalendarEdit">
+            <property name="placeholderText">
+             <string>e.g. TARGET</string>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="0">
+           <widget class="QLabel" name="labelRateCutoff">
+            <property name="text">
+             <string>Rate Cutoff:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="1">
+           <widget class="QSpinBox" name="rateCutoffEdit">
+            <property name="minimum">
+             <number>-1</number>
+            </property>
+            <property name="maximum">
+             <number>30</number>
+            </property>
+            <property name="specialValueText">
+             <string>(unset)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="0">
+           <widget class="QLabel" name="labelEndOfMonth">
+            <property name="text">
+             <string>End Of Month:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="1">
+           <widget class="QCheckBox" name="endOfMonthEdit">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="tristate">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="provenanceTab">
+      <attribute name="title"><string>Provenance</string></attribute>
+      <layout class="QVBoxLayout" name="provenanceTabLayout">
+       <item>
+        <widget class="ores::qt::ProvenanceWidget" name="provenanceWidget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="deleteButton">
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveButton">
+       <property name="text">
+        <string>Save</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ores::qt::ProvenanceWidget</class>
+   <extends>QWidget</extends>
+   <header>ores.qt/ProvenanceWidget.hpp</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt.refdata/ui/OisConventionHistoryDialog.ui
+++ b/projects/ores.qt.refdata/ui/OisConventionHistoryDialog.ui
@@ -1,0 +1,430 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OisConventionHistoryDialog</class>
+ <widget class="QWidget" name="OisConventionHistoryDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>900</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>OIS Convention History</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>OIS Convention History</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QTableWidget" name="versionListWidget">
+      <property name="minimumHeight">
+       <number>150</number>
+      </property>
+      <property name="maximumHeight">
+       <number>250</number>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="editTriggers">
+       <set>QAbstractItemView::NoEditTriggers</set>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+      <column>
+       <property name="text">
+        <string>Version</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Recorded At</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Modified By</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Commentary</string>
+       </property>
+      </column>
+     </widget>
+     <widget class="QWidget" name="detailWidget">
+      <layout class="QVBoxLayout" name="detailLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTabWidget" name="tabWidget">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="changesTab">
+          <attribute name="title">
+           <string>Changes</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="changesTabLayout">
+           <item>
+            <widget class="QTableWidget" name="changesTableWidget">
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="alternatingRowColors">
+              <bool>true</bool>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::SingleSelection</enum>
+             </property>
+             <property name="selectionBehavior">
+              <enum>QAbstractItemView::SelectRows</enum>
+             </property>
+             <column>
+              <property name="text">
+               <string>Field</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Old Value</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>New Value</string>
+              </property>
+             </column>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="fullDetailsTab">
+          <attribute name="title">
+           <string>Full Details</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="fullDetailsTabLayout">
+           <item>
+            <widget class="QScrollArea" name="scrollArea">
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>560</width>
+                <height>450</height>
+               </rect>
+              </property>
+              <layout class="QFormLayout" name="formLayout">
+               <item row="0" column="0">
+                <widget class="QLabel" name="idLabel">
+                 <property name="text">
+                  <string>Id:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="idValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="indexLabel">
+                 <property name="text">
+                  <string>Index:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="indexValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="spot_lagLabel">
+                 <property name="text">
+                  <string>Spot Lag:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLabel" name="spotLagValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="fixed_day_count_fractionLabel">
+                 <property name="text">
+                  <string>Fixed Day Count Fraction:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="fixedDayCountFractionValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="fixed_calendarLabel">
+                 <property name="text">
+                  <string>Fixed Calendar:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLabel" name="fixedCalendarValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="payment_lagLabel">
+                 <property name="text">
+                  <string>Payment Lag:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QLabel" name="paymentLagValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="fixed_frequencyLabel">
+                 <property name="text">
+                  <string>Fixed Frequency:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QLabel" name="fixedFrequencyValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="fixed_conventionLabel">
+                 <property name="text">
+                  <string>Fixed Convention:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QLabel" name="fixedConventionValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="0">
+                <widget class="QLabel" name="fixed_payment_conventionLabel">
+                 <property name="text">
+                  <string>Fixed Payment Convention:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QLabel" name="fixedPaymentConventionValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0">
+                <widget class="QLabel" name="ruleLabel">
+                 <property name="text">
+                  <string>Rule:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QLabel" name="ruleValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="0">
+                <widget class="QLabel" name="payment_calendarLabel">
+                 <property name="text">
+                  <string>Payment Calendar:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="1">
+                <widget class="QLabel" name="paymentCalendarValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="0">
+                <widget class="QLabel" name="rate_cutoffLabel">
+                 <property name="text">
+                  <string>Rate Cutoff:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="1">
+                <widget class="QLabel" name="rateCutoffValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="0">
+                <widget class="QLabel" name="end_of_monthLabel">
+                 <property name="text">
+                  <string>End Of Month:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="1">
+                <widget class="QLabel" name="endOfMonthValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="0">
+                <widget class="QLabel" name="versionNumberLabel">
+                 <property name="text">
+                  <string>Version:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="1">
+                <widget class="QLabel" name="versionNumberValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="0">
+                <widget class="QLabel" name="modifiedByLabel">
+                 <property name="text">
+                  <string>Modified By:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="1">
+                <widget class="QLabel" name="modifiedByValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="15" column="0">
+                <widget class="QLabel" name="recordedAtLabel">
+                 <property name="text">
+                  <string>Recorded At:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="15" column="1">
+                <widget class="QLabel" name="recordedAtValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="16" column="0">
+                <widget class="QLabel" name="changeCommentaryLabel">
+                 <property name="text">
+                  <string>Change Commentary:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="16" column="1">
+                <widget class="QLabel" name="changeCommentaryValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size><width>40</width><height>20</height></size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt.refdata/ui/OvernightIndexConventionDetailDialog.ui
+++ b/projects/ores.qt.refdata/ui/OvernightIndexConventionDetailDialog.ui
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OvernightIndexConventionDetailDialog</class>
+ <widget class="QWidget" name="OvernightIndexConventionDetailDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>500</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>600</width>
+    <height>500</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Overnight Index Convention Details</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex"><number>0</number></property>
+     <widget class="QWidget" name="generalTab">
+      <attribute name="title"><string>General</string></attribute>
+      <layout class="QVBoxLayout" name="generalLayout">
+       <item>
+        <widget class="QGroupBox" name="basicInfoGroup">
+         <property name="title">
+          <string>Basic Information</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelId">
+            <property name="text">
+             <string>Id:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="idEdit">
+            <property name="placeholderText">
+             <string>Enter index id</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelFixingCalendar">
+            <property name="text">
+             <string>Fixing Calendar:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="fixingCalendarEdit">
+            <property name="placeholderText">
+             <string>e.g. TARGET</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelDayCountFraction">
+            <property name="text">
+             <string>Day Count Fraction:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="dayCountFractionEdit">
+            <property name="placeholderText">
+             <string>e.g. ACT/360</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelSettlementDays">
+            <property name="text">
+             <string>Settlement Days:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QSpinBox" name="settlementDaysEdit">
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="provenanceTab">
+      <attribute name="title"><string>Provenance</string></attribute>
+      <layout class="QVBoxLayout" name="provenanceTabLayout">
+       <item>
+        <widget class="ores::qt::ProvenanceWidget" name="provenanceWidget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="deleteButton">
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveButton">
+       <property name="text">
+        <string>Save</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ores::qt::ProvenanceWidget</class>
+   <extends>QWidget</extends>
+   <header>ores.qt/ProvenanceWidget.hpp</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt.refdata/ui/OvernightIndexConventionHistoryDialog.ui
+++ b/projects/ores.qt.refdata/ui/OvernightIndexConventionHistoryDialog.ui
@@ -1,0 +1,304 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OvernightIndexConventionHistoryDialog</class>
+ <widget class="QWidget" name="OvernightIndexConventionHistoryDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>900</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Overnight Index Convention History</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Overnight Index Convention History</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QTableWidget" name="versionListWidget">
+      <property name="minimumHeight">
+       <number>150</number>
+      </property>
+      <property name="maximumHeight">
+       <number>250</number>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="editTriggers">
+       <set>QAbstractItemView::NoEditTriggers</set>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+      <column>
+       <property name="text">
+        <string>Version</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Recorded At</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Modified By</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Commentary</string>
+       </property>
+      </column>
+     </widget>
+     <widget class="QWidget" name="detailWidget">
+      <layout class="QVBoxLayout" name="detailLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTabWidget" name="tabWidget">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="changesTab">
+          <attribute name="title">
+           <string>Changes</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="changesTabLayout">
+           <item>
+            <widget class="QTableWidget" name="changesTableWidget">
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="alternatingRowColors">
+              <bool>true</bool>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::SingleSelection</enum>
+             </property>
+             <property name="selectionBehavior">
+              <enum>QAbstractItemView::SelectRows</enum>
+             </property>
+             <column>
+              <property name="text">
+               <string>Field</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Old Value</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>New Value</string>
+              </property>
+             </column>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="fullDetailsTab">
+          <attribute name="title">
+           <string>Full Details</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="fullDetailsTabLayout">
+           <item>
+            <widget class="QScrollArea" name="scrollArea">
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>560</width>
+                <height>450</height>
+               </rect>
+              </property>
+              <layout class="QFormLayout" name="formLayout">
+               <item row="0" column="0">
+                <widget class="QLabel" name="idLabel">
+                 <property name="text">
+                  <string>Id:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="idValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="fixing_calendarLabel">
+                 <property name="text">
+                  <string>Fixing Calendar:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="fixingCalendarValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="day_count_fractionLabel">
+                 <property name="text">
+                  <string>Day Count Fraction:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLabel" name="dayCountFractionValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="settlement_daysLabel">
+                 <property name="text">
+                  <string>Settlement Days:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="settlementDaysValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="versionNumberLabel">
+                 <property name="text">
+                  <string>Version:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLabel" name="versionNumberValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="modifiedByLabel">
+                 <property name="text">
+                  <string>Modified By:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QLabel" name="modifiedByValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="recordedAtLabel">
+                 <property name="text">
+                  <string>Recorded At:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QLabel" name="recordedAtValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="changeCommentaryLabel">
+                 <property name="text">
+                  <string>Change Commentary:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QLabel" name="changeCommentaryValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size><width>40</width><height>20</height></size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt.refdata/ui/SwapConventionDetailDialog.ui
+++ b/projects/ores.qt.refdata/ui/SwapConventionDetailDialog.ui
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SwapConventionDetailDialog</class>
+ <widget class="QWidget" name="SwapConventionDetailDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>500</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>600</width>
+    <height>500</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Swap Convention Details</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex"><number>0</number></property>
+     <widget class="QWidget" name="generalTab">
+      <attribute name="title"><string>General</string></attribute>
+      <layout class="QVBoxLayout" name="generalLayout">
+       <item>
+        <widget class="QGroupBox" name="basicInfoGroup">
+         <property name="title">
+          <string>Basic Information</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelId">
+            <property name="text">
+             <string>Id:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="idEdit">
+            <property name="placeholderText">
+             <string>Enter convention id</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelFixedFrequency">
+            <property name="text">
+             <string>Fixed Frequency:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="fixedFrequencyEdit">
+            <property name="placeholderText">
+             <string>e.g. Annual</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelFixedDayCountFraction">
+            <property name="text">
+             <string>Fixed Day Count Fraction:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="fixedDayCountFractionEdit">
+            <property name="placeholderText">
+             <string>e.g. 30/360</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelIndex">
+            <property name="text">
+             <string>Index:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="indexEdit">
+            <property name="placeholderText">
+             <string>e.g. EUR-EURIBOR-6M</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelFixedCalendar">
+            <property name="text">
+             <string>Fixed Calendar:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="fixedCalendarEdit">
+            <property name="placeholderText">
+             <string>e.g. TARGET</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="labelFixedConvention">
+            <property name="text">
+             <string>Fixed Convention:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLineEdit" name="fixedConventionEdit">
+            <property name="placeholderText">
+             <string>e.g. ModifiedFollowing</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="labelFloatFrequency">
+            <property name="text">
+             <string>Float Frequency:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QLineEdit" name="floatFrequencyEdit">
+            <property name="placeholderText">
+             <string>e.g. Semiannual</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="labelSubPeriodsCouponType">
+            <property name="text">
+             <string>Sub-Periods Coupon Type:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QLineEdit" name="subPeriodsCouponTypeEdit">
+            <property name="placeholderText">
+             <string>e.g. Compounding</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="provenanceTab">
+      <attribute name="title"><string>Provenance</string></attribute>
+      <layout class="QVBoxLayout" name="provenanceTabLayout">
+       <item>
+        <widget class="ores::qt::ProvenanceWidget" name="provenanceWidget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="deleteButton">
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveButton">
+       <property name="text">
+        <string>Save</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ores::qt::ProvenanceWidget</class>
+   <extends>QWidget</extends>
+   <header>ores.qt/ProvenanceWidget.hpp</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.qt.refdata/ui/SwapConventionHistoryDialog.ui
+++ b/projects/ores.qt.refdata/ui/SwapConventionHistoryDialog.ui
@@ -1,0 +1,360 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SwapConventionHistoryDialog</class>
+ <widget class="QWidget" name="SwapConventionHistoryDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>900</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Swap Convention History</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Swap Convention History</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QTableWidget" name="versionListWidget">
+      <property name="minimumHeight">
+       <number>150</number>
+      </property>
+      <property name="maximumHeight">
+       <number>250</number>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="editTriggers">
+       <set>QAbstractItemView::NoEditTriggers</set>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+      <column>
+       <property name="text">
+        <string>Version</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Recorded At</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Modified By</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Commentary</string>
+       </property>
+      </column>
+     </widget>
+     <widget class="QWidget" name="detailWidget">
+      <layout class="QVBoxLayout" name="detailLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTabWidget" name="tabWidget">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="changesTab">
+          <attribute name="title">
+           <string>Changes</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="changesTabLayout">
+           <item>
+            <widget class="QTableWidget" name="changesTableWidget">
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="alternatingRowColors">
+              <bool>true</bool>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::SingleSelection</enum>
+             </property>
+             <property name="selectionBehavior">
+              <enum>QAbstractItemView::SelectRows</enum>
+             </property>
+             <column>
+              <property name="text">
+               <string>Field</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Old Value</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>New Value</string>
+              </property>
+             </column>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="fullDetailsTab">
+          <attribute name="title">
+           <string>Full Details</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="fullDetailsTabLayout">
+           <item>
+            <widget class="QScrollArea" name="scrollArea">
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>560</width>
+                <height>450</height>
+               </rect>
+              </property>
+              <layout class="QFormLayout" name="formLayout">
+               <item row="0" column="0">
+                <widget class="QLabel" name="idLabel">
+                 <property name="text">
+                  <string>Id:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="idValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="fixed_frequencyLabel">
+                 <property name="text">
+                  <string>Fixed Frequency:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="fixedFrequencyValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="fixed_day_count_fractionLabel">
+                 <property name="text">
+                  <string>Fixed Day Count Fraction:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLabel" name="fixedDayCountFractionValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="indexLabel">
+                 <property name="text">
+                  <string>Index:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="indexValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="fixed_calendarLabel">
+                 <property name="text">
+                  <string>Fixed Calendar:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLabel" name="fixedCalendarValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="fixed_conventionLabel">
+                 <property name="text">
+                  <string>Fixed Convention:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QLabel" name="fixedConventionValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="float_frequencyLabel">
+                 <property name="text">
+                  <string>Float Frequency:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QLabel" name="floatFrequencyValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="sub_periods_coupon_typeLabel">
+                 <property name="text">
+                  <string>Sub-Periods Coupon Type:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QLabel" name="subPeriodsCouponTypeValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="0">
+                <widget class="QLabel" name="versionNumberLabel">
+                 <property name="text">
+                  <string>Version:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QLabel" name="versionNumberValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0">
+                <widget class="QLabel" name="modifiedByLabel">
+                 <property name="text">
+                  <string>Modified By:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QLabel" name="modifiedByValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="0">
+                <widget class="QLabel" name="recordedAtLabel">
+                 <property name="text">
+                  <string>Recorded At:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="1">
+                <widget class="QLabel" name="recordedAtValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="0">
+                <widget class="QLabel" name="changeCommentaryLabel">
+                 <property name="text">
+                  <string>Change Commentary:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="1">
+                <widget class="QLabel" name="changeCommentaryValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size><width>40</width><height>20</height></size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/cds_convention.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/cds_convention.hpp
@@ -17,8 +17,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_API_DOMAIN_CDS_CONVENTION_HPP
-#define ORES_REFDATA_API_DOMAIN_CDS_CONVENTION_HPP
+#ifndef ORES_REFDATA_DOMAIN_CDS_CONVENTION_HPP
+#define ORES_REFDATA_DOMAIN_CDS_CONVENTION_HPP
 
 #include <chrono>
 #include <string>
@@ -30,11 +30,9 @@ namespace ores::refdata::domain {
 /**
  * @brief Conventions for a credit default swap (CDS).
  *
- * Defines the settlement lag, premium payment schedule, and accrual rules for
- * a vanilla CDS. Corresponds to the @c <CDS> element in @c conventions.xml.
- *
- * The @c rule field governs how IMM dates and standard CDS roll dates are
- * generated (e.g. "CDS2015" for the 2015 ISDA CDS Standard Model).
+ * Defines the settlement lag, premium payment schedule, and accrual rules
+ * for a vanilla CDS. Corresponds to the <CDS> element in ORE conventions.xml.
+ * The rule field governs IMM dates and standard CDS roll dates.
  */
 struct cds_convention final {
     /**
@@ -48,7 +46,9 @@ struct cds_convention final {
     utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
-     * @brief Unique convention identifier (e.g. "CDS-STANDARD-CONVENTIONS").
+     * @brief Unique convention identifier.
+     *
+     * Examples: 'CDS-STANDARD-CONVENTIONS', 'EUR-CDS-CONVENTIONS'.
      */
     std::string id;
 
@@ -58,12 +58,12 @@ struct cds_convention final {
     int settlement_days = 0;
 
     /**
-     * @brief Calendar used for premium payment date adjustment (e.g. "WeekendsOnly").
+     * @brief Calendar used for premium payment date adjustment (e.g. 'WeekendsOnly').
      */
     std::string calendar;
 
     /**
-     * @brief Premium payment frequency (canonical CDM, e.g. "Quarterly").
+     * @brief Premium payment frequency (canonical CDM, e.g. 'Quarterly').
      */
     std::string frequency;
 
@@ -73,14 +73,24 @@ struct cds_convention final {
     std::string payment_convention;
 
     /**
-     * @brief Date generation rule (e.g. "CDS2015", "Backward", "TwentiethIMM").
+     * @brief Date generation rule (e.g. 'CDS2015', 'Backward', 'TwentiethIMM').
      */
     std::string rule;
 
     /**
-     * @brief Day count fraction for premium accrual (canonical FpML, e.g. "ACT/360").
+     * @brief Day count fraction for premium accrual (canonical FpML, e.g. 'ACT/360').
      */
     std::string day_count_fraction;
+
+    /**
+     * @brief Whether accrued interest is settled on default.
+     */
+    bool settles_accrual = false;
+
+    /**
+     * @brief Whether the protection payment is made at the time of default.
+     */
+    bool pays_at_default_time = false;
 
     /**
      * @brief Override for the upfront cash settlement lag (business days).
@@ -88,29 +98,24 @@ struct cds_convention final {
     std::optional<int> upfront_settlement_days;
 
     /**
-     * @brief Whether accrued interest is settled on default.
-     */
-    bool settles_accrual = true;
-
-    /**
-     * @brief Whether the protection payment is made at the time of default.
-     * When @c false payment occurs at the scheduled payment date.
-     */
-    bool pays_at_default_time = true;
-
-    /**
-     * @brief Day count fraction for the last coupon period (canonical FpML).
-     * When absent the same fraction as @c day_count_fraction is used.
+     * @brief Day count fraction for the last coupon period (canonical FpML). When absent the same fraction as day_count_fraction is used.
      */
     std::optional<std::string> last_period_day_count_fraction;
 
     /**
-     * @brief Username of the person who recorded this version.
+     * @brief Username of the person who last modified this CDS convention.
      */
     std::string modified_by;
 
     /**
+     * @brief Username of the account that performed this action.
+     */
+    std::string performed_by;
+
+    /**
      * @brief Code identifying the reason for the change.
+     *
+     * References change_reasons table (soft FK).
      */
     std::string change_reason_code;
 
@@ -118,11 +123,6 @@ struct cds_convention final {
      * @brief Free-text commentary explaining the change.
      */
     std::string change_commentary;
-
-    /**
-     * @brief Username of the account that performed this operation.
-     */
-    std::string performed_by;
 
     /**
      * @brief Timestamp when this version of the record was recorded.

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/cds_convention_json_io.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/cds_convention_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_CDS_CONVENTION_JSON_IO_HPP
+#define ORES_REFDATA_DOMAIN_CDS_CONVENTION_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.refdata.api/domain/cds_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the cds_convention to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const cds_convention& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/cds_convention_table.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/cds_convention_table.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_CDS_CONVENTION_TABLE_HPP
+#define ORES_REFDATA_DOMAIN_CDS_CONVENTION_TABLE_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata.api/domain/cds_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Converts cds_conventions to the table format.
+ */
+std::string convert_to_table(const std::vector<cds_convention>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/cds_convention_table_io.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/cds_convention_table_io.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_CDS_CONVENTION_TABLE_IO_HPP
+#define ORES_REFDATA_DOMAIN_CDS_CONVENTION_TABLE_IO_HPP
+
+#include <iosfwd>
+#include <vector>
+#include "ores.refdata.api/domain/cds_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the cds_convention objects to a stream in table format.
+ */
+std::ostream& operator<<(std::ostream& s, const std::vector<cds_convention>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/fra_convention.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/fra_convention.hpp
@@ -17,8 +17,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_API_DOMAIN_FRA_CONVENTION_HPP
-#define ORES_REFDATA_API_DOMAIN_FRA_CONVENTION_HPP
+#ifndef ORES_REFDATA_DOMAIN_FRA_CONVENTION_HPP
+#define ORES_REFDATA_DOMAIN_FRA_CONVENTION_HPP
 
 #include <chrono>
 #include <string>
@@ -29,9 +29,9 @@ namespace ores::refdata::domain {
 /**
  * @brief Conventions for a forward rate agreement (FRA).
  *
- * A FRA convention is the simplest convention type: it ties a FRA instrument
- * to an IBOR index whose own conventions (calendar, day count, settlement)
- * govern the FRA. Corresponds to the @c <FRA> element in @c conventions.xml.
+ * A FRA convention ties a FRA instrument to an IBOR index whose own
+ * conventions (calendar, day count, settlement) govern the FRA.
+ * Corresponds to the <FRA> element in ORE conventions.xml.
  */
 struct fra_convention final {
     /**
@@ -45,25 +45,31 @@ struct fra_convention final {
     utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
-     * @brief Unique convention identifier (e.g. "EUR-6M-FRA-CONVENTIONS").
+     * @brief Unique convention identifier.
+     *
+     * Examples: 'EUR-6M-FRA-CONVENTIONS', 'USD-3M-FRA-CONVENTIONS'.
      */
     std::string id;
 
     /**
-     * @brief IBOR index identifier (e.g. "EUR-EURIBOR-6M").
-     *
-     * All settlement, calendar, and day count details are inherited from the
-     * referenced index convention.
+     * @brief IBOR index identifier (e.g. 'EUR-EURIBOR-6M'). All settlement, calendar, and day count details are inherited from the referenced index convention.
      */
     std::string index;
 
     /**
-     * @brief Username of the person who recorded this version.
+     * @brief Username of the person who last modified this FRA convention.
      */
     std::string modified_by;
 
     /**
+     * @brief Username of the account that performed this action.
+     */
+    std::string performed_by;
+
+    /**
      * @brief Code identifying the reason for the change.
+     *
+     * References change_reasons table (soft FK).
      */
     std::string change_reason_code;
 
@@ -71,11 +77,6 @@ struct fra_convention final {
      * @brief Free-text commentary explaining the change.
      */
     std::string change_commentary;
-
-    /**
-     * @brief Username of the account that performed this operation.
-     */
-    std::string performed_by;
 
     /**
      * @brief Timestamp when this version of the record was recorded.

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/fra_convention_json_io.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/fra_convention_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_FRA_CONVENTION_JSON_IO_HPP
+#define ORES_REFDATA_DOMAIN_FRA_CONVENTION_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.refdata.api/domain/fra_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the fra_convention to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const fra_convention& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/fra_convention_table.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/fra_convention_table.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_FRA_CONVENTION_TABLE_HPP
+#define ORES_REFDATA_DOMAIN_FRA_CONVENTION_TABLE_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata.api/domain/fra_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Converts fra_conventions to the table format.
+ */
+std::string convert_to_table(const std::vector<fra_convention>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/fra_convention_table_io.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/fra_convention_table_io.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_FRA_CONVENTION_TABLE_IO_HPP
+#define ORES_REFDATA_DOMAIN_FRA_CONVENTION_TABLE_IO_HPP
+
+#include <iosfwd>
+#include <vector>
+#include "ores.refdata.api/domain/fra_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the fra_convention objects to a stream in table format.
+ */
+std::ostream& operator<<(std::ostream& s, const std::vector<fra_convention>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/fx_convention.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/fx_convention.hpp
@@ -17,8 +17,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_API_DOMAIN_FX_CONVENTION_HPP
-#define ORES_REFDATA_API_DOMAIN_FX_CONVENTION_HPP
+#ifndef ORES_REFDATA_DOMAIN_FX_CONVENTION_HPP
+#define ORES_REFDATA_DOMAIN_FX_CONVENTION_HPP
 
 #include <chrono>
 #include <string>
@@ -31,11 +31,8 @@ namespace ores::refdata::domain {
  * @brief Conventions for FX spot and forward contracts.
  *
  * Defines the spot settlement lag, pip factor, and adjustment conventions for
- * a currency pair. Corresponds to the @c <FX> element in @c conventions.xml.
- *
- * The @c id typically takes the form "@c CCY1-CCY2-FX-CONVENTIONS" (e.g.
- * "EUR-USD-FX-CONVENTIONS"). The @c source_currency / @c target_currency pair
- * determines the quote convention direction.
+ * a currency pair. Corresponds to the <FX> element in ORE conventions.xml.
+ * The id typically takes the form 'CCY1-CCY2-FX-CONVENTIONS'.
  */
 struct fx_convention final {
     /**
@@ -49,7 +46,9 @@ struct fx_convention final {
     utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
-     * @brief Unique convention identifier (e.g. "EUR-USD-FX-CONVENTIONS").
+     * @brief Unique convention identifier.
+     *
+     * Examples: 'EUR-USD-FX-CONVENTIONS', 'GBP-USD-FX-CONVENTIONS'.
      */
     std::string id;
 
@@ -59,22 +58,19 @@ struct fx_convention final {
     int spot_days = 0;
 
     /**
-     * @brief ISO 4217 code of the source (base) currency (e.g. "EUR").
+     * @brief ISO 4217 code of the source (base) currency (e.g. 'EUR').
      */
     std::string source_currency;
 
     /**
-     * @brief ISO 4217 code of the target (quote) currency (e.g. "USD").
+     * @brief ISO 4217 code of the target (quote) currency (e.g. 'USD').
      */
     std::string target_currency;
 
     /**
-     * @brief Divisor applied to quoted FX points to obtain the rate increment.
-     *
-     * For most pairs this is 10000.0 (i.e. 1 pip = 0.0001); for JPY pairs
-     * it is typically 100.0.
+     * @brief Divisor applied to quoted FX points to obtain the rate increment (e.g. 10000.0 for most pairs).
      */
-    double points_factor = 0.0;
+    double points_factor;
 
     /**
      * @brief Calendar used when advancing from spot to forward dates.
@@ -97,12 +93,19 @@ struct fx_convention final {
     std::optional<std::string> convention;
 
     /**
-     * @brief Username of the person who recorded this version.
+     * @brief Username of the person who last modified this FX convention.
      */
     std::string modified_by;
 
     /**
+     * @brief Username of the account that performed this action.
+     */
+    std::string performed_by;
+
+    /**
      * @brief Code identifying the reason for the change.
+     *
+     * References change_reasons table (soft FK).
      */
     std::string change_reason_code;
 
@@ -110,11 +113,6 @@ struct fx_convention final {
      * @brief Free-text commentary explaining the change.
      */
     std::string change_commentary;
-
-    /**
-     * @brief Username of the account that performed this operation.
-     */
-    std::string performed_by;
 
     /**
      * @brief Timestamp when this version of the record was recorded.

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/fx_convention_json_io.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/fx_convention_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_FX_CONVENTION_JSON_IO_HPP
+#define ORES_REFDATA_DOMAIN_FX_CONVENTION_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.refdata.api/domain/fx_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the fx_convention to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const fx_convention& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/fx_convention_table.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/fx_convention_table.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_FX_CONVENTION_TABLE_HPP
+#define ORES_REFDATA_DOMAIN_FX_CONVENTION_TABLE_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata.api/domain/fx_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Converts fx_conventions to the table format.
+ */
+std::string convert_to_table(const std::vector<fx_convention>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/fx_convention_table_io.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/fx_convention_table_io.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_FX_CONVENTION_TABLE_IO_HPP
+#define ORES_REFDATA_DOMAIN_FX_CONVENTION_TABLE_IO_HPP
+
+#include <iosfwd>
+#include <vector>
+#include "ores.refdata.api/domain/fx_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the fx_convention objects to a stream in table format.
+ */
+std::ostream& operator<<(std::ostream& s, const std::vector<fx_convention>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/ibor_index_convention.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/ibor_index_convention.hpp
@@ -17,8 +17,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_API_DOMAIN_IBOR_INDEX_CONVENTION_HPP
-#define ORES_REFDATA_API_DOMAIN_IBOR_INDEX_CONVENTION_HPP
+#ifndef ORES_REFDATA_DOMAIN_IBOR_INDEX_CONVENTION_HPP
+#define ORES_REFDATA_DOMAIN_IBOR_INDEX_CONVENTION_HPP
 
 #include <chrono>
 #include <string>
@@ -31,13 +31,7 @@ namespace ores::refdata::domain {
  *
  * Defines the fixing calendar, day count, settlement lag, and business day
  * convention for a term IBOR index such as EURIBOR or USD LIBOR.
- * Corresponds to the @c <IborIndex> element in @c conventions.xml.
- *
- * The @c id typically takes the form "@c CCY-NAME" (e.g. "EUR-EURIBOR",
- * "USD-LIBOR"). The per-tenor variant (e.g. "EUR-EURIBOR-6M") is resolved
- * by ORE from the base index id and the instrument tenor.
- *
- * Aligns with the FpML @c FloatingRateIndex concept.
+ * Corresponds to the <IborIndex> element in ORE conventions.xml.
  */
 struct ibor_index_convention final {
     /**
@@ -51,17 +45,19 @@ struct ibor_index_convention final {
     utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
-     * @brief Unique index identifier (e.g. "EUR-EURIBOR", "USD-LIBOR").
+     * @brief Unique index identifier.
+     *
+     * Examples: 'EUR-EURIBOR', 'USD-LIBOR'.
      */
     std::string id;
 
     /**
-     * @brief Calendar used to determine valid fixing dates (e.g. "TARGET").
+     * @brief Calendar used to determine valid fixing dates (e.g. 'TARGET').
      */
     std::string fixing_calendar;
 
     /**
-     * @brief Day count fraction for accrual (canonical FpML, e.g. "ACT/360").
+     * @brief Day count fraction for accrual (canonical FpML, e.g. 'ACT/360').
      */
     std::string day_count_fraction;
 
@@ -81,12 +77,19 @@ struct ibor_index_convention final {
     bool end_of_month = false;
 
     /**
-     * @brief Username of the person who recorded this version.
+     * @brief Username of the person who last modified this IBOR index convention.
      */
     std::string modified_by;
 
     /**
+     * @brief Username of the account that performed this action.
+     */
+    std::string performed_by;
+
+    /**
      * @brief Code identifying the reason for the change.
+     *
+     * References change_reasons table (soft FK).
      */
     std::string change_reason_code;
 
@@ -94,11 +97,6 @@ struct ibor_index_convention final {
      * @brief Free-text commentary explaining the change.
      */
     std::string change_commentary;
-
-    /**
-     * @brief Username of the account that performed this operation.
-     */
-    std::string performed_by;
 
     /**
      * @brief Timestamp when this version of the record was recorded.

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/ibor_index_convention_json_io.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/ibor_index_convention_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_IBOR_INDEX_CONVENTION_JSON_IO_HPP
+#define ORES_REFDATA_DOMAIN_IBOR_INDEX_CONVENTION_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.refdata.api/domain/ibor_index_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the ibor_index_convention to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const ibor_index_convention& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/ibor_index_convention_table.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/ibor_index_convention_table.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_IBOR_INDEX_CONVENTION_TABLE_HPP
+#define ORES_REFDATA_DOMAIN_IBOR_INDEX_CONVENTION_TABLE_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata.api/domain/ibor_index_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Converts ibor_index_conventions to the table format.
+ */
+std::string convert_to_table(const std::vector<ibor_index_convention>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/ibor_index_convention_table_io.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/ibor_index_convention_table_io.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_IBOR_INDEX_CONVENTION_TABLE_IO_HPP
+#define ORES_REFDATA_DOMAIN_IBOR_INDEX_CONVENTION_TABLE_IO_HPP
+
+#include <iosfwd>
+#include <vector>
+#include "ores.refdata.api/domain/ibor_index_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the ibor_index_convention objects to a stream in table format.
+ */
+std::ostream& operator<<(std::ostream& s, const std::vector<ibor_index_convention>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/ois_convention.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/ois_convention.hpp
@@ -17,8 +17,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_API_DOMAIN_OIS_CONVENTION_HPP
-#define ORES_REFDATA_API_DOMAIN_OIS_CONVENTION_HPP
+#ifndef ORES_REFDATA_DOMAIN_OIS_CONVENTION_HPP
+#define ORES_REFDATA_DOMAIN_OIS_CONVENTION_HPP
 
 #include <chrono>
 #include <string>
@@ -32,7 +32,7 @@ namespace ores::refdata::domain {
  *
  * Defines the fixed-leg and overnight floating-leg parameters for an OIS.
  * OIS are used to bootstrap risk-free overnight discount curves (e.g. EONIA,
- * SOFR, SONIA). Corresponds to the @c <OIS> element in @c conventions.xml.
+ * SOFR, SONIA). Corresponds to the <OIS> element in ORE conventions.xml.
  */
 struct ois_convention final {
     /**
@@ -46,7 +46,9 @@ struct ois_convention final {
     utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
-     * @brief Unique convention identifier (e.g. "EUR-OIS-CONVENTIONS").
+     * @brief Unique convention identifier.
+     *
+     * Examples: 'EUR-OIS-CONVENTIONS', 'USD-OIS-CONVENTIONS'.
      */
     std::string id;
 
@@ -56,7 +58,7 @@ struct ois_convention final {
     int spot_lag = 0;
 
     /**
-     * @brief Overnight index identifier (e.g. "EUR-EONIA", "USD-SOFR").
+     * @brief Overnight index identifier (e.g. 'EUR-EONIA', 'USD-SOFR').
      */
     std::string index;
 
@@ -66,7 +68,7 @@ struct ois_convention final {
     std::string fixed_day_count_fraction;
 
     /**
-     * @brief Fixed-leg payment calendar (e.g. "TARGET").
+     * @brief Fixed-leg payment calendar (e.g. 'TARGET').
      */
     std::optional<std::string> fixed_calendar;
 
@@ -81,7 +83,7 @@ struct ois_convention final {
     std::optional<bool> end_of_month;
 
     /**
-     * @brief Fixed-leg payment frequency (canonical CDM, e.g. "Annual").
+     * @brief Fixed-leg payment frequency (canonical CDM, e.g. 'Annual').
      */
     std::optional<std::string> fixed_frequency;
 
@@ -96,12 +98,12 @@ struct ois_convention final {
     std::optional<std::string> fixed_payment_convention;
 
     /**
-     * @brief Date generation rule for the schedule (e.g. "Backward", "CDS2015").
+     * @brief Date generation rule for the schedule (e.g. 'Backward', 'CDS2015').
      */
     std::optional<std::string> rule;
 
     /**
-     * @brief Payment calendar override (e.g. "TARGET").
+     * @brief Payment calendar override (e.g. 'TARGET').
      */
     std::optional<std::string> payment_calendar;
 
@@ -111,12 +113,19 @@ struct ois_convention final {
     std::optional<int> rate_cutoff;
 
     /**
-     * @brief Username of the person who recorded this version.
+     * @brief Username of the person who last modified this OIS convention.
      */
     std::string modified_by;
 
     /**
+     * @brief Username of the account that performed this action.
+     */
+    std::string performed_by;
+
+    /**
      * @brief Code identifying the reason for the change.
+     *
+     * References change_reasons table (soft FK).
      */
     std::string change_reason_code;
 
@@ -124,11 +133,6 @@ struct ois_convention final {
      * @brief Free-text commentary explaining the change.
      */
     std::string change_commentary;
-
-    /**
-     * @brief Username of the account that performed this operation.
-     */
-    std::string performed_by;
 
     /**
      * @brief Timestamp when this version of the record was recorded.

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/ois_convention_json_io.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/ois_convention_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_OIS_CONVENTION_JSON_IO_HPP
+#define ORES_REFDATA_DOMAIN_OIS_CONVENTION_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.refdata.api/domain/ois_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the ois_convention to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const ois_convention& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/ois_convention_table.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/ois_convention_table.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_OIS_CONVENTION_TABLE_HPP
+#define ORES_REFDATA_DOMAIN_OIS_CONVENTION_TABLE_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata.api/domain/ois_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Converts ois_conventions to the table format.
+ */
+std::string convert_to_table(const std::vector<ois_convention>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/ois_convention_table_io.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/ois_convention_table_io.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_OIS_CONVENTION_TABLE_IO_HPP
+#define ORES_REFDATA_DOMAIN_OIS_CONVENTION_TABLE_IO_HPP
+
+#include <iosfwd>
+#include <vector>
+#include "ores.refdata.api/domain/ois_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the ois_convention objects to a stream in table format.
+ */
+std::ostream& operator<<(std::ostream& s, const std::vector<ois_convention>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/overnight_index_convention.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/overnight_index_convention.hpp
@@ -17,8 +17,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_API_DOMAIN_OVERNIGHT_INDEX_CONVENTION_HPP
-#define ORES_REFDATA_API_DOMAIN_OVERNIGHT_INDEX_CONVENTION_HPP
+#ifndef ORES_REFDATA_DOMAIN_OVERNIGHT_INDEX_CONVENTION_HPP
+#define ORES_REFDATA_DOMAIN_OVERNIGHT_INDEX_CONVENTION_HPP
 
 #include <chrono>
 #include <string>
@@ -30,12 +30,8 @@ namespace ores::refdata::domain {
  * @brief Conventions for an overnight index (e.g. EONIA, SONIA, SOFR).
  *
  * Defines the fixing calendar, day count, and settlement lag for a risk-free
- * overnight rate index. Overnight indices differ from IBOR indices in that
- * they are published daily and have no term structure of their own — the OIS
- * convention governs how they are used in swap products.
- *
- * Corresponds to the @c <OvernightIndex> element in @c conventions.xml.
- * Aligns with the FpML @c OvernightIndex concept.
+ * overnight rate index. Corresponds to the <OvernightIndex> element in
+ * ORE conventions.xml.
  */
 struct overnight_index_convention final {
     /**
@@ -49,17 +45,19 @@ struct overnight_index_convention final {
     utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
-     * @brief Unique index identifier (e.g. "EUR-EONIA", "USD-SOFR", "GBP-SONIA").
+     * @brief Unique index identifier.
+     *
+     * Examples: 'EUR-EONIA', 'USD-SOFR', 'GBP-SONIA'.
      */
     std::string id;
 
     /**
-     * @brief Calendar used to determine valid fixing dates (e.g. "TARGET").
+     * @brief Calendar used to determine valid fixing dates (e.g. 'TARGET').
      */
     std::string fixing_calendar;
 
     /**
-     * @brief Day count fraction for accrual (canonical FpML, e.g. "ACT/360").
+     * @brief Day count fraction for accrual (canonical FpML, e.g. 'ACT/360').
      */
     std::string day_count_fraction;
 
@@ -69,12 +67,19 @@ struct overnight_index_convention final {
     int settlement_days = 0;
 
     /**
-     * @brief Username of the person who recorded this version.
+     * @brief Username of the person who last modified this overnight index convention.
      */
     std::string modified_by;
 
     /**
+     * @brief Username of the account that performed this action.
+     */
+    std::string performed_by;
+
+    /**
      * @brief Code identifying the reason for the change.
+     *
+     * References change_reasons table (soft FK).
      */
     std::string change_reason_code;
 
@@ -82,11 +87,6 @@ struct overnight_index_convention final {
      * @brief Free-text commentary explaining the change.
      */
     std::string change_commentary;
-
-    /**
-     * @brief Username of the account that performed this operation.
-     */
-    std::string performed_by;
 
     /**
      * @brief Timestamp when this version of the record was recorded.

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/overnight_index_convention_json_io.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/overnight_index_convention_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_OVERNIGHT_INDEX_CONVENTION_JSON_IO_HPP
+#define ORES_REFDATA_DOMAIN_OVERNIGHT_INDEX_CONVENTION_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.refdata.api/domain/overnight_index_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the overnight_index_convention to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const overnight_index_convention& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/overnight_index_convention_table.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/overnight_index_convention_table.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_OVERNIGHT_INDEX_CONVENTION_TABLE_HPP
+#define ORES_REFDATA_DOMAIN_OVERNIGHT_INDEX_CONVENTION_TABLE_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata.api/domain/overnight_index_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Converts overnight_index_conventions to the table format.
+ */
+std::string convert_to_table(const std::vector<overnight_index_convention>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/overnight_index_convention_table_io.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/overnight_index_convention_table_io.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_OVERNIGHT_INDEX_CONVENTION_TABLE_IO_HPP
+#define ORES_REFDATA_DOMAIN_OVERNIGHT_INDEX_CONVENTION_TABLE_IO_HPP
+
+#include <iosfwd>
+#include <vector>
+#include "ores.refdata.api/domain/overnight_index_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the overnight_index_convention objects to a stream in table format.
+ */
+std::ostream& operator<<(std::ostream& s, const std::vector<overnight_index_convention>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/swap_convention.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/swap_convention.hpp
@@ -17,8 +17,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_REFDATA_API_DOMAIN_SWAP_CONVENTION_HPP
-#define ORES_REFDATA_API_DOMAIN_SWAP_CONVENTION_HPP
+#ifndef ORES_REFDATA_DOMAIN_SWAP_CONVENTION_HPP
+#define ORES_REFDATA_DOMAIN_SWAP_CONVENTION_HPP
 
 #include <chrono>
 #include <string>
@@ -32,10 +32,7 @@ namespace ores::refdata::domain {
  *
  * Defines the fixed-leg schedule and the floating-leg index for a standard
  * interest rate swap. Used by ORE to bootstrap par swap rates off a yield
- * curve. Corresponds to the @c <Swap> element in @c conventions.xml.
- *
- * The @c index field references an IBOR or overnight index convention by its
- * ORE identifier (e.g. "EUR-EURIBOR-6M").
+ * curve. Corresponds to the <Swap> element in ORE conventions.xml.
  */
 struct swap_convention final {
     /**
@@ -49,17 +46,19 @@ struct swap_convention final {
     utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
-     * @brief Unique convention identifier (e.g. "EUR-6M-SWAP-CONVENTIONS").
+     * @brief Unique convention identifier.
+     *
+     * Examples: 'EUR-6M-SWAP-CONVENTIONS', 'USD-3M-SWAP-CONVENTIONS'.
      */
     std::string id;
 
     /**
-     * @brief Fixed-leg payment calendar (e.g. "TARGET").
+     * @brief Fixed-leg payment calendar (e.g. 'TARGET').
      */
     std::optional<std::string> fixed_calendar;
 
     /**
-     * @brief Fixed-leg payment frequency (canonical CDM, e.g. "Annual").
+     * @brief Fixed-leg payment frequency (canonical CDM, e.g. 'Annual').
      */
     std::string fixed_frequency;
 
@@ -69,34 +68,39 @@ struct swap_convention final {
     std::optional<std::string> fixed_convention;
 
     /**
-     * @brief Day count fraction for the fixed leg (canonical FpML, e.g. "30/360").
+     * @brief Day count fraction for the fixed leg (canonical FpML, e.g. '30/360').
      */
     std::string fixed_day_count_fraction;
 
     /**
-     * @brief Floating-leg index identifier (e.g. "EUR-EURIBOR-6M").
+     * @brief Floating-leg index identifier (e.g. 'EUR-EURIBOR-6M').
      */
     std::string index;
 
     /**
-     * @brief Floating-leg payment frequency override (canonical CDM).
-     * When absent the frequency is derived from the index tenor.
+     * @brief Floating-leg payment frequency override (canonical CDM). When absent the frequency is derived from the index tenor.
      */
     std::optional<std::string> float_frequency;
 
     /**
-     * @brief Sub-period coupon type when the float leg uses sub-periods.
-     * Either "Compounding" or "Averaging".
+     * @brief Sub-period coupon type when the float leg uses sub-periods. Either 'Compounding' or 'Averaging'.
      */
     std::optional<std::string> sub_periods_coupon_type;
 
     /**
-     * @brief Username of the person who recorded this version.
+     * @brief Username of the person who last modified this swap convention.
      */
     std::string modified_by;
 
     /**
+     * @brief Username of the account that performed this action.
+     */
+    std::string performed_by;
+
+    /**
      * @brief Code identifying the reason for the change.
+     *
+     * References change_reasons table (soft FK).
      */
     std::string change_reason_code;
 
@@ -104,11 +108,6 @@ struct swap_convention final {
      * @brief Free-text commentary explaining the change.
      */
     std::string change_commentary;
-
-    /**
-     * @brief Username of the account that performed this operation.
-     */
-    std::string performed_by;
 
     /**
      * @brief Timestamp when this version of the record was recorded.

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/swap_convention_json_io.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/swap_convention_json_io.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_SWAP_CONVENTION_JSON_IO_HPP
+#define ORES_REFDATA_DOMAIN_SWAP_CONVENTION_JSON_IO_HPP
+
+#include <iosfwd>
+#include "ores.refdata.api/domain/swap_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the swap_convention to a stream in JSON format.
+ */
+std::ostream& operator<<(std::ostream& s, const swap_convention& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/swap_convention_table.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/swap_convention_table.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_SWAP_CONVENTION_TABLE_HPP
+#define ORES_REFDATA_DOMAIN_SWAP_CONVENTION_TABLE_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata.api/domain/swap_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Converts swap_conventions to the table format.
+ */
+std::string convert_to_table(const std::vector<swap_convention>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/swap_convention_table_io.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/swap_convention_table_io.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_DOMAIN_SWAP_CONVENTION_TABLE_IO_HPP
+#define ORES_REFDATA_DOMAIN_SWAP_CONVENTION_TABLE_IO_HPP
+
+#include <iosfwd>
+#include <vector>
+#include "ores.refdata.api/domain/swap_convention.hpp"
+
+namespace ores::refdata::domain {
+
+/**
+ * @brief Dumps the swap_convention objects to a stream in table format.
+ */
+std::ostream& operator<<(std::ostream& s, const std::vector<swap_convention>& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/generators/cds_convention_generator.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/generators/cds_convention_generator.hpp
@@ -1,0 +1,44 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_GENERATORS_CDS_CONVENTION_GENERATOR_HPP
+#define ORES_REFDATA_GENERATORS_CDS_CONVENTION_GENERATOR_HPP
+
+#include <vector>
+#include "ores.refdata.api/domain/cds_convention.hpp"
+#include "ores.utility/generation/generation_context.hpp"
+
+namespace ores::refdata::generators {
+
+/**
+ * @brief Generates a synthetic cds_convention.
+ */
+domain::cds_convention generate_synthetic_cds_convention(
+    utility::generation::generation_context& ctx);
+
+/**
+ * @brief Generates N synthetic cds_conventions.
+ */
+std::vector<domain::cds_convention>
+generate_synthetic_cds_conventions(std::size_t n,
+    utility::generation::generation_context& ctx);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/generators/fra_convention_generator.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/generators/fra_convention_generator.hpp
@@ -1,0 +1,44 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_GENERATORS_FRA_CONVENTION_GENERATOR_HPP
+#define ORES_REFDATA_GENERATORS_FRA_CONVENTION_GENERATOR_HPP
+
+#include <vector>
+#include "ores.refdata.api/domain/fra_convention.hpp"
+#include "ores.utility/generation/generation_context.hpp"
+
+namespace ores::refdata::generators {
+
+/**
+ * @brief Generates a synthetic fra_convention.
+ */
+domain::fra_convention generate_synthetic_fra_convention(
+    utility::generation::generation_context& ctx);
+
+/**
+ * @brief Generates N synthetic fra_conventions.
+ */
+std::vector<domain::fra_convention>
+generate_synthetic_fra_conventions(std::size_t n,
+    utility::generation::generation_context& ctx);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/generators/fx_convention_generator.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/generators/fx_convention_generator.hpp
@@ -1,0 +1,44 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_GENERATORS_FX_CONVENTION_GENERATOR_HPP
+#define ORES_REFDATA_GENERATORS_FX_CONVENTION_GENERATOR_HPP
+
+#include <vector>
+#include "ores.refdata.api/domain/fx_convention.hpp"
+#include "ores.utility/generation/generation_context.hpp"
+
+namespace ores::refdata::generators {
+
+/**
+ * @brief Generates a synthetic fx_convention.
+ */
+domain::fx_convention generate_synthetic_fx_convention(
+    utility::generation::generation_context& ctx);
+
+/**
+ * @brief Generates N synthetic fx_conventions.
+ */
+std::vector<domain::fx_convention>
+generate_synthetic_fx_conventions(std::size_t n,
+    utility::generation::generation_context& ctx);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/generators/ibor_index_convention_generator.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/generators/ibor_index_convention_generator.hpp
@@ -1,0 +1,44 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_GENERATORS_IBOR_INDEX_CONVENTION_GENERATOR_HPP
+#define ORES_REFDATA_GENERATORS_IBOR_INDEX_CONVENTION_GENERATOR_HPP
+
+#include <vector>
+#include "ores.refdata.api/domain/ibor_index_convention.hpp"
+#include "ores.utility/generation/generation_context.hpp"
+
+namespace ores::refdata::generators {
+
+/**
+ * @brief Generates a synthetic ibor_index_convention.
+ */
+domain::ibor_index_convention generate_synthetic_ibor_index_convention(
+    utility::generation::generation_context& ctx);
+
+/**
+ * @brief Generates N synthetic ibor_index_conventions.
+ */
+std::vector<domain::ibor_index_convention>
+generate_synthetic_ibor_index_conventions(std::size_t n,
+    utility::generation::generation_context& ctx);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/generators/ois_convention_generator.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/generators/ois_convention_generator.hpp
@@ -1,0 +1,44 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_GENERATORS_OIS_CONVENTION_GENERATOR_HPP
+#define ORES_REFDATA_GENERATORS_OIS_CONVENTION_GENERATOR_HPP
+
+#include <vector>
+#include "ores.refdata.api/domain/ois_convention.hpp"
+#include "ores.utility/generation/generation_context.hpp"
+
+namespace ores::refdata::generators {
+
+/**
+ * @brief Generates a synthetic ois_convention.
+ */
+domain::ois_convention generate_synthetic_ois_convention(
+    utility::generation::generation_context& ctx);
+
+/**
+ * @brief Generates N synthetic ois_conventions.
+ */
+std::vector<domain::ois_convention>
+generate_synthetic_ois_conventions(std::size_t n,
+    utility::generation::generation_context& ctx);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/generators/overnight_index_convention_generator.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/generators/overnight_index_convention_generator.hpp
@@ -1,0 +1,44 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_GENERATORS_OVERNIGHT_INDEX_CONVENTION_GENERATOR_HPP
+#define ORES_REFDATA_GENERATORS_OVERNIGHT_INDEX_CONVENTION_GENERATOR_HPP
+
+#include <vector>
+#include "ores.refdata.api/domain/overnight_index_convention.hpp"
+#include "ores.utility/generation/generation_context.hpp"
+
+namespace ores::refdata::generators {
+
+/**
+ * @brief Generates a synthetic overnight_index_convention.
+ */
+domain::overnight_index_convention generate_synthetic_overnight_index_convention(
+    utility::generation::generation_context& ctx);
+
+/**
+ * @brief Generates N synthetic overnight_index_conventions.
+ */
+std::vector<domain::overnight_index_convention>
+generate_synthetic_overnight_index_conventions(std::size_t n,
+    utility::generation::generation_context& ctx);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/generators/swap_convention_generator.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/generators/swap_convention_generator.hpp
@@ -1,0 +1,44 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_GENERATORS_SWAP_CONVENTION_GENERATOR_HPP
+#define ORES_REFDATA_GENERATORS_SWAP_CONVENTION_GENERATOR_HPP
+
+#include <vector>
+#include "ores.refdata.api/domain/swap_convention.hpp"
+#include "ores.utility/generation/generation_context.hpp"
+
+namespace ores::refdata::generators {
+
+/**
+ * @brief Generates a synthetic swap_convention.
+ */
+domain::swap_convention generate_synthetic_swap_convention(
+    utility::generation::generation_context& ctx);
+
+/**
+ * @brief Generates N synthetic swap_conventions.
+ */
+std::vector<domain::swap_convention>
+generate_synthetic_swap_conventions(std::size_t n,
+    utility::generation::generation_context& ctx);
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/messaging/cds_convention_protocol.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/messaging/cds_convention_protocol.hpp
@@ -1,0 +1,81 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_CDS_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_MESSAGING_CDS_CONVENTION_PROTOCOL_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata.api/domain/cds_convention.hpp"
+
+namespace ores::refdata::messaging {
+
+struct get_cds_conventions_request {
+    using response_type = struct get_cds_conventions_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.cds_conventions.list";
+};
+
+struct get_cds_conventions_response {
+    std::vector<ores::refdata::domain::cds_convention> cds_conventions;
+    int total_available_count = 0;
+    bool success = true;
+    std::string message;
+};
+
+struct save_cds_convention_request {
+    using response_type = struct save_cds_convention_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.cds_conventions.save";
+    ores::refdata::domain::cds_convention data;
+};
+
+struct save_cds_convention_response {
+    bool success = false;
+    std::string message;
+};
+
+struct delete_cds_convention_request {
+    using response_type = struct delete_cds_convention_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.cds_conventions.delete";
+    std::vector<std::string> codes;
+};
+
+struct delete_cds_convention_response {
+    bool success = false;
+    std::string message;
+};
+
+struct get_cds_convention_history_request {
+    using response_type = struct get_cds_convention_history_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.cds_conventions.history";
+    std::string id;
+};
+
+struct get_cds_convention_history_response {
+    std::vector<ores::refdata::domain::cds_convention> cds_conventions;
+    bool success = false;
+    std::string message;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/messaging/fra_convention_protocol.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/messaging/fra_convention_protocol.hpp
@@ -1,0 +1,81 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_FRA_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_MESSAGING_FRA_CONVENTION_PROTOCOL_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata.api/domain/fra_convention.hpp"
+
+namespace ores::refdata::messaging {
+
+struct get_fra_conventions_request {
+    using response_type = struct get_fra_conventions_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.fra_conventions.list";
+};
+
+struct get_fra_conventions_response {
+    std::vector<ores::refdata::domain::fra_convention> fra_conventions;
+    int total_available_count = 0;
+    bool success = true;
+    std::string message;
+};
+
+struct save_fra_convention_request {
+    using response_type = struct save_fra_convention_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.fra_conventions.save";
+    ores::refdata::domain::fra_convention data;
+};
+
+struct save_fra_convention_response {
+    bool success = false;
+    std::string message;
+};
+
+struct delete_fra_convention_request {
+    using response_type = struct delete_fra_convention_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.fra_conventions.delete";
+    std::vector<std::string> codes;
+};
+
+struct delete_fra_convention_response {
+    bool success = false;
+    std::string message;
+};
+
+struct get_fra_convention_history_request {
+    using response_type = struct get_fra_convention_history_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.fra_conventions.history";
+    std::string id;
+};
+
+struct get_fra_convention_history_response {
+    std::vector<ores::refdata::domain::fra_convention> fra_conventions;
+    bool success = false;
+    std::string message;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/messaging/fx_convention_protocol.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/messaging/fx_convention_protocol.hpp
@@ -1,0 +1,81 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_FX_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_MESSAGING_FX_CONVENTION_PROTOCOL_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata.api/domain/fx_convention.hpp"
+
+namespace ores::refdata::messaging {
+
+struct get_fx_conventions_request {
+    using response_type = struct get_fx_conventions_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.fx_conventions.list";
+};
+
+struct get_fx_conventions_response {
+    std::vector<ores::refdata::domain::fx_convention> fx_conventions;
+    int total_available_count = 0;
+    bool success = true;
+    std::string message;
+};
+
+struct save_fx_convention_request {
+    using response_type = struct save_fx_convention_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.fx_conventions.save";
+    ores::refdata::domain::fx_convention data;
+};
+
+struct save_fx_convention_response {
+    bool success = false;
+    std::string message;
+};
+
+struct delete_fx_convention_request {
+    using response_type = struct delete_fx_convention_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.fx_conventions.delete";
+    std::vector<std::string> codes;
+};
+
+struct delete_fx_convention_response {
+    bool success = false;
+    std::string message;
+};
+
+struct get_fx_convention_history_request {
+    using response_type = struct get_fx_convention_history_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.fx_conventions.history";
+    std::string id;
+};
+
+struct get_fx_convention_history_response {
+    std::vector<ores::refdata::domain::fx_convention> fx_conventions;
+    bool success = false;
+    std::string message;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/messaging/ibor_index_convention_protocol.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/messaging/ibor_index_convention_protocol.hpp
@@ -1,0 +1,81 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_IBOR_INDEX_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_MESSAGING_IBOR_INDEX_CONVENTION_PROTOCOL_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata.api/domain/ibor_index_convention.hpp"
+
+namespace ores::refdata::messaging {
+
+struct get_ibor_index_conventions_request {
+    using response_type = struct get_ibor_index_conventions_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.ibor_index_conventions.list";
+};
+
+struct get_ibor_index_conventions_response {
+    std::vector<ores::refdata::domain::ibor_index_convention> ibor_index_conventions;
+    int total_available_count = 0;
+    bool success = true;
+    std::string message;
+};
+
+struct save_ibor_index_convention_request {
+    using response_type = struct save_ibor_index_convention_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.ibor_index_conventions.save";
+    ores::refdata::domain::ibor_index_convention data;
+};
+
+struct save_ibor_index_convention_response {
+    bool success = false;
+    std::string message;
+};
+
+struct delete_ibor_index_convention_request {
+    using response_type = struct delete_ibor_index_convention_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.ibor_index_conventions.delete";
+    std::vector<std::string> codes;
+};
+
+struct delete_ibor_index_convention_response {
+    bool success = false;
+    std::string message;
+};
+
+struct get_ibor_index_convention_history_request {
+    using response_type = struct get_ibor_index_convention_history_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.ibor_index_conventions.history";
+    std::string id;
+};
+
+struct get_ibor_index_convention_history_response {
+    std::vector<ores::refdata::domain::ibor_index_convention> ibor_index_conventions;
+    bool success = false;
+    std::string message;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/messaging/ois_convention_protocol.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/messaging/ois_convention_protocol.hpp
@@ -1,0 +1,81 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_OIS_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_MESSAGING_OIS_CONVENTION_PROTOCOL_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata.api/domain/ois_convention.hpp"
+
+namespace ores::refdata::messaging {
+
+struct get_ois_conventions_request {
+    using response_type = struct get_ois_conventions_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.ois_conventions.list";
+};
+
+struct get_ois_conventions_response {
+    std::vector<ores::refdata::domain::ois_convention> ois_conventions;
+    int total_available_count = 0;
+    bool success = true;
+    std::string message;
+};
+
+struct save_ois_convention_request {
+    using response_type = struct save_ois_convention_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.ois_conventions.save";
+    ores::refdata::domain::ois_convention data;
+};
+
+struct save_ois_convention_response {
+    bool success = false;
+    std::string message;
+};
+
+struct delete_ois_convention_request {
+    using response_type = struct delete_ois_convention_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.ois_conventions.delete";
+    std::vector<std::string> codes;
+};
+
+struct delete_ois_convention_response {
+    bool success = false;
+    std::string message;
+};
+
+struct get_ois_convention_history_request {
+    using response_type = struct get_ois_convention_history_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.ois_conventions.history";
+    std::string id;
+};
+
+struct get_ois_convention_history_response {
+    std::vector<ores::refdata::domain::ois_convention> ois_conventions;
+    bool success = false;
+    std::string message;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/messaging/overnight_index_convention_protocol.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/messaging/overnight_index_convention_protocol.hpp
@@ -1,0 +1,81 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_OVERNIGHT_INDEX_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_MESSAGING_OVERNIGHT_INDEX_CONVENTION_PROTOCOL_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata.api/domain/overnight_index_convention.hpp"
+
+namespace ores::refdata::messaging {
+
+struct get_overnight_index_conventions_request {
+    using response_type = struct get_overnight_index_conventions_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.overnight_index_conventions.list";
+};
+
+struct get_overnight_index_conventions_response {
+    std::vector<ores::refdata::domain::overnight_index_convention> overnight_index_conventions;
+    int total_available_count = 0;
+    bool success = true;
+    std::string message;
+};
+
+struct save_overnight_index_convention_request {
+    using response_type = struct save_overnight_index_convention_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.overnight_index_conventions.save";
+    ores::refdata::domain::overnight_index_convention data;
+};
+
+struct save_overnight_index_convention_response {
+    bool success = false;
+    std::string message;
+};
+
+struct delete_overnight_index_convention_request {
+    using response_type = struct delete_overnight_index_convention_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.overnight_index_conventions.delete";
+    std::vector<std::string> codes;
+};
+
+struct delete_overnight_index_convention_response {
+    bool success = false;
+    std::string message;
+};
+
+struct get_overnight_index_convention_history_request {
+    using response_type = struct get_overnight_index_convention_history_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.overnight_index_conventions.history";
+    std::string id;
+};
+
+struct get_overnight_index_convention_history_response {
+    std::vector<ores::refdata::domain::overnight_index_convention> overnight_index_conventions;
+    bool success = false;
+    std::string message;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.api/include/ores.refdata.api/messaging/swap_convention_protocol.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/messaging/swap_convention_protocol.hpp
@@ -1,0 +1,81 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_SWAP_CONVENTION_PROTOCOL_HPP
+#define ORES_REFDATA_MESSAGING_SWAP_CONVENTION_PROTOCOL_HPP
+
+#include <string>
+#include <vector>
+#include "ores.refdata.api/domain/swap_convention.hpp"
+
+namespace ores::refdata::messaging {
+
+struct get_swap_conventions_request {
+    using response_type = struct get_swap_conventions_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.swap_conventions.list";
+};
+
+struct get_swap_conventions_response {
+    std::vector<ores::refdata::domain::swap_convention> swap_conventions;
+    int total_available_count = 0;
+    bool success = true;
+    std::string message;
+};
+
+struct save_swap_convention_request {
+    using response_type = struct save_swap_convention_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.swap_conventions.save";
+    ores::refdata::domain::swap_convention data;
+};
+
+struct save_swap_convention_response {
+    bool success = false;
+    std::string message;
+};
+
+struct delete_swap_convention_request {
+    using response_type = struct delete_swap_convention_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.swap_conventions.delete";
+    std::vector<std::string> codes;
+};
+
+struct delete_swap_convention_response {
+    bool success = false;
+    std::string message;
+};
+
+struct get_swap_convention_history_request {
+    using response_type = struct get_swap_convention_history_response;
+    static constexpr std::string_view nats_subject =
+        "refdata.v1.swap_conventions.history";
+    std::string id;
+};
+
+struct get_swap_convention_history_response {
+    std::vector<ores::refdata::domain::swap_convention> swap_conventions;
+    bool success = false;
+    std::string message;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.api/src/domain/cds_convention_json_io.cpp
+++ b/projects/ores.refdata.api/src/domain/cds_convention_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/cds_convention_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::domain {
+
+std::ostream& operator<<(std::ostream& s, const cds_convention& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/cds_convention_table.cpp
+++ b/projects/ores.refdata.api/src/domain/cds_convention_table.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/cds_convention_table.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <fort.hpp>
+
+namespace ores::refdata::domain {
+
+
+std::string convert_to_table(const std::vector<cds_convention>& v) {
+    fort::char_table table;
+    table.set_border_style(FT_BASIC_STYLE);
+
+    table << fort::header << "Id" << "Frequency" << "Rule" << "DCF" << "Modified By" << "Version" << fort::endr;
+
+    for (const auto& cc : v) {
+        table << cc.id << cc.frequency << cc.rule << cc.day_count_fraction << cc.modified_by << cc.version << fort::endr;
+    }
+    return table.to_string();
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/cds_convention_table_io.cpp
+++ b/projects/ores.refdata.api/src/domain/cds_convention_table_io.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/cds_convention_table_io.hpp"
+
+#include <ostream>
+#include "ores.refdata.api/domain/cds_convention_table.hpp"
+
+namespace ores::refdata::domain {
+
+namespace {
+
+void print_cds_convention_table(std::ostream& s, const std::vector<cds_convention>& v) {
+    s << std::endl << convert_to_table(v) << std::endl;
+}
+
+}
+
+std::ostream& operator<<(std::ostream& s, const std::vector<cds_convention>& v) {
+    print_cds_convention_table(s, v);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/fra_convention_json_io.cpp
+++ b/projects/ores.refdata.api/src/domain/fra_convention_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/fra_convention_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::domain {
+
+std::ostream& operator<<(std::ostream& s, const fra_convention& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/fra_convention_table.cpp
+++ b/projects/ores.refdata.api/src/domain/fra_convention_table.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/fra_convention_table.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <fort.hpp>
+
+namespace ores::refdata::domain {
+
+
+std::string convert_to_table(const std::vector<fra_convention>& v) {
+    fort::char_table table;
+    table.set_border_style(FT_BASIC_STYLE);
+
+    table << fort::header << "Id" << "Index" << "Modified By" << "Version" << fort::endr;
+
+    for (const auto& fc : v) {
+        table << fc.id << fc.index << fc.modified_by << fc.version << fort::endr;
+    }
+    return table.to_string();
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/fra_convention_table_io.cpp
+++ b/projects/ores.refdata.api/src/domain/fra_convention_table_io.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/fra_convention_table_io.hpp"
+
+#include <ostream>
+#include "ores.refdata.api/domain/fra_convention_table.hpp"
+
+namespace ores::refdata::domain {
+
+namespace {
+
+void print_fra_convention_table(std::ostream& s, const std::vector<fra_convention>& v) {
+    s << std::endl << convert_to_table(v) << std::endl;
+}
+
+}
+
+std::ostream& operator<<(std::ostream& s, const std::vector<fra_convention>& v) {
+    print_fra_convention_table(s, v);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/fx_convention_json_io.cpp
+++ b/projects/ores.refdata.api/src/domain/fx_convention_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/fx_convention_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::domain {
+
+std::ostream& operator<<(std::ostream& s, const fx_convention& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/fx_convention_table.cpp
+++ b/projects/ores.refdata.api/src/domain/fx_convention_table.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/fx_convention_table.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <fort.hpp>
+
+namespace ores::refdata::domain {
+
+
+std::string convert_to_table(const std::vector<fx_convention>& v) {
+    fort::char_table table;
+    table.set_border_style(FT_BASIC_STYLE);
+
+    table << fort::header << "Id" << "Source CCY" << "Target CCY" << "Spot Days" << "Modified By" << "Version" << fort::endr;
+
+    for (const auto& fxc : v) {
+        table << fxc.id << fxc.source_currency << fxc.target_currency << fxc.spot_days << fxc.modified_by << fxc.version << fort::endr;
+    }
+    return table.to_string();
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/fx_convention_table_io.cpp
+++ b/projects/ores.refdata.api/src/domain/fx_convention_table_io.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/fx_convention_table_io.hpp"
+
+#include <ostream>
+#include "ores.refdata.api/domain/fx_convention_table.hpp"
+
+namespace ores::refdata::domain {
+
+namespace {
+
+void print_fx_convention_table(std::ostream& s, const std::vector<fx_convention>& v) {
+    s << std::endl << convert_to_table(v) << std::endl;
+}
+
+}
+
+std::ostream& operator<<(std::ostream& s, const std::vector<fx_convention>& v) {
+    print_fx_convention_table(s, v);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/ibor_index_convention_json_io.cpp
+++ b/projects/ores.refdata.api/src/domain/ibor_index_convention_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/ibor_index_convention_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::domain {
+
+std::ostream& operator<<(std::ostream& s, const ibor_index_convention& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/ibor_index_convention_table.cpp
+++ b/projects/ores.refdata.api/src/domain/ibor_index_convention_table.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/ibor_index_convention_table.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <fort.hpp>
+
+namespace ores::refdata::domain {
+
+
+std::string convert_to_table(const std::vector<ibor_index_convention>& v) {
+    fort::char_table table;
+    table.set_border_style(FT_BASIC_STYLE);
+
+    table << fort::header << "Id" << "Fixing Calendar" << "DCF" << "Settlement Days" << "Modified By" << "Version" << fort::endr;
+
+    for (const auto& ic : v) {
+        table << ic.id << ic.fixing_calendar << ic.day_count_fraction << ic.settlement_days << ic.modified_by << ic.version << fort::endr;
+    }
+    return table.to_string();
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/ibor_index_convention_table_io.cpp
+++ b/projects/ores.refdata.api/src/domain/ibor_index_convention_table_io.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/ibor_index_convention_table_io.hpp"
+
+#include <ostream>
+#include "ores.refdata.api/domain/ibor_index_convention_table.hpp"
+
+namespace ores::refdata::domain {
+
+namespace {
+
+void print_ibor_index_convention_table(std::ostream& s, const std::vector<ibor_index_convention>& v) {
+    s << std::endl << convert_to_table(v) << std::endl;
+}
+
+}
+
+std::ostream& operator<<(std::ostream& s, const std::vector<ibor_index_convention>& v) {
+    print_ibor_index_convention_table(s, v);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/ois_convention_json_io.cpp
+++ b/projects/ores.refdata.api/src/domain/ois_convention_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/ois_convention_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::domain {
+
+std::ostream& operator<<(std::ostream& s, const ois_convention& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/ois_convention_table.cpp
+++ b/projects/ores.refdata.api/src/domain/ois_convention_table.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/ois_convention_table.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <fort.hpp>
+
+namespace ores::refdata::domain {
+
+
+std::string convert_to_table(const std::vector<ois_convention>& v) {
+    fort::char_table table;
+    table.set_border_style(FT_BASIC_STYLE);
+
+    table << fort::header << "Id" << "Index" << "Spot Lag" << "Fixed DCF" << "Modified By" << "Version" << fort::endr;
+
+    for (const auto& oc : v) {
+        table << oc.id << oc.index << oc.spot_lag << oc.fixed_day_count_fraction << oc.modified_by << oc.version << fort::endr;
+    }
+    return table.to_string();
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/ois_convention_table_io.cpp
+++ b/projects/ores.refdata.api/src/domain/ois_convention_table_io.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/ois_convention_table_io.hpp"
+
+#include <ostream>
+#include "ores.refdata.api/domain/ois_convention_table.hpp"
+
+namespace ores::refdata::domain {
+
+namespace {
+
+void print_ois_convention_table(std::ostream& s, const std::vector<ois_convention>& v) {
+    s << std::endl << convert_to_table(v) << std::endl;
+}
+
+}
+
+std::ostream& operator<<(std::ostream& s, const std::vector<ois_convention>& v) {
+    print_ois_convention_table(s, v);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/overnight_index_convention_json_io.cpp
+++ b/projects/ores.refdata.api/src/domain/overnight_index_convention_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/overnight_index_convention_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::domain {
+
+std::ostream& operator<<(std::ostream& s, const overnight_index_convention& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/overnight_index_convention_table.cpp
+++ b/projects/ores.refdata.api/src/domain/overnight_index_convention_table.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/overnight_index_convention_table.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <fort.hpp>
+
+namespace ores::refdata::domain {
+
+
+std::string convert_to_table(const std::vector<overnight_index_convention>& v) {
+    fort::char_table table;
+    table.set_border_style(FT_BASIC_STYLE);
+
+    table << fort::header << "Id" << "Fixing Calendar" << "DCF" << "Settlement Days" << "Modified By" << "Version" << fort::endr;
+
+    for (const auto& ni : v) {
+        table << ni.id << ni.fixing_calendar << ni.day_count_fraction << ni.settlement_days << ni.modified_by << ni.version << fort::endr;
+    }
+    return table.to_string();
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/overnight_index_convention_table_io.cpp
+++ b/projects/ores.refdata.api/src/domain/overnight_index_convention_table_io.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/overnight_index_convention_table_io.hpp"
+
+#include <ostream>
+#include "ores.refdata.api/domain/overnight_index_convention_table.hpp"
+
+namespace ores::refdata::domain {
+
+namespace {
+
+void print_overnight_index_convention_table(std::ostream& s, const std::vector<overnight_index_convention>& v) {
+    s << std::endl << convert_to_table(v) << std::endl;
+}
+
+}
+
+std::ostream& operator<<(std::ostream& s, const std::vector<overnight_index_convention>& v) {
+    print_overnight_index_convention_table(s, v);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/swap_convention_json_io.cpp
+++ b/projects/ores.refdata.api/src/domain/swap_convention_json_io.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/swap_convention_json_io.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::domain {
+
+std::ostream& operator<<(std::ostream& s, const swap_convention& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/swap_convention_table.cpp
+++ b/projects/ores.refdata.api/src/domain/swap_convention_table.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/swap_convention_table.hpp"
+
+#include <boost/uuid/uuid_io.hpp>
+#include <fort.hpp>
+
+namespace ores::refdata::domain {
+
+
+std::string convert_to_table(const std::vector<swap_convention>& v) {
+    fort::char_table table;
+    table.set_border_style(FT_BASIC_STYLE);
+
+    table << fort::header << "Id" << "Fixed Freq" << "Fixed DCF" << "Index" << "Modified By" << "Version" << fort::endr;
+
+    for (const auto& sc : v) {
+        table << sc.id << sc.fixed_frequency << sc.fixed_day_count_fraction << sc.index << sc.modified_by << sc.version << fort::endr;
+    }
+    return table.to_string();
+}
+
+}

--- a/projects/ores.refdata.api/src/domain/swap_convention_table_io.cpp
+++ b/projects/ores.refdata.api/src/domain/swap_convention_table_io.cpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/domain/swap_convention_table_io.hpp"
+
+#include <ostream>
+#include "ores.refdata.api/domain/swap_convention_table.hpp"
+
+namespace ores::refdata::domain {
+
+namespace {
+
+void print_swap_convention_table(std::ostream& s, const std::vector<swap_convention>& v) {
+    s << std::endl << convert_to_table(v) << std::endl;
+}
+
+}
+
+std::ostream& operator<<(std::ostream& s, const std::vector<swap_convention>& v) {
+    print_swap_convention_table(s, v);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.api/src/generators/cds_convention_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/cds_convention_generator.cpp
@@ -1,0 +1,69 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/generators/cds_convention_generator.hpp"
+
+#include <atomic>
+#include <string>
+#include <faker-cxx/faker.h> // IWYU pragma: keep.
+#include "ores.utility/generation/generation_keys.hpp"
+
+namespace ores::refdata::generators {
+
+using ores::utility::generation::generation_keys;
+
+domain::cds_convention generate_synthetic_cds_convention(
+    utility::generation::generation_context& ctx) {
+    static std::atomic<int> counter{0};
+    const auto modified_by = ctx.env().get_or(
+        std::string(generation_keys::modified_by), "system");
+
+    domain::cds_convention r;
+    r.version = 1;
+    r.id = std::string("CDS-STANDARD-CONVENTIONS") + "-"
+        + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
+    r.settlement_days = 3;
+    r.calendar = std::string("WeekendsOnly");
+    r.frequency = std::string("Quarterly");
+    r.payment_convention = std::string("Following");
+    r.rule = std::string("CDS2015");
+    r.day_count_fraction = std::string("ACT/360");
+    r.settles_accrual = true;
+    r.pays_at_default_time = true;
+    r.upfront_settlement_days = std::nullopt;
+    r.last_period_day_count_fraction = std::nullopt;
+    r.modified_by = modified_by;
+    r.performed_by = modified_by;
+    r.change_reason_code = "system.new";
+    r.change_commentary = "Synthetic test data";
+    r.recorded_at = ctx.past_timepoint();
+    return r;
+}
+
+std::vector<domain::cds_convention>
+generate_synthetic_cds_conventions(std::size_t n,
+    utility::generation::generation_context& ctx) {
+    std::vector<domain::cds_convention> r;
+    r.reserve(n);
+    while (r.size() < n)
+        r.push_back(generate_synthetic_cds_convention(ctx));
+    return r;
+}
+
+}

--- a/projects/ores.refdata.api/src/generators/fra_convention_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/fra_convention_generator.cpp
@@ -1,0 +1,60 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/generators/fra_convention_generator.hpp"
+
+#include <atomic>
+#include <string>
+#include <faker-cxx/faker.h> // IWYU pragma: keep.
+#include "ores.utility/generation/generation_keys.hpp"
+
+namespace ores::refdata::generators {
+
+using ores::utility::generation::generation_keys;
+
+domain::fra_convention generate_synthetic_fra_convention(
+    utility::generation::generation_context& ctx) {
+    static std::atomic<int> counter{0};
+    const auto modified_by = ctx.env().get_or(
+        std::string(generation_keys::modified_by), "system");
+
+    domain::fra_convention r;
+    r.version = 1;
+    r.id = std::string("EUR-6M-FRA-CONVENTIONS") + "-"
+        + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
+    r.index = std::string("EUR-EURIBOR-6M");
+    r.modified_by = modified_by;
+    r.performed_by = modified_by;
+    r.change_reason_code = "system.new";
+    r.change_commentary = "Synthetic test data";
+    r.recorded_at = ctx.past_timepoint();
+    return r;
+}
+
+std::vector<domain::fra_convention>
+generate_synthetic_fra_conventions(std::size_t n,
+    utility::generation::generation_context& ctx) {
+    std::vector<domain::fra_convention> r;
+    r.reserve(n);
+    while (r.size() < n)
+        r.push_back(generate_synthetic_fra_convention(ctx));
+    return r;
+}
+
+}

--- a/projects/ores.refdata.api/src/generators/fx_convention_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/fx_convention_generator.cpp
@@ -1,0 +1,67 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/generators/fx_convention_generator.hpp"
+
+#include <atomic>
+#include <string>
+#include <faker-cxx/faker.h> // IWYU pragma: keep.
+#include "ores.utility/generation/generation_keys.hpp"
+
+namespace ores::refdata::generators {
+
+using ores::utility::generation::generation_keys;
+
+domain::fx_convention generate_synthetic_fx_convention(
+    utility::generation::generation_context& ctx) {
+    static std::atomic<int> counter{0};
+    const auto modified_by = ctx.env().get_or(
+        std::string(generation_keys::modified_by), "system");
+
+    domain::fx_convention r;
+    r.version = 1;
+    r.id = std::string("EUR-USD-FX-CONVENTIONS") + "-"
+        + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
+    r.spot_days = 2;
+    r.source_currency = std::string("EUR");
+    r.target_currency = std::string("USD");
+    r.points_factor = 10000.0;
+    r.advance_calendar = std::nullopt;
+    r.spot_relative = std::nullopt;
+    r.end_of_month = std::nullopt;
+    r.convention = std::nullopt;
+    r.modified_by = modified_by;
+    r.performed_by = modified_by;
+    r.change_reason_code = "system.new";
+    r.change_commentary = "Synthetic test data";
+    r.recorded_at = ctx.past_timepoint();
+    return r;
+}
+
+std::vector<domain::fx_convention>
+generate_synthetic_fx_conventions(std::size_t n,
+    utility::generation::generation_context& ctx) {
+    std::vector<domain::fx_convention> r;
+    r.reserve(n);
+    while (r.size() < n)
+        r.push_back(generate_synthetic_fx_convention(ctx));
+    return r;
+}
+
+}

--- a/projects/ores.refdata.api/src/generators/ibor_index_convention_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/ibor_index_convention_generator.cpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/generators/ibor_index_convention_generator.hpp"
+
+#include <atomic>
+#include <string>
+#include <faker-cxx/faker.h> // IWYU pragma: keep.
+#include "ores.utility/generation/generation_keys.hpp"
+
+namespace ores::refdata::generators {
+
+using ores::utility::generation::generation_keys;
+
+domain::ibor_index_convention generate_synthetic_ibor_index_convention(
+    utility::generation::generation_context& ctx) {
+    static std::atomic<int> counter{0};
+    const auto modified_by = ctx.env().get_or(
+        std::string(generation_keys::modified_by), "system");
+
+    domain::ibor_index_convention r;
+    r.version = 1;
+    r.id = std::string("EUR-EURIBOR") + "-"
+        + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
+    r.fixing_calendar = std::string("TARGET");
+    r.day_count_fraction = std::string("ACT/360");
+    r.settlement_days = 2;
+    r.business_day_convention = std::string("ModifiedFollowing");
+    r.end_of_month = false;
+    r.modified_by = modified_by;
+    r.performed_by = modified_by;
+    r.change_reason_code = "system.new";
+    r.change_commentary = "Synthetic test data";
+    r.recorded_at = ctx.past_timepoint();
+    return r;
+}
+
+std::vector<domain::ibor_index_convention>
+generate_synthetic_ibor_index_conventions(std::size_t n,
+    utility::generation::generation_context& ctx) {
+    std::vector<domain::ibor_index_convention> r;
+    r.reserve(n);
+    while (r.size() < n)
+        r.push_back(generate_synthetic_ibor_index_convention(ctx));
+    return r;
+}
+
+}

--- a/projects/ores.refdata.api/src/generators/ois_convention_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/ois_convention_generator.cpp
@@ -1,0 +1,71 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/generators/ois_convention_generator.hpp"
+
+#include <atomic>
+#include <string>
+#include <faker-cxx/faker.h> // IWYU pragma: keep.
+#include "ores.utility/generation/generation_keys.hpp"
+
+namespace ores::refdata::generators {
+
+using ores::utility::generation::generation_keys;
+
+domain::ois_convention generate_synthetic_ois_convention(
+    utility::generation::generation_context& ctx) {
+    static std::atomic<int> counter{0};
+    const auto modified_by = ctx.env().get_or(
+        std::string(generation_keys::modified_by), "system");
+
+    domain::ois_convention r;
+    r.version = 1;
+    r.id = std::string("EUR-OIS-CONVENTIONS") + "-"
+        + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
+    r.spot_lag = 2;
+    r.index = std::string("EUR-EONIA");
+    r.fixed_day_count_fraction = std::string("ACT/360");
+    r.fixed_calendar = std::string("TARGET");
+    r.payment_lag = std::nullopt;
+    r.end_of_month = std::nullopt;
+    r.fixed_frequency = std::nullopt;
+    r.fixed_convention = std::nullopt;
+    r.fixed_payment_convention = std::nullopt;
+    r.rule = std::nullopt;
+    r.payment_calendar = std::nullopt;
+    r.rate_cutoff = std::nullopt;
+    r.modified_by = modified_by;
+    r.performed_by = modified_by;
+    r.change_reason_code = "system.new";
+    r.change_commentary = "Synthetic test data";
+    r.recorded_at = ctx.past_timepoint();
+    return r;
+}
+
+std::vector<domain::ois_convention>
+generate_synthetic_ois_conventions(std::size_t n,
+    utility::generation::generation_context& ctx) {
+    std::vector<domain::ois_convention> r;
+    r.reserve(n);
+    while (r.size() < n)
+        r.push_back(generate_synthetic_ois_convention(ctx));
+    return r;
+}
+
+}

--- a/projects/ores.refdata.api/src/generators/overnight_index_convention_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/overnight_index_convention_generator.cpp
@@ -1,0 +1,62 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/generators/overnight_index_convention_generator.hpp"
+
+#include <atomic>
+#include <string>
+#include <faker-cxx/faker.h> // IWYU pragma: keep.
+#include "ores.utility/generation/generation_keys.hpp"
+
+namespace ores::refdata::generators {
+
+using ores::utility::generation::generation_keys;
+
+domain::overnight_index_convention generate_synthetic_overnight_index_convention(
+    utility::generation::generation_context& ctx) {
+    static std::atomic<int> counter{0};
+    const auto modified_by = ctx.env().get_or(
+        std::string(generation_keys::modified_by), "system");
+
+    domain::overnight_index_convention r;
+    r.version = 1;
+    r.id = std::string("EUR-EONIA") + "-"
+        + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
+    r.fixing_calendar = std::string("TARGET");
+    r.day_count_fraction = std::string("ACT/360");
+    r.settlement_days = 0;
+    r.modified_by = modified_by;
+    r.performed_by = modified_by;
+    r.change_reason_code = "system.new";
+    r.change_commentary = "Synthetic test data";
+    r.recorded_at = ctx.past_timepoint();
+    return r;
+}
+
+std::vector<domain::overnight_index_convention>
+generate_synthetic_overnight_index_conventions(std::size_t n,
+    utility::generation::generation_context& ctx) {
+    std::vector<domain::overnight_index_convention> r;
+    r.reserve(n);
+    while (r.size() < n)
+        r.push_back(generate_synthetic_overnight_index_convention(ctx));
+    return r;
+}
+
+}

--- a/projects/ores.refdata.api/src/generators/swap_convention_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/swap_convention_generator.cpp
@@ -1,0 +1,66 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.api/generators/swap_convention_generator.hpp"
+
+#include <atomic>
+#include <string>
+#include <faker-cxx/faker.h> // IWYU pragma: keep.
+#include "ores.utility/generation/generation_keys.hpp"
+
+namespace ores::refdata::generators {
+
+using ores::utility::generation::generation_keys;
+
+domain::swap_convention generate_synthetic_swap_convention(
+    utility::generation::generation_context& ctx) {
+    static std::atomic<int> counter{0};
+    const auto modified_by = ctx.env().get_or(
+        std::string(generation_keys::modified_by), "system");
+
+    domain::swap_convention r;
+    r.version = 1;
+    r.id = std::string("EUR-6M-SWAP-CONVENTIONS") + "-"
+        + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
+    r.fixed_calendar = std::string("TARGET");
+    r.fixed_frequency = std::string("Annual");
+    r.fixed_convention = std::string("ModifiedFollowing");
+    r.fixed_day_count_fraction = std::string("30/360");
+    r.index = std::string("EUR-EURIBOR-6M");
+    r.float_frequency = std::nullopt;
+    r.sub_periods_coupon_type = std::nullopt;
+    r.modified_by = modified_by;
+    r.performed_by = modified_by;
+    r.change_reason_code = "system.new";
+    r.change_commentary = "Synthetic test data";
+    r.recorded_at = ctx.past_timepoint();
+    return r;
+}
+
+std::vector<domain::swap_convention>
+generate_synthetic_swap_conventions(std::size_t n,
+    utility::generation::generation_context& ctx) {
+    std::vector<domain::swap_convention> r;
+    r.reserve(n);
+    while (r.size() < n)
+        r.push_back(generate_synthetic_swap_convention(ctx));
+    return r;
+}
+
+}

--- a/projects/ores.refdata.core/include/ores.refdata.core/messaging/cds_convention_handler.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/messaging/cds_convention_handler.hpp
@@ -1,0 +1,197 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_CDS_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_MESSAGING_CDS_CONVENTION_HANDLER_HPP
+
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.refdata.api/messaging/cds_convention_protocol.hpp"
+#include "ores.refdata.core/service/cds_convention_service.hpp"
+
+namespace ores::refdata::messaging {
+
+namespace {
+inline auto& cds_convention_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.cds_convention_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using ores::service::messaging::has_permission;
+using namespace ores::logging;
+
+/**
+ * @brief NATS message handler for CDS convention operations.
+ */
+class cds_convention_handler {
+public:
+    cds_convention_handler(ores::nats::service::client& nats,
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
+
+    void list(ores::nats::message msg) {
+        BOOST_LOG_SEV(cds_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::cds_convention_service svc(req_ctx);
+        get_cds_conventions_response resp;
+        try {
+            resp.cds_conventions = svc.list_cds_conventions();
+            resp.total_available_count =
+                static_cast<int>(resp.cds_conventions.size());
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(cds_convention_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            resp.success = false;
+            resp.message = e.what();
+        }
+        BOOST_LOG_SEV(cds_convention_handler_lg(), debug)
+            << "Completed " << msg.subject;
+        reply(nats_, msg, resp);
+    }
+
+    void save(ores::nats::message msg) {
+        BOOST_LOG_SEV(cds_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::cds_conventions:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::cds_convention_service svc(req_ctx);
+        if (auto req = decode<save_cds_convention_request>(msg)) {
+            try {
+                svc.save_cds_convention(req->data);
+                BOOST_LOG_SEV(cds_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_cds_convention_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(cds_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_cds_convention_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(cds_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void history(ores::nats::message msg) {
+        BOOST_LOG_SEV(cds_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::cds_convention_service svc(req_ctx);
+        if (auto req = decode<get_cds_convention_history_request>(msg)) {
+            try {
+                auto hist = svc.get_cds_convention_history(req->id);
+                BOOST_LOG_SEV(cds_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_cds_convention_history_response{
+                    .cds_conventions = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(cds_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_cds_convention_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(cds_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(cds_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::cds_conventions:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::cds_convention_service svc(req_ctx);
+        if (auto req = decode<delete_cds_convention_request>(msg)) {
+            try {
+                for (const auto& code : req->codes)
+                    svc.remove_cds_convention(code);
+                BOOST_LOG_SEV(cds_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_cds_convention_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(cds_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_cds_convention_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(cds_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::refdata::messaging
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/messaging/fra_convention_handler.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/messaging/fra_convention_handler.hpp
@@ -1,0 +1,197 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_FRA_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_MESSAGING_FRA_CONVENTION_HANDLER_HPP
+
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.refdata.api/messaging/fra_convention_protocol.hpp"
+#include "ores.refdata.core/service/fra_convention_service.hpp"
+
+namespace ores::refdata::messaging {
+
+namespace {
+inline auto& fra_convention_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.fra_convention_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using ores::service::messaging::has_permission;
+using namespace ores::logging;
+
+/**
+ * @brief NATS message handler for FRA convention operations.
+ */
+class fra_convention_handler {
+public:
+    fra_convention_handler(ores::nats::service::client& nats,
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
+
+    void list(ores::nats::message msg) {
+        BOOST_LOG_SEV(fra_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::fra_convention_service svc(req_ctx);
+        get_fra_conventions_response resp;
+        try {
+            resp.fra_conventions = svc.list_fra_conventions();
+            resp.total_available_count =
+                static_cast<int>(resp.fra_conventions.size());
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(fra_convention_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            resp.success = false;
+            resp.message = e.what();
+        }
+        BOOST_LOG_SEV(fra_convention_handler_lg(), debug)
+            << "Completed " << msg.subject;
+        reply(nats_, msg, resp);
+    }
+
+    void save(ores::nats::message msg) {
+        BOOST_LOG_SEV(fra_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::fra_conventions:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::fra_convention_service svc(req_ctx);
+        if (auto req = decode<save_fra_convention_request>(msg)) {
+            try {
+                svc.save_fra_convention(req->data);
+                BOOST_LOG_SEV(fra_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_fra_convention_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(fra_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_fra_convention_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(fra_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void history(ores::nats::message msg) {
+        BOOST_LOG_SEV(fra_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::fra_convention_service svc(req_ctx);
+        if (auto req = decode<get_fra_convention_history_request>(msg)) {
+            try {
+                auto hist = svc.get_fra_convention_history(req->id);
+                BOOST_LOG_SEV(fra_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_fra_convention_history_response{
+                    .fra_conventions = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(fra_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_fra_convention_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(fra_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(fra_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::fra_conventions:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::fra_convention_service svc(req_ctx);
+        if (auto req = decode<delete_fra_convention_request>(msg)) {
+            try {
+                for (const auto& code : req->codes)
+                    svc.remove_fra_convention(code);
+                BOOST_LOG_SEV(fra_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_fra_convention_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(fra_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_fra_convention_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(fra_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::refdata::messaging
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/messaging/fx_convention_handler.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/messaging/fx_convention_handler.hpp
@@ -1,0 +1,197 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_FX_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_MESSAGING_FX_CONVENTION_HANDLER_HPP
+
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.refdata.api/messaging/fx_convention_protocol.hpp"
+#include "ores.refdata.core/service/fx_convention_service.hpp"
+
+namespace ores::refdata::messaging {
+
+namespace {
+inline auto& fx_convention_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.fx_convention_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using ores::service::messaging::has_permission;
+using namespace ores::logging;
+
+/**
+ * @brief NATS message handler for FX convention operations.
+ */
+class fx_convention_handler {
+public:
+    fx_convention_handler(ores::nats::service::client& nats,
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
+
+    void list(ores::nats::message msg) {
+        BOOST_LOG_SEV(fx_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::fx_convention_service svc(req_ctx);
+        get_fx_conventions_response resp;
+        try {
+            resp.fx_conventions = svc.list_fx_conventions();
+            resp.total_available_count =
+                static_cast<int>(resp.fx_conventions.size());
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(fx_convention_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            resp.success = false;
+            resp.message = e.what();
+        }
+        BOOST_LOG_SEV(fx_convention_handler_lg(), debug)
+            << "Completed " << msg.subject;
+        reply(nats_, msg, resp);
+    }
+
+    void save(ores::nats::message msg) {
+        BOOST_LOG_SEV(fx_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::fx_conventions:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::fx_convention_service svc(req_ctx);
+        if (auto req = decode<save_fx_convention_request>(msg)) {
+            try {
+                svc.save_fx_convention(req->data);
+                BOOST_LOG_SEV(fx_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_fx_convention_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(fx_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_fx_convention_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(fx_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void history(ores::nats::message msg) {
+        BOOST_LOG_SEV(fx_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::fx_convention_service svc(req_ctx);
+        if (auto req = decode<get_fx_convention_history_request>(msg)) {
+            try {
+                auto hist = svc.get_fx_convention_history(req->id);
+                BOOST_LOG_SEV(fx_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_fx_convention_history_response{
+                    .fx_conventions = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(fx_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_fx_convention_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(fx_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(fx_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::fx_conventions:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::fx_convention_service svc(req_ctx);
+        if (auto req = decode<delete_fx_convention_request>(msg)) {
+            try {
+                for (const auto& code : req->codes)
+                    svc.remove_fx_convention(code);
+                BOOST_LOG_SEV(fx_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_fx_convention_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(fx_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_fx_convention_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(fx_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::refdata::messaging
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/messaging/ibor_index_convention_handler.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/messaging/ibor_index_convention_handler.hpp
@@ -1,0 +1,197 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_IBOR_INDEX_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_MESSAGING_IBOR_INDEX_CONVENTION_HANDLER_HPP
+
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.refdata.api/messaging/ibor_index_convention_protocol.hpp"
+#include "ores.refdata.core/service/ibor_index_convention_service.hpp"
+
+namespace ores::refdata::messaging {
+
+namespace {
+inline auto& ibor_index_convention_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.ibor_index_convention_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using ores::service::messaging::has_permission;
+using namespace ores::logging;
+
+/**
+ * @brief NATS message handler for IBOR index convention operations.
+ */
+class ibor_index_convention_handler {
+public:
+    ibor_index_convention_handler(ores::nats::service::client& nats,
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
+
+    void list(ores::nats::message msg) {
+        BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::ibor_index_convention_service svc(req_ctx);
+        get_ibor_index_conventions_response resp;
+        try {
+            resp.ibor_index_conventions = svc.list_ibor_index_conventions();
+            resp.total_available_count =
+                static_cast<int>(resp.ibor_index_conventions.size());
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(ibor_index_convention_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            resp.success = false;
+            resp.message = e.what();
+        }
+        BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug)
+            << "Completed " << msg.subject;
+        reply(nats_, msg, resp);
+    }
+
+    void save(ores::nats::message msg) {
+        BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::ibor_index_conventions:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::ibor_index_convention_service svc(req_ctx);
+        if (auto req = decode<save_ibor_index_convention_request>(msg)) {
+            try {
+                svc.save_ibor_index_convention(req->data);
+                BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_ibor_index_convention_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(ibor_index_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_ibor_index_convention_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(ibor_index_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void history(ores::nats::message msg) {
+        BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::ibor_index_convention_service svc(req_ctx);
+        if (auto req = decode<get_ibor_index_convention_history_request>(msg)) {
+            try {
+                auto hist = svc.get_ibor_index_convention_history(req->id);
+                BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_ibor_index_convention_history_response{
+                    .ibor_index_conventions = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(ibor_index_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_ibor_index_convention_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(ibor_index_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::ibor_index_conventions:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::ibor_index_convention_service svc(req_ctx);
+        if (auto req = decode<delete_ibor_index_convention_request>(msg)) {
+            try {
+                for (const auto& code : req->codes)
+                    svc.remove_ibor_index_convention(code);
+                BOOST_LOG_SEV(ibor_index_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_ibor_index_convention_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(ibor_index_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_ibor_index_convention_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(ibor_index_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::refdata::messaging
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/messaging/ois_convention_handler.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/messaging/ois_convention_handler.hpp
@@ -1,0 +1,197 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_OIS_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_MESSAGING_OIS_CONVENTION_HANDLER_HPP
+
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.refdata.api/messaging/ois_convention_protocol.hpp"
+#include "ores.refdata.core/service/ois_convention_service.hpp"
+
+namespace ores::refdata::messaging {
+
+namespace {
+inline auto& ois_convention_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.ois_convention_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using ores::service::messaging::has_permission;
+using namespace ores::logging;
+
+/**
+ * @brief NATS message handler for OIS convention operations.
+ */
+class ois_convention_handler {
+public:
+    ois_convention_handler(ores::nats::service::client& nats,
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
+
+    void list(ores::nats::message msg) {
+        BOOST_LOG_SEV(ois_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::ois_convention_service svc(req_ctx);
+        get_ois_conventions_response resp;
+        try {
+            resp.ois_conventions = svc.list_ois_conventions();
+            resp.total_available_count =
+                static_cast<int>(resp.ois_conventions.size());
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(ois_convention_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            resp.success = false;
+            resp.message = e.what();
+        }
+        BOOST_LOG_SEV(ois_convention_handler_lg(), debug)
+            << "Completed " << msg.subject;
+        reply(nats_, msg, resp);
+    }
+
+    void save(ores::nats::message msg) {
+        BOOST_LOG_SEV(ois_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::ois_conventions:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::ois_convention_service svc(req_ctx);
+        if (auto req = decode<save_ois_convention_request>(msg)) {
+            try {
+                svc.save_ois_convention(req->data);
+                BOOST_LOG_SEV(ois_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_ois_convention_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(ois_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_ois_convention_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(ois_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void history(ores::nats::message msg) {
+        BOOST_LOG_SEV(ois_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::ois_convention_service svc(req_ctx);
+        if (auto req = decode<get_ois_convention_history_request>(msg)) {
+            try {
+                auto hist = svc.get_ois_convention_history(req->id);
+                BOOST_LOG_SEV(ois_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_ois_convention_history_response{
+                    .ois_conventions = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(ois_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_ois_convention_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(ois_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(ois_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::ois_conventions:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::ois_convention_service svc(req_ctx);
+        if (auto req = decode<delete_ois_convention_request>(msg)) {
+            try {
+                for (const auto& code : req->codes)
+                    svc.remove_ois_convention(code);
+                BOOST_LOG_SEV(ois_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_ois_convention_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(ois_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_ois_convention_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(ois_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::refdata::messaging
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/messaging/overnight_index_convention_handler.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/messaging/overnight_index_convention_handler.hpp
@@ -1,0 +1,197 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_OVERNIGHT_INDEX_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_MESSAGING_OVERNIGHT_INDEX_CONVENTION_HANDLER_HPP
+
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.refdata.api/messaging/overnight_index_convention_protocol.hpp"
+#include "ores.refdata.core/service/overnight_index_convention_service.hpp"
+
+namespace ores::refdata::messaging {
+
+namespace {
+inline auto& overnight_index_convention_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.overnight_index_convention_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using ores::service::messaging::has_permission;
+using namespace ores::logging;
+
+/**
+ * @brief NATS message handler for overnight index convention operations.
+ */
+class overnight_index_convention_handler {
+public:
+    overnight_index_convention_handler(ores::nats::service::client& nats,
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
+
+    void list(ores::nats::message msg) {
+        BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::overnight_index_convention_service svc(req_ctx);
+        get_overnight_index_conventions_response resp;
+        try {
+            resp.overnight_index_conventions = svc.list_overnight_index_conventions();
+            resp.total_available_count =
+                static_cast<int>(resp.overnight_index_conventions.size());
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(overnight_index_convention_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            resp.success = false;
+            resp.message = e.what();
+        }
+        BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug)
+            << "Completed " << msg.subject;
+        reply(nats_, msg, resp);
+    }
+
+    void save(ores::nats::message msg) {
+        BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::overnight_index_conventions:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::overnight_index_convention_service svc(req_ctx);
+        if (auto req = decode<save_overnight_index_convention_request>(msg)) {
+            try {
+                svc.save_overnight_index_convention(req->data);
+                BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_overnight_index_convention_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(overnight_index_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_overnight_index_convention_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(overnight_index_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void history(ores::nats::message msg) {
+        BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::overnight_index_convention_service svc(req_ctx);
+        if (auto req = decode<get_overnight_index_convention_history_request>(msg)) {
+            try {
+                auto hist = svc.get_overnight_index_convention_history(req->id);
+                BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_overnight_index_convention_history_response{
+                    .overnight_index_conventions = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(overnight_index_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_overnight_index_convention_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(overnight_index_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::overnight_index_conventions:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::overnight_index_convention_service svc(req_ctx);
+        if (auto req = decode<delete_overnight_index_convention_request>(msg)) {
+            try {
+                for (const auto& code : req->codes)
+                    svc.remove_overnight_index_convention(code);
+                BOOST_LOG_SEV(overnight_index_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_overnight_index_convention_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(overnight_index_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_overnight_index_convention_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(overnight_index_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::refdata::messaging
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/messaging/swap_convention_handler.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/messaging/swap_convention_handler.hpp
@@ -1,0 +1,197 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_MESSAGING_SWAP_CONVENTION_HANDLER_HPP
+#define ORES_REFDATA_MESSAGING_SWAP_CONVENTION_HANDLER_HPP
+
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.service/messaging/handler_helpers.hpp"
+#include "ores.service/service/request_context.hpp"
+#include "ores.refdata.api/messaging/swap_convention_protocol.hpp"
+#include "ores.refdata.core/service/swap_convention_service.hpp"
+
+namespace ores::refdata::messaging {
+
+namespace {
+inline auto& swap_convention_handler_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.refdata.messaging.swap_convention_handler");
+    return instance;
+}
+} // namespace
+
+using ores::service::messaging::reply;
+using ores::service::messaging::decode;
+using ores::service::messaging::error_reply;
+using ores::service::messaging::has_permission;
+using namespace ores::logging;
+
+/**
+ * @brief NATS message handler for swap convention operations.
+ */
+class swap_convention_handler {
+public:
+    swap_convention_handler(ores::nats::service::client& nats,
+        ores::database::context ctx,
+        std::optional<ores::security::jwt::jwt_authenticator> verifier)
+        : nats_(nats), ctx_(std::move(ctx)), verifier_(std::move(verifier)) {}
+
+    void list(ores::nats::message msg) {
+        BOOST_LOG_SEV(swap_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::swap_convention_service svc(req_ctx);
+        get_swap_conventions_response resp;
+        try {
+            resp.swap_conventions = svc.list_swap_conventions();
+            resp.total_available_count =
+                static_cast<int>(resp.swap_conventions.size());
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(swap_convention_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            resp.success = false;
+            resp.message = e.what();
+        }
+        BOOST_LOG_SEV(swap_convention_handler_lg(), debug)
+            << "Completed " << msg.subject;
+        reply(nats_, msg, resp);
+    }
+
+    void save(ores::nats::message msg) {
+        BOOST_LOG_SEV(swap_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::swap_conventions:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::swap_convention_service svc(req_ctx);
+        if (auto req = decode<save_swap_convention_request>(msg)) {
+            try {
+                svc.save_swap_convention(req->data);
+                BOOST_LOG_SEV(swap_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    save_swap_convention_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(swap_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, save_swap_convention_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(swap_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void history(ores::nats::message msg) {
+        BOOST_LOG_SEV(swap_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        service::swap_convention_service svc(req_ctx);
+        if (auto req = decode<get_swap_convention_history_request>(msg)) {
+            try {
+                auto hist = svc.get_swap_convention_history(req->id);
+                BOOST_LOG_SEV(swap_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg, get_swap_convention_history_response{
+                    .swap_conventions = std::move(hist), .success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(swap_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, get_swap_convention_history_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(swap_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+    void remove(ores::nats::message msg) {
+        BOOST_LOG_SEV(swap_convention_handler_lg(), debug)
+            << "Handling " << msg.subject;
+        auto req_ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!req_ctx_expected) {
+            error_reply(nats_, msg, req_ctx_expected.error());
+            return;
+        }
+        const auto& req_ctx = *req_ctx_expected;
+        if (!has_permission(req_ctx, "refdata::swap_conventions:write")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::swap_convention_service svc(req_ctx);
+        if (auto req = decode<delete_swap_convention_request>(msg)) {
+            try {
+                for (const auto& code : req->codes)
+                    svc.remove_swap_convention(code);
+                BOOST_LOG_SEV(swap_convention_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+                reply(nats_, msg,
+                    delete_swap_convention_response{.success = true});
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(swap_convention_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                reply(nats_, msg, delete_swap_convention_response{
+                    .success = false, .message = e.what()});
+            }
+        } else {
+            BOOST_LOG_SEV(swap_convention_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            error_reply(nats_, msg, ores::service::error_code::bad_request);
+        }
+    }
+
+private:
+    ores::nats::service::client& nats_;
+    ores::database::context ctx_;
+    std::optional<ores::security::jwt::jwt_authenticator> verifier_;
+};
+
+} // namespace ores::refdata::messaging
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/cds_convention_entity.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/cds_convention_entity.hpp
@@ -1,0 +1,63 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_CDS_CONVENTION_ENTITY_HPP
+#define ORES_REFDATA_REPOSITORY_CDS_CONVENTION_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Represents a cds convention in the database.
+ */
+struct cds_convention_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_refdata_cds_conventions_tbl";
+
+    sqlgen::PrimaryKey<std::string> id;
+    std::string tenant_id;
+    int version = 0;
+    int settlement_days = 0;
+    std::string calendar;
+    std::string frequency;
+    std::string payment_convention;
+    std::string rule;
+    std::string day_count_fraction;
+    bool settles_accrual = false;
+    bool pays_at_default_time = false;
+    std::optional<int> upfront_settlement_days;
+    std::optional<std::string> last_period_day_count_fraction;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const cds_convention_entity& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/cds_convention_mapper.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/cds_convention_mapper.hpp
@@ -1,0 +1,54 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_CDS_CONVENTION_MAPPER_HPP
+#define ORES_REFDATA_REPOSITORY_CDS_CONVENTION_MAPPER_HPP
+
+#include "ores.refdata.api/domain/cds_convention.hpp"
+#include "ores.refdata.core/repository/cds_convention_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Maps cds_convention domain entities to data storage layer and vice-versa.
+ */
+class cds_convention_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.cds_convention_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::cds_convention map(const cds_convention_entity& v);
+    static cds_convention_entity map(const domain::cds_convention& v);
+
+    static std::vector<domain::cds_convention>
+    map(const std::vector<cds_convention_entity>& v);
+    static std::vector<cds_convention_entity>
+    map(const std::vector<domain::cds_convention>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/cds_convention_repository.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/cds_convention_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_CDS_CONVENTION_REPOSITORY_HPP
+#define ORES_REFDATA_REPOSITORY_CDS_CONVENTION_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata.api/domain/cds_convention.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Reads and writes CDS conventions to data storage.
+ */
+class cds_convention_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.cds_convention_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::cds_convention& v);
+    void write(context ctx, const std::vector<domain::cds_convention>& v);
+
+    std::vector<domain::cds_convention> read_latest(context ctx);
+    std::vector<domain::cds_convention>
+    read_latest(context ctx, const std::string& id);
+    std::vector<domain::cds_convention>
+    read_all(context ctx, const std::string& id);
+
+    void remove(context ctx, const std::string& id);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/fra_convention_entity.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/fra_convention_entity.hpp
@@ -1,0 +1,54 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_FRA_CONVENTION_ENTITY_HPP
+#define ORES_REFDATA_REPOSITORY_FRA_CONVENTION_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Represents a fra convention in the database.
+ */
+struct fra_convention_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_refdata_fra_conventions_tbl";
+
+    sqlgen::PrimaryKey<std::string> id;
+    std::string tenant_id;
+    int version = 0;
+    std::string index;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const fra_convention_entity& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/fra_convention_mapper.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/fra_convention_mapper.hpp
@@ -1,0 +1,54 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_FRA_CONVENTION_MAPPER_HPP
+#define ORES_REFDATA_REPOSITORY_FRA_CONVENTION_MAPPER_HPP
+
+#include "ores.refdata.api/domain/fra_convention.hpp"
+#include "ores.refdata.core/repository/fra_convention_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Maps fra_convention domain entities to data storage layer and vice-versa.
+ */
+class fra_convention_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.fra_convention_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::fra_convention map(const fra_convention_entity& v);
+    static fra_convention_entity map(const domain::fra_convention& v);
+
+    static std::vector<domain::fra_convention>
+    map(const std::vector<fra_convention_entity>& v);
+    static std::vector<fra_convention_entity>
+    map(const std::vector<domain::fra_convention>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/fra_convention_repository.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/fra_convention_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_FRA_CONVENTION_REPOSITORY_HPP
+#define ORES_REFDATA_REPOSITORY_FRA_CONVENTION_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata.api/domain/fra_convention.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Reads and writes FRA conventions to data storage.
+ */
+class fra_convention_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.fra_convention_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::fra_convention& v);
+    void write(context ctx, const std::vector<domain::fra_convention>& v);
+
+    std::vector<domain::fra_convention> read_latest(context ctx);
+    std::vector<domain::fra_convention>
+    read_latest(context ctx, const std::string& id);
+    std::vector<domain::fra_convention>
+    read_all(context ctx, const std::string& id);
+
+    void remove(context ctx, const std::string& id);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/fx_convention_entity.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/fx_convention_entity.hpp
@@ -1,0 +1,61 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_FX_CONVENTION_ENTITY_HPP
+#define ORES_REFDATA_REPOSITORY_FX_CONVENTION_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Represents a fx convention in the database.
+ */
+struct fx_convention_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_refdata_fx_conventions_tbl";
+
+    sqlgen::PrimaryKey<std::string> id;
+    std::string tenant_id;
+    int version = 0;
+    int spot_days = 0;
+    std::string source_currency;
+    std::string target_currency;
+    double points_factor;
+    std::optional<std::string> advance_calendar;
+    std::optional<bool> spot_relative;
+    std::optional<bool> end_of_month;
+    std::optional<std::string> convention;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const fx_convention_entity& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/fx_convention_mapper.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/fx_convention_mapper.hpp
@@ -1,0 +1,54 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_FX_CONVENTION_MAPPER_HPP
+#define ORES_REFDATA_REPOSITORY_FX_CONVENTION_MAPPER_HPP
+
+#include "ores.refdata.api/domain/fx_convention.hpp"
+#include "ores.refdata.core/repository/fx_convention_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Maps fx_convention domain entities to data storage layer and vice-versa.
+ */
+class fx_convention_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.fx_convention_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::fx_convention map(const fx_convention_entity& v);
+    static fx_convention_entity map(const domain::fx_convention& v);
+
+    static std::vector<domain::fx_convention>
+    map(const std::vector<fx_convention_entity>& v);
+    static std::vector<fx_convention_entity>
+    map(const std::vector<domain::fx_convention>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/fx_convention_repository.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/fx_convention_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_FX_CONVENTION_REPOSITORY_HPP
+#define ORES_REFDATA_REPOSITORY_FX_CONVENTION_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata.api/domain/fx_convention.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Reads and writes FX conventions to data storage.
+ */
+class fx_convention_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.fx_convention_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::fx_convention& v);
+    void write(context ctx, const std::vector<domain::fx_convention>& v);
+
+    std::vector<domain::fx_convention> read_latest(context ctx);
+    std::vector<domain::fx_convention>
+    read_latest(context ctx, const std::string& id);
+    std::vector<domain::fx_convention>
+    read_all(context ctx, const std::string& id);
+
+    void remove(context ctx, const std::string& id);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/ibor_index_convention_entity.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/ibor_index_convention_entity.hpp
@@ -1,0 +1,58 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_IBOR_INDEX_CONVENTION_ENTITY_HPP
+#define ORES_REFDATA_REPOSITORY_IBOR_INDEX_CONVENTION_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Represents a ibor index convention in the database.
+ */
+struct ibor_index_convention_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_refdata_ibor_index_conventions_tbl";
+
+    sqlgen::PrimaryKey<std::string> id;
+    std::string tenant_id;
+    int version = 0;
+    std::string fixing_calendar;
+    std::string day_count_fraction;
+    int settlement_days = 0;
+    std::string business_day_convention;
+    bool end_of_month = false;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const ibor_index_convention_entity& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/ibor_index_convention_mapper.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/ibor_index_convention_mapper.hpp
@@ -1,0 +1,54 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_IBOR_INDEX_CONVENTION_MAPPER_HPP
+#define ORES_REFDATA_REPOSITORY_IBOR_INDEX_CONVENTION_MAPPER_HPP
+
+#include "ores.refdata.api/domain/ibor_index_convention.hpp"
+#include "ores.refdata.core/repository/ibor_index_convention_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Maps ibor_index_convention domain entities to data storage layer and vice-versa.
+ */
+class ibor_index_convention_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.ibor_index_convention_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::ibor_index_convention map(const ibor_index_convention_entity& v);
+    static ibor_index_convention_entity map(const domain::ibor_index_convention& v);
+
+    static std::vector<domain::ibor_index_convention>
+    map(const std::vector<ibor_index_convention_entity>& v);
+    static std::vector<ibor_index_convention_entity>
+    map(const std::vector<domain::ibor_index_convention>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/ibor_index_convention_repository.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/ibor_index_convention_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_IBOR_INDEX_CONVENTION_REPOSITORY_HPP
+#define ORES_REFDATA_REPOSITORY_IBOR_INDEX_CONVENTION_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata.api/domain/ibor_index_convention.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Reads and writes IBOR index conventions to data storage.
+ */
+class ibor_index_convention_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.ibor_index_convention_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::ibor_index_convention& v);
+    void write(context ctx, const std::vector<domain::ibor_index_convention>& v);
+
+    std::vector<domain::ibor_index_convention> read_latest(context ctx);
+    std::vector<domain::ibor_index_convention>
+    read_latest(context ctx, const std::string& id);
+    std::vector<domain::ibor_index_convention>
+    read_all(context ctx, const std::string& id);
+
+    void remove(context ctx, const std::string& id);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/ois_convention_entity.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/ois_convention_entity.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_OIS_CONVENTION_ENTITY_HPP
+#define ORES_REFDATA_REPOSITORY_OIS_CONVENTION_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Represents a ois convention in the database.
+ */
+struct ois_convention_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_refdata_ois_conventions_tbl";
+
+    sqlgen::PrimaryKey<std::string> id;
+    std::string tenant_id;
+    int version = 0;
+    int spot_lag = 0;
+    std::string index;
+    std::string fixed_day_count_fraction;
+    std::optional<std::string> fixed_calendar;
+    std::optional<int> payment_lag;
+    std::optional<bool> end_of_month;
+    std::optional<std::string> fixed_frequency;
+    std::optional<std::string> fixed_convention;
+    std::optional<std::string> fixed_payment_convention;
+    std::optional<std::string> rule;
+    std::optional<std::string> payment_calendar;
+    std::optional<int> rate_cutoff;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const ois_convention_entity& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/ois_convention_mapper.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/ois_convention_mapper.hpp
@@ -1,0 +1,54 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_OIS_CONVENTION_MAPPER_HPP
+#define ORES_REFDATA_REPOSITORY_OIS_CONVENTION_MAPPER_HPP
+
+#include "ores.refdata.api/domain/ois_convention.hpp"
+#include "ores.refdata.core/repository/ois_convention_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Maps ois_convention domain entities to data storage layer and vice-versa.
+ */
+class ois_convention_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.ois_convention_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::ois_convention map(const ois_convention_entity& v);
+    static ois_convention_entity map(const domain::ois_convention& v);
+
+    static std::vector<domain::ois_convention>
+    map(const std::vector<ois_convention_entity>& v);
+    static std::vector<ois_convention_entity>
+    map(const std::vector<domain::ois_convention>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/ois_convention_repository.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/ois_convention_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_OIS_CONVENTION_REPOSITORY_HPP
+#define ORES_REFDATA_REPOSITORY_OIS_CONVENTION_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata.api/domain/ois_convention.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Reads and writes OIS conventions to data storage.
+ */
+class ois_convention_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.ois_convention_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::ois_convention& v);
+    void write(context ctx, const std::vector<domain::ois_convention>& v);
+
+    std::vector<domain::ois_convention> read_latest(context ctx);
+    std::vector<domain::ois_convention>
+    read_latest(context ctx, const std::string& id);
+    std::vector<domain::ois_convention>
+    read_all(context ctx, const std::string& id);
+
+    void remove(context ctx, const std::string& id);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/overnight_index_convention_entity.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/overnight_index_convention_entity.hpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_OVERNIGHT_INDEX_CONVENTION_ENTITY_HPP
+#define ORES_REFDATA_REPOSITORY_OVERNIGHT_INDEX_CONVENTION_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Represents a overnight index convention in the database.
+ */
+struct overnight_index_convention_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_refdata_overnight_index_conventions_tbl";
+
+    sqlgen::PrimaryKey<std::string> id;
+    std::string tenant_id;
+    int version = 0;
+    std::string fixing_calendar;
+    std::string day_count_fraction;
+    int settlement_days = 0;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const overnight_index_convention_entity& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/overnight_index_convention_mapper.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/overnight_index_convention_mapper.hpp
@@ -1,0 +1,54 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_OVERNIGHT_INDEX_CONVENTION_MAPPER_HPP
+#define ORES_REFDATA_REPOSITORY_OVERNIGHT_INDEX_CONVENTION_MAPPER_HPP
+
+#include "ores.refdata.api/domain/overnight_index_convention.hpp"
+#include "ores.refdata.core/repository/overnight_index_convention_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Maps overnight_index_convention domain entities to data storage layer and vice-versa.
+ */
+class overnight_index_convention_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.overnight_index_convention_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::overnight_index_convention map(const overnight_index_convention_entity& v);
+    static overnight_index_convention_entity map(const domain::overnight_index_convention& v);
+
+    static std::vector<domain::overnight_index_convention>
+    map(const std::vector<overnight_index_convention_entity>& v);
+    static std::vector<overnight_index_convention_entity>
+    map(const std::vector<domain::overnight_index_convention>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/overnight_index_convention_repository.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/overnight_index_convention_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_OVERNIGHT_INDEX_CONVENTION_REPOSITORY_HPP
+#define ORES_REFDATA_REPOSITORY_OVERNIGHT_INDEX_CONVENTION_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata.api/domain/overnight_index_convention.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Reads and writes overnight index conventions to data storage.
+ */
+class overnight_index_convention_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.overnight_index_convention_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::overnight_index_convention& v);
+    void write(context ctx, const std::vector<domain::overnight_index_convention>& v);
+
+    std::vector<domain::overnight_index_convention> read_latest(context ctx);
+    std::vector<domain::overnight_index_convention>
+    read_latest(context ctx, const std::string& id);
+    std::vector<domain::overnight_index_convention>
+    read_all(context ctx, const std::string& id);
+
+    void remove(context ctx, const std::string& id);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/swap_convention_entity.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/swap_convention_entity.hpp
@@ -1,0 +1,60 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_SWAP_CONVENTION_ENTITY_HPP
+#define ORES_REFDATA_REPOSITORY_SWAP_CONVENTION_ENTITY_HPP
+
+#include <string>
+#include <optional>
+#include <ostream>
+#include "sqlgen/Timestamp.hpp"
+#include "sqlgen/PrimaryKey.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Represents a swap convention in the database.
+ */
+struct swap_convention_entity {
+    constexpr static const char* schema = "public";
+    constexpr static const char* tablename = "ores_refdata_swap_conventions_tbl";
+
+    sqlgen::PrimaryKey<std::string> id;
+    std::string tenant_id;
+    int version = 0;
+    std::optional<std::string> fixed_calendar;
+    std::string fixed_frequency;
+    std::optional<std::string> fixed_convention;
+    std::string fixed_day_count_fraction;
+    std::string index;
+    std::optional<std::string> float_frequency;
+    std::optional<std::string> sub_periods_coupon_type;
+    std::string modified_by;
+    std::string performed_by;
+    std::string change_reason_code;
+    std::string change_commentary;
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_from = "9999-12-31 23:59:59";
+    std::optional<sqlgen::Timestamp<"%Y-%m-%d %H:%M:%S">> valid_to = "9999-12-31 23:59:59";
+};
+
+std::ostream& operator<<(std::ostream& s, const swap_convention_entity& v);
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/swap_convention_mapper.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/swap_convention_mapper.hpp
@@ -1,0 +1,54 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_SWAP_CONVENTION_MAPPER_HPP
+#define ORES_REFDATA_REPOSITORY_SWAP_CONVENTION_MAPPER_HPP
+
+#include "ores.refdata.api/domain/swap_convention.hpp"
+#include "ores.refdata.core/repository/swap_convention_entity.hpp"
+#include "ores.logging/make_logger.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Maps swap_convention domain entities to data storage layer and vice-versa.
+ */
+class swap_convention_mapper {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.swap_convention_mapper";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+public:
+    static domain::swap_convention map(const swap_convention_entity& v);
+    static swap_convention_entity map(const domain::swap_convention& v);
+
+    static std::vector<domain::swap_convention>
+    map(const std::vector<swap_convention_entity>& v);
+    static std::vector<swap_convention_entity>
+    map(const std::vector<domain::swap_convention>& v);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/repository/swap_convention_repository.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/repository/swap_convention_repository.hpp
@@ -1,0 +1,65 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_REPOSITORY_SWAP_CONVENTION_REPOSITORY_HPP
+#define ORES_REFDATA_REPOSITORY_SWAP_CONVENTION_REPOSITORY_HPP
+
+#include <string>
+#include <vector>
+#include <sqlgen/postgres.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata.api/domain/swap_convention.hpp"
+
+namespace ores::refdata::repository {
+
+/**
+ * @brief Reads and writes swap conventions to data storage.
+ */
+class swap_convention_repository {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.repository.swap_convention_repository";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    std::string sql();
+
+    void write(context ctx, const domain::swap_convention& v);
+    void write(context ctx, const std::vector<domain::swap_convention>& v);
+
+    std::vector<domain::swap_convention> read_latest(context ctx);
+    std::vector<domain::swap_convention>
+    read_latest(context ctx, const std::string& id);
+    std::vector<domain::swap_convention>
+    read_all(context ctx, const std::string& id);
+
+    void remove(context ctx, const std::string& id);
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/service/cds_convention_service.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/service/cds_convention_service.hpp
@@ -1,0 +1,71 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_SERVICE_CDS_CONVENTION_SERVICE_HPP
+#define ORES_REFDATA_SERVICE_CDS_CONVENTION_SERVICE_HPP
+
+#include <string>
+#include <vector>
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata.api/domain/cds_convention.hpp"
+#include "ores.refdata.core/repository/cds_convention_repository.hpp"
+
+namespace ores::refdata::service {
+
+/**
+ * @brief Service for managing CDS conventions.
+ */
+class cds_convention_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.service.cds_convention_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit cds_convention_service(context ctx);
+
+    std::vector<domain::cds_convention> list_cds_conventions();
+
+    std::optional<domain::cds_convention>
+    get_cds_convention(const std::string& id);
+
+    void save_cds_convention(const domain::cds_convention& v);
+
+    void remove_cds_convention(const std::string& id);
+
+    std::vector<domain::cds_convention>
+    get_cds_convention_history(const std::string& id);
+
+private:
+    context ctx_;
+    repository::cds_convention_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/service/fra_convention_service.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/service/fra_convention_service.hpp
@@ -1,0 +1,71 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_SERVICE_FRA_CONVENTION_SERVICE_HPP
+#define ORES_REFDATA_SERVICE_FRA_CONVENTION_SERVICE_HPP
+
+#include <string>
+#include <vector>
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata.api/domain/fra_convention.hpp"
+#include "ores.refdata.core/repository/fra_convention_repository.hpp"
+
+namespace ores::refdata::service {
+
+/**
+ * @brief Service for managing FRA conventions.
+ */
+class fra_convention_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.service.fra_convention_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit fra_convention_service(context ctx);
+
+    std::vector<domain::fra_convention> list_fra_conventions();
+
+    std::optional<domain::fra_convention>
+    get_fra_convention(const std::string& id);
+
+    void save_fra_convention(const domain::fra_convention& v);
+
+    void remove_fra_convention(const std::string& id);
+
+    std::vector<domain::fra_convention>
+    get_fra_convention_history(const std::string& id);
+
+private:
+    context ctx_;
+    repository::fra_convention_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/service/fx_convention_service.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/service/fx_convention_service.hpp
@@ -1,0 +1,71 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_SERVICE_FX_CONVENTION_SERVICE_HPP
+#define ORES_REFDATA_SERVICE_FX_CONVENTION_SERVICE_HPP
+
+#include <string>
+#include <vector>
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata.api/domain/fx_convention.hpp"
+#include "ores.refdata.core/repository/fx_convention_repository.hpp"
+
+namespace ores::refdata::service {
+
+/**
+ * @brief Service for managing FX conventions.
+ */
+class fx_convention_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.service.fx_convention_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit fx_convention_service(context ctx);
+
+    std::vector<domain::fx_convention> list_fx_conventions();
+
+    std::optional<domain::fx_convention>
+    get_fx_convention(const std::string& id);
+
+    void save_fx_convention(const domain::fx_convention& v);
+
+    void remove_fx_convention(const std::string& id);
+
+    std::vector<domain::fx_convention>
+    get_fx_convention_history(const std::string& id);
+
+private:
+    context ctx_;
+    repository::fx_convention_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/service/ibor_index_convention_service.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/service/ibor_index_convention_service.hpp
@@ -1,0 +1,71 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_SERVICE_IBOR_INDEX_CONVENTION_SERVICE_HPP
+#define ORES_REFDATA_SERVICE_IBOR_INDEX_CONVENTION_SERVICE_HPP
+
+#include <string>
+#include <vector>
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata.api/domain/ibor_index_convention.hpp"
+#include "ores.refdata.core/repository/ibor_index_convention_repository.hpp"
+
+namespace ores::refdata::service {
+
+/**
+ * @brief Service for managing IBOR index conventions.
+ */
+class ibor_index_convention_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.service.ibor_index_convention_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit ibor_index_convention_service(context ctx);
+
+    std::vector<domain::ibor_index_convention> list_ibor_index_conventions();
+
+    std::optional<domain::ibor_index_convention>
+    get_ibor_index_convention(const std::string& id);
+
+    void save_ibor_index_convention(const domain::ibor_index_convention& v);
+
+    void remove_ibor_index_convention(const std::string& id);
+
+    std::vector<domain::ibor_index_convention>
+    get_ibor_index_convention_history(const std::string& id);
+
+private:
+    context ctx_;
+    repository::ibor_index_convention_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/service/ois_convention_service.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/service/ois_convention_service.hpp
@@ -1,0 +1,71 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_SERVICE_OIS_CONVENTION_SERVICE_HPP
+#define ORES_REFDATA_SERVICE_OIS_CONVENTION_SERVICE_HPP
+
+#include <string>
+#include <vector>
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata.api/domain/ois_convention.hpp"
+#include "ores.refdata.core/repository/ois_convention_repository.hpp"
+
+namespace ores::refdata::service {
+
+/**
+ * @brief Service for managing OIS conventions.
+ */
+class ois_convention_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.service.ois_convention_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit ois_convention_service(context ctx);
+
+    std::vector<domain::ois_convention> list_ois_conventions();
+
+    std::optional<domain::ois_convention>
+    get_ois_convention(const std::string& id);
+
+    void save_ois_convention(const domain::ois_convention& v);
+
+    void remove_ois_convention(const std::string& id);
+
+    std::vector<domain::ois_convention>
+    get_ois_convention_history(const std::string& id);
+
+private:
+    context ctx_;
+    repository::ois_convention_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/service/overnight_index_convention_service.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/service/overnight_index_convention_service.hpp
@@ -1,0 +1,71 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_SERVICE_OVERNIGHT_INDEX_CONVENTION_SERVICE_HPP
+#define ORES_REFDATA_SERVICE_OVERNIGHT_INDEX_CONVENTION_SERVICE_HPP
+
+#include <string>
+#include <vector>
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata.api/domain/overnight_index_convention.hpp"
+#include "ores.refdata.core/repository/overnight_index_convention_repository.hpp"
+
+namespace ores::refdata::service {
+
+/**
+ * @brief Service for managing overnight index conventions.
+ */
+class overnight_index_convention_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.service.overnight_index_convention_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit overnight_index_convention_service(context ctx);
+
+    std::vector<domain::overnight_index_convention> list_overnight_index_conventions();
+
+    std::optional<domain::overnight_index_convention>
+    get_overnight_index_convention(const std::string& id);
+
+    void save_overnight_index_convention(const domain::overnight_index_convention& v);
+
+    void remove_overnight_index_convention(const std::string& id);
+
+    std::vector<domain::overnight_index_convention>
+    get_overnight_index_convention_history(const std::string& id);
+
+private:
+    context ctx_;
+    repository::overnight_index_convention_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/service/swap_convention_service.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/service/swap_convention_service.hpp
@@ -1,0 +1,71 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_SERVICE_SWAP_CONVENTION_SERVICE_HPP
+#define ORES_REFDATA_SERVICE_SWAP_CONVENTION_SERVICE_HPP
+
+#include <string>
+#include <vector>
+#include <optional>
+#include "ores.logging/make_logger.hpp"
+#include "ores.database/domain/context.hpp"
+#include "ores.refdata.api/domain/swap_convention.hpp"
+#include "ores.refdata.core/repository/swap_convention_repository.hpp"
+
+namespace ores::refdata::service {
+
+/**
+ * @brief Service for managing swap conventions.
+ */
+class swap_convention_service {
+private:
+    inline static std::string_view logger_name =
+        "ores.refdata.service.swap_convention_service";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    using context = ores::database::context;
+
+    explicit swap_convention_service(context ctx);
+
+    std::vector<domain::swap_convention> list_swap_conventions();
+
+    std::optional<domain::swap_convention>
+    get_swap_convention(const std::string& id);
+
+    void save_swap_convention(const domain::swap_convention& v);
+
+    void remove_swap_convention(const std::string& id);
+
+    std::vector<domain::swap_convention>
+    get_swap_convention_history(const std::string& id);
+
+private:
+    context ctx_;
+    repository::swap_convention_repository repo_;
+};
+
+}
+
+#endif

--- a/projects/ores.refdata.core/src/messaging/registrar.cpp
+++ b/projects/ores.refdata.core/src/messaging/registrar.cpp
@@ -48,6 +48,13 @@
 #include "ores.refdata.core/messaging/asset_class_handler.hpp"
 #include "ores.refdata.core/messaging/zero_convention_handler.hpp"
 #include "ores.refdata.core/messaging/deposit_convention_handler.hpp"
+#include "ores.refdata.core/messaging/swap_convention_handler.hpp"
+#include "ores.refdata.core/messaging/ois_convention_handler.hpp"
+#include "ores.refdata.core/messaging/fra_convention_handler.hpp"
+#include "ores.refdata.core/messaging/ibor_index_convention_handler.hpp"
+#include "ores.refdata.core/messaging/overnight_index_convention_handler.hpp"
+#include "ores.refdata.core/messaging/fx_convention_handler.hpp"
+#include "ores.refdata.core/messaging/cds_convention_handler.hpp"
 #include "ores.refdata.api/messaging/country_protocol.hpp"
 #include "ores.refdata.api/messaging/currency_protocol.hpp"
 #include "ores.refdata.api/messaging/currency_history_protocol.hpp"
@@ -74,6 +81,13 @@
 #include "ores.refdata.api/messaging/asset_class_protocol.hpp"
 #include "ores.refdata.api/messaging/zero_convention_protocol.hpp"
 #include "ores.refdata.api/messaging/deposit_convention_protocol.hpp"
+#include "ores.refdata.api/messaging/swap_convention_protocol.hpp"
+#include "ores.refdata.api/messaging/ois_convention_protocol.hpp"
+#include "ores.refdata.api/messaging/fra_convention_protocol.hpp"
+#include "ores.refdata.api/messaging/ibor_index_convention_protocol.hpp"
+#include "ores.refdata.api/messaging/overnight_index_convention_protocol.hpp"
+#include "ores.refdata.api/messaging/fx_convention_protocol.hpp"
+#include "ores.refdata.api/messaging/cds_convention_protocol.hpp"
 
 namespace ores::refdata::messaging {
 
@@ -182,6 +196,146 @@ registrar::register_handlers(ores::nats::service::client& nats,
             [h](ores::nats::message msg) { h->remove(std::move(msg)); }));
         subs.push_back(nats.queue_subscribe(
             get_deposit_convention_history_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->history(std::move(msg)); }));
+    }
+
+    // ----------------------------------------------------------------
+    // Swap conventions
+    // ----------------------------------------------------------------
+    {
+        auto h = std::make_shared<swap_convention_handler>(
+            nats, ctx, verifier);
+        subs.push_back(nats.queue_subscribe(
+            get_swap_conventions_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->list(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            save_swap_convention_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->save(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            delete_swap_convention_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->remove(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            get_swap_convention_history_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->history(std::move(msg)); }));
+    }
+
+    // ----------------------------------------------------------------
+    // OIS conventions
+    // ----------------------------------------------------------------
+    {
+        auto h = std::make_shared<ois_convention_handler>(
+            nats, ctx, verifier);
+        subs.push_back(nats.queue_subscribe(
+            get_ois_conventions_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->list(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            save_ois_convention_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->save(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            delete_ois_convention_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->remove(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            get_ois_convention_history_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->history(std::move(msg)); }));
+    }
+
+    // ----------------------------------------------------------------
+    // FRA conventions
+    // ----------------------------------------------------------------
+    {
+        auto h = std::make_shared<fra_convention_handler>(
+            nats, ctx, verifier);
+        subs.push_back(nats.queue_subscribe(
+            get_fra_conventions_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->list(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            save_fra_convention_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->save(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            delete_fra_convention_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->remove(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            get_fra_convention_history_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->history(std::move(msg)); }));
+    }
+
+    // ----------------------------------------------------------------
+    // IBOR index conventions
+    // ----------------------------------------------------------------
+    {
+        auto h = std::make_shared<ibor_index_convention_handler>(
+            nats, ctx, verifier);
+        subs.push_back(nats.queue_subscribe(
+            get_ibor_index_conventions_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->list(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            save_ibor_index_convention_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->save(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            delete_ibor_index_convention_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->remove(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            get_ibor_index_convention_history_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->history(std::move(msg)); }));
+    }
+
+    // ----------------------------------------------------------------
+    // Overnight index conventions
+    // ----------------------------------------------------------------
+    {
+        auto h = std::make_shared<overnight_index_convention_handler>(
+            nats, ctx, verifier);
+        subs.push_back(nats.queue_subscribe(
+            get_overnight_index_conventions_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->list(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            save_overnight_index_convention_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->save(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            delete_overnight_index_convention_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->remove(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            get_overnight_index_convention_history_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->history(std::move(msg)); }));
+    }
+
+    // ----------------------------------------------------------------
+    // FX conventions
+    // ----------------------------------------------------------------
+    {
+        auto h = std::make_shared<fx_convention_handler>(
+            nats, ctx, verifier);
+        subs.push_back(nats.queue_subscribe(
+            get_fx_conventions_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->list(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            save_fx_convention_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->save(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            delete_fx_convention_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->remove(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            get_fx_convention_history_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->history(std::move(msg)); }));
+    }
+
+    // ----------------------------------------------------------------
+    // CDS conventions
+    // ----------------------------------------------------------------
+    {
+        auto h = std::make_shared<cds_convention_handler>(
+            nats, ctx, verifier);
+        subs.push_back(nats.queue_subscribe(
+            get_cds_conventions_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->list(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            save_cds_convention_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->save(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            delete_cds_convention_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->remove(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            get_cds_convention_history_request::nats_subject, queue_group,
             [h](ores::nats::message msg) { h->history(std::move(msg)); }));
     }
 

--- a/projects/ores.refdata.core/src/repository/cds_convention_entity.cpp
+++ b/projects/ores.refdata.core/src/repository/cds_convention_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/cds_convention_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::refdata::repository {
+
+std::ostream& operator<<(std::ostream& s, const cds_convention_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/cds_convention_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/cds_convention_mapper.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/cds_convention_mapper.hpp"
+
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.refdata.api/domain/cds_convention_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::cds_convention
+cds_convention_mapper::map(const cds_convention_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::cds_convention r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.id = v.id.value();
+    r.settlement_days = v.settlement_days;
+    r.calendar = v.calendar;
+    r.frequency = v.frequency;
+    r.payment_convention = v.payment_convention;
+    r.rule = v.rule;
+    r.day_count_fraction = v.day_count_fraction;
+    r.settles_accrual = v.settles_accrual;
+    r.pays_at_default_time = v.pays_at_default_time;
+    r.upfront_settlement_days = v.upfront_settlement_days;
+    r.last_period_day_count_fraction = v.last_period_day_count_fraction;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+cds_convention_entity
+cds_convention_mapper::map(const domain::cds_convention& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    cds_convention_entity r;
+    r.id = v.id;
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.settlement_days = v.settlement_days;
+    r.calendar = v.calendar;
+    r.frequency = v.frequency;
+    r.payment_convention = v.payment_convention;
+    r.rule = v.rule;
+    r.day_count_fraction = v.day_count_fraction;
+    r.settles_accrual = v.settles_accrual;
+    r.pays_at_default_time = v.pays_at_default_time;
+    r.upfront_settlement_days = v.upfront_settlement_days;
+    r.last_period_day_count_fraction = v.last_period_day_count_fraction;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::cds_convention>
+cds_convention_mapper::map(const std::vector<cds_convention_entity>& v) {
+    return map_vector<cds_convention_entity, domain::cds_convention>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<cds_convention_entity>
+cds_convention_mapper::map(const std::vector<domain::cds_convention>& v) {
+    return map_vector<domain::cds_convention, cds_convention_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/cds_convention_repository.cpp
+++ b/projects/ores.refdata.core/src/repository/cds_convention_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/cds_convention_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.refdata.api/domain/cds_convention_json_io.hpp" // IWYU pragma: keep.
+#include "ores.refdata.core/repository/cds_convention_entity.hpp"
+#include "ores.refdata.core/repository/cds_convention_mapper.hpp"
+
+namespace ores::refdata::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string cds_convention_repository::sql() {
+    return generate_create_table_sql<cds_convention_entity>(lg());
+}
+
+void cds_convention_repository::write(context ctx, const domain::cds_convention& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing CDS convention: " << v.id;
+    execute_write_query(ctx, cds_convention_mapper::map(v),
+        lg(), "Writing CDS convention to database.");
+}
+
+void cds_convention_repository::write(
+    context ctx, const std::vector<domain::cds_convention>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing CDS conventions. Count: " << v.size();
+    execute_write_query(ctx, cds_convention_mapper::map(v),
+        lg(), "Writing CDS conventions to database.");
+}
+
+std::vector<domain::cds_convention>
+cds_convention_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<cds_convention_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("id"_c);
+
+    return execute_read_query<cds_convention_entity, domain::cds_convention>(
+        ctx, query,
+        [](const auto& entities) { return cds_convention_mapper::map(entities); },
+        lg(), "Reading latest CDS conventions");
+}
+
+std::vector<domain::cds_convention>
+cds_convention_repository::read_latest(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest CDS convention. id: " << id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<cds_convention_entity>> |
+        where("tenant_id"_c == tid && "id"_c == id && "valid_to"_c == max.value());
+
+    return execute_read_query<cds_convention_entity, domain::cds_convention>(
+        ctx, query,
+        [](const auto& entities) { return cds_convention_mapper::map(entities); },
+        lg(), "Reading latest CDS convention by id.");
+}
+
+std::vector<domain::cds_convention>
+cds_convention_repository::read_all(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all CDS convention versions. id: " << id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<cds_convention_entity>> |
+        where("tenant_id"_c == tid && "id"_c == id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<cds_convention_entity, domain::cds_convention>(
+        ctx, query,
+        [](const auto& entities) { return cds_convention_mapper::map(entities); },
+        lg(), "Reading all CDS convention versions by id.");
+}
+
+void cds_convention_repository::remove(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing CDS convention: " << id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<cds_convention_entity> |
+        where("tenant_id"_c == tid && "id"_c == id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing CDS convention from database.");
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/fra_convention_entity.cpp
+++ b/projects/ores.refdata.core/src/repository/fra_convention_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/fra_convention_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::refdata::repository {
+
+std::ostream& operator<<(std::ostream& s, const fra_convention_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/fra_convention_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/fra_convention_mapper.cpp
@@ -1,0 +1,87 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/fra_convention_mapper.hpp"
+
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.refdata.api/domain/fra_convention_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::fra_convention
+fra_convention_mapper::map(const fra_convention_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::fra_convention r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.id = v.id.value();
+    r.index = v.index;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+fra_convention_entity
+fra_convention_mapper::map(const domain::fra_convention& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    fra_convention_entity r;
+    r.id = v.id;
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.index = v.index;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::fra_convention>
+fra_convention_mapper::map(const std::vector<fra_convention_entity>& v) {
+    return map_vector<fra_convention_entity, domain::fra_convention>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<fra_convention_entity>
+fra_convention_mapper::map(const std::vector<domain::fra_convention>& v) {
+    return map_vector<domain::fra_convention, fra_convention_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/fra_convention_repository.cpp
+++ b/projects/ores.refdata.core/src/repository/fra_convention_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/fra_convention_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.refdata.api/domain/fra_convention_json_io.hpp" // IWYU pragma: keep.
+#include "ores.refdata.core/repository/fra_convention_entity.hpp"
+#include "ores.refdata.core/repository/fra_convention_mapper.hpp"
+
+namespace ores::refdata::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string fra_convention_repository::sql() {
+    return generate_create_table_sql<fra_convention_entity>(lg());
+}
+
+void fra_convention_repository::write(context ctx, const domain::fra_convention& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FRA convention: " << v.id;
+    execute_write_query(ctx, fra_convention_mapper::map(v),
+        lg(), "Writing FRA convention to database.");
+}
+
+void fra_convention_repository::write(
+    context ctx, const std::vector<domain::fra_convention>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FRA conventions. Count: " << v.size();
+    execute_write_query(ctx, fra_convention_mapper::map(v),
+        lg(), "Writing FRA conventions to database.");
+}
+
+std::vector<domain::fra_convention>
+fra_convention_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fra_convention_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("id"_c);
+
+    return execute_read_query<fra_convention_entity, domain::fra_convention>(
+        ctx, query,
+        [](const auto& entities) { return fra_convention_mapper::map(entities); },
+        lg(), "Reading latest FRA conventions");
+}
+
+std::vector<domain::fra_convention>
+fra_convention_repository::read_latest(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest FRA convention. id: " << id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fra_convention_entity>> |
+        where("tenant_id"_c == tid && "id"_c == id && "valid_to"_c == max.value());
+
+    return execute_read_query<fra_convention_entity, domain::fra_convention>(
+        ctx, query,
+        [](const auto& entities) { return fra_convention_mapper::map(entities); },
+        lg(), "Reading latest FRA convention by id.");
+}
+
+std::vector<domain::fra_convention>
+fra_convention_repository::read_all(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all FRA convention versions. id: " << id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fra_convention_entity>> |
+        where("tenant_id"_c == tid && "id"_c == id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<fra_convention_entity, domain::fra_convention>(
+        ctx, query,
+        [](const auto& entities) { return fra_convention_mapper::map(entities); },
+        lg(), "Reading all FRA convention versions by id.");
+}
+
+void fra_convention_repository::remove(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing FRA convention: " << id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<fra_convention_entity> |
+        where("tenant_id"_c == tid && "id"_c == id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing FRA convention from database.");
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/fx_convention_entity.cpp
+++ b/projects/ores.refdata.core/src/repository/fx_convention_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/fx_convention_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::refdata::repository {
+
+std::ostream& operator<<(std::ostream& s, const fx_convention_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/fx_convention_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/fx_convention_mapper.cpp
@@ -1,0 +1,101 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/fx_convention_mapper.hpp"
+
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.refdata.api/domain/fx_convention_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::fx_convention
+fx_convention_mapper::map(const fx_convention_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::fx_convention r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.id = v.id.value();
+    r.spot_days = v.spot_days;
+    r.source_currency = v.source_currency;
+    r.target_currency = v.target_currency;
+    r.points_factor = v.points_factor;
+    r.advance_calendar = v.advance_calendar;
+    r.spot_relative = v.spot_relative;
+    r.end_of_month = v.end_of_month;
+    r.convention = v.convention;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+fx_convention_entity
+fx_convention_mapper::map(const domain::fx_convention& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    fx_convention_entity r;
+    r.id = v.id;
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.spot_days = v.spot_days;
+    r.source_currency = v.source_currency;
+    r.target_currency = v.target_currency;
+    r.points_factor = v.points_factor;
+    r.advance_calendar = v.advance_calendar;
+    r.spot_relative = v.spot_relative;
+    r.end_of_month = v.end_of_month;
+    r.convention = v.convention;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::fx_convention>
+fx_convention_mapper::map(const std::vector<fx_convention_entity>& v) {
+    return map_vector<fx_convention_entity, domain::fx_convention>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<fx_convention_entity>
+fx_convention_mapper::map(const std::vector<domain::fx_convention>& v) {
+    return map_vector<domain::fx_convention, fx_convention_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/fx_convention_repository.cpp
+++ b/projects/ores.refdata.core/src/repository/fx_convention_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/fx_convention_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.refdata.api/domain/fx_convention_json_io.hpp" // IWYU pragma: keep.
+#include "ores.refdata.core/repository/fx_convention_entity.hpp"
+#include "ores.refdata.core/repository/fx_convention_mapper.hpp"
+
+namespace ores::refdata::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string fx_convention_repository::sql() {
+    return generate_create_table_sql<fx_convention_entity>(lg());
+}
+
+void fx_convention_repository::write(context ctx, const domain::fx_convention& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX convention: " << v.id;
+    execute_write_query(ctx, fx_convention_mapper::map(v),
+        lg(), "Writing FX convention to database.");
+}
+
+void fx_convention_repository::write(
+    context ctx, const std::vector<domain::fx_convention>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX conventions. Count: " << v.size();
+    execute_write_query(ctx, fx_convention_mapper::map(v),
+        lg(), "Writing FX conventions to database.");
+}
+
+std::vector<domain::fx_convention>
+fx_convention_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_convention_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("id"_c);
+
+    return execute_read_query<fx_convention_entity, domain::fx_convention>(
+        ctx, query,
+        [](const auto& entities) { return fx_convention_mapper::map(entities); },
+        lg(), "Reading latest FX conventions");
+}
+
+std::vector<domain::fx_convention>
+fx_convention_repository::read_latest(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest FX convention. id: " << id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_convention_entity>> |
+        where("tenant_id"_c == tid && "id"_c == id && "valid_to"_c == max.value());
+
+    return execute_read_query<fx_convention_entity, domain::fx_convention>(
+        ctx, query,
+        [](const auto& entities) { return fx_convention_mapper::map(entities); },
+        lg(), "Reading latest FX convention by id.");
+}
+
+std::vector<domain::fx_convention>
+fx_convention_repository::read_all(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all FX convention versions. id: " << id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<fx_convention_entity>> |
+        where("tenant_id"_c == tid && "id"_c == id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<fx_convention_entity, domain::fx_convention>(
+        ctx, query,
+        [](const auto& entities) { return fx_convention_mapper::map(entities); },
+        lg(), "Reading all FX convention versions by id.");
+}
+
+void fx_convention_repository::remove(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing FX convention: " << id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<fx_convention_entity> |
+        where("tenant_id"_c == tid && "id"_c == id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing FX convention from database.");
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/ibor_index_convention_entity.cpp
+++ b/projects/ores.refdata.core/src/repository/ibor_index_convention_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/ibor_index_convention_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::refdata::repository {
+
+std::ostream& operator<<(std::ostream& s, const ibor_index_convention_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/ibor_index_convention_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/ibor_index_convention_mapper.cpp
@@ -1,0 +1,95 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/ibor_index_convention_mapper.hpp"
+
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.refdata.api/domain/ibor_index_convention_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::ibor_index_convention
+ibor_index_convention_mapper::map(const ibor_index_convention_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::ibor_index_convention r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.id = v.id.value();
+    r.fixing_calendar = v.fixing_calendar;
+    r.day_count_fraction = v.day_count_fraction;
+    r.settlement_days = v.settlement_days;
+    r.business_day_convention = v.business_day_convention;
+    r.end_of_month = v.end_of_month;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+ibor_index_convention_entity
+ibor_index_convention_mapper::map(const domain::ibor_index_convention& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    ibor_index_convention_entity r;
+    r.id = v.id;
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.fixing_calendar = v.fixing_calendar;
+    r.day_count_fraction = v.day_count_fraction;
+    r.settlement_days = v.settlement_days;
+    r.business_day_convention = v.business_day_convention;
+    r.end_of_month = v.end_of_month;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::ibor_index_convention>
+ibor_index_convention_mapper::map(const std::vector<ibor_index_convention_entity>& v) {
+    return map_vector<ibor_index_convention_entity, domain::ibor_index_convention>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<ibor_index_convention_entity>
+ibor_index_convention_mapper::map(const std::vector<domain::ibor_index_convention>& v) {
+    return map_vector<domain::ibor_index_convention, ibor_index_convention_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/ibor_index_convention_repository.cpp
+++ b/projects/ores.refdata.core/src/repository/ibor_index_convention_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/ibor_index_convention_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.refdata.api/domain/ibor_index_convention_json_io.hpp" // IWYU pragma: keep.
+#include "ores.refdata.core/repository/ibor_index_convention_entity.hpp"
+#include "ores.refdata.core/repository/ibor_index_convention_mapper.hpp"
+
+namespace ores::refdata::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string ibor_index_convention_repository::sql() {
+    return generate_create_table_sql<ibor_index_convention_entity>(lg());
+}
+
+void ibor_index_convention_repository::write(context ctx, const domain::ibor_index_convention& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing IBOR index convention: " << v.id;
+    execute_write_query(ctx, ibor_index_convention_mapper::map(v),
+        lg(), "Writing IBOR index convention to database.");
+}
+
+void ibor_index_convention_repository::write(
+    context ctx, const std::vector<domain::ibor_index_convention>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing IBOR index conventions. Count: " << v.size();
+    execute_write_query(ctx, ibor_index_convention_mapper::map(v),
+        lg(), "Writing IBOR index conventions to database.");
+}
+
+std::vector<domain::ibor_index_convention>
+ibor_index_convention_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<ibor_index_convention_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("id"_c);
+
+    return execute_read_query<ibor_index_convention_entity, domain::ibor_index_convention>(
+        ctx, query,
+        [](const auto& entities) { return ibor_index_convention_mapper::map(entities); },
+        lg(), "Reading latest IBOR index conventions");
+}
+
+std::vector<domain::ibor_index_convention>
+ibor_index_convention_repository::read_latest(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest IBOR index convention. id: " << id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<ibor_index_convention_entity>> |
+        where("tenant_id"_c == tid && "id"_c == id && "valid_to"_c == max.value());
+
+    return execute_read_query<ibor_index_convention_entity, domain::ibor_index_convention>(
+        ctx, query,
+        [](const auto& entities) { return ibor_index_convention_mapper::map(entities); },
+        lg(), "Reading latest IBOR index convention by id.");
+}
+
+std::vector<domain::ibor_index_convention>
+ibor_index_convention_repository::read_all(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all IBOR index convention versions. id: " << id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<ibor_index_convention_entity>> |
+        where("tenant_id"_c == tid && "id"_c == id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<ibor_index_convention_entity, domain::ibor_index_convention>(
+        ctx, query,
+        [](const auto& entities) { return ibor_index_convention_mapper::map(entities); },
+        lg(), "Reading all IBOR index convention versions by id.");
+}
+
+void ibor_index_convention_repository::remove(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing IBOR index convention: " << id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<ibor_index_convention_entity> |
+        where("tenant_id"_c == tid && "id"_c == id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing IBOR index convention from database.");
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/ois_convention_entity.cpp
+++ b/projects/ores.refdata.core/src/repository/ois_convention_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/ois_convention_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::refdata::repository {
+
+std::ostream& operator<<(std::ostream& s, const ois_convention_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/ois_convention_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/ois_convention_mapper.cpp
@@ -1,0 +1,109 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/ois_convention_mapper.hpp"
+
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.refdata.api/domain/ois_convention_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::ois_convention
+ois_convention_mapper::map(const ois_convention_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::ois_convention r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.id = v.id.value();
+    r.spot_lag = v.spot_lag;
+    r.index = v.index;
+    r.fixed_day_count_fraction = v.fixed_day_count_fraction;
+    r.fixed_calendar = v.fixed_calendar;
+    r.payment_lag = v.payment_lag;
+    r.end_of_month = v.end_of_month;
+    r.fixed_frequency = v.fixed_frequency;
+    r.fixed_convention = v.fixed_convention;
+    r.fixed_payment_convention = v.fixed_payment_convention;
+    r.rule = v.rule;
+    r.payment_calendar = v.payment_calendar;
+    r.rate_cutoff = v.rate_cutoff;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+ois_convention_entity
+ois_convention_mapper::map(const domain::ois_convention& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    ois_convention_entity r;
+    r.id = v.id;
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.spot_lag = v.spot_lag;
+    r.index = v.index;
+    r.fixed_day_count_fraction = v.fixed_day_count_fraction;
+    r.fixed_calendar = v.fixed_calendar;
+    r.payment_lag = v.payment_lag;
+    r.end_of_month = v.end_of_month;
+    r.fixed_frequency = v.fixed_frequency;
+    r.fixed_convention = v.fixed_convention;
+    r.fixed_payment_convention = v.fixed_payment_convention;
+    r.rule = v.rule;
+    r.payment_calendar = v.payment_calendar;
+    r.rate_cutoff = v.rate_cutoff;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::ois_convention>
+ois_convention_mapper::map(const std::vector<ois_convention_entity>& v) {
+    return map_vector<ois_convention_entity, domain::ois_convention>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<ois_convention_entity>
+ois_convention_mapper::map(const std::vector<domain::ois_convention>& v) {
+    return map_vector<domain::ois_convention, ois_convention_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/ois_convention_repository.cpp
+++ b/projects/ores.refdata.core/src/repository/ois_convention_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/ois_convention_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.refdata.api/domain/ois_convention_json_io.hpp" // IWYU pragma: keep.
+#include "ores.refdata.core/repository/ois_convention_entity.hpp"
+#include "ores.refdata.core/repository/ois_convention_mapper.hpp"
+
+namespace ores::refdata::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string ois_convention_repository::sql() {
+    return generate_create_table_sql<ois_convention_entity>(lg());
+}
+
+void ois_convention_repository::write(context ctx, const domain::ois_convention& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing OIS convention: " << v.id;
+    execute_write_query(ctx, ois_convention_mapper::map(v),
+        lg(), "Writing OIS convention to database.");
+}
+
+void ois_convention_repository::write(
+    context ctx, const std::vector<domain::ois_convention>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing OIS conventions. Count: " << v.size();
+    execute_write_query(ctx, ois_convention_mapper::map(v),
+        lg(), "Writing OIS conventions to database.");
+}
+
+std::vector<domain::ois_convention>
+ois_convention_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<ois_convention_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("id"_c);
+
+    return execute_read_query<ois_convention_entity, domain::ois_convention>(
+        ctx, query,
+        [](const auto& entities) { return ois_convention_mapper::map(entities); },
+        lg(), "Reading latest OIS conventions");
+}
+
+std::vector<domain::ois_convention>
+ois_convention_repository::read_latest(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest OIS convention. id: " << id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<ois_convention_entity>> |
+        where("tenant_id"_c == tid && "id"_c == id && "valid_to"_c == max.value());
+
+    return execute_read_query<ois_convention_entity, domain::ois_convention>(
+        ctx, query,
+        [](const auto& entities) { return ois_convention_mapper::map(entities); },
+        lg(), "Reading latest OIS convention by id.");
+}
+
+std::vector<domain::ois_convention>
+ois_convention_repository::read_all(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all OIS convention versions. id: " << id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<ois_convention_entity>> |
+        where("tenant_id"_c == tid && "id"_c == id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<ois_convention_entity, domain::ois_convention>(
+        ctx, query,
+        [](const auto& entities) { return ois_convention_mapper::map(entities); },
+        lg(), "Reading all OIS convention versions by id.");
+}
+
+void ois_convention_repository::remove(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing OIS convention: " << id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<ois_convention_entity> |
+        where("tenant_id"_c == tid && "id"_c == id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing OIS convention from database.");
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/overnight_index_convention_entity.cpp
+++ b/projects/ores.refdata.core/src/repository/overnight_index_convention_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/overnight_index_convention_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::refdata::repository {
+
+std::ostream& operator<<(std::ostream& s, const overnight_index_convention_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/overnight_index_convention_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/overnight_index_convention_mapper.cpp
@@ -1,0 +1,91 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/overnight_index_convention_mapper.hpp"
+
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.refdata.api/domain/overnight_index_convention_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::overnight_index_convention
+overnight_index_convention_mapper::map(const overnight_index_convention_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::overnight_index_convention r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.id = v.id.value();
+    r.fixing_calendar = v.fixing_calendar;
+    r.day_count_fraction = v.day_count_fraction;
+    r.settlement_days = v.settlement_days;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+overnight_index_convention_entity
+overnight_index_convention_mapper::map(const domain::overnight_index_convention& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    overnight_index_convention_entity r;
+    r.id = v.id;
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.fixing_calendar = v.fixing_calendar;
+    r.day_count_fraction = v.day_count_fraction;
+    r.settlement_days = v.settlement_days;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::overnight_index_convention>
+overnight_index_convention_mapper::map(const std::vector<overnight_index_convention_entity>& v) {
+    return map_vector<overnight_index_convention_entity, domain::overnight_index_convention>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<overnight_index_convention_entity>
+overnight_index_convention_mapper::map(const std::vector<domain::overnight_index_convention>& v) {
+    return map_vector<domain::overnight_index_convention, overnight_index_convention_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/overnight_index_convention_repository.cpp
+++ b/projects/ores.refdata.core/src/repository/overnight_index_convention_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/overnight_index_convention_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.refdata.api/domain/overnight_index_convention_json_io.hpp" // IWYU pragma: keep.
+#include "ores.refdata.core/repository/overnight_index_convention_entity.hpp"
+#include "ores.refdata.core/repository/overnight_index_convention_mapper.hpp"
+
+namespace ores::refdata::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string overnight_index_convention_repository::sql() {
+    return generate_create_table_sql<overnight_index_convention_entity>(lg());
+}
+
+void overnight_index_convention_repository::write(context ctx, const domain::overnight_index_convention& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing overnight index convention: " << v.id;
+    execute_write_query(ctx, overnight_index_convention_mapper::map(v),
+        lg(), "Writing overnight index convention to database.");
+}
+
+void overnight_index_convention_repository::write(
+    context ctx, const std::vector<domain::overnight_index_convention>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing overnight index conventions. Count: " << v.size();
+    execute_write_query(ctx, overnight_index_convention_mapper::map(v),
+        lg(), "Writing overnight index conventions to database.");
+}
+
+std::vector<domain::overnight_index_convention>
+overnight_index_convention_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<overnight_index_convention_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("id"_c);
+
+    return execute_read_query<overnight_index_convention_entity, domain::overnight_index_convention>(
+        ctx, query,
+        [](const auto& entities) { return overnight_index_convention_mapper::map(entities); },
+        lg(), "Reading latest overnight index conventions");
+}
+
+std::vector<domain::overnight_index_convention>
+overnight_index_convention_repository::read_latest(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest overnight index convention. id: " << id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<overnight_index_convention_entity>> |
+        where("tenant_id"_c == tid && "id"_c == id && "valid_to"_c == max.value());
+
+    return execute_read_query<overnight_index_convention_entity, domain::overnight_index_convention>(
+        ctx, query,
+        [](const auto& entities) { return overnight_index_convention_mapper::map(entities); },
+        lg(), "Reading latest overnight index convention by id.");
+}
+
+std::vector<domain::overnight_index_convention>
+overnight_index_convention_repository::read_all(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all overnight index convention versions. id: " << id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<overnight_index_convention_entity>> |
+        where("tenant_id"_c == tid && "id"_c == id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<overnight_index_convention_entity, domain::overnight_index_convention>(
+        ctx, query,
+        [](const auto& entities) { return overnight_index_convention_mapper::map(entities); },
+        lg(), "Reading all overnight index convention versions by id.");
+}
+
+void overnight_index_convention_repository::remove(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing overnight index convention: " << id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<overnight_index_convention_entity> |
+        where("tenant_id"_c == tid && "id"_c == id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing overnight index convention from database.");
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/swap_convention_entity.cpp
+++ b/projects/ores.refdata.core/src/repository/swap_convention_entity.cpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/swap_convention_entity.hpp"
+
+#include <ostream>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+namespace ores::refdata::repository {
+
+std::ostream& operator<<(std::ostream& s, const swap_convention_entity& v) {
+    rfl::json::write(v, s);
+    return s;
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/swap_convention_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/swap_convention_mapper.cpp
@@ -1,0 +1,99 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/swap_convention_mapper.hpp"
+
+#include "ores.database/repository/mapper_helpers.hpp"
+#include "ores.refdata.api/domain/swap_convention_json_io.hpp" // IWYU pragma: keep.
+
+namespace ores::refdata::repository {
+
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+domain::swap_convention
+swap_convention_mapper::map(const swap_convention_entity& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
+
+    domain::swap_convention r;
+    r.version = v.version;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.id = v.id.value();
+    r.fixed_calendar = v.fixed_calendar;
+    r.fixed_frequency = v.fixed_frequency;
+    r.fixed_convention = v.fixed_convention;
+    r.fixed_day_count_fraction = v.fixed_day_count_fraction;
+    r.index = v.index;
+    r.float_frequency = v.float_frequency;
+    r.sub_periods_coupon_type = v.sub_periods_coupon_type;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+    if (!v.valid_from)
+        throw std::logic_error("Cannot map entity with null valid_from to domain object.");
+    r.recorded_at = timestamp_to_timepoint(*v.valid_from);
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
+    return r;
+}
+
+swap_convention_entity
+swap_convention_mapper::map(const domain::swap_convention& v) {
+    BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
+
+    swap_convention_entity r;
+    r.id = v.id;
+    r.tenant_id = v.tenant_id.to_string();
+    r.version = v.version;
+    r.fixed_calendar = v.fixed_calendar;
+    r.fixed_frequency = v.fixed_frequency;
+    r.fixed_convention = v.fixed_convention;
+    r.fixed_day_count_fraction = v.fixed_day_count_fraction;
+    r.index = v.index;
+    r.float_frequency = v.float_frequency;
+    r.sub_periods_coupon_type = v.sub_periods_coupon_type;
+    r.modified_by = v.modified_by;
+    r.performed_by = v.performed_by;
+    r.change_reason_code = v.change_reason_code;
+    r.change_commentary = v.change_commentary;
+
+    BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
+    return r;
+}
+
+std::vector<domain::swap_convention>
+swap_convention_mapper::map(const std::vector<swap_convention_entity>& v) {
+    return map_vector<swap_convention_entity, domain::swap_convention>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "db entities");
+}
+
+std::vector<swap_convention_entity>
+swap_convention_mapper::map(const std::vector<domain::swap_convention>& v) {
+    return map_vector<domain::swap_convention, swap_convention_entity>(
+        v,
+        [](const auto& ve) { return map(ve); },
+        lg(),
+        "domain entities");
+}
+
+}

--- a/projects/ores.refdata.core/src/repository/swap_convention_repository.cpp
+++ b/projects/ores.refdata.core/src/repository/swap_convention_repository.cpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/repository/swap_convention_repository.hpp"
+
+#include <sqlgen/postgres.hpp>
+#include "ores.database/repository/helpers.hpp"
+#include "ores.database/repository/bitemporal_operations.hpp"
+#include "ores.refdata.api/domain/swap_convention_json_io.hpp" // IWYU pragma: keep.
+#include "ores.refdata.core/repository/swap_convention_entity.hpp"
+#include "ores.refdata.core/repository/swap_convention_mapper.hpp"
+
+namespace ores::refdata::repository {
+
+using namespace sqlgen;
+using namespace sqlgen::literals;
+using namespace ores::logging;
+using namespace ores::database::repository;
+
+std::string swap_convention_repository::sql() {
+    return generate_create_table_sql<swap_convention_entity>(lg());
+}
+
+void swap_convention_repository::write(context ctx, const domain::swap_convention& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing swap convention: " << v.id;
+    execute_write_query(ctx, swap_convention_mapper::map(v),
+        lg(), "Writing swap convention to database.");
+}
+
+void swap_convention_repository::write(
+    context ctx, const std::vector<domain::swap_convention>& v) {
+    BOOST_LOG_SEV(lg(), debug) << "Writing swap conventions. Count: " << v.size();
+    execute_write_query(ctx, swap_convention_mapper::map(v),
+        lg(), "Writing swap conventions to database.");
+}
+
+std::vector<domain::swap_convention>
+swap_convention_repository::read_latest(context ctx) {
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<swap_convention_entity>> |
+        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        order_by("id"_c);
+
+    return execute_read_query<swap_convention_entity, domain::swap_convention>(
+        ctx, query,
+        [](const auto& entities) { return swap_convention_mapper::map(entities); },
+        lg(), "Reading latest swap conventions");
+}
+
+std::vector<domain::swap_convention>
+swap_convention_repository::read_latest(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading latest swap convention. id: " << id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<swap_convention_entity>> |
+        where("tenant_id"_c == tid && "id"_c == id && "valid_to"_c == max.value());
+
+    return execute_read_query<swap_convention_entity, domain::swap_convention>(
+        ctx, query,
+        [](const auto& entities) { return swap_convention_mapper::map(entities); },
+        lg(), "Reading latest swap convention by id.");
+}
+
+std::vector<domain::swap_convention>
+swap_convention_repository::read_all(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Reading all swap convention versions. id: " << id;
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::read<std::vector<swap_convention_entity>> |
+        where("tenant_id"_c == tid && "id"_c == id) |
+        order_by("version"_c.desc());
+
+    return execute_read_query<swap_convention_entity, domain::swap_convention>(
+        ctx, query,
+        [](const auto& entities) { return swap_convention_mapper::map(entities); },
+        lg(), "Reading all swap convention versions by id.");
+}
+
+void swap_convention_repository::remove(context ctx, const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing swap convention: " << id;
+    static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
+    const auto tid = ctx.tenant_id().to_string();
+    const auto query = sqlgen::delete_from<swap_convention_entity> |
+        where("tenant_id"_c == tid && "id"_c == id && "valid_to"_c == max.value());
+
+    execute_delete_query(ctx, query, lg(), "Removing swap convention from database.");
+}
+
+}

--- a/projects/ores.refdata.core/src/service/cds_convention_service.cpp
+++ b/projects/ores.refdata.core/src/service/cds_convention_service.cpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/service/cds_convention_service.hpp"
+
+#include <stdexcept>
+
+namespace ores::refdata::service {
+
+using namespace ores::logging;
+
+cds_convention_service::cds_convention_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+std::vector<domain::cds_convention> cds_convention_service::list_cds_conventions() {
+    BOOST_LOG_SEV(lg(), debug) << "Listing all CDS conventions";
+    return repo_.read_latest(ctx_);
+}
+
+std::optional<domain::cds_convention>
+cds_convention_service::get_cds_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting CDS convention: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
+void cds_convention_service::save_cds_convention(const domain::cds_convention& v) {
+    if (v.id.empty())
+        throw std::invalid_argument("CDS Convention id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving CDS convention: " << v.id;
+    repo_.write(ctx_, v);
+    BOOST_LOG_SEV(lg(), info) << "Saved CDS convention: " << v.id;
+}
+
+void cds_convention_service::remove_cds_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing CDS convention: " << id;
+    repo_.remove(ctx_, id);
+    BOOST_LOG_SEV(lg(), info) << "Removed CDS convention: " << id;
+}
+
+std::vector<domain::cds_convention>
+cds_convention_service::get_cds_convention_history(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting history for CDS convention: " << id;
+    return repo_.read_all(ctx_, id);
+}
+
+}

--- a/projects/ores.refdata.core/src/service/fra_convention_service.cpp
+++ b/projects/ores.refdata.core/src/service/fra_convention_service.cpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/service/fra_convention_service.hpp"
+
+#include <stdexcept>
+
+namespace ores::refdata::service {
+
+using namespace ores::logging;
+
+fra_convention_service::fra_convention_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+std::vector<domain::fra_convention> fra_convention_service::list_fra_conventions() {
+    BOOST_LOG_SEV(lg(), debug) << "Listing all FRA conventions";
+    return repo_.read_latest(ctx_);
+}
+
+std::optional<domain::fra_convention>
+fra_convention_service::get_fra_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting FRA convention: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
+void fra_convention_service::save_fra_convention(const domain::fra_convention& v) {
+    if (v.id.empty())
+        throw std::invalid_argument("FRA Convention id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving FRA convention: " << v.id;
+    repo_.write(ctx_, v);
+    BOOST_LOG_SEV(lg(), info) << "Saved FRA convention: " << v.id;
+}
+
+void fra_convention_service::remove_fra_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing FRA convention: " << id;
+    repo_.remove(ctx_, id);
+    BOOST_LOG_SEV(lg(), info) << "Removed FRA convention: " << id;
+}
+
+std::vector<domain::fra_convention>
+fra_convention_service::get_fra_convention_history(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting history for FRA convention: " << id;
+    return repo_.read_all(ctx_, id);
+}
+
+}

--- a/projects/ores.refdata.core/src/service/fx_convention_service.cpp
+++ b/projects/ores.refdata.core/src/service/fx_convention_service.cpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/service/fx_convention_service.hpp"
+
+#include <stdexcept>
+
+namespace ores::refdata::service {
+
+using namespace ores::logging;
+
+fx_convention_service::fx_convention_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+std::vector<domain::fx_convention> fx_convention_service::list_fx_conventions() {
+    BOOST_LOG_SEV(lg(), debug) << "Listing all FX conventions";
+    return repo_.read_latest(ctx_);
+}
+
+std::optional<domain::fx_convention>
+fx_convention_service::get_fx_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting FX convention: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
+void fx_convention_service::save_fx_convention(const domain::fx_convention& v) {
+    if (v.id.empty())
+        throw std::invalid_argument("FX Convention id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving FX convention: " << v.id;
+    repo_.write(ctx_, v);
+    BOOST_LOG_SEV(lg(), info) << "Saved FX convention: " << v.id;
+}
+
+void fx_convention_service::remove_fx_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing FX convention: " << id;
+    repo_.remove(ctx_, id);
+    BOOST_LOG_SEV(lg(), info) << "Removed FX convention: " << id;
+}
+
+std::vector<domain::fx_convention>
+fx_convention_service::get_fx_convention_history(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting history for FX convention: " << id;
+    return repo_.read_all(ctx_, id);
+}
+
+}

--- a/projects/ores.refdata.core/src/service/ibor_index_convention_service.cpp
+++ b/projects/ores.refdata.core/src/service/ibor_index_convention_service.cpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/service/ibor_index_convention_service.hpp"
+
+#include <stdexcept>
+
+namespace ores::refdata::service {
+
+using namespace ores::logging;
+
+ibor_index_convention_service::ibor_index_convention_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+std::vector<domain::ibor_index_convention> ibor_index_convention_service::list_ibor_index_conventions() {
+    BOOST_LOG_SEV(lg(), debug) << "Listing all IBOR index conventions";
+    return repo_.read_latest(ctx_);
+}
+
+std::optional<domain::ibor_index_convention>
+ibor_index_convention_service::get_ibor_index_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting IBOR index convention: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
+void ibor_index_convention_service::save_ibor_index_convention(const domain::ibor_index_convention& v) {
+    if (v.id.empty())
+        throw std::invalid_argument("IBOR Index Convention id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving IBOR index convention: " << v.id;
+    repo_.write(ctx_, v);
+    BOOST_LOG_SEV(lg(), info) << "Saved IBOR index convention: " << v.id;
+}
+
+void ibor_index_convention_service::remove_ibor_index_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing IBOR index convention: " << id;
+    repo_.remove(ctx_, id);
+    BOOST_LOG_SEV(lg(), info) << "Removed IBOR index convention: " << id;
+}
+
+std::vector<domain::ibor_index_convention>
+ibor_index_convention_service::get_ibor_index_convention_history(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting history for IBOR index convention: " << id;
+    return repo_.read_all(ctx_, id);
+}
+
+}

--- a/projects/ores.refdata.core/src/service/ois_convention_service.cpp
+++ b/projects/ores.refdata.core/src/service/ois_convention_service.cpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/service/ois_convention_service.hpp"
+
+#include <stdexcept>
+
+namespace ores::refdata::service {
+
+using namespace ores::logging;
+
+ois_convention_service::ois_convention_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+std::vector<domain::ois_convention> ois_convention_service::list_ois_conventions() {
+    BOOST_LOG_SEV(lg(), debug) << "Listing all OIS conventions";
+    return repo_.read_latest(ctx_);
+}
+
+std::optional<domain::ois_convention>
+ois_convention_service::get_ois_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting OIS convention: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
+void ois_convention_service::save_ois_convention(const domain::ois_convention& v) {
+    if (v.id.empty())
+        throw std::invalid_argument("OIS Convention id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving OIS convention: " << v.id;
+    repo_.write(ctx_, v);
+    BOOST_LOG_SEV(lg(), info) << "Saved OIS convention: " << v.id;
+}
+
+void ois_convention_service::remove_ois_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing OIS convention: " << id;
+    repo_.remove(ctx_, id);
+    BOOST_LOG_SEV(lg(), info) << "Removed OIS convention: " << id;
+}
+
+std::vector<domain::ois_convention>
+ois_convention_service::get_ois_convention_history(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting history for OIS convention: " << id;
+    return repo_.read_all(ctx_, id);
+}
+
+}

--- a/projects/ores.refdata.core/src/service/overnight_index_convention_service.cpp
+++ b/projects/ores.refdata.core/src/service/overnight_index_convention_service.cpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/service/overnight_index_convention_service.hpp"
+
+#include <stdexcept>
+
+namespace ores::refdata::service {
+
+using namespace ores::logging;
+
+overnight_index_convention_service::overnight_index_convention_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+std::vector<domain::overnight_index_convention> overnight_index_convention_service::list_overnight_index_conventions() {
+    BOOST_LOG_SEV(lg(), debug) << "Listing all overnight index conventions";
+    return repo_.read_latest(ctx_);
+}
+
+std::optional<domain::overnight_index_convention>
+overnight_index_convention_service::get_overnight_index_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting overnight index convention: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
+void overnight_index_convention_service::save_overnight_index_convention(const domain::overnight_index_convention& v) {
+    if (v.id.empty())
+        throw std::invalid_argument("Overnight Index Convention id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving overnight index convention: " << v.id;
+    repo_.write(ctx_, v);
+    BOOST_LOG_SEV(lg(), info) << "Saved overnight index convention: " << v.id;
+}
+
+void overnight_index_convention_service::remove_overnight_index_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing overnight index convention: " << id;
+    repo_.remove(ctx_, id);
+    BOOST_LOG_SEV(lg(), info) << "Removed overnight index convention: " << id;
+}
+
+std::vector<domain::overnight_index_convention>
+overnight_index_convention_service::get_overnight_index_convention_history(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting history for overnight index convention: " << id;
+    return repo_.read_all(ctx_, id);
+}
+
+}

--- a/projects/ores.refdata.core/src/service/swap_convention_service.cpp
+++ b/projects/ores.refdata.core/src/service/swap_convention_service.cpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.refdata.core/service/swap_convention_service.hpp"
+
+#include <stdexcept>
+
+namespace ores::refdata::service {
+
+using namespace ores::logging;
+
+swap_convention_service::swap_convention_service(context ctx)
+    : ctx_(std::move(ctx)) {}
+
+std::vector<domain::swap_convention> swap_convention_service::list_swap_conventions() {
+    BOOST_LOG_SEV(lg(), debug) << "Listing all swap conventions";
+    return repo_.read_latest(ctx_);
+}
+
+std::optional<domain::swap_convention>
+swap_convention_service::get_swap_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting swap convention: " << id;
+    auto results = repo_.read_latest(ctx_, id);
+    if (results.empty()) return std::nullopt;
+    return results.front();
+}
+
+void swap_convention_service::save_swap_convention(const domain::swap_convention& v) {
+    if (v.id.empty())
+        throw std::invalid_argument("Swap Convention id cannot be empty.");
+    BOOST_LOG_SEV(lg(), debug) << "Saving swap convention: " << v.id;
+    repo_.write(ctx_, v);
+    BOOST_LOG_SEV(lg(), info) << "Saved swap convention: " << v.id;
+}
+
+void swap_convention_service::remove_swap_convention(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Removing swap convention: " << id;
+    repo_.remove(ctx_, id);
+    BOOST_LOG_SEV(lg(), info) << "Removed swap convention: " << id;
+}
+
+std::vector<domain::swap_convention>
+swap_convention_service::get_swap_convention_history(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting history for swap convention: " << id;
+    return repo_.read_all(ctx_, id);
+}
+
+}

--- a/projects/ores.sql/create/refdata/refdata_cds_conventions_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_cds_conventions_create.sql
@@ -1,0 +1,130 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+/**
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_domain_entity_create.mustache
+ * To modify, update the template and regenerate.
+ *
+ *  Table
+ *
+ * Defines the settlement lag, premium payment schedule, and accrual rules
+ * for a vanilla CDS. Corresponds to the <CDS> element in ORE conventions.xml.
+ * The rule field governs IMM dates and standard CDS roll dates.
+ */
+
+create table if not exists "ores_refdata_cds_conventions_tbl" (
+    "id" text not null,
+    "tenant_id" uuid not null,
+    "version" integer not null,
+    "settlement_days" integer not null,
+    "calendar" text not null,
+    "frequency" text not null,
+    "payment_convention" text not null,
+    "rule" text not null,
+    "day_count_fraction" text not null,
+    "settles_accrual" boolean not null,
+    "pays_at_default_time" boolean not null,
+    "upfront_settlement_days" integer null,
+    "last_period_day_count_fraction" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("id" <> '')
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_refdata_cds_conventions_version_uniq_idx
+on "ores_refdata_cds_conventions_tbl" (tenant_id, id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create unique index if not exists ores_refdata_cds_conventions_id_uniq_idx
+on "ores_refdata_cds_conventions_tbl" (tenant_id, id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create index if not exists ores_refdata_cds_conventions_tenant_idx
+on "ores_refdata_cds_conventions_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create or replace function ores_refdata_cds_conventions_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Version management
+    select version into current_version
+    from "ores_refdata_cds_conventions_tbl"
+    where tenant_id = NEW.tenant_id
+      and id = NEW.id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_refdata_cds_conventions_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and id = NEW.id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_actor_fn(), current_user);
+
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    return NEW;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_refdata_cds_conventions_insert_trg
+before insert on "ores_refdata_cds_conventions_tbl"
+for each row execute function ores_refdata_cds_conventions_insert_fn();
+
+create or replace rule ores_refdata_cds_conventions_delete_rule as
+on delete to "ores_refdata_cds_conventions_tbl" do instead
+    update "ores_refdata_cds_conventions_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and id = OLD.id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/refdata/refdata_cds_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_cds_conventions_notify_trigger_create.sql
@@ -1,0 +1,58 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+/*
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_notify_trigger.mustache
+ * To modify, update the template and regenerate.
+ */
+
+create or replace function ores_refdata_cds_conventions_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.refdata.cds_convention';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.id;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.id;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_cds_conventions', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_refdata_cds_conventions_notify_trg
+after insert or update or delete on ores_refdata_cds_conventions_tbl
+for each row execute function ores_refdata_cds_conventions_notify_fn();

--- a/projects/ores.sql/create/refdata/refdata_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_create.sql
@@ -124,3 +124,17 @@
 \ir ./refdata_zero_conventions_notify_trigger_create.sql
 \ir ./refdata_deposit_conventions_create.sql
 \ir ./refdata_deposit_conventions_notify_trigger_create.sql
+\ir ./refdata_swap_conventions_create.sql
+\ir ./refdata_swap_conventions_notify_trigger_create.sql
+\ir ./refdata_ois_conventions_create.sql
+\ir ./refdata_ois_conventions_notify_trigger_create.sql
+\ir ./refdata_fra_conventions_create.sql
+\ir ./refdata_fra_conventions_notify_trigger_create.sql
+\ir ./refdata_ibor_index_conventions_create.sql
+\ir ./refdata_ibor_index_conventions_notify_trigger_create.sql
+\ir ./refdata_overnight_index_conventions_create.sql
+\ir ./refdata_overnight_index_conventions_notify_trigger_create.sql
+\ir ./refdata_fx_conventions_create.sql
+\ir ./refdata_fx_conventions_notify_trigger_create.sql
+\ir ./refdata_cds_conventions_create.sql
+\ir ./refdata_cds_conventions_notify_trigger_create.sql

--- a/projects/ores.sql/create/refdata/refdata_fra_conventions_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_fra_conventions_create.sql
@@ -1,0 +1,121 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+/**
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_domain_entity_create.mustache
+ * To modify, update the template and regenerate.
+ *
+ *  Table
+ *
+ * A FRA convention ties a FRA instrument to an IBOR index whose own
+ * conventions (calendar, day count, settlement) govern the FRA.
+ * Corresponds to the <FRA> element in ORE conventions.xml.
+ */
+
+create table if not exists "ores_refdata_fra_conventions_tbl" (
+    "id" text not null,
+    "tenant_id" uuid not null,
+    "version" integer not null,
+    "index" text not null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("id" <> '')
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_refdata_fra_conventions_version_uniq_idx
+on "ores_refdata_fra_conventions_tbl" (tenant_id, id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create unique index if not exists ores_refdata_fra_conventions_id_uniq_idx
+on "ores_refdata_fra_conventions_tbl" (tenant_id, id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create index if not exists ores_refdata_fra_conventions_tenant_idx
+on "ores_refdata_fra_conventions_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create or replace function ores_refdata_fra_conventions_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Version management
+    select version into current_version
+    from "ores_refdata_fra_conventions_tbl"
+    where tenant_id = NEW.tenant_id
+      and id = NEW.id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_refdata_fra_conventions_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and id = NEW.id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_actor_fn(), current_user);
+
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    return NEW;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_refdata_fra_conventions_insert_trg
+before insert on "ores_refdata_fra_conventions_tbl"
+for each row execute function ores_refdata_fra_conventions_insert_fn();
+
+create or replace rule ores_refdata_fra_conventions_delete_rule as
+on delete to "ores_refdata_fra_conventions_tbl" do instead
+    update "ores_refdata_fra_conventions_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and id = OLD.id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/refdata/refdata_fra_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_fra_conventions_notify_trigger_create.sql
@@ -1,0 +1,58 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+/*
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_notify_trigger.mustache
+ * To modify, update the template and regenerate.
+ */
+
+create or replace function ores_refdata_fra_conventions_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.refdata.fra_convention';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.id;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.id;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_fra_conventions', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_refdata_fra_conventions_notify_trg
+after insert or update or delete on ores_refdata_fra_conventions_tbl
+for each row execute function ores_refdata_fra_conventions_notify_fn();

--- a/projects/ores.sql/create/refdata/refdata_fx_conventions_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_fx_conventions_create.sql
@@ -1,0 +1,128 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+/**
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_domain_entity_create.mustache
+ * To modify, update the template and regenerate.
+ *
+ *  Table
+ *
+ * Defines the spot settlement lag, pip factor, and adjustment conventions for
+ * a currency pair. Corresponds to the <FX> element in ORE conventions.xml.
+ * The id typically takes the form 'CCY1-CCY2-FX-CONVENTIONS'.
+ */
+
+create table if not exists "ores_refdata_fx_conventions_tbl" (
+    "id" text not null,
+    "tenant_id" uuid not null,
+    "version" integer not null,
+    "spot_days" integer not null,
+    "source_currency" text not null,
+    "target_currency" text not null,
+    "points_factor" double precision not null,
+    "advance_calendar" text null,
+    "spot_relative" boolean null,
+    "end_of_month" boolean null,
+    "convention" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("id" <> '')
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_refdata_fx_conventions_version_uniq_idx
+on "ores_refdata_fx_conventions_tbl" (tenant_id, id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create unique index if not exists ores_refdata_fx_conventions_id_uniq_idx
+on "ores_refdata_fx_conventions_tbl" (tenant_id, id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create index if not exists ores_refdata_fx_conventions_tenant_idx
+on "ores_refdata_fx_conventions_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create or replace function ores_refdata_fx_conventions_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Version management
+    select version into current_version
+    from "ores_refdata_fx_conventions_tbl"
+    where tenant_id = NEW.tenant_id
+      and id = NEW.id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_refdata_fx_conventions_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and id = NEW.id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_actor_fn(), current_user);
+
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    return NEW;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_refdata_fx_conventions_insert_trg
+before insert on "ores_refdata_fx_conventions_tbl"
+for each row execute function ores_refdata_fx_conventions_insert_fn();
+
+create or replace rule ores_refdata_fx_conventions_delete_rule as
+on delete to "ores_refdata_fx_conventions_tbl" do instead
+    update "ores_refdata_fx_conventions_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and id = OLD.id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/refdata/refdata_fx_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_fx_conventions_notify_trigger_create.sql
@@ -1,0 +1,58 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+/*
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_notify_trigger.mustache
+ * To modify, update the template and regenerate.
+ */
+
+create or replace function ores_refdata_fx_conventions_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.refdata.fx_convention';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.id;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.id;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_fx_conventions', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_refdata_fx_conventions_notify_trg
+after insert or update or delete on ores_refdata_fx_conventions_tbl
+for each row execute function ores_refdata_fx_conventions_notify_fn();

--- a/projects/ores.sql/create/refdata/refdata_ibor_index_conventions_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_ibor_index_conventions_create.sql
@@ -1,0 +1,125 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+/**
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_domain_entity_create.mustache
+ * To modify, update the template and regenerate.
+ *
+ *  Table
+ *
+ * Defines the fixing calendar, day count, settlement lag, and business day
+ * convention for a term IBOR index such as EURIBOR or USD LIBOR.
+ * Corresponds to the <IborIndex> element in ORE conventions.xml.
+ */
+
+create table if not exists "ores_refdata_ibor_index_conventions_tbl" (
+    "id" text not null,
+    "tenant_id" uuid not null,
+    "version" integer not null,
+    "fixing_calendar" text not null,
+    "day_count_fraction" text not null,
+    "settlement_days" integer not null,
+    "business_day_convention" text not null,
+    "end_of_month" boolean not null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("id" <> '')
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_refdata_ibor_index_conventions_version_uniq_idx
+on "ores_refdata_ibor_index_conventions_tbl" (tenant_id, id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create unique index if not exists ores_refdata_ibor_index_conventions_id_uniq_idx
+on "ores_refdata_ibor_index_conventions_tbl" (tenant_id, id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create index if not exists ores_refdata_ibor_index_conventions_tenant_idx
+on "ores_refdata_ibor_index_conventions_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create or replace function ores_refdata_ibor_index_conventions_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Version management
+    select version into current_version
+    from "ores_refdata_ibor_index_conventions_tbl"
+    where tenant_id = NEW.tenant_id
+      and id = NEW.id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_refdata_ibor_index_conventions_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and id = NEW.id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_actor_fn(), current_user);
+
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    return NEW;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_refdata_ibor_index_conventions_insert_trg
+before insert on "ores_refdata_ibor_index_conventions_tbl"
+for each row execute function ores_refdata_ibor_index_conventions_insert_fn();
+
+create or replace rule ores_refdata_ibor_index_conventions_delete_rule as
+on delete to "ores_refdata_ibor_index_conventions_tbl" do instead
+    update "ores_refdata_ibor_index_conventions_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and id = OLD.id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/refdata/refdata_ibor_index_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_ibor_index_conventions_notify_trigger_create.sql
@@ -1,0 +1,58 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+/*
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_notify_trigger.mustache
+ * To modify, update the template and regenerate.
+ */
+
+create or replace function ores_refdata_ibor_index_conventions_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.refdata.ibor_index_convention';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.id;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.id;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_ibor_index_conventions', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_refdata_ibor_index_conventions_notify_trg
+after insert or update or delete on ores_refdata_ibor_index_conventions_tbl
+for each row execute function ores_refdata_ibor_index_conventions_notify_fn();

--- a/projects/ores.sql/create/refdata/refdata_ois_conventions_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_ois_conventions_create.sql
@@ -1,0 +1,132 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+/**
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_domain_entity_create.mustache
+ * To modify, update the template and regenerate.
+ *
+ *  Table
+ *
+ * Defines the fixed-leg and overnight floating-leg parameters for an OIS.
+ * OIS are used to bootstrap risk-free overnight discount curves (e.g. EONIA,
+ * SOFR, SONIA). Corresponds to the <OIS> element in ORE conventions.xml.
+ */
+
+create table if not exists "ores_refdata_ois_conventions_tbl" (
+    "id" text not null,
+    "tenant_id" uuid not null,
+    "version" integer not null,
+    "spot_lag" integer not null,
+    "index" text not null,
+    "fixed_day_count_fraction" text not null,
+    "fixed_calendar" text null,
+    "payment_lag" integer null,
+    "end_of_month" boolean null,
+    "fixed_frequency" text null,
+    "fixed_convention" text null,
+    "fixed_payment_convention" text null,
+    "rule" text null,
+    "payment_calendar" text null,
+    "rate_cutoff" integer null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("id" <> '')
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_refdata_ois_conventions_version_uniq_idx
+on "ores_refdata_ois_conventions_tbl" (tenant_id, id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create unique index if not exists ores_refdata_ois_conventions_id_uniq_idx
+on "ores_refdata_ois_conventions_tbl" (tenant_id, id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create index if not exists ores_refdata_ois_conventions_tenant_idx
+on "ores_refdata_ois_conventions_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create or replace function ores_refdata_ois_conventions_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Version management
+    select version into current_version
+    from "ores_refdata_ois_conventions_tbl"
+    where tenant_id = NEW.tenant_id
+      and id = NEW.id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_refdata_ois_conventions_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and id = NEW.id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_actor_fn(), current_user);
+
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    return NEW;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_refdata_ois_conventions_insert_trg
+before insert on "ores_refdata_ois_conventions_tbl"
+for each row execute function ores_refdata_ois_conventions_insert_fn();
+
+create or replace rule ores_refdata_ois_conventions_delete_rule as
+on delete to "ores_refdata_ois_conventions_tbl" do instead
+    update "ores_refdata_ois_conventions_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and id = OLD.id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/refdata/refdata_ois_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_ois_conventions_notify_trigger_create.sql
@@ -1,0 +1,58 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+/*
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_notify_trigger.mustache
+ * To modify, update the template and regenerate.
+ */
+
+create or replace function ores_refdata_ois_conventions_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.refdata.ois_convention';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.id;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.id;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_ois_conventions', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_refdata_ois_conventions_notify_trg
+after insert or update or delete on ores_refdata_ois_conventions_tbl
+for each row execute function ores_refdata_ois_conventions_notify_fn();

--- a/projects/ores.sql/create/refdata/refdata_overnight_index_conventions_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_overnight_index_conventions_create.sql
@@ -1,0 +1,123 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+/**
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_domain_entity_create.mustache
+ * To modify, update the template and regenerate.
+ *
+ *  Table
+ *
+ * Defines the fixing calendar, day count, and settlement lag for a risk-free
+ * overnight rate index. Corresponds to the <OvernightIndex> element in
+ * ORE conventions.xml.
+ */
+
+create table if not exists "ores_refdata_overnight_index_conventions_tbl" (
+    "id" text not null,
+    "tenant_id" uuid not null,
+    "version" integer not null,
+    "fixing_calendar" text not null,
+    "day_count_fraction" text not null,
+    "settlement_days" integer not null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("id" <> '')
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_refdata_overnight_index_conventions_version_uniq_idx
+on "ores_refdata_overnight_index_conventions_tbl" (tenant_id, id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create unique index if not exists ores_refdata_overnight_index_conventions_id_uniq_idx
+on "ores_refdata_overnight_index_conventions_tbl" (tenant_id, id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create index if not exists ores_refdata_overnight_index_conventions_tenant_idx
+on "ores_refdata_overnight_index_conventions_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create or replace function ores_refdata_overnight_index_conventions_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Version management
+    select version into current_version
+    from "ores_refdata_overnight_index_conventions_tbl"
+    where tenant_id = NEW.tenant_id
+      and id = NEW.id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_refdata_overnight_index_conventions_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and id = NEW.id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_actor_fn(), current_user);
+
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    return NEW;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_refdata_overnight_index_conventions_insert_trg
+before insert on "ores_refdata_overnight_index_conventions_tbl"
+for each row execute function ores_refdata_overnight_index_conventions_insert_fn();
+
+create or replace rule ores_refdata_overnight_index_conventions_delete_rule as
+on delete to "ores_refdata_overnight_index_conventions_tbl" do instead
+    update "ores_refdata_overnight_index_conventions_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and id = OLD.id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/refdata/refdata_overnight_index_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_overnight_index_conventions_notify_trigger_create.sql
@@ -1,0 +1,58 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+/*
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_notify_trigger.mustache
+ * To modify, update the template and regenerate.
+ */
+
+create or replace function ores_refdata_overnight_index_conventions_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.refdata.overnight_index_convention';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.id;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.id;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_overnight_index_conventions', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_refdata_overnight_index_conventions_notify_trg
+after insert or update or delete on ores_refdata_overnight_index_conventions_tbl
+for each row execute function ores_refdata_overnight_index_conventions_notify_fn();

--- a/projects/ores.sql/create/refdata/refdata_rls_policies_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_rls_policies_create.sql
@@ -79,6 +79,97 @@ with check (
 );
 
 -- -----------------------------------------------------------------------------
+-- Swap Conventions
+-- -----------------------------------------------------------------------------
+alter table ores_refdata_swap_conventions_tbl enable row level security;
+
+create policy ores_refdata_swap_conventions_tenant_isolation_policy on ores_refdata_swap_conventions_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+-- -----------------------------------------------------------------------------
+-- OIS Conventions
+-- -----------------------------------------------------------------------------
+alter table ores_refdata_ois_conventions_tbl enable row level security;
+
+create policy ores_refdata_ois_conventions_tenant_isolation_policy on ores_refdata_ois_conventions_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+-- -----------------------------------------------------------------------------
+-- FRA Conventions
+-- -----------------------------------------------------------------------------
+alter table ores_refdata_fra_conventions_tbl enable row level security;
+
+create policy ores_refdata_fra_conventions_tenant_isolation_policy on ores_refdata_fra_conventions_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+-- -----------------------------------------------------------------------------
+-- IBOR Index Conventions
+-- -----------------------------------------------------------------------------
+alter table ores_refdata_ibor_index_conventions_tbl enable row level security;
+
+create policy ores_refdata_ibor_index_conventions_tenant_isolation_policy on ores_refdata_ibor_index_conventions_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+-- -----------------------------------------------------------------------------
+-- Overnight Index Conventions
+-- -----------------------------------------------------------------------------
+alter table ores_refdata_overnight_index_conventions_tbl enable row level security;
+
+create policy ores_refdata_overnight_index_conventions_tenant_isolation_policy on ores_refdata_overnight_index_conventions_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+-- -----------------------------------------------------------------------------
+-- FX Conventions
+-- -----------------------------------------------------------------------------
+alter table ores_refdata_fx_conventions_tbl enable row level security;
+
+create policy ores_refdata_fx_conventions_tenant_isolation_policy on ores_refdata_fx_conventions_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+-- -----------------------------------------------------------------------------
+-- CDS Conventions
+-- -----------------------------------------------------------------------------
+alter table ores_refdata_cds_conventions_tbl enable row level security;
+
+create policy ores_refdata_cds_conventions_tenant_isolation_policy on ores_refdata_cds_conventions_tbl
+for all using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+)
+with check (
+    tenant_id = ores_iam_current_tenant_id_fn()
+);
+
+-- -----------------------------------------------------------------------------
 -- Currencies
 -- -----------------------------------------------------------------------------
 alter table ores_refdata_currencies_tbl enable row level security;

--- a/projects/ores.sql/create/refdata/refdata_swap_conventions_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_swap_conventions_create.sql
@@ -1,0 +1,127 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+/**
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_domain_entity_create.mustache
+ * To modify, update the template and regenerate.
+ *
+ *  Table
+ *
+ * Defines the fixed-leg schedule and the floating-leg index for a standard
+ * interest rate swap. Used by ORE to bootstrap par swap rates off a yield
+ * curve. Corresponds to the <Swap> element in ORE conventions.xml.
+ */
+
+create table if not exists "ores_refdata_swap_conventions_tbl" (
+    "id" text not null,
+    "tenant_id" uuid not null,
+    "version" integer not null,
+    "fixed_calendar" text null,
+    "fixed_frequency" text not null,
+    "fixed_convention" text null,
+    "fixed_day_count_fraction" text not null,
+    "index" text not null,
+    "float_frequency" text null,
+    "sub_periods_coupon_type" text null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+    primary key (tenant_id, id, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        id WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+    check ("valid_from" < "valid_to"),
+    check ("id" <> '')
+);
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists ores_refdata_swap_conventions_version_uniq_idx
+on "ores_refdata_swap_conventions_tbl" (tenant_id, id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create unique index if not exists ores_refdata_swap_conventions_id_uniq_idx
+on "ores_refdata_swap_conventions_tbl" (tenant_id, id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create index if not exists ores_refdata_swap_conventions_tenant_idx
+on "ores_refdata_swap_conventions_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create or replace function ores_refdata_swap_conventions_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+    -- Validate tenant_id
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+
+    -- Version management
+    select version into current_version
+    from "ores_refdata_swap_conventions_tbl"
+    where tenant_id = NEW.tenant_id
+      and id = NEW.id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if NEW.version != 0 and NEW.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                NEW.version, current_version
+                using errcode = 'P0002';
+        end if;
+        NEW.version = current_version + 1;
+
+        update "ores_refdata_swap_conventions_tbl"
+        set valid_to = current_timestamp
+        where tenant_id = NEW.tenant_id
+          and id = NEW.id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        NEW.version = 1;
+    end if;
+
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_actor_fn(), current_user);
+
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+    return NEW;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_refdata_swap_conventions_insert_trg
+before insert on "ores_refdata_swap_conventions_tbl"
+for each row execute function ores_refdata_swap_conventions_insert_fn();
+
+create or replace rule ores_refdata_swap_conventions_delete_rule as
+on delete to "ores_refdata_swap_conventions_tbl" do instead
+    update "ores_refdata_swap_conventions_tbl"
+    set valid_to = current_timestamp
+    where tenant_id = OLD.tenant_id
+      and id = OLD.id
+      and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/refdata/refdata_swap_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_swap_conventions_notify_trigger_create.sql
@@ -1,0 +1,58 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+/*
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_notify_trigger.mustache
+ * To modify, update the template and regenerate.
+ */
+
+create or replace function ores_refdata_swap_conventions_notify_fn()
+returns trigger as $$
+declare
+    notification_payload jsonb;
+    entity_name text := 'ores.refdata.swap_convention';
+    change_timestamp timestamptz := NOW();
+    changed_id text;
+    changed_tenant_id text;
+begin
+    if TG_OP = 'DELETE' then
+        changed_id := OLD.id;
+        changed_tenant_id := OLD.tenant_id::text;
+    else
+        changed_id := NEW.id;
+        changed_tenant_id := NEW.tenant_id::text;
+    end if;
+
+    notification_payload := jsonb_build_object(
+        'entity', entity_name,
+        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'entity_ids', jsonb_build_array(changed_id),
+        'tenant_id', changed_tenant_id
+    );
+
+    perform pg_notify('ores_swap_conventions', notification_payload::text);
+
+    return null;
+end;
+$$ language plpgsql;
+
+create or replace trigger ores_refdata_swap_conventions_notify_trg
+after insert or update or delete on ores_refdata_swap_conventions_tbl
+for each row execute function ores_refdata_swap_conventions_notify_fn();

--- a/projects/ores.sql/drop/refdata/refdata_cds_conventions_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_cds_conventions_drop.sql
@@ -1,0 +1,24 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop rule if exists ores_refdata_cds_conventions_delete_rule on "ores_refdata_cds_conventions_tbl";
+drop trigger if exists ores_refdata_cds_conventions_insert_trg on "ores_refdata_cds_conventions_tbl";
+drop function if exists ores_refdata_cds_conventions_insert_fn;
+drop table if exists "ores_refdata_cds_conventions_tbl";

--- a/projects/ores.sql/drop/refdata/refdata_cds_conventions_notify_trigger_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_cds_conventions_notify_trigger_drop.sql
@@ -1,0 +1,22 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_refdata_cds_conventions_notify_trg on "ores_refdata_cds_conventions_tbl";
+drop function if exists ores_refdata_cds_conventions_notify_fn;

--- a/projects/ores.sql/drop/refdata/refdata_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_drop.sql
@@ -19,6 +19,20 @@
  */
 
 -- ORE conventions (no dependants, drop first)
+\ir ./refdata_cds_conventions_notify_trigger_drop.sql
+\ir ./refdata_cds_conventions_drop.sql
+\ir ./refdata_fx_conventions_notify_trigger_drop.sql
+\ir ./refdata_fx_conventions_drop.sql
+\ir ./refdata_overnight_index_conventions_notify_trigger_drop.sql
+\ir ./refdata_overnight_index_conventions_drop.sql
+\ir ./refdata_ibor_index_conventions_notify_trigger_drop.sql
+\ir ./refdata_ibor_index_conventions_drop.sql
+\ir ./refdata_fra_conventions_notify_trigger_drop.sql
+\ir ./refdata_fra_conventions_drop.sql
+\ir ./refdata_ois_conventions_notify_trigger_drop.sql
+\ir ./refdata_ois_conventions_drop.sql
+\ir ./refdata_swap_conventions_notify_trigger_drop.sql
+\ir ./refdata_swap_conventions_drop.sql
 \ir ./refdata_zero_conventions_notify_trigger_drop.sql
 \ir ./refdata_zero_conventions_drop.sql
 \ir ./refdata_deposit_conventions_notify_trigger_drop.sql

--- a/projects/ores.sql/drop/refdata/refdata_fra_conventions_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_fra_conventions_drop.sql
@@ -1,0 +1,24 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop rule if exists ores_refdata_fra_conventions_delete_rule on "ores_refdata_fra_conventions_tbl";
+drop trigger if exists ores_refdata_fra_conventions_insert_trg on "ores_refdata_fra_conventions_tbl";
+drop function if exists ores_refdata_fra_conventions_insert_fn;
+drop table if exists "ores_refdata_fra_conventions_tbl";

--- a/projects/ores.sql/drop/refdata/refdata_fra_conventions_notify_trigger_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_fra_conventions_notify_trigger_drop.sql
@@ -1,0 +1,22 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_refdata_fra_conventions_notify_trg on "ores_refdata_fra_conventions_tbl";
+drop function if exists ores_refdata_fra_conventions_notify_fn;

--- a/projects/ores.sql/drop/refdata/refdata_fx_conventions_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_fx_conventions_drop.sql
@@ -1,0 +1,24 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop rule if exists ores_refdata_fx_conventions_delete_rule on "ores_refdata_fx_conventions_tbl";
+drop trigger if exists ores_refdata_fx_conventions_insert_trg on "ores_refdata_fx_conventions_tbl";
+drop function if exists ores_refdata_fx_conventions_insert_fn;
+drop table if exists "ores_refdata_fx_conventions_tbl";

--- a/projects/ores.sql/drop/refdata/refdata_fx_conventions_notify_trigger_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_fx_conventions_notify_trigger_drop.sql
@@ -1,0 +1,22 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_refdata_fx_conventions_notify_trg on "ores_refdata_fx_conventions_tbl";
+drop function if exists ores_refdata_fx_conventions_notify_fn;

--- a/projects/ores.sql/drop/refdata/refdata_ibor_index_conventions_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_ibor_index_conventions_drop.sql
@@ -1,0 +1,24 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop rule if exists ores_refdata_ibor_index_conventions_delete_rule on "ores_refdata_ibor_index_conventions_tbl";
+drop trigger if exists ores_refdata_ibor_index_conventions_insert_trg on "ores_refdata_ibor_index_conventions_tbl";
+drop function if exists ores_refdata_ibor_index_conventions_insert_fn;
+drop table if exists "ores_refdata_ibor_index_conventions_tbl";

--- a/projects/ores.sql/drop/refdata/refdata_ibor_index_conventions_notify_trigger_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_ibor_index_conventions_notify_trigger_drop.sql
@@ -1,0 +1,22 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_refdata_ibor_index_conventions_notify_trg on "ores_refdata_ibor_index_conventions_tbl";
+drop function if exists ores_refdata_ibor_index_conventions_notify_fn;

--- a/projects/ores.sql/drop/refdata/refdata_ois_conventions_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_ois_conventions_drop.sql
@@ -1,0 +1,24 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop rule if exists ores_refdata_ois_conventions_delete_rule on "ores_refdata_ois_conventions_tbl";
+drop trigger if exists ores_refdata_ois_conventions_insert_trg on "ores_refdata_ois_conventions_tbl";
+drop function if exists ores_refdata_ois_conventions_insert_fn;
+drop table if exists "ores_refdata_ois_conventions_tbl";

--- a/projects/ores.sql/drop/refdata/refdata_ois_conventions_notify_trigger_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_ois_conventions_notify_trigger_drop.sql
@@ -1,0 +1,22 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_refdata_ois_conventions_notify_trg on "ores_refdata_ois_conventions_tbl";
+drop function if exists ores_refdata_ois_conventions_notify_fn;

--- a/projects/ores.sql/drop/refdata/refdata_overnight_index_conventions_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_overnight_index_conventions_drop.sql
@@ -1,0 +1,24 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop rule if exists ores_refdata_overnight_index_conventions_delete_rule on "ores_refdata_overnight_index_conventions_tbl";
+drop trigger if exists ores_refdata_overnight_index_conventions_insert_trg on "ores_refdata_overnight_index_conventions_tbl";
+drop function if exists ores_refdata_overnight_index_conventions_insert_fn;
+drop table if exists "ores_refdata_overnight_index_conventions_tbl";

--- a/projects/ores.sql/drop/refdata/refdata_overnight_index_conventions_notify_trigger_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_overnight_index_conventions_notify_trigger_drop.sql
@@ -1,0 +1,22 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_refdata_overnight_index_conventions_notify_trg on "ores_refdata_overnight_index_conventions_tbl";
+drop function if exists ores_refdata_overnight_index_conventions_notify_fn;

--- a/projects/ores.sql/drop/refdata/refdata_rls_policies_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_rls_policies_drop.sql
@@ -108,6 +108,30 @@ drop policy if exists ores_refdata_currencies_tenant_isolation_policy on "ores_r
 -- Currency Market Tiers
 drop policy if exists ores_refdata_currency_market_tiers_tenant_isolation_policy on "ores_refdata_currency_market_tiers_tbl";
 
+-- CDS Conventions
+drop policy if exists ores_refdata_cds_conventions_tenant_isolation_policy on "ores_refdata_cds_conventions_tbl";
+
+-- FX Conventions
+drop policy if exists ores_refdata_fx_conventions_tenant_isolation_policy on "ores_refdata_fx_conventions_tbl";
+
+-- Overnight Index Conventions
+drop policy if exists ores_refdata_overnight_index_conventions_tenant_isolation_policy on "ores_refdata_overnight_index_conventions_tbl";
+
+-- IBOR Index Conventions
+drop policy if exists ores_refdata_ibor_index_conventions_tenant_isolation_policy on "ores_refdata_ibor_index_conventions_tbl";
+
+-- FRA Conventions
+drop policy if exists ores_refdata_fra_conventions_tenant_isolation_policy on "ores_refdata_fra_conventions_tbl";
+
+-- OIS Conventions
+drop policy if exists ores_refdata_ois_conventions_tenant_isolation_policy on "ores_refdata_ois_conventions_tbl";
+
+-- Swap Conventions
+drop policy if exists ores_refdata_swap_conventions_tenant_isolation_policy on "ores_refdata_swap_conventions_tbl";
+
+-- Deposit Conventions
+drop policy if exists ores_refdata_deposit_conventions_tenant_isolation_policy on "ores_refdata_deposit_conventions_tbl";
+
 -- Zero Conventions
 drop policy if exists ores_refdata_zero_conventions_tenant_isolation_policy on "ores_refdata_zero_conventions_tbl";
 

--- a/projects/ores.sql/drop/refdata/refdata_swap_conventions_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_swap_conventions_drop.sql
@@ -1,0 +1,24 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop rule if exists ores_refdata_swap_conventions_delete_rule on "ores_refdata_swap_conventions_tbl";
+drop trigger if exists ores_refdata_swap_conventions_insert_trg on "ores_refdata_swap_conventions_tbl";
+drop function if exists ores_refdata_swap_conventions_insert_fn;
+drop table if exists "ores_refdata_swap_conventions_tbl";

--- a/projects/ores.sql/drop/refdata/refdata_swap_conventions_notify_trigger_drop.sql
+++ b/projects/ores.sql/drop/refdata/refdata_swap_conventions_notify_trigger_drop.sql
@@ -1,0 +1,22 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop trigger if exists ores_refdata_swap_conventions_notify_trg on "ores_refdata_swap_conventions_tbl";
+drop function if exists ores_refdata_swap_conventions_notify_fn;


### PR DESCRIPTION
## Summary

- Expands ORE import convention coverage from 2 (zero, deposit) to all 9 types: swap, ois, fra, ibor_index, overnight_index, fx, and cds
- Seven new domain entity JSON models drive generation of the complete backend + Qt stack via `ores.codegen`
- Replaces bare domain headers with full codegen output: JSON I/O, table I/O, generator, protocol, entity, mapper, repository, service, and NATS message handler (22 backend files × 7 = 154 files)
- SQL create/drop scripts for all seven new tables with LISTEN/NOTIFY triggers (28 SQL files)
- NATS registrar wires list/save/remove/history handlers for each of the 7 new types
- Qt plugin adds controller, client model, MDI window, detail dialog, and history dialog for each type (12 Qt files × 7 = 84 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)