### PR TITLE
[shell] Build ores.shell.lib as STATIC to fix Windows plugin DLL link

### DIFF
--- a/projects/ores.shell/include/ores.shell/app/repl.hpp
+++ b/projects/ores.shell/include/ores.shell/app/repl.hpp
@@ -25,6 +25,7 @@
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/service/nats_client.hpp"
 #include "ores.shell/app/pagination_context.hpp"
+#include "ores.shell/export.hpp"
 
 namespace cli {
 
@@ -42,7 +43,7 @@ namespace ores::shell::app {
  * Provides a command-line interface for interacting with the ORE Studio server,
  * including commands for connection management and data retrieval.
  */
-class repl final {
+class ORES_SHELL_EXPORT repl final {
 private:
     inline static std::string_view logger_name =
         "ores.shell.app.repl";

--- a/projects/ores.shell/include/ores.shell/export.hpp
+++ b/projects/ores.shell/include/ores.shell/export.hpp
@@ -1,0 +1,31 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SHELL_EXPORT_HPP
+#define ORES_SHELL_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_SHELL_LIBRARY
+#  define ORES_SHELL_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_SHELL_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.shell/src/CMakeLists.txt
+++ b/projects/ores.shell/src/CMakeLists.txt
@@ -27,13 +27,8 @@ file(GLOB_RECURSE files RELATIVE
 set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
-# STATIC: ores.shell has no export.hpp / BOOST_SYMBOL_EXPORT annotations, so on
-# Windows its symbols are not exported from a DLL. It is consumed only by
-# ores.shell.exe and (transiently) ores.qt.lib's ShellMdiWindow, which is then
-# pulled into the plugin DLLs (ores.qt.compute, ores.qt.workflow) and fails to
-# link against an unexported repl::repl / repl::run. Building STATIC bakes the
-# objects into each consumer and bypasses the DLL-export requirement.
-add_library(${lib_target_name} STATIC ${lib_files})
+add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_SHELL_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.shell/src/CMakeLists.txt
+++ b/projects/ores.shell/src/CMakeLists.txt
@@ -27,7 +27,13 @@ file(GLOB_RECURSE files RELATIVE
 set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
-add_library(${lib_target_name} ${lib_files})
+# STATIC: ores.shell has no export.hpp / BOOST_SYMBOL_EXPORT annotations, so on
+# Windows its symbols are not exported from a DLL. It is consumed only by
+# ores.shell.exe and (transiently) ores.qt.lib's ShellMdiWindow, which is then
+# pulled into the plugin DLLs (ores.qt.compute, ores.qt.workflow) and fails to
+# link against an unexported repl::repl / repl::run. Building STATIC bakes the
+# objects into each consumer and bypasses the DLL-export requirement.
+add_library(${lib_target_name} STATIC ${lib_files})
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}


### PR DESCRIPTION
## Summary

Hotfix for the Windows `Continuous Windows` workflow on `main`, which has been failing all four configurations (msvc/clang × debug/release) since 34dc6520 with lld-link errors while building the plugin DLLs:

```
lld-link: error: undefined symbol: ores::shell::app::repl::repl(nats_client&)
lld-link: error: undefined symbol: ores::shell::app::repl::run(istream&, ostream&)
>>> referenced by ores.qt.lib(ShellMdiWindow.cpp.obj)
[2646/4820] Linking CXX shared library publish\bin\ores.qt.compute.dll  FAILED
[2647/4820] Linking CXX shared library publish\bin\ores.qt.workflow.dll  FAILED
```

## Root cause

`ores.shell.lib` is built as a SHARED library (default for `BUILD_SHARED_LIBS=ON`), but unlike every other shared library in this codebase it has no `export.hpp` / `BOOST_SYMBOL_EXPORT` annotations on its public API. On Windows that means `ores.shell.dll`'s import library does not export `repl::repl` or `repl::run`.

`ShellMdiWindow.cpp` lives in `ores.qt.lib` (STATIC) and is pulled into each plugin DLL via the PRIVATE link against `ores.qt.lib`. The references to `repl::repl` and `repl::run` then cannot be resolved at link time.

Linux/macOS did not catch this because GCC/Clang default to "default" visibility (everything exported) on shared objects.

## Fix

Change `add_library(ores.shell.lib …)` to `add_library(ores.shell.lib STATIC …)`. `ores.shell.lib` is only consumed by `ores.shell.exe` and (transiently) `ores.qt.lib`, so the change has no other downstream impact. The repl objects get baked into each consumer and the DLL-export requirement disappears.

A proper follow-up would be to add an `export.hpp` for `ores.shell` and tag the public API with `BOOST_SYMBOL_EXPORT`, matching the rest of the codebase — but that is out of scope for an unblock-main hotfix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G235jdHv7mq4t1XzALM7uX)_