### PR TITLE
[sql] Codegen drift remediation: template fixes + report_definitions

### DIFF
--- a/doc/plans/2026-05-14-codegen-sql-debt.org
+++ b/doc/plans/2026-05-14-codegen-sql-debt.org
@@ -1,7 +1,7 @@
 #+TITLE: Codegen SQL Debt — Hand-Written Files with Existing Models
 #+DATE: 2026-05-14
 #+AUTHOR: ORE Studio Team
-#+STATUS: IN PROGRESS
+#+STATUS: IN PROGRESS (PR #752)
 
 * Problem
 
@@ -29,7 +29,7 @@ Remediation work started in PR #747 (~investigation/codegen-drift~,
 
 * Category A — SQL Exists But Not Codegen-Managed
 
-Originally 24 files; 20 resolved as of 2026-05-15.
+Originally 24 files; 21 resolved as of 2026-05-16.
 
 ** IAM (1 remaining of 4)
 
@@ -46,20 +46,20 @@ Originally 24 files; 20 resolved as of 2026-05-15.
 |----------+------------+--------|
 | ~dq/dq_artefact_types_create.sql~ | ~dq/artefact_type_entity.json~ | DONE — auto-generated via ~sql_schema_table_create.mustache~ (pre-PR #747) |
 
-** Reporting (2 remaining of 4)
+** Reporting (1 remaining of 4)
 
 | SQL file | Model file | Status |
 |----------+------------+--------|
 | ~reporting/reporting_concurrency_policies_create.sql~ | ~reporting/concurrency_policy_domain_entity.json~ | DONE — PR #747 |
-| ~reporting/reporting_report_definitions_create.sql~ | ~reporting/report_definition_domain_entity.json~ | DEFERRED — template needs extensions for soft-FK validations and ~SECURITY DEFINER set search_path~ |
-| ~reporting/reporting_report_instances_create.sql~ | ~reporting/report_instance_domain_entity.json~ | DEFERRED — same as ~report_definitions~ |
+| ~reporting/reporting_report_definitions_create.sql~ | ~reporting/report_definition_domain_entity.json~ | DONE — PR #752 (template extended with prefix_columns + soft_fk_validations) |
+| ~reporting/reporting_report_instances_create.sql~ | ~reporting/report_instance_domain_entity.json~ | DEFERRED — template needs extension for ~definition_id~ denormalization (SELECT + conditional copy) |
 | ~reporting/reporting_report_types_create.sql~ | ~reporting/report_type_domain_entity.json~ | DONE — PR #747 |
 
 ** Scheduler (1 remaining of 1)
 
 | SQL file | Model file | Status |
 |----------+------------+--------|
-| ~scheduler/scheduler_job_definitions_create.sql~ | ~scheduler/job_definition_domain_entity.json~ | TODO — model significantly out of date; requires model update before regeneration |
+| ~scheduler/scheduler_job_definitions_create.sql~ | ~scheduler/job_definition_domain_entity.json~ | DEFERRED — model has nullable tenant_id and system-scope jobs; template always assumes non-null tenant_id |
 
 ** Trading (1 remaining of 14)
 
@@ -77,7 +77,7 @@ Originally 24 files; 20 resolved as of 2026-05-15.
 | ~trading/trading_leg_types_create.sql~ | ~trading/leg_type_domain_entity.json~ | DONE — PR #747 |
 | ~trading/trading_payment_frequency_types_create.sql~ | ~trading/payment_frequency_type_domain_entity.json~ | DONE — PR #747 |
 | ~trading/trading_swaption_instruments_create.sql~ | ~trading/swaption_instrument_domain_entity.json~ | DONE — PR #747 |
-| ~trading/trading_trades_create.sql~ | ~trading/trade_domain_entity.json~ | TODO |
+| ~trading/trading_trades_create.sql~ | ~trading/trade_domain_entity.json~ | DEFERRED — requires party_id denormalization from book_id and cross-validation (portfolio match); cannot template these |
 | ~trading/trading_vanilla_swap_instruments_create.sql~ | ~trading/vanilla_swap_instrument_domain_entity.json~ | DONE — PR #747 |
 
 ** Remediation per file
@@ -95,16 +95,16 @@ IAM ~tenants~ should be done last (most complex custom logic).
 
 * Category B — Model Exists But No SQL File
 
-Originally 9 files; 6 resolved as of 2026-05-15.
+Originally 9 files; all resolved as of 2026-05-16.
 
-** DQ (3 remaining of 4)
+** DQ (0 remaining of 4)
 
 | Expected SQL path | Model file | Status |
 |-------------------+------------+--------|
 | ~dq/dq_dataset_bundles_create.sql~ | ~dq/dataset_bundle_domain_entity.json~ | RESOLVED — hand-written ~dq_dataset_bundle_create.sql~ (singular) is the intended file |
-| ~dq/dq_lei_entities_create.sql~ | ~dq/lei_entities_entity.json~ | TODO — LEI entity table not yet in schema |
-| ~dq/dq_lei_relationships_create.sql~ | ~dq/lei_relationships_entity.json~ | TODO — LEI relationship table not yet in schema |
-| ~dq/dq_report_definitions_create.sql~ | ~dq/report_definitions_entity.json~ | TODO — verify intent; distinct from ~ores_dq_report_definitions_artefact_tbl~ |
+| ~dq/dq_lei_entities_create.sql~ | ~dq/lei_entities_entity.json~ | RESOLVED — entity.json generates ~_artefact_create.sql~ only; artefact file already codegen-managed |
+| ~dq/dq_lei_relationships_create.sql~ | ~dq/lei_relationships_entity.json~ | RESOLVED — entity.json generates ~_artefact_create.sql~ only; artefact file already codegen-managed |
+| ~dq/dq_report_definitions_create.sql~ | ~dq/report_definitions_entity.json~ | RESOLVED — entity.json generates ~_artefact_create.sql~ only; artefact file already codegen-managed |
 
 ** Database (0 remaining of 1)
 
@@ -132,19 +132,15 @@ For each remaining Category B file, determine whether:
 - (c) The model is stale and the entity will not be implemented: delete the
   model file.
 
-* Remaining Work (as of 2026-05-15)
+* Remaining Work (as of 2026-05-16)
 
-Category A — 4 files outstanding:
-- ~iam/iam_tenants_create.sql~ — do last; most complex
-- ~reporting/reporting_report_definitions_create.sql~ — deferred; needs template extensions
-- ~reporting/reporting_report_instances_create.sql~ — deferred; needs template extensions
-- ~scheduler/scheduler_job_definitions_create.sql~ — model needs update first
-- ~trading/trading_trades_create.sql~
+Category A — 4 files outstanding (all require template extensions beyond current scope):
+- ~iam/iam_tenants_create.sql~ — do last; most complex (custom RLS, system-scoped PK, bitemporal trigger)
+- ~reporting/reporting_report_instances_create.sql~ — deferred; needs definition_id denormalization template support
+- ~scheduler/scheduler_job_definitions_create.sql~ — deferred; nullable tenant_id not supported by template
+- ~trading/trading_trades_create.sql~ — deferred; party_id denormalization + cross-validation cannot be templatized
 
-Category B — 3 files outstanding:
-- ~dq/dq_lei_entities_create.sql~
-- ~dq/dq_lei_relationships_create.sql~
-- ~dq/dq_report_definitions_create.sql~
+Category B — all resolved.
 
 * Impact on Identifier Cleanup
 
@@ -157,10 +153,8 @@ no action in the cleanup branch.
 
 * Execution Order
 
-Remaining work suggested order:
-1. ~trading_trades~ (straightforward domain entity).
-2. ~scheduler_job_definitions~ (update model first).
-3. DQ Category B items (investigate intent, generate or delete).
-4. ~reporting_report_definitions~ and ~reporting_report_instances~ (extend
-   template for soft-FK validations and ~SECURITY DEFINER set search_path~).
-5. ~iam_tenants~ (last; most custom logic).
+Remaining work suggested order (all require non-trivial template extensions):
+1. ~reporting_report_instances~ — extend template for denormalization-with-fallback pattern.
+2. ~trading_trades~ — extend template for multi-column denormalization and cross-validation.
+3. ~scheduler_job_definitions~ — extend template for nullable tenant_id / system-scope jobs.
+4. ~iam_tenants~ (last; most custom logic: RLS, custom trigger, delete rule side effects).

--- a/projects/ores.codegen/library/templates/sql_schema_domain_entity_create.mustache
+++ b/projects/ores.codegen/library/templates/sql_schema_domain_entity_create.mustache
@@ -160,7 +160,7 @@ begin
 
     return NEW;
 end;
-$$ language plpgsql{{#domain_entity.sql.security_definer}} security definer{{/domain_entity.sql.security_definer}};
+$$ language plpgsql{{#domain_entity.sql.security_definer}} security definer set search_path = public, pg_temp{{/domain_entity.sql.security_definer}};
 
 create or replace trigger {{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_insert_trg
 before insert on "{{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_tbl"

--- a/projects/ores.codegen/library/templates/sql_schema_domain_entity_create.mustache
+++ b/projects/ores.codegen/library/templates/sql_schema_domain_entity_create.mustache
@@ -53,7 +53,7 @@ create table if not exists "{{domain_entity.product}}_{{domain_entity.component}
 -- Unique {{column}} for active records
 {{#domain_entity.has_tenant_id}}
 create unique index if not exists {{domain_entity.index_name_prefix}}_{{column}}_uniq_idx
-on "{{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_tbl" (tenant_id, {{column}})
+on "{{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_tbl" (tenant_id{{#prefix_columns}}, {{prefix_columns}}{{/prefix_columns}}, {{column}})
 where valid_to = ores_utility_infinity_timestamp_fn();
 {{/domain_entity.has_tenant_id}}
 {{^domain_entity.has_tenant_id}}
@@ -112,6 +112,38 @@ begin
     NEW.party_id := current_setting('app.current_party_id')::uuid;
 
 {{/domain_entity.sql.party_id_from_session}}
+{{#domain_entity.sql.soft_fk_validations}}
+{{^nullable}}
+    -- Validate {{column}} (soft FK to {{table}})
+    if not exists (
+        select 1 from {{table}}
+        where {{^use_system_tenant}}tenant_id = NEW.tenant_id
+          and {{/use_system_tenant}}{{#use_system_tenant}}tenant_id = ores_utility_system_tenant_id_fn()
+          and {{/use_system_tenant}}id = NEW.{{column}}
+          and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
+        raise exception '{{error_message}}', NEW.{{column}}
+            using errcode = '23503';
+    end if;
+
+{{/nullable}}
+{{#nullable}}
+    -- Validate {{column}} (optional soft FK to {{table}})
+    if NEW.{{column}} is not null then
+        if not exists (
+            select 1 from {{table}}
+            where {{^use_system_tenant}}tenant_id = NEW.tenant_id
+              and {{/use_system_tenant}}{{#use_system_tenant}}tenant_id = ores_utility_system_tenant_id_fn()
+              and {{/use_system_tenant}}id = NEW.{{column}}
+              and valid_to = ores_utility_infinity_timestamp_fn()
+        ) then
+            raise exception '{{error_message}}', NEW.{{column}}
+                using errcode = '23503';
+        end if;
+    end if;
+
+{{/nullable}}
+{{/domain_entity.sql.soft_fk_validations}}
 {{#domain_entity.validations}}
     -- Validate {{column}}
     NEW.{{column}} := {{validation_function}}({{#domain_entity.has_tenant_id}}NEW.tenant_id, {{/domain_entity.has_tenant_id}}NEW.{{column}});

--- a/projects/ores.codegen/models/reporting/report_definition_domain_entity.json
+++ b/projects/ores.codegen/models/reporting/report_definition_domain_entity.json
@@ -14,6 +14,7 @@
       "column": "id",
       "type": "uuid",
       "cpp_type": "boost::uuids::uuid",
+      "uuid_check_fn": "ores_utility_nil_uuid_fn()",
       "description": "UUID uniquely identifying this report definition."
     },
 
@@ -22,9 +23,21 @@
         "column": "name",
         "type": "text",
         "cpp_type": "std::string",
-        "description": "Unique name for the report definition within a tenant.",
+        "prefix_columns": "party_id",
+        "description": "Unique name for the report definition within a party.",
         "generator_expr": "std::string(faker::word::noun()) + \"_report\""
       }
+    ],
+
+    "validations": [
+      {"column": "report_type", "validation_function": "ores_reporting_validate_report_type_fn"},
+      {"column": "concurrency_policy", "validation_function": "ores_reporting_validate_concurrency_policy_fn"}
+    ],
+
+    "indexes": [
+      {"unique": true, "name": "scheduler_job_id_uniq", "columns": "scheduler_job_id", "current_only": true, "where_extra": "scheduler_job_id is not null"},
+      {"name": "party", "columns": "tenant_id, party_id", "current_only": true},
+      {"name": "fsm_state", "columns": "tenant_id, fsm_state_id", "current_only": true}
     ],
 
     "columns": [
@@ -41,6 +54,7 @@
         "type": "text",
         "cpp_type": "std::string",
         "nullable": false,
+        "default": "''",
         "description": "Human-readable description of the report.",
         "generator_expr": "std::string(faker::lorem::sentence())"
       },
@@ -73,6 +87,7 @@
         "type": "text",
         "cpp_type": "std::string",
         "nullable": false,
+        "default": "'skip'",
         "description": "Concurrency policy code (FK to ores_reporting_concurrency_policies_tbl).",
         "generator_expr": "std::string(\"skip\")"
       },
@@ -87,7 +102,25 @@
     ],
 
     "sql": {
-      "tablename": "ores_reporting_report_definitions_tbl"
+      "tablename": "ores_reporting_report_definitions_tbl",
+      "security_definer": true,
+      "extra_checks": ["\"name\" <> ''", "\"schedule_expression\" <> ''"],
+      "soft_fk_validations": [
+        {
+          "column": "party_id",
+          "table": "ores_refdata_parties_tbl",
+          "error_message": "Invalid party_id: %. No active party found with this id.",
+          "nullable": false,
+          "use_system_tenant": false
+        },
+        {
+          "column": "fsm_state_id",
+          "table": "ores_dq_fsm_states_tbl",
+          "error_message": "Invalid fsm_state_id: %. No active FSM state found with this id.",
+          "nullable": true,
+          "use_system_tenant": true
+        }
+      ]
     },
 
     "repository": {

--- a/projects/ores.sql/create/reporting/reporting_report_definitions_create.sql
+++ b/projects/ores.sql/create/reporting/reporting_report_definitions_create.sql
@@ -17,9 +17,12 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-
 /**
- * Report Definitions Table
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_domain_entity_create.mustache
+ * To modify, update the template and regenerate.
+ *
+ *  Table
  *
  * The persistent template for a report. Describes what to run, when to run it,
  * and how to handle concurrent executions. Type-specific configuration (e.g.
@@ -34,23 +37,23 @@
  */
 
 create table if not exists "ores_reporting_report_definitions_tbl" (
-    "id"                   uuid    not null,
-    "tenant_id"            uuid    not null,
-    "version"              integer not null,
-    "party_id"             uuid    not null,
-    "name"                 text    not null,
-    "description"          text    not null default '',
-    "report_type"          text    not null,
-    "fsm_state_id"         uuid    null,
-    "schedule_expression"  text    not null,
-    "concurrency_policy"   text    not null default 'skip',
-    "scheduler_job_id"     uuid    null,
-    "modified_by"          text    not null,
-    "performed_by"         text    not null,
-    "change_reason_code"   text    not null,
-    "change_commentary"    text    not null,
-    "valid_from"           timestamp with time zone not null,
-    "valid_to"             timestamp with time zone not null,
+    "id" uuid not null,
+    "tenant_id" uuid not null,
+    "version" integer not null,
+    "name" text not null,
+    "party_id" uuid not null,
+    "description" text not null default '',
+    "report_type" text not null,
+    "fsm_state_id" uuid null,
+    "schedule_expression" text not null,
+    "concurrency_policy" text not null default 'skip',
+    "scheduler_job_id" uuid null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
     primary key (tenant_id, id, valid_from, valid_to),
     exclude using gist (
         tenant_id WITH =,
@@ -63,37 +66,33 @@ create table if not exists "ores_reporting_report_definitions_tbl" (
     check ("schedule_expression" <> '')
 );
 
+-- Unique name for active records
+create unique index if not exists report_definitions_name_uniq_idx
+on "ores_reporting_report_definitions_tbl" (tenant_id, party_id, name)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
 -- Version uniqueness for optimistic concurrency
 create unique index if not exists report_definitions_version_uniq_idx
 on "ores_reporting_report_definitions_tbl" (tenant_id, id, version)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- Current record uniqueness
 create unique index if not exists report_definitions_id_uniq_idx
 on "ores_reporting_report_definitions_tbl" (tenant_id, id)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- Natural key: unique definition name per party
-create unique index if not exists report_definitions_name_uniq_idx
-on "ores_reporting_report_definitions_tbl" (tenant_id, party_id, name)
-where valid_to = ores_utility_infinity_timestamp_fn();
-
--- Unique scheduler_job_id among active records (NULL allowed when not scheduled)
-create unique index if not exists report_definitions_scheduler_job_id_uniq_idx
-on "ores_reporting_report_definitions_tbl" (scheduler_job_id)
-where valid_to = ores_utility_infinity_timestamp_fn() and scheduler_job_id is not null;
-
--- Tenant index
 create index if not exists report_definitions_tenant_idx
 on "ores_reporting_report_definitions_tbl" (tenant_id)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- Party index for party-scoped lookups
+create unique index if not exists report_definitions_scheduler_job_id_uniq_idx
+on "ores_reporting_report_definitions_tbl" (scheduler_job_id)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and scheduler_job_id is not null;
+
 create index if not exists report_definitions_party_idx
 on "ores_reporting_report_definitions_tbl" (tenant_id, party_id)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- FSM state index for state-based filtering
 create index if not exists report_definitions_fsm_state_idx
 on "ores_reporting_report_definitions_tbl" (tenant_id, fsm_state_id)
 where valid_to = ores_utility_infinity_timestamp_fn();
@@ -104,77 +103,75 @@ declare
     current_version integer;
 begin
     -- Validate tenant_id
-    new.tenant_id := ores_iam_validate_tenant_fn(new.tenant_id);
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
 
     -- Validate party_id (soft FK to ores_refdata_parties_tbl)
     if not exists (
         select 1 from ores_refdata_parties_tbl
-        where tenant_id = new.tenant_id
-          and id = new.party_id
+        where tenant_id = NEW.tenant_id
+          and id = NEW.party_id
           and valid_to = ores_utility_infinity_timestamp_fn()
     ) then
-        raise exception 'Invalid party_id: %. No active party found with this id.',
-            new.party_id
+        raise exception 'Invalid party_id: %. No active party found with this id.', NEW.party_id
             using errcode = '23503';
     end if;
 
-    -- Validate report_type
-    new.report_type := ores_reporting_validate_report_type_fn(new.tenant_id, new.report_type);
-
-    -- Validate concurrency_policy
-    new.concurrency_policy := ores_reporting_validate_concurrency_policy_fn(new.tenant_id, new.concurrency_policy);
-
-    -- Validate fsm_state_id (soft FK to ores_dq_fsm_states_tbl)
-    if new.fsm_state_id is not null then
+    -- Validate fsm_state_id (optional soft FK to ores_dq_fsm_states_tbl)
+    if NEW.fsm_state_id is not null then
         if not exists (
             select 1 from ores_dq_fsm_states_tbl
             where tenant_id = ores_utility_system_tenant_id_fn()
-              and id = new.fsm_state_id
+              and id = NEW.fsm_state_id
               and valid_to = ores_utility_infinity_timestamp_fn()
         ) then
-            raise exception 'Invalid fsm_state_id: %. No active FSM state found with this id.',
-                new.fsm_state_id
+            raise exception 'Invalid fsm_state_id: %. No active FSM state found with this id.', NEW.fsm_state_id
                 using errcode = '23503';
         end if;
     end if;
 
+    -- Validate report_type
+    NEW.report_type := ores_reporting_validate_report_type_fn(NEW.tenant_id, NEW.report_type);
+
+    -- Validate concurrency_policy
+    NEW.concurrency_policy := ores_reporting_validate_concurrency_policy_fn(NEW.tenant_id, NEW.concurrency_policy);
+
+    -- Validate change_reason_code
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
     -- Version management
     select version into current_version
     from "ores_reporting_report_definitions_tbl"
-    where tenant_id = new.tenant_id
-      and id = new.id
+    where tenant_id = NEW.tenant_id
+      and id = NEW.id
       and valid_to = ores_utility_infinity_timestamp_fn()
     for update;
 
     if found then
-        if new.version != 0 and new.version != current_version then
+        if NEW.version != 0 and NEW.version != current_version then
             raise exception 'Version conflict: expected version %, but current version is %',
-                new.version, current_version
+                NEW.version, current_version
                 using errcode = 'P0002';
         end if;
-        new.version = current_version + 1;
+        NEW.version = current_version + 1;
 
         update "ores_reporting_report_definitions_tbl"
         set valid_to = current_timestamp
-        where tenant_id = new.tenant_id
-          and id = new.id
+        where tenant_id = NEW.tenant_id
+          and id = NEW.id
           and valid_to = ores_utility_infinity_timestamp_fn()
           and valid_from < current_timestamp;
     else
-        new.version = 1;
+        NEW.version = 1;
     end if;
 
-    new.valid_from = current_timestamp;
-    new.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
 
-    new.modified_by := ores_iam_validate_account_username_fn(new.modified_by);
-    new.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
-
-    new.change_reason_code := ores_dq_validate_change_reason_fn(new.tenant_id, new.change_reason_code);
-
-    return new;
+    return NEW;
 end;
-$$ language plpgsql security definer set search_path = public;
+$$ language plpgsql security definer set search_path = public, pg_temp;
 
 create or replace trigger ores_reporting_report_definitions_insert_trg
 before insert on "ores_reporting_report_definitions_tbl"
@@ -184,6 +181,6 @@ create or replace rule ores_reporting_report_definitions_delete_rule as
 on delete to "ores_reporting_report_definitions_tbl" do instead
     update "ores_reporting_report_definitions_tbl"
     set valid_to = current_timestamp
-    where tenant_id = old.tenant_id
-      and id = old.id
+    where tenant_id = OLD.tenant_id
+      and id = OLD.id
       and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/trading/trading_balance_guaranteed_swap_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_balance_guaranteed_swap_instruments_create.sql
@@ -129,7 +129,7 @@ begin
 
     return NEW;
 end;
-$$ language plpgsql security definer;
+$$ language plpgsql security definer set search_path = public, pg_temp;
 
 create or replace trigger ores_trading_balance_guaranteed_swap_instruments_insert_trg
 before insert on "ores_trading_balance_guaranteed_swap_instruments_tbl"

--- a/projects/ores.sql/create/trading/trading_callable_swap_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_callable_swap_instruments_create.sql
@@ -130,7 +130,7 @@ begin
 
     return NEW;
 end;
-$$ language plpgsql security definer;
+$$ language plpgsql security definer set search_path = public, pg_temp;
 
 create or replace trigger ores_trading_callable_swap_instruments_insert_trg
 before insert on "ores_trading_callable_swap_instruments_tbl"

--- a/projects/ores.sql/create/trading/trading_cap_floor_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_cap_floor_instruments_create.sql
@@ -127,7 +127,7 @@ begin
 
     return NEW;
 end;
-$$ language plpgsql security definer;
+$$ language plpgsql security definer set search_path = public, pg_temp;
 
 create or replace trigger ores_trading_cap_floor_instruments_insert_trg
 before insert on "ores_trading_cap_floor_instruments_tbl"

--- a/projects/ores.sql/create/trading/trading_fra_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_fra_instruments_create.sql
@@ -136,7 +136,7 @@ begin
 
     return NEW;
 end;
-$$ language plpgsql security definer;
+$$ language plpgsql security definer set search_path = public, pg_temp;
 
 create or replace trigger ores_trading_fra_instruments_insert_trg
 before insert on "ores_trading_fra_instruments_tbl"

--- a/projects/ores.sql/create/trading/trading_inflation_swap_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_inflation_swap_instruments_create.sql
@@ -132,7 +132,7 @@ begin
 
     return NEW;
 end;
-$$ language plpgsql security definer;
+$$ language plpgsql security definer set search_path = public, pg_temp;
 
 create or replace trigger ores_trading_inflation_swap_instruments_insert_trg
 before insert on "ores_trading_inflation_swap_instruments_tbl"

--- a/projects/ores.sql/create/trading/trading_knock_out_swap_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_knock_out_swap_instruments_create.sql
@@ -131,7 +131,7 @@ begin
 
     return NEW;
 end;
-$$ language plpgsql security definer;
+$$ language plpgsql security definer set search_path = public, pg_temp;
 
 create or replace trigger ores_trading_knock_out_swap_instruments_insert_trg
 before insert on "ores_trading_knock_out_swap_instruments_tbl"

--- a/projects/ores.sql/create/trading/trading_swaption_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_swaption_instruments_create.sql
@@ -135,7 +135,7 @@ begin
 
     return NEW;
 end;
-$$ language plpgsql security definer;
+$$ language plpgsql security definer set search_path = public, pg_temp;
 
 create or replace trigger ores_trading_swaption_instruments_insert_trg
 before insert on "ores_trading_swaption_instruments_tbl"

--- a/projects/ores.sql/create/trading/trading_vanilla_swap_instruments_create.sql
+++ b/projects/ores.sql/create/trading/trading_vanilla_swap_instruments_create.sql
@@ -130,7 +130,7 @@ begin
 
     return NEW;
 end;
-$$ language plpgsql security definer;
+$$ language plpgsql security definer set search_path = public, pg_temp;
 
 create or replace trigger ores_trading_vanilla_swap_instruments_insert_trg
 before insert on "ores_trading_vanilla_swap_instruments_tbl"


### PR DESCRIPTION
## Summary

Continues codegen drift remediation from PR #747, addressing three categories of work:

- **Template fix**: `sql_schema_domain_entity_create.mustache` was missing `set search_path = public, pg_temp` on the `SECURITY DEFINER` line (required by CLAUDE.md). Fixed and regenerated all 8 affected trading instrument files.

- **Template extension**: Added two new capabilities to the domain entity create template:
  - `prefix_columns` on `natural_keys` entries for compound unique indexes (e.g. `(tenant_id, party_id, name)` instead of `(tenant_id, name)`)
  - `soft_fk_validations` block for table-existence soft FK checks (supports nullable/mandatory and current-tenant/system-tenant variants)

- **reporting_report_definitions_create.sql**: Updated model with soft FK validations for `party_id` and `fsm_state_id`, compound name unique index, extra indexes, `security_definer`, simple validations for `report_type`/`concurrency_policy`, and extra checks. Replaced hand-crafted file with codegen output.

- **Plan update**: Resolved all Category B DQ items (the `entity.json` models generate `_artefact_create.sql` only; those files already exist and are codegen-managed). Documented the 4 remaining Category A files as DEFERRED with specific blocking reasons.

## Commits

1. `[sql]` Fix SECURITY DEFINER missing set search_path in insert trigger template
2. `[sql]` Replace hand-crafted reporting_report_definitions_create with codegen
3. `[doc]` Update codegen SQL debt plan with PR #752 progress

## Remaining deferred (require further template extensions)

- `reporting_report_instances` — needs denormalization-with-fallback from `report_definitions`
- `trading_trades` — needs party_id denormalization from book + portfolio cross-validation
- `scheduler_job_definitions` — nullable `tenant_id` not supported by template
- `iam_tenants` — custom RLS, system-scoped PK, bitemporal trigger (most complex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)