### PR TITLE
[hotfix] Restore two-phase rfl parse in getTradeDetail to fix MSVC C1202

### DIFF
--- a/projects/ores.qt.api/src/ClientManagerTrades.cpp
+++ b/projects/ores.qt.api/src/ClientManagerTrades.cpp
@@ -72,24 +72,31 @@ ClientManager::getTradeDetail(const std::string& trade_id) {
             rfl::json::write(request),
             std::chrono::seconds(30));
 
-        auto response = rfl::json::read<
-            trading::messaging::get_trade_detail_response,
-            rfl::AddTagsToVariants>(raw);
-        if (!response) {
+        auto base = rfl::json::read<
+            trading::messaging::get_trade_detail_response_base>(raw);
+        if (!base) {
             BOOST_LOG_SEV(lg(), error)
-                << "getTradeDetail deserialize error: "
-                << response.error().what();
+                << "getTradeDetail deserialize error: " << base.error().what();
             return std::nullopt;
         }
-        if (!response->success) {
+        if (!base->success) {
             BOOST_LOG_SEV(lg(), error)
-                << "getTradeDetail server error: " << response->message;
+                << "getTradeDetail server error: " << base->message;
+            return std::nullopt;
+        }
+        auto inst = rfl::json::read<
+            trading::messaging::get_trade_detail_instrument_wrapper,
+            rfl::AddTagsToVariants>(raw);
+        if (!inst) {
+            BOOST_LOG_SEV(lg(), error)
+                << "getTradeDetail instrument deserialize error: "
+                << inst.error().what();
             return std::nullopt;
         }
 
         trading::messaging::trade_export_item item;
-        item.trade = std::move(response->trade);
-        item.instrument = std::move(response->instrument);
+        item.trade = std::move(base->trade);
+        item.instrument = std::move(inst->instrument);
         return item;
     } catch (const ores::nats::service::nats_connect_error&) {
         throw;

--- a/projects/ores.trading.api/include/ores.trading.api/messaging/trade_protocol.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/messaging/trade_protocol.hpp
@@ -88,6 +88,21 @@ struct get_trade_detail_response {
     ores::trading::domain::trade_instrument instrument;
 };
 
+// Two-phase deserialization helpers for ClientManager on MSVC.
+// Parsing trade (nested sub-structs) and trade_instrument (8-alternative
+// variant + rfl::AddTagsToVariants) in a single rfl call exceeds MSVC's
+// constexpr depth budget (C1202). Splitting into two independent reads keeps
+// each instantiation within the limit.
+struct get_trade_detail_response_base {
+    bool success = false;
+    std::string message;
+    ores::trading::domain::trade trade;
+};
+
+struct get_trade_detail_instrument_wrapper {
+    ores::trading::domain::trade_instrument instrument;
+};
+
 struct save_trade_request {
     using response_type = struct save_trade_response;
     static constexpr std::string_view nats_subject = "trading.v1.trades.save";

--- a/projects/ores.trading.core/include/ores.trading.core/export.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/export.hpp
@@ -24,9 +24,6 @@
 
 #ifdef ORES_TRADING_CORE_LIBRARY
 #  define ORES_TRADING_CORE_EXPORT BOOST_SYMBOL_EXPORT
-#elif defined(ORES_TRADING_CORE_STATIC)
-// Static archive on Windows: no DLL import decoration needed.
-#  define ORES_TRADING_CORE_EXPORT
 #else
 #  define ORES_TRADING_CORE_EXPORT BOOST_SYMBOL_IMPORT
 #endif

--- a/projects/ores.trading.core/include/ores.trading.core/export.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/export.hpp
@@ -22,7 +22,11 @@
 
 #include <boost/config.hpp>
 
-#ifdef ORES_TRADING_CORE_LIBRARY
+// On Windows this library is always a static archive (see src/CMakeLists.txt),
+// so DLL import/export decorations are never needed on that platform.
+#if defined(_WIN32)
+#  define ORES_TRADING_CORE_EXPORT
+#elif defined(ORES_TRADING_CORE_LIBRARY)
 #  define ORES_TRADING_CORE_EXPORT BOOST_SYMBOL_EXPORT
 #else
 #  define ORES_TRADING_CORE_EXPORT BOOST_SYMBOL_IMPORT

--- a/projects/ores.trading.core/include/ores.trading.core/export.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/export.hpp
@@ -24,6 +24,9 @@
 
 #ifdef ORES_TRADING_CORE_LIBRARY
 #  define ORES_TRADING_CORE_EXPORT BOOST_SYMBOL_EXPORT
+#elif defined(ORES_TRADING_CORE_STATIC)
+// Static archive on Windows: no DLL import decoration needed.
+#  define ORES_TRADING_CORE_EXPORT
 #else
 #  define ORES_TRADING_CORE_EXPORT BOOST_SYMBOL_IMPORT
 #endif

--- a/projects/ores.trading.core/src/CMakeLists.txt
+++ b/projects/ores.trading.core/src/CMakeLists.txt
@@ -32,10 +32,6 @@ set(lib_files ${files})
 # Build it as a static library on Windows to avoid the limit.
 if(WIN32)
     add_library(${lib_target_name} STATIC ${lib_files})
-    # Propagate STATIC flag to consumers so export.hpp uses an empty macro
-    # instead of __declspec(dllimport), which would cause LNK2019 errors when
-    # linking a static archive.
-    target_compile_definitions(${lib_target_name} INTERFACE ORES_TRADING_CORE_STATIC)
 else()
     add_library(${lib_target_name} ${lib_files})
 endif()

--- a/projects/ores.trading.core/src/CMakeLists.txt
+++ b/projects/ores.trading.core/src/CMakeLists.txt
@@ -32,6 +32,10 @@ set(lib_files ${files})
 # Build it as a static library on Windows to avoid the limit.
 if(WIN32)
     add_library(${lib_target_name} STATIC ${lib_files})
+    # Propagate STATIC flag to consumers so export.hpp uses an empty macro
+    # instead of __declspec(dllimport), which would cause LNK2019 errors when
+    # linking a static archive.
+    target_compile_definitions(${lib_target_name} INTERFACE ORES_TRADING_CORE_STATIC)
 else()
     add_library(${lib_target_name} ${lib_files})
 endif()


### PR DESCRIPTION
## Summary

PR #763 merged `getTradeDetail` back into `ClientManagerTrades.cpp` and replaced the two-phase rfl parse with a single `rfl::json::read<get_trade_detail_response, rfl::AddTagsToVariants>`. This still hits MSVC C1202.

**Root cause**: even with `trade` decomposed into sub-structs, the combination of nested struct reflection + an 8-alternative tagged variant (`trade_instrument`) in a single rfl call exceeds MSVC's constexpr depth budget. The C1202 is driven by the variant, not by `trade`'s field count.

## Fix

Restore `get_trade_detail_response_base` and `get_trade_detail_instrument_wrapper` in `trade_protocol.hpp` and use the two-phase parse in `ClientManagerTrades.cpp`. Both functions remain in the same TU — only the deserialization is split, not the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)