### PR TITLE
[sql] Replace 4 remaining hand-crafted SQL files with codegen

### DIFF
--- a/doc/plans/2026-05-14-codegen-sql-debt.org
+++ b/doc/plans/2026-05-14-codegen-sql-debt.org
@@ -1,7 +1,7 @@
 #+TITLE: Codegen SQL Debt — Hand-Written Files with Existing Models
 #+DATE: 2026-05-14
 #+AUTHOR: ORE Studio Team
-#+STATUS: IN PROGRESS (PR #752)
+#+STATUS: COMPLETE (PR #752, investigation/codegen-drift-3)
 
 * Problem
 
@@ -36,7 +36,7 @@ Originally 24 files; 21 resolved as of 2026-05-16.
 | SQL file | Model file | Status |
 |----------+------------+--------|
 | ~iam/iam_account_types_create.sql~ | ~iam/account_type_entity.json~ | DONE — auto-generated via ~sql_schema_table_create.mustache~ (pre-PR #747) |
-| ~iam/iam_tenants_create.sql~ | ~iam/tenant_domain_entity.json~ | TODO — most complex: custom RLS policies and bitemporal trigger; do last |
+| ~iam/iam_tenants_create.sql~ | ~iam/tenant_domain_entity.json~ | DONE — investigation/codegen-drift-3 (system_scope + text_code_validations + extra_delete_sets) |
 | ~iam/iam_tenant_statuses_create.sql~ | ~iam/tenant_status_entity.json~ | DONE — auto-generated via ~sql_schema_table_create.mustache~ (pre-PR #747) |
 | ~iam/iam_tenant_types_create.sql~ | ~iam/tenant_type_entity.json~ | DONE — auto-generated via ~sql_schema_table_create.mustache~ (pre-PR #747) |
 
@@ -52,14 +52,14 @@ Originally 24 files; 21 resolved as of 2026-05-16.
 |----------+------------+--------|
 | ~reporting/reporting_concurrency_policies_create.sql~ | ~reporting/concurrency_policy_domain_entity.json~ | DONE — PR #747 |
 | ~reporting/reporting_report_definitions_create.sql~ | ~reporting/report_definition_domain_entity.json~ | DONE — PR #752 (template extended with prefix_columns + soft_fk_validations) |
-| ~reporting/reporting_report_instances_create.sql~ | ~reporting/report_instance_domain_entity.json~ | DEFERRED — template needs extension for ~definition_id~ denormalization (SELECT + conditional copy) |
+| ~reporting/reporting_report_instances_create.sql~ | ~reporting/report_instance_domain_entity.json~ | DONE — investigation/codegen-drift-3 (fk_copy_validations + nullable soft_fk) |
 | ~reporting/reporting_report_types_create.sql~ | ~reporting/report_type_domain_entity.json~ | DONE — PR #747 |
 
 ** Scheduler (1 remaining of 1)
 
 | SQL file | Model file | Status |
 |----------+------------+--------|
-| ~scheduler/scheduler_job_definitions_create.sql~ | ~scheduler/job_definition_domain_entity.json~ | DEFERRED — model has nullable tenant_id and system-scope jobs; template always assumes non-null tenant_id |
+| ~scheduler/scheduler_job_definitions_create.sql~ | ~scheduler/job_definition_domain_entity.json~ | DONE — investigation/codegen-drift-3 (nullable_tenant_id mode + null-safe version management) |
 
 ** Trading (1 remaining of 14)
 
@@ -77,7 +77,7 @@ Originally 24 files; 21 resolved as of 2026-05-16.
 | ~trading/trading_leg_types_create.sql~ | ~trading/leg_type_domain_entity.json~ | DONE — PR #747 |
 | ~trading/trading_payment_frequency_types_create.sql~ | ~trading/payment_frequency_type_domain_entity.json~ | DONE — PR #747 |
 | ~trading/trading_swaption_instruments_create.sql~ | ~trading/swaption_instrument_domain_entity.json~ | DONE — PR #747 |
-| ~trading/trading_trades_create.sql~ | ~trading/trade_domain_entity.json~ | DEFERRED — requires party_id denormalization from book_id and cross-validation (portfolio match); cannot template these |
+| ~trading/trading_trades_create.sql~ | ~trading/trade_domain_entity.json~ | DONE — investigation/codegen-drift-3 (party_id_from_book_id + use_no_tenant soft FK) |
 | ~trading/trading_vanilla_swap_instruments_create.sql~ | ~trading/vanilla_swap_instrument_domain_entity.json~ | DONE — PR #747 |
 
 ** Remediation per file
@@ -132,29 +132,28 @@ For each remaining Category B file, determine whether:
 - (c) The model is stale and the entity will not be implemented: delete the
   model file.
 
-* Remaining Work (as of 2026-05-16)
+* Remaining Work (as of 2026-05-17)
 
-Category A — 4 files outstanding (all require template extensions beyond current scope):
-- ~iam/iam_tenants_create.sql~ — do last; most complex (custom RLS, system-scoped PK, bitemporal trigger)
-- ~reporting/reporting_report_instances_create.sql~ — deferred; needs definition_id denormalization template support
-- ~scheduler/scheduler_job_definitions_create.sql~ — deferred; nullable tenant_id not supported by template
-- ~trading/trading_trades_create.sql~ — deferred; party_id denormalization + cross-validation cannot be templatized
+Category A — all 4 files resolved in investigation/codegen-drift-3.
 
 Category B — all resolved.
 
+All Category A SQL debt is now cleared.  Every ~*_create.sql~ file in
+~projects/ores.sql/create/~ for entities that have a codegen model is now
+auto-generated and carries the AUTO-GENERATED FILE header.
+
 * Impact on Identifier Cleanup
 
-For the ~feature/identifier-length-cleanup~ branch all Category A files are
-treated as hand-written (Phase 3 sed pass strips the ~ores_<service>_~ prefix
-from their index names).  No special handling is needed.
+All files are now codegen-managed.  The Phase 3 sed pass (identifier cleanup)
+should target only files that still lack the AUTO-GENERATED FILE header.
 
 Category B files have no SQL, so they produce no truncation notices and require
 no action in the cleanup branch.
 
 * Execution Order
 
-Remaining work suggested order (all require non-trivial template extensions):
-1. ~reporting_report_instances~ — extend template for denormalization-with-fallback pattern.
-2. ~trading_trades~ — extend template for multi-column denormalization and cross-validation.
-3. ~scheduler_job_definitions~ — extend template for nullable tenant_id / system-scope jobs.
-4. ~iam_tenants~ (last; most custom logic: RLS, custom trigger, delete rule side effects).
+COMPLETE — all 4 remaining Category A files converted in investigation/codegen-drift-3:
+1. ~reporting_report_instances~ — fk_copy_validations + nullable soft_fk template extensions
+2. ~trading_trades~ — party_id_from_book_id + use_no_tenant soft FK
+3. ~scheduler_job_definitions~ — nullable_tenant_id mode + null-safe version management
+4. ~iam_tenants~ — system_scope + text_code_validations + extra_delete_sets

--- a/projects/ores.codegen/library/templates/sql_schema_domain_entity_create.mustache
+++ b/projects/ores.codegen/library/templates/sql_schema_domain_entity_create.mustache
@@ -13,7 +13,17 @@
 create table if not exists "{{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_tbl" (
     "{{domain_entity.primary_key.column}}" {{domain_entity.primary_key.type}} not null,
 {{#domain_entity.has_tenant_id}}
+{{#domain_entity.sql.system_scope}}
+    "tenant_id" uuid not null default ores_utility_system_tenant_id_fn(),
+{{/domain_entity.sql.system_scope}}
+{{#domain_entity.sql.nullable_tenant_id}}
+    "tenant_id" uuid,
+{{/domain_entity.sql.nullable_tenant_id}}
+{{^domain_entity.sql.system_scope}}
+{{^domain_entity.sql.nullable_tenant_id}}
     "tenant_id" uuid not null,
+{{/domain_entity.sql.nullable_tenant_id}}
+{{/domain_entity.sql.system_scope}}
 {{/domain_entity.has_tenant_id}}
     "version" integer not null,
 {{#domain_entity.natural_keys}}
@@ -28,43 +38,43 @@ create table if not exists "{{domain_entity.product}}_{{domain_entity.component}
     "change_commentary" text not null,
     "valid_from" timestamp with time zone not null,
     "valid_to" timestamp with time zone not null,
-{{#domain_entity.has_tenant_id}}
+{{#domain_entity.has_tenant_in_pk}}
     primary key (tenant_id, {{domain_entity.primary_key.column}}, valid_from, valid_to),
     exclude using gist (
         tenant_id WITH =,
         {{domain_entity.primary_key.column}} WITH =,
         tstzrange(valid_from, valid_to) WITH &&
     ),
-{{/domain_entity.has_tenant_id}}
-{{^domain_entity.has_tenant_id}}
+{{/domain_entity.has_tenant_in_pk}}
+{{^domain_entity.has_tenant_in_pk}}
     primary key ({{domain_entity.primary_key.column}}, valid_from, valid_to),
     exclude using gist (
         {{domain_entity.primary_key.column}} WITH =,
         tstzrange(valid_from, valid_to) WITH &&
     ),
-{{/domain_entity.has_tenant_id}}
-    check ("valid_from" < "valid_to"){{#domain_entity.primary_key.is_uuid}},
-    check ("{{domain_entity.primary_key.column}}" <> {{domain_entity.primary_key.uuid_check_fn}}){{/domain_entity.primary_key.is_uuid}}{{#domain_entity.primary_key.is_text}},
+{{/domain_entity.has_tenant_in_pk}}
+    check ("valid_from" < "valid_to"){{#domain_entity.primary_key.is_uuid}}{{^domain_entity.primary_key.skip_uuid_check}},
+    check ("{{domain_entity.primary_key.column}}" <> {{domain_entity.primary_key.uuid_check_fn}}){{/domain_entity.primary_key.skip_uuid_check}}{{/domain_entity.primary_key.is_uuid}}{{#domain_entity.primary_key.is_text}},
     check ("{{domain_entity.primary_key.column}}" <> ''){{/domain_entity.primary_key.is_text}}{{#domain_entity.sql.extra_checks}},
     check ({{{.}}}){{/domain_entity.sql.extra_checks}}
 );
 {{#domain_entity.natural_keys}}
 
 -- Unique {{column}} for active records
-{{#domain_entity.has_tenant_id}}
+{{#domain_entity.has_tenant_in_pk}}
 create unique index if not exists {{domain_entity.index_name_prefix}}_{{column}}_uniq_idx
 on "{{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_tbl" (tenant_id{{#prefix_columns}}, {{prefix_columns}}{{/prefix_columns}}, {{column}})
 where valid_to = ores_utility_infinity_timestamp_fn();
-{{/domain_entity.has_tenant_id}}
-{{^domain_entity.has_tenant_id}}
+{{/domain_entity.has_tenant_in_pk}}
+{{^domain_entity.has_tenant_in_pk}}
 create unique index if not exists {{domain_entity.index_name_prefix}}_{{column}}_uniq_idx
 on "{{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_tbl" ({{column}})
 where valid_to = ores_utility_infinity_timestamp_fn();
-{{/domain_entity.has_tenant_id}}
+{{/domain_entity.has_tenant_in_pk}}
 {{/domain_entity.natural_keys}}
 
 -- Version uniqueness for optimistic concurrency
-{{#domain_entity.has_tenant_id}}
+{{#domain_entity.has_tenant_in_pk}}
 create unique index if not exists {{domain_entity.index_name_prefix}}_version_uniq_idx
 on "{{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_tbl" (tenant_id, {{domain_entity.primary_key.column}}, version)
 where valid_to = ores_utility_infinity_timestamp_fn();
@@ -83,12 +93,22 @@ where valid_to = ores_utility_infinity_timestamp_fn();
 create index if not exists {{domain_entity.index_name_prefix}}_tenant_idx
 on "{{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_tbl" (tenant_id)
 where valid_to = ores_utility_infinity_timestamp_fn();
-{{/domain_entity.has_tenant_id}}
-{{^domain_entity.has_tenant_id}}
+{{/domain_entity.has_tenant_in_pk}}
+{{^domain_entity.has_tenant_in_pk}}
 create unique index if not exists {{domain_entity.index_name_prefix}}_version_uniq_idx
 on "{{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_tbl" ({{domain_entity.primary_key.column}}, version)
 where valid_to = ores_utility_infinity_timestamp_fn();
-{{/domain_entity.has_tenant_id}}
+
+{{#domain_entity.sql.nullable_tenant_id}}
+create unique index if not exists {{domain_entity.index_name_prefix}}_id_uniq_idx
+on "{{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_tbl" ({{domain_entity.primary_key.column}})
+where valid_to = ores_utility_infinity_timestamp_fn();
+
+create index if not exists {{domain_entity.index_name_prefix}}_tenant_idx
+on "{{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+{{/domain_entity.sql.nullable_tenant_id}}
+{{/domain_entity.has_tenant_in_pk}}
 {{#domain_entity.indexes}}
 
 create{{#unique}} unique{{/unique}} index if not exists {{domain_entity.index_name_prefix}}_{{name}}_idx
@@ -101,25 +121,84 @@ create or replace function {{domain_entity.product}}_{{domain_entity.component}}
 returns trigger as $$
 declare
     current_version integer;
+{{#domain_entity.sql.party_id_from_book_id}}
+    v_book_portfolio_id uuid;
+{{/domain_entity.sql.party_id_from_book_id}}
+{{#domain_entity.sql.fk_copy_validations}}
+{{#declare_vars}}
+    {{name}} {{type}};
+{{/declare_vars}}
+{{/domain_entity.sql.fk_copy_validations}}
 begin
-{{#domain_entity.has_tenant_id}}
+{{#domain_entity.has_tenant_in_pk}}
     -- Validate tenant_id
     NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
 
-{{/domain_entity.has_tenant_id}}
+{{/domain_entity.has_tenant_in_pk}}
+{{#domain_entity.sql.nullable_tenant_id}}
+    -- Validate tenant_id only when set (system records have NULL tenant_id)
+    if NEW.tenant_id is not null then
+        NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
+    end if;
+
+{{/domain_entity.sql.nullable_tenant_id}}
+{{#domain_entity.sql.system_scope}}
+    -- All {{domain_entity.entity_plural}} belong to the system tenant
+    NEW.tenant_id := ores_utility_system_tenant_id_fn();
+
+{{/domain_entity.sql.system_scope}}
 {{#domain_entity.sql.party_id_from_session}}
     -- Set party_id from session context
     NEW.party_id := current_setting('app.current_party_id')::uuid;
 
 {{/domain_entity.sql.party_id_from_session}}
+{{#domain_entity.sql.party_id_from_book_id}}
+    -- Validate book_id (soft FK to {{book_table}})
+    if not exists (
+        select 1 from {{book_table}}
+        where tenant_id = NEW.tenant_id
+          and id = NEW.book_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
+        raise exception '{{book_error_message}}', NEW.book_id
+            using errcode = '23503';
+    end if;
+
+    -- Denormalise party_id and capture parent_portfolio_id from book
+    select party_id, parent_portfolio_id
+      into NEW.party_id, v_book_portfolio_id
+    from {{book_table}}
+    where id = NEW.book_id
+      and tenant_id = NEW.tenant_id
+      and valid_to = ores_utility_infinity_timestamp_fn();
+
+    -- Validate portfolio_id (soft FK to {{portfolio_table}})
+    if not exists (
+        select 1 from {{portfolio_table}}
+        where tenant_id = NEW.tenant_id
+          and id = NEW.portfolio_id
+          and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
+        raise exception '{{portfolio_error_message}}', NEW.portfolio_id
+            using errcode = '23503';
+    end if;
+
+    -- Validate that portfolio_id matches the book's parent portfolio
+    if NEW.portfolio_id != v_book_portfolio_id then
+        raise exception '{{cross_check_error_message}}',
+            NEW.portfolio_id, v_book_portfolio_id
+            using errcode = '23514';
+    end if;
+
+{{/domain_entity.sql.party_id_from_book_id}}
 {{#domain_entity.sql.soft_fk_validations}}
 {{^nullable}}
     -- Validate {{column}} (soft FK to {{table}})
     if not exists (
         select 1 from {{table}}
-        where {{^use_system_tenant}}tenant_id = NEW.tenant_id
+        where {{^use_no_tenant}}{{^use_system_tenant}}tenant_id = NEW.tenant_id
           and {{/use_system_tenant}}{{#use_system_tenant}}tenant_id = ores_utility_system_tenant_id_fn()
-          and {{/use_system_tenant}}id = NEW.{{column}}
+          and {{/use_system_tenant}}{{/use_no_tenant}}id = NEW.{{column}}
           and valid_to = ores_utility_infinity_timestamp_fn()
     ) then
         raise exception '{{error_message}}', NEW.{{column}}
@@ -132,9 +211,9 @@ begin
     if NEW.{{column}} is not null then
         if not exists (
             select 1 from {{table}}
-            where {{^use_system_tenant}}tenant_id = NEW.tenant_id
+            where {{^use_no_tenant}}{{^use_system_tenant}}tenant_id = NEW.tenant_id
               and {{/use_system_tenant}}{{#use_system_tenant}}tenant_id = ores_utility_system_tenant_id_fn()
-              and {{/use_system_tenant}}id = NEW.{{column}}
+              and {{/use_system_tenant}}{{/use_no_tenant}}id = NEW.{{column}}
               and valid_to = ores_utility_infinity_timestamp_fn()
         ) then
             raise exception '{{error_message}}', NEW.{{column}}
@@ -144,16 +223,73 @@ begin
 
 {{/nullable}}
 {{/domain_entity.sql.soft_fk_validations}}
+{{#domain_entity.sql.fk_copy_validations}}
+    -- Validate {{column}}; copy {{select_fields}} from {{table}} if not provided
+    select {{select_fields}}
+      into {{into_vars}}
+    from {{table}}
+    where tenant_id = NEW.tenant_id
+      and id = NEW.{{column}}
+      and valid_to = ores_utility_infinity_timestamp_fn();
+
+    if not found then
+        raise exception '{{error_message}}',
+            NEW.{{column}}
+            using errcode = '23503';
+    end if;
+
+{{#copy_empty}}
+    if NEW.{{target}} = '' then
+{{#coalesce}}
+        NEW.{{target}} := coalesce({{source}}, '');
+{{/coalesce}}
+{{^coalesce}}
+        NEW.{{target}} := {{source}};
+{{/coalesce}}
+    end if;
+{{/copy_empty}}
+{{/domain_entity.sql.fk_copy_validations}}
+{{#domain_entity.sql.text_code_validations}}
+    -- Validate {{column}} FK
+    if not exists (
+        select 1 from {{table}}
+        where {{lookup_column}} = NEW.{{column}}
+          and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
+        raise exception '{{error_message}}',
+            NEW.{{column}} using errcode = '23503';
+    end if;
+
+{{/domain_entity.sql.text_code_validations}}
 {{#domain_entity.validations}}
+{{#nullable}}
+    -- Validate {{column}} (optional field -- skip validation when null)
+    if NEW.{{column}} is not null then
+        NEW.{{column}} := {{validation_function}}({{#domain_entity.has_tenant_id}}NEW.tenant_id, {{/domain_entity.has_tenant_id}}NEW.{{column}});
+    end if;
+
+{{/nullable}}
+{{^nullable}}
     -- Validate {{column}}
     NEW.{{column}} := {{validation_function}}({{#domain_entity.has_tenant_id}}NEW.tenant_id, {{/domain_entity.has_tenant_id}}NEW.{{column}});
 
+{{/nullable}}
 {{/domain_entity.validations}}
-{{#domain_entity.has_tenant_id}}
+{{#domain_entity.has_tenant_in_pk}}
     -- Validate change_reason_code
     NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
 
-{{/domain_entity.has_tenant_id}}
+{{/domain_entity.has_tenant_in_pk}}
+{{#domain_entity.sql.nullable_tenant_id}}
+    -- Validate change_reason_code
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
+{{/domain_entity.sql.nullable_tenant_id}}
+{{#domain_entity.sql.system_scope}}
+    -- Validate change_reason_code (use system tenant for {{domain_entity.entity_plural}} records)
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(ores_utility_system_tenant_id_fn(), NEW.change_reason_code);
+
+{{/domain_entity.sql.system_scope}}
 {{^domain_entity.has_tenant_id}}
     -- Validate change_reason_code
     NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.change_reason_code);
@@ -162,8 +298,9 @@ begin
     -- Version management
     select version into current_version
     from "{{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_tbl"
-    where {{#domain_entity.has_tenant_id}}tenant_id = NEW.tenant_id
-      and {{/domain_entity.has_tenant_id}}{{domain_entity.primary_key.column}} = NEW.{{domain_entity.primary_key.column}}
+    where {{#domain_entity.has_tenant_in_pk}}tenant_id = NEW.tenant_id
+      and {{/domain_entity.has_tenant_in_pk}}{{#domain_entity.sql.nullable_tenant_id}}(tenant_id = NEW.tenant_id or (tenant_id is null and NEW.tenant_id is null))
+      and {{/domain_entity.sql.nullable_tenant_id}}{{domain_entity.primary_key.column}} = NEW.{{domain_entity.primary_key.column}}
       and valid_to = ores_utility_infinity_timestamp_fn()
     for update;
 
@@ -177,8 +314,9 @@ begin
 
         update "{{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_tbl"
         set valid_to = current_timestamp
-        where {{#domain_entity.has_tenant_id}}tenant_id = NEW.tenant_id
-          and {{/domain_entity.has_tenant_id}}{{domain_entity.primary_key.column}} = NEW.{{domain_entity.primary_key.column}}
+        where {{#domain_entity.has_tenant_in_pk}}tenant_id = NEW.tenant_id
+          and {{/domain_entity.has_tenant_in_pk}}{{#domain_entity.sql.nullable_tenant_id}}(tenant_id = NEW.tenant_id or (tenant_id is null and NEW.tenant_id is null))
+          and {{/domain_entity.sql.nullable_tenant_id}}{{domain_entity.primary_key.column}} = NEW.{{domain_entity.primary_key.column}}
           and valid_to = ores_utility_infinity_timestamp_fn()
           and valid_from < current_timestamp;
     else
@@ -201,7 +339,9 @@ for each row execute function {{domain_entity.product}}_{{domain_entity.componen
 create or replace rule {{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_delete_rule as
 on delete to "{{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_tbl" do instead
     update "{{domain_entity.product}}_{{domain_entity.component}}_{{domain_entity.entity_plural}}_tbl"
-    set valid_to = current_timestamp
-    where {{#domain_entity.has_tenant_id}}tenant_id = OLD.tenant_id
-      and {{/domain_entity.has_tenant_id}}{{domain_entity.primary_key.column}} = OLD.{{domain_entity.primary_key.column}}
+    set valid_to = current_timestamp{{#domain_entity.sql.extra_delete_sets}},
+        {{{.}}}{{/domain_entity.sql.extra_delete_sets}}
+    where {{#domain_entity.has_tenant_in_pk}}tenant_id = OLD.tenant_id
+      and {{/domain_entity.has_tenant_in_pk}}{{#domain_entity.sql.nullable_tenant_id}}(tenant_id = OLD.tenant_id or (tenant_id is null and OLD.tenant_id is null))
+      and {{/domain_entity.sql.nullable_tenant_id}}{{domain_entity.primary_key.column}} = OLD.{{domain_entity.primary_key.column}}
       and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.codegen/library/templates/sql_schema_domain_entity_create.mustache
+++ b/projects/ores.codegen/library/templates/sql_schema_domain_entity_create.mustache
@@ -5,7 +5,7 @@
  * Template: sql_schema_domain_entity_create.mustache
  * To modify, update the template and regenerate.
  *
- * {{domain_entity.entity_singular_title}} Table
+ * {{domain_entity.entity_title}} Table
  *
  * {{{domain_entity.description_formatted}}}
  */

--- a/projects/ores.codegen/models/iam/tenant_domain_entity.json
+++ b/projects/ores.codegen/models/iam/tenant_domain_entity.json
@@ -1,10 +1,12 @@
 {
   "domain_entity": {
     "schema": "public",
+    "product": "ores",
     "component": "iam",
     "entity_singular": "tenant",
     "entity_plural": "tenants",
     "entity_title": "Tenant",
+    "has_tenant_id": true,
     "brief": "A tenant representing an isolated organisation or the system platform.",
     "description": "Core entity for multi-tenancy support. Each tenant represents an isolated\norganisation with its own users, roles, and data. The system tenant (UUID all zeros)\nis a special tenant used for shared reference data and system administration.\n\nTenants are identified by:\n- id: UUID primary key (SQL also has tenant_id = id for self-reference)\n- code: Unique text code for stable referencing (e.g., 'system', 'acme')\n- hostname: Unique hostname for tenant routing during login",
 
@@ -13,7 +15,8 @@
       "type": "uuid",
       "cpp_type": "boost::uuids::uuid",
       "description": "UUID uniquely identifying this tenant.",
-      "detail": "The system tenant has UUID 00000000-0000-0000-0000-000000000000. In SQL, tenant_id = id for tenant records."
+      "detail": "The system tenant has UUID 00000000-0000-0000-0000-000000000000. In SQL, tenant_id = id for tenant records.",
+      "skip_uuid_check": true
     },
 
     "natural_keys": [
@@ -24,17 +27,18 @@
         "description": "Unique code for stable referencing.",
         "detail": "Examples: 'system', 'acme', 'demo'.",
         "generator_expr": "std::string(faker::word::noun()) + \"_tenant\""
-      },
-      {
-        "column": "name",
-        "type": "text",
-        "cpp_type": "std::string",
-        "description": "Human-readable name for the tenant.",
-        "generator_expr": "std::string(faker::company::name())"
       }
     ],
 
     "columns": [
+      {
+        "name": "name",
+        "type": "text",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "description": "Human-readable display name for the tenant.",
+        "generator_expr": "std::string(faker::company::name())"
+      },
       {
         "name": "type",
         "type": "text",
@@ -70,8 +74,41 @@
     ],
 
     "sql": {
-      "tablename": "ores_iam_tenants_tbl"
+      "tablename": "ores_iam_tenants_tbl",
+      "system_scope": true,
+      "extra_checks": [
+        "\"id\" <> 'ffffffff-ffff-ffff-ffff-ffffffffffff'::uuid or \"code\" = 'system'",
+        "\"tenant_id\" = ores_utility_system_tenant_id_fn()",
+        "\"code\" <> ''",
+        "\"hostname\" <> ''"
+      ],
+      "text_code_validations": [
+        {
+          "column": "type",
+          "table": "ores_iam_tenant_types_tbl",
+          "lookup_column": "type",
+          "error_message": "Invalid tenant type: %. Must exist in ores_iam_tenant_types_tbl."
+        },
+        {
+          "column": "status",
+          "table": "ores_iam_tenant_statuses_tbl",
+          "lookup_column": "status",
+          "error_message": "Invalid tenant status: %. Must exist in ores_iam_tenant_statuses_tbl."
+        }
+      ],
+      "extra_delete_sets": [
+        "status = 'terminated'"
+      ]
     },
+
+    "indexes": [
+      {
+        "name": "hostname_uniq",
+        "unique": true,
+        "columns": "hostname",
+        "current_only": true
+      }
+    ],
 
     "repository": {
       "entity_singular_short": "tenant",

--- a/projects/ores.codegen/models/reporting/report_instance_domain_entity.json
+++ b/projects/ores.codegen/models/reporting/report_instance_domain_entity.json
@@ -14,23 +14,27 @@
       "column": "id",
       "type": "uuid",
       "cpp_type": "boost::uuids::uuid",
-      "description": "UUID uniquely identifying this report instance."
+      "description": "UUID uniquely identifying this report instance.",
+      "uuid_check_fn": "ores_utility_nil_uuid_fn()"
     },
 
-    "columns": [
+    "natural_keys": [
       {
-        "name": "name",
+        "column": "name",
         "type": "text",
         "cpp_type": "std::string",
-        "nullable": false,
         "description": "Human-readable name copied from the report definition at creation time.",
         "generator_expr": "std::string(faker::word::noun()) + \"_instance\""
-      },
+      }
+    ],
+
+    "columns": [
       {
         "name": "description",
         "type": "text",
         "cpp_type": "std::string",
         "nullable": false,
+        "default": "''",
         "description": "Description copied from the report definition at creation time.",
         "generator_expr": "std::string(faker::lorem::sentence())"
       },
@@ -71,12 +75,13 @@
         "type": "text",
         "cpp_type": "std::string",
         "nullable": false,
+        "default": "''",
         "description": "Execution log or error message.",
         "generator_expr": "std::string()"
       },
       {
         "name": "started_at",
-        "type": "timestamp",
+        "type": "timestamp with time zone",
         "cpp_type": "std::optional<std::chrono::system_clock::time_point>",
         "nullable": true,
         "description": "When execution began. NULL if cancelled before starting.",
@@ -84,7 +89,7 @@
       },
       {
         "name": "completed_at",
-        "type": "timestamp",
+        "type": "timestamp with time zone",
         "cpp_type": "std::optional<std::chrono::system_clock::time_point>",
         "nullable": true,
         "description": "When execution completed. NULL while running or before start.",
@@ -93,8 +98,60 @@
     ],
 
     "sql": {
-      "tablename": "ores_reporting_report_instances_tbl"
+      "tablename": "ores_reporting_report_instances_tbl",
+      "security_definer": true,
+      "extra_checks": [
+        "\"name\" <> ''",
+        "\"completed_at\" is null or \"started_at\" is not null"
+      ],
+      "soft_fk_validations": [
+        {
+          "column": "party_id",
+          "table": "ores_refdata_parties_tbl",
+          "nullable": false,
+          "error_message": "Invalid party_id: %. No active party found with this id."
+        },
+        {
+          "column": "fsm_state_id",
+          "table": "ores_dq_fsm_states_tbl",
+          "nullable": true,
+          "use_system_tenant": true,
+          "error_message": "Invalid fsm_state_id: %. No active FSM state found with this id."
+        }
+      ],
+      "fk_copy_validations": [
+        {
+          "column": "definition_id",
+          "table": "ores_reporting_report_definitions_tbl",
+          "error_message": "Invalid definition_id: %. No active report definition found with this id.",
+          "select_fields": "name, description",
+          "into_vars": "def_name, def_description",
+          "declare_vars": [
+            {"name": "def_name",        "type": "text"},
+            {"name": "def_description", "type": "text"}
+          ],
+          "copy_empty": [
+            {"target": "name",        "source": "def_name",        "coalesce": false},
+            {"target": "description", "source": "def_description", "coalesce": true}
+          ]
+        }
+      ]
     },
+
+    "indexes": [
+      {
+        "name": "definition",
+        "unique": false,
+        "columns": "tenant_id, definition_id",
+        "current_only": true
+      },
+      {
+        "name": "fsm_state",
+        "unique": false,
+        "columns": "tenant_id, fsm_state_id",
+        "current_only": true
+      }
+    ],
 
     "repository": {
       "entity_singular_short": "instance",

--- a/projects/ores.codegen/models/scheduler/job_definition_domain_entity.json
+++ b/projects/ores.codegen/models/scheduler/job_definition_domain_entity.json
@@ -1,6 +1,7 @@
 {
   "domain_entity": {
     "schema": "public",
+    "product": "ores",
     "component": "scheduler",
     "entity_singular": "job_definition",
     "entity_plural": "job_definitions",
@@ -14,57 +15,116 @@
       "column": "id",
       "type": "uuid",
       "cpp_type": "boost::uuids::uuid",
-      "description": "UUID primary key for the job definition."
+      "description": "UUID primary key for the job definition.",
+      "uuid_check_fn": "ores_utility_nil_uuid_fn()"
     },
 
     "columns": [
+      {
+        "name": "party_id",
+        "type": "uuid",
+        "cpp_type": "std::optional<boost::uuids::uuid>",
+        "nullable": true,
+        "description": "Optional party scope for this job (NULL for tenant-scoped or system jobs)."
+      },
       {
         "name": "job_name",
         "type": "text",
         "cpp_type": "std::string",
         "nullable": false,
-        "description": "Unique name passed to pg_cron."
+        "description": "Unique name for the scheduled job."
       },
       {
         "name": "description",
         "type": "text",
         "cpp_type": "std::string",
-        "nullable": true,
-        "description": "Human-readable label for UI."
+        "nullable": false,
+        "default": "''",
+        "description": "Human-readable description of the job."
       },
       {
         "name": "command",
         "type": "text",
         "cpp_type": "std::string",
         "nullable": false,
-        "description": "SQL command to execute."
+        "default": "''",
+        "description": "SQL command to execute (used when action_type = execute_sql)."
       },
       {
         "name": "schedule_expression",
         "type": "text",
         "cpp_type": "std::string",
         "nullable": false,
-        "description": "Validated cron expression (stored as string, typed as cron_expression)."
+        "description": "Cron expression defining the schedule."
       },
       {
-        "name": "database_name",
+        "name": "action_type",
         "type": "text",
         "cpp_type": "std::string",
         "nullable": false,
-        "description": "Target PostgreSQL database name."
+        "default": "'execute_sql'",
+        "description": "Execution mode: execute_sql or nats_publish."
+      },
+      {
+        "name": "action_payload",
+        "type": "jsonb",
+        "cpp_type": "std::string",
+        "nullable": false,
+        "default": "'{}'::jsonb",
+        "description": "Payload for nats_publish action type."
       },
       {
         "name": "is_active",
-        "type": "boolean",
-        "cpp_type": "bool",
+        "type": "integer",
+        "cpp_type": "int",
         "nullable": false,
-        "description": "False = paused (unscheduled from pg_cron)."
+        "default": "1",
+        "description": "1 = active, 0 = paused."
       }
     ],
 
     "sql": {
-      "tablename": "ores_scheduler_job_definitions_tbl"
+      "tablename": "ores_scheduler_job_definitions_tbl",
+      "nullable_tenant_id": true,
+      "security_definer": true,
+      "extra_checks": [
+        "\"job_name\" <> ''",
+        "action_type in ('execute_sql','nats_publish')",
+        "action_type != 'execute_sql' or \"command\" <> ''",
+        "\"schedule_expression\" <> ''"
+      ],
+      "soft_fk_validations": [
+        {
+          "column": "party_id",
+          "table": "ores_refdata_parties_tbl",
+          "nullable": true,
+          "error_message": "Invalid party_id: %. No active party found with this id."
+        }
+      ]
     },
+
+    "indexes": [
+      {
+        "name": "name_tenant_uniq",
+        "unique": true,
+        "columns": "tenant_id, job_name",
+        "current_only": true,
+        "where_extra": "tenant_id is not null"
+      },
+      {
+        "name": "name_system_uniq",
+        "unique": true,
+        "columns": "job_name",
+        "current_only": true,
+        "where_extra": "tenant_id is null"
+      },
+      {
+        "name": "party",
+        "unique": false,
+        "columns": "tenant_id, party_id",
+        "current_only": true
+      }
+    ],
 
     "repository": {
       "entity_singular_short": "definition",

--- a/projects/ores.codegen/models/trading/trade_domain_entity.json
+++ b/projects/ores.codegen/models/trading/trade_domain_entity.json
@@ -212,7 +212,7 @@
           "column": "status_id",
           "table": "ores_dq_fsm_states_tbl",
           "nullable": false,
-          "use_no_tenant": true,
+          "use_system_tenant": true,
           "error_message": "Invalid status_id: %. FSM state must exist."
         }
       ]

--- a/projects/ores.codegen/models/trading/trade_domain_entity.json
+++ b/projects/ores.codegen/models/trading/trade_domain_entity.json
@@ -16,10 +16,19 @@
       "type": "uuid",
       "cpp_type": "boost::uuids::uuid",
       "description": "UUID uniquely identifying this trade.",
-      "detail": "Surrogate key for the trade record."
+      "detail": "Surrogate key for the trade record.",
+      "uuid_check_fn": "ores_utility_nil_uuid_fn()"
     },
 
     "columns": [
+      {
+        "name": "party_id",
+        "type": "uuid",
+        "cpp_type": "boost::uuids::uuid",
+        "nullable": false,
+        "description": "Internal party owning this trade (denormalized from book_id).",
+        "generator_expr": "boost::uuids::random_generator()()"
+      },
       {
         "name": "external_id",
         "type": "text",
@@ -75,9 +84,9 @@
       },
       {
         "name": "product_type",
-        "type": "text",
+        "type": "product_type_t",
         "cpp_type": "std::string",
-        "nullable": false,
+        "nullable": true,
         "description": "ORE product type discriminator.",
         "generator_expr": "std::string(\"Swap\")"
       },
@@ -109,24 +118,24 @@
       {
         "name": "activity_type_code",
         "type": "text",
-        "cpp_type": "std::optional<std::string>",
-        "nullable": true,
+        "cpp_type": "std::string",
+        "nullable": false,
         "description": "Activity type code (soft FK to ores_trading_activity_types_tbl).",
-        "generator_expr": "std::nullopt"
+        "generator_expr": "std::string(\"New\")"
       },
       {
         "name": "status_id",
         "type": "uuid",
-        "cpp_type": "std::optional<boost::uuids::uuid>",
-        "nullable": true,
+        "cpp_type": "boost::uuids::uuid",
+        "nullable": false,
         "description": "Current FSM state (soft FK to ores_dq_fsm_states_tbl).",
-        "generator_expr": "std::nullopt"
+        "generator_expr": "boost::uuids::random_generator()()"
       },
       {
         "name": "trade_date",
         "type": "date",
         "cpp_type": "std::string",
-        "nullable": false,
+        "nullable": true,
         "description": "Date the trade was agreed.",
         "detail": "ISO 8601 date: YYYY-MM-DD.",
         "generator_expr": "std::string(\"2025-01-15\")"
@@ -135,7 +144,7 @@
         "name": "execution_timestamp",
         "type": "timestamp with time zone",
         "cpp_type": "std::string",
-        "nullable": false,
+        "nullable": true,
         "description": "Timestamp when the trade was executed (with timezone).",
         "detail": "ISO 8601 timestamp: YYYY-MM-DD HH:MM:SS+TZ.",
         "generator_expr": "std::string(\"2025-01-15 10:00:00\")"
@@ -144,7 +153,7 @@
         "name": "effective_date",
         "type": "date",
         "cpp_type": "std::string",
-        "nullable": false,
+        "nullable": true,
         "description": "Date from which the trade is effective.",
         "detail": "ISO 8601 date: YYYY-MM-DD.",
         "generator_expr": "std::string(\"2025-01-16\")"
@@ -153,16 +162,82 @@
         "name": "termination_date",
         "type": "date",
         "cpp_type": "std::string",
-        "nullable": false,
+        "nullable": true,
         "description": "Date on which the trade matures or terminates.",
         "detail": "ISO 8601 date: YYYY-MM-DD.",
         "generator_expr": "std::string(\"2026-01-15\")"
       }
     ],
 
+    "validations": [
+      {
+        "column": "asset_class",
+        "validation_function": "ores_refdata_validate_asset_class_fn",
+        "nullable": true
+      },
+      {
+        "column": "trade_type",
+        "validation_function": "ores_trading_validate_trade_type_fn"
+      },
+      {
+        "column": "activity_type_code",
+        "validation_function": "ores_trading_validate_activity_type_fn"
+      }
+    ],
+
     "sql": {
-      "tablename": "ores_trading_trades_tbl"
+      "tablename": "ores_trading_trades_tbl",
+      "security_definer": true,
+      "party_id_from_book_id": {
+        "book_table": "ores_refdata_books_tbl",
+        "book_error_message": "Invalid book_id: %. Book must exist for tenant.",
+        "portfolio_table": "ores_refdata_portfolios_tbl",
+        "portfolio_error_message": "Invalid portfolio_id: %. Portfolio must exist for tenant.",
+        "cross_check_error_message": "portfolio_id % does not match book parent_portfolio_id %."
+      },
+      "soft_fk_validations": [
+        {
+          "column": "successor_trade_id",
+          "table": "ores_trading_trades_tbl",
+          "nullable": true,
+          "error_message": "Invalid successor_trade_id: %. Trade must exist for tenant."
+        },
+        {
+          "column": "counterparty_id",
+          "table": "ores_refdata_counterparties_tbl",
+          "nullable": true,
+          "error_message": "Invalid counterparty_id: %. Counterparty must exist for tenant."
+        },
+        {
+          "column": "status_id",
+          "table": "ores_dq_fsm_states_tbl",
+          "nullable": false,
+          "use_no_tenant": true,
+          "error_message": "Invalid status_id: %. FSM state must exist."
+        }
+      ]
     },
+
+    "indexes": [
+      {"name": "book",         "unique": false, "columns": "tenant_id, book_id",        "current_only": true},
+      {"name": "portfolio",    "unique": false, "columns": "tenant_id, portfolio_id",   "current_only": true},
+      {"name": "netting_set",  "unique": false, "columns": "tenant_id, netting_set_id", "current_only": true},
+      {"name": "trade_type",   "unique": false, "columns": "tenant_id, trade_type",     "current_only": true},
+      {
+        "name": "instrument",
+        "unique": false,
+        "columns": "tenant_id, product_type, instrument_id",
+        "current_only": true,
+        "where_extra": "instrument_id is not null"
+      },
+      {
+        "name": "asset_class",
+        "unique": false,
+        "columns": "tenant_id, asset_class",
+        "current_only": true,
+        "where_extra": "asset_class is not null"
+      }
+    ],
 
     "repository": {
       "entity_singular_short": "trade",

--- a/projects/ores.codegen/src/generator.py
+++ b/projects/ores.codegen/src/generator.py
@@ -1337,6 +1337,26 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
         sql_section = domain_entity.get('sql', {})
         domain_entity['index_name_prefix'] = sql_section.get(
             'index_prefix', domain_entity.get('entity_plural', 'unknown'))
+        # Compute has_tenant_in_pk: tenant_id is in the primary key when has_tenant_id
+        # is set but neither system_scope nor nullable_tenant_id overrides the PK.
+        has_tenant_id = domain_entity.get('has_tenant_id', False)
+        domain_entity['has_tenant_in_pk'] = (
+            has_tenant_id
+            and not sql_section.get('system_scope', False)
+            and not sql_section.get('nullable_tenant_id', False)
+        )
+        # Mark last items in new iterable sql sub-sections for template rendering
+        if 'fk_copy_validations' in sql_section:
+            _mark_last_item(sql_section['fk_copy_validations'])
+            for fkc in sql_section['fk_copy_validations']:
+                if 'declare_vars' in fkc:
+                    _mark_last_item(fkc['declare_vars'])
+                if 'copy_empty' in fkc:
+                    _mark_last_item(fkc['copy_empty'])
+        if 'text_code_validations' in sql_section:
+            _mark_last_item(sql_section['text_code_validations'])
+        if 'extra_delete_sets' in sql_section:
+            _mark_last_item(sql_section['extra_delete_sets'])
         # Add computed properties for primary key type detection
         if 'primary_key' in domain_entity:
             pk = domain_entity['primary_key']
@@ -1344,7 +1364,7 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
             pk['is_uuid'] = pk_type == 'uuid'
             pk['is_text'] = pk_type == 'text'
             if pk['is_uuid'] and 'uuid_check_fn' not in pk:
-                pk['uuid_check_fn'] = 'ores_utility_system_tenant_id_fn()'
+                pk['uuid_check_fn'] = 'ores_utility_nil_uuid_fn()'
             # Ensure cpp_type is set with sensible defaults
             if 'cpp_type' not in pk:
                 if pk['is_uuid']:

--- a/projects/ores.sql/create/iam/iam_tenants_create.sql
+++ b/projects/ores.sql/create/iam/iam_tenants_create.sql
@@ -22,7 +22,7 @@
  * Template: sql_schema_domain_entity_create.mustache
  * To modify, update the template and regenerate.
  *
- *  Table
+ * Tenant Table
  *
  * Core entity for multi-tenancy support. Each tenant represents an isolated
  * organisation with its own users, roles, and data. The system tenant (UUID all zeros)

--- a/projects/ores.sql/create/iam/iam_tenants_create.sql
+++ b/projects/ores.sql/create/iam/iam_tenants_create.sql
@@ -1,6 +1,6 @@
 /* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -17,31 +17,31 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-
--- =============================================================================
--- Tenants Table
--- Core table for multi-tenancy support. Each tenant represents an isolated
--- organisation or the system tenant.
---
--- Note: All tenant records belong to the system tenant (tenant_id = system_tenant_id).
--- This allows the system tenant to manage all tenants. Regular tenants can still
--- see their own record via RLS policy that checks id = current_tenant_id.
---
--- IMPORTANT: Unlike other tenant-aware tables, tenant_id is intentionally NOT
--- included in the primary key or EXCLUDE constraint because:
---   1. tenant_id is always system_tenant_id for ALL rows (constant value)
---   2. The tenant's identity is stored in 'id', not 'tenant_id'
---   3. Including tenant_id would be redundant and provide no uniqueness benefit
--- =============================================================================
+/**
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_domain_entity_create.mustache
+ * To modify, update the template and regenerate.
+ *
+ *  Table
+ *
+ * Core entity for multi-tenancy support. Each tenant represents an isolated
+ * organisation with its own users, roles, and data. The system tenant (UUID all zeros)
+ * is a special tenant used for shared reference data and system administration.
+ *
+ * Tenants are identified by:
+ * - id: UUID primary key (SQL also has tenant_id = id for self-reference)
+ * - code: Unique text code for stable referencing (e.g., 'system', 'acme')
+ * - hostname: Unique hostname for tenant routing during login
+ */
 
 create table if not exists "ores_iam_tenants_tbl" (
     "id" uuid not null,
     "tenant_id" uuid not null default ores_utility_system_tenant_id_fn(),
     "version" integer not null,
-    "type" text not null,
     "code" text not null,
     "name" text not null,
-    "description" text,
+    "type" text not null,
+    "description" text null,
     "hostname" text not null,
     "status" text not null,
     "modified_by" text not null,
@@ -57,29 +57,25 @@ create table if not exists "ores_iam_tenants_tbl" (
     ),
     check ("valid_from" < "valid_to"),
     check ("id" <> 'ffffffff-ffff-ffff-ffff-ffffffffffff'::uuid or "code" = 'system'),
-    check ("tenant_id" = ores_utility_system_tenant_id_fn()),  -- All tenants owned by system
+    check ("tenant_id" = ores_utility_system_tenant_id_fn()),
     check ("code" <> ''),
     check ("hostname" <> '')
 );
 
--- Unique indexes for active records
--- Note: tenant_id is always system tenant, so not needed in uniqueness constraints
+-- Unique code for active records
 create unique index if not exists tenants_code_uniq_idx
-on ores_iam_tenants_tbl (code)
+on "ores_iam_tenants_tbl" (code)
 where valid_to = ores_utility_infinity_timestamp_fn();
+
+-- Version uniqueness for optimistic concurrency
+create unique index if not exists tenants_version_uniq_idx
+on "ores_iam_tenants_tbl" (id, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
 
 create unique index if not exists tenants_hostname_uniq_idx
-on ores_iam_tenants_tbl (hostname)
+on "ores_iam_tenants_tbl" (hostname)
 where valid_to = ores_utility_infinity_timestamp_fn();
-
-create unique index if not exists tenants_version_uniq_idx
-on ores_iam_tenants_tbl (id, version)
-where valid_to = ores_utility_infinity_timestamp_fn();
-
--- =============================================================================
--- Insert Trigger Function
--- Handles version management, temporal fields, and FK validation.
--- =============================================================================
 
 create or replace function ores_iam_tenants_insert_fn()
 returns trigger as $$
@@ -87,78 +83,72 @@ declare
     current_version integer;
 begin
     -- All tenants belong to the system tenant
-    new.tenant_id := ores_utility_system_tenant_id_fn();
+    NEW.tenant_id := ores_utility_system_tenant_id_fn();
 
     -- Validate type FK
     if not exists (
         select 1 from ores_iam_tenant_types_tbl
-        where type = new.type
+        where type = NEW.type
           and valid_to = ores_utility_infinity_timestamp_fn()
     ) then
         raise exception 'Invalid tenant type: %. Must exist in ores_iam_tenant_types_tbl.',
-            new.type using errcode = '23503';
+            NEW.type using errcode = '23503';
     end if;
 
     -- Validate status FK
     if not exists (
         select 1 from ores_iam_tenant_statuses_tbl
-        where status = new.status
+        where status = NEW.status
           and valid_to = ores_utility_infinity_timestamp_fn()
     ) then
         raise exception 'Invalid tenant status: %. Must exist in ores_iam_tenant_statuses_tbl.',
-            new.status using errcode = '23503';
+            NEW.status using errcode = '23503';
     end if;
+
+    -- Validate change_reason_code (use system tenant for tenants records)
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(ores_utility_system_tenant_id_fn(), NEW.change_reason_code);
 
     -- Version management
     select version into current_version
-    from ores_iam_tenants_tbl
-    where id = new.id
+    from "ores_iam_tenants_tbl"
+    where id = NEW.id
       and valid_to = ores_utility_infinity_timestamp_fn()
     for update;
 
     if found then
-        if new.version != 0 and new.version != current_version then
+        if NEW.version != 0 and NEW.version != current_version then
             raise exception 'Version conflict: expected version %, but current version is %',
-                new.version, current_version using errcode = 'P0002';
+                NEW.version, current_version
+                using errcode = 'P0002';
         end if;
-        new.version = current_version + 1;
+        NEW.version = current_version + 1;
 
-        update ores_iam_tenants_tbl
+        update "ores_iam_tenants_tbl"
         set valid_to = current_timestamp
-        where id = new.id
+        where id = NEW.id
           and valid_to = ores_utility_infinity_timestamp_fn()
           and valid_from < current_timestamp;
     else
-        new.version = 1;
+        NEW.version = 1;
     end if;
 
-    new.valid_from = current_timestamp;
-    new.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
 
-    new.modified_by := ores_iam_validate_account_username_fn(new.modified_by);
-    new.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
-
-    -- Validate change_reason_code (use system tenant for tenant records)
-    new.change_reason_code := ores_dq_validate_change_reason_fn(ores_utility_system_tenant_id_fn(), new.change_reason_code);
-
-    return new;
+    return NEW;
 end;
 $$ language plpgsql;
 
 create or replace trigger ores_iam_tenants_insert_trg
-before insert on ores_iam_tenants_tbl
-for each row
-execute function ores_iam_tenants_insert_fn();
-
--- =============================================================================
--- Delete Rule (Soft Delete)
--- =============================================================================
+before insert on "ores_iam_tenants_tbl"
+for each row execute function ores_iam_tenants_insert_fn();
 
 create or replace rule ores_iam_tenants_delete_rule as
-on delete to ores_iam_tenants_tbl
-do instead
-    update ores_iam_tenants_tbl
+on delete to "ores_iam_tenants_tbl" do instead
+    update "ores_iam_tenants_tbl"
     set valid_to = current_timestamp,
         status = 'terminated'
-    where id = old.id
+    where id = OLD.id
       and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/iam/iam_tenants_notify_trigger_create.sql
+++ b/projects/ores.sql/create/iam/iam_tenants_notify_trigger_create.sql
@@ -1,6 +1,6 @@
 /* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -17,27 +17,27 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-
--- =============================================================================
--- Tenants Notification Trigger
--- Sends notifications on tenant changes for real-time UI updates.
--- =============================================================================
+/*
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_notify_trigger.mustache
+ * To modify, update the template and regenerate.
+ */
 
 create or replace function ores_iam_tenants_notify_fn()
 returns trigger as $$
 declare
     notification_payload jsonb;
     entity_name text := 'ores.iam.tenant';
-    change_timestamp timestamptz := now();
-    changed_id text;
+    change_timestamp timestamptz := NOW();
+    changed_id uuid;
     changed_tenant_id text;
 begin
     if TG_OP = 'DELETE' then
-        changed_id := old.id::text;
-        changed_tenant_id := old.tenant_id::text;
+        changed_id := OLD.id;
+        changed_tenant_id := OLD.tenant_id::text;
     else
-        changed_id := new.id::text;
-        changed_tenant_id := new.tenant_id::text;
+        changed_id := NEW.id;
+        changed_tenant_id := NEW.tenant_id::text;
     end if;
 
     notification_payload := jsonb_build_object(
@@ -47,7 +47,8 @@ begin
         'tenant_id', changed_tenant_id
     );
 
-    perform pg_notify('ores_tenants', notification_payload::text);
+    perform pg_notify('ores_iam_tenants', notification_payload::text);
+
     return null;
 end;
 $$ language plpgsql;

--- a/projects/ores.sql/create/reporting/reporting_report_instances_create.sql
+++ b/projects/ores.sql/create/reporting/reporting_report_instances_create.sql
@@ -22,7 +22,7 @@
  * Template: sql_schema_domain_entity_create.mustache
  * To modify, update the template and regenerate.
  *
- *  Table
+ * Report Instance Table
  *
  * A single execution of a report_definition. Created automatically when the
  * scheduler fires a trigger for an active definition.

--- a/projects/ores.sql/create/reporting/reporting_report_instances_create.sql
+++ b/projects/ores.sql/create/reporting/reporting_report_instances_create.sql
@@ -17,9 +17,12 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-
 /**
- * Report Instances Table
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_domain_entity_create.mustache
+ * To modify, update the template and regenerate.
+ *
+ *  Table
  *
  * A single execution of a report_definition. Created automatically when the
  * scheduler fires a trigger for an active definition.
@@ -27,36 +30,29 @@
  * Lifecycle is managed through the report_instance_lifecycle FSM machine.
  * fsm_state_id points to the current state in ores_dq_fsm_states_tbl.
  *
- * The initial fsm_state depends on the definition's concurrency_policy and
- * whether another instance for the same definition is already running:
- *   - No running instance          -> pending
- *   - Running + policy = queue     -> queued
- *   - Running + policy = skip      -> skipped (terminal)
- *   - Running + policy = fail      -> failed  (terminal)
- *
  * started_at is NULL when the instance is cancelled or skipped before execution
  * begins. completed_at is NULL while running or in a terminal-before-start state.
  */
 
 create table if not exists "ores_reporting_report_instances_tbl" (
-    "id"               uuid    not null,
-    "tenant_id"        uuid    not null,
-    "version"          integer not null,
-    "name"             text    not null,
-    "description"      text    not null default '',
-    "party_id"         uuid    not null,
-    "definition_id"    uuid    not null,
-    "fsm_state_id"     uuid    null,
-    "trigger_run_id"   bigint  not null,
-    "output_message"   text    not null default '',
-    "started_at"       timestamp with time zone null,
-    "completed_at"     timestamp with time zone null,
-    "modified_by"      text    not null,
-    "performed_by"     text    not null,
-    "change_reason_code" text  not null,
-    "change_commentary"  text  not null,
-    "valid_from"       timestamp with time zone not null,
-    "valid_to"         timestamp with time zone not null,
+    "id" uuid not null,
+    "tenant_id" uuid not null,
+    "version" integer not null,
+    "name" text not null,
+    "description" text not null default '',
+    "party_id" uuid not null,
+    "definition_id" uuid not null,
+    "fsm_state_id" uuid null,
+    "trigger_run_id" bigint not null,
+    "output_message" text not null default '',
+    "started_at" timestamp with time zone null,
+    "completed_at" timestamp with time zone null,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
     primary key (tenant_id, id, valid_from, valid_to),
     exclude using gist (
         tenant_id WITH =,
@@ -69,32 +65,28 @@ create table if not exists "ores_reporting_report_instances_tbl" (
     check ("completed_at" is null or "started_at" is not null)
 );
 
+-- Unique name for active records
+create unique index if not exists report_instances_name_uniq_idx
+on "ores_reporting_report_instances_tbl" (tenant_id, name)
+where valid_to = ores_utility_infinity_timestamp_fn();
+
 -- Version uniqueness for optimistic concurrency
 create unique index if not exists report_instances_version_uniq_idx
 on "ores_reporting_report_instances_tbl" (tenant_id, id, version)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- Current record uniqueness
 create unique index if not exists report_instances_id_uniq_idx
 on "ores_reporting_report_instances_tbl" (tenant_id, id)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- Natural key: unique instance name per tenant
-create unique index if not exists report_instances_name_uniq_idx
-on "ores_reporting_report_instances_tbl" (tenant_id, name)
-where valid_to = ores_utility_infinity_timestamp_fn();
-
--- Tenant index
 create index if not exists report_instances_tenant_idx
 on "ores_reporting_report_instances_tbl" (tenant_id)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- Definition index for listing instances per definition
 create index if not exists report_instances_definition_idx
 on "ores_reporting_report_instances_tbl" (tenant_id, definition_id)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- FSM state index for state-based filtering (e.g. "find all running instances")
 create index if not exists report_instances_fsm_state_idx
 on "ores_reporting_report_instances_tbl" (tenant_id, fsm_state_id)
 where valid_to = ores_utility_infinity_timestamp_fn();
@@ -103,95 +95,93 @@ create or replace function ores_reporting_report_instances_insert_fn()
 returns trigger as $$
 declare
     current_version integer;
-    def_name        text;
+    def_name text;
     def_description text;
 begin
     -- Validate tenant_id
-    new.tenant_id := ores_iam_validate_tenant_fn(new.tenant_id);
+    NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
 
     -- Validate party_id (soft FK to ores_refdata_parties_tbl)
     if not exists (
         select 1 from ores_refdata_parties_tbl
-        where tenant_id = new.tenant_id
-          and id = new.party_id
+        where tenant_id = NEW.tenant_id
+          and id = NEW.party_id
           and valid_to = ores_utility_infinity_timestamp_fn()
     ) then
-        raise exception 'Invalid party_id: %. No active party found with this id.',
-            new.party_id
+        raise exception 'Invalid party_id: %. No active party found with this id.', NEW.party_id
             using errcode = '23503';
     end if;
 
-    -- Validate definition_id; copy name/description from definition if not provided
-    select name, description into def_name, def_description
-    from ores_reporting_report_definitions_tbl
-    where tenant_id = new.tenant_id
-      and id = new.definition_id
-      and valid_to = ores_utility_infinity_timestamp_fn();
-
-    if not found then
-        raise exception 'Invalid definition_id: %. No active report definition found with this id.',
-            new.definition_id
-            using errcode = '23503';
-    end if;
-
-    if new.name = '' then
-        new.name := def_name;
-    end if;
-    if new.description = '' then
-        new.description := coalesce(def_description, '');
-    end if;
-
-    -- Validate fsm_state_id (soft FK to ores_dq_fsm_states_tbl)
-    if new.fsm_state_id is not null then
+    -- Validate fsm_state_id (optional soft FK to ores_dq_fsm_states_tbl)
+    if NEW.fsm_state_id is not null then
         if not exists (
             select 1 from ores_dq_fsm_states_tbl
             where tenant_id = ores_utility_system_tenant_id_fn()
-              and id = new.fsm_state_id
+              and id = NEW.fsm_state_id
               and valid_to = ores_utility_infinity_timestamp_fn()
         ) then
-            raise exception 'Invalid fsm_state_id: %. No active FSM state found with this id.',
-                new.fsm_state_id
+            raise exception 'Invalid fsm_state_id: %. No active FSM state found with this id.', NEW.fsm_state_id
                 using errcode = '23503';
         end if;
     end if;
 
+    -- Validate definition_id; copy name, description from ores_reporting_report_definitions_tbl if not provided
+    select name, description
+      into def_name, def_description
+    from ores_reporting_report_definitions_tbl
+    where tenant_id = NEW.tenant_id
+      and id = NEW.definition_id
+      and valid_to = ores_utility_infinity_timestamp_fn();
+
+    if not found then
+        raise exception 'Invalid definition_id: %. No active report definition found with this id.',
+            NEW.definition_id
+            using errcode = '23503';
+    end if;
+
+    if NEW.name = '' then
+        NEW.name := def_name;
+    end if;
+    if NEW.description = '' then
+        NEW.description := coalesce(def_description, '');
+    end if;
+    -- Validate change_reason_code
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
     -- Version management
     select version into current_version
     from "ores_reporting_report_instances_tbl"
-    where tenant_id = new.tenant_id
-      and id = new.id
+    where tenant_id = NEW.tenant_id
+      and id = NEW.id
       and valid_to = ores_utility_infinity_timestamp_fn()
     for update;
 
     if found then
-        if new.version != 0 and new.version != current_version then
+        if NEW.version != 0 and NEW.version != current_version then
             raise exception 'Version conflict: expected version %, but current version is %',
-                new.version, current_version
+                NEW.version, current_version
                 using errcode = 'P0002';
         end if;
-        new.version = current_version + 1;
+        NEW.version = current_version + 1;
 
         update "ores_reporting_report_instances_tbl"
         set valid_to = current_timestamp
-        where tenant_id = new.tenant_id
-          and id = new.id
+        where tenant_id = NEW.tenant_id
+          and id = NEW.id
           and valid_to = ores_utility_infinity_timestamp_fn()
           and valid_from < current_timestamp;
     else
-        new.version = 1;
+        NEW.version = 1;
     end if;
 
-    new.valid_from = current_timestamp;
-    new.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.valid_from = current_timestamp;
+    NEW.valid_to = ores_utility_infinity_timestamp_fn();
+    NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
 
-    new.modified_by := ores_iam_validate_account_username_fn(new.modified_by);
-    new.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
-
-    new.change_reason_code := ores_dq_validate_change_reason_fn(new.tenant_id, new.change_reason_code);
-
-    return new;
+    return NEW;
 end;
-$$ language plpgsql security definer set search_path = public;
+$$ language plpgsql security definer set search_path = public, pg_temp;
 
 create or replace trigger ores_reporting_report_instances_insert_trg
 before insert on "ores_reporting_report_instances_tbl"
@@ -201,6 +191,6 @@ create or replace rule ores_reporting_report_instances_delete_rule as
 on delete to "ores_reporting_report_instances_tbl" do instead
     update "ores_reporting_report_instances_tbl"
     set valid_to = current_timestamp
-    where tenant_id = old.tenant_id
-      and id = old.id
+    where tenant_id = OLD.tenant_id
+      and id = OLD.id
       and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/scheduler/scheduler_job_definitions_create.sql
+++ b/projects/ores.sql/create/scheduler/scheduler_job_definitions_create.sql
@@ -17,44 +17,35 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-
 /**
- * Scheduler Job Definitions Table
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_domain_entity_create.mustache
+ * To modify, update the template and regenerate.
  *
- * Stores job definitions for OreStudio's built-in scheduler. Each row
- * represents a versioned, auditable job definition with tenant/party
- * isolation, human-readable description, and a soft-pause mechanism
- * (is_active).
+ *  Table
  *
- * Jobs can be system-scoped (tenant_id IS NULL, party_id IS NULL),
- * tenant-scoped (tenant_id set, party_id IS NULL), or party-scoped
- * (both tenant_id and party_id set).
- *
- * The action_type column controls how the scheduler executes the job:
- *   - 'execute_sql'    : run the SQL in the command column directly.
- *   - 'nats_publish'  : publish a NATS message; action_payload carries
- *                        the subject and body.
+ * Metadata overlay for a pg_cron cron.job entry. Tracks the job name,
+ * cron expression, SQL command, target database, and active state.
  */
 
 create table if not exists "ores_scheduler_job_definitions_tbl" (
-    "id"                  uuid not null,
-    "tenant_id"           uuid,
-    "version"             integer not null,
-    "party_id"            uuid,
-    "job_name"            text not null,
-    "description"         text not null default '',
-    "command"             text not null default '',
+    "id" uuid not null,
+    "tenant_id" uuid,
+    "version" integer not null,
+    "party_id" uuid null,
+    "job_name" text not null,
+    "description" text not null default '',
+    "command" text not null default '',
     "schedule_expression" text not null,
-    "action_type"         text not null default 'execute_sql'
-                          check (action_type in ('execute_sql','nats_publish')),
-    "action_payload"      jsonb not null default '{}'::jsonb,
-    "is_active"           integer not null default 1,
-    "modified_by"         text not null,
-    "performed_by"        text not null,
-    "change_reason_code"  text not null,
-    "change_commentary"   text not null,
-    "valid_from"          timestamp with time zone not null,
-    "valid_to"            timestamp with time zone not null,
+    "action_type" text not null default 'execute_sql',
+    "action_payload" jsonb not null default '{}'::jsonb,
+    "is_active" integer not null default 1,
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
     primary key (id, valid_from, valid_to),
     exclude using gist (
         id WITH =,
@@ -63,36 +54,34 @@ create table if not exists "ores_scheduler_job_definitions_tbl" (
     check ("valid_from" < "valid_to"),
     check ("id" <> ores_utility_nil_uuid_fn()),
     check ("job_name" <> ''),
+    check (action_type in ('execute_sql','nats_publish')),
     check (action_type != 'execute_sql' or "command" <> ''),
     check ("schedule_expression" <> '')
 );
-
--- Unique job_name per tenant among active records.
--- System jobs (tenant_id IS NULL) are handled by a separate partial index.
-create unique index if not exists job_definitions_name_tenant_uniq_idx
-on "ores_scheduler_job_definitions_tbl" (tenant_id, job_name)
-where valid_to = ores_utility_infinity_timestamp_fn() and tenant_id is not null;
-
-create unique index if not exists job_definitions_name_system_uniq_idx
-on "ores_scheduler_job_definitions_tbl" (job_name)
-where valid_to = ores_utility_infinity_timestamp_fn() and tenant_id is null;
 
 -- Version uniqueness for optimistic concurrency
 create unique index if not exists job_definitions_version_uniq_idx
 on "ores_scheduler_job_definitions_tbl" (id, version)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- Current record uniqueness
 create unique index if not exists job_definitions_id_uniq_idx
 on "ores_scheduler_job_definitions_tbl" (id)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- Tenant index
 create index if not exists job_definitions_tenant_idx
 on "ores_scheduler_job_definitions_tbl" (tenant_id)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- Party index for party-scoped lookups
+create unique index if not exists job_definitions_name_tenant_uniq_idx
+on "ores_scheduler_job_definitions_tbl" (tenant_id, job_name)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and tenant_id is not null;
+
+create unique index if not exists job_definitions_name_system_uniq_idx
+on "ores_scheduler_job_definitions_tbl" (job_name)
+where valid_to = ores_utility_infinity_timestamp_fn()
+  and tenant_id is null;
+
 create index if not exists job_definitions_party_idx
 on "ores_scheduler_job_definitions_tbl" (tenant_id, party_id)
 where valid_to = ores_utility_infinity_timestamp_fn();
@@ -102,12 +91,12 @@ returns trigger as $$
 declare
     current_version integer;
 begin
-    -- Validate tenant_id only when set (system jobs have NULL tenant_id)
+    -- Validate tenant_id only when set (system records have NULL tenant_id)
     if NEW.tenant_id is not null then
         NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
     end if;
 
-    -- Validate party_id (soft FK to ores_refdata_parties_tbl) only when set
+    -- Validate party_id (optional soft FK to ores_refdata_parties_tbl)
     if NEW.party_id is not null then
         if not exists (
             select 1 from ores_refdata_parties_tbl
@@ -115,17 +104,19 @@ begin
               and id = NEW.party_id
               and valid_to = ores_utility_infinity_timestamp_fn()
         ) then
-            raise exception 'Invalid party_id: %. No active party found with this id.',
-                NEW.party_id
+            raise exception 'Invalid party_id: %. No active party found with this id.', NEW.party_id
                 using errcode = '23503';
         end if;
     end if;
 
+    -- Validate change_reason_code
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+
     -- Version management
     select version into current_version
     from "ores_scheduler_job_definitions_tbl"
-    where id = NEW.id
-      and (tenant_id = NEW.tenant_id or (tenant_id is null and NEW.tenant_id is null))
+    where (tenant_id = NEW.tenant_id or (tenant_id is null and NEW.tenant_id is null))
+      and id = NEW.id
       and valid_to = ores_utility_infinity_timestamp_fn()
     for update;
 
@@ -139,8 +130,8 @@ begin
 
         update "ores_scheduler_job_definitions_tbl"
         set valid_to = current_timestamp
-        where id = NEW.id
-          and (tenant_id = NEW.tenant_id or (tenant_id is null and NEW.tenant_id is null))
+        where (tenant_id = NEW.tenant_id or (tenant_id is null and NEW.tenant_id is null))
+          and id = NEW.id
           and valid_to = ores_utility_infinity_timestamp_fn()
           and valid_from < current_timestamp;
     else
@@ -149,15 +140,12 @@ begin
 
     NEW.valid_from = current_timestamp;
     NEW.valid_to = ores_utility_infinity_timestamp_fn();
-
     NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
     NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
 
-    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
-
     return NEW;
 end;
-$$ language plpgsql security definer;
+$$ language plpgsql security definer set search_path = public, pg_temp;
 
 create or replace trigger ores_scheduler_job_definitions_insert_trg
 before insert on "ores_scheduler_job_definitions_tbl"
@@ -167,6 +155,6 @@ create or replace rule ores_scheduler_job_definitions_delete_rule as
 on delete to "ores_scheduler_job_definitions_tbl" do instead
     update "ores_scheduler_job_definitions_tbl"
     set valid_to = current_timestamp
-    where id = OLD.id
-      and (tenant_id = OLD.tenant_id or (tenant_id is null and OLD.tenant_id is null))
+    where (tenant_id = OLD.tenant_id or (tenant_id is null and OLD.tenant_id is null))
+      and id = OLD.id
       and valid_to = ores_utility_infinity_timestamp_fn();

--- a/projects/ores.sql/create/scheduler/scheduler_job_definitions_create.sql
+++ b/projects/ores.sql/create/scheduler/scheduler_job_definitions_create.sql
@@ -22,7 +22,7 @@
  * Template: sql_schema_domain_entity_create.mustache
  * To modify, update the template and regenerate.
  *
- *  Table
+ * Job Definition Table
  *
  * Metadata overlay for a pg_cron cron.job entry. Tracks the job name,
  * cron expression, SQL command, target database, and active state.

--- a/projects/ores.sql/create/scheduler/scheduler_job_definitions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/scheduler/scheduler_job_definitions_notify_trigger_create.sql
@@ -17,6 +17,11 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
+/*
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_notify_trigger.mustache
+ * To modify, update the template and regenerate.
+ */
 
 create or replace function ores_scheduler_job_definitions_notify_fn()
 returns trigger as $$
@@ -24,14 +29,14 @@ declare
     notification_payload jsonb;
     entity_name text := 'ores.scheduler.job_definition';
     change_timestamp timestamptz := NOW();
-    changed_id text;
+    changed_id uuid;
     changed_tenant_id text;
 begin
     if TG_OP = 'DELETE' then
-        changed_id := OLD.id::text;
+        changed_id := OLD.id;
         changed_tenant_id := OLD.tenant_id::text;
     else
-        changed_id := NEW.id::text;
+        changed_id := NEW.id;
         changed_tenant_id := NEW.tenant_id::text;
     end if;
 

--- a/projects/ores.sql/create/trading/trading_trades_create.sql
+++ b/projects/ores.sql/create/trading/trading_trades_create.sql
@@ -17,16 +17,16 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-
 /**
- * Trade Table
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_domain_entity_create.mustache
+ * To modify, update the template and regenerate.
  *
- * Temporal trade record capturing FpML Trade Header properties. Each lifecycle
- * event (New, Amendment, Novation, etc.) creates a new temporal row for the
- * same trade id. The internal party is derived from book_id -> books.party_id.
+ *  Table
  *
- * Hand-crafted: inline soft FK validations for book_id, portfolio_id, and
- * successor_trade_id cannot be expressed by the standard templates.
+ * Temporal trade record. Each lifecycle event (New, Amendment, Novation,
+ * etc.) creates a new temporal row for the same trade id. The internal party
+ * is derived from book_id via books.party_id.
  */
 
 create table if not exists "ores_trading_trades_tbl" (
@@ -38,18 +38,18 @@ create table if not exists "ores_trading_trades_tbl" (
     "book_id" uuid not null,
     "portfolio_id" uuid not null,
     "successor_trade_id" uuid null,
-    "counterparty_id" uuid null,
     "trade_type" text not null,
+    "counterparty_id" uuid null,
     "product_type" product_type_t null,
     "instrument_id" uuid null,
     "asset_class" text null,
     "netting_set_id" text not null,
     "activity_type_code" text not null,
     "status_id" uuid not null,
-    "trade_date" date,
-    "execution_timestamp" timestamp with time zone,
-    "effective_date" date,
-    "termination_date" date,
+    "trade_date" date null,
+    "execution_timestamp" timestamp with time zone null,
+    "effective_date" date null,
+    "termination_date" date null,
     "modified_by" text not null,
     "performed_by" text not null,
     "change_reason_code" text not null,
@@ -71,44 +71,35 @@ create unique index if not exists trades_version_uniq_idx
 on "ores_trading_trades_tbl" (tenant_id, id, version)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- Current record uniqueness
 create unique index if not exists trades_id_uniq_idx
 on "ores_trading_trades_tbl" (tenant_id, id)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- Tenant index
 create index if not exists trades_tenant_idx
 on "ores_trading_trades_tbl" (tenant_id)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- Book index for portfolio lookups
 create index if not exists trades_book_idx
 on "ores_trading_trades_tbl" (tenant_id, book_id)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- Portfolio index
 create index if not exists trades_portfolio_idx
 on "ores_trading_trades_tbl" (tenant_id, portfolio_id)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- Netting set index for ORE aggregation
 create index if not exists trades_netting_set_idx
 on "ores_trading_trades_tbl" (tenant_id, netting_set_id)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- Trade type index for product filtering
 create index if not exists trades_trade_type_idx
 on "ores_trading_trades_tbl" (tenant_id, trade_type)
 where valid_to = ores_utility_infinity_timestamp_fn();
 
--- Product routing index (product_type + instrument_id used to open
--- the associated instrument record from a trade)
 create index if not exists trades_instrument_idx
 on "ores_trading_trades_tbl" (tenant_id, product_type, instrument_id)
 where valid_to = ores_utility_infinity_timestamp_fn()
   and instrument_id is not null;
 
--- Asset class index for filtering trades by asset class
 create index if not exists trades_asset_class_idx
 on "ores_trading_trades_tbl" (tenant_id, asset_class)
 where valid_to = ores_utility_infinity_timestamp_fn()
@@ -117,8 +108,8 @@ where valid_to = ores_utility_infinity_timestamp_fn()
 create or replace function ores_trading_trades_insert_fn()
 returns trigger as $$
 declare
-    current_version      integer;
-    v_book_portfolio_id  uuid;
+    current_version integer;
+    v_book_portfolio_id uuid;
 begin
     -- Validate tenant_id
     NEW.tenant_id := ores_iam_validate_tenant_fn(NEW.tenant_id);
@@ -160,7 +151,7 @@ begin
             using errcode = '23514';
     end if;
 
-    -- Validate successor_trade_id (optional self-referencing soft FK)
+    -- Validate successor_trade_id (optional soft FK to ores_trading_trades_tbl)
     if NEW.successor_trade_id is not null then
         if not exists (
             select 1 from ores_trading_trades_tbl
@@ -186,18 +177,6 @@ begin
         end if;
     end if;
 
-    -- Validate asset_class (optional field — skip validation when null)
-    if NEW.asset_class is not null then
-        NEW.asset_class := ores_refdata_validate_asset_class_fn(
-            NEW.tenant_id, NEW.asset_class);
-    end if;
-
-    -- Validate trade_type
-    NEW.trade_type := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type);
-
-    -- Validate activity_type_code
-    NEW.activity_type_code := ores_trading_validate_activity_type_fn(NEW.tenant_id, NEW.activity_type_code);
-
     -- Validate status_id (soft FK to ores_dq_fsm_states_tbl)
     if not exists (
         select 1 from ores_dq_fsm_states_tbl
@@ -207,6 +186,20 @@ begin
         raise exception 'Invalid status_id: %. FSM state must exist.', NEW.status_id
             using errcode = '23503';
     end if;
+
+    -- Validate asset_class (optional field -- skip validation when null)
+    if NEW.asset_class is not null then
+        NEW.asset_class := ores_refdata_validate_asset_class_fn(NEW.tenant_id, NEW.asset_class);
+    end if;
+
+    -- Validate trade_type
+    NEW.trade_type := ores_trading_validate_trade_type_fn(NEW.tenant_id, NEW.trade_type);
+
+    -- Validate activity_type_code
+    NEW.activity_type_code := ores_trading_validate_activity_type_fn(NEW.tenant_id, NEW.activity_type_code);
+
+    -- Validate change_reason_code
+    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
 
     -- Version management
     select version into current_version
@@ -237,9 +230,7 @@ begin
     NEW.valid_from = current_timestamp;
     NEW.valid_to = ores_utility_infinity_timestamp_fn();
     NEW.modified_by := ores_iam_validate_account_username_fn(NEW.modified_by);
-    new.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
-
-    NEW.change_reason_code := ores_dq_validate_change_reason_fn(NEW.tenant_id, NEW.change_reason_code);
+    NEW.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
 
     return NEW;
 end;

--- a/projects/ores.sql/create/trading/trading_trades_create.sql
+++ b/projects/ores.sql/create/trading/trading_trades_create.sql
@@ -22,7 +22,7 @@
  * Template: sql_schema_domain_entity_create.mustache
  * To modify, update the template and regenerate.
  *
- *  Table
+ * Trade Table
  *
  * Temporal trade record. Each lifecycle event (New, Amendment, Novation,
  * etc.) creates a new temporal row for the same trade id. The internal party
@@ -180,7 +180,8 @@ begin
     -- Validate status_id (soft FK to ores_dq_fsm_states_tbl)
     if not exists (
         select 1 from ores_dq_fsm_states_tbl
-        where id = NEW.status_id
+        where tenant_id = ores_utility_system_tenant_id_fn()
+          and id = NEW.status_id
           and valid_to = ores_utility_infinity_timestamp_fn()
     ) then
         raise exception 'Invalid status_id: %. FSM state must exist.', NEW.status_id

--- a/projects/ores.sql/create/trading/trading_trades_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_trades_notify_trigger_create.sql
@@ -17,6 +17,11 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
+/*
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_notify_trigger.mustache
+ * To modify, update the template and regenerate.
+ */
 
 create or replace function ores_trading_trades_notify_fn()
 returns trigger as $$
@@ -24,14 +29,14 @@ declare
     notification_payload jsonb;
     entity_name text := 'ores.trading.trade';
     change_timestamp timestamptz := NOW();
-    changed_id text;
+    changed_id uuid;
     changed_tenant_id text;
 begin
     if TG_OP = 'DELETE' then
-        changed_id := OLD.id::text;
+        changed_id := OLD.id;
         changed_tenant_id := OLD.tenant_id::text;
     else
-        changed_id := NEW.id::text;
+        changed_id := NEW.id;
         changed_tenant_id := NEW.tenant_id::text;
     end if;
 
@@ -43,6 +48,7 @@ begin
     );
 
     perform pg_notify('ores_trading_trades', notification_payload::text);
+
     return null;
 end;
 $$ language plpgsql;

--- a/projects/ores.sql/drop/iam/iam_tenants_drop.sql
+++ b/projects/ores.sql/drop/iam/iam_tenants_drop.sql
@@ -1,6 +1,6 @@
 /* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -18,7 +18,7 @@
  *
  */
 
-drop trigger if exists ores_iam_tenants_insert_trg on ores_iam_tenants_tbl cascade;
-drop rule if exists ores_iam_tenants_delete_rule on ores_iam_tenants_tbl cascade;
-drop function if exists ores_iam_tenants_insert_fn cascade;
-drop table if exists ores_iam_tenants_tbl cascade;
+drop rule if exists ores_iam_tenants_delete_rule on "ores_iam_tenants_tbl";
+drop trigger if exists ores_iam_tenants_insert_trg on "ores_iam_tenants_tbl";
+drop function if exists ores_iam_tenants_insert_fn;
+drop table if exists "ores_iam_tenants_tbl";

--- a/projects/ores.sql/drop/iam/iam_tenants_notify_trigger_drop.sql
+++ b/projects/ores.sql/drop/iam/iam_tenants_notify_trigger_drop.sql
@@ -1,6 +1,6 @@
 /* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
  *
- * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -18,5 +18,5 @@
  *
  */
 
-drop trigger if exists ores_iam_tenants_notify_trg on ores_iam_tenants_tbl cascade;
-drop function if exists ores_iam_tenants_notify_fn cascade;
+drop trigger if exists ores_iam_tenants_notify_trg on "ores_iam_tenants_tbl";
+drop function if exists ores_iam_tenants_notify_fn;

--- a/projects/ores.sql/drop/scheduler/scheduler_job_definitions_drop.sql
+++ b/projects/ores.sql/drop/scheduler/scheduler_job_definitions_drop.sql
@@ -21,10 +21,4 @@
 drop rule if exists ores_scheduler_job_definitions_delete_rule on "ores_scheduler_job_definitions_tbl";
 drop trigger if exists ores_scheduler_job_definitions_insert_trg on "ores_scheduler_job_definitions_tbl";
 drop function if exists ores_scheduler_job_definitions_insert_fn;
-drop index if exists job_definitions_party_idx;
-drop index if exists job_definitions_tenant_idx;
-drop index if exists job_definitions_id_uniq_idx;
-drop index if exists job_definitions_version_uniq_idx;
-drop index if exists job_definitions_name_uniq_idx;
-drop index if exists job_definitions_cron_job_id_uniq_idx;
 drop table if exists "ores_scheduler_job_definitions_tbl";


### PR DESCRIPTION
## Summary

- Extends `sql_schema_domain_entity_create.mustache` and `generator.py` with
  six new template capabilities to handle the last four Category A files that
  were previously marked DEFERRED in `doc/plans/2026-05-14-codegen-sql-debt.org`
- All four files now carry the `AUTO-GENERATED FILE` header; every
  `*_create.sql` file in `projects/ores.sql/create/` is now codegen-managed

## Files converted

| File | Model | New template features used |
|------|-------|---------------------------|
| `reporting/reporting_report_instances_create.sql` | `report_instance_domain_entity.json` | `fk_copy_validations`, `use_system_tenant` soft FK |
| `trading/trading_trades_create.sql` | `trade_domain_entity.json` | `party_id_from_book_id`, `use_no_tenant` soft FK, nullable column validations |
| `scheduler/scheduler_job_definitions_create.sql` | `job_definition_domain_entity.json` | `nullable_tenant_id` mode, null-safe version management and delete rule |
| `iam/iam_tenants_create.sql` | `tenant_domain_entity.json` | `system_scope` mode, `text_code_validations`, `extra_delete_sets`, `skip_uuid_check` |

## Template extensions (generator.py + mustache)

- **`system_scope`**: forces `tenant_id = system_tenant_id()` in trigger; tenant_id not in PK, EXCLUDE, or natural-key indexes
- **`nullable_tenant_id`**: tenant_id column nullable; null-safe `(tenant_id = NEW.tenant_id OR (tenant_id IS NULL AND NEW.tenant_id IS NULL))` in version management and delete rule
- **`has_tenant_in_pk`**: computed flag (`has_tenant_id AND NOT system_scope AND NOT nullable_tenant_id`) drives PK/EXCLUDE/index branching
- **`fk_copy_validations`**: SELECT fields from FK table into declared vars, then conditionally copy to NEW row if target column is empty
- **`party_id_from_book_id`**: validate book soft FK, denormalize `party_id` and capture `parent_portfolio_id`, validate portfolio soft FK, cross-check portfolio matches book's parent
- **`text_code_validations`**: FK lookup against tables with a text code column (tenant type/status lookup tables)
- **`extra_delete_sets`**: additional `SET` clauses in the soft-delete rule (sets `status = 'terminated'` on tenant soft-delete)
- **`skip_uuid_check`**: suppresses the default `check (id <> nil_uuid_fn())` — needed for tenants because the system tenant's own id IS the nil UUID
- **`use_no_tenant`**: soft FK check with no tenant filter (cross-component FSM states table)
- **Bug fix**: `extra_delete_sets` template used `{{.}}` (HTML-encoding) instead of `{{{.}}}` (raw), which mangled single quotes in the value

## Verification

- `projects/ores.sql/utility/validate_schemas.sh` — passed (211 tables, 0 warnings)
- `./projects/ores.sql/recreate_database.sh` — full database recreation succeeded with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)