### PR TITLE
[workflow] ORE import error reporting, step log, and service isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,23 +32,17 @@ architecture.
 
 Each domain service user (`ores_<env>_<service>_service`) holds DML only on
 its own `ores_<service>_*` tables. This is the strict service table isolation
-invariant. Key rules:
+invariant. Full rules and patterns are in
+`projects/ores.sql/modeling/ores.sql.org` under "Service Table Isolation".
+
+Key points for daily work:
 
 - **Do not add cross-component SELECT/DML grants** to the service registry
   (`projects/ores.codegen/models/services/ores_services_service_registry.json`)
-  without a documented justification. Any such addition is a tracked violation.
-- **FK constraints do not require SELECT grants** on the referenced table at
-  runtime. PostgreSQL enforces FKs internally; the `REFERENCES` privilege is
-  only needed when creating the constraint (done by the DDL user).
-- **Cross-component trigger validation functions** (`ores_iam_validate_tenant_fn`,
-  `ores_dq_validate_change_reason_fn`) are `SECURITY DEFINER` — they run as
-  the DDL owner and require no cross-component grants on calling service users.
-- **New trigger validation functions** that SELECT from another service's tables
-  must be `SECURITY DEFINER` with `SET search_path = public, pg_temp`.
-
-All tracked cross-component grants have been removed (Phases 4.3, 5.2, 5.3
-complete). The strict service table isolation invariant is now fully enforced.
-See `doc/plans/2026-05-13-cross-service-write-decoupling.org` for history.
+  without a documented justification.
+- **Trigger functions that SELECT from another service's tables** must be
+  `SECURITY DEFINER SET search_path = public, pg_temp`. Never add a
+  cross-component SELECT grant to satisfy a trigger check.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,10 +46,9 @@ invariant. Key rules:
 - **New trigger validation functions** that SELECT from another service's tables
   must be `SECURITY DEFINER` with `SET search_path = public, pg_temp`.
 
-The remaining cross-component grants (IAM↔variability, IAM/workflow↔refdata,
-ORE↔workflow, trading↔refdata) are tracked in
-`doc/plans/2026-05-12-strict-service-table-isolation.org` with phase targets
-for removal.
+All tracked cross-component grants have been removed (Phases 4.3, 5.2, 5.3
+complete). The strict service table isolation invariant is now fully enforced.
+See `doc/plans/2026-05-13-cross-service-write-decoupling.org` for history.
 
 ## Testing
 

--- a/doc/plans/2026-05-12-strict-service-table-isolation.org
+++ b/doc/plans/2026-05-12-strict-service-table-isolation.org
@@ -165,6 +165,21 @@ Steps:
 3. Remove ~select _ores_grant_select_fn('ores_refdata_', :'trading_service_user')~
    from the service registry and regenerate the grants file.
 
+* Phase 3a — Trading reads FSM transitions via NATS (deferred)
+
+*Status: DEFERRED — no DB grant; trading service trade saves will fail until resolved.*
+
+~trade_status_service.cpp~ calls ~dq::repository::fsm_transition_repository::find_by_id()~
+directly. No DB grant is issued; this must be replaced with a NATS call.
+
+Fix:
+1. In ~trade_handler::save()~, call ~dq.v1.fsm-transitions.list~ once per request
+   (before iterating trades) to fetch the full set of transitions into a lookup map.
+2. Inject the map into ~trade_service~ / ~trade_status_service::resolve_status()~
+   so no direct DB access to ~ores_dq_fsm_transitions_tbl~ is needed.
+3. Remove ~#include "ores.dq.core/repository/fsm_transition_repository.hpp"~
+   from ~trade_status_service.cpp~ and the corresponding CMake link.
+
 * Phase 4 — Lock the Invariant
 
 *Status: COMPLETE*

--- a/doc/plans/2026-05-12-strict-service-table-isolation.org
+++ b/doc/plans/2026-05-12-strict-service-table-isolation.org
@@ -165,20 +165,23 @@ Steps:
 3. Remove ~select _ores_grant_select_fn('ores_refdata_', :'trading_service_user')~
    from the service registry and regenerate the grants file.
 
-* Phase 3a — Trading reads FSM transitions via NATS (deferred)
+* Phase 3a — Trading reads FSM transitions via NATS
 
-*Status: DEFERRED — no DB grant; trading service trade saves will fail until resolved.*
+*Status: COMPLETE*
 
-~trade_status_service.cpp~ calls ~dq::repository::fsm_transition_repository::find_by_id()~
-directly. No DB grant is issued; this must be replaced with a NATS call.
+~trade_status_service.cpp~ previously called
+~dq::repository::fsm_transition_repository::find_by_id()~ directly, violating
+service isolation.
 
-Fix:
-1. In ~trade_handler::save()~, call ~dq.v1.fsm-transitions.list~ once per request
-   (before iterating trades) to fetch the full set of transitions into a lookup map.
-2. Inject the map into ~trade_service~ / ~trade_status_service::resolve_status()~
-   so no direct DB access to ~ores_dq_fsm_transitions_tbl~ is needed.
-3. Remove ~#include "ores.dq.core/repository/fsm_transition_repository.hpp"~
-   from ~trade_status_service.cpp~ and the corresponding CMake link.
+Fix applied:
+1. ~trade_handler::save()~ calls ~dq.v1.fsm-transitions.list~ once per request
+   via the private ~fetch_fsm_transitions()~ helper, returning a
+   ~service::fsm_transition_map~ keyed by UUID.
+2. The map is passed into ~trade_service::save_trades()~ →
+   ~trade_status_service::resolve_status()~, which looks up the transition
+   by UUID without any DB access to ~ores_dq_fsm_transitions_tbl~.
+3. ~#include "ores.dq.core/repository/fsm_transition_repository.hpp"~
+   removed from ~trade_status_service.cpp~.
 
 * Phase 4 — Lock the Invariant
 

--- a/doc/plans/2026-05-14-workflow-engine-hardening.org
+++ b/doc/plans/2026-05-14-workflow-engine-hardening.org
@@ -2,8 +2,91 @@
 #+SUBTITLE: Dynamic steps, ownership relocation, idempotency, and a reusable step widget
 #+DATE: 2026-05-14
 #+AUTHOR: ORE Studio Team
-#+STATUS: PROPOSAL
+#+STATUS: IN PROGRESS
 #+OPTIONS: toc:t num:nil
+
+* Progress
+
+Items 3 and 4 from the original plan are complete. Items 1 and 2 remain
+pending. Additional hardening work was done on branches
+~feature/workflow-step-log~ and ~feature/dq-publish-pattern-microservices~
+that is closely related to this plan but addresses bugs surfaced during
+integration testing.
+
+** Completed — Error surfacing pipeline fixes
+
+Three bugs prevented workflow step errors from appearing in the UI.
+All three are now fixed:
+
+1. ~workflow_step_context::fail()~ was discarding the accumulated log
+   (fixed in commit ~db41924b1~, ~feature/workflow-step-log~).
+
+2. ~workflow_engine.cpp~ ~on_step_completed~: the ~failed~ outcome
+   branch was passing ~""~ for ~step_log_json~ in
+   ~step_repo_.update_state()~, silently dropping the log on DB write
+   even when it was correctly forwarded by the handler (fixed in commit
+   ~90fb7eb12~, ~feature/workflow-step-log~):
+
+   #+begin_src cpp
+   // Before (log discarded):
+   case outcome::failed:
+       step_repo_.update_state(ctx_, step_id,
+           step_states_.require("failed"), "", event.error_message, "");
+   // After:
+   case outcome::failed:
+       step_repo_.update_state(ctx_, step_id,
+           step_states_.require("failed"), "", event.error_message, log_json);
+   #+end_src
+
+3. ~trade_status_service~ was calling ~dq::repository::fsm_transition_repository~
+   directly, causing permission-denied errors in the trading service user.
+   Resolved as part of Phase 3a service isolation (see below).
+
+** Completed — Phase 3a: trading service isolation (NATS)
+
+~trade_status_service.cpp~ was bypassing service table isolation by
+directly calling the DQ ~fsm_transition_repository~. Fixed on branch
+~feature/dq-publish-pattern-microservices~ (commit ~ff3c1b505~):
+
+- ~trade_handler::fetch_fsm_transitions()~ fetches the full FSM
+  transition map from ~dq.v1.fsm-transitions.list~ via NATS, with a
+  5-minute process-level static cache to avoid one NATS call per trade
+  during bulk imports.
+- The map is passed through ~trade_service::save_trades()~ →
+  ~trade_status_service::resolve_status()~.
+- ~ores.dq.core.lib~ removed from ~ores.trading.core~'s CMake link
+  libraries; replaced with ~ores.dq.api.lib~.
+- Phase 3a in
+  [[file:2026-05-12-strict-service-table-isolation.org][strict-service-table-isolation.org]]
+  marked COMPLETE.
+
+** Completed — Workflow instance list: Completed At column
+
+~WorkflowMdiWindow~ now shows a ~Completed At~ column. The
+~workflow_instance_summary.completed_at~ field was already populated by
+~workflow_query_handler.cpp~; only the UI column was missing.
+
+** Completed — Item 3: Idempotency guard
+
+~check_step_idempotency~ is implemented in
+~projects/ores.service/include/ores.service/messaging/workflow_helpers.hpp~
+alongside the existing ~publish_step_completion~ helper. Handlers call
+it to replay the cached completion event on re-dispatch rather than
+re-executing the operation.
+
+** Completed — Item 4: Reusable step widget
+
+~WorkflowStepsWidget~ and ~WorkflowStepLogWidget~ exist in
+~projects/ores.qt.workflow/~. ~WorkflowInstanceDetailDialog~ uses the
+factored-out widget. The DQ publish pattern PR can embed the widget
+directly without adding a new per-step component.
+
+** Pending — Items 1 and 2
+
+Dynamic step lists (Item 1) and relocation of workflow definitions to
+owning service API packages (Item 2) remain unimplemented. These are
+prerequisites for the bundle publish workflow. See the original item
+sections below for the design.
 
 * Context
 
@@ -70,7 +153,7 @@ on top of the engine. This plan addresses them in one PR.
 - Compensation semantics (the existing ~begin_compensation~ /
   ~check_compensation_complete~ flow continues unchanged).
 
-* Item 1 — Dynamic step lists (mandatory, no static path)
+* Item 1 — Dynamic step lists (mandatory, no static path) [PENDING]
 
 ** Current shape
 
@@ -145,7 +228,7 @@ def.build_steps = [](const std::string& /*request_json*/) {
 No behavioural change for ~provision_parties~, ~ore_import~, or
 ~report_execution~; only the registration path is rewritten.
 
-* Item 2 — Move definitions to the owning service's API package
+* Item 2 — Move definitions to the owning service's API package [PENDING]
 
 ** Current shape
 
@@ -195,7 +278,7 @@ This is still compile-time coupling, but in the correct direction:
 registration symbol), and each api package owns its own workflow
 declarations.
 
-* Item 3 — Idempotency guard contract
+* Item 3 — Idempotency guard contract [DONE]
 
 ** Current behaviour
 
@@ -259,7 +342,7 @@ The existing ~workflow_step.workflow_step_id~ column already serves as
 the idempotency key inside the engine. No new column needed; the new
 endpoint just exposes a read.
 
-* Item 4 — Reusable step widget
+* Item 4 — Reusable step widget [DONE]
 
 ** Factor out
 
@@ -336,7 +419,7 @@ dialog stores that id and binds it to a ~WorkflowStepsWidget~. On
 ~instanceReachedTerminalState(true)~ the dialog enables its Close
 button; on ~stepFailed~ it surfaces a banner above the widget.
 
-* Item 5 — End-to-end verification
+* Item 5 — End-to-end verification [PENDING]
 
 Smoke tests added in the same PR:
 

--- a/doc/plans/2026-05-14-workflow-engine-hardening.org
+++ b/doc/plans/2026-05-14-workflow-engine-hardening.org
@@ -2,7 +2,7 @@
 #+SUBTITLE: Dynamic steps, ownership relocation, idempotency, and a reusable step widget
 #+DATE: 2026-05-14
 #+AUTHOR: ORE Studio Team
-#+STATUS: IN PROGRESS
+#+STATUS: COMPLETE
 #+OPTIONS: toc:t num:nil
 
 * Progress
@@ -103,14 +103,32 @@ dependency: workflow definition headers (for ~ore_import~,
 ~provision_parties~, ~report_execution~) still live inside ~ores.workflow~
 and include domain API headers, keeping the dependency direction inverted.
 
-** Pending — Items 1 and 2
+** Completed — Item 1: Dynamic step lists
 
-Dynamic step lists (Item 1) and relocation of workflow definitions to
-owning service API packages (Item 2) remain unimplemented. These are
-prerequisites for the bundle publish workflow. The SQL-level isolation
-(Phases 5.2/5.3 above) is the runtime half of the work Item 2 describes;
-the remaining half is the compile-time restructuring. See the original
-item sections below for the design.
+~workflow_definition~ in ~ores.workflow.api~ already uses ~build_steps~ as
+a ~std::function~ callback (signature:
+~(request_json, tenant_id, correlation_id) → vector<workflow_step_def>~).
+~materialised_step~ struct and ~workflow_instance.materialised_steps_json~
+column both exist. ~workflow_engine.cpp~ calls ~def->build_steps(...)~ at
+instance start, recovery, and dispatch. No static step path remains.
+
+** Completed — Item 2: Definitions moved to owning service API packages
+
+All three definitions already live in their respective owning API packages:
+
+| Workflow               | Location                                                     |
+|------------------------+--------------------------------------------------------------|
+| ~provision_parties~    | ~ores.refdata.api/workflow/provision_parties_workflow.hpp~   |
+| ~ore_import~           | ~ores.ore.api/workflow/ore_import_workflow.hpp~              |
+| ~report_execution~     | ~ores.reporting.api/workflow/report_execution_workflow.hpp~  |
+
+~registrar.cpp~ calls ~refdata::workflow::register_provision_parties_workflow~,
+~ore::workflow::register_ore_import_workflow~, and
+~reporting::workflow::register_report_execution_workflow~. The ~ores.workflow~
+package no longer includes domain headers directly for these definitions.
+
+The SQL-level isolation (Phases 5.2/5.3 above) is the runtime complement:
+DML grants are gone and all domain writes go through NATS.
 
 * Context
 

--- a/doc/plans/2026-05-14-workflow-engine-hardening.org
+++ b/doc/plans/2026-05-14-workflow-engine-hardening.org
@@ -81,12 +81,36 @@ re-executing the operation.
 factored-out widget. The DQ publish pattern PR can embed the widget
 directly without adding a new per-step component.
 
+** Completed — SQL-level service isolation for workflow and ORE (Phases 5.2 and 5.3)
+
+Landed on main in PRs #745 and #746:
+
+- *Phase 5.2* (~feature/workflow-iam-refdata-write-apis~): Removed dead
+  ~ores_iam_*~ and ~ores_refdata_parties~ DML grants from the workflow service
+  registry. The ~provision_parties~ workflow already routes all writes
+  through NATS (~refdata.v1.parties.save~, ~iam.v1.accounts.save~,
+  ~iam.v1.account-parties.save~). The grants were dead leftovers.
+
+- *Phase 5.3* (~feature/ore-workflow-write-decoupling~): Removed dead
+  ~ores_workflow_*~ DML grant from the workflow service registry and the
+  ~ores.workflow.core.lib~ CMake link from ~ores.ore.service~. The ORE
+  import handler already submits workflows via NATS (~nats_.js_publish~)
+  and never called workflow.core directly.
+
+The runtime (SQL) isolation between the workflow service and all domain
+services is now clean. What remains for Item 2 is the *compile-time*
+dependency: workflow definition headers (for ~ore_import~,
+~provision_parties~, ~report_execution~) still live inside ~ores.workflow~
+and include domain API headers, keeping the dependency direction inverted.
+
 ** Pending — Items 1 and 2
 
 Dynamic step lists (Item 1) and relocation of workflow definitions to
 owning service API packages (Item 2) remain unimplemented. These are
-prerequisites for the bundle publish workflow. See the original item
-sections below for the design.
+prerequisites for the bundle publish workflow. The SQL-level isolation
+(Phases 5.2/5.3 above) is the runtime half of the work Item 2 describes;
+the remaining half is the compile-time restructuring. See the original
+item sections below for the design.
 
 * Context
 

--- a/doc/plans/2026-05-15-login-environment-filter.org
+++ b/doc/plans/2026-05-15-login-environment-filter.org
@@ -1,0 +1,366 @@
+#+title: Environment / Instance Domain Model and Login Filter
+#+date: 2026-05-15
+#+author: Marco Craveiro
+
+* Problem
+
+The login dialog's saved-connections combo is a flat list that shows every
+server bookmark and every connection, making it hard to find what you need
+when bookmarks span multiple deployment tiers.  In practice, users work within
+one tier at a time and rarely cross tiers in a single session.
+
+A second gap: when several client windows are open simultaneously there is no
+reliable signal telling the user which tier each window belongs to.  The
+existing ~--instance-name~ / ~--instance-color~ flags address multi-instance
+labelling generically, but they have no first-class concept of a deployment
+tier.
+
+Both problems share a root: the domain model conflates the deployment tier
+(~dev~, ~staging~, ~prod~) with the specific server bookmark (~local1~,
+~local2~).  Separating them fixes the naming throughout — the domain, the
+connection browser, the login dialog, and the CLI.
+
+* Terminology
+
+Standard DevOps and financial IT usage:
+
+| Term            | Meaning                                      | Examples                      |
+|-----------------+----------------------------------------------+-------------------------------|
+| *Environment*   | A deployment tier (the "what kind")          | ~dev~, ~staging~, ~prod~      |
+| *Instance*      | A specific server within an environment      | ~local1~, ~local2~, ~local3~  |
+| *Connection*    | Saved credentials linked to an instance      | ~alice@local2~                |
+
+An instance belongs to at most one environment.  Connections are linked to
+instances.  The NATS ~subject_prefix~ field already uses this split:
+~ores.{environment}.{instance}~ — e.g., ~ores.dev.local2~.
+
+The existing ~--instance-name~ CLI flag already uses the right word.  The
+~--environment~ flag proposed below completes the pair.
+
+* Current State
+
+** Domain model
+
+~ores.connections~ has two domain objects whose names do not match their roles:
+
+- *Environment* (currently): used as a host/port bookmark — i.e., what should
+  be called an *instance*.  Fields: ~name~, ~host~, ~port~, ~http_port~,
+  ~subject_prefix~, ~folder_id~.
+- *Connection*: credential bookmark linked to an environment (instance).
+  Fields: ~name~, ~username~, ~encrypted_password~, ~environment_id~.
+- *Folder*: arbitrary hierarchical container, orthogonal to tier semantics.
+
+There is no domain object for a deployment tier (environment).  The tier is
+implicit only in the ~subject_prefix~ string and in user-imposed naming
+conventions.
+
+** Connection browser
+
+~ConnectionBrowserMdiWindow~ shows ~Folder → Environment(instance)~ in its
+tree.  Without a tier object, users rely on folder naming to group bookmarks
+by tier.
+
+** Login dialog
+
+All instance bookmarks and connections are shown in two flat sections, with no
+tier-level grouping or filtering possible.  ~QuickConnectItem~ carries
+~{Type, name, subtitle}~ with no tier membership.
+
+** CLI flags
+
+~CommandLineParser~ has ~--instance-name~ (arbitrary label), ~--instance-color~
+(hex RGB dot), ~--http-base-url~, and logging flags.  No tier-aware flag exists.
+
+* Design
+
+** Rename and introduce domain objects
+
+*** Rename: environment → instance
+
+The existing ~environment~ struct is renamed to ~instance~.  All fields and
+semantics stay the same; only the name changes:
+
+#+begin_src cpp
+// ores.connections/domain/instance.hpp  (was environment.hpp)
+struct instance final {
+    boost::uuids::uuid                 id;
+    std::optional<boost::uuids::uuid>  environment_id;  // was folder_id (see below)
+    std::string                        name;            // e.g., "local1"
+    std::string                        host;
+    int                                port{0};
+    int                                http_port{8080};
+    std::string                        description;
+    std::string                        subject_prefix;  // "ores.dev.local1"
+};
+#+end_src
+
+The ~folder_id~ field is replaced by ~environment_id~ (pointing to the new
+~environment~ object).  Folder support is removed from instances — the tier is
+the natural grouping and folders added complexity without semantic value.
+
+*** New: environment
+
+#+begin_src cpp
+// ores.connections/domain/environment.hpp  (new)
+struct environment final {
+    boost::uuids::uuid  id;
+    std::string         name;         // "dev", "staging", "prod"
+    std::string         description;
+};
+#+end_src
+
+Minimal by design.  A colour field can be added later if needed.
+
+*** Connection: rename foreign key
+
+~connection.environment_id~ is renamed to ~connection.instance_id~ to match
+the new name:
+
+#+begin_src cpp
+struct connection final {
+    boost::uuids::uuid                 id;
+    std::optional<boost::uuids::uuid>  instance_id;  // was environment_id
+    std::string                        name;
+    std::string                        username;
+    std::string                        encrypted_password;
+    std::string                        description;
+};
+#+end_src
+
+** Updated connection_manager API
+
+Remove environment operations; add instance and environment operations:
+
+#+begin_src cpp
+// Environment (tier) operations — all new
+void create_environment(const domain::environment&);
+void update_environment(const domain::environment&);
+void delete_environment(const boost::uuids::uuid& id);
+std::vector<domain::environment> get_all_environments();
+std::optional<domain::environment> get_environment(const boost::uuids::uuid& id);
+std::optional<domain::environment> get_environment_by_name(const std::string& name);
+
+// Instance operations — renamed from environment_*
+void create_instance(const domain::instance&);
+void update_instance(const domain::instance&);
+void delete_instance(const boost::uuids::uuid& id);
+std::vector<domain::instance> get_all_instances();
+std::optional<domain::instance> get_instance(const boost::uuids::uuid& id);
+std::vector<domain::instance> get_instances_for_environment(const boost::uuids::uuid& env_id);
+
+// Connection: instance_id replaces environment_id in resolved_connection
+struct resolved_connection {
+    std::string host;
+    int         port{0};
+    int         http_port{8080};
+    std::string username;
+    std::string password;
+    std::string name;
+    std::string subject_prefix;
+    std::optional<boost::uuids::uuid>  instance_id;
+    std::optional<std::string>         instance_name;
+    std::optional<boost::uuids::uuid>  environment_id;
+    std::optional<std::string>         environment_name;
+};
+#+end_src
+
+** SQLite schema
+
+New table ~environments~.  Existing ~environments~ table (currently holding
+instances) is renamed to ~instances~; ~folder_id~ column replaced by
+~environment_id~ (nullable FK to ~environments~).  ~connections.environment_id~
+column renamed to ~instance_id~.  The migration is applied inside
+~connection_manager~'s constructor with lightweight ALTER TABLE / RENAME
+statements guarded by existence checks.
+
+** Connection browser: environment → instance → connection tree
+
+The ~ConnectionBrowserMdiWindow~ tree changes to:
+
+#+begin_example
+  dev                   ← environment node
+    local1              ← instance node
+    local2              ← instance node
+        alice@local2    ← connection node
+  staging               ← environment node
+    staging1            ← instance node
+  Unassigned            ← instances with no environment
+    legacy-test
+#+end_example
+
+Toolbar actions: create environment, create instance (under selected
+environment), create connection (under selected instance), rename, delete.
+Drag-and-drop for moving instances between environments.
+
+A new ~EnvironmentDetailPanel~ section shows: environment name, description,
+list of member instances.  The existing instance detail panel is updated to
+show its parent environment name.
+
+Folder support is removed from the tree view.  The ~folder~ domain object and
+~folder_id~ column can be dropped in a follow-up cleanup once confirmed no
+data relies on them.
+
+** Login dialog filter
+
+A *Environment* filter row appears above the quick-connect combo:
+
+#+begin_example
+  Environment: [ All ▼ ]     ← hidden when <2 environments defined
+  Quick connect: [ ── ▼ ]
+#+end_example
+
+Filter options: "All", then each environment name sorted alphabetically.  An
+"Unassigned" entry appears when ungrouped instances or connections exist.
+
+When an environment is selected, the quick-connect combo is restricted to:
+- *Instances* section: only instances belonging to that environment.
+- *Connections* section: only connections whose linked instance belongs to
+  that environment.
+
+The filter is a pure narrowing control; it does not fill form fields.
+
+*** QuickConnectItem
+
+#+begin_src cpp
+struct QuickConnectItem {
+    enum class Type { Instance, Connection };
+    Type    type;
+    QString name;
+    QString subtitle;
+    // ── new ──
+    std::optional<QString>            environment_name;
+    std::optional<boost::uuids::uuid> environment_id;
+};
+#+end_src
+
+Note: ~Type::Environment~ is renamed to ~Type::Instance~ to match the domain.
+~MainWindow~ populates ~environment_name~ / ~environment_id~ for each item by
+looking up the instance's ~environment_id~.
+
+*** LoginDialog additions
+
+#+begin_src
+QLabel*    environmentFilterLabel_   (hidden when <2 environments)
+QComboBox* environmentFilterCombo_   (hidden when <2 environments)
+#+end_src
+
+New public method:
+#+begin_src cpp
+void setActiveEnvironment(const QString& environmentName);
+#+end_src
+Pre-selects the filter; called by ~MainWindow~ when ~--environment~ was passed.
+
+** ~--environment~ CLI flag
+
+Names a deployment tier (environment), not an instance.
+
+#+begin_src
+  -E, --environment NAME
+      Deployment environment to use as the default context for this client
+      instance (e.g. dev, staging, prod).  Filters the login dialog to the
+      specified environment and labels the window title.
+#+end_src
+
+Semantics in ~MainWindow~:
+
+1. Call ~get_environment_by_name(name)~ (case-insensitive) after
+   ~initializeConnectionManager()~ succeeds.
+2. If found: store as ~activeEnvironmentName_~; pre-select filter; update title.
+3. If not found: ~warn~-level log; fall back to "All".  Do not abort startup.
+
+** Window title
+
+#+begin_example
+  ORE Studio v1.2.3                          (no flags)
+  ORE Studio v1.2.3 {dev}                    (--environment dev)
+  ORE Studio v1.2.3 [local2]                 (--instance-name local2)
+  ORE Studio v1.2.3 {dev} [local2]           (both)
+#+end_example
+
+~{env}~ = tier in curly braces; ~[instance]~ = disambiguation label in square
+brackets.  ~activeEnvironmentName_~ is a new ~MainWindow~ member.
+
+The two flags are designed to be used together: ~--environment~ identifies the
+tier; ~--instance-name~ disambiguates when multiple windows target the same tier.
+
+* Implementation
+
+** Item 1 — Rename environment → instance in domain layer
+
+New file: ~domain/instance.hpp~ (copy of ~environment.hpp~ with renames).
+Update ~environment.hpp~ to the new tier object.
+Update ~CMakeLists.txt~.
+
+** Item 2 — SQLite migration in connection_manager
+
+~connection_manager.cpp~: rename tables, replace ~folder_id~ with
+~environment_id~ on instances, rename ~connections.environment_id~ →
+~instance_id~.  Add ~environments~ table for tiers.
+
+** Item 3 — connection_manager API: environment + instance CRUD
+
+Add all environment and instance operations to header and implementation.
+Update ~resolved_connection~ to carry both ~instance_name~ and
+~environment_name~.
+
+** Item 4 — ConnectionBrowserMdiWindow: three-level tree
+
+Rebuild tree model for Environment → Instance → Connection hierarchy.
+Add toolbar actions for all three levels.  Add ~EnvironmentDetailPanel~.
+Remove folder nodes from the default view.
+
+** Item 5 — QuickConnectItem: add environment fields; rename Type::Environment
+
+File: ~LoginDialog.hpp~.
+
+** Item 6 — Populate environment metadata in MainWindow
+
+File: ~MainWindow.cpp~ — look up environment for each instance when building
+quick-connect items.
+
+** Item 7 — Add environment filter combo to LoginDialog
+
+Files: ~LoginDialog.hpp~, ~LoginDialog.cpp~.
+Filter row with label + combo.  ~setActiveEnvironment()~ public method.
+~onEnvironmentFilterChanged()~ slot.  Full item list cached; visible list
+filtered.
+
+** Item 8 — Add ~--environment~ to CommandLineParser
+
+Files: ~CommandLineParser.hpp~, ~CommandLineParser.cpp~.
+Add option; add ~environmentName() const -> QString~ accessor.
+
+** Item 9 — Wire ~--environment~ in main.cpp / MainWindow
+
+Files: ~main.cpp~, ~MainWindow.cpp~.
+~setEnvironmentContext(QString)~ method on ~MainWindow~; stores
+~activeEnvironmentName_~, looks up UUID, updates title, pre-selects filter.
+
+** Item 10 — Update updateWindowTitle()
+
+File: ~MainWindow.cpp~.
+Append ~{envName}~ when ~activeEnvironmentName_~ is set, before ~[instanceName]~.
+
+* Non-goals
+
+- Colour field on ~environment~ (can be added later; ~--instance-color~ covers
+  the immediate need).
+- UUID argument support for ~--environment~.
+- Persisting the last-used filter across sessions.
+- Server-side environment discovery.
+- Immediate removal of the ~folder~ table from the schema (leave it; clean up
+  later once confirmed unused).
+
+* Open Questions
+
+- Many-to-one vs many-to-many for instance → environment: current proposal is
+  many-to-one (each instance belongs to at most one environment).  No known
+  use case for an instance belonging to multiple tiers.
+
+- Should the environment filter appear when there is exactly one environment?
+  Current proposal: only when ≥2 environments are defined.  Could always show
+  it once any environment is defined, for consistency.
+
+- Should deleting an environment cascade-delete its instances, or unassign them
+  (set ~instance.environment_id = null~)?  Proposal: unassign, so bookmarks are
+  not silently lost.

--- a/doc/plans/2026-05-15-ore-import-error-reporting.org
+++ b/doc/plans/2026-05-15-ore-import-error-reporting.org
@@ -1,6 +1,25 @@
 #+title: ORE Import Error Reporting and Step Warning State
 #+date: 2026-05-15
 #+author: Marco Craveiro
+#+STATUS: COMPLETE
+
+* Status
+
+All six items are implemented on ~feature/workflow-step-log~.  The root-cause
+permission error noted in "What This Does NOT Fix" is also resolved — Phase 3a
+on ~feature/dq-publish-pattern-microservices~ replaced the direct DQ DB access
+in ~trade_status_service~ with a NATS call to ~dq.v1.fsm-transitions.list~,
+eliminating the ~permission denied for table ores_dq_fsm_transitions_tbl~ error.
+
+| Item | Description                                      | Status   |
+|------+--------------------------------------------------+----------|
+|    1 | ~step_outcome~ tri-state enum + DB FSM state     | DONE     |
+|    2 | ~step_log_entry~ + ~step_log_json~ column        | DONE     |
+|    3 | ~ore_import_execute~ handler: outcome + log      | DONE     |
+|    4 | Workflow detail dialog: step log panel           | DONE     |
+|    5 | ~WorkflowStepsWidget~: warning badge             | DONE     |
+|    6 | ~OreImportWizard~ done page: import summary      | DONE     |
+| n/a  | Root-cause fix: FSM transitions via NATS         | DONE     |
 
 * Problem
 

--- a/external/ore/examples/Products/SupportedTrades/FX_Forward_Invalid.xml
+++ b/external/ore/examples/Products/SupportedTrades/FX_Forward_Invalid.xml
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Deliberately invalid sample: BoughtAmount=0 violates the DB check constraint
+     (bought_amount > 0) on ores_trading_fx_forward_instruments_tbl.
+     Used to verify that per-item instrument errors surface in the workflow
+     step log panel after a partially-failed import. -->
+<Portfolio>
+    <Trade id="FXFWD_INVALID_ZERO_AMOUNT">
+        <TradeType>FxForward</TradeType>
+        <Envelope>
+            <CounterParty>CPTY</CounterParty>
+            <NettingSetId>NS</NettingSetId>
+            <AdditionalFields>
+                <party_id>party</party_id>
+                <valuation_date>2025-02-10</valuation_date>
+            </AdditionalFields>
+        </Envelope>
+        <FxForwardData>
+            <ValueDate>2033-02-20</ValueDate>
+            <BoughtCurrency>EUR</BoughtCurrency>
+            <BoughtAmount>0</BoughtAmount>
+            <SoldCurrency>USD</SoldCurrency>
+            <SoldAmount>0</SoldAmount>
+            <Settlement>Cash</Settlement>
+            <SettlementData>
+                <Currency>USD</Currency>
+                <FXIndex>FX-TR20H-EUR-USD</FXIndex>
+                <Date>2033-02-24</Date>
+                <Rules>
+                    <PaymentLag>2D</PaymentLag>
+                    <PaymentCalendar>USD</PaymentCalendar>
+                    <PaymentConvention>Following</PaymentConvention>
+                </Rules>
+            </SettlementData>
+        </FxForwardData>
+    </Trade>
+</Portfolio>

--- a/projects/modeling/system_model.org
+++ b/projects/modeling/system_model.org
@@ -105,68 +105,18 @@ Each domain service runs as a dedicated PostgreSQL role
 tables (~ores_<service>_*~). This is the strict service table isolation
 invariant.
 
-** Cross-component validation functions
+** Service table isolation
 
-Service table triggers call validator functions that must read across service
-boundaries. These functions are defined as ~SECURITY DEFINER~ with
-~SET search_path = public, pg_temp~ so they execute as the DDL owner, not as
-the calling service user. No cross-component ~SELECT~ grant is needed on the
-calling service user.
-
-Two categories:
-
-*** Shared validators (called from every service)
-
-- ~ores_iam_validate_tenant_fn~ — validates ~tenant_id~ on every INSERT/UPDATE
-  across all service components.  Lives in ~iam_tenant_functions_create.sql~.
-- ~ores_dq_validate_change_reason_fn~ — validates ~change_reason_code~ on
-  every INSERT/UPDATE across all service components.  Lives in
-  ~dq_change_reason_functions_create.sql~.
-
-This means no service user needs ~SELECT ON ores_iam_tenants_tbl~ or
-~SELECT ON ores_dq_change_reasons_tbl~.
-
-*** Per-table soft-FK validators (called from one service's trigger)
-
-Trigger functions that enforce referential integrity against a table owned by
-another service must also be ~SECURITY DEFINER~.  The canonical example:
-
-- ~ores_iam_account_parties_insert_fn~ — validates ~party_id~ exists in
-  ~ores_refdata_parties_tbl~ before inserting an account-party link.  Lives in
-  ~iam_account_party_create.sql~.
-
-*Rule:* any trigger function body that contains a ~SELECT~ from
-~ores_<other_service>_*~ must be declared ~SECURITY DEFINER SET search_path =
-public, pg_temp~.  Never add a cross-component ~SELECT~ grant to a service user
-to satisfy a trigger check; use ~SECURITY DEFINER~ instead.
-
-** Foreign keys across service boundaries
-
-PostgreSQL FK constraint enforcement does /not/ require the session user
-to hold ~SELECT~ on the referenced table.  The ~REFERENCES~ privilege needed
-to /create/ a FK is granted to the DDL user; at runtime, the FK check is
-system-internal.  Service users therefore need no cross-component ~SELECT~
-grant solely because of FK constraints.
-
-** Remaining cross-component grants
-
-All tracked cross-component grants have been removed. The strict service table
-isolation invariant is fully enforced:
-
-| Grant                                          | Owner    | Plan phase | Status   |
-|------------------------------------------------+----------+------------+----------|
-| DML on ~ores_refdata_parties~                  | IAM      | 4.3        | REMOVED  |
-| DML on ~ores_iam_*~ and ~ores_refdata_parties~ | Workflow | 5.2        | REMOVED  |
-| DML on ~ores_workflow_*~                       | ORE      | 5.3        | REMOVED  |
-
-See
-[[file:../doc/plans/2026-05-13-cross-service-write-decoupling.org][cross-service-write-decoupling.org]]
-for implementation details.
+Each domain service user holds DML only on its own ~ores_<service>_*~ tables.
+Cross-service reads inside trigger functions use ~SECURITY DEFINER~; cross-service
+writes go through NATS. All tracked cross-component grants have been removed.
 
 The synthetic service holds broad SELECT on all domains and is classified
 as ~role: "tooling"~ — a permanent exception, not a service.
 
-See [[file:../doc/plans/2026-05-12-strict-service-table-isolation.org][strict-service-table-isolation.org]] for the full migration plan.
+Full rules, patterns, and examples are in the
+[[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ORE Studio SQL Schema]] document
+under "Service Table Isolation".
 
 * Useful Pages
 

--- a/projects/modeling/system_model.org
+++ b/projects/modeling/system_model.org
@@ -107,9 +107,15 @@ invariant.
 
 ** Cross-component validation functions
 
-Service table triggers call shared validator functions for tenant and
-change-reason validation. These functions are defined as ~SECURITY DEFINER~
-so they execute as the DDL owner, not as the calling service user:
+Service table triggers call validator functions that must read across service
+boundaries. These functions are defined as ~SECURITY DEFINER~ with
+~SET search_path = public, pg_temp~ so they execute as the DDL owner, not as
+the calling service user. No cross-component ~SELECT~ grant is needed on the
+calling service user.
+
+Two categories:
+
+*** Shared validators (called from every service)
 
 - ~ores_iam_validate_tenant_fn~ — validates ~tenant_id~ on every INSERT/UPDATE
   across all service components.  Lives in ~iam_tenant_functions_create.sql~.
@@ -118,8 +124,21 @@ so they execute as the DDL owner, not as the calling service user:
   ~dq_change_reason_functions_create.sql~.
 
 This means no service user needs ~SELECT ON ores_iam_tenants_tbl~ or
-~SELECT ON ores_dq_change_reasons_tbl~ — FK enforcement and trigger
-validation work without those grants.
+~SELECT ON ores_dq_change_reasons_tbl~.
+
+*** Per-table soft-FK validators (called from one service's trigger)
+
+Trigger functions that enforce referential integrity against a table owned by
+another service must also be ~SECURITY DEFINER~.  The canonical example:
+
+- ~ores_iam_account_parties_insert_fn~ — validates ~party_id~ exists in
+  ~ores_refdata_parties_tbl~ before inserting an account-party link.  Lives in
+  ~iam_account_party_create.sql~.
+
+*Rule:* any trigger function body that contains a ~SELECT~ from
+~ores_<other_service>_*~ must be declared ~SECURITY DEFINER SET search_path =
+public, pg_temp~.  Never add a cross-component ~SELECT~ grant to a service user
+to satisfy a trigger check; use ~SECURITY DEFINER~ instead.
 
 ** Foreign keys across service boundaries
 
@@ -131,18 +150,18 @@ grant solely because of FK constraints.
 
 ** Remaining cross-component grants
 
-The following grants are genuine architectural coupling and are tracked
-in the deferred plan for eventual removal:
+All tracked cross-component grants have been removed. The strict service table
+isolation invariant is fully enforced:
 
-| Grant                                          | Owner    | Plan phase |
-|------------------------------------------------+----------+------------|
-| DML on ~ores_refdata_parties~                  | IAM      | 4.3        |
-| DML on ~ores_iam_*~ and ~ores_refdata_parties~ | Workflow | 5.2        |
-| DML on ~ores_workflow_*~                       | ORE      | 5.3        |
+| Grant                                          | Owner    | Plan phase | Status   |
+|------------------------------------------------+----------+------------+----------|
+| DML on ~ores_refdata_parties~                  | IAM      | 4.3        | REMOVED  |
+| DML on ~ores_iam_*~ and ~ores_refdata_parties~ | Workflow | 5.2        | REMOVED  |
+| DML on ~ores_workflow_*~                       | ORE      | 5.3        | REMOVED  |
 
-Phases 2.1, 2.2, and 3 of the isolation plan are complete. The three
-remaining items require NATS write APIs and are tracked separately in
-[[file:../doc/plans/2026-05-13-cross-service-write-decoupling.org][cross-service-write-decoupling.org]].
+See
+[[file:../doc/plans/2026-05-13-cross-service-write-decoupling.org][cross-service-write-decoupling.org]]
+for implementation details.
 
 The synthetic service holds broad SELECT on all domains and is classified
 as ~role: "tooling"~ — a permanent exception, not a service.

--- a/projects/ores.compute.service/src/app/batch_workflow_bridge.cpp
+++ b/projects/ores.compute.service/src/app/batch_workflow_bridge.cpp
@@ -81,7 +81,7 @@ void batch_workflow_bridge::poll_once() {
             ores::workflow::messaging::step_completed_event evt;
             evt.workflow_instance_id = link.workflow_instance_id;
             evt.step_id              = link.workflow_step_id;
-            evt.success              = true;
+            evt.outcome              = ores::workflow::messaging::step_outcome::completed;
             evt.result_json          = std::format(
                 R"({{"success":true,"batch_id":"{}","message":"Compute batch completed"}})",
                 batch_id);

--- a/projects/ores.iam.core/include/ores.iam.core/messaging/account_handler.hpp
+++ b/projects/ores.iam.core/include/ores.iam.core/messaging/account_handler.hpp
@@ -178,13 +178,15 @@ public:
             // Idempotency guard: replay cached result if this step already completed.
             if (auto cached = check_step_idempotency(nats_, step_id)) {
                 publish_step_completion(nats_, step_id, inst_id,
-                    cached->success, cached->result_json, cached->error_message);
+                    cached->outcome, cached->result_json, cached->error_message,
+                    cached->log);
                 return;
             }
 
             auto req = decode<save_account_request>(msg);
             if (!req) {
-                publish_step_completion(nats_, step_id, inst_id, false, "",
+                publish_step_completion(nats_, step_id, inst_id,
+                    ores::workflow::messaging::step_outcome::failed, "",
                     "Failed to decode save_account_request");
                 return;
             }
@@ -211,13 +213,15 @@ public:
                 const auto resp = save_account_response{
                     .success = true,
                     .account_id = boost::uuids::to_string(acct.id)};
-                publish_step_completion(nats_, step_id, inst_id, true,
+                publish_step_completion(nats_, step_id, inst_id,
+                    ores::workflow::messaging::step_outcome::completed,
                     rfl::json::write(resp), "");
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(account_handler_lg(), error)
                     << "Workflow step failed: " << msg.subject
                     << " — " << e.what();
-                publish_step_completion(nats_, step_id, inst_id, false, "", e.what());
+                publish_step_completion(nats_, step_id, inst_id,
+                    ores::workflow::messaging::step_outcome::failed, "", e.what());
             }
             return;
         }

--- a/projects/ores.iam.core/include/ores.iam.core/messaging/account_party_handler.hpp
+++ b/projects/ores.iam.core/include/ores.iam.core/messaging/account_party_handler.hpp
@@ -126,13 +126,15 @@ public:
             // Idempotency guard: replay cached result if this step already completed.
             if (auto cached = check_step_idempotency(nats_, step_id)) {
                 publish_step_completion(nats_, step_id, inst_id,
-                    cached->success, cached->result_json, cached->error_message);
+                    cached->outcome, cached->result_json, cached->error_message,
+                    cached->log);
                 return;
             }
 
             auto req = decode<save_account_party_request>(msg);
             if (!req) {
-                publish_step_completion(nats_, step_id, inst_id, false, "",
+                publish_step_completion(nats_, step_id, inst_id,
+                    ores::workflow::messaging::step_outcome::failed, "",
                     "Failed to decode save_account_party_request");
                 return;
             }
@@ -146,13 +148,15 @@ public:
                 }
                 BOOST_LOG_SEV(account_party_handler_lg(), debug)
                     << "Workflow step completed: " << msg.subject;
-                publish_step_completion(nats_, step_id, inst_id, true,
+                publish_step_completion(nats_, step_id, inst_id,
+                    ores::workflow::messaging::step_outcome::completed,
                     rfl::json::write(save_account_party_response{.success = true}), "");
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(account_party_handler_lg(), error)
                     << "Workflow step failed: " << msg.subject
                     << " — " << e.what();
-                publish_step_completion(nats_, step_id, inst_id, false, "", e.what());
+                publish_step_completion(nats_, step_id, inst_id,
+                    ores::workflow::messaging::step_outcome::failed, "", e.what());
             }
             return;
         }

--- a/projects/ores.ore.service/src/messaging/ore_import_execute_handler.cpp
+++ b/projects/ores.ore.service/src/messaging/ore_import_execute_handler.cpp
@@ -105,7 +105,8 @@ void ore_import_execute_handler::execute(ores::nats::message msg) {
     if (!parsed) {
         BOOST_LOG_SEV(lg(), error) << "ore.import.execute: failed to decode request | step="
                                    << step_id;
-        publish_step_completion(nats_, step_id, inst_id, false, "",
+        publish_step_completion(nats_, step_id, inst_id,
+            ores::workflow::messaging::step_outcome::failed, "",
             "Failed to decode ore_import_execute_request");
         return;
     }
@@ -143,7 +144,8 @@ void ore_import_execute_handler::execute(ores::nats::message msg) {
         const auto failure = std::format("fetch_and_unpack failed: {}", e.what());
         BOOST_LOG_SEV(lg(), error) << "ore.import.execute step 0 failed | corr="
                                    << req.correlation_id << " error=" << failure;
-        publish_step_completion(nats_, step_id, inst_id, false, "", failure);
+        publish_step_completion(nats_, step_id, inst_id,
+            ores::workflow::messaging::step_outcome::failed, "", failure);
         return;
     }
 
@@ -162,7 +164,8 @@ void ore_import_execute_handler::execute(ores::nats::message msg) {
         const auto failure = std::format("Directory scan failed: {}", e.what());
         BOOST_LOG_SEV(lg(), error) << "ore.import.execute step 1 failed | corr="
                                    << req.correlation_id << " error=" << failure;
-        publish_step_completion(nats_, step_id, inst_id, false, "", failure);
+        publish_step_completion(nats_, step_id, inst_id,
+            ores::workflow::messaging::step_outcome::failed, "", failure);
         return;
     }
 
@@ -186,7 +189,8 @@ void ore_import_execute_handler::execute(ores::nats::message msg) {
         if (!list_resp) {
             BOOST_LOG_SEV(lg(), error) << "ore.import.execute step 2 failed | corr="
                                        << req.correlation_id << " error=" << err;
-            publish_step_completion(nats_, step_id, inst_id, false, "", err);
+            publish_step_completion(nats_, step_id, inst_id,
+                ores::workflow::messaging::step_outcome::failed, "", err);
             return;
         }
         for (const auto& c : list_resp->currencies)
@@ -209,7 +213,8 @@ void ore_import_execute_handler::execute(ores::nats::message msg) {
                 parsed_choices.error().what());
             BOOST_LOG_SEV(lg(), error) << "ore.import.execute step 3 failed | corr="
                                        << req.correlation_id << " error=" << failure;
-            publish_step_completion(nats_, step_id, inst_id, false, "", failure);
+            publish_step_completion(nats_, step_id, inst_id,
+                ores::workflow::messaging::step_outcome::failed, "", failure);
             return;
         }
         choices = std::move(*parsed_choices);
@@ -224,7 +229,8 @@ void ore_import_execute_handler::execute(ores::nats::message msg) {
         const auto failure = std::format("Import plan failed: {}", e.what());
         BOOST_LOG_SEV(lg(), error) << "ore.import.execute step 3 failed | corr="
                                    << req.correlation_id << " error=" << failure;
-        publish_step_completion(nats_, step_id, inst_id, false, "", failure);
+        publish_step_completion(nats_, step_id, inst_id,
+            ores::workflow::messaging::step_outcome::failed, "", failure);
         return;
     }
 
@@ -252,7 +258,8 @@ void ore_import_execute_handler::execute(ores::nats::message msg) {
             BOOST_LOG_SEV(lg(), error) << "ore.import.execute step 4 failed | corr="
                                        << req.correlation_id
                                        << " iso_code=" << iso << " error=" << failure;
-            publish_step_completion(nats_, step_id, inst_id, false, "", failure);
+            publish_step_completion(nats_, step_id, inst_id,
+                ores::workflow::messaging::step_outcome::failed, "", failure);
             return;
         }
         result.saved_currency_iso_codes.push_back(iso);
@@ -280,7 +287,8 @@ void ore_import_execute_handler::execute(ores::nats::message msg) {
             BOOST_LOG_SEV(lg(), error) << "ore.import.execute step 5 failed | corr="
                                        << req.correlation_id
                                        << " portfolio=" << pid << " error=" << failure;
-            publish_step_completion(nats_, step_id, inst_id, false, "", failure);
+            publish_step_completion(nats_, step_id, inst_id,
+                ores::workflow::messaging::step_outcome::failed, "", failure);
             return;
         }
         result.saved_portfolio_ids.push_back(pid);
@@ -308,7 +316,8 @@ void ore_import_execute_handler::execute(ores::nats::message msg) {
             BOOST_LOG_SEV(lg(), error) << "ore.import.execute step 6 failed | corr="
                                        << req.correlation_id
                                        << " book=" << bid << " error=" << failure;
-            publish_step_completion(nats_, step_id, inst_id, false, "", failure);
+            publish_step_completion(nats_, step_id, inst_id,
+                ores::workflow::messaging::step_outcome::failed, "", failure);
             return;
         }
         result.saved_book_ids.push_back(bid);
@@ -545,20 +554,68 @@ void ore_import_execute_handler::execute(ores::nats::message msg) {
                               << " instruments_saved=" << instruments_saved;
 
     // -------------------------------------------------------------------------
-    // Done — publish result
+    // Done — determine step outcome and publish
     // -------------------------------------------------------------------------
-    result.success = true;
-    result.message = "ORE import completed.";
+    // Total failure: all planned trades failed to save (and at least one was attempted).
+    // Adjust this constant to change the threshold for saga compensation.
+    const bool all_trades_failed =
+        !plan.trades.empty() &&
+        result.saved_trade_ids.empty() &&
+        !result.item_errors.empty();
+
+    using wf_outcome = ores::workflow::messaging::step_outcome;
+    using wf_log_level = ores::workflow::messaging::step_log_level;
+    using wf_log_entry = ores::workflow::messaging::step_log_entry;
+
+    wf_outcome outcome;
+    if (result.item_errors.empty()) {
+        outcome = wf_outcome::completed;
+    } else if (all_trades_failed) {
+        outcome = wf_outcome::failed;
+    } else {
+        outcome = wf_outcome::completed_with_warnings;
+    }
+
+    std::vector<wf_log_entry> step_log;
+    if (!result.saved_trade_ids.empty()) {
+        step_log.push_back({
+            .level = wf_log_level::info,
+            .message = std::format("Saved {} trade(s).",
+                result.saved_trade_ids.size()),
+            .context = {}});
+    }
+    for (const auto& ie : result.item_errors) {
+        step_log.push_back({
+            .level = (outcome == wf_outcome::failed)
+                ? wf_log_level::error : wf_log_level::warn,
+            .message = ie.message,
+            .context = ie.item_id.empty() ? ie.source_file : ie.item_id});
+    }
+
+    result.success = outcome != wf_outcome::failed;
+    result.message = result.item_errors.empty()
+        ? "ORE import completed."
+        : std::format("ORE import completed with {} error(s).",
+            result.item_errors.size());
 
     BOOST_LOG_SEV(lg(), info) << "ore.import.execute complete | corr=" << req.correlation_id
                               << " currencies=" << result.saved_currency_iso_codes.size()
                               << " portfolios=" << result.saved_portfolio_ids.size()
                               << " books=" << result.saved_book_ids.size()
                               << " trades=" << result.saved_trade_ids.size()
-                              << " item_errors=" << result.item_errors.size();
+                              << " item_errors=" << result.item_errors.size()
+                              << " outcome=" << ores::workflow::messaging::to_string(outcome);
 
-    publish_step_completion(nats_, step_id, inst_id, true,
-        rfl::json::write(result), "");
+    if (outcome == wf_outcome::failed) {
+        publish_step_completion(nats_, step_id, inst_id,
+            wf_outcome::failed, rfl::json::write(result),
+            std::format("All {} trade save(s) failed.",
+                result.item_errors.size()),
+            step_log);
+    } else {
+        publish_step_completion(nats_, step_id, inst_id,
+            outcome, rfl::json::write(result), "", step_log);
+    }
 }
 
 void ore_import_execute_handler::rollback(ores::nats::message msg) {
@@ -573,7 +630,8 @@ void ore_import_execute_handler::rollback(ores::nats::message msg) {
     if (!parsed) {
         BOOST_LOG_SEV(lg(), error) << "ore.import.rollback: failed to decode request | step="
                                    << step_id;
-        publish_step_completion(nats_, step_id, inst_id, false, "",
+        publish_step_completion(nats_, step_id, inst_id,
+            ores::workflow::messaging::step_outcome::failed, "",
             "Failed to decode ore_import_rollback_request");
         return;
     }
@@ -652,7 +710,8 @@ void ore_import_execute_handler::rollback(ores::nats::message msg) {
     }
 
     BOOST_LOG_SEV(lg(), info) << "ore.import.rollback complete | corr=" << req.correlation_id;
-    publish_step_completion(nats_, step_id, inst_id, true, "{\"success\":true}", "");
+    publish_step_completion(nats_, step_id, inst_id,
+        ores::workflow::messaging::step_outcome::completed, "{\"success\":true}", "");
 }
 
 }

--- a/projects/ores.qt.api/include/ores.qt/ClientManager.hpp
+++ b/projects/ores.qt.api/include/ores.qt/ClientManager.hpp
@@ -201,8 +201,12 @@ public:
 
     /**
      * @brief Logout the current user without disconnecting.
+     *
+     * @param timeout  How long to wait for the server acknowledgement.
+     *                 Pass a short value (e.g. 3 s) when called from
+     *                 disconnect() so the UI does not block on a dead server.
      */
-    bool logout();
+    bool logout(std::chrono::milliseconds timeout = std::chrono::seconds(30));
 
     /**
      * @brief Check if currently connected.

--- a/projects/ores.qt.api/src/ClientManager.cpp
+++ b/projects/ores.qt.api/src/ClientManager.cpp
@@ -528,7 +528,7 @@ void ClientManager::disconnect() {
         QMetaObject::invokeMethod(refresh_timer_, &QTimer::stop, Qt::QueuedConnection);
     nats_subscriptions_.clear();
     if (session_.is_logged_in()) {
-        logout();
+        logout(std::chrono::seconds(3));
     }
     if (session_.is_connected()) {
         session_.disconnect();
@@ -549,14 +549,15 @@ void ClientManager::disconnect() {
     QMetaObject::invokeMethod(this, "disconnected", Qt::QueuedConnection);
 }
 
-bool ClientManager::logout() {
+bool ClientManager::logout(std::chrono::milliseconds timeout) {
     BOOST_LOG_SEV(lg(), info) << "Logging out";
     if (!session_.is_logged_in()) {
         return false;
     }
 
     try {
-        auto result = process_authenticated_request(iam::messaging::logout_request{});
+        auto result = process_authenticated_request(
+            iam::messaging::logout_request{}, timeout);
         session_.clear_auth();
         http_base_url_.clear();
         return result && result->success;

--- a/projects/ores.qt.trading/include/ores.qt/OreImportWizard.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/OreImportWizard.hpp
@@ -42,6 +42,7 @@
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/WorkflowStepsWidget.hpp"
+#include "ores.qt/WorkflowStepLogWidget.hpp"
 #include "ores.ore.core/scanner/scan_result.hpp"
 #include "ores.ore.core/planner/import_choices.hpp"
 #include "ores.ore.core/planner/ore_import_plan.hpp"
@@ -324,6 +325,7 @@ public:
 
 private slots:
     void onStepFailed(int stepIndex, const QString& errorMessage);
+    void onWorkflowCompleted(bool success);
 
 private:
     OreImportWizard* wizard_;
@@ -338,6 +340,9 @@ private:
 
     // Live step progress — shown only for async (workflow-backed) imports.
     WorkflowStepsWidget* stepsWidget_ = nullptr;
+
+    // Per-item import log — shown after workflow completes when there are warnings.
+    WorkflowStepLogWidget* importLogWidget_ = nullptr;
 };
 
 }

--- a/projects/ores.qt.trading/src/OreImportWizard.cpp
+++ b/projects/ores.qt.trading/src/OreImportWizard.cpp
@@ -984,7 +984,16 @@ OreDonePage::OreDonePage(OreImportWizard* wizard)
     stepsWidget_->hide();
     connect(stepsWidget_, &WorkflowStepsWidget::stepFailed,
             this, &OreDonePage::onStepFailed);
+    connect(stepsWidget_, &WorkflowStepsWidget::instanceReachedTerminalState,
+            this, &OreDonePage::onWorkflowCompleted);
     layout->addWidget(stepsWidget_);
+
+    // Per-item import log — populated and shown after workflow completes with warnings.
+    importLogWidget_ = new WorkflowStepLogWidget(this);
+    importLogWidget_->setSizePolicy(
+        QSizePolicy::Expanding, QSizePolicy::Preferred);
+    importLogWidget_->hide();
+    layout->addWidget(importLogWidget_);
 
     layout->addStretch();
 }
@@ -996,6 +1005,8 @@ void OreDonePage::initializePage() {
     correlIdRow_->hide();
     errorBanner_->hide();
     stepsWidget_->hide();
+    importLogWidget_->hide();
+    importLogWidget_->clear();
 
     if (wizard_->importSuccess()) {
         QString html;
@@ -1064,6 +1075,59 @@ void OreDonePage::onStepFailed(int stepIndex, const QString& errorMessage) {
     errorBanner_->setText(
         tr("Step %1 failed: %2").arg(stepIndex + 1).arg(errorMessage));
     errorBanner_->show();
+}
+
+void OreDonePage::onWorkflowCompleted(bool success) {
+    namespace wf = ores::workflow::messaging;
+
+    // Scan all steps for saved-trade count (info entries) and issues (warn/error).
+    int saved_count = 0;
+    std::vector<wf::step_log_entry> issues;
+
+    for (const auto& step : stepsWidget_->steps()) {
+        for (const auto& entry : step.log) {
+            if (entry.level == wf::step_log_level::info) {
+                // Info messages from ore_import_execute read "Saved N trade(s)."
+                const auto msg = QString::fromStdString(entry.message);
+                if (msg.startsWith(QStringLiteral("Saved "))) {
+                    const auto parts = msg.split(QLatin1Char(' '));
+                    if (parts.size() >= 2)
+                        saved_count += parts[1].toInt();
+                }
+            } else {
+                issues.push_back(entry);
+            }
+        }
+    }
+
+    const int M = static_cast<int>(issues.size());
+
+    QString html;
+    if (success && M == 0) {
+        html = tr("<p><b>Imported %1 trade(s) successfully.</b></p>")
+            .arg(saved_count);
+        html += tr("<p>The data is now available in the Portfolio Explorer.</p>");
+    } else if (success) {
+        html = tr("<p><b>Imported %1 trade(s) with %2 warning(s).</b></p>")
+            .arg(saved_count).arg(M);
+        html += tr("<p>See the import log below for details.</p>");
+    } else {
+        if (saved_count > 0) {
+            html = tr("<p><b>Import partially failed — "
+                      "%1 trade(s) saved, %2 failed.</b></p>")
+                .arg(saved_count).arg(M);
+        } else {
+            html = tr("<p><b>Import failed — "
+                      "%1 trade save(s) failed.</b></p>").arg(M);
+        }
+        html += tr("<p>See the import log below for details.</p>");
+    }
+    summaryLabel_->setText(html);
+
+    if (!issues.empty()) {
+        importLogWidget_->showLog(tr("Import"), issues);
+        importLogWidget_->show();
+    }
 }
 
 }

--- a/projects/ores.qt.workflow/include/ores.qt/WorkflowInstanceDetailDialog.hpp
+++ b/projects/ores.qt.workflow/include/ores.qt/WorkflowInstanceDetailDialog.hpp
@@ -24,6 +24,7 @@
 #include "ores.qt/ClientManager.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.qt/WorkflowStepsWidget.hpp"
+#include "ores.qt/WorkflowStepLogWidget.hpp"
 
 namespace ores::qt {
 
@@ -69,6 +70,7 @@ private:
 
     QLabel* statusLabel_;
     WorkflowStepsWidget* stepsWidget_;
+    WorkflowStepLogWidget* logWidget_;
 };
 
 }  // namespace ores::qt

--- a/projects/ores.qt.workflow/include/ores.qt/WorkflowMdiWindow.hpp
+++ b/projects/ores.qt.workflow/include/ores.qt/WorkflowMdiWindow.hpp
@@ -151,6 +151,7 @@ private:
     // Async fetch — steps
     QFutureWatcher<StepsFetchResult>* stepsWatcher_;
     QString selectedInstanceId_;
+    std::vector<ores::workflow::messaging::workflow_step_summary> currentSteps_;
 };
 
 }

--- a/projects/ores.qt.workflow/include/ores.qt/WorkflowStepLogWidget.hpp
+++ b/projects/ores.qt.workflow/include/ores.qt/WorkflowStepLogWidget.hpp
@@ -24,7 +24,7 @@
 #include <QWidget>
 #include <QTableWidget>
 #include "ores.qt/WorkflowExport.hpp"
-#include "ores.workflow.api/messaging/workflow_events.hpp"
+#include "ores.workflow.api/messaging/step_log_types.hpp"
 
 namespace ores::qt {
 

--- a/projects/ores.qt.workflow/include/ores.qt/WorkflowStepLogWidget.hpp
+++ b/projects/ores.qt.workflow/include/ores.qt/WorkflowStepLogWidget.hpp
@@ -1,0 +1,67 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_WORKFLOW_STEP_LOG_WIDGET_HPP
+#define ORES_QT_WORKFLOW_STEP_LOG_WIDGET_HPP
+
+#include <vector>
+#include <QLabel>
+#include <QWidget>
+#include <QTableWidget>
+#include "ores.qt/WorkflowExport.hpp"
+#include "ores.workflow.api/messaging/workflow_events.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief Panel showing structured log entries for a single workflow step.
+ *
+ * Displays one row per step_log_entry with colour-coded level badge,
+ * message text, and optional context field.  Populated via showLog()
+ * whenever the user selects a step in WorkflowStepsWidget.
+ */
+class ORES_QT_WORKFLOW_EXPORT WorkflowStepLogWidget final : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit WorkflowStepLogWidget(QWidget* parent = nullptr);
+
+    /**
+     * @brief Populate the panel with log entries from the named step.
+     *
+     * Replaces any previously displayed entries.  If entries is empty a
+     * placeholder row is shown.
+     */
+    void showLog(const QString& stepName,
+        const std::vector<ores::workflow::messaging::step_log_entry>& entries);
+
+    /**
+     * @brief Reset to the "no step selected" placeholder state.
+     */
+    void clear();
+
+private:
+    void setupUi();
+
+    QLabel* headerLabel_;
+    QTableWidget* logTable_;
+};
+
+}  // namespace ores::qt
+
+#endif

--- a/projects/ores.qt.workflow/include/ores.qt/WorkflowStepsWidget.hpp
+++ b/projects/ores.qt.workflow/include/ores.qt/WorkflowStepsWidget.hpp
@@ -86,6 +86,14 @@ public:
      */
     void setMaxVisibleSteps(int n);
 
+    /**
+     * @brief Returns the most recently fetched step summaries (including log).
+     *
+     * Empty until the first successful fetch completes.
+     */
+    const std::vector<ores::workflow::messaging::workflow_step_summary>&
+    steps() const { return currentSteps_; }
+
 signals:
     /**
      * @brief Emitted once when the bound instance enters a terminal state.

--- a/projects/ores.qt.workflow/include/ores.qt/WorkflowStepsWidget.hpp
+++ b/projects/ores.qt.workflow/include/ores.qt/WorkflowStepsWidget.hpp
@@ -90,8 +90,8 @@ signals:
     /**
      * @brief Emitted once when the bound instance enters a terminal state.
      *
-     * @p success is true if all steps completed successfully; false if any
-     * step failed or the instance was compensated.
+     * @p success is true if all steps completed successfully or with
+     * warnings; false if any step failed or the instance was compensated.
      */
     void instanceReachedTerminalState(bool success);
 
@@ -102,6 +102,14 @@ signals:
      * refreshes — callers should de-duplicate by stepIndex if needed.
      */
     void stepFailed(int stepIndex, const QString& errorMessage);
+
+    /**
+     * @brief Emitted when the user selects a step row.
+     *
+     * Carries the full step summary so the parent dialog can display its
+     * structured log in WorkflowStepLogWidget.
+     */
+    void stepSelected(const ores::workflow::messaging::workflow_step_summary& step);
 
 private slots:
     void onFetchFinished();
@@ -119,6 +127,7 @@ private:
     QFutureWatcher<FetchResult>* watcher_;
     int maxVisibleSteps_ = -1;
     bool terminalReached_ = false;
+    std::vector<ores::workflow::messaging::workflow_step_summary> currentSteps_;
 };
 
 }  // namespace ores::qt

--- a/projects/ores.qt.workflow/src/WorkflowInstanceDetailDialog.cpp
+++ b/projects/ores.qt.workflow/src/WorkflowInstanceDetailDialog.cpp
@@ -20,6 +20,7 @@
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
+#include <QSplitter>
 #include <QDialogButtonBox>
 
 namespace ores::qt {
@@ -36,14 +37,15 @@ WorkflowInstanceDetailDialog::WorkflowInstanceDetailDialog(
     , workflowType_(workflowType)
     , workflowStatus_(workflowStatus)
     , statusLabel_(nullptr)
-    , stepsWidget_(nullptr) {
+    , stepsWidget_(nullptr)
+    , logWidget_(nullptr) {
 
     setupUi();
     setWindowTitle(tr("Workflow: %1").arg(workflowType_));
 }
 
 void WorkflowInstanceDetailDialog::setupUi() {
-    setMinimumSize(700, 450);
+    setMinimumSize(750, 600);
 
     auto* layout = new QVBoxLayout(this);
 
@@ -66,9 +68,25 @@ void WorkflowInstanceDetailDialog::setupUi() {
     headerLayout->addStretch();
     layout->addLayout(headerLayout);
 
-    // ── Steps widget ──────────────────────────────────────────────────────────
-    stepsWidget_ = new WorkflowStepsWidget(clientManager_, this);
-    layout->addWidget(stepsWidget_);
+    // ── Steps + log splitter ──────────────────────────────────────────────────
+    auto* splitter = new QSplitter(Qt::Vertical, this);
+
+    stepsWidget_ = new WorkflowStepsWidget(clientManager_, splitter);
+    splitter->addWidget(stepsWidget_);
+
+    logWidget_ = new WorkflowStepLogWidget(splitter);
+    splitter->addWidget(logWidget_);
+
+    splitter->setStretchFactor(0, 2);
+    splitter->setStretchFactor(1, 1);
+
+    layout->addWidget(splitter);
+
+    connect(stepsWidget_, &WorkflowStepsWidget::stepSelected,
+        this, [this](const ores::workflow::messaging::workflow_step_summary& step) {
+            logWidget_->showLog(
+                QString::fromStdString(step.name), step.log);
+        });
 
     // ── Buttons ───────────────────────────────────────────────────────────────
     auto* buttons = new QDialogButtonBox(QDialogButtonBox::Close, this);

--- a/projects/ores.qt.workflow/src/WorkflowMdiWindow.cpp
+++ b/projects/ores.qt.workflow/src/WorkflowMdiWindow.cpp
@@ -79,6 +79,7 @@ enum class Col {
     Steps,
     CreatedBy,
     CreatedAt,
+    CompletedAt,
     WorkflowId,
     Count
 };
@@ -363,7 +364,7 @@ void WorkflowMdiWindow::setupExecutionListTab(QWidget* tab) {
     instanceTable_ = new QTableWidget(0, static_cast<int>(Col::Count), tab);
     instanceTable_->setHorizontalHeaderLabels(
         {tr("Status"), tr("Type"), tr("Steps"),
-         tr("Created By"), tr("Created At"), tr("Workflow ID")});
+         tr("Created By"), tr("Created At"), tr("Completed At"), tr("Workflow ID")});
     instanceTable_->horizontalHeader()->setSectionResizeMode(
         QHeaderView::ResizeToContents);
     instanceTable_->horizontalHeader()->setStretchLastSection(true);
@@ -587,6 +588,11 @@ void WorkflowMdiWindow::populateExecutionList(
 
         instanceTable_->setItem(row, static_cast<int>(Col::CreatedAt),
             make_item(QString::fromStdString(inst.created_at)));
+
+        instanceTable_->setItem(row, static_cast<int>(Col::CompletedAt),
+            make_item(inst.completed_at
+                ? QString::fromStdString(*inst.completed_at)
+                : QStringLiteral("—")));
 
         instanceTable_->setItem(row, static_cast<int>(Col::WorkflowId),
             make_item(id));

--- a/projects/ores.qt.workflow/src/WorkflowMdiWindow.cpp
+++ b/projects/ores.qt.workflow/src/WorkflowMdiWindow.cpp
@@ -19,6 +19,7 @@
 #include "ores.qt/WorkflowMdiWindow.hpp"
 
 #include <algorithm>
+#include "ores.qt/WorkflowStepLogWidget.hpp"
 #include <QCloseEvent>
 #include <QDialog>
 #include <QDialogButtonBox>
@@ -68,8 +69,7 @@ enum ItemRole {
     BadgeTagRole   = Qt::UserRole,
     BadgeColorRole = Qt::UserRole + 1,
     InstanceIdRole = Qt::UserRole + 2,
-    ErrorDetailRole = Qt::UserRole + 3,
-    CorrIdRole     = Qt::UserRole + 4,
+    CorrIdRole     = Qt::UserRole + 3,
 };
 
 // Execution list table columns
@@ -168,12 +168,16 @@ QString display_status(const QString& status) {
     if (status == QStringLiteral("compensating") ||
         status == QStringLiteral("compensated"))
         return QStringLiteral("Failed");
+    if (status == QStringLiteral("completed_with_warnings"))
+        return QStringLiteral("Warnings");
     return status;
 }
 
 QColor status_color(const QString& status) {
     if (status == QStringLiteral("completed"))
         return color_constants::level_info;
+    if (status == QStringLiteral("completed_with_warnings"))
+        return color_constants::level_warn;
     if (status == QStringLiteral("failed") ||
         status == QStringLiteral("compensating") ||
         status == QStringLiteral("compensated"))
@@ -656,6 +660,7 @@ void WorkflowMdiWindow::onStepsFetchFinished() {
 void WorkflowMdiWindow::populateSteps(
     const std::vector<wf::workflow_step_summary>& steps) {
 
+    currentSteps_ = steps;
     stepsTable_->setRowCount(0);
 
     for (const auto& step : steps) {
@@ -677,15 +682,10 @@ void WorkflowMdiWindow::populateSteps(
                 ? QString::fromStdString(*step.started_at)
                 : QStringLiteral("—")));
 
-        auto* completedItem = make_item(step.completed_at
-                ? QString::fromStdString(*step.completed_at)
-                : QStringLiteral("—"));
         stepsTable_->setItem(row, static_cast<int>(SCol::CompletedAt),
-            completedItem);
-
-        // Store full error text on the last visible item for the details dialog.
-        const QString fullError = QString::fromStdString(step.error);
-        completedItem->setData(ErrorDetailRole, fullError);
+            make_item(step.completed_at
+                ? QString::fromStdString(*step.completed_at)
+                : QStringLiteral("—")));
     }
 
     stepsTable_->resizeColumnsToContents();
@@ -724,6 +724,7 @@ void WorkflowMdiWindow::onInstanceSelectionChanged() {
     const int row = instanceTable_->currentRow();
     if (row < 0) {
         selectedInstanceId_.clear();
+        currentSteps_.clear();
         stepsTable_->setRowCount(0);
         stepsGroup_->setTitle(tr("Steps"));
         return;
@@ -748,15 +749,11 @@ void WorkflowMdiWindow::onInstanceSelectionChanged() {
 }
 
 void WorkflowMdiWindow::onStepDoubleClicked(int row, int /*col*/) {
-    // Error text is stored on the CompletedAt column item.
-    auto* dataItem = stepsTable_->item(row, static_cast<int>(SCol::CompletedAt));
-    if (!dataItem) return;
+    if (row < 0 || row >= static_cast<int>(currentSteps_.size())) return;
 
-    const QString fullError = dataItem->data(ErrorDetailRole).toString();
-
-    // Always show the dialog (even without an error) so the user can see step info.
-    auto* nameItem = stepsTable_->item(row, static_cast<int>(SCol::Name));
-    const QString stepName = nameItem ? nameItem->text() : QString{};
+    const auto& step = currentSteps_[static_cast<std::size_t>(row)];
+    const QString stepName = QString::fromStdString(step.name);
+    const QString fullError = QString::fromStdString(step.error);
 
     // Find correlation ID and workflow ID from the selected instance row.
     const int instRow = instanceTable_->currentRow();
@@ -772,7 +769,7 @@ void WorkflowMdiWindow::onStepDoubleClicked(int row, int /*col*/) {
     auto* dlg = new QDialog(nullptr);  // no parent → independent top-level window
     dlg->setAttribute(Qt::WA_DeleteOnClose);
     dlg->setWindowTitle(tr("Step details — %1").arg(stepName));
-    dlg->resize(760, 520);
+    dlg->resize(760, 600);
 
     auto* vbox = new QVBoxLayout(dlg);
 
@@ -796,14 +793,22 @@ void WorkflowMdiWindow::onStepDoubleClicked(int row, int /*col*/) {
 
     vbox->addLayout(form);
 
-    // ── Error message ─────────────────────────────────────────────────────────
-    vbox->addWidget(new QLabel(tr("Error:"), dlg));
-    const QFont fixed = QFontDatabase::systemFont(QFontDatabase::FixedFont);
-    auto* edit = new QPlainTextEdit(
-        fullError.isEmpty() ? tr("(no error)") : fullError, dlg);
-    edit->setReadOnly(true);
-    edit->setFont(fixed);
-    vbox->addWidget(edit);
+    // ── Step log ──────────────────────────────────────────────────────────────
+    auto* logWidget = new WorkflowStepLogWidget(dlg);
+    logWidget->showLog(stepName, step.log);
+    vbox->addWidget(logWidget, 1);
+
+    // ── Fatal error (only shown when non-empty) ───────────────────────────────
+    if (!fullError.isEmpty()) {
+        auto* errorLabel = new QLabel(tr("Fatal error:"), dlg);
+        vbox->addWidget(errorLabel);
+        const QFont fixed = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+        auto* edit = new QPlainTextEdit(fullError, dlg);
+        edit->setReadOnly(true);
+        edit->setFont(fixed);
+        edit->setMaximumHeight(100);
+        vbox->addWidget(edit);
+    }
 
     auto* buttons = new QDialogButtonBox(QDialogButtonBox::Close, dlg);
     connect(buttons, &QDialogButtonBox::rejected, dlg, &QDialog::accept);

--- a/projects/ores.qt.workflow/src/WorkflowStepLogWidget.cpp
+++ b/projects/ores.qt.workflow/src/WorkflowStepLogWidget.cpp
@@ -1,0 +1,198 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/WorkflowStepLogWidget.hpp"
+
+#include <QPainter>
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QApplication>
+#include <QStyledItemDelegate>
+#include <QStyleOptionViewItem>
+#include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/DelegatePaintUtils.hpp"
+
+namespace ores::qt {
+
+namespace wfev = ores::workflow::messaging;
+
+namespace {
+
+enum ItemRole {
+    BadgeTagRole   = Qt::UserRole,
+    BadgeColorRole = Qt::UserRole + 1,
+};
+
+enum class Col { Level = 0, Message, Context, Count };
+
+class LevelBadgeDelegate final : public QStyledItemDelegate {
+public:
+    explicit LevelBadgeDelegate(QObject* parent = nullptr)
+        : QStyledItemDelegate(parent) {}
+
+    void paint(QPainter* painter, const QStyleOptionViewItem& option,
+               const QModelIndex& index) const override {
+        if (index.data(BadgeTagRole).toString() != QStringLiteral("badge")) {
+            QStyledItemDelegate::paint(painter, option, index);
+            return;
+        }
+        QStyleOptionViewItem opt = option;
+        initStyleOption(&opt, index);
+        QApplication::style()->drawPrimitive(
+            QStyle::PE_PanelItemViewItem, &opt, painter);
+
+        const QString text = index.data(Qt::DisplayRole).toString();
+        const QColor  bg   = index.data(BadgeColorRole).value<QColor>();
+        const QColor  fg   = color_constants::level_text;
+
+        QFont badgeFont = opt.font;
+        badgeFont.setPointSize(qRound(badgeFont.pointSize() * 0.8));
+        badgeFont.setBold(true);
+        DelegatePaintUtils::draw_centered_badge(
+            painter, opt.rect, text, bg, fg, badgeFont);
+    }
+
+    QSize sizeHint(const QStyleOptionViewItem& option,
+                   const QModelIndex& index) const override {
+        QSize s = QStyledItemDelegate::sizeHint(option, index);
+        if (index.data(BadgeTagRole).toString() == QStringLiteral("badge"))
+            s = QSize(qMax(s.width(), 70), qMax(s.height(), 24));
+        return s;
+    }
+};
+
+QTableWidgetItem* make_badge_item(const QString& text, const QColor& bg) {
+    auto* item = new QTableWidgetItem(text);
+    item->setData(BadgeTagRole,   QStringLiteral("badge"));
+    item->setData(BadgeColorRole, bg);
+    item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+    return item;
+}
+
+QTableWidgetItem* make_item(const QString& text) {
+    auto* item = new QTableWidgetItem(text);
+    item->setTextAlignment(Qt::AlignVCenter | Qt::AlignLeft);
+    item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+    return item;
+}
+
+QColor level_color(wfev::step_log_level level) {
+    switch (level) {
+    case wfev::step_log_level::info:  return color_constants::level_info;
+    case wfev::step_log_level::warn:  return color_constants::level_warn;
+    case wfev::step_log_level::error: return color_constants::level_error;
+    }
+    return color_constants::level_debug;
+}
+
+QString level_label(wfev::step_log_level level) {
+    switch (level) {
+    case wfev::step_log_level::info:  return QStringLiteral("info");
+    case wfev::step_log_level::warn:  return QStringLiteral("warn");
+    case wfev::step_log_level::error: return QStringLiteral("error");
+    }
+    return QStringLiteral("?");
+}
+
+}  // namespace
+
+WorkflowStepLogWidget::WorkflowStepLogWidget(QWidget* parent)
+    : QWidget(parent)
+    , headerLabel_(nullptr)
+    , logTable_(nullptr) {
+    setupUi();
+}
+
+void WorkflowStepLogWidget::setupUi() {
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 4, 0, 0);
+
+    headerLabel_ = new QLabel(tr("Step log — select a step above to view its log"), this);
+    layout->addWidget(headerLabel_);
+
+    logTable_ = new QTableWidget(0, static_cast<int>(Col::Count), this);
+    logTable_->setHorizontalHeaderLabels(
+        {tr("Level"), tr("Message"), tr("Context")});
+    logTable_->horizontalHeader()->setSectionResizeMode(
+        static_cast<int>(Col::Level),   QHeaderView::ResizeToContents);
+    logTable_->horizontalHeader()->setSectionResizeMode(
+        static_cast<int>(Col::Message), QHeaderView::Stretch);
+    logTable_->horizontalHeader()->setSectionResizeMode(
+        static_cast<int>(Col::Context), QHeaderView::ResizeToContents);
+    logTable_->setSelectionBehavior(QAbstractItemView::SelectRows);
+    logTable_->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    logTable_->setAlternatingRowColors(true);
+    logTable_->setItemDelegate(new LevelBadgeDelegate(logTable_));
+    layout->addWidget(logTable_);
+}
+
+void WorkflowStepLogWidget::showLog(const QString& stepName,
+    const std::vector<wfev::step_log_entry>& entries) {
+
+    if (entries.empty()) {
+        headerLabel_->setText(
+            tr("Step log — %1 (no log entries)").arg(stepName));
+        logTable_->setRowCount(0);
+        return;
+    }
+
+    int warn_count  = 0;
+    int error_count = 0;
+    for (const auto& e : entries) {
+        if (e.level == wfev::step_log_level::warn)  ++warn_count;
+        if (e.level == wfev::step_log_level::error) ++error_count;
+    }
+
+    QString summary;
+    if (error_count > 0 && warn_count > 0)
+        summary = tr("%1 error(s), %2 warning(s)").arg(error_count).arg(warn_count);
+    else if (error_count > 0)
+        summary = tr("%1 error(s)").arg(error_count);
+    else if (warn_count > 0)
+        summary = tr("%1 warning(s)").arg(warn_count);
+    else
+        summary = tr("%1 info entr%2")
+            .arg(static_cast<int>(entries.size()))
+            .arg(entries.size() == 1 ? QStringLiteral("y") : QStringLiteral("ies"));
+
+    headerLabel_->setText(
+        tr("Step log — %1 (%2)").arg(stepName).arg(summary));
+
+    logTable_->setRowCount(static_cast<int>(entries.size()));
+
+    int row = 0;
+    for (const auto& entry : entries) {
+        logTable_->setItem(row, static_cast<int>(Col::Level),
+            make_badge_item(level_label(entry.level), level_color(entry.level)));
+        logTable_->setItem(row, static_cast<int>(Col::Message),
+            make_item(QString::fromStdString(entry.message)));
+        logTable_->setItem(row, static_cast<int>(Col::Context),
+            make_item(entry.context.empty()
+                ? QStringLiteral("—")
+                : QString::fromStdString(entry.context)));
+        ++row;
+    }
+}
+
+void WorkflowStepLogWidget::clear() {
+    headerLabel_->setText(
+        tr("Step log — select a step above to view its log"));
+    logTable_->setRowCount(0);
+}
+
+}  // namespace ores::qt

--- a/projects/ores.qt.workflow/src/WorkflowStepsWidget.cpp
+++ b/projects/ores.qt.workflow/src/WorkflowStepsWidget.cpp
@@ -18,6 +18,7 @@
  */
 #include "ores.qt/WorkflowStepsWidget.hpp"
 
+#include <algorithm>
 #include <QPainter>
 #include <QVBoxLayout>
 #include <QHeaderView>
@@ -44,6 +45,7 @@ enum class Col {
     Index = 0,
     Name,
     Status,
+    Warnings,
     StartedAt,
     CompletedAt,
     Error,
@@ -104,6 +106,8 @@ QTableWidgetItem* make_item(const QString& text) {
 QColor status_color(const QString& status) {
     if (status == QStringLiteral("completed"))
         return color_constants::level_info;
+    if (status == QStringLiteral("completed_with_warnings"))
+        return color_constants::level_warn;
     if (status == QStringLiteral("failed"))
         return color_constants::level_error;
     if (status == QStringLiteral("in_progress") ||
@@ -112,6 +116,15 @@ QColor status_color(const QString& status) {
     if (status == QStringLiteral("compensated"))
         return color_constants::level_debug;
     return color_constants::level_trace;
+}
+
+int count_issues(const std::vector<wf::workflow_step_summary>& steps, int row) {
+    const auto& log = steps[static_cast<std::size_t>(row)].log;
+    return static_cast<int>(std::count_if(log.begin(), log.end(),
+        [](const wf::step_log_entry& e) {
+            return e.level == wf::step_log_level::warn ||
+                   e.level == wf::step_log_level::error;
+        }));
 }
 
 constexpr int kRefreshIntervalMs = 3000;
@@ -146,7 +159,7 @@ void WorkflowStepsWidget::setupUi() {
 
     stepsTable_ = new QTableWidget(0, static_cast<int>(Col::Count), this);
     stepsTable_->setHorizontalHeaderLabels(
-        {tr("#"), tr("Name"), tr("Status"),
+        {tr("#"), tr("Name"), tr("Status"), tr("Warnings"),
          tr("Started At"), tr("Completed At"), tr("Error")});
     stepsTable_->horizontalHeader()->setSectionResizeMode(
         QHeaderView::ResizeToContents);
@@ -156,6 +169,16 @@ void WorkflowStepsWidget::setupUi() {
     stepsTable_->setAlternatingRowColors(true);
     stepsTable_->setItemDelegate(new BadgeDelegate(stepsTable_));
     layout->addWidget(stepsTable_);
+
+    connect(stepsTable_->selectionModel(),
+            &QItemSelectionModel::currentRowChanged,
+            this, [this](const QModelIndex& current, const QModelIndex&) {
+                const int row = current.row();
+                if (row >= 0 &&
+                    row < static_cast<int>(currentSteps_.size()))
+                    emit stepSelected(currentSteps_[
+                        static_cast<std::size_t>(row)]);
+            });
 }
 
 void WorkflowStepsWidget::setInstance(const QUuid& instanceId) {
@@ -234,6 +257,7 @@ void WorkflowStepsWidget::populateSteps(
                     visible.size()) - maxVisibleSteps_);
     }
 
+    currentSteps_ = visible;
     stepsTable_->setRowCount(static_cast<int>(visible.size()));
 
     int row = 0;
@@ -247,6 +271,24 @@ void WorkflowStepsWidget::populateSteps(
         const QString status = QString::fromStdString(step.status);
         stepsTable_->setItem(row, static_cast<int>(Col::Status),
             make_badge_item(status, status_color(status)));
+
+        const int issues = count_issues(visible, row);
+        if (issues > 0) {
+            const bool has_errors = std::any_of(
+                step.log.begin(), step.log.end(),
+                [](const wf::step_log_entry& e) {
+                    return e.level == wf::step_log_level::error;
+                });
+            const QColor badge_col = has_errors
+                ? color_constants::level_error
+                : color_constants::level_warn;
+            const QString badge_text = tr("%1 issue(s)").arg(issues);
+            stepsTable_->setItem(row, static_cast<int>(Col::Warnings),
+                make_badge_item(badge_text, badge_col));
+        } else {
+            stepsTable_->setItem(row, static_cast<int>(Col::Warnings),
+                make_item(QStringLiteral("—")));
+        }
 
         stepsTable_->setItem(row, static_cast<int>(Col::StartedAt),
             make_item(step.started_at
@@ -266,20 +308,26 @@ void WorkflowStepsWidget::populateSteps(
 
     // Update header label: show running step or terminal state.
     const int total = static_cast<int>(steps.size());
-    int runningIdx = -1;
-    int failedIdx  = -1;
+    int runningIdx   = -1;
+    int failedIdx    = -1;
     int completedCount = 0;
+    int warnedCount    = 0;
     QString failedError;
 
     for (const auto& s : steps) {
         const auto st = QString::fromStdString(s.status);
-        if (st == QStringLiteral("in_progress") || st == QStringLiteral("compensating"))
+        if (st == QStringLiteral("in_progress") ||
+            st == QStringLiteral("compensating"))
             runningIdx = s.step_index;
         else if (st == QStringLiteral("failed")) {
             failedIdx  = s.step_index;
             failedError = QString::fromStdString(s.error);
-        } else if (st == QStringLiteral("completed"))
+        } else if (st == QStringLiteral("completed_with_warnings")) {
             ++completedCount;
+            ++warnedCount;
+        } else if (st == QStringLiteral("completed")) {
+            ++completedCount;
+        }
     }
 
     if (failedIdx >= 0) {
@@ -292,7 +340,14 @@ void WorkflowStepsWidget::populateSteps(
             emit instanceReachedTerminalState(false);
         }
     } else if (total > 0 && completedCount == total) {
-        headerLabel_->setText(tr("All %1 step(s) completed").arg(total));
+        if (warnedCount > 0) {
+            headerLabel_->setText(
+                tr("All %1 step(s) completed (%2 with warnings)")
+                .arg(total).arg(warnedCount));
+        } else {
+            headerLabel_->setText(
+                tr("All %1 step(s) completed").arg(total));
+        }
         if (!terminalReached_) {
             terminalReached_ = true;
             refreshTimer_->stop();

--- a/projects/ores.qt/src/MainWindow.cpp
+++ b/projects/ores.qt/src/MainWindow.cpp
@@ -805,7 +805,7 @@ void MainWindow::performDisconnectCleanup() {
     // The disconnected() signal is emitted via QueuedConnection from inside
     // disconnect(), so all UI state updates land on the main thread regardless.
     QPointer<ClientManager> cm = clientManager_;
-    QtConcurrent::run([cm]() {
+    QThreadPool::globalInstance()->start([cm]() {
         if (cm)
             cm->disconnect();
     });

--- a/projects/ores.qt/src/MainWindow.cpp
+++ b/projects/ores.qt/src/MainWindow.cpp
@@ -21,6 +21,7 @@
 
 #include <chrono>
 #include <functional>
+#include <QtConcurrent>
 #include <QDebug>
 #include <QTimer>
 #include <QApplication>
@@ -720,14 +721,9 @@ void MainWindow::closeEvent(QCloseEvent* event) {
 
 MainWindow::~MainWindow() {
     BOOST_LOG_SEV(lg(), debug) << "MainWindow destructor called";
-    // ClientManager and Controllers are children, so they will be destroyed automatically.
-    // However, we want to ensure windows are closed properly.
-    // No manual deletion loop needed as ClientManager ensures IO context lives long enough
-    // for normal Qt object destruction if we just let it happen.
-    // But explicitly disconnecting client is good practice.
-    if (clientManager_) {
-        clientManager_->disconnect();
-    }
+    // ClientManager is a child QObject and is destroyed automatically.
+    // Its own destructor calls session_.disconnect() directly (no logout NATS
+    // call), so there is nothing to do here.
 }
 
 void MainWindow::onLoginTriggered() {
@@ -801,8 +797,18 @@ void MainWindow::performDisconnectCleanup() {
     // Menus remain in the menubar (disabled by updateMenuState).
     // They are re-enabled on next login without being recreated.
 
-    if (clientManager_)
-        clientManager_->disconnect();
+    if (!clientManager_)
+        return;
+
+    // Run disconnect on a background thread so the logout NATS call (capped at
+    // 3 s by ClientManager::disconnect) does not block the UI thread.
+    // The disconnected() signal is emitted via QueuedConnection from inside
+    // disconnect(), so all UI state updates land on the main thread regardless.
+    QPointer<ClientManager> cm = clientManager_;
+    QtConcurrent::run([cm]() {
+        if (cm)
+            cm->disconnect();
+    });
 }
 
 bool MainWindow::initializeConnectionManager() {

--- a/projects/ores.refdata.core/include/ores.refdata.core/messaging/party_handler.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/messaging/party_handler.hpp
@@ -110,13 +110,15 @@ public:
             // Idempotency guard: replay cached result if this step already completed.
             if (auto cached = check_step_idempotency(nats_, step_id)) {
                 publish_step_completion(nats_, step_id, inst_id,
-                    cached->success, cached->result_json, cached->error_message);
+                    cached->outcome, cached->result_json, cached->error_message,
+                    cached->log);
                 return;
             }
 
             auto req = decode<save_party_request>(msg);
             if (!req) {
-                publish_step_completion(nats_, step_id, inst_id, false, "",
+                publish_step_completion(nats_, step_id, inst_id,
+                    ores::workflow::messaging::step_outcome::failed, "",
                     "Failed to decode save_party_request");
                 return;
             }
@@ -127,13 +129,15 @@ public:
                 svc.save_party(req->data);
                 BOOST_LOG_SEV(party_handler_lg(), debug)
                     << "Workflow step completed: " << msg.subject;
-                publish_step_completion(nats_, step_id, inst_id, true,
+                publish_step_completion(nats_, step_id, inst_id,
+                    ores::workflow::messaging::step_outcome::completed,
                     rfl::json::write(save_party_response{.success = true}), "");
             } catch (const std::exception& e) {
                 BOOST_LOG_SEV(party_handler_lg(), error)
                     << "Workflow step failed: " << msg.subject
                     << " — " << e.what();
-                publish_step_completion(nats_, step_id, inst_id, false, "", e.what());
+                publish_step_completion(nats_, step_id, inst_id,
+                    ores::workflow::messaging::step_outcome::failed, "", e.what());
             }
             return;
         }

--- a/projects/ores.service/include/ores.service/messaging/workflow_helpers.hpp
+++ b/projects/ores.service/include/ores.service/messaging/workflow_helpers.hpp
@@ -156,10 +156,14 @@ struct workflow_step_context {
      * @brief Publishes a failed step-completed event.
      *
      * @param error_msg Human-readable error description.
+     * @param log       Optional per-item diagnostic entries (e.g. one per
+     *                  failed trade). Stored in step_log_json so the UI can
+     *                  show individual failure reasons.
      */
-    void fail(const std::string& error_msg) const {
+    void fail(const std::string& error_msg,
+        const std::vector<ores::workflow::messaging::step_log_entry>& log = {}) const {
         publish(ores::workflow::messaging::step_outcome::failed,
-            "", error_msg, {});
+            "", error_msg, log);
     }
 
 private:
@@ -215,7 +219,7 @@ inline void publish_step_completion(
         ctx.warn(result_json, log);
         break;
     case ores::workflow::messaging::step_outcome::failed:
-        ctx.fail(error_msg);
+        ctx.fail(error_msg, log);
         break;
     }
 }

--- a/projects/ores.service/include/ores.service/messaging/workflow_helpers.hpp
+++ b/projects/ores.service/include/ores.service/messaging/workflow_helpers.hpp
@@ -132,7 +132,24 @@ struct workflow_step_context {
      * @param result_json Serialised JSON result payload.
      */
     void complete(const std::string& result_json) const {
-        publish(true, result_json, "");
+        publish(ores::workflow::messaging::step_outcome::completed,
+            result_json, "", {});
+    }
+
+    /**
+     * @brief Publishes a step-completed event with partial failures.
+     *
+     * Use when the step ran to completion but some items failed (e.g. some
+     * trades could not be saved). The workflow advances but the step record
+     * is marked completed_with_warnings rather than completed.
+     *
+     * @param result_json Serialised JSON result payload.
+     * @param log         Ordered list of per-item log entries.
+     */
+    void warn(const std::string& result_json,
+        const std::vector<ores::workflow::messaging::step_log_entry>& log) const {
+        publish(ores::workflow::messaging::step_outcome::completed_with_warnings,
+            result_json, "", log);
     }
 
     /**
@@ -141,19 +158,24 @@ struct workflow_step_context {
      * @param error_msg Human-readable error description.
      */
     void fail(const std::string& error_msg) const {
-        publish(false, "", error_msg);
+        publish(ores::workflow::messaging::step_outcome::failed,
+            "", error_msg, {});
     }
 
 private:
-    void publish(bool success, const std::string& result_json,
-        const std::string& error_msg) const {
+    void publish(
+        ores::workflow::messaging::step_outcome outcome,
+        const std::string& result_json,
+        const std::string& error_msg,
+        const std::vector<ores::workflow::messaging::step_log_entry>& log) const {
 
         ores::workflow::messaging::step_completed_event event{
             .workflow_instance_id = instance_id,
             .step_id              = step_id,
-            .success              = success,
+            .outcome              = outcome,
             .result_json          = result_json,
-            .error_message        = error_msg};
+            .error_message        = error_msg,
+            .log                  = log};
 
         const auto json = rfl::json::write(event);
         const auto data = std::as_bytes(
@@ -167,16 +189,17 @@ private:
  * @brief Publishes a step-completed event to the workflow engine.
  *
  * Low-level function for cases where a workflow_step_context is not
- * convenient.  Prefer workflow_step_context::complete() / fail() for
- * new code.
+ * convenient.  Prefer workflow_step_context::complete() / warn() / fail()
+ * for new code.
  */
 inline void publish_step_completion(
     ores::nats::service::client& nats,
     const std::string& step_id,
     const std::string& instance_id,
-    bool success,
+    ores::workflow::messaging::step_outcome outcome,
     const std::string& result_json,
-    const std::string& error_msg) {
+    const std::string& error_msg,
+    const std::vector<ores::workflow::messaging::step_log_entry>& log = {}) {
 
     workflow_step_context ctx{
         .step_id = step_id,
@@ -184,10 +207,17 @@ inline void publish_step_completion(
         .tenant_id = {},
         .nats = &nats};
 
-    if (success)
+    switch (outcome) {
+    case ores::workflow::messaging::step_outcome::completed:
         ctx.complete(result_json);
-    else
+        break;
+    case ores::workflow::messaging::step_outcome::completed_with_warnings:
+        ctx.warn(result_json, log);
+        break;
+    case ores::workflow::messaging::step_outcome::failed:
         ctx.fail(error_msg);
+        break;
+    }
 }
 
 /**
@@ -198,9 +228,11 @@ inline void publish_step_completion(
  * the original outcome without re-executing the operation.
  */
 struct cached_step_result {
-    bool success = false;
+    ores::workflow::messaging::step_outcome outcome =
+        ores::workflow::messaging::step_outcome::completed;
     std::string result_json;
     std::string error_message;
+    std::vector<ores::workflow::messaging::step_log_entry> log;
 };
 
 /**
@@ -239,9 +271,10 @@ inline std::optional<cached_step_result> check_step_idempotency(
         if (!resp || !resp->found) return std::nullopt;
 
         return cached_step_result{
-            .success       = resp->success,
+            .outcome       = resp->outcome,
             .result_json   = resp->result_json,
-            .error_message = resp->error_message};
+            .error_message = resp->error_message,
+            .log           = resp->log};
     } catch (const std::exception&) {
         // Fail open: if the workflow service is unreachable, proceed with
         // normal execution. The engine's own idempotency guard (step state

--- a/projects/ores.sql/create/iam/iam_account_party_create.sql
+++ b/projects/ores.sql/create/iam/iam_account_party_create.sql
@@ -70,7 +70,10 @@ on "ores_iam_account_parties_tbl" (tenant_id)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
 create or replace function ores_iam_account_parties_insert_fn()
-returns trigger as $$
+returns trigger
+security definer
+set search_path = public, pg_temp
+as $$
 declare
     current_version integer;
 begin

--- a/projects/ores.sql/create/refdata/refdata_countries_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_countries_create.sql
@@ -72,7 +72,10 @@ on "ores_refdata_countries_tbl" (numeric_code)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
 create or replace function ores_refdata_countries_insert_fn()
-returns trigger as $$
+returns trigger
+security definer
+set search_path = public, pg_temp
+as $$
 declare
     current_version integer;
 begin

--- a/projects/ores.sql/create/refdata/refdata_currencies_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_currencies_create.sql
@@ -151,9 +151,8 @@ do instead
 
 -- =============================================================================
 -- Validation function for currency
--- Validates that a iso_code exists in the currencies table.
--- Returns the validated value, or default if null/empty.
--- Uses system tenant data (shared reference data).
+-- Validates that a iso_code exists in the currencies table for the given tenant.
+-- Returns the validated value, or raises if not found.
 -- =============================================================================
 create or replace function ores_refdata_validate_currency_fn(
     p_tenant_id uuid,
@@ -171,17 +170,17 @@ begin
         return p_value;
     end if;
 
-    -- Validate against reference data
+    -- Validate against tenant's reference data
     if not exists (
         select 1 from ores_refdata_currencies_tbl
-        where tenant_id = ores_utility_system_tenant_id_fn()
+        where tenant_id = p_tenant_id
           and iso_code = p_value
           and valid_to = ores_utility_infinity_timestamp_fn()
     ) then
         raise exception 'Invalid currency: %. Must be one of: %', p_value, (
             select string_agg(iso_code::text, ', ' order by iso_code)
             from ores_refdata_currencies_tbl
-            where tenant_id = ores_utility_system_tenant_id_fn()
+            where tenant_id = p_tenant_id
               and valid_to = ores_utility_infinity_timestamp_fn()
         ) using errcode = '23503';
     end if;

--- a/projects/ores.sql/create/refdata/refdata_currencies_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_currencies_create.sql
@@ -170,17 +170,19 @@ begin
         return p_value;
     end if;
 
-    -- Validate against tenant's reference data
+    -- Validate against the tenant's currencies and the system tenant's currencies.
+    -- System-tenant currencies are the standard reference set (published once);
+    -- tenant-specific currencies extend them after bundle publish.
     if not exists (
         select 1 from ores_refdata_currencies_tbl
-        where tenant_id = p_tenant_id
+        where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
           and iso_code = p_value
           and valid_to = ores_utility_infinity_timestamp_fn()
     ) then
         raise exception 'Invalid currency: %. Must be one of: %', p_value, (
             select string_agg(iso_code::text, ', ' order by iso_code)
             from ores_refdata_currencies_tbl
-            where tenant_id = p_tenant_id
+            where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
               and valid_to = ores_utility_infinity_timestamp_fn()
         ) using errcode = '23503';
     end if;

--- a/projects/ores.sql/create/workflow/workflow_workflow_step_create.sql
+++ b/projects/ores.sql/create/workflow/workflow_workflow_step_create.sql
@@ -47,6 +47,7 @@ create table if not exists "ores_workflow_workflow_steps_tbl" (
     "started_at" timestamptz null,
     "completed_at" timestamptz null,
     "created_at" timestamp with time zone not null default current_timestamp,
+    "step_log_json" jsonb null,
     primary key (id),
     check ("id" <> ores_utility_nil_uuid_fn())
 );

--- a/projects/ores.sql/modeling/ores.sql.org
+++ b/projects/ores.sql/modeling/ores.sql.org
@@ -428,6 +428,100 @@ Additional tables populated via operational processes (not publication):
 |            | =ores_iam_login_info_tbl=               | Login tracking                            |
 | Variability| =ores_variability_system_settings_tbl=  | Runtime configuration                     |
 
+* Service Table Isolation
+
+Each domain service runs as a dedicated PostgreSQL role
+(=ores_<env>_<service>_service=) and holds DML privileges only on its own
+component tables (=ores_<service>_*=). This is the *strict service table
+isolation invariant*: no service user may read from or write to a table owned
+by another service, except through the patterns described below.
+
+** Why it matters
+
+Without this invariant:
+- Grant files stop being the source of truth for "who can write where". Auditing
+  correctness requires reading every function body.
+- Cross-service writes bypass application-layer logic (cache invalidation,
+  projection updates, per-service event emission) in the target service.
+- Schema changes in a target table force edits to files owned by another domain.
+
+** Intra-service writes (normal path)
+
+The default: a service handler receives a NATS message, validates the payload,
+and calls its own repository, which INSERTs into =ores_<service>_*= tables. No
+cross-service DB access at all.
+
+** Cross-service reads via SECURITY DEFINER (trigger validation)
+
+DB trigger functions sometimes need to validate a soft FK against a table owned
+by another service. Since trigger functions run as the calling service user, a
+plain =SELECT= would fail. The solution is =SECURITY DEFINER=:
+
+#+begin_src sql
+create or replace function ores_<service>_<entity>_insert_fn()
+returns trigger
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+    -- can now SELECT from ores_<other_service>_* safely
+    if not exists (
+        select 1 from ores_other_service_entities_tbl
+        where id = new.entity_id ...
+    ) then
+        raise exception '...';
+    end if;
+    ...
+end;
+$$ language plpgsql;
+#+end_src
+
+The function executes as the DDL owner, so no service user needs a
+cross-component =SELECT= grant. The grants file remains the authoritative
+record of service permissions.
+
+Two system-wide shared validators follow this pattern and are called from
+every service's triggers:
+
+- =ores_iam_validate_tenant_fn= — validates =tenant_id= on every INSERT/UPDATE.
+- =ores_dq_validate_change_reason_fn= — validates =change_reason_code= on every
+  INSERT/UPDATE.
+
+Per-table soft-FK validators also follow this pattern when they cross a service
+boundary:
+
+- =ores_iam_account_parties_insert_fn= — validates =party_id= against
+  =ores_refdata_parties_tbl=.
+- =ores_refdata_countries_insert_fn= — validates =coding_scheme_code= against
+  =ores_dq_coding_schemes_tbl=.
+
+*Rule:* any trigger function body containing a =SELECT= from
+=ores_<other_service>_*= must be declared =SECURITY DEFINER SET search_path =
+public, pg_temp=. Never add a cross-component =SELECT= grant to a service user
+to satisfy a trigger check.
+
+** Cross-service writes via NATS (application layer)
+
+When a service needs to write to another service's tables (e.g. the workflow
+engine provisioning parties), it publishes a NATS message to the target
+service's write API (e.g. =refdata.v1.parties.save=). The target service
+handles the message and writes to its own tables. No cross-service DML grants
+are needed or permitted.
+
+** Foreign key constraints
+
+PostgreSQL FK enforcement does /not/ require the session user to hold =SELECT=
+on the referenced table. The =REFERENCES= privilege is only needed when
+creating the constraint (granted to the DDL user). At runtime, the FK check is
+system-internal. Service users therefore need no cross-component =SELECT= grant
+solely because of FK constraints.
+
+** Current status
+
+All tracked cross-component grants have been removed. For migration history see
+[[file:../../doc/plans/2026-05-12-strict-service-table-isolation.org][strict-service-table-isolation.org]] and
+[[file:../../doc/plans/2026-05-13-cross-service-write-decoupling.org][cross-service-write-decoupling.org]].
+
 * Multi-Environment Architecture
 
 ORE Studio supports multiple isolated development environments. For full

--- a/projects/ores.sql/populate/dq/dq_fsm_workflow_step_populate.sql
+++ b/projects/ores.sql/populate/dq/dq_fsm_workflow_step_populate.sql
@@ -23,12 +23,14 @@
  *
  * Seeds the workflow_step state machine with:
  * - 1 machine: workflow_step
- * - 5 states: pending, in_progress, completed, failed, compensated
- * - 4 transitions:
- *     initial_start  (NULL         -> in_progress)
- *     complete       (in_progress  -> completed)
- *     fail           (in_progress  -> failed)
- *     compensate     (failed       -> compensated)
+ * - 6 states: pending, in_progress, completed, completed_with_warnings,
+ *             failed, compensated
+ * - 5 transitions:
+ *     initial_start          (NULL         -> in_progress)
+ *     complete               (in_progress  -> completed)
+ *     complete_with_warnings (in_progress  -> completed_with_warnings)
+ *     fail                   (in_progress  -> failed)
+ *     compensate             (failed       -> compensated)
  *
  * This script is idempotent: it skips insertion if the machine already exists.
  */
@@ -37,13 +39,14 @@
 
 do $$
 declare
-    v_machine_id        uuid;
-    v_state_pending     uuid;
-    v_state_in_progress uuid;
-    v_state_completed   uuid;
-    v_state_failed      uuid;
-    v_state_compensated uuid;
-    v_sys_tenant        uuid := ores_utility_system_tenant_id_fn();
+    v_machine_id                  uuid;
+    v_state_pending               uuid;
+    v_state_in_progress           uuid;
+    v_state_completed             uuid;
+    v_state_completed_with_warn   uuid;
+    v_state_failed                uuid;
+    v_state_compensated           uuid;
+    v_sys_tenant                  uuid := ores_utility_system_tenant_id_fn();
 begin
     -- -------------------------------------------------------------------------
     -- Machine
@@ -77,11 +80,12 @@ begin
     -- -------------------------------------------------------------------------
     -- States
     -- -------------------------------------------------------------------------
-    v_state_pending     := gen_random_uuid();
-    v_state_in_progress := gen_random_uuid();
-    v_state_completed   := gen_random_uuid();
-    v_state_failed      := gen_random_uuid();
-    v_state_compensated := gen_random_uuid();
+    v_state_pending             := gen_random_uuid();
+    v_state_in_progress         := gen_random_uuid();
+    v_state_completed           := gen_random_uuid();
+    v_state_completed_with_warn := gen_random_uuid();
+    v_state_failed              := gen_random_uuid();
+    v_state_compensated         := gen_random_uuid();
 
     insert into ores_dq_fsm_states_tbl (
         id, tenant_id, version,
@@ -97,6 +101,9 @@ begin
         (v_state_completed, v_sys_tenant, 0,
          v_machine_id, 'completed', 0, 1,
          current_user, 'system.initial_load', 'Seed workflow_step state: completed'),
+        (v_state_completed_with_warn, v_sys_tenant, 0,
+         v_machine_id, 'completed_with_warnings', 0, 1,
+         current_user, 'system.initial_load', 'Seed workflow_step state: completed_with_warnings'),
         (v_state_failed, v_sys_tenant, 0,
          v_machine_id, 'failed', 0, 1,
          current_user, 'system.initial_load', 'Seed workflow_step state: failed'),
@@ -104,7 +111,7 @@ begin
          v_machine_id, 'compensated', 0, 1,
          current_user, 'system.initial_load', 'Seed workflow_step state: compensated');
 
-    raise debug 'Created 5 workflow_step states.';
+    raise debug 'Created 6 workflow_step states.';
 
     -- -------------------------------------------------------------------------
     -- Transitions (4 total)
@@ -122,6 +129,12 @@ begin
         (gen_random_uuid(), v_sys_tenant, 0,
          v_machine_id, v_state_in_progress, v_state_completed, 'complete', null,
          current_user, 'system.initial_load', 'in_progress -> completed'),
+        -- Step completed with partial item failures (non-fatal)
+        (gen_random_uuid(), v_sys_tenant, 0,
+         v_machine_id, v_state_in_progress, v_state_completed_with_warn,
+         'complete_with_warnings', null,
+         current_user, 'system.initial_load',
+         'in_progress -> completed_with_warnings'),
         -- Step failed
         (gen_random_uuid(), v_sys_tenant, 0,
          v_machine_id, v_state_in_progress, v_state_failed, 'fail', null,
@@ -131,6 +144,6 @@ begin
          v_machine_id, v_state_failed, v_state_compensated, 'compensate', null,
          current_user, 'system.initial_load', 'failed -> compensated');
 
-    raise debug 'Created 4 workflow_step transitions.';
+    raise debug 'Created 5 workflow_step transitions.';
 end;
 $$;

--- a/projects/ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp
@@ -20,8 +20,11 @@
 #ifndef ORES_TRADING_MESSAGING_TRADE_HANDLER_HPP
 #define ORES_TRADING_MESSAGING_TRADE_HANDLER_HPP
 
+#include <chrono>
 #include <optional>
+#include <span>
 #include <unordered_map>
+#include <rfl/json.hpp>
 #include <rfl/msgpack.hpp>
 #include <boost/uuid/string_generator.hpp>
 #include "ores.logging/make_logger.hpp"
@@ -66,6 +69,8 @@
 #include "ores.trading.core/service/composite_instrument_service.hpp"
 #include "ores.trading.core/service/scripted_instrument_service.hpp"
 #include "ores.utility/uuid/tenant_id.hpp"
+#include "ores.dq.api/messaging/fsm_protocol.hpp"
+#include "ores.trading.core/service/trade_status_service.hpp"
 #include "ores.trading.core/export.hpp"
 
 namespace ores::trading::messaging {
@@ -460,7 +465,8 @@ public:
         service::trade_service svc(ctx);
         if (auto req = decode<save_trade_request>(msg)) {
             try {
-                svc.save_trades(req->trades);
+                const auto transitions = fetch_fsm_transitions();
+                svc.save_trades(req->trades, transitions);
                 BOOST_LOG_SEV(trade_handler_lg(), debug)
                     << "Completed " << msg.subject;
                 reply(nats_, msg, save_trade_response{.success = true});
@@ -695,6 +701,59 @@ public:
     }
 
 private:
+    /**
+     * @brief Fetches all FSM transitions from the DQ service via NATS.
+     *
+     * Results are cached process-wide for 5 minutes; FSM transitions are
+     * system-level reference data that change only on schema migrations.
+     * The cache avoids an extra NATS round-trip per trade when the ore import
+     * handler sends one save_trade message per trade.
+     * Returns an empty map on failure so save operations degrade gracefully.
+     */
+    service::fsm_transition_map fetch_fsm_transitions() {
+        using namespace ores::dq::messaging;
+
+        {
+            std::lock_guard lock(s_cache_mutex_);
+            const auto age = std::chrono::steady_clock::now() - s_cache_fetched_;
+            if (!s_cache_.empty() && age < std::chrono::minutes(5))
+                return s_cache_;
+        }
+
+        service::fsm_transition_map result;
+        const get_fsm_transitions_request req{};
+        const auto json = rfl::json::write(req);
+        const auto* p = reinterpret_cast<const std::byte*>(json.data());
+        try {
+            const auto reply = nats_.request_sync(
+                get_fsm_transitions_request::nats_subject,
+                std::span<const std::byte>(p, json.size()),
+                {}, std::chrono::seconds(10));
+            const std::string_view sv(
+                reinterpret_cast<const char*>(reply.data.data()),
+                reply.data.size());
+            const auto resp = rfl::json::read<get_fsm_transitions_response>(sv);
+            if (resp && resp->success) {
+                for (auto& t : resp->transitions)
+                    result[t.id] = std::move(t);
+            }
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(trade_handler_lg(), warn)
+                << "fetch_fsm_transitions: " << e.what();
+        }
+
+        {
+            std::lock_guard lock(s_cache_mutex_);
+            s_cache_ = result;
+            s_cache_fetched_ = std::chrono::steady_clock::now();
+        }
+        return result;
+    }
+
+    inline static std::mutex s_cache_mutex_;
+    inline static service::fsm_transition_map s_cache_;
+    inline static std::chrono::steady_clock::time_point s_cache_fetched_{};
+
     ores::nats::service::client& nats_;
     ores::database::context ctx_;
     std::optional<ores::security::jwt::jwt_authenticator> verifier_;

--- a/projects/ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp
@@ -728,7 +728,7 @@ private:
             const auto reply = nats_.request_sync(
                 get_fsm_transitions_request::nats_subject,
                 std::span<const std::byte>(p, json.size()),
-                {}, std::chrono::seconds(10));
+                {}, std::chrono::seconds(2));
             const std::string_view sv(
                 reinterpret_cast<const char*>(reply.data.data()),
                 reply.data.size());

--- a/projects/ores.trading.core/include/ores.trading.core/service/trade_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/trade_service.hpp
@@ -28,6 +28,7 @@
 #include "ores.database/domain/context.hpp"
 #include "ores.trading.api/domain/trade.hpp"
 #include "ores.trading.core/repository/trade_repository.hpp"
+#include "ores.trading.core/service/trade_status_service.hpp"
 #include "ores.trading.core/export.hpp"
 
 namespace ores::trading::service {
@@ -75,9 +76,11 @@ public:
     std::optional<domain::trade>
     find_trade(const std::string& id);
 
-    void save_trade(const domain::trade& v);
+    void save_trade(const domain::trade& v,
+        const fsm_transition_map& transitions);
 
-    void save_trades(const std::vector<domain::trade>& trades);
+    void save_trades(const std::vector<domain::trade>& trades,
+        const fsm_transition_map& transitions);
 
     void remove_trade(const std::string& id);
 

--- a/projects/ores.trading.core/include/ores.trading.core/service/trade_status_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/trade_status_service.hpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <unordered_map>
 #include <boost/uuid/uuid.hpp>
+#include <boost/container_hash/hash.hpp>
 #include "ores.logging/make_logger.hpp"
 #include "ores.database/domain/context.hpp"
 #include "ores.dq.api/domain/fsm_transition.hpp"
@@ -40,7 +41,7 @@ namespace ores::trading::service {
 using fsm_transition_map = std::unordered_map<
     boost::uuids::uuid,
     ores::dq::domain::fsm_transition,
-    std::hash<boost::uuids::uuid>>;
+    boost::hash<boost::uuids::uuid>>;
 
 /**
  * @brief Resolves trade status transitions via the FSM.

--- a/projects/ores.trading.core/include/ores.trading.core/service/trade_status_service.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/service/trade_status_service.hpp
@@ -22,12 +22,25 @@
 
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <boost/uuid/uuid.hpp>
 #include "ores.logging/make_logger.hpp"
 #include "ores.database/domain/context.hpp"
+#include "ores.dq.api/domain/fsm_transition.hpp"
 #include "ores.trading.core/export.hpp"
 
 namespace ores::trading::service {
+
+/**
+ * @brief Lookup map of FSM transitions keyed by their UUID.
+ *
+ * Fetched once per request from the DQ service via NATS and passed into
+ * resolve_status() to avoid a cross-service DB read.
+ */
+using fsm_transition_map = std::unordered_map<
+    boost::uuids::uuid,
+    ores::dq::domain::fsm_transition,
+    std::hash<boost::uuids::uuid>>;
 
 /**
  * @brief Resolves trade status transitions via the FSM.
@@ -54,22 +67,24 @@ public:
     /**
      * @brief Resolves the new status_id for a trade.
      *
-     * Given an activity_type_code and the trade's current status_id
-     * (std::nullopt for brand-new trades not yet in the database), returns
-     * the resulting status_id after applying the FSM transition linked to
-     * the activity type.
+     * Given an activity_type_code, the trade's current status_id
+     * (std::nullopt for brand-new trades), and a pre-fetched transitions
+     * map (keyed by UUID, retrieved once per batch from the DQ service
+     * via NATS), returns the resulting status_id after applying the FSM
+     * transition linked to the activity type.
      *
      * If the activity type has no linked FSM transition, the current
      * status_id is returned unchanged (nil UUID for new trades).
      *
      * @throws std::invalid_argument if the activity_type_code is unknown.
      * @throws std::logic_error if the transition is invalid from the
-     *         current status.
+     *         current status, or if the transition id is not in the map.
      */
     static boost::uuids::uuid resolve_status(
         context ctx,
         const std::string& activity_type_code,
-        std::optional<boost::uuids::uuid> current_status_id);
+        std::optional<boost::uuids::uuid> current_status_id,
+        const fsm_transition_map& transitions);
 };
 
 }

--- a/projects/ores.trading.core/src/CMakeLists.txt
+++ b/projects/ores.trading.core/src/CMakeLists.txt
@@ -58,7 +58,7 @@ target_link_libraries(${lib_target_name}
         ores.service.lib
         ores.storage.lib
         ores.database.lib
-        ores.dq.core.lib
+        ores.dq.api.lib
         ores.utility.lib
         ores.security.lib
         sqlgen::sqlgen

--- a/projects/ores.trading.core/src/service/trade_service.cpp
+++ b/projects/ores.trading.core/src/service/trade_service.cpp
@@ -23,7 +23,6 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/nil_generator.hpp>
 #include "ores.service/messaging/handler_helpers.hpp"
-#include "ores.trading.core/service/trade_status_service.hpp"
 
 using ores::service::messaging::stamp;
 
@@ -73,7 +72,8 @@ trade_service::find_trade(const std::string& id) {
     return results.front();
 }
 
-void trade_service::save_trade(const domain::trade& v) {
+void trade_service::save_trade(const domain::trade& v,
+    const fsm_transition_map& transitions) {
     if (v.id.is_nil())
         throw std::invalid_argument("Trade id cannot be empty.");
     BOOST_LOG_SEV(lg(), debug) << "Saving trade: " << v.id;
@@ -83,12 +83,13 @@ void trade_service::save_trade(const domain::trade& v) {
         t.status_id.is_nil() ? std::nullopt
                              : std::make_optional(t.status_id);
     t.status_id = trade_status_service::resolve_status(
-        ctx_, t.activity_type_code, current);
+        ctx_, t.activity_type_code, current, transitions);
     repo_.write(ctx_, t);
     BOOST_LOG_SEV(lg(), info) << "Saved trade: " << t.id;
 }
 
-void trade_service::save_trades(const std::vector<domain::trade>& trades) {
+void trade_service::save_trades(const std::vector<domain::trade>& trades,
+    const fsm_transition_map& transitions) {
     for (const auto& t : trades) {
         if (t.id.is_nil())
             throw std::invalid_argument("Trade id cannot be empty.");
@@ -101,7 +102,7 @@ void trade_service::save_trades(const std::vector<domain::trade>& trades) {
             t.status_id.is_nil() ? std::nullopt
                                  : std::make_optional(t.status_id);
         t.status_id = trade_status_service::resolve_status(
-            ctx_, t.activity_type_code, current);
+            ctx_, t.activity_type_code, current, transitions);
     }
     repo_.write(ctx_, resolved);
 }

--- a/projects/ores.trading.core/src/service/trade_status_service.cpp
+++ b/projects/ores.trading.core/src/service/trade_status_service.cpp
@@ -22,7 +22,6 @@
 #include <stdexcept>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/nil_generator.hpp>
-#include "ores.dq.core/repository/fsm_transition_repository.hpp"
 #include "ores.trading.core/repository/activity_type_repository.hpp"
 #include "ores.utility/uuid/tenant_id.hpp"
 
@@ -33,7 +32,8 @@ using namespace ores::logging;
 boost::uuids::uuid trade_status_service::resolve_status(
     context ctx,
     const std::string& activity_type_code,
-    std::optional<boost::uuids::uuid> current_status_id) {
+    std::optional<boost::uuids::uuid> current_status_id,
+    const fsm_transition_map& transitions) {
 
     BOOST_LOG_SEV(lg(), debug)
         << "Resolving trade status for activity type: " << activity_type_code;
@@ -59,14 +59,14 @@ boost::uuids::uuid trade_status_service::resolve_status(
         return current_status_id.value_or(boost::uuids::nil_uuid());
     }
 
-    // Step 3: Load the FSM transition.
-    dq::repository::fsm_transition_repository tr_repo;
-    const auto transition = tr_repo.find_by_id(sys_ctx, *at.fsm_transition_id);
-    if (!transition.has_value()) {
+    // Step 3: Load the FSM transition from the pre-fetched map.
+    const auto it = transitions.find(*at.fsm_transition_id);
+    if (it == transitions.end()) {
         throw std::logic_error(
             "FSM transition not found for id: "
             + boost::uuids::to_string(*at.fsm_transition_id));
     }
+    const auto& transition_ref = it->second;
 
     // Step 4: Validate that the current status matches the transition's
     // from_state_id.  A null from_state_id means this is the initial booking
@@ -74,21 +74,21 @@ boost::uuids::uuid trade_status_service::resolve_status(
     const auto current_id =
         current_status_id.value_or(boost::uuids::nil_uuid());
 
-    if (!transition->from_state_id.has_value()) {
+    if (!transition_ref.from_state_id.has_value()) {
         // Initial transition: current status must be nil (new trade).
         if (!boost::uuids::uuid(current_id).is_nil()) {
             throw std::logic_error(
-                "Invalid FSM transition '" + transition->name
+                "Invalid FSM transition '" + transition_ref.name
                 + "': initial booking requires nil current status, but got "
                 + boost::uuids::to_string(current_id));
         }
     } else {
         // Non-initial transition: current status must match from_state_id.
-        if (current_id != *transition->from_state_id) {
+        if (current_id != *transition_ref.from_state_id) {
             throw std::logic_error(
-                "Invalid FSM transition '" + transition->name
+                "Invalid FSM transition '" + transition_ref.name
                 + "': expected from_state_id "
-                + boost::uuids::to_string(*transition->from_state_id)
+                + boost::uuids::to_string(*transition_ref.from_state_id)
                 + " but current status is "
                 + boost::uuids::to_string(current_id));
         }
@@ -96,10 +96,10 @@ boost::uuids::uuid trade_status_service::resolve_status(
 
     // Step 5: Return the target state.
     BOOST_LOG_SEV(lg(), debug)
-        << "FSM transition '" << transition->name
+        << "FSM transition '" << transition_ref.name
         << "' applied: new status_id = "
-        << boost::uuids::to_string(transition->to_state_id);
-    return transition->to_state_id;
+        << boost::uuids::to_string(transition_ref.to_state_id);
+    return transition_ref.to_state_id;
 }
 
 }

--- a/projects/ores.workflow.api/include/ores.workflow.api/messaging/step_log_types.hpp
+++ b/projects/ores.workflow.api/include/ores.workflow.api/messaging/step_log_types.hpp
@@ -1,0 +1,75 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_WORKFLOW_API_MESSAGING_STEP_LOG_TYPES_HPP
+#define ORES_WORKFLOW_API_MESSAGING_STEP_LOG_TYPES_HPP
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace ores::workflow::messaging {
+
+/**
+ * @brief Severity of a step log entry.
+ *
+ * Serialises as a lowercase string ("info", "warn", "error") so that
+ * step_log_json columns in the DB are human-readable and queryable via
+ * JSON containment (@>).
+ */
+enum class step_log_level : std::uint8_t {
+    info  = 0,
+    warn  = 1,
+    error = 2
+};
+
+[[nodiscard]] inline std::string_view to_string(step_log_level v) {
+    switch (v) {
+    case step_log_level::info:  return "info";
+    case step_log_level::warn:  return "warn";
+    case step_log_level::error: return "error";
+    }
+    throw std::invalid_argument("Out-of-range step_log_level");
+}
+
+[[nodiscard]] inline step_log_level step_log_level_from_string(std::string_view sv) {
+    if (sv == "info")  return step_log_level::info;
+    if (sv == "warn")  return step_log_level::warn;
+    if (sv == "error") return step_log_level::error;
+    throw std::invalid_argument("Invalid step_log_level: '" + std::string(sv) + "'");
+}
+
+/**
+ * @brief A single structured log entry emitted by a step handler.
+ *
+ * Entries are stored as a JSON array in workflow_step.step_log_json and
+ * surfaced in the workflow instance detail dialog.  The context field
+ * carries item-level identifiers (trade ID, filename, etc.) so the user
+ * can locate the source of each message.
+ */
+struct step_log_entry {
+    step_log_level level = step_log_level::info;
+    std::string    message;
+    std::string    context;
+};
+
+}  // namespace ores::workflow::messaging
+
+#endif

--- a/projects/ores.workflow.api/include/ores.workflow.api/messaging/steps_query_protocol.hpp
+++ b/projects/ores.workflow.api/include/ores.workflow.api/messaging/steps_query_protocol.hpp
@@ -22,6 +22,8 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
+#include "ores.workflow.api/messaging/workflow_events.hpp"
 
 namespace ores::workflow::messaging {
 
@@ -60,25 +62,32 @@ struct get_step_result_response {
     bool found = false;
 
     /**
-     * @brief true if the step completed successfully; false if it failed.
+     * @brief Terminal outcome of the step.
      *
      * Valid only when found == true.
      */
-    bool success = false;
+    step_outcome outcome = step_outcome::completed;
 
     /**
      * @brief Serialised JSON result from the original execution.
      *
-     * Non-empty when found == true && success == true.
+     * Non-empty when found == true && outcome != failed.
      */
     std::string result_json;
 
     /**
      * @brief Human-readable error from the original execution.
      *
-     * Non-empty when found == true && success == false.
+     * Non-empty when found == true && outcome == failed.
      */
     std::string error_message;
+
+    /**
+     * @brief Log entries emitted during the original execution.
+     *
+     * Non-empty when the step produced user-visible diagnostics.
+     */
+    std::vector<step_log_entry> log;
 };
 
 }  // namespace ores::workflow::messaging

--- a/projects/ores.workflow.api/include/ores.workflow.api/messaging/workflow_events.hpp
+++ b/projects/ores.workflow.api/include/ores.workflow.api/messaging/workflow_events.hpp
@@ -20,10 +20,90 @@
 #ifndef ORES_WORKFLOW_API_MESSAGING_WORKFLOW_EVENTS_HPP
 #define ORES_WORKFLOW_API_MESSAGING_WORKFLOW_EVENTS_HPP
 
+#include <cstdint>
+#include <stdexcept>
 #include <string>
 #include <string_view>
+#include <vector>
+#include <rfl.hpp>
 
 namespace ores::workflow::messaging {
+
+/**
+ * @brief Severity of a step log entry.
+ *
+ * Serialises as a lowercase string ("info", "warn", "error") so that
+ * step_log_json columns in the DB are human-readable and queryable via
+ * JSON containment (@>).
+ */
+enum class step_log_level : std::uint8_t {
+    info  = 0,
+    warn  = 1,
+    error = 2
+};
+
+[[nodiscard]] inline std::string_view to_string(step_log_level v) {
+    switch (v) {
+    case step_log_level::info:  return "info";
+    case step_log_level::warn:  return "warn";
+    case step_log_level::error: return "error";
+    }
+    throw std::invalid_argument("Out-of-range step_log_level");
+}
+
+[[nodiscard]] inline step_log_level step_log_level_from_string(std::string_view sv) {
+    if (sv == "info")  return step_log_level::info;
+    if (sv == "warn")  return step_log_level::warn;
+    if (sv == "error") return step_log_level::error;
+    throw std::invalid_argument("Invalid step_log_level: '" + std::string(sv) + "'");
+}
+
+/**
+ * @brief A single structured log entry emitted by a step handler.
+ *
+ * Entries are stored as a JSON array in workflow_step.step_log_json and
+ * surfaced in the workflow instance detail dialog.  The context field
+ * carries item-level identifiers (trade ID, filename, etc.) so the user
+ * can locate the source of each message.
+ */
+struct step_log_entry {
+    step_log_level level = step_log_level::info;
+    std::string    message;
+    std::string    context;
+};
+
+/**
+ * @brief Terminal outcome of a workflow step.
+ *
+ * Replaces the previous bool success field to express three distinct states:
+ *   completed               — succeeded with no issues
+ *   completed_with_warnings — ran to completion but some items failed
+ *   failed                  — fatal; saga compensation will be triggered
+ *
+ * Serialises as a lowercase string for the same DB queryability reasons
+ * as step_log_level.
+ */
+enum class step_outcome : std::uint8_t {
+    completed               = 0,
+    completed_with_warnings = 1,
+    failed                  = 2
+};
+
+[[nodiscard]] inline std::string_view to_string(step_outcome v) {
+    switch (v) {
+    case step_outcome::completed:               return "completed";
+    case step_outcome::completed_with_warnings: return "completed_with_warnings";
+    case step_outcome::failed:                  return "failed";
+    }
+    throw std::invalid_argument("Out-of-range step_outcome");
+}
+
+[[nodiscard]] inline step_outcome step_outcome_from_string(std::string_view sv) {
+    if (sv == "completed")               return step_outcome::completed;
+    if (sv == "completed_with_warnings") return step_outcome::completed_with_warnings;
+    if (sv == "failed")                  return step_outcome::failed;
+    throw std::invalid_argument("Invalid step_outcome: '" + std::string(sv) + "'");
+}
 
 /**
  * @brief Fire-and-forget event published by domain services on step completion.
@@ -53,9 +133,9 @@ struct step_completed_event {
     std::string step_id;
 
     /**
-     * @brief true if the step succeeded; false if it failed.
+     * @brief Terminal outcome of this step.
      */
-    bool success = false;
+    step_outcome outcome = step_outcome::completed;
 
     /**
      * @brief Serialised JSON result payload from the domain service.
@@ -66,11 +146,20 @@ struct step_completed_event {
     std::string result_json;
 
     /**
-     * @brief Human-readable error message on failure.
+     * @brief Human-readable error message on fatal failure.
      *
      * Stored in workflow_step.error and workflow_instance.error.
+     * Non-empty only when outcome == failed.
      */
     std::string error_message;
+
+    /**
+     * @brief Ordered list of log entries emitted by this step.
+     *
+     * Serialised to step_log_json in the workflow step record.  Empty for
+     * steps that produce no user-visible diagnostic output.
+     */
+    std::vector<step_log_entry> log;
 };
 
 /**
@@ -114,6 +203,36 @@ struct start_workflow_message {
      * Empty string (default) means the engine generates a fresh UUID.
      */
     std::string instance_id;
+};
+
+}
+
+namespace rfl {
+
+template<>
+struct Reflector<ores::workflow::messaging::step_log_level> {
+    using ReflType = std::string;
+
+    static ores::workflow::messaging::step_log_level to(const ReflType& s) {
+        return ores::workflow::messaging::step_log_level_from_string(s);
+    }
+
+    static ReflType from(const ores::workflow::messaging::step_log_level& v) {
+        return std::string(ores::workflow::messaging::to_string(v));
+    }
+};
+
+template<>
+struct Reflector<ores::workflow::messaging::step_outcome> {
+    using ReflType = std::string;
+
+    static ores::workflow::messaging::step_outcome to(const ReflType& s) {
+        return ores::workflow::messaging::step_outcome_from_string(s);
+    }
+
+    static ReflType from(const ores::workflow::messaging::step_outcome& v) {
+        return std::string(ores::workflow::messaging::to_string(v));
+    }
 };
 
 }

--- a/projects/ores.workflow.api/include/ores.workflow.api/messaging/workflow_events.hpp
+++ b/projects/ores.workflow.api/include/ores.workflow.api/messaging/workflow_events.hpp
@@ -26,51 +26,9 @@
 #include <string_view>
 #include <vector>
 #include <rfl.hpp>
+#include "ores.workflow.api/messaging/step_log_types.hpp"
 
 namespace ores::workflow::messaging {
-
-/**
- * @brief Severity of a step log entry.
- *
- * Serialises as a lowercase string ("info", "warn", "error") so that
- * step_log_json columns in the DB are human-readable and queryable via
- * JSON containment (@>).
- */
-enum class step_log_level : std::uint8_t {
-    info  = 0,
-    warn  = 1,
-    error = 2
-};
-
-[[nodiscard]] inline std::string_view to_string(step_log_level v) {
-    switch (v) {
-    case step_log_level::info:  return "info";
-    case step_log_level::warn:  return "warn";
-    case step_log_level::error: return "error";
-    }
-    throw std::invalid_argument("Out-of-range step_log_level");
-}
-
-[[nodiscard]] inline step_log_level step_log_level_from_string(std::string_view sv) {
-    if (sv == "info")  return step_log_level::info;
-    if (sv == "warn")  return step_log_level::warn;
-    if (sv == "error") return step_log_level::error;
-    throw std::invalid_argument("Invalid step_log_level: '" + std::string(sv) + "'");
-}
-
-/**
- * @brief A single structured log entry emitted by a step handler.
- *
- * Entries are stored as a JSON array in workflow_step.step_log_json and
- * surfaced in the workflow instance detail dialog.  The context field
- * carries item-level identifiers (trade ID, filename, etc.) so the user
- * can locate the source of each message.
- */
-struct step_log_entry {
-    step_log_level level = step_log_level::info;
-    std::string    message;
-    std::string    context;
-};
 
 /**
  * @brief Terminal outcome of a workflow step.

--- a/projects/ores.workflow.api/include/ores.workflow.api/messaging/workflow_query_protocol.hpp
+++ b/projects/ores.workflow.api/include/ores.workflow.api/messaging/workflow_query_protocol.hpp
@@ -24,7 +24,7 @@
 #include <vector>
 #include <optional>
 #include <string_view>
-#include "ores.workflow.api/messaging/workflow_events.hpp"
+#include "ores.workflow.api/messaging/step_log_types.hpp"
 
 namespace ores::workflow::messaging {
 

--- a/projects/ores.workflow.api/include/ores.workflow.api/messaging/workflow_query_protocol.hpp
+++ b/projects/ores.workflow.api/include/ores.workflow.api/messaging/workflow_query_protocol.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <optional>
 #include <string_view>
+#include "ores.workflow.api/messaging/workflow_events.hpp"
 
 namespace ores::workflow::messaging {
 
@@ -98,6 +99,7 @@ struct workflow_step_summary {
     std::optional<std::string> started_at;
     std::optional<std::string> completed_at;
     std::string error;
+    std::vector<step_log_entry> log;
 };
 
 /**

--- a/projects/ores.workflow.core/include/ores.workflow.core/domain/workflow_step.hpp
+++ b/projects/ores.workflow.core/include/ores.workflow.core/domain/workflow_step.hpp
@@ -123,6 +123,15 @@ struct workflow_step final {
     std::optional<std::chrono::system_clock::time_point> completed_at;
 
     /**
+     * @brief Serialised JSON array of step_log_entry records.
+     *
+     * Populated when the step handler emits log entries (via warn() or
+     * complete() with a non-empty log). Empty for steps that produce no
+     * user-visible diagnostic output.
+     */
+    std::string step_log_json;
+
+    /**
      * @brief Timestamp when this record was created.
      */
     std::chrono::system_clock::time_point created_at;

--- a/projects/ores.workflow.core/include/ores.workflow.core/repository/workflow_step_entity.hpp
+++ b/projects/ores.workflow.core/include/ores.workflow.core/repository/workflow_step_entity.hpp
@@ -54,6 +54,7 @@ struct workflow_step_entity {
     std::optional<db_timestamp> started_at;
     std::optional<db_timestamp> completed_at;
     std::optional<db_timestamp> created_at;
+    std::optional<std::string> step_log_json;
 };
 
 std::ostream& operator<<(std::ostream& s, const workflow_step_entity& v);

--- a/projects/ores.workflow.core/include/ores.workflow.core/repository/workflow_step_repository.hpp
+++ b/projects/ores.workflow.core/include/ores.workflow.core/repository/workflow_step_repository.hpp
@@ -76,12 +76,15 @@ public:
     /**
      * @brief Updates the FSM state (and optional response/error) of a workflow step.
      *
-     * Sets @p state_id, @p response_json, @p error, and stamps completed_at to now.
+     * Sets @p state_id, @p response_json, @p error, @p step_log_json, and
+     * stamps completed_at to now.  Pass an empty string for @p step_log_json
+     * when the step produces no log entries.
      */
     void update_state(context ctx, const boost::uuids::uuid& id,
         const boost::uuids::uuid& state_id,
         const std::string& response_json,
-        const std::string& error);
+        const std::string& error,
+        const std::string& step_log_json = {});
 
     /**
      * @brief Records that the step command was successfully published.

--- a/projects/ores.workflow.core/src/messaging/workflow_query_handler.cpp
+++ b/projects/ores.workflow.core/src/messaging/workflow_query_handler.cpp
@@ -25,6 +25,7 @@
 #include "ores.service/error_code.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
 #include "ores.service/service/request_context.hpp"
+#include <rfl/json.hpp>
 #include "ores.workflow.api/messaging/workflow_query_protocol.hpp"
 #include "ores.workflow.api/messaging/steps_query_protocol.hpp"
 
@@ -215,6 +216,12 @@ void workflow_query_handler::get_steps(ores::nats::message msg) {
         ws.started_at = fmt_opt_tp(s.started_at);
         ws.completed_at = fmt_opt_tp(s.completed_at);
         ws.error      = s.error;
+        if (!s.step_log_json.empty()) {
+            auto log = rfl::json::read<
+                std::vector<ores::workflow::messaging::step_log_entry>>(
+                    s.step_log_json);
+            if (log) ws.log = std::move(*log);
+        }
         resp.steps.push_back(std::move(ws));
     }
 
@@ -300,15 +307,34 @@ void workflow_query_handler::get_step_result(ores::nats::message msg) {
         return;
     }
 
-    const bool success = (sname == "completed");
+    using outcome = ores::workflow::messaging::step_outcome;
+    const auto step_outcome = (sname == "completed")
+        ? outcome::completed
+        : (sname == "completed_with_warnings")
+            ? outcome::completed_with_warnings
+            : outcome::failed;
+    const bool is_success =
+        step_outcome == outcome::completed ||
+        step_outcome == outcome::completed_with_warnings;
+
     BOOST_LOG_SEV(lg(), debug)
         << "get_step_result: step=" << req->step_id
         << " state=" << sname;
+
+    std::vector<ores::workflow::messaging::step_log_entry> log;
+    if (!step->step_log_json.empty()) {
+        auto parsed = rfl::json::read<
+            std::vector<ores::workflow::messaging::step_log_entry>>(
+                step->step_log_json);
+        if (parsed) log = std::move(*parsed);
+    }
+
     reply(nats_, msg, get_step_result_response{
         .found         = true,
-        .success       = success,
-        .result_json   = success ? step->response_json : "",
-        .error_message = success ? "" : step->error});
+        .outcome       = step_outcome,
+        .result_json   = is_success ? step->response_json : "",
+        .error_message = is_success ? "" : step->error,
+        .log           = std::move(log)});
 }
 
 }  // namespace ores::workflow::messaging

--- a/projects/ores.workflow.core/src/repository/workflow_step_mapper.cpp
+++ b/projects/ores.workflow.core/src/repository/workflow_step_mapper.cpp
@@ -56,6 +56,7 @@ workflow_step_mapper::map(const workflow_step_entity& v) {
     if (!v.created_at)
         throw std::logic_error("Cannot map entity with null created_at to domain object.");
     r.created_at = timestamp_to_timepoint(*v.created_at);
+    r.step_log_json = v.step_log_json.value_or("");
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -97,6 +98,8 @@ workflow_step_mapper::to_entity(const domain::workflow_step& v) {
     if (v.completed_at)
         r.completed_at = timepoint_to_timestamp(*v.completed_at, lg());
     r.created_at = timepoint_to_timestamp(v.created_at, lg());
+    r.step_log_json = v.step_log_json.empty()
+        ? std::nullopt : std::optional<std::string>(v.step_log_json);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain object to entity.";
     return r;

--- a/projects/ores.workflow.core/src/repository/workflow_step_repository.cpp
+++ b/projects/ores.workflow.core/src/repository/workflow_step_repository.cpp
@@ -108,7 +108,8 @@ void workflow_step_repository::update_state(
     context ctx, const boost::uuids::uuid& id,
     const boost::uuids::uuid& state_id,
     const std::string& response_json,
-    const std::string& error) {
+    const std::string& error,
+    const std::string& step_log_json) {
     BOOST_LOG_SEV(lg(), debug) << "Updating workflow step state: "
                                << boost::uuids::to_string(id)
                                << " -> " << boost::uuids::to_string(state_id);
@@ -123,6 +124,9 @@ void workflow_step_repository::update_state(
     const auto opt_error = error.empty()
         ? std::optional<std::string>{}
         : std::optional<std::string>(error);
+    const auto opt_log = step_log_json.empty()
+        ? std::optional<std::string>{}
+        : std::optional<std::string>(step_log_json);
     using ts_t = ores::database::repository::db_timestamp;
     const auto opt_now = std::optional<ts_t>(now);
 
@@ -130,6 +134,7 @@ void workflow_step_repository::update_state(
         "state_id"_c.set(state_id_str),
         "response_json"_c.set(opt_response),
         "error"_c.set(opt_error),
+        "step_log_json"_c.set(opt_log),
         "completed_at"_c.set(opt_now)
     ) | where("id"_c == id_str);
 

--- a/projects/ores.workflow.core/src/service/workflow_engine.cpp
+++ b/projects/ores.workflow.core/src/service/workflow_engine.cpp
@@ -376,7 +376,7 @@ void workflow_engine::on_step_completed(ores::nats::message msg) {
         break;
     case outcome::failed:
         step_repo_.update_state(ctx_, step_id,
-            step_states_.require("failed"), "", event.error_message, "");
+            step_states_.require("failed"), "", event.error_message, log_json);
         break;
     }
 

--- a/projects/ores.workflow.core/src/service/workflow_engine.cpp
+++ b/projects/ores.workflow.core/src/service/workflow_engine.cpp
@@ -330,8 +330,9 @@ void workflow_engine::on_step_completed(ores::nats::message msg) {
         << "Step-completed event received:"
         << " workflow=" << event.workflow_instance_id
         << " step=" << event.step_id
-        << " success=" << (event.success ? "true" : "false")
-        << (event.success ? "" : " error=" + event.error_message);
+        << " outcome=" << ores::workflow::messaging::to_string(event.outcome)
+        << (event.outcome == ores::workflow::messaging::step_outcome::failed
+            ? " error=" + event.error_message : "");
 
     // Load the workflow step.
     boost::uuids::uuid step_id;
@@ -356,13 +357,27 @@ void workflow_engine::on_step_completed(ores::nats::message msg) {
         return;
     }
 
+    // Serialize log entries (empty string when there are none).
+    const auto log_json = event.log.empty()
+        ? std::string{}
+        : rfl::json::write(event.log);
+
     // Update step state.
-    if (event.success) {
+    using outcome = ores::workflow::messaging::step_outcome;
+    switch (event.outcome) {
+    case outcome::completed:
         step_repo_.update_state(ctx_, step_id,
-            step_states_.require("completed"), event.result_json, "");
-    } else {
+            step_states_.require("completed"), event.result_json, "", "");
+        break;
+    case outcome::completed_with_warnings:
         step_repo_.update_state(ctx_, step_id,
-            step_states_.require("failed"), "", event.error_message);
+            step_states_.require("completed_with_warnings"),
+            event.result_json, "", log_json);
+        break;
+    case outcome::failed:
+        step_repo_.update_state(ctx_, step_id,
+            step_states_.require("failed"), "", event.error_message, "");
+        break;
     }
 
     // Load the workflow instance.
@@ -384,9 +399,14 @@ void workflow_engine::on_step_completed(ores::nats::message msg) {
     }
 
     // Distinguish between forward steps and compensation steps.
+    using outcome = ores::workflow::messaging::step_outcome;
+    const bool is_success =
+        event.outcome == outcome::completed ||
+        event.outcome == outcome::completed_with_warnings;
+
     if (step->step_index < 0) {
         // Compensation step completed — check if all compensations are done.
-        if (!event.success) {
+        if (!is_success) {
             BOOST_LOG_SEV(lg(), error)
                 << "Compensation step " << event.step_id << " failed: "
                 << event.error_message;
@@ -394,7 +414,7 @@ void workflow_engine::on_step_completed(ores::nats::message msg) {
         check_compensation_complete(*instance);
     } else {
         // Forward step completed.
-        if (event.success) {
+        if (is_success) {
             dispatch_next_step(*instance, event.result_json);
         } else {
             begin_compensation(*instance, event.error_message);


### PR DESCRIPTION
## Summary

- **Step outcome tri-state**: replaces the binary `success` flag with `step_outcome` (`completed` / `completed_with_warnings` / `failed`) in `step_completed_event`. The workflow engine maps each to a distinct DB FSM state; `completed_with_warnings` is terminal but visually distinct.
- **Step log**: adds `step_log_entry` (level + message + context) and `step_log_json` column on `workflow_steps`. The `ore_import_execute` handler emits per-trade warn/error entries and selects `completed_with_warnings` vs `failed` based on whether any trades saved successfully.
- **Workflow UI**: new `WorkflowStepLogWidget` (colour-coded log panel); `WorkflowStepsWidget` gains amber warning state and warning-count badge; `WorkflowMdiWindow` detail dialog embeds the log panel; `WorkflowMdiWindow` instance list gains a Completed At column; `OreImportWizard` done page shows an import summary and per-item warning table.
- **Service isolation Phase 3a**: `trade_status_service` no longer queries `ores_dq_fsm_transitions_tbl` directly. `trade_handler` fetches the FSM transition map from `dq.v1.fsm-transitions.list` via NATS (5-minute process-level cache) and passes it through `trade_service` → `trade_status_service::resolve_status`. Removes `ores.dq.core.lib` from `ores.trading.core` CMake link libraries.
- **`workflow_engine` bug fix**: the `failed` outcome branch was passing `""` for `step_log_json` in `step_repo_.update_state`, silently discarding the log on DB write even when the handler correctly populated it.
- **UI bug fix**: `MainWindow::performDisconnectCleanup` switched from `QtConcurrent::run` (nodiscard `QFuture<void>`) to `QThreadPool::globalInstance()->start` to fix `-Wunused-result` under `-Werror`.
- **UI bug fix**: `ClientManager` disconnect/reconnect no longer blocks the UI thread when services are down.
- **Currency validation fix**: `ores_refdata_currencies_check_fn` now validates against the tenant's own currencies rather than a fixed set.
- **Test sample**: `external/ore/examples/Products/SupportedTrades/FX_Forward_Invalid.xml` — a zero-amount FX Forward that passes XML parsing but fails the DB `bought_amount > 0` constraint, producing a `completed_with_warnings` step with a per-item log entry.
- **Doc**: workflow-engine-hardening and ore-import-error-reporting plans updated to reflect all completed work.