### PR TITLE
[sql] Phase 5.2: remove dead workflow DML grants on IAM and refdata tables

### DIFF
--- a/doc/agile/v0/sprint_backlog_17.org
+++ b/doc/agile/v0/sprint_backlog_17.org
@@ -211,9 +211,10 @@ Story is BLOCKED pending:
 
 All implementation is complete and committed to =feature/cross-service-write-decoupling=.
 
-*** STARTED Workflow write decoupling (Phase 5.2 cross-service decoupling)  :code:
+*** BLOCKED Workflow write decoupling (Phase 5.2 cross-service decoupling)  :code:
+CLOSED: [2026-05-15 Thu 00:00]
 :LOGBOOK:
-CLOCK: [2026-05-15 Thu 00:00]
+CLOCK: [2026-05-15 Thu 00:00]--[2026-05-15 Thu 00:00] =>  0:00
 :END:
 
 Implement Phase 5.2 of =doc/plans/2026-05-13-cross-service-write-decoupling.org=.
@@ -228,15 +229,21 @@ grants in the workflow service registry are leftovers.
 - [X] Remove =ores_iam_= and =ores_refdata_parties= from workflow =dml_prefixes= in service registry
 - [X] Regenerate SQL grants and populate files via codegen
 - [X] Run validate_schemas.sh — passes clean
-- [ ] Update plan document with implementation note
-- [ ] Commit and push; create PR
+- [X] Update plan document with implementation note
+- [X] Commit and push; create PR
 
 ***** Notes
+
+Story is BLOCKED pending:
+- User build verification (=make -C build/output/linux-clang-debug-make -j$(nproc)=)
+- Runtime testing (tenant onboarding flow)
+- Pull request review
 
 Steps 1–3 of the plan (expose NATS APIs, replace direct writes) were already
 complete. Only step 4 (removing the grants) was needed.
 
 Branch: =feature/workflow-iam-refdata-write-apis=
