### PR TITLE
[hotfix] Fix Windows build: C1202 TU split and workflow.api export

### DIFF
--- a/projects/ores.qt.api/src/ClientManagerTradeDetail.cpp
+++ b/projects/ores.qt.api/src/ClientManagerTradeDetail.cpp
@@ -1,0 +1,84 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+// getTradeDetail() is isolated here so that the two-phase rfl deserialization
+// (trade base, 22 fields) + (instrument variant, 8 alternatives) does not
+// share a TU with listTrades (vector<trade>, 25 fields) and push MSVC over the
+// C1202 constexpr-depth limit.
+#include "ores.qt/ClientManager.hpp"
+
+#include "ores.nats/service/nats_connect_error.hpp"
+#include "ores.nats/service/session_expired_error.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+std::optional<trading::messaging::trade_export_item>
+ClientManager::getTradeDetail(const std::string& trade_id) {
+    try {
+        trading::messaging::get_trade_detail_request request;
+        request.trade_id = trade_id;
+        const auto raw = send_authenticated_request(
+            trading::messaging::get_trade_detail_request::nats_subject,
+            rfl::json::write(request),
+            std::chrono::seconds(30));
+
+        // Two-phase parse: avoid combining trade (22 fields) with the
+        // trade_instrument variant (8 alternatives) in a single rfl call,
+        // which exceeds MSVC's constexpr depth budget (C1202).
+        auto base = rfl::json::read<
+            trading::messaging::get_trade_detail_response_base>(raw);
+        if (!base) {
+            BOOST_LOG_SEV(lg(), error)
+                << "getTradeDetail deserialize error: " << base.error().what();
+            return std::nullopt;
+        }
+        if (!base->success) {
+            BOOST_LOG_SEV(lg(), error)
+                << "getTradeDetail server error: " << base->message;
+            return std::nullopt;
+        }
+        auto inst = rfl::json::read<
+            trading::messaging::get_trade_detail_instrument_wrapper,
+            rfl::AddTagsToVariants>(raw);
+        if (!inst) {
+            BOOST_LOG_SEV(lg(), error)
+                << "getTradeDetail instrument deserialize error: "
+                << inst.error().what();
+            return std::nullopt;
+        }
+        trading::messaging::trade_export_item item;
+        item.trade = std::move(base->trade);
+        item.instrument = std::move(inst->instrument);
+        return item;
+    } catch (const ores::nats::service::nats_connect_error&) {
+        throw;
+    } catch (const ores::nats::service::session_expired_error& e) {
+        using namespace ores::logging;
+        BOOST_LOG_SEV(lg(), warn) << "Session expired: " << e.what();
+        QMetaObject::invokeMethod(this, [this] { emit sessionExpired(); }, Qt::QueuedConnection);
+        return std::nullopt;
+    } catch (const std::exception& e) {
+        BOOST_LOG_SEV(lg(), error) << "getTradeDetail failed: " << e.what();
+        return std::nullopt;
+    }
+}
+
+}

--- a/projects/ores.qt.api/src/ClientManagerTradeDetail.cpp
+++ b/projects/ores.qt.api/src/ClientManagerTradeDetail.cpp
@@ -72,7 +72,7 @@ ClientManager::getTradeDetail(const std::string& trade_id) {
         throw;
     } catch (const ores::nats::service::session_expired_error& e) {
         using namespace ores::logging;
-        BOOST_LOG_SEV(lg(), warn) << "Session expired: " << e.what();
+        BOOST_LOG_SEV(lg(), warn) << "Session expired: " << boost::diagnostic_information(e);
         QMetaObject::invokeMethod(this, [this] { emit sessionExpired(); }, Qt::QueuedConnection);
         return std::nullopt;
     } catch (const std::exception& e) {

--- a/projects/ores.qt.api/src/ClientManagerTrades.cpp
+++ b/projects/ores.qt.api/src/ClientManagerTrades.cpp
@@ -17,16 +17,12 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-// listTrades() and getTradeDetail() are isolated here so that the heavy
-// rfl::json::read<get_trades_response> instantiation (trade has 25 fields)
-// and the two-phase trade-detail parsing are confined to a single TU and
-// cannot combine with the IAM/session types in ClientManager.cpp to push
-// MSVC over the C1202 constexpr-depth limit.
+// Isolated in its own TU: rfl::json::read<get_trades_response> instantiates
+// reflection for vector<trade> (25 fields) and must not share a TU with other
+// heavy rfl types to avoid MSVC C1202 constexpr-depth limit.
 #include "ores.qt/ClientManager.hpp"
 
 #include <boost/uuid/uuid_io.hpp>
-#include "ores.nats/service/nats_connect_error.hpp"
-#include "ores.nats/service/session_expired_error.hpp"
 
 namespace ores::qt {
 
@@ -63,57 +59,6 @@ std::optional<TradeListResult> ClientManager::listTrades(
         };
     } catch (const std::exception& e) {
         BOOST_LOG_SEV(lg(), error) << "listTrades failed: " << e.what();
-        return std::nullopt;
-    }
-}
-
-std::optional<trading::messaging::trade_export_item>
-ClientManager::getTradeDetail(const std::string& trade_id) {
-    try {
-        trading::messaging::get_trade_detail_request request;
-        request.trade_id = trade_id;
-        const auto raw = send_authenticated_request(
-            trading::messaging::get_trade_detail_request::nats_subject,
-            rfl::json::write(request),
-            std::chrono::seconds(30));
-
-        // Two-phase parse: avoid combining trade (22 fields) with the
-        // trade_instrument variant (8 alternatives) in a single rfl call,
-        // which exceeds MSVC's constexpr depth budget (C1202).
-        auto base = rfl::json::read<
-            trading::messaging::get_trade_detail_response_base>(raw);
-        if (!base) {
-            BOOST_LOG_SEV(lg(), error)
-                << "getTradeDetail deserialize error: " << base.error().what();
-            return std::nullopt;
-        }
-        if (!base->success) {
-            BOOST_LOG_SEV(lg(), error)
-                << "getTradeDetail server error: " << base->message;
-            return std::nullopt;
-        }
-        auto inst = rfl::json::read<
-            trading::messaging::get_trade_detail_instrument_wrapper,
-            rfl::AddTagsToVariants>(raw);
-        if (!inst) {
-            BOOST_LOG_SEV(lg(), error)
-                << "getTradeDetail instrument deserialize error: "
-                << inst.error().what();
-            return std::nullopt;
-        }
-        trading::messaging::trade_export_item item;
-        item.trade = std::move(base->trade);
-        item.instrument = std::move(inst->instrument);
-        return item;
-    } catch (const ores::nats::service::nats_connect_error&) {
-        throw;
-    } catch (const ores::nats::service::session_expired_error& e) {
-        using namespace ores::logging;
-        BOOST_LOG_SEV(lg(), warn) << "Session expired: " << e.what();
-        QMetaObject::invokeMethod(this, [this] { emit sessionExpired(); }, Qt::QueuedConnection);
-        return std::nullopt;
-    } catch (const std::exception& e) {
-        BOOST_LOG_SEV(lg(), error) << "getTradeDetail failed: " << e.what();
         return std::nullopt;
     }
 }

--- a/projects/ores.workflow.api/include/ores.workflow.api/export.hpp
+++ b/projects/ores.workflow.api/include/ores.workflow.api/export.hpp
@@ -19,12 +19,9 @@
 #ifndef ORES_WORKFLOW_API_EXPORT_HPP
 #define ORES_WORKFLOW_API_EXPORT_HPP
 
-#include <boost/config.hpp>
-
-#ifdef ORES_WORKFLOW_API_LIBRARY
-#  define ORES_WORKFLOW_API_EXPORT BOOST_SYMBOL_EXPORT
-#else
-#  define ORES_WORKFLOW_API_EXPORT BOOST_SYMBOL_IMPORT
-#endif
+// ores.workflow.api is a header-only (INTERFACE) library — all types and
+// methods are defined in headers and compiled into each consuming TU.
+// No DLL boundary exists, so no dllexport/dllimport decoration is needed.
+#define ORES_WORKFLOW_API_EXPORT
 
 #endif


### PR DESCRIPTION
## Summary

Two Windows build failures fixed in this PR:

**1. MSVC C1202 in ClientManagerTrades.cpp**

`listTrades` (reflecting `vector<trade>`, 25 fields) and `getTradeDetail` (two-phase rfl parse: 22-field base + 8-alternative instrument variant) combined in one TU still exceeded MSVC's recursive template dependency depth budget (`C1202: recursive type or function dependency context too complex`). `getTradeDetail` is moved to a new `ClientManagerTradeDetail.cpp` so each function has its own TU with a single heavy rfl instantiation.

**2. Linker errors: undefined `__declspec(dllimport)` symbols for workflow types**

`ores.workflow.api` is an INTERFACE (header-only) library — `ORES_WORKFLOW_API_LIBRARY` is never defined. The `export.hpp` was using the standard dllexport/dllimport pattern, so the macro always expanded to `__declspec(dllimport)` for all consumers. This caused lld-link to look for `workflow_registry`, `workflow_definition`, `workflow_step_def`, and `materialised_step` symbols in an external DLL that does not exist. Since all types are defined entirely in headers, no DLL decoration is needed — `ORES_WORKFLOW_API_EXPORT` is now defined as empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)