### PR TITLE
[hotfix] Fix boost::diagnostic_information compile error in ClientManagerTradeDetail

### DIFF
--- a/projects/ores.qt.api/src/ClientManagerTradeDetail.cpp
+++ b/projects/ores.qt.api/src/ClientManagerTradeDetail.cpp
@@ -72,7 +72,7 @@ ClientManager::getTradeDetail(const std::string& trade_id) {
         throw;
     } catch (const ores::nats::service::session_expired_error& e) {
         using namespace ores::logging;
-        BOOST_LOG_SEV(lg(), warn) << "Session expired: " << boost::diagnostic_information(e);
+        BOOST_LOG_SEV(lg(), warn) << "Session expired: " << e.what();
         QMetaObject::invokeMethod(this, [this] { emit sessionExpired(); }, Qt::QueuedConnection);
         return std::nullopt;
     } catch (const std::exception& e) {


### PR DESCRIPTION
## Summary

- `ClientManagerTradeDetail.cpp:75` calls `boost::diagnostic_information(e)` which requires `<boost/exception/diagnostic_information.hpp>` — that header is not included in this TU, causing a compile error on all Linux builds
- Fix: replace with `e.what()`, which is what `ClientManagerTrades.cpp` uses in the equivalent catch block

Fixes CI run https://github.com/OreStudio/OreStudio/actions/runs/25983392216

🤖 Generated with [Claude Code](https://claude.com/claude-code)