+Pull Request: [[https://github.com/OreStudio/OreStudio/pull/745][#745]]
 
 *** Footer
 

--- a/doc/agile/v0/sprint_backlog_17.org
+++ b/doc/agile/v0/sprint_backlog_17.org
@@ -211,6 +211,33 @@ Story is BLOCKED pending:
 
 All implementation is complete and committed to =feature/cross-service-write-decoupling=.
 
+*** STARTED Workflow write decoupling (Phase 5.2 cross-service decoupling)  :code:
+:LOGBOOK:
+CLOCK: [2026-05-15 Thu 00:00]
+:END:
+
+Implement Phase 5.2 of =doc/plans/2026-05-13-cross-service-write-decoupling.org=.
+
+Remove dead DML grants from the workflow service: the =provision_parties= workflow
+already routes all writes through NATS, so =ores_iam_*= and =ores_refdata_parties=
+grants in the workflow service registry are leftovers.
+
+***** Tasks
+
+- [X] Verify workflow core makes no direct IAM/refdata DB writes
+- [X] Remove =ores_iam_= and =ores_refdata_parties= from workflow =dml_prefixes= in service registry
+- [X] Regenerate SQL grants and populate files via codegen
+- [X] Run validate_schemas.sh — passes clean
+- [ ] Update plan document with implementation note
+- [ ] Commit and push; create PR
+
+***** Notes
+
+Steps 1–3 of the plan (expose NATS APIs, replace direct writes) were already
+complete. Only step 4 (removing the grants) was needed.
+
+Branch: =feature/workflow-iam-refdata-write-apis=
+
 *** Footer
 
 | Previous: [[id:154212FF-BB02-8D84-1E33-9338B458380A][Version Zero]] |

--- a/doc/plans/2026-05-13-cross-service-write-decoupling.org
+++ b/doc/plans/2026-05-13-cross-service-write-decoupling.org
@@ -119,6 +119,18 @@ Phase 4.3 must be fully landed before 5.2 ships, because the refdata parties
 NATS write API (step 2) is the same surface that Phase 4.3's party cache reads
 will rely on for change notifications.
 
+** Implementation note
+
+When Phase 5.2 was implemented it turned out that steps 1–3 were already
+complete: the ~provision_parties~ workflow was already routing all writes
+through NATS (~refdata.v1.parties.save~, ~iam.v1.accounts.save~,
+~iam.v1.account-parties.save~), and ~ores.workflow.core~ links only against
+API packages, not ~ores.iam.core~ or ~ores.refdata.core~. The
+~workflow_handler::provision_parties()~ entry point only publishes a
+JetStream message and never writes to IAM or refdata tables directly. The
+DML grants in the service registry were therefore dead leftovers. Step 4
+(removing the grants and regenerating) was all that was needed.
+
 * Phase 5.3 — ORE Write API (Workflow)
 
 *Effort: M. Risk: Medium.*
@@ -141,11 +153,11 @@ conventions that 5.3 must follow.
 
 * Sequencing and Effort
 
-| Phase | Title                                    | Effort | Risk   | Blocked by |
-|-------+------------------------------------------+--------+--------+------------|
-| 4.3   | IAM party cache (NATS-backed)            | L      | Medium | —          |
-| 5.2   | Workflow→IAM/refdata NATS write APIs     | L      | High   | 4.3        |
-| 5.3   | ORE→workflow NATS write API              | M      | Medium | 5.2        |
+| Phase | Title                                    | Effort | Risk   | Blocked by | Status   |
+|-------+------------------------------------------+--------+--------+------------+----------|
+| 4.3   | IAM party cache (NATS-backed)            | L      | Medium | —          | COMPLETE |
+| 5.2   | Workflow→IAM/refdata NATS write APIs     | L      | High   | 4.3        | COMPLETE |
+| 5.3   | ORE→workflow NATS write API              | M      | Medium | 5.2        | —        |
 
 All phases here begin after the isolation plan invariant is locked (Phase 4 of
 [[file:2026-05-12-strict-service-table-isolation.org][strict-service-table-isolation.org]]).

--- a/projects/ores.codegen/models/services/ores_services_service_registry.json
+++ b/projects/ores.codegen/models/services/ores_services_service_registry.json
@@ -162,9 +162,7 @@
         "description": "Workflow Orchestration",
         "email": "workflow_service@system.ores",
         "dml_prefixes": [
-          {"prefix": "ores_workflow_"},
-          {"prefix": "ores_iam_"},
-          {"prefix": "ores_refdata_parties"}
+          {"prefix": "ores_workflow_"}
         ],
         "select_tables": [],
         "select_prefixes": []

--- a/projects/ores.sql/create/iam/iam_service_db_grants_create.sql
+++ b/projects/ores.sql/create/iam/iam_service_db_grants_create.sql
@@ -122,7 +122,6 @@ alter default privileges in schema public
 -- iam_service: IAM domain service
 -- ---------------------------------------------------------------------------
 select _ores_grant_dml_fn('ores_iam_', :'iam_service_user');
-select _ores_grant_dml_fn('ores_refdata_parties', :'iam_service_user');
 
 -- ---------------------------------------------------------------------------
 -- refdata_service: Reference Data domain service
@@ -187,8 +186,6 @@ select _ores_grant_select_fn('ores_telemetry_', :'synthetic_service_user');
 -- workflow_service: Workflow Orchestration domain service
 -- ---------------------------------------------------------------------------
 select _ores_grant_dml_fn('ores_workflow_', :'workflow_service_user');
-select _ores_grant_dml_fn('ores_iam_', :'workflow_service_user');
-select _ores_grant_dml_fn('ores_refdata_parties', :'workflow_service_user');
 
 -- ---------------------------------------------------------------------------
 -- ore_service: ORE Import domain service

--- a/projects/ores.sql/populate/iam/iam_service_account_roles_populate.sql
+++ b/projects/ores.sql/populate/iam/iam_service_account_roles_populate.sql
@@ -30,76 +30,55 @@
  * This script is idempotent.
  */
 
-SET "ores.iam_service_user"         = :'iam_service_user';
-SET "ores.refdata_service_user"     = :'refdata_service_user';
-SET "ores.dq_service_user"          = :'dq_service_user';
-SET "ores.variability_service_user" = :'variability_service_user';
-SET "ores.assets_service_user"      = :'assets_service_user';
-SET "ores.scheduler_service_user"   = :'scheduler_service_user';
-SET "ores.reporting_service_user"   = :'reporting_service_user';
-SET "ores.telemetry_service_user"   = :'telemetry_service_user';
-SET "ores.trading_service_user"     = :'trading_service_user';
-SET "ores.compute_service_user"     = :'compute_service_user';
-SET "ores.synthetic_service_user"   = :'synthetic_service_user';
-SET "ores.workflow_service_user"    = :'workflow_service_user';
-SET "ores.ore_service_user"         = :'ore_service_user';
-SET "ores.marketdata_service_user"  = :'marketdata_service_user';
-SET "ores.controller_service_user"  = :'controller_service_user';
-SET "ores.analytics_service_user"   = :'analytics_service_user';
+\echo '--- Service Account Role Assignments ---'
 
-DO $$
-BEGIN
-    -- --- Service Account Role Assignments ---
+select ores_iam_account_role_assign_fn(
+    ores_utility_system_tenant_id_fn(), :'iam_service_user', 'IamService');
 
-    PERFORM ores_iam_account_role_assign_fn(
-        ores_utility_system_tenant_id_fn(), current_setting('ores.iam_service_user'), 'IamService');
+select ores_iam_account_role_assign_fn(
+    ores_utility_system_tenant_id_fn(), :'refdata_service_user', 'RefdataService');
 
-    PERFORM ores_iam_account_role_assign_fn(
-        ores_utility_system_tenant_id_fn(), current_setting('ores.refdata_service_user'), 'RefdataService');
+select ores_iam_account_role_assign_fn(
+    ores_utility_system_tenant_id_fn(), :'dq_service_user', 'DqService');
 
-    PERFORM ores_iam_account_role_assign_fn(
-        ores_utility_system_tenant_id_fn(), current_setting('ores.dq_service_user'), 'DqService');
+select ores_iam_account_role_assign_fn(
+    ores_utility_system_tenant_id_fn(), :'variability_service_user', 'VariabilityService');
 
-    PERFORM ores_iam_account_role_assign_fn(
-        ores_utility_system_tenant_id_fn(), current_setting('ores.variability_service_user'), 'VariabilityService');
+select ores_iam_account_role_assign_fn(
+    ores_utility_system_tenant_id_fn(), :'assets_service_user', 'AssetsService');
 
-    PERFORM ores_iam_account_role_assign_fn(
-        ores_utility_system_tenant_id_fn(), current_setting('ores.assets_service_user'), 'AssetsService');
+select ores_iam_account_role_assign_fn(
+    ores_utility_system_tenant_id_fn(), :'scheduler_service_user', 'SchedulerService');
 
-    PERFORM ores_iam_account_role_assign_fn(
-        ores_utility_system_tenant_id_fn(), current_setting('ores.scheduler_service_user'), 'SchedulerService');
+select ores_iam_account_role_assign_fn(
+    ores_utility_system_tenant_id_fn(), :'reporting_service_user', 'ReportingService');
 
-    PERFORM ores_iam_account_role_assign_fn(
-        ores_utility_system_tenant_id_fn(), current_setting('ores.reporting_service_user'), 'ReportingService');
+select ores_iam_account_role_assign_fn(
+    ores_utility_system_tenant_id_fn(), :'telemetry_service_user', 'TelemetryService');
 
-    PERFORM ores_iam_account_role_assign_fn(
-        ores_utility_system_tenant_id_fn(), current_setting('ores.telemetry_service_user'), 'TelemetryService');
+select ores_iam_account_role_assign_fn(
+    ores_utility_system_tenant_id_fn(), :'trading_service_user', 'TradingService');
 
-    PERFORM ores_iam_account_role_assign_fn(
-        ores_utility_system_tenant_id_fn(), current_setting('ores.trading_service_user'), 'TradingService');
+select ores_iam_account_role_assign_fn(
+    ores_utility_system_tenant_id_fn(), :'compute_service_user', 'ComputeService');
 
-    PERFORM ores_iam_account_role_assign_fn(
-        ores_utility_system_tenant_id_fn(), current_setting('ores.compute_service_user'), 'ComputeService');
+select ores_iam_account_role_assign_fn(
+    ores_utility_system_tenant_id_fn(), :'synthetic_service_user', 'SyntheticService');
 
-    PERFORM ores_iam_account_role_assign_fn(
-        ores_utility_system_tenant_id_fn(), current_setting('ores.synthetic_service_user'), 'SyntheticService');
+select ores_iam_account_role_assign_fn(
+    ores_utility_system_tenant_id_fn(), :'workflow_service_user', 'WorkflowService');
 
-    PERFORM ores_iam_account_role_assign_fn(
-        ores_utility_system_tenant_id_fn(), current_setting('ores.workflow_service_user'), 'WorkflowService');
+select ores_iam_account_role_assign_fn(
+    ores_utility_system_tenant_id_fn(), :'ore_service_user', 'OreService');
 
-    PERFORM ores_iam_account_role_assign_fn(
-        ores_utility_system_tenant_id_fn(), current_setting('ores.ore_service_user'), 'OreService');
+select ores_iam_account_role_assign_fn(
+    ores_utility_system_tenant_id_fn(), :'marketdata_service_user', 'MarketdataService');
 
-    PERFORM ores_iam_account_role_assign_fn(
-        ores_utility_system_tenant_id_fn(), current_setting('ores.marketdata_service_user'), 'MarketdataService');
+select ores_iam_account_role_assign_fn(
+    ores_utility_system_tenant_id_fn(), :'controller_service_user', 'ControllerService');
 
-    PERFORM ores_iam_account_role_assign_fn(
-        ores_utility_system_tenant_id_fn(), current_setting('ores.controller_service_user'), 'ControllerService');
-
-    PERFORM ores_iam_account_role_assign_fn(
-        ores_utility_system_tenant_id_fn(), current_setting('ores.analytics_service_user'), 'AnalyticsService');
-END $$;
-
+select ores_iam_account_role_assign_fn(
+    ores_utility_system_tenant_id_fn(), :'analytics_service_user', 'AnalyticsService');
 
 -- Summary
 select 'Service Account Role Assignments' as entity, count(*) as count

--- a/projects/ores.sql/populate/iam/iam_service_accounts_populate.sql
+++ b/projects/ores.sql/populate/iam/iam_service_accounts_populate.sql
@@ -34,6 +34,8 @@
  * This script is idempotent.
  */
 
+\echo '--- Service Accounts ---'
+
 -- Capture service DB passwords from the environment so they are never stored
 -- in plaintext in committed SQL. The backtick syntax runs a shell command at
 -- psql execution time; the result is bound to the named variable.
@@ -56,207 +58,161 @@
 \set controller_service_pw    `echo "$ORES_CONTROLLER_SERVICE_DB_PASSWORD"`
 \set analytics_service_pw    `echo "$ORES_ANALYTICS_SERVICE_DB_PASSWORD"`
 
-SET "ores.ddl_user"                 = :'ddl_user';
-SET "ores.cli_user"                 = :'cli_user';
-SET "ores.wt_user"                  = :'wt_user';
-SET "ores.shell_user"               = :'shell_user';
-SET "ores.http_user"                = :'http_user';
-SET "ores.test_ddl_user"            = :'test_ddl_user';
-SET "ores.test_dml_user"            = :'test_dml_user';
-SET "ores.iam_service_user"         = :'iam_service_user';
-SET "ores.refdata_service_user"     = :'refdata_service_user';
-SET "ores.dq_service_user"          = :'dq_service_user';
-SET "ores.variability_service_user" = :'variability_service_user';
-SET "ores.assets_service_user"      = :'assets_service_user';
-SET "ores.scheduler_service_user"   = :'scheduler_service_user';
-SET "ores.reporting_service_user"   = :'reporting_service_user';
-SET "ores.telemetry_service_user"   = :'telemetry_service_user';
-SET "ores.trading_service_user"     = :'trading_service_user';
-SET "ores.compute_service_user"     = :'compute_service_user';
-SET "ores.synthetic_service_user"   = :'synthetic_service_user';
-SET "ores.workflow_service_user"    = :'workflow_service_user';
-SET "ores.ore_service_user"         = :'ore_service_user';
-SET "ores.marketdata_service_user"  = :'marketdata_service_user';
-SET "ores.controller_service_user"  = :'controller_service_user';
-SET "ores.analytics_service_user"   = :'analytics_service_user';
-SET "ores.wt_service_pw"            = :'wt_service_pw';
-SET "ores.http_service_pw"          = :'http_service_pw';
-SET "ores.iam_service_pw"           = :'iam_service_pw';
-SET "ores.refdata_service_pw"       = :'refdata_service_pw';
-SET "ores.dq_service_pw"            = :'dq_service_pw';
-SET "ores.variability_service_pw"   = :'variability_service_pw';
-SET "ores.assets_service_pw"        = :'assets_service_pw';
-SET "ores.scheduler_service_pw"     = :'scheduler_service_pw';
-SET "ores.reporting_service_pw"     = :'reporting_service_pw';
-SET "ores.telemetry_service_pw"     = :'telemetry_service_pw';
-SET "ores.trading_service_pw"       = :'trading_service_pw';
-SET "ores.compute_service_pw"       = :'compute_service_pw';
-SET "ores.synthetic_service_pw"     = :'synthetic_service_pw';
-SET "ores.workflow_service_pw"      = :'workflow_service_pw';
-SET "ores.ore_service_pw"           = :'ore_service_pw';
-SET "ores.marketdata_service_pw"    = :'marketdata_service_pw';
-SET "ores.controller_service_pw"    = :'controller_service_pw';
-SET "ores.analytics_service_pw"     = :'analytics_service_pw';
+select ores_iam_service_accounts_upsert_fn(
+    :'ddl_user',
+    'ddl@system.ores',
+    'System service account for DDL operations and schema migrations'
+);
 
-DO $$
-BEGIN
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.ddl_user'),
-        'ddl@system.ores',
-        'System service account for DDL operations and schema migrations'
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'cli_user',
+    'cli@system.ores',
+    'System service account for CLI operations'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.cli_user'),
-        'cli@system.ores',
-        'System service account for CLI operations'
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'wt_user',
+    'wt@system.ores',
+    'System service account for Wt web application',
+    :'wt_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.wt_user'),
-        'wt@system.ores',
-        'System service account for Wt web application',
-        current_setting('ores.wt_service_pw')
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'shell_user',
+    'shell@system.ores',
+    'System service account for interactive shell'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.shell_user'),
-        'shell@system.ores',
-        'System service account for interactive shell'
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'http_user',
+    'http@system.ores',
+    'System service account for HTTP REST API server',
+    :'http_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.http_user'),
-        'http@system.ores',
-        'System service account for HTTP REST API server',
-        current_setting('ores.http_service_pw')
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'test_ddl_user',
+    'test_ddl@system.ores',
+    'System service account for test DDL operations'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.test_ddl_user'),
-        'test_ddl@system.ores',
-        'System service account for test DDL operations'
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'test_dml_user',
+    'test_dml@system.ores',
+    'System service account for test DML operations'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.test_dml_user'),
-        'test_dml@system.ores',
-        'System service account for test DML operations'
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'iam_service_user',
+    'iam_service@system.ores',
+    'System service account for IAM NATS domain service',
+    :'iam_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.iam_service_user'),
-        'iam_service@system.ores',
-        'System service account for IAM NATS domain service',
-        current_setting('ores.iam_service_pw')
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'refdata_service_user',
+    'refdata_service@system.ores',
+    'System service account for Reference Data NATS domain service',
+    :'refdata_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.refdata_service_user'),
-        'refdata_service@system.ores',
-        'System service account for Reference Data NATS domain service',
-        current_setting('ores.refdata_service_pw')
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'dq_service_user',
+    'dq_service@system.ores',
+    'System service account for Data Quality NATS domain service',
+    :'dq_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.dq_service_user'),
-        'dq_service@system.ores',
-        'System service account for Data Quality NATS domain service',
-        current_setting('ores.dq_service_pw')
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'variability_service_user',
+    'variability_service@system.ores',
+    'System service account for Variability NATS domain service',
+    :'variability_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.variability_service_user'),
-        'variability_service@system.ores',
-        'System service account for Variability NATS domain service',
-        current_setting('ores.variability_service_pw')
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'assets_service_user',
+    'assets_service@system.ores',
+    'System service account for Assets NATS domain service',
+    :'assets_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.assets_service_user'),
-        'assets_service@system.ores',
-        'System service account for Assets NATS domain service',
-        current_setting('ores.assets_service_pw')
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'scheduler_service_user',
+    'scheduler_service@system.ores',
+    'System service account for Scheduler NATS domain service',
+    :'scheduler_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.scheduler_service_user'),
-        'scheduler_service@system.ores',
-        'System service account for Scheduler NATS domain service',
-        current_setting('ores.scheduler_service_pw')
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'reporting_service_user',
+    'reporting_service@system.ores',
+    'System service account for Reporting NATS domain service',
+    :'reporting_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.reporting_service_user'),
-        'reporting_service@system.ores',
-        'System service account for Reporting NATS domain service',
-        current_setting('ores.reporting_service_pw')
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'telemetry_service_user',
+    'telemetry_service@system.ores',
+    'System service account for Telemetry NATS domain service',
+    :'telemetry_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.telemetry_service_user'),
-        'telemetry_service@system.ores',
-        'System service account for Telemetry NATS domain service',
-        current_setting('ores.telemetry_service_pw')
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'trading_service_user',
+    'trading_service@system.ores',
+    'System service account for Trading NATS domain service',
+    :'trading_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.trading_service_user'),
-        'trading_service@system.ores',
-        'System service account for Trading NATS domain service',
-        current_setting('ores.trading_service_pw')
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'compute_service_user',
+    'compute_service@system.ores',
+    'System service account for Compute Grid NATS domain service',
+    :'compute_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.compute_service_user'),
-        'compute_service@system.ores',
-        'System service account for Compute Grid NATS domain service',
-        current_setting('ores.compute_service_pw')
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'synthetic_service_user',
+    'synthetic_service@system.ores',
+    'System service account for Synthetic NATS domain service',
+    :'synthetic_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.synthetic_service_user'),
-        'synthetic_service@system.ores',
-        'System service account for Synthetic NATS domain service',
-        current_setting('ores.synthetic_service_pw')
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'workflow_service_user',
+    'workflow_service@system.ores',
+    'System service account for Workflow Orchestration NATS domain service',
+    :'workflow_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.workflow_service_user'),
-        'workflow_service@system.ores',
-        'System service account for Workflow Orchestration NATS domain service',
-        current_setting('ores.workflow_service_pw')
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'ore_service_user',
+    'ore_service@system.ores',
+    'System service account for ORE Import NATS domain service',
+    :'ore_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.ore_service_user'),
-        'ore_service@system.ores',
-        'System service account for ORE Import NATS domain service',
-        current_setting('ores.ore_service_pw')
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'marketdata_service_user',
+    'marketdata_service@system.ores',
+    'System service account for Market Data NATS domain service',
+    :'marketdata_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.marketdata_service_user'),
-        'marketdata_service@system.ores',
-        'System service account for Market Data NATS domain service',
-        current_setting('ores.marketdata_service_pw')
-    );
+select ores_iam_service_accounts_upsert_fn(
+    :'controller_service_user',
+    'controller_service@system.ores',
+    'System service account for Service Controller NATS domain service',
+    :'controller_service_pw'
+);
 
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.controller_service_user'),
-        'controller_service@system.ores',
-        'System service account for Service Controller NATS domain service',
-        current_setting('ores.controller_service_pw')
-    );
-
-    PERFORM ores_iam_service_accounts_upsert_fn(
-        current_setting('ores.analytics_service_user'),
-        'analytics_service@system.ores',
-        'System service account for Analytics NATS domain service',
-        current_setting('ores.analytics_service_pw')
-    );
-END $$;
-
+select ores_iam_service_accounts_upsert_fn(
+    :'analytics_service_user',
+    'analytics_service@system.ores',
+    'System service account for Analytics NATS domain service',
+    :'analytics_service_pw'
+);
 
 -- Summary
 select 'Service Accounts' as entity, count(*) as count


### PR DESCRIPTION
## Summary

- Verifies `provision_parties` workflow routes all writes through NATS (`refdata.v1.parties.save`, `iam.v1.accounts.save`, `iam.v1.account-parties.save`) and never writes to IAM or refdata tables directly
- Confirms `ores.workflow.core` links only API packages (`ores.iam.api.lib`, `ores.refdata.api.lib`), not core packages — no repository access possible
- Removes dead `ores_iam_` and `ores_refdata_parties` DML grants from the workflow service registry entry
- Regenerates SQL grants and populate files via codegen (`service-registry` profile)
- Also picks up the Phase 4.3 leftover: `ores_refdata_parties` SELECT grant on the IAM service was never regenerated after Phase 4.3 landed; that is now cleaned up too
- `validate_schemas.sh` passes: 210 tables, 0 warnings

## Notes

Steps 1–3 of Phase 5.2 (expose NATS APIs, replace direct writes) were already complete before this PR. The `provision_parties` workflow was implemented using NATS from the start. The DML grants in the service registry were dead leftovers. Only step 4 (grant removal + regeneration) was needed.

Part of the cross-service write decoupling plan:
`doc/plans/2026-05-13-cross-service-write-decoupling.org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)