### PR TITLE
[trading] Raise MSVC /constexpr:depth to 100000 to fix C1202 in ores.qt.api

### DIFF
--- a/projects/ores.qt.api/src/CMakeLists.txt
+++ b/projects/ores.qt.api/src/CMakeLists.txt
@@ -39,16 +39,6 @@ add_library(${lib_target_name} SHARED ${files} ${HEADERS} ${FORMS})
 # expands to BOOST_SYMBOL_EXPORT instead of BOOST_SYMBOL_IMPORT.
 target_compile_definitions(${lib_target_name} PRIVATE ORES_QT_API_LIBRARY)
 
-# ClientManagerTrades.cpp calls rfl::json::read with the trade_instrument
-# variant (8 alternatives, ~150 combined fields). rfl's no_duplicate_field_names
-# check is O(n²) in constexpr depth, which exceeds MSVC's default of 512.
-# Raise both limits here rather than fighting the variant structure.
-if(MSVC)
-    target_compile_options(${lib_target_name} PRIVATE
-        /constexpr:depth100000
-        /constexpr:steps10000000)
-endif()
-
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name}
     AUTOUIC_SEARCH_PATHS ${ORES_QT_API_DIR}/ui

--- a/projects/ores.trading.api/src/CMakeLists.txt
+++ b/projects/ores.trading.api/src/CMakeLists.txt
@@ -48,14 +48,12 @@ target_link_libraries(${lib_target_name}
         faker-cxx::faker-cxx
         libfort::fort)
 
-# Trading types have up to 22 fields; rfl's duplicate-field-names check performs
-# an O(N²) constexpr expansion that exhausts MSVC's default depth (512) and
-# step (100 000) budgets, producing C1202. Consumers like ores.qt.api instantiate
-# these types inside deeper template contexts (e.g. process_authenticated_request),
-# consuming extra depth budget before rfl evaluation starts, so depth must be
-# raised to 2048. PUBLIC propagates to all consumers automatically.
+# rfl's no_duplicate_field_names check is O(n²) in constexpr recursion depth.
+# The trade_instrument variant (8 alternatives, ~150 combined fields with
+# rfl::AddTagsToVariants) requires depth >> 512. PUBLIC propagates to all
+# consumers automatically so they don't need to set this independently.
 target_compile_options(${lib_target_name} PUBLIC
-    $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<COMPILE_LANGUAGE:CXX>>:/constexpr:depth2048>
+    $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<COMPILE_LANGUAGE:CXX>>:/constexpr:depth100000>
     $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<COMPILE_LANGUAGE:CXX>>:/constexpr:steps10000000>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)


### PR DESCRIPTION
## Summary

- The `ores.trading.api` target sets `/constexpr:depth` as `PUBLIC`, meaning it propagates to all consumers and the last occurrence wins when MSVC sees duplicate flags
- PR #768 added `/constexpr:depth100000` to `ores.qt.api` as `PRIVATE`, but the `PUBLIC` `/constexpr:depth2048` from `ores.trading.api` appeared later in the compiler command and overrode it — so the build still failed with C1202
- Fix: raise the value in `ores.trading.api` from 2048 → 100000 (the `trade_instrument` variant has ~150 combined fields with `rfl::AddTagsToVariants`, requiring depth >> 2048), and remove the now-redundant per-target block from `ores.qt.api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)