### PR TITLE
[iam][refdata] Phase 4.3: IAM party cache via NATS, remove cross-service DB reads

### DIFF
--- a/CTest.cmake
+++ b/CTest.cmake
@@ -342,14 +342,8 @@ endif()
 #
 # Step: code coverage
 #
-if(WITH_COVERAGE)
-    set(cov_result "")
-    set(cov_capture_result "")
-    ctest_coverage(RETURN_VALUE cov_result
-        CAPTURE_CMAKE_ERROR cov_capture_result
-        QUIET)
-    message(STATUS "Result: ${cov_result}")
-    message(STATUS "Cov capture result: ${cov_capture_result}")
+if(WITH_COVERAGE AND configure_result EQUAL 0 AND build_result EQUAL 0)
+    ctest_coverage(QUIET)
 endif()
 
 #

--- a/doc/agile/v0/sprint_backlog_17.org
+++ b/doc/agile/v0/sprint_backlog_17.org
@@ -179,6 +179,38 @@ print(p)
 [[file:sprint_backlog_17_tags.png]]
 
 
+*** BLOCKED IAM party cache via NATS (Phase 4.3 cross-service decoupling)  :code:
+CLOSED: [2026-05-15 Thu 00:00]
+:LOGBOOK:
+CLOCK: [2026-05-15 Thu 00:00]--[2026-05-15 Thu 00:00] =>  0:00
+:END:
+
+Implement Phase 4.3 of =doc/plans/2026-05-13-cross-service-write-decoupling.org=.
+
+Replace direct IAM→refdata DB reads with an in-process party_cache backed by
+NATS so the IAM service no longer requires cross-service DB grants on refdata
+party tables.
+
+***** Tasks
+
+- [X] Add =read_parties_for_cache_request/response= to =party_protocol.hpp=
+- [X] Add =read_for_cache= handler to =party_handler.hpp=; register subject in refdata registrar
+- [X] Wire =party_changed_event= publish to =refdata.v1.parties.changed= in refdata service
+- [X] Create =ores.iam.core/service/party_cache.hpp= with NATS-backed per-tenant cache
+- [X] Update =auth_handler.hpp=: replace party_repository with party_cache
+- [X] Update =account_handler.hpp=: replace party_repository with party_cache
+- [X] Update IAM registrar: create party_cache, subscribe to changes, pass to handlers
+- [X] Remove =ores_refdata_parties= from IAM dml_prefixes in service registry
+
+***** Notes
+
+Story is BLOCKED pending:
+- User build verification (=make -C build/output/linux-clang-debug-make -j$(nproc)=)
+- Runtime testing (login + select_party flows)
+- Pull request review
+
+All implementation is complete and committed to =feature/cross-service-write-decoupling=.
+
 *** Footer
 
 | Previous: [[id:154212FF-BB02-8D84-1E33-9338B458380A][Version Zero]] |

--- a/doc/plans/2026-05-13-cross-service-write-decoupling.org
+++ b/doc/plans/2026-05-13-cross-service-write-decoupling.org
@@ -2,7 +2,7 @@
 #+SUBTITLE: IAM party cache + NATS write APIs for workflow/ORE
 #+DATE: 2026-05-13
 #+AUTHOR: ORE Studio Team
-#+STATUS: PLANNING
+#+STATUS: IN PROGRESS
 #+OPTIONS: toc:t num:nil
 
 * Context

--- a/doc/plans/2026-05-13-identifier-length-cleanup.org
+++ b/doc/plans/2026-05-13-identifier-length-cleanup.org
@@ -2,7 +2,7 @@
 #+SUBTITLE: Eliminate NAMEDATALEN truncation warnings for RLS policies and indexes
 #+DATE: 2026-05-13
 #+AUTHOR: ORE Studio Team
-#+STATUS: PLANNED
+#+STATUS: COMPLETE
 #+OPTIONS: toc:t num:nil
 
 * Problem

--- a/doc/plans/2026-05-13-symbol-visibility-migration.org
+++ b/doc/plans/2026-05-13-symbol-visibility-migration.org
@@ -2,6 +2,7 @@
 :ID: F2A4C6E8-B1D3-4E5F-A7B9-2C4D6E8F0A1B
 :END:
 #+title: Symbol Visibility Migration
+#+STATUS: COMPLETE
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/projects/ores.codegen/models/services/ores_services_service_registry.json
+++ b/projects/ores.codegen/models/services/ores_services_service_registry.json
@@ -9,8 +9,7 @@
         "description": "IAM",
         "email": "iam_service@system.ores",
         "dml_prefixes": [
-          {"prefix": "ores_iam_"},
-          {"prefix": "ores_refdata_parties"}
+          {"prefix": "ores_iam_"}
         ],
         "select_tables": [],
         "select_prefixes": []

--- a/projects/ores.iam.core/include/ores.iam.core/messaging/account_handler.hpp
+++ b/projects/ores.iam.core/include/ores.iam.core/messaging/account_handler.hpp
@@ -21,6 +21,7 @@
 #define ORES_IAM_MESSAGING_ACCOUNT_HANDLER_HPP
 
 #include <chrono>
+#include <memory>
 #include <stdexcept>
 #include <boost/uuid/string_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -39,7 +40,7 @@
 #include "ores.iam.api/domain/session.hpp"
 #include "ores.iam.core/repository/account_party_repository.hpp"
 #include "ores.iam.core/repository/tenant_repository.hpp"
-#include "ores.refdata.core/repository/party_repository.hpp"
+#include "ores.iam.core/service/party_cache.hpp"
 #include "ores.database/service/tenant_context.hpp"
 #include "ores.iam.core/service/account_service.hpp"
 #include "ores.iam.core/service/authorization_service.hpp"
@@ -70,36 +71,17 @@ inline std::string acct_extract_bearer_token(const ores::nats::message& msg) {
 }
 
 inline std::vector<boost::uuids::uuid> acct_compute_visible_party_ids(
-    const ores::database::context& ctx,
+    const service::party_cache& cache,
+    const std::string& tenant_id,
     const boost::uuids::uuid& party_id) {
-    try {
-        refdata::repository::party_repository repo(ctx);
-        auto ids = repo.read_descendants(party_id);
-        if (ids.empty())
-            return {party_id};
-        return ids;
-    } catch (const std::exception& e) {
-        using namespace ores::logging;
-        BOOST_LOG_SEV(account_handler_lg(), warn)
-            << "Failed to compute visible party IDs: " << e.what();
-        return {party_id};
-    }
+    return cache.compute_visible_party_ids(tenant_id, party_id);
 }
 
 inline std::optional<refdata::domain::party> acct_lookup_party(
-    const ores::database::context& ctx,
+    const service::party_cache& cache,
+    const std::string& tenant_id,
     const boost::uuids::uuid& party_id) {
-    try {
-        refdata::repository::party_repository repo(ctx);
-        auto parties = repo.read_latest(party_id);
-        if (!parties.empty())
-            return parties.front();
-    } catch (const std::exception& e) {
-        using namespace ores::logging;
-        BOOST_LOG_SEV(account_handler_lg(), warn)
-            << "Failed to look up party: " << e.what();
-    }
-    return std::nullopt;
+    return cache.lookup_party(tenant_id, party_id);
 }
 
 inline std::string acct_lookup_tenant_name(
@@ -131,8 +113,10 @@ class account_handler {
 public:
     account_handler(ores::nats::service::client& nats,
         ores::database::context ctx,
-        ores::security::jwt::jwt_authenticator signer)
-        : nats_(nats), ctx_(std::move(ctx)), signer_(std::move(signer)) {
+        ores::security::jwt::jwt_authenticator signer,
+        std::shared_ptr<service::party_cache> party_cache)
+        : nats_(nats), ctx_(std::move(ctx)), signer_(std::move(signer)),
+          party_cache_(std::move(party_cache)) {
         reload_token_settings();
     }
 
@@ -737,7 +721,7 @@ public:
             }
 
             auto visible = acct_compute_visible_party_ids(
-                ctx, requested_party_id);
+                *party_cache_, tenant_id_str, requested_party_id);
 
             security::jwt::jwt_claims new_claims;
             new_claims.subject = claims_result->subject;
@@ -772,7 +756,7 @@ public:
                        "party selection: " << e.what();
             }
             bool party_setup_required = false;
-            if (const auto p = acct_lookup_party(ctx, requested_party_id)) {
+            if (const auto p = acct_lookup_party(*party_cache_, tenant_id_str, requested_party_id)) {
                 p_name = p->full_name;
                 party_setup_required = p->status == "Inactive";
             }
@@ -842,6 +826,7 @@ private:
     ores::nats::service::client& nats_;
     ores::database::context ctx_;
     ores::security::jwt::jwt_authenticator signer_;
+    std::shared_ptr<service::party_cache> party_cache_;
     domain::token_settings token_settings_;
 };
 

--- a/projects/ores.iam.core/include/ores.iam.core/messaging/auth_handler.hpp
+++ b/projects/ores.iam.core/include/ores.iam.core/messaging/auth_handler.hpp
@@ -21,6 +21,7 @@
 #define ORES_IAM_MESSAGING_AUTH_HANDLER_HPP
 
 #include <chrono>
+#include <memory>
 #include <stdexcept>
 #include <boost/asio/ip/address.hpp>
 #include <boost/uuid/random_generator.hpp>
@@ -42,7 +43,7 @@
 #include "ores.iam.core/repository/account_repository.hpp"
 #include "ores.iam.core/repository/session_repository.hpp"
 #include "ores.iam.core/repository/tenant_repository.hpp"
-#include "ores.refdata.core/repository/party_repository.hpp"
+#include "ores.iam.core/service/party_cache.hpp"
 #include "ores.iam.core/service/account_service.hpp"
 #include "ores.iam.core/service/authorization_service.hpp"
 #include "ores.iam.core/service/account_setup_service.hpp"
@@ -74,36 +75,17 @@ inline std::string auth_extract_bearer_token(const ores::nats::message& msg) {
 }
 
 inline std::vector<boost::uuids::uuid> auth_compute_visible_party_ids(
-    const ores::database::context& ctx,
+    const service::party_cache& cache,
+    const std::string& tenant_id,
     const boost::uuids::uuid& party_id) {
-    try {
-        refdata::repository::party_repository repo(ctx);
-        auto ids = repo.read_descendants(party_id);
-        if (ids.empty())
-            return {party_id};
-        return ids;
-    } catch (const std::exception& e) {
-        using namespace ores::logging;
-        BOOST_LOG_SEV(auth_handler_lg(), warn)
-            << "Failed to compute visible party IDs: " << e.what();
-        return {party_id};
-    }
+    return cache.compute_visible_party_ids(tenant_id, party_id);
 }
 
 inline std::optional<refdata::domain::party> auth_lookup_party(
-    const ores::database::context& ctx,
+    const service::party_cache& cache,
+    const std::string& tenant_id,
     const boost::uuids::uuid& party_id) {
-    try {
-        refdata::repository::party_repository repo(ctx);
-        auto parties = repo.read_latest(party_id);
-        if (!parties.empty())
-            return parties.front();
-    } catch (const std::exception& e) {
-        using namespace ores::logging;
-        BOOST_LOG_SEV(auth_handler_lg(), warn)
-            << "Failed to look up party: " << e.what();
-    }
-    return std::nullopt;
+    return cache.lookup_party(tenant_id, party_id);
 }
 
 inline std::string auth_lookup_tenant_name(
@@ -166,8 +148,10 @@ class auth_handler {
 public:
     auth_handler(ores::nats::service::client& nats,
         ores::database::context ctx,
-        ores::security::jwt::jwt_authenticator signer)
-        : nats_(nats), ctx_(std::move(ctx)), signer_(std::move(signer)) {
+        ores::security::jwt::jwt_authenticator signer,
+        std::shared_ptr<service::party_cache> party_cache)
+        : nats_(nats), ctx_(std::move(ctx)), signer_(std::move(signer)),
+          party_cache_(std::move(party_cache)) {
         reload_token_settings();
     }
 
@@ -299,7 +283,7 @@ public:
                 const auto& party_id =
                     account_parties.front().party_id;
                 auto visible = auth_compute_visible_party_ids(
-                    login_ctx, party_id);
+                    *party_cache_, acct.tenant_id.to_string(), party_id);
 
                 security::jwt::jwt_claims claims;
                 claims.subject = boost::uuids::to_string(acct.id);
@@ -329,7 +313,8 @@ public:
                 resp.access_lifetime_s = token_settings_.access_lifetime_s;
                 resp.session_id = session_id_str;
                 for (const auto& ap : account_parties) {
-                    auto p = auth_lookup_party(login_ctx, ap.party_id);
+                    auto p = auth_lookup_party(
+                        *party_cache_, acct.tenant_id.to_string(), ap.party_id);
                     if (ap.party_id == party_id)
                         resp.party_setup_required =
                             p && p->status == "Inactive";
@@ -380,7 +365,8 @@ public:
                 resp.access_lifetime_s = token_settings_.party_selection_lifetime_s;
                 resp.session_id = session_id_str;
                 for (const auto& ap : account_parties) {
-                    auto p = auth_lookup_party(login_ctx, ap.party_id);
+                    auto p = auth_lookup_party(
+                        *party_cache_, acct.tenant_id.to_string(), ap.party_id);
                     resp.available_parties.push_back(party_summary{
                         .id = boost::uuids::to_string(ap.party_id),
                         .name = p ? p->full_name : std::string{},
@@ -689,6 +675,7 @@ private:
     ores::nats::service::client& nats_;
     ores::database::context ctx_;
     ores::security::jwt::jwt_authenticator signer_;
+    std::shared_ptr<service::party_cache> party_cache_;
     domain::token_settings token_settings_;
 };
 

--- a/projects/ores.iam.core/include/ores.iam.core/service/party_cache.hpp
+++ b/projects/ores.iam.core/include/ores.iam.core/service/party_cache.hpp
@@ -1,0 +1,143 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_IAM_SERVICE_PARTY_CACHE_HPP
+#define ORES_IAM_SERVICE_PARTY_CACHE_HPP
+
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <rfl/json.hpp>
+#include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
+#include "ores.nats/service/client.hpp"
+#include "ores.refdata.api/domain/party.hpp"
+#include "ores.refdata.api/messaging/party_protocol.hpp"
+
+namespace ores::iam::service {
+
+namespace {
+inline auto& party_cache_lg() {
+    static auto instance = ores::logging::make_logger(
+        "ores.iam.service.party_cache");
+    return instance;
+}
+} // namespace
+
+/**
+ * @brief In-process per-tenant cache of refdata party data.
+ *
+ * Populated via NATS request to refdata.v1.parties.read at startup and
+ * reloaded on receipt of refdata.v1.parties.changed notifications.
+ * Eliminates direct cross-service DB reads from IAM to refdata party tables.
+ */
+class party_cache {
+public:
+    explicit party_cache(ores::nats::service::client& nats)
+        : nats_(nats) {}
+
+    void load(const std::string& tenant_id) {
+        using namespace ores::logging;
+        try {
+            const auto req_json = rfl::json::write(
+                ores::refdata::messaging::read_parties_for_cache_request{
+                    .tenant_id = tenant_id});
+            const auto reply = nats_.request_sync(
+                ores::refdata::messaging::read_parties_for_cache_request::nats_subject,
+                ores::nats::as_bytes(req_json));
+            auto resp = rfl::json::read<
+                ores::refdata::messaging::read_parties_for_cache_response>(
+                    ores::nats::as_string_view(reply.data));
+            if (!resp || !resp->success) {
+                const auto msg = resp ? resp->message : "parse error";
+                BOOST_LOG_SEV(party_cache_lg(), warn)
+                    << "Party cache load failed for tenant " << tenant_id
+                    << ": " << msg;
+                return;
+            }
+            std::unordered_map<std::string, ores::refdata::domain::party> partition;
+            partition.reserve(resp->parties.size());
+            for (auto& p : resp->parties)
+                partition.emplace(boost::uuids::to_string(p.id), std::move(p));
+            {
+                std::unique_lock lock(mutex_);
+                cache_[tenant_id] = std::move(partition);
+            }
+            BOOST_LOG_SEV(party_cache_lg(), debug)
+                << "Loaded " << resp->parties.size()
+                << " parties for tenant " << tenant_id;
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(party_cache_lg(), warn)
+                << "Party cache load exception for tenant " << tenant_id
+                << ": " << e.what();
+        }
+    }
+
+    std::optional<ores::refdata::domain::party> lookup_party(
+        const std::string& tenant_id,
+        const boost::uuids::uuid& party_id) const {
+        std::shared_lock lock(mutex_);
+        const auto t_it = cache_.find(tenant_id);
+        if (t_it == cache_.end())
+            return std::nullopt;
+        const auto p_it = t_it->second.find(boost::uuids::to_string(party_id));
+        if (p_it == t_it->second.end())
+            return std::nullopt;
+        return p_it->second;
+    }
+
+    std::vector<boost::uuids::uuid> compute_visible_party_ids(
+        const std::string& tenant_id,
+        const boost::uuids::uuid& root_id) const {
+        std::shared_lock lock(mutex_);
+        const auto t_it = cache_.find(tenant_id);
+        if (t_it == cache_.end())
+            return {root_id};
+        const auto& partition = t_it->second;
+        std::vector<boost::uuids::uuid> result;
+        collect_subtree(partition, root_id, result);
+        if (result.empty())
+            return {root_id};
+        return result;
+    }
+
+private:
+    void collect_subtree(
+        const std::unordered_map<std::string, ores::refdata::domain::party>& partition,
+        const boost::uuids::uuid& node_id,
+        std::vector<boost::uuids::uuid>& out) const {
+        out.push_back(node_id);
+        for (const auto& [id_str, p] : partition) {
+            if (p.parent_party_id && *p.parent_party_id == node_id)
+                collect_subtree(partition, p.id, out);
+        }
+    }
+
+    ores::nats::service::client& nats_;
+    mutable std::shared_mutex mutex_;
+    std::unordered_map<std::string,
+        std::unordered_map<std::string, ores::refdata::domain::party>> cache_;
+};
+
+} // namespace ores::iam::service
+#endif

--- a/projects/ores.iam.core/include/ores.iam.core/service/party_cache.hpp
+++ b/projects/ores.iam.core/include/ores.iam.core/service/party_cache.hpp
@@ -25,8 +25,8 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <boost/container_hash/hash.hpp>
 #include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_io.hpp>
 #include <rfl/json.hpp>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
@@ -36,13 +36,11 @@
 
 namespace ores::iam::service {
 
-namespace {
 inline auto& party_cache_lg() {
     static auto instance = ores::logging::make_logger(
         "ores.iam.service.party_cache");
     return instance;
 }
-} // namespace
 
 /**
  * @brief In-process per-tenant cache of refdata party data.
@@ -52,6 +50,21 @@ inline auto& party_cache_lg() {
  * Eliminates direct cross-service DB reads from IAM to refdata party tables.
  */
 class party_cache {
+    using uuid_hash = boost::hash<boost::uuids::uuid>;
+    using party_map = std::unordered_map<
+        boost::uuids::uuid,
+        ores::refdata::domain::party,
+        uuid_hash>;
+    using children_map = std::unordered_map<
+        boost::uuids::uuid,
+        std::vector<boost::uuids::uuid>,
+        uuid_hash>;
+
+    struct partition_t {
+        party_map   parties;
+        children_map children;  // parent_id → [child_id, ...]
+    };
+
 public:
     explicit party_cache(ores::nats::service::client& nats)
         : nats_(nats) {}
@@ -75,13 +88,16 @@ public:
                     << ": " << msg;
                 return;
             }
-            std::unordered_map<std::string, ores::refdata::domain::party> partition;
-            partition.reserve(resp->parties.size());
-            for (auto& p : resp->parties)
-                partition.emplace(boost::uuids::to_string(p.id), std::move(p));
+            partition_t data;
+            data.parties.reserve(resp->parties.size());
+            for (auto& p : resp->parties) {
+                if (p.parent_party_id)
+                    data.children[*p.parent_party_id].push_back(p.id);
+                data.parties.emplace(p.id, std::move(p));
+            }
             {
                 std::unique_lock lock(mutex_);
-                cache_[tenant_id] = std::move(partition);
+                cache_[tenant_id] = std::move(data);
             }
             BOOST_LOG_SEV(party_cache_lg(), debug)
                 << "Loaded " << resp->parties.size()
@@ -100,8 +116,8 @@ public:
         const auto t_it = cache_.find(tenant_id);
         if (t_it == cache_.end())
             return std::nullopt;
-        const auto p_it = t_it->second.find(boost::uuids::to_string(party_id));
-        if (p_it == t_it->second.end())
+        const auto p_it = t_it->second.parties.find(party_id);
+        if (p_it == t_it->second.parties.end())
             return std::nullopt;
         return p_it->second;
     }
@@ -113,30 +129,27 @@ public:
         const auto t_it = cache_.find(tenant_id);
         if (t_it == cache_.end())
             return {root_id};
-        const auto& partition = t_it->second;
         std::vector<boost::uuids::uuid> result;
-        collect_subtree(partition, root_id, result);
+        collect_subtree(t_it->second.children, root_id, result);
         if (result.empty())
             return {root_id};
         return result;
     }
 
 private:
-    void collect_subtree(
-        const std::unordered_map<std::string, ores::refdata::domain::party>& partition,
-        const boost::uuids::uuid& node_id,
-        std::vector<boost::uuids::uuid>& out) const {
-        out.push_back(node_id);
-        for (const auto& [id_str, p] : partition) {
-            if (p.parent_party_id && *p.parent_party_id == node_id)
-                collect_subtree(partition, p.id, out);
-        }
+    void collect_subtree(const children_map& children,
+                         const boost::uuids::uuid& node,
+                         std::vector<boost::uuids::uuid>& out) const {
+        out.push_back(node);
+        const auto it = children.find(node);
+        if (it != children.end())
+            for (const auto& child : it->second)
+                collect_subtree(children, child, out);
     }
 
     ores::nats::service::client& nats_;
     mutable std::shared_mutex mutex_;
-    std::unordered_map<std::string,
-        std::unordered_map<std::string, ores::refdata::domain::party>> cache_;
+    std::unordered_map<std::string, partition_t> cache_;
 };
 
 } // namespace ores::iam::service

--- a/projects/ores.iam.core/include/ores.iam.core/service/party_cache.hpp
+++ b/projects/ores.iam.core/include/ores.iam.core/service/party_cache.hpp
@@ -36,11 +36,13 @@
 
 namespace ores::iam::service {
 
+namespace {
 inline auto& party_cache_lg() {
     static auto instance = ores::logging::make_logger(
         "ores.iam.service.party_cache");
     return instance;
 }
+} // namespace
 
 /**
  * @brief In-process per-tenant cache of refdata party data.

--- a/projects/ores.iam.core/src/CMakeLists.txt
+++ b/projects/ores.iam.core/src/CMakeLists.txt
@@ -51,7 +51,7 @@ target_link_libraries(${lib_target_name}
     PRIVATE
         ores.service.lib
         ores.utility.lib
-        ores.refdata.core.lib
+        ores.refdata.api.lib
         faker-cxx::faker-cxx
         libfort::fort)
 

--- a/projects/ores.iam.core/src/messaging/registrar.cpp
+++ b/projects/ores.iam.core/src/messaging/registrar.cpp
@@ -21,12 +21,14 @@
 
 #include <memory>
 #include <rfl/json.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
 #include "ores.eventing/domain/entity_change_event.hpp"
 #include "ores.iam.core/service/party_cache.hpp"
+#include "ores.iam.core/repository/tenant_repository.hpp"
 #include "ores.iam.core/messaging/auth_handler.hpp"
 #include "ores.iam.core/messaging/bootstrap_handler.hpp"
 #include "ores.iam.core/messaging/account_handler.hpp"
@@ -71,8 +73,20 @@ registrar::register_handlers(ores::nats::service::client& nats,
     constexpr auto qg = "ores.iam.service";
 
     // --- Party cache ---
-    // Populated from refdata service via NATS; invalidated on change events.
+    // Warm the cache at startup for all known active tenants, then subscribe
+    // to change events so each affected tenant is reloaded on any mutation.
     auto pc = std::make_shared<service::party_cache>(nats);
+    try {
+        repository::tenant_repository tenant_repo(ctx);
+        const auto tenants = tenant_repo.read_latest();
+        BOOST_LOG_SEV(lg(), debug)
+            << "Warming party cache for " << tenants.size() << " tenant(s)";
+        for (const auto& t : tenants)
+            pc->load(boost::uuids::to_string(t.id));
+    } catch (const std::exception& e) {
+        BOOST_LOG_SEV(lg(), warn)
+            << "Party cache warm-up failed: " << e.what();
+    }
     subs.push_back(nats.subscribe(
         "refdata.v1.parties.changed",
         [pc](ores::nats::message msg) {

--- a/projects/ores.iam.core/src/messaging/registrar.cpp
+++ b/projects/ores.iam.core/src/messaging/registrar.cpp
@@ -20,6 +20,7 @@
 #include "ores.iam.core/messaging/registrar.hpp"
 
 #include <memory>
+#include <thread>
 #include <rfl/json.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include "ores.logging/make_logger.hpp"
@@ -93,8 +94,13 @@ registrar::register_handlers(ores::nats::service::client& nats,
             using ores::eventing::domain::entity_change_event;
             auto evt = rfl::json::read<entity_change_event>(
                 ores::nats::as_string_view(msg.data));
-            if (evt && !evt->tenant_id.empty())
-                pc->load(evt->tenant_id);
+            if (evt && !evt->tenant_id.empty()) {
+                // Offload to a detached thread: load() calls request_sync,
+                // which would block the NATS callback thread if called inline.
+                std::thread([pc, tid = evt->tenant_id]() {
+                    pc->load(tid);
+                }).detach();
+            }
         }));
 
     // --- Auth ---

--- a/projects/ores.iam.core/src/messaging/registrar.cpp
+++ b/projects/ores.iam.core/src/messaging/registrar.cpp
@@ -20,9 +20,13 @@
 #include "ores.iam.core/messaging/registrar.hpp"
 
 #include <memory>
+#include <rfl/json.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.nats/domain/message.hpp"
 #include "ores.nats/service/client.hpp"
 #include "ores.security/jwt/jwt_authenticator.hpp"
+#include "ores.eventing/domain/entity_change_event.hpp"
+#include "ores.iam.core/service/party_cache.hpp"
 #include "ores.iam.core/messaging/auth_handler.hpp"
 #include "ores.iam.core/messaging/bootstrap_handler.hpp"
 #include "ores.iam.core/messaging/account_handler.hpp"
@@ -66,8 +70,21 @@ registrar::register_handlers(ores::nats::service::client& nats,
     std::vector<ores::nats::service::subscription> subs;
     constexpr auto qg = "ores.iam.service";
 
+    // --- Party cache ---
+    // Populated from refdata service via NATS; invalidated on change events.
+    auto pc = std::make_shared<service::party_cache>(nats);
+    subs.push_back(nats.subscribe(
+        "refdata.v1.parties.changed",
+        [pc](ores::nats::message msg) {
+            using ores::eventing::domain::entity_change_event;
+            auto evt = rfl::json::read<entity_change_event>(
+                ores::nats::as_string_view(msg.data));
+            if (evt && !evt->tenant_id.empty())
+                pc->load(evt->tenant_id);
+        }));
+
     // --- Auth ---
-    auto ah = std::make_shared<auth_handler>(nats, ctx, signer);
+    auto ah = std::make_shared<auth_handler>(nats, ctx, signer, pc);
     subs.push_back(nats.queue_subscribe(
         signup_request::nats_subject, qg,
         [ah](ores::nats::message msg) { ah->signup(std::move(msg)); }));
@@ -100,7 +117,7 @@ registrar::register_handlers(ores::nats::service::client& nats,
         [bh](ores::nats::message msg) { bh->provision_tenant(std::move(msg)); }));
 
     // --- Accounts ---
-    auto acth = std::make_shared<account_handler>(nats, ctx, signer);
+    auto acth = std::make_shared<account_handler>(nats, ctx, signer, pc);
     subs.push_back(nats.queue_subscribe(
         get_accounts_request_typed::nats_subject, qg,
         [acth](ores::nats::message msg) { acth->list(std::move(msg)); }));

--- a/projects/ores.refdata.api/include/ores.refdata.api/messaging/party_protocol.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/messaging/party_protocol.hpp
@@ -72,6 +72,24 @@ struct get_party_history_response {
     std::vector<ores::refdata::domain::party> history;
 };
 
+/**
+ * @brief Reads all active parties for a tenant — used by IAM party cache.
+ *
+ * Returns the full, unpaginated party set for the given tenant so that
+ * consumers can build an in-process cache without multiple round-trips.
+ */
+struct read_parties_for_cache_request {
+    using response_type = struct read_parties_for_cache_response;
+    static constexpr std::string_view nats_subject = "refdata.v1.parties.read";
+    std::string tenant_id;
+};
+
+struct read_parties_for_cache_response {
+    bool success = false;
+    std::string message;
+    std::vector<ores::refdata::domain::party> parties;
+};
+
 }
 
 #endif

--- a/projects/ores.refdata.core/include/ores.refdata.core/messaging/party_handler.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/messaging/party_handler.hpp
@@ -207,6 +207,37 @@ public:
         }
     }
 
+    void read_for_cache(ores::nats::message msg) {
+        [[maybe_unused]] const auto correlation_id =
+            log_handler_entry(party_handler_lg(), msg);
+        auto req = decode<read_parties_for_cache_request>(msg);
+        if (!req) {
+            BOOST_LOG_SEV(party_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            reply(nats_, msg, read_parties_for_cache_response{
+                .success = false, .message = "Failed to decode request"});
+            return;
+        }
+        try {
+            using ores::database::service::tenant_context;
+            auto tctx = tenant_context::with_tenant(ctx_, req->tenant_id);
+            service::party_service svc(tctx);
+            auto parties = svc.list_parties();
+            BOOST_LOG_SEV(party_handler_lg(), debug)
+                << "Completed " << msg.subject
+                << " (tenant=" << req->tenant_id
+                << ", count=" << parties.size() << ")";
+            reply(nats_, msg, read_parties_for_cache_response{
+                .success = true,
+                .parties = std::move(parties)});
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(party_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            reply(nats_, msg, read_parties_for_cache_response{
+                .success = false, .message = e.what()});
+        }
+    }
+
     void history(ores::nats::message msg) {
         [[maybe_unused]] const auto correlation_id =
             log_handler_entry(party_handler_lg(), msg);

--- a/projects/ores.refdata.core/src/messaging/registrar.cpp
+++ b/projects/ores.refdata.core/src/messaging/registrar.cpp
@@ -356,6 +356,9 @@ registrar::register_handlers(ores::nats::service::client& nats,
         subs.push_back(nats.queue_subscribe(
             get_party_history_request::nats_subject, queue_group,
             [h](ores::nats::message msg) { h->history(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            read_parties_for_cache_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->read_for_cache(std::move(msg)); }));
     }
 
     // ----------------------------------------------------------------

--- a/projects/ores.refdata.service/src/app/application.cpp
+++ b/projects/ores.refdata.service/src/app/application.cpp
@@ -31,6 +31,7 @@
 #include "ores.eventing/service/registrar.hpp"
 #include "ores.eventing/domain/entity_change_event.hpp"
 #include "ores.refdata.api/eventing/book_changed_event.hpp"
+#include "ores.refdata.api/eventing/party_changed_event.hpp"
 #include "ores.refdata.api/eventing/portfolio_changed_event.hpp"
 #include "ores.refdata.core/messaging/registrar.hpp"
 #include <boost/asio/co_spawn.hpp>
@@ -111,6 +112,8 @@ application::run(boost::asio::io_context& io_ctx,
 
     ev::service::registrar::register_mapping<rdev::book_changed_event>(
         event_source, "ores.refdata.book", "ores_books");
+    ev::service::registrar::register_mapping<rdev::party_changed_event>(
+        event_source, "ores.refdata.party_changed", "ores_parties");
     ev::service::registrar::register_mapping<rdev::portfolio_changed_event>(
         event_source, "ores.refdata.portfolio", "ores_portfolios");
 
@@ -119,6 +122,17 @@ application::run(boost::asio::io_context& io_ctx,
             publish_entity_event(nats, "ores.refdata.book_changed",
                 ev::domain::entity_change_event{
                     .entity     = "ores.refdata.book",
+                    .timestamp  = e.timestamp,
+                    .entity_ids = e.ids,
+                    .tenant_id  = e.tenant_id
+                });
+        });
+
+    auto party_sub = event_bus.subscribe<rdev::party_changed_event>(
+        [&nats](const rdev::party_changed_event& e) {
+            publish_entity_event(nats, "refdata.v1.parties.changed",
+                ev::domain::entity_change_event{
+                    .entity     = "ores.refdata.party_changed",
                     .timestamp  = e.timestamp,
                     .entity_ids = e.ids,
                     .tenant_id  = e.tenant_id

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_accumulator_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_accumulator_instrument_json_io.hpp
@@ -22,13 +22,14 @@
 
 #include <iosfwd>
 #include "ores.trading.api/domain/equity_accumulator_instrument.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Dumps the equity_accumulator_instrument to a stream in JSON format.
  */
-std::ostream& operator<<(std::ostream& s, const equity_accumulator_instrument& v);
+ORES_TRADING_API_EXPORT std::ostream& operator<<(std::ostream& s, const equity_accumulator_instrument& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_asian_option_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_asian_option_instrument_json_io.hpp
@@ -22,13 +22,14 @@
 
 #include <iosfwd>
 #include "ores.trading.api/domain/equity_asian_option_instrument.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Dumps the equity_asian_option_instrument to a stream in JSON format.
  */
-std::ostream& operator<<(std::ostream& s, const equity_asian_option_instrument& v);
+ORES_TRADING_API_EXPORT std::ostream& operator<<(std::ostream& s, const equity_asian_option_instrument& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_barrier_option_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_barrier_option_instrument_json_io.hpp
@@ -22,13 +22,14 @@
 
 #include <iosfwd>
 #include "ores.trading.api/domain/equity_barrier_option_instrument.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Dumps the equity_barrier_option_instrument to a stream in JSON format.
  */
-std::ostream& operator<<(std::ostream& s, const equity_barrier_option_instrument& v);
+ORES_TRADING_API_EXPORT std::ostream& operator<<(std::ostream& s, const equity_barrier_option_instrument& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_digital_option_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_digital_option_instrument_json_io.hpp
@@ -22,13 +22,14 @@
 
 #include <iosfwd>
 #include "ores.trading.api/domain/equity_digital_option_instrument.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Dumps the equity_digital_option_instrument to a stream in JSON format.
  */
-std::ostream& operator<<(std::ostream& s, const equity_digital_option_instrument& v);
+ORES_TRADING_API_EXPORT std::ostream& operator<<(std::ostream& s, const equity_digital_option_instrument& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_forward_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_forward_instrument_json_io.hpp
@@ -22,13 +22,14 @@
 
 #include <iosfwd>
 #include "ores.trading.api/domain/equity_forward_instrument.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Dumps the equity_forward_instrument to a stream in JSON format.
  */
-std::ostream& operator<<(std::ostream& s, const equity_forward_instrument& v);
+ORES_TRADING_API_EXPORT std::ostream& operator<<(std::ostream& s, const equity_forward_instrument& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_option_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_option_instrument_json_io.hpp
@@ -22,13 +22,14 @@
 
 #include <iosfwd>
 #include "ores.trading.api/domain/equity_option_instrument.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Dumps the equity_option_instrument to a stream in JSON format.
  */
-std::ostream& operator<<(std::ostream& s, const equity_option_instrument& v);
+ORES_TRADING_API_EXPORT std::ostream& operator<<(std::ostream& s, const equity_option_instrument& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_position_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_position_instrument_json_io.hpp
@@ -22,13 +22,14 @@
 
 #include <iosfwd>
 #include "ores.trading.api/domain/equity_position_instrument.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Dumps the equity_position_instrument to a stream in JSON format.
  */
-std::ostream& operator<<(std::ostream& s, const equity_position_instrument& v);
+ORES_TRADING_API_EXPORT std::ostream& operator<<(std::ostream& s, const equity_position_instrument& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_swap_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_swap_instrument_json_io.hpp
@@ -22,13 +22,14 @@
 
 #include <iosfwd>
 #include "ores.trading.api/domain/equity_swap_instrument.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Dumps the equity_swap_instrument to a stream in JSON format.
  */
-std::ostream& operator<<(std::ostream& s, const equity_swap_instrument& v);
+ORES_TRADING_API_EXPORT std::ostream& operator<<(std::ostream& s, const equity_swap_instrument& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/domain/equity_variance_swap_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/equity_variance_swap_instrument_json_io.hpp
@@ -22,13 +22,14 @@
 
 #include <iosfwd>
 #include "ores.trading.api/domain/equity_variance_swap_instrument.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Dumps the equity_variance_swap_instrument to a stream in JSON format.
  */
-std::ostream& operator<<(std::ostream& s, const equity_variance_swap_instrument& v);
+ORES_TRADING_API_EXPORT std::ostream& operator<<(std::ostream& s, const equity_variance_swap_instrument& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/domain/trade_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/trade_json_io.hpp
@@ -22,13 +22,14 @@
 
 #include <iosfwd>
 #include "ores.trading.api/domain/trade.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Dumps the trade to a stream in JSON format.
  */
-std::ostream& operator<<(std::ostream& s, const trade& v);
+ORES_TRADING_API_EXPORT std::ostream& operator<<(std::ostream& s, const trade& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/domain/trade_party_role_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/trade_party_role_json_io.hpp
@@ -22,13 +22,14 @@
 
 #include <iosfwd>
 #include "ores.trading.api/domain/trade_party_role.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Dumps the trade_party_role to a stream in JSON format.
  */
-std::ostream& operator<<(std::ostream& s, const trade_party_role& v);
+ORES_TRADING_API_EXPORT std::ostream& operator<<(std::ostream& s, const trade_party_role& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/domain/trade_party_role_table.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/trade_party_role_table.hpp
@@ -23,13 +23,14 @@
 #include <string>
 #include <vector>
 #include "ores.trading.api/domain/trade_party_role.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Converts trade_party_roles to the table format.
  */
-std::string convert_to_table(const std::vector<trade_party_role>& v);
+ORES_TRADING_API_EXPORT std::string convert_to_table(const std::vector<trade_party_role>& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/domain/trade_table.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/trade_table.hpp
@@ -23,13 +23,14 @@
 #include <string>
 #include <vector>
 #include "ores.trading.api/domain/trade.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Converts trades to the table format.
  */
-std::string convert_to_table(const std::vector<trade>& v);
+ORES_TRADING_API_EXPORT std::string convert_to_table(const std::vector<trade>& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/domain/trade_type_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/trade_type_json_io.hpp
@@ -22,13 +22,14 @@
 
 #include <iosfwd>
 #include "ores.trading.api/domain/trade_type.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Dumps the trade_type to a stream in JSON format.
  */
-std::ostream& operator<<(std::ostream& s, const trade_type& v);
+ORES_TRADING_API_EXPORT std::ostream& operator<<(std::ostream& s, const trade_type& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/domain/trade_type_table.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/trade_type_table.hpp
@@ -23,13 +23,14 @@
 #include <string>
 #include <vector>
 #include "ores.trading.api/domain/trade_type.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Converts trade_types to the table format.
  */
-std::string convert_to_table(const std::vector<trade_type>& v);
+ORES_TRADING_API_EXPORT std::string convert_to_table(const std::vector<trade_type>& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/domain/vanilla_swap_instrument_json_io.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/vanilla_swap_instrument_json_io.hpp
@@ -22,13 +22,14 @@
 
 #include <iosfwd>
 #include "ores.trading.api/domain/vanilla_swap_instrument.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Dumps the vanilla_swap_instrument to a stream in JSON format.
  */
-std::ostream& operator<<(std::ostream& s, const vanilla_swap_instrument& v);
+ORES_TRADING_API_EXPORT std::ostream& operator<<(std::ostream& s, const vanilla_swap_instrument& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/domain/vanilla_swap_instrument_table.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/domain/vanilla_swap_instrument_table.hpp
@@ -23,13 +23,14 @@
 #include <string>
 #include <vector>
 #include "ores.trading.api/domain/vanilla_swap_instrument.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::domain {
 
 /**
  * @brief Converts vanilla_swap_instruments to the table format.
  */
-std::string convert_to_table(const std::vector<vanilla_swap_instrument>& v);
+ORES_TRADING_API_EXPORT std::string convert_to_table(const std::vector<vanilla_swap_instrument>& v);
 
 }
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/activity_type_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/activity_type_generator.hpp
@@ -23,19 +23,20 @@
 #include <vector>
 #include "ores.trading.api/domain/activity_type.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic activity_type.
  */
-domain::activity_type generate_synthetic_activity_type(
+ORES_TRADING_API_EXPORT domain::activity_type generate_synthetic_activity_type(
     utility::generation::generation_context& ctx);
 
 /**
  * @brief Generates N synthetic activity_types.
  */
-std::vector<domain::activity_type>
+ORES_TRADING_API_EXPORT std::vector<domain::activity_type>
 generate_synthetic_activity_types(std::size_t n,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/business_day_convention_type_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/business_day_convention_type_generator.hpp
@@ -23,19 +23,20 @@
 #include <vector>
 #include "ores.trading.api/domain/business_day_convention_type.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic business_day_convention_type.
  */
-domain::business_day_convention_type generate_synthetic_business_day_convention_type(
+ORES_TRADING_API_EXPORT domain::business_day_convention_type generate_synthetic_business_day_convention_type(
     utility::generation::generation_context& ctx);
 
 /**
  * @brief Generates N synthetic business_day_convention_types.
  */
-std::vector<domain::business_day_convention_type>
+ORES_TRADING_API_EXPORT std::vector<domain::business_day_convention_type>
 generate_synthetic_business_day_convention_types(std::size_t n,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/composite_instrument_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/composite_instrument_generator.hpp
@@ -23,19 +23,20 @@
 #include <vector>
 #include "ores.trading.api/domain/composite_instrument.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic composite_instrument.
  */
-domain::composite_instrument generate_synthetic_composite_instrument(
+ORES_TRADING_API_EXPORT domain::composite_instrument generate_synthetic_composite_instrument(
     utility::generation::generation_context& ctx);
 
 /**
  * @brief Generates N synthetic composite_instruments.
  */
-std::vector<domain::composite_instrument>
+ORES_TRADING_API_EXPORT std::vector<domain::composite_instrument>
 generate_synthetic_composite_instruments(std::size_t n,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/composite_leg_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/composite_leg_generator.hpp
@@ -24,13 +24,14 @@
 #include <boost/uuid/uuid.hpp>
 #include "ores.trading.api/domain/composite_leg.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic composite_leg for the given instrument_id.
  */
-domain::composite_leg generate_synthetic_composite_leg(
+ORES_TRADING_API_EXPORT domain::composite_leg generate_synthetic_composite_leg(
     const boost::uuids::uuid& instrument_id,
     int leg_sequence,
     utility::generation::generation_context& ctx);
@@ -38,7 +39,7 @@ domain::composite_leg generate_synthetic_composite_leg(
 /**
  * @brief Generates a synthetic pair of composite legs for an instrument.
  */
-std::vector<domain::composite_leg>
+ORES_TRADING_API_EXPORT std::vector<domain::composite_leg>
 generate_synthetic_composite_legs(const boost::uuids::uuid& instrument_id,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/day_count_fraction_type_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/day_count_fraction_type_generator.hpp
@@ -23,19 +23,20 @@
 #include <vector>
 #include "ores.trading.api/domain/day_count_fraction_type.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic day_count_fraction_type.
  */
-domain::day_count_fraction_type generate_synthetic_day_count_fraction_type(
+ORES_TRADING_API_EXPORT domain::day_count_fraction_type generate_synthetic_day_count_fraction_type(
     utility::generation::generation_context& ctx);
 
 /**
  * @brief Generates N synthetic day_count_fraction_types.
  */
-std::vector<domain::day_count_fraction_type>
+ORES_TRADING_API_EXPORT std::vector<domain::day_count_fraction_type>
 generate_synthetic_day_count_fraction_types(std::size_t n,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/floating_index_type_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/floating_index_type_generator.hpp
@@ -23,19 +23,20 @@
 #include <vector>
 #include "ores.trading.api/domain/floating_index_type.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic floating_index_type.
  */
-domain::floating_index_type generate_synthetic_floating_index_type(
+ORES_TRADING_API_EXPORT domain::floating_index_type generate_synthetic_floating_index_type(
     utility::generation::generation_context& ctx);
 
 /**
  * @brief Generates N synthetic floating_index_types.
  */
-std::vector<domain::floating_index_type>
+ORES_TRADING_API_EXPORT std::vector<domain::floating_index_type>
 generate_synthetic_floating_index_types(std::size_t n,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/fpml_event_type_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/fpml_event_type_generator.hpp
@@ -23,19 +23,20 @@
 #include <vector>
 #include "ores.trading.api/domain/fpml_event_type.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic fpml_event_type.
  */
-domain::fpml_event_type generate_synthetic_fpml_event_type(
+ORES_TRADING_API_EXPORT domain::fpml_event_type generate_synthetic_fpml_event_type(
     utility::generation::generation_context& ctx);
 
 /**
  * @brief Generates N synthetic fpml_event_types.
  */
-std::vector<domain::fpml_event_type>
+ORES_TRADING_API_EXPORT std::vector<domain::fpml_event_type>
 generate_synthetic_fpml_event_types(std::size_t n,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/leg_type_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/leg_type_generator.hpp
@@ -23,19 +23,20 @@
 #include <vector>
 #include "ores.trading.api/domain/leg_type.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic leg_type.
  */
-domain::leg_type generate_synthetic_leg_type(
+ORES_TRADING_API_EXPORT domain::leg_type generate_synthetic_leg_type(
     utility::generation::generation_context& ctx);
 
 /**
  * @brief Generates N synthetic leg_types.
  */
-std::vector<domain::leg_type>
+ORES_TRADING_API_EXPORT std::vector<domain::leg_type>
 generate_synthetic_leg_types(std::size_t n,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/lifecycle_event_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/lifecycle_event_generator.hpp
@@ -23,19 +23,20 @@
 #include <vector>
 #include "ores.trading.api/domain/lifecycle_event.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic lifecycle_event.
  */
-domain::lifecycle_event generate_synthetic_lifecycle_event(
+ORES_TRADING_API_EXPORT domain::lifecycle_event generate_synthetic_lifecycle_event(
     utility::generation::generation_context& ctx);
 
 /**
  * @brief Generates N synthetic lifecycle_events.
  */
-std::vector<domain::lifecycle_event>
+ORES_TRADING_API_EXPORT std::vector<domain::lifecycle_event>
 generate_synthetic_lifecycle_events(std::size_t n,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/party_role_type_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/party_role_type_generator.hpp
@@ -23,19 +23,20 @@
 #include <vector>
 #include "ores.trading.api/domain/party_role_type.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic party_role_type.
  */
-domain::party_role_type generate_synthetic_party_role_type(
+ORES_TRADING_API_EXPORT domain::party_role_type generate_synthetic_party_role_type(
     utility::generation::generation_context& ctx);
 
 /**
  * @brief Generates N synthetic party_role_types.
  */
-std::vector<domain::party_role_type>
+ORES_TRADING_API_EXPORT std::vector<domain::party_role_type>
 generate_synthetic_party_role_types(std::size_t n,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/payment_frequency_type_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/payment_frequency_type_generator.hpp
@@ -23,19 +23,20 @@
 #include <vector>
 #include "ores.trading.api/domain/payment_frequency_type.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic payment_frequency_type.
  */
-domain::payment_frequency_type generate_synthetic_payment_frequency_type(
+ORES_TRADING_API_EXPORT domain::payment_frequency_type generate_synthetic_payment_frequency_type(
     utility::generation::generation_context& ctx);
 
 /**
  * @brief Generates N synthetic payment_frequency_types.
  */
-std::vector<domain::payment_frequency_type>
+ORES_TRADING_API_EXPORT std::vector<domain::payment_frequency_type>
 generate_synthetic_payment_frequency_types(std::size_t n,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/scripted_instrument_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/scripted_instrument_generator.hpp
@@ -23,19 +23,20 @@
 #include <vector>
 #include "ores.trading.api/domain/scripted_instrument.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic scripted_instrument.
  */
-domain::scripted_instrument generate_synthetic_scripted_instrument(
+ORES_TRADING_API_EXPORT domain::scripted_instrument generate_synthetic_scripted_instrument(
     utility::generation::generation_context& ctx);
 
 /**
  * @brief Generates N synthetic scripted_instruments.
  */
-std::vector<domain::scripted_instrument>
+ORES_TRADING_API_EXPORT std::vector<domain::scripted_instrument>
 generate_synthetic_scripted_instruments(std::size_t n,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/swap_leg_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/swap_leg_generator.hpp
@@ -24,13 +24,14 @@
 #include <boost/uuid/uuid.hpp>
 #include "ores.trading.api/domain/swap_leg.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic swap_leg for the given instrument_id.
  */
-domain::swap_leg generate_synthetic_swap_leg(
+ORES_TRADING_API_EXPORT domain::swap_leg generate_synthetic_swap_leg(
     const boost::uuids::uuid& instrument_id,
     int leg_number,
     utility::generation::generation_context& ctx);
@@ -38,7 +39,7 @@ domain::swap_leg generate_synthetic_swap_leg(
 /**
  * @brief Generates a synthetic fixed+floating leg pair for an instrument.
  */
-std::vector<domain::swap_leg>
+ORES_TRADING_API_EXPORT std::vector<domain::swap_leg>
 generate_synthetic_swap_legs(const boost::uuids::uuid& instrument_id,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/trade_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/trade_generator.hpp
@@ -23,19 +23,20 @@
 #include <vector>
 #include "ores.trading.api/domain/trade.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic trade.
  */
-domain::trade generate_synthetic_trade(
+ORES_TRADING_API_EXPORT domain::trade generate_synthetic_trade(
     utility::generation::generation_context& ctx);
 
 /**
  * @brief Generates N synthetic trades.
  */
-std::vector<domain::trade>
+ORES_TRADING_API_EXPORT std::vector<domain::trade>
 generate_synthetic_trades(std::size_t n,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/trade_id_type_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/trade_id_type_generator.hpp
@@ -23,19 +23,20 @@
 #include <vector>
 #include "ores.trading.api/domain/trade_id_type.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic trade_id_type.
  */
-domain::trade_id_type generate_synthetic_trade_id_type(
+ORES_TRADING_API_EXPORT domain::trade_id_type generate_synthetic_trade_id_type(
     utility::generation::generation_context& ctx);
 
 /**
  * @brief Generates N synthetic trade_id_types.
  */
-std::vector<domain::trade_id_type>
+ORES_TRADING_API_EXPORT std::vector<domain::trade_id_type>
 generate_synthetic_trade_id_types(std::size_t n,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/trade_identifier_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/trade_identifier_generator.hpp
@@ -23,19 +23,20 @@
 #include <vector>
 #include "ores.trading.api/domain/trade_identifier.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic trade_identifier.
  */
-domain::trade_identifier generate_synthetic_trade_identifier(
+ORES_TRADING_API_EXPORT domain::trade_identifier generate_synthetic_trade_identifier(
     utility::generation::generation_context& ctx);
 
 /**
  * @brief Generates N synthetic trade_identifiers.
  */
-std::vector<domain::trade_identifier>
+ORES_TRADING_API_EXPORT std::vector<domain::trade_identifier>
 generate_synthetic_trade_identifiers(std::size_t n,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/trade_party_role_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/trade_party_role_generator.hpp
@@ -23,19 +23,20 @@
 #include <vector>
 #include "ores.trading.api/domain/trade_party_role.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic trade_party_role.
  */
-domain::trade_party_role generate_synthetic_trade_party_role(
+ORES_TRADING_API_EXPORT domain::trade_party_role generate_synthetic_trade_party_role(
     utility::generation::generation_context& ctx);
 
 /**
  * @brief Generates N synthetic trade_party_roles.
  */
-std::vector<domain::trade_party_role>
+ORES_TRADING_API_EXPORT std::vector<domain::trade_party_role>
 generate_synthetic_trade_party_roles(std::size_t n,
     utility::generation::generation_context& ctx);
 

--- a/projects/ores.trading.api/include/ores.trading.api/generators/trade_type_generator.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/generators/trade_type_generator.hpp
@@ -23,19 +23,20 @@
 #include <vector>
 #include "ores.trading.api/domain/trade_type.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.trading.api/export.hpp"
 
 namespace ores::trading::generator {
 
 /**
  * @brief Generates a synthetic trade_type.
  */
-domain::trade_type generate_synthetic_trade_type(
+ORES_TRADING_API_EXPORT domain::trade_type generate_synthetic_trade_type(
     utility::generation::generation_context& ctx);
 
 /**
  * @brief Generates N synthetic trade_types.
  */
-std::vector<domain::trade_type>
+ORES_TRADING_API_EXPORT std::vector<domain::trade_type>
 generate_synthetic_trade_types(std::size_t n,
     utility::generation::generation_context& ctx);
 


### PR DESCRIPTION
## Summary

- Removes direct IAM→refdata DB reads by introducing an in-process party cache backed by NATS
- \`party_cache\` holds per-tenant flat maps of party records; warmed at startup for all active tenants and reloaded on \`refdata.v1.parties.changed\` events
- Eliminates the \`ores_refdata_parties\` cross-service DML grant from the IAM service registry
- Drops \`ores.refdata.core.lib\` link dependency from \`ores.iam.core\`

## Changes

**refdata (API/core/service)**
- \`party_protocol.hpp\`: add \`read_parties_for_cache_request/response\` with subject \`refdata.v1.parties.read\`
- \`party_handler.hpp\`: add \`read_for_cache\` method that scopes to tenant and returns all active parties
- \`registrar.cpp\`: register the new \`refdata.v1.parties.read\` NATS subject
- \`application.cpp\`: wire \`party_changed_event\` → \`refdata.v1.parties.changed\` publish via existing PostgreSQL LISTEN/NOTIFY pipeline

**iam (core)**
- \`service/party_cache.hpp\`: new in-process cache; \`load()\` calls \`refdata.v1.parties.read\`; \`compute_visible_party_ids()\` walks \`parent_party_id\` tree in-process; \`lookup_party()\` does O(1) UUID lookup
- \`auth_handler.hpp\`: remove \`party_repository\` include; accept \`shared_ptr<party_cache>\`; use cache for visible-party computation and party lookup
- \`account_handler.hpp\`: same — replace \`party_repository\` with cache
- \`registrar.cpp\`: query \`tenant_repository::read_latest()\` at startup and call \`party_cache::load()\` for each active tenant; subscribe to \`refdata.v1.parties.changed\` to reload per-tenant on mutations; pass cache to handlers

**service registry**
- Remove \`ores_refdata_parties\` from IAM \`dml_prefixes\` (cross-service grant no longer needed)

**doc**
- Mark identifier-length-cleanup and symbol-visibility-migration plans as COMPLETE
- Update cross-service-write-decoupling plan STATUS to IN PROGRESS
- Sprint 17: add BLOCKED story for Phase 4.3

## Notes

- Cache warm-up failures (e.g. refdata service not yet up) are caught and logged; IAM continues to start and the \`{party_id}\` fallback in \`compute_visible_party_ids\` keeps login functional
- Bootstrap flow (\`bootstrap_handler\`) does not use the party cache; provisioning works before the cache is warm
- Phases 5.2 and 5.3 (workflow→IAM/refdata NATS write APIs) remain to be implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)