### PR TITLE
[sql] Fix refdata validate functions: use p_tenant_id not system_tenant_id

### DIFF
--- a/doc/agile/v0/sprint_backlog_17.org
+++ b/doc/agile/v0/sprint_backlog_17.org
@@ -281,6 +281,39 @@ and CMake link, then regenerating) was needed.
 Branch: =feature/ore-workflow-write-decoupling=
 Pull Request: [[https://github.com/OreStudio/OreStudio/pull/746][#746]]
 
+*** BLOCKED Fix refdata RLS validate function bug                    :code:
+CLOSED: [2026-05-16 Sat 00:00]
+:LOGBOOK:
+CLOCK: [2026-05-16 Sat 00:00]--[2026-05-16 Sat 00:00] =>  0:00
+:END:
+
+Fix =ores_refdata_validate_monetary_nature_fn=, =ores_refdata_validate_currency_market_tier_fn=,
+and =ores_refdata_validate_rounding_type_fn= to use =p_tenant_id= instead of
+=ores_utility_system_tenant_id_fn()=.
+
+With RLS enabled on =ores_refdata_monetary_natures_tbl= and
+=ores_refdata_currency_market_tiers_tbl=, a provisioned test-tenant session cannot see
+system-tenant rows. The bootstrap pass-through is bypassed (test-tenant rows are visible),
+but the system-tenant validation query returns zero rows, causing:
+=ERROR: Invalid monetary_nature: fiat. Must be one of: <NULL>=
+
+***** Tasks
+
+- [X] Change =system_tenant_validation: true= → =false= in three entity JSON models
+- [X] Regenerate SQL via =generate_refdata_schema.sh=
+- [X] Run =validate_schemas.sh= — passes clean
+- [X] Commit and push; create PR
+
+***** Notes
+
+Story is BLOCKED pending:
+- User build verification
+- Runtime testing (currency insert flows)
+- Pull request review
+
+Branch: =feature/fix-refdata-rls-validate-fn=
+Pull Request: [[https://github.com/OreStudio/OreStudio/pull/750][#750]]
+
 *** Footer
 
 | Previous: [[id:154212FF-BB02-8D84-1E33-9338B458380A][Version Zero]] |

--- a/projects/ores.codegen/models/refdata/currency_market_tier_entity.json
+++ b/projects/ores.codegen/models/refdata/currency_market_tier_entity.json
@@ -7,7 +7,7 @@
     "entity_plural": "currency_market_tiers",
     "description": "Currency market tier classification. Drives UI priority, liquidity expectations, and risk limits.",
     "has_tenant_id": true,
-    "system_tenant_validation": true,
+    "system_tenant_validation": false,
     "has_display_order": true,
     "default_value": "g10",
     "primary_key": {

--- a/projects/ores.codegen/models/refdata/monetary_nature_entity.json
+++ b/projects/ores.codegen/models/refdata/monetary_nature_entity.json
@@ -7,7 +7,7 @@
     "entity_plural": "monetary_natures",
     "description": "Monetary nature classification. Defines the monetary nature of the currency.",
     "has_tenant_id": true,
-    "system_tenant_validation": true,
+    "system_tenant_validation": false,
     "has_display_order": true,
     "default_value": "fiat",
     "primary_key": {

--- a/projects/ores.codegen/models/refdata/rounding_type_entity.json
+++ b/projects/ores.codegen/models/refdata/rounding_type_entity.json
@@ -7,7 +7,7 @@
     "entity_plural": "rounding_types",
     "description": "Rounding Types - Valid rounding methods per ORE XML schema (roundingType)",
     "has_tenant_id": true,
-    "system_tenant_validation": true,
+    "system_tenant_validation": false,
     "has_display_order": true,
     "default_value": "Closest",
     "primary_key": {

--- a/projects/ores.sql/create/refdata/refdata_currency_market_tiers_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_currency_market_tiers_create.sql
@@ -125,7 +125,7 @@ do instead
 -- Validation function for currency_market_tier
 -- Validates that a code exists in the currency_market_tiers table.
 -- Returns the validated value, or default if null/empty.
--- Uses system tenant data (shared reference data).
+-- Uses current tenant data.
 -- =============================================================================
 create or replace function ores_refdata_validate_currency_market_tier_fn(
     p_tenant_id uuid,
@@ -145,14 +145,14 @@ begin
     -- Validate against reference data
     if not exists (
         select 1 from ores_refdata_currency_market_tiers_tbl
-        where tenant_id = ores_utility_system_tenant_id_fn()
+        where tenant_id = p_tenant_id
           and code = p_value
           and valid_to = ores_utility_infinity_timestamp_fn()
     ) then
         raise exception 'Invalid currency_market_tier: %. Must be one of: %', p_value, (
             select string_agg(code::text, ', ' order by display_order)
             from ores_refdata_currency_market_tiers_tbl
-            where tenant_id = ores_utility_system_tenant_id_fn()
+            where tenant_id = p_tenant_id
               and valid_to = ores_utility_infinity_timestamp_fn()
         ) using errcode = '23503';
     end if;

--- a/projects/ores.sql/create/refdata/refdata_monetary_natures_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_monetary_natures_create.sql
@@ -125,7 +125,7 @@ do instead
 -- Validation function for monetary_nature
 -- Validates that a code exists in the monetary_natures table.
 -- Returns the validated value, or default if null/empty.
--- Uses system tenant data (shared reference data).
+-- Uses current tenant data.
 -- =============================================================================
 create or replace function ores_refdata_validate_monetary_nature_fn(
     p_tenant_id uuid,
@@ -145,14 +145,14 @@ begin
     -- Validate against reference data
     if not exists (
         select 1 from ores_refdata_monetary_natures_tbl
-        where tenant_id = ores_utility_system_tenant_id_fn()
+        where tenant_id = p_tenant_id
           and code = p_value
           and valid_to = ores_utility_infinity_timestamp_fn()
     ) then
         raise exception 'Invalid monetary_nature: %. Must be one of: %', p_value, (
             select string_agg(code::text, ', ' order by display_order)
             from ores_refdata_monetary_natures_tbl
-            where tenant_id = ores_utility_system_tenant_id_fn()
+            where tenant_id = p_tenant_id
               and valid_to = ores_utility_infinity_timestamp_fn()
         ) using errcode = '23503';
     end if;

--- a/projects/ores.sql/create/refdata/refdata_rounding_types_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_rounding_types_create.sql
@@ -125,7 +125,7 @@ do instead
 -- Validation function for rounding_type
 -- Validates that a code exists in the rounding_types table.
 -- Returns the validated value, or default if null/empty.
--- Uses system tenant data (shared reference data).
+-- Uses current tenant data.
 -- =============================================================================
 create or replace function ores_refdata_validate_rounding_type_fn(
     p_tenant_id uuid,
@@ -145,14 +145,14 @@ begin
     -- Validate against reference data
     if not exists (
         select 1 from ores_refdata_rounding_types_tbl
-        where tenant_id = ores_utility_system_tenant_id_fn()
+        where tenant_id = p_tenant_id
           and code = p_value
           and valid_to = ores_utility_infinity_timestamp_fn()
     ) then
         raise exception 'Invalid rounding_type: %. Must be one of: %', p_value, (
             select string_agg(code::text, ', ' order by display_order)
             from ores_refdata_rounding_types_tbl
-            where tenant_id = ores_utility_system_tenant_id_fn()
+            where tenant_id = p_tenant_id
               and valid_to = ores_utility_infinity_timestamp_fn()
         ) using errcode = '23503';
     end if;


### PR DESCRIPTION
## Summary

- `ores_refdata_validate_monetary_nature_fn`, `ores_refdata_validate_currency_market_tier_fn`, and `ores_refdata_validate_rounding_type_fn` were querying with `tenant_id = ores_utility_system_tenant_id_fn()` (the max-UUID system tenant).
- `ores_refdata_monetary_natures_tbl` and `ores_refdata_currency_market_tiers_tbl` have Row Level Security enabled (`tenant_id = ores_iam_current_tenant_id_fn()`). Service users cannot see rows from other tenants, including the system tenant.
- When a provisioned test tenant's session inserts a currency: the bootstrap skip (`not exists … limit 1`) is bypassed because the test tenant's own monetary-nature rows are visible; the system-tenant validation query then returns zero rows (filtered by RLS); `string_agg` returns NULL; the exception fires: `ERROR: Invalid monetary_nature: fiat. Must be one of: <NULL>`.

**Fix:** Set `system_tenant_validation: false` in the three entity JSON models and regenerate. The validate functions now use `p_tenant_id` (the currency's own tenant). Each provisioned tenant already receives its own copy of these lookup tables via `ores_iam_provision_tenant_fn`, so validating against the caller's tenant is correct and RLS-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)