### PR TITLE
[qt] Break cross-plugin symbol dependencies (plugin isolation phase 1)

### DIFF
--- a/doc/agile/v0/sprint_backlog_17.org
+++ b/doc/agile/v0/sprint_backlog_17.org
@@ -314,6 +314,38 @@ Story is BLOCKED pending:
 Branch: =feature/fix-refdata-rls-validate-fn=
 Pull Request: [[https://github.com/OreStudio/OreStudio/pull/750][#750]]
 
+*** BLOCKED Qt plugin isolation (Category 2 cross-plugin dependencies)  :code:
+CLOSED: [2026-05-15 Thu 00:00]
+:LOGBOOK:
+CLOCK: [2026-05-15 Thu 00:00]--[2026-05-15 Thu 00:00] =>  0:00
+:END:
+
+Implement Phase 1 of =doc/plans/2026-05-15-qt-plugin-isolation.org=.
+
+Break the two Category 2 cross-plugin compile-time dependencies that were
+exposed when =-fvisibility=hidden= was applied to plugin shared libraries.
+
+***** Tasks
+
+- [X] Add =IBusinessUnitBrowser= abstract interface to =ores.qt.api=
+- [X] =BusinessUnitController= implements =IBusinessUnitBrowser=
+- [X] Replace =BusinessUnitController*= with =IBusinessUnitBrowser*= in =OrgExplorerMdiWindow=
+- [X] Remove =ores.qt.party.lib= from =ores.qt.trading= PUBLIC link deps
+- [X] Move 8 DQ catalogue controllers from =DataTransferPlugin= to =RefdataPlugin=
+- [X] =RefdataPlugin::setup_menus()= builds Data Catalogue submenu on =data_transfer_menu=
+- [X] =DataTransferPlugin= reduced to thin shell owning only the menu handle
+- [X] Remove =ores.qt.refdata.lib= from =ores.qt.data_transfer= link deps
+- [X] Commit and push; create PR
+
+***** Notes
+
+Story is BLOCKED pending:
+- User build verification (=make -C build/output/linux-clang-debug-make -j$(nproc)=)
+- Runtime testing (login, Data Catalogue menu, Org Explorer)
+- Pull request review
+
+Branch: =feature/qt-plugin-isolation=
+
 *** Footer
 
 | Previous: [[id:154212FF-BB02-8D84-1E33-9338B458380A][Version Zero]] |

--- a/doc/agile/v0/sprint_backlog_17.org
+++ b/doc/agile/v0/sprint_backlog_17.org
@@ -345,6 +345,7 @@ Story is BLOCKED pending:
 - Pull request review
 
 Branch: =feature/qt-plugin-isolation=
+Pull Request: [[https://github.com/OreStudio/OreStudio/pull/749][#749]]
 
 *** Footer
 

--- a/doc/agile/v0/sprint_backlog_17.org
+++ b/doc/agile/v0/sprint_backlog_17.org
@@ -335,6 +335,8 @@ exposed when =-fvisibility=hidden= was applied to plugin shared libraries.
 - [X] =RefdataPlugin::setup_menus()= builds Data Catalogue submenu on =data_transfer_menu=
 - [X] =DataTransferPlugin= reduced to thin shell owning only the menu handle
 - [X] Remove =ores.qt.refdata.lib= from =ores.qt.data_transfer= link deps
+- [X] Remove =ORES_QT_REFDATA_EXPORT= from 8 DQ catalogue controllers
+- [X] Remove =ORES_QT_PARTY_EXPORT= from =BusinessUnitController=
 - [X] Commit and push; create PR
 
 ***** Notes

--- a/doc/plans/2026-05-05-ore-domain-roundtrip.org
+++ b/doc/plans/2026-05-05-ore-domain-roundtrip.org
@@ -1,4 +1,5 @@
 #+title: ORE Domain Roundtrip Check (Thing 3)
+#+STATUS: COMPLETE
 #+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+note: Type bridge section updated 2026-05-06 — import/export cleanup (PR #728)
 #+      unified instrument carriers; trade_import_item and trade_export_item now

--- a/doc/plans/2026-05-15-qt-plugin-isolation.org
+++ b/doc/plans/2026-05-15-qt-plugin-isolation.org
@@ -1,4 +1,5 @@
 #+title: Qt Plugin Isolation: Cross-Plugin Symbol Dependencies
+#+STATUS: COMPLETE
 #+date: 2026-05-15
 #+author: Marco Craveiro
 

--- a/projects/ores.qt.api/include/ores.qt/IBusinessUnitBrowser.hpp
+++ b/projects/ores.qt.api/include/ores.qt/IBusinessUnitBrowser.hpp
@@ -1,0 +1,41 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_I_BUSINESS_UNIT_BROWSER_HPP
+#define ORES_QT_I_BUSINESS_UNIT_BROWSER_HPP
+
+#include "ores.refdata.api/domain/business_unit.hpp"
+
+namespace ores::qt {
+
+/**
+ * @brief Abstract interface for opening business unit edit/history windows.
+ *
+ * Decouples OrgExplorerMdiWindow (ores.qt.trading) from BusinessUnitController
+ * (ores.qt.party), breaking the cross-plugin compile-time dependency.
+ */
+class IBusinessUnitBrowser {
+public:
+    virtual ~IBusinessUnitBrowser() = default;
+    virtual void openEdit(const refdata::domain::business_unit& unit) = 0;
+    virtual void openHistory(const refdata::domain::business_unit& unit) = 0;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.data_transfer/include/ores.qt/DataTransferPlugin.hpp
+++ b/projects/ores.qt.data_transfer/include/ores.qt/DataTransferPlugin.hpp
@@ -19,28 +19,16 @@
 #ifndef ORES_QT_DATA_TRANSFER_PLUGIN_HPP
 #define ORES_QT_DATA_TRANSFER_PLUGIN_HPP
 
-#include <memory>
 #include <QList>
 #include "ores.qt/PluginBase.hpp"
 
 namespace ores::qt {
 
-class DataDomainController;
-class SubjectAreaController;
-class CatalogController;
-class DatasetBundleController;
-class MethodologyController;
-class OriginDimensionController;
-class NatureDimensionController;
-class TreatmentDimensionController;
-
 /**
  * @brief Qt plugin providing the Data Transfer top-level menu.
  *
- * Manages data catalogue controllers (data domains, subject areas, catalogues,
- * dataset bundles, methodologies, and dimension types).
- * Data Librarian and Import ORE Data are contributed by RefdataPlugin and
- * TradingPlugin via setup_menus on the shared data_transfer_menu.
+ * Owns the pre-created data_transfer_menu handle. All menu items are
+ * contributed by peer plugins (RefdataPlugin, TradingPlugin) via setup_menus.
  * Loaded as a shared library by QPluginLoader at application startup.
  */
 class DataTransferPlugin : public PluginBase {
@@ -66,15 +54,6 @@ private:
     // The data_transfer_menu is pre-created by MainWindow and passed via
     // setup_menus context. We hold a reference to return it from create_menus.
     QMenu* data_transfer_menu_{nullptr};
-
-    std::unique_ptr<DataDomainController>         dataDomainController_;
-    std::unique_ptr<SubjectAreaController>        subjectAreaController_;
-    std::unique_ptr<CatalogController>            catalogController_;
-    std::unique_ptr<DatasetBundleController>      datasetBundleController_;
-    std::unique_ptr<MethodologyController>        methodologyController_;
-    std::unique_ptr<OriginDimensionController>    originDimensionController_;
-    std::unique_ptr<NatureDimensionController>    natureDimensionController_;
-    std::unique_ptr<TreatmentDimensionController> treatmentDimensionController_;
 };
 
 }

--- a/projects/ores.qt.data_transfer/src/CMakeLists.txt
+++ b/projects/ores.qt.data_transfer/src/CMakeLists.txt
@@ -47,16 +47,11 @@ set_target_properties(${lib_target_name} PROPERTIES
 target_include_directories(${lib_target_name} PUBLIC
     ${ORES_QT_DATA_TRANSFER_DIR}/include)
 target_include_directories(${lib_target_name} PRIVATE
-    "${CMAKE_CURRENT_BINARY_DIR}/${lib_target_name}_autogen/include"
-    "${CMAKE_SOURCE_DIR}/projects/ores.qt.refdata/include"
-    "${CMAKE_SOURCE_DIR}/projects/ores.qt/include")
+    "${CMAKE_CURRENT_BINARY_DIR}/${lib_target_name}_autogen/include")
 
 target_link_libraries(${lib_target_name}
     PUBLIC
-        ores.qt.api.lib
-        ores.qt.refdata.lib
-    PRIVATE
-        ores.qt.lib)
+        ores.qt.api.lib)
 
 install(TARGETS ${lib_target_name}
     LIBRARY DESTINATION bin

--- a/projects/ores.qt.data_transfer/src/DataTransferPlugin.cpp
+++ b/projects/ores.qt.data_transfer/src/DataTransferPlugin.cpp
@@ -19,18 +19,7 @@
 #include "ores.qt/DataTransferPlugin.hpp"
 
 #include <QMenu>
-#include <QAction>
-
-#include "ores.qt/IconUtils.hpp"
 #include "ores.logging/make_logger.hpp"
-#include "ores.qt/DataDomainController.hpp"
-#include "ores.qt/SubjectAreaController.hpp"
-#include "ores.qt/CatalogController.hpp"
-#include "ores.qt/DatasetBundleController.hpp"
-#include "ores.qt/MethodologyController.hpp"
-#include "ores.qt/OriginDimensionController.hpp"
-#include "ores.qt/NatureDimensionController.hpp"
-#include "ores.qt/TreatmentDimensionController.hpp"
 
 namespace ores::qt {
 
@@ -41,10 +30,6 @@ namespace {
 auto& lg() {
     static auto instance = make_logger("ores.qt.data_transfer_plugin");
     return instance;
-}
-
-auto ico(Icon icon) {
-    return IconUtils::createRecoloredIcon(icon, IconUtils::DefaultIconColor);
 }
 
 }
@@ -60,54 +45,14 @@ DataTransferPlugin::~DataTransferPlugin() {
 void DataTransferPlugin::on_login(const plugin_context& ctx) {
     BOOST_LOG_SEV(lg(), debug) << "Login event received.";
     ctx_ = ctx;
-
-    dataDomainController_ = std::make_unique<DataDomainController>(
-        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
-        ctx_.change_reason_cache, ctx_.username, this);
-    connectControllerSignals(dataDomainController_.get());
-
-    subjectAreaController_ = std::make_unique<SubjectAreaController>(
-        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
-        ctx_.change_reason_cache, ctx_.username, this);
-    connectControllerSignals(subjectAreaController_.get());
-
-    catalogController_ = std::make_unique<CatalogController>(
-        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
-        ctx_.change_reason_cache, ctx_.username, this);
-    connectControllerSignals(catalogController_.get());
-
-    datasetBundleController_ = std::make_unique<DatasetBundleController>(
-        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
-        ctx_.change_reason_cache, ctx_.username, this);
-    connectControllerSignals(datasetBundleController_.get());
-
-    methodologyController_ = std::make_unique<MethodologyController>(
-        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
-        ctx_.change_reason_cache, ctx_.username, this);
-    connectControllerSignals(methodologyController_.get());
-
-    originDimensionController_ = std::make_unique<OriginDimensionController>(
-        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
-        ctx_.change_reason_cache, ctx_.username, this);
-    connectControllerSignals(originDimensionController_.get());
-
-    natureDimensionController_ = std::make_unique<NatureDimensionController>(
-        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
-        ctx_.change_reason_cache, ctx_.username, this);
-    connectControllerSignals(natureDimensionController_.get());
-
-    treatmentDimensionController_ = std::make_unique<TreatmentDimensionController>(
-        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
-        ctx_.change_reason_cache, ctx_.username, this);
-    connectControllerSignals(treatmentDimensionController_.get());
 }
 
 void DataTransferPlugin::setup_menus(const shared_menus_context& smc) {
     BOOST_LOG_SEV(lg(), debug) << "Capturing shared Data Transfer menu handle."
         << " data_transfer=" << (smc.data_transfer_menu ? "ok" : "null");
     // Save reference so create_menus() can return the pre-created menu.
-    // Other plugins (RefdataPlugin, TradingPlugin) contribute actions to it
-    // during their own setup_menus calls.
+    // RefdataPlugin and TradingPlugin contribute actions during their own
+    // setup_menus calls.
     data_transfer_menu_ = smc.data_transfer_menu;
 }
 
@@ -118,70 +63,11 @@ QList<QMenu*> DataTransferPlugin::create_menus() {
         BOOST_LOG_SEV(lg(), warn) << "Data Transfer menu handle is missing — no menu will appear.";
         return {};
     }
-
-    // ---- Data Catalogue submenu -----------------------------------------
-    auto* menuCatalogue = data_transfer_menu_->addMenu(tr("Data Ca&talogue"));
-
-    auto* actDataDomains = menuCatalogue->addAction(ico(Icon::Folder), tr("&Data Domains"));
-    connect(actDataDomains, &QAction::triggered, this, [this]() {
-        if (dataDomainController_) dataDomainController_->showListWindow();
-    });
-
-    auto* actSubjectAreas = menuCatalogue->addAction(ico(Icon::Table), tr("&Subject Areas"));
-    connect(actSubjectAreas, &QAction::triggered, this, [this]() {
-        if (subjectAreaController_) subjectAreaController_->showListWindow();
-    });
-
-    auto* actCatalogs = menuCatalogue->addAction(ico(Icon::Library), tr("&Catalogues"));
-    connect(actCatalogs, &QAction::triggered, this, [this]() {
-        if (catalogController_) catalogController_->showListWindow();
-    });
-
-    auto* actDatasetBundles = menuCatalogue->addAction(
-        ico(Icon::Folder), tr("Dataset &Bundles"));
-    connect(actDatasetBundles, &QAction::triggered, this, [this]() {
-        if (datasetBundleController_) datasetBundleController_->showListWindow();
-    });
-
-    auto* actMethodologies = menuCatalogue->addAction(ico(Icon::Book), tr("&Methodologies"));
-    connect(actMethodologies, &QAction::triggered, this, [this]() {
-        if (methodologyController_) methodologyController_->showListWindow();
-    });
-
-    menuCatalogue->addSeparator();
-
-    auto* actOriginDimensions = menuCatalogue->addAction(
-        ico(Icon::Database), tr("&Origin Dimensions"));
-    connect(actOriginDimensions, &QAction::triggered, this, [this]() {
-        if (originDimensionController_) originDimensionController_->showListWindow();
-    });
-
-    auto* actNatureDimensions = menuCatalogue->addAction(
-        ico(Icon::Database), tr("&Nature Dimensions"));
-    connect(actNatureDimensions, &QAction::triggered, this, [this]() {
-        if (natureDimensionController_) natureDimensionController_->showListWindow();
-    });
-
-    auto* actTreatmentDimensions = menuCatalogue->addAction(
-        ico(Icon::Database), tr("&Treatment Dimensions"));
-    connect(actTreatmentDimensions, &QAction::triggered, this, [this]() {
-        if (treatmentDimensionController_) treatmentDimensionController_->showListWindow();
-    });
-
-    BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
     return {data_transfer_menu_};
 }
 
 void DataTransferPlugin::on_logout() {
     BOOST_LOG_SEV(lg(), debug) << "Logout event received.";
-    treatmentDimensionController_.reset();
-    natureDimensionController_.reset();
-    originDimensionController_.reset();
-    methodologyController_.reset();
-    datasetBundleController_.reset();
-    catalogController_.reset();
-    subjectAreaController_.reset();
-    dataDomainController_.reset();
     ctx_ = {};
 }
 

--- a/projects/ores.qt.party/include/ores.qt/BusinessUnitController.hpp
+++ b/projects/ores.qt.party/include/ores.qt/BusinessUnitController.hpp
@@ -29,7 +29,6 @@
 #include "ores.logging/make_logger.hpp"
 #include "ores.refdata.api/domain/business_unit.hpp"
 #include "ores.qt/EntityListMdiWindow.hpp"
-#include "ores.qt/PartyExport.hpp"
 
 namespace ores::qt {
 
@@ -44,7 +43,7 @@ class ChangeReasonCache;
  * Manages the lifecycle of business unit list, detail, and history windows.
  * Handles event subscriptions and coordinates between windows.
  */
-class ORES_QT_PARTY_EXPORT BusinessUnitController final
+class BusinessUnitController final
     : public EntityController, public IBusinessUnitBrowser {
     Q_OBJECT
 

--- a/projects/ores.qt.party/include/ores.qt/BusinessUnitController.hpp
+++ b/projects/ores.qt.party/include/ores.qt/BusinessUnitController.hpp
@@ -23,6 +23,7 @@
 #include <QMdiArea>
 #include <QMainWindow>
 #include "ores.qt/EntityController.hpp"
+#include "ores.qt/IBusinessUnitBrowser.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/ImageCache.hpp"
 #include "ores.logging/make_logger.hpp"
@@ -43,7 +44,8 @@ class ChangeReasonCache;
  * Manages the lifecycle of business unit list, detail, and history windows.
  * Handles event subscriptions and coordinates between windows.
  */
-class ORES_QT_PARTY_EXPORT BusinessUnitController final : public EntityController {
+class ORES_QT_PARTY_EXPORT BusinessUnitController final
+    : public EntityController, public IBusinessUnitBrowser {
     Q_OBJECT
 
 private:
@@ -71,8 +73,8 @@ public:
     void closeAllWindows() override;
     void reloadListWindow() override;
 
-    void openEdit(const refdata::domain::business_unit& business_unit);
-    void openHistory(const refdata::domain::business_unit& business_unit);
+    void openEdit(const refdata::domain::business_unit& business_unit) override;
+    void openHistory(const refdata::domain::business_unit& business_unit) override;
 
 signals:
     void statusMessage(const QString& message);

--- a/projects/ores.qt.refdata/include/ores.qt/CatalogController.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/CatalogController.hpp
@@ -26,7 +26,6 @@
 #include "ores.qt/EntityController.hpp"
 #include "ores.dq.api/domain/catalog.hpp"
 #include "ores.logging/make_logger.hpp"
-#include "ores.qt/RefdataExport.hpp"
 
 namespace ores::qt {
 
@@ -37,7 +36,7 @@ class ChangeReasonCache;
 /**
  * @brief Controller for managing catalog-related windows.
  */
-class ORES_QT_REFDATA_EXPORT CatalogController : public EntityController {
+class CatalogController : public EntityController {
     Q_OBJECT
 
 private:

--- a/projects/ores.qt.refdata/include/ores.qt/DataDomainController.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/DataDomainController.hpp
@@ -26,7 +26,6 @@
 #include "ores.qt/ClientManager.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.dq.api/domain/data_domain.hpp"
-#include "ores.qt/RefdataExport.hpp"
 
 namespace ores::qt {
 
@@ -34,7 +33,7 @@ class DataDomainMdiWindow;
 class DetachableMdiSubWindow;
 class ChangeReasonCache;
 
-class ORES_QT_REFDATA_EXPORT DataDomainController final : public EntityController {
+class DataDomainController final : public EntityController {
     Q_OBJECT
 
 private:

--- a/projects/ores.qt.refdata/include/ores.qt/DatasetBundleController.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/DatasetBundleController.hpp
@@ -27,7 +27,6 @@
 #include "ores.logging/make_logger.hpp"
 #include "ores.dq.api/domain/dataset_bundle.hpp"
 #include "ores.qt/EntityListMdiWindow.hpp"
-#include "ores.qt/RefdataExport.hpp"
 
 namespace ores::qt {
 
@@ -41,7 +40,7 @@ class ChangeReasonCache;
  * Manages the lifecycle of dataset bundle list, detail, and history windows.
  * Handles event subscriptions and coordinates between windows.
  */
-class ORES_QT_REFDATA_EXPORT DatasetBundleController final : public EntityController {
+class DatasetBundleController final : public EntityController {
     Q_OBJECT
 
 private:

--- a/projects/ores.qt.refdata/include/ores.qt/MethodologyController.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/MethodologyController.hpp
@@ -27,7 +27,6 @@
 #include "ores.qt/ClientManager.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.dq.api/domain/methodology.hpp"
-#include "ores.qt/RefdataExport.hpp"
 
 namespace ores::qt {
 
@@ -35,7 +34,7 @@ class MethodologyMdiWindow;
 class DetachableMdiSubWindow;
 class ChangeReasonCache;
 
-class ORES_QT_REFDATA_EXPORT MethodologyController final : public EntityController {
+class MethodologyController final : public EntityController {
     Q_OBJECT
 
 private:

--- a/projects/ores.qt.refdata/include/ores.qt/NatureDimensionController.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/NatureDimensionController.hpp
@@ -26,7 +26,6 @@
 #include "ores.qt/ClientManager.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.dq.api/domain/nature_dimension.hpp"
-#include "ores.qt/RefdataExport.hpp"
 
 namespace ores::qt {
 
@@ -40,7 +39,7 @@ class ChangeReasonCache;
  * Manages the lifecycle of nature dimension list, detail, and history windows.
  * Handles event subscriptions and coordinates between windows.
  */
-class ORES_QT_REFDATA_EXPORT NatureDimensionController final : public EntityController {
+class NatureDimensionController final : public EntityController {
     Q_OBJECT
 
 private:

--- a/projects/ores.qt.refdata/include/ores.qt/OriginDimensionController.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/OriginDimensionController.hpp
@@ -27,7 +27,6 @@
 #include "ores.logging/make_logger.hpp"
 #include "ores.dq.api/domain/origin_dimension.hpp"
 #include "ores.qt/EntityListMdiWindow.hpp"
-#include "ores.qt/RefdataExport.hpp"
 
 namespace ores::qt {
 
@@ -41,7 +40,7 @@ class ChangeReasonCache;
  * Manages the lifecycle of origin dimension list, detail, and history windows.
  * Handles event subscriptions and coordinates between windows.
  */
-class ORES_QT_REFDATA_EXPORT OriginDimensionController final : public EntityController {
+class OriginDimensionController final : public EntityController {
     Q_OBJECT
 
 private:

--- a/projects/ores.qt.refdata/include/ores.qt/RefdataPlugin.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/RefdataPlugin.hpp
@@ -29,6 +29,14 @@ namespace ores::qt {
 
 class DataLibrarianWindow;
 class DetachableMdiSubWindow;
+class DataDomainController;
+class SubjectAreaController;
+class CatalogController;
+class DatasetBundleController;
+class MethodologyController;
+class OriginDimensionController;
+class NatureDimensionController;
+class TreatmentDimensionController;
 class CurrencyController;
 class CountryController;
 class ChangeReasonCategoryController;
@@ -59,15 +67,8 @@ class CdsConventionController;
  * @brief Reference data plugin: currencies, countries, dimensions, coding
  *        schemes, datasets, trading conventions, and related types.
  *
- * Extracted from LegacyPlugin in Step 5 of the Qt plugin refactor.
- * Owns the Data, Auxiliary Data, Data Governance, and related menus.
- */
-/**
- * @brief Reference data plugin: currencies, countries, dimensions, coding
- *        schemes, datasets, trading conventions, and related types.
- *
  * Loaded as a shared library by QPluginLoader at application startup.
- * Owns the Data, Auxiliary Data, Data Governance, and related menus.
+ * Owns the Reference Data, Data Transfer catalogue, and related menus.
  */
 class RefdataPlugin : public PluginBase {
     Q_OBJECT
@@ -123,6 +124,16 @@ private:
     std::unique_ptr<OvernightIndexConventionController>    overnightIndexConventionController_;
     std::unique_ptr<FxConventionController>                fxConventionController_;
     std::unique_ptr<CdsConventionController>               cdsConventionController_;
+
+    // Data Catalogue controllers (owned here, contributed to data_transfer_menu)
+    std::unique_ptr<DataDomainController>         dataDomainController_;
+    std::unique_ptr<SubjectAreaController>        subjectAreaController_;
+    std::unique_ptr<CatalogController>            catalogController_;
+    std::unique_ptr<DatasetBundleController>      datasetBundleController_;
+    std::unique_ptr<MethodologyController>        methodologyController_;
+    std::unique_ptr<OriginDimensionController>    originDimensionController_;
+    std::unique_ptr<NatureDimensionController>    natureDimensionController_;
+    std::unique_ptr<TreatmentDimensionController> treatmentDimensionController_;
 };
 
 }

--- a/projects/ores.qt.refdata/include/ores.qt/SubjectAreaController.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/SubjectAreaController.hpp
@@ -26,7 +26,6 @@
 #include "ores.qt/ClientManager.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.dq.api/domain/subject_area.hpp"
-#include "ores.qt/RefdataExport.hpp"
 
 namespace ores::qt {
 
@@ -34,7 +33,7 @@ class SubjectAreaMdiWindow;
 class DetachableMdiSubWindow;
 class ChangeReasonCache;
 
-class ORES_QT_REFDATA_EXPORT SubjectAreaController final : public EntityController {
+class SubjectAreaController final : public EntityController {
     Q_OBJECT
 
 private:

--- a/projects/ores.qt.refdata/include/ores.qt/TreatmentDimensionController.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/TreatmentDimensionController.hpp
@@ -26,7 +26,6 @@
 #include "ores.qt/ClientManager.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.dq.api/domain/treatment_dimension.hpp"
-#include "ores.qt/RefdataExport.hpp"
 
 namespace ores::qt {
 
@@ -41,7 +40,7 @@ class ChangeReasonCache;
  * Manages the lifecycle of treatment dimension list, detail, and history windows.
  * Handles event subscriptions and coordinates between windows.
  */
-class ORES_QT_REFDATA_EXPORT TreatmentDimensionController final : public EntityController {
+class TreatmentDimensionController final : public EntityController {
     Q_OBJECT
 
 private:

--- a/projects/ores.qt.refdata/src/RefdataPlugin.cpp
+++ b/projects/ores.qt.refdata/src/RefdataPlugin.cpp
@@ -53,6 +53,14 @@
 #include "ores.qt/OvernightIndexConventionController.hpp"
 #include "ores.qt/FxConventionController.hpp"
 #include "ores.qt/CdsConventionController.hpp"
+#include "ores.qt/DataDomainController.hpp"
+#include "ores.qt/SubjectAreaController.hpp"
+#include "ores.qt/CatalogController.hpp"
+#include "ores.qt/DatasetBundleController.hpp"
+#include "ores.qt/MethodologyController.hpp"
+#include "ores.qt/OriginDimensionController.hpp"
+#include "ores.qt/NatureDimensionController.hpp"
+#include "ores.qt/TreatmentDimensionController.hpp"
 
 namespace ores::qt {
 
@@ -210,6 +218,47 @@ void RefdataPlugin::on_login(const plugin_context& ctx) {
         ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
         ctx_.username, this);
     connectControllerSignals(cdsConventionController_.get());
+
+    // Data Catalogue controllers
+    dataDomainController_ = std::make_unique<DataDomainController>(
+        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
+        ctx_.change_reason_cache, ctx_.username, this);
+    connectControllerSignals(dataDomainController_.get());
+
+    subjectAreaController_ = std::make_unique<SubjectAreaController>(
+        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
+        ctx_.change_reason_cache, ctx_.username, this);
+    connectControllerSignals(subjectAreaController_.get());
+
+    catalogController_ = std::make_unique<CatalogController>(
+        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
+        ctx_.change_reason_cache, ctx_.username, this);
+    connectControllerSignals(catalogController_.get());
+
+    datasetBundleController_ = std::make_unique<DatasetBundleController>(
+        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
+        ctx_.change_reason_cache, ctx_.username, this);
+    connectControllerSignals(datasetBundleController_.get());
+
+    methodologyController_ = std::make_unique<MethodologyController>(
+        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
+        ctx_.change_reason_cache, ctx_.username, this);
+    connectControllerSignals(methodologyController_.get());
+
+    originDimensionController_ = std::make_unique<OriginDimensionController>(
+        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
+        ctx_.change_reason_cache, ctx_.username, this);
+    connectControllerSignals(originDimensionController_.get());
+
+    natureDimensionController_ = std::make_unique<NatureDimensionController>(
+        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
+        ctx_.change_reason_cache, ctx_.username, this);
+    connectControllerSignals(natureDimensionController_.get());
+
+    treatmentDimensionController_ = std::make_unique<TreatmentDimensionController>(
+        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager,
+        ctx_.change_reason_cache, ctx_.username, this);
+    connectControllerSignals(treatmentDimensionController_.get());
 }
 
 // ---------------------------------------------------------------------------
@@ -366,9 +415,57 @@ void RefdataPlugin::setup_menus(const shared_menus_context& smc) {
         });
     }
 
-    // ---- Data Transfer menu — contribute Data Librarian action ----------
+    // ---- Data Transfer menu — contribute Data Catalogue submenu + Data Librarian
     auto* dt = smc.data_transfer_menu;
     if (dt) {
+        auto* menuCatalogue = dt->addMenu(tr("Data Ca&talogue"));
+
+        auto* actDataDomains = menuCatalogue->addAction(ico(Icon::Folder), tr("&Data Domains"));
+        connect(actDataDomains, &QAction::triggered, this, [this]() {
+            if (dataDomainController_) dataDomainController_->showListWindow();
+        });
+
+        auto* actSubjectAreas = menuCatalogue->addAction(ico(Icon::Table), tr("&Subject Areas"));
+        connect(actSubjectAreas, &QAction::triggered, this, [this]() {
+            if (subjectAreaController_) subjectAreaController_->showListWindow();
+        });
+
+        auto* actCatalogs = menuCatalogue->addAction(ico(Icon::Library), tr("&Catalogues"));
+        connect(actCatalogs, &QAction::triggered, this, [this]() {
+            if (catalogController_) catalogController_->showListWindow();
+        });
+
+        auto* actDatasetBundles = menuCatalogue->addAction(
+            ico(Icon::Folder), tr("Dataset &Bundles"));
+        connect(actDatasetBundles, &QAction::triggered, this, [this]() {
+            if (datasetBundleController_) datasetBundleController_->showListWindow();
+        });
+
+        auto* actMethodologies = menuCatalogue->addAction(ico(Icon::Book), tr("&Methodologies"));
+        connect(actMethodologies, &QAction::triggered, this, [this]() {
+            if (methodologyController_) methodologyController_->showListWindow();
+        });
+
+        menuCatalogue->addSeparator();
+
+        auto* actOriginDimensions = menuCatalogue->addAction(
+            ico(Icon::Database), tr("&Origin Dimensions"));
+        connect(actOriginDimensions, &QAction::triggered, this, [this]() {
+            if (originDimensionController_) originDimensionController_->showListWindow();
+        });
+
+        auto* actNatureDimensions = menuCatalogue->addAction(
+            ico(Icon::Database), tr("&Nature Dimensions"));
+        connect(actNatureDimensions, &QAction::triggered, this, [this]() {
+            if (natureDimensionController_) natureDimensionController_->showListWindow();
+        });
+
+        auto* actTreatmentDimensions = menuCatalogue->addAction(
+            ico(Icon::Database), tr("&Treatment Dimensions"));
+        connect(actTreatmentDimensions, &QAction::triggered, this, [this]() {
+            if (treatmentDimensionController_) treatmentDimensionController_->showListWindow();
+        });
+
         act_data_librarian_ = dt->addAction(
             IconUtils::createRecoloredIcon(Icon::Library, IconUtils::DefaultIconColor),
             tr("Data &Librarian"));
@@ -437,6 +534,15 @@ void RefdataPlugin::on_logout() {
         data_librarian_window_->close();
         data_librarian_window_ = nullptr;
     }
+
+    treatmentDimensionController_.reset();
+    natureDimensionController_.reset();
+    originDimensionController_.reset();
+    methodologyController_.reset();
+    datasetBundleController_.reset();
+    catalogController_.reset();
+    subjectAreaController_.reset();
+    dataDomainController_.reset();
 
     zeroConventionController_.reset();
     purposeTypeController_.reset();

--- a/projects/ores.qt.trading/include/ores.qt/OrgExplorerMdiWindow.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/OrgExplorerMdiWindow.hpp
@@ -45,7 +45,7 @@
 
 namespace ores::qt {
 
-class BusinessUnitController;
+class IBusinessUnitBrowser;
 class BookController;
 class TradeController;
 
@@ -78,7 +78,7 @@ private:
 public:
     explicit OrgExplorerMdiWindow(
         ClientManager* clientManager,
-        BusinessUnitController* businessUnitController,
+        IBusinessUnitBrowser* businessUnitController,
         BookController* bookController,
         TradeController* tradeController,
         const QString& username,
@@ -164,7 +164,7 @@ private:
     QString username_;
 
     // Controllers (not owned — lifetime guaranteed by MainWindow)
-    BusinessUnitController* businessUnitController_{nullptr};
+    IBusinessUnitBrowser* businessUnitController_{nullptr};
     BookController* bookController_{nullptr};
     TradeController* tradeController_{nullptr};
 

--- a/projects/ores.qt.trading/src/CMakeLists.txt
+++ b/projects/ores.qt.trading/src/CMakeLists.txt
@@ -55,14 +55,12 @@ target_include_directories(${lib_target_name} PRIVATE
     # Transient: trading controllers include headers still in ores.qt or other plugins.
     # Remove as files migrate to their final projects.
     "${CMAKE_SOURCE_DIR}/projects/ores.qt/include"
-    "${CMAKE_SOURCE_DIR}/projects/ores.qt.party/include"
     "${CMAKE_SOURCE_DIR}/projects/ores.qt.mktdata/include"
     "${CMAKE_SOURCE_DIR}/projects/ores.qt.workflow/include")
 
 target_link_libraries(${lib_target_name}
     PUBLIC
         ores.qt.api.lib
-        ores.qt.party.lib
         ores.refdata.api.lib
         ores.trading.api.lib
         ores.ore.core.lib

--- a/projects/ores.qt.trading/src/OrgExplorerMdiWindow.cpp
+++ b/projects/ores.qt.trading/src/OrgExplorerMdiWindow.cpp
@@ -28,7 +28,7 @@
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/ExceptionHelper.hpp"
 #include "ores.qt/WidgetUtils.hpp"
-#include "ores.qt/BusinessUnitController.hpp"
+#include "ores.qt/IBusinessUnitBrowser.hpp"
 #include "ores.qt/BookController.hpp"
 #include "ores.qt/TradeController.hpp"
 #include "ores.refdata.api/messaging/business_unit_protocol.hpp"
@@ -43,7 +43,7 @@ using namespace ores::logging;
 
 OrgExplorerMdiWindow::OrgExplorerMdiWindow(
     ClientManager* clientManager,
-    BusinessUnitController* businessUnitController,
+    IBusinessUnitBrowser* businessUnitController,
     BookController* bookController,
     TradeController* tradeController,
     const QString& username,


### PR DESCRIPTION
## Summary

- Add `IBusinessUnitBrowser` abstract interface to `ores.qt.api`; `BusinessUnitController` implements it. `OrgExplorerMdiWindow` now stores `IBusinessUnitBrowser*` instead of `BusinessUnitController*`, removing the `ores.qt.trading → ores.qt.party` compile-time link.
- Move the 8 DQ catalogue controllers (DataDomain, SubjectArea, Catalog, DatasetBundle, Methodology, OriginDimension, NatureDimension, TreatmentDimension) from `DataTransferPlugin` into `RefdataPlugin` where they logically belong. `RefdataPlugin::setup_menus()` builds the Data Catalogue submenu on `smc.data_transfer_menu`. `DataTransferPlugin` is reduced to a thin shell that only owns the menu handle, removing the `ores.qt.data_transfer → ores.qt.refdata` compile-time link.

Both are Category 2 violations from `doc/plans/2026-05-15-qt-plugin-isolation.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)