### PR TITLE
Fix pg_notify pipeline, badge RLS, and system reset

### DIFF
--- a/.github/workflows/canary-linux.yml
+++ b/.github/workflows/canary-linux.yml
@@ -155,7 +155,10 @@ jobs:
         run: |
           git diff origin/main...HEAD --name-only 2>/dev/null \
             | grep -E '\.(cpp|hpp|h)$' \
-            | while IFS= read -r f; do [ -f "$f" ] && touch "$f"; done || true
+            | while IFS= read -r f; do
+                [ -f "$f" ] && touch "$f"
+                [[ "$f" == *.cpp ]] && find build/output/linux-gcc-debug-ninja -name "${f##*/}.gcda" -delete 2>/dev/null || true
+              done || true
 
       - name: Run CTest workflow
         run: |

--- a/build/scripts/nats.sh
+++ b/build/scripts/nats.sh
@@ -26,7 +26,7 @@ if [[ -f "${ENV_FILE}" ]]; then
 fi
 
 exec nats \
-    --server "${ORES_NATS_URL}" \
+    --server "${ORES_NATS_URL/nats:\/\//tls:\/\/}" \
     --tlsca  "${ORES_NATS_TLS_CA}" \
     --tlscert "${ORES_NATS_TLS_CERT}" \
     --tlskey  "${ORES_NATS_TLS_KEY}" \

--- a/doc/plans/2026-05-14-dq-publish-pattern.org
+++ b/doc/plans/2026-05-14-dq-publish-pattern.org
@@ -2,7 +2,7 @@
 #+SUBTITLE: Reconciling bulk artefact publishing with strict service table isolation
 #+DATE: 2026-05-14
 #+AUTHOR: ORE Studio Team
-#+STATUS: PROPOSAL
+#+STATUS: IN PROGRESS
 #+OPTIONS: toc:t num:nil
 
 * Background
@@ -573,6 +573,10 @@ publish path is no longer a special case.
 
 * Implementation Status
 
+Core implementation merged as PR #767 (~feature/dq-publish-pattern~).
+Follow-up bug fixes merged as PR #772 (~feature/badge-rls-colours~) —
+see "Post-merge fixes" below.
+
 Branch: ~feature/dq-publish-pattern~
 
 ** SQL phase
@@ -617,6 +621,34 @@ Branch: ~feature/dq-publish-pattern~
 ** Documentation
 
 - [X] ~projects/modeling/system_model.org~ — add "Publish exception" architectural rule
+
+** Post-merge fixes (PR #772)
+
+Bugs surfaced during end-to-end testing of the publish pattern after
+PR #767 merged:
+
+- [X] ~pg_notify~ timestamp format: all 143 notify triggers now emit
+  ISO 8601 UTC (~YYYY-MM-DDThh:mm:ssZ~); ~datetime::from_iso8601_utc~
+  updated to accept both ~T~ and space separators — previously every
+  notification was silently dropped, breaking cache refresh and
+  workflow step events
+- [X] Party cache refresh: ~register_mapping~ in refdata service used
+  ~"ores.refdata.party_changed"~ but the trigger emits
+  ~"ores.refdata.party"~ — party activation never propagated to the IAM
+  cache, causing the party provisioning wizard to reappear on every login
+- [X] Badge RLS: added read policies for ~ores_dq_badge_severities_tbl~,
+  ~ores_dq_badge_definitions_tbl~, ~ores_dq_badge_mappings_tbl~ so
+  system-tenant badge data is visible to all tenants; removed redundant
+  explicit ~tenant_id~ filters from badge repository read methods
+- [X] System reset (~ores_iam_reset_system_fn~): added missing
+  ~iam_tenant_purger_create.sql~ to create/drop sequences; fixed
+  bootstrap detection in ~ores_iam_validate_account_username_fn~ to
+  filter by active accounts only (soft-deleted accounts no longer
+  block re-bootstrap after a reset)
+- [X] ~build/scripts/nats.sh~: use ~tls://~ scheme so mTLS CLI
+  connections succeed
+- [X] ~postgres_event_source~: log registered entity names at startup
+  and in the no-mapping warning path
 
 * Open Questions
 

--- a/projects/ores.dq.core/src/repository/badge_definition_repository.cpp
+++ b/projects/ores.dq.core/src/repository/badge_definition_repository.cpp
@@ -53,9 +53,8 @@ void badge_definition_repository::write(
 std::vector<domain::badge_definition>
 badge_definition_repository::read_latest(context ctx) {
     static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
-    const auto tid = ctx.tenant_id().to_string();
     const auto query = sqlgen::read<std::vector<badge_definition_entity>> |
-        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        where("valid_to"_c == max.value()) |
         order_by("code"_c);
 
     return execute_read_query<badge_definition_entity, domain::badge_definition>(
@@ -68,9 +67,8 @@ std::vector<domain::badge_definition>
 badge_definition_repository::read_latest(context ctx, const std::string& code) {
     BOOST_LOG_SEV(lg(), debug) << "Reading latest badge definition. code: " << code;
     static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
-    const auto tid = ctx.tenant_id().to_string();
     const auto query = sqlgen::read<std::vector<badge_definition_entity>> |
-        where("tenant_id"_c == tid && "code"_c == code && "valid_to"_c == max.value());
+        where("code"_c == code && "valid_to"_c == max.value());
 
     return execute_read_query<badge_definition_entity, domain::badge_definition>(
         ctx, query,
@@ -81,9 +79,8 @@ badge_definition_repository::read_latest(context ctx, const std::string& code) {
 std::vector<domain::badge_definition>
 badge_definition_repository::read_all(context ctx, const std::string& code) {
     BOOST_LOG_SEV(lg(), debug) << "Reading all badge definition versions. code: " << code;
-    const auto tid = ctx.tenant_id().to_string();
     const auto query = sqlgen::read<std::vector<badge_definition_entity>> |
-        where("tenant_id"_c == tid && "code"_c == code) |
+        where("code"_c == code) |
         order_by("version"_c.desc());
 
     return execute_read_query<badge_definition_entity, domain::badge_definition>(

--- a/projects/ores.dq.core/src/repository/badge_mapping_repository.cpp
+++ b/projects/ores.dq.core/src/repository/badge_mapping_repository.cpp
@@ -37,9 +37,8 @@ badge_mapping_repository::badge_mapping_repository(context ctx)
 std::vector<messaging::badge_mapping> badge_mapping_repository::read_all() {
     BOOST_LOG_SEV(lg(), debug) << "Reading all active badge mappings";
     static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
-    const auto tid = ctx_.tenant_id().to_string();
     const auto query = sqlgen::read<std::vector<badge_mapping_entity>> |
-        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        where("valid_to"_c == max.value()) |
         order_by("code_domain_code"_c, "entity_code"_c);
 
     return execute_read_query<badge_mapping_entity, messaging::badge_mapping>(

--- a/projects/ores.dq.core/src/repository/badge_severity_repository.cpp
+++ b/projects/ores.dq.core/src/repository/badge_severity_repository.cpp
@@ -53,9 +53,8 @@ void badge_severity_repository::write(
 std::vector<domain::badge_severity>
 badge_severity_repository::read_latest(context ctx) {
     static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
-    const auto tid = ctx.tenant_id().to_string();
     const auto query = sqlgen::read<std::vector<badge_severity_entity>> |
-        where("tenant_id"_c == tid && "valid_to"_c == max.value()) |
+        where("valid_to"_c == max.value()) |
         order_by("code"_c);
 
     return execute_read_query<badge_severity_entity, domain::badge_severity>(
@@ -68,9 +67,8 @@ std::vector<domain::badge_severity>
 badge_severity_repository::read_latest(context ctx, const std::string& code) {
     BOOST_LOG_SEV(lg(), debug) << "Reading latest badge severity. code: " << code;
     static auto max(make_timestamp(MAX_TIMESTAMP, lg()));
-    const auto tid = ctx.tenant_id().to_string();
     const auto query = sqlgen::read<std::vector<badge_severity_entity>> |
-        where("tenant_id"_c == tid && "code"_c == code && "valid_to"_c == max.value());
+        where("code"_c == code && "valid_to"_c == max.value());
 
     return execute_read_query<badge_severity_entity, domain::badge_severity>(
         ctx, query,
@@ -81,9 +79,8 @@ badge_severity_repository::read_latest(context ctx, const std::string& code) {
 std::vector<domain::badge_severity>
 badge_severity_repository::read_all(context ctx, const std::string& code) {
     BOOST_LOG_SEV(lg(), debug) << "Reading all badge severity versions. code: " << code;
-    const auto tid = ctx.tenant_id().to_string();
     const auto query = sqlgen::read<std::vector<badge_severity_entity>> |
-        where("tenant_id"_c == tid && "code"_c == code) |
+        where("code"_c == code) |
         order_by("version"_c.desc());
 
     return execute_read_query<badge_severity_entity, domain::badge_severity>(

--- a/projects/ores.eventing/include/ores.eventing/service/postgres_event_source.hpp
+++ b/projects/ores.eventing/include/ores.eventing/service/postgres_event_source.hpp
@@ -157,6 +157,7 @@ private:
     event_bus& bus_;
     ores::database::service::postgres_listener_service listener_;
     std::unordered_map<std::string, entity_mapping> entity_mappings_;
+    std::string registered_entities_;
 };
 
 }

--- a/projects/ores.eventing/src/service/postgres_event_source.cpp
+++ b/projects/ores.eventing/src/service/postgres_event_source.cpp
@@ -56,8 +56,13 @@ postgres_event_source::~postgres_event_source() {
 }
 
 void postgres_event_source::start() {
-    BOOST_LOG_SEV(lg(), info) << "Starting postgres event source with "
-                              << entity_mappings_.size() << " registered mappings.";
+    std::string registered;
+    for (const auto& kv : entity_mappings_) {
+        if (!registered.empty()) registered += ", ";
+        registered += kv.first;
+    }
+    BOOST_LOG_SEV(lg(), info) << "Starting postgres event source. Registered entities: ["
+                              << registered << "]";
     listener_.start();
 }
 
@@ -73,9 +78,14 @@ void postgres_event_source::on_entity_change(const domain::entity_change_event& 
 
     auto it = entity_mappings_.find(e.entity);
     if (it == entity_mappings_.end()) {
+        std::string registered;
+        for (const auto& kv : entity_mappings_) {
+            if (!registered.empty()) registered += ", ";
+            registered += kv.first;
+        }
         BOOST_LOG_SEV(lg(), warn)
-            << "No event mapping registered for entity: " << e.entity
-            << " - notification will be ignored";
+            << "No event mapping registered for entity: '" << e.entity
+            << "'. Registered: [" << registered << "] - notification ignored";
         return;
     }
 

--- a/projects/ores.eventing/src/service/postgres_event_source.cpp
+++ b/projects/ores.eventing/src/service/postgres_event_source.cpp
@@ -56,13 +56,12 @@ postgres_event_source::~postgres_event_source() {
 }
 
 void postgres_event_source::start() {
-    std::string registered;
     for (const auto& kv : entity_mappings_) {
-        if (!registered.empty()) registered += ", ";
-        registered += kv.first;
+        if (!registered_entities_.empty()) registered_entities_ += ", ";
+        registered_entities_ += kv.first;
     }
     BOOST_LOG_SEV(lg(), info) << "Starting postgres event source. Registered entities: ["
-                              << registered << "]";
+                              << registered_entities_ << "]";
     listener_.start();
 }
 
@@ -78,14 +77,9 @@ void postgres_event_source::on_entity_change(const domain::entity_change_event& 
 
     auto it = entity_mappings_.find(e.entity);
     if (it == entity_mappings_.end()) {
-        std::string registered;
-        for (const auto& kv : entity_mappings_) {
-            if (!registered.empty()) registered += ", ";
-            registered += kv.first;
-        }
         BOOST_LOG_SEV(lg(), warn)
             << "No event mapping registered for entity: '" << e.entity
-            << "'. Registered: [" << registered << "] - notification ignored";
+            << "'. Registered: [" << registered_entities_ << "] - notification ignored";
         return;
     }
 

--- a/projects/ores.platform/include/ores.platform/time/datetime.hpp
+++ b/projects/ores.platform/include/ores.platform/time/datetime.hpp
@@ -58,6 +58,7 @@ public:
     /**
      * @brief Parses an ISO 8601 UTC string to a time point.
      *
+     * Accepted date/time separators: 'T' (ISO 8601 standard) or ' ' (relaxed).
      * Accepted UTC designators: 'Z', '+00', '+00:00'.
      * Throws std::invalid_argument if the designator is absent or the offset
      * is non-zero — callers must not pass ambiguous local-time strings.

--- a/projects/ores.platform/src/time/datetime.cpp
+++ b/projects/ores.platform/src/time/datetime.cpp
@@ -66,6 +66,10 @@ std::chrono::system_clock::time_point datetime::from_iso8601_utc(
     while (!clean.empty() && clean.back() == ' ')
         clean.pop_back();
 
+    // Accept both 'T' (ISO 8601 standard) and ' ' (relaxed) as date/time separator.
+    if (clean.size() > 10 && clean[10] == 'T')
+        clean[10] = ' ';
+
     std::tm tm = {};
     std::istringstream ss(clean);
     ss >> std::get_time(&tm, "%Y-%m-%d %H:%M:%S");

--- a/projects/ores.refdata.service/src/app/application.cpp
+++ b/projects/ores.refdata.service/src/app/application.cpp
@@ -113,7 +113,7 @@ application::run(boost::asio::io_context& io_ctx,
     ev::service::registrar::register_mapping<rdev::book_changed_event>(
         event_source, "ores.refdata.book", "ores_books");
     ev::service::registrar::register_mapping<rdev::party_changed_event>(
-        event_source, "ores.refdata.party_changed", "ores_parties");
+        event_source, "ores.refdata.party", "ores_parties");
     ev::service::registrar::register_mapping<rdev::portfolio_changed_event>(
         event_source, "ores.refdata.portfolio", "ores_portfolios");
 

--- a/projects/ores.sql/create/analytics/analytics_pricing_engine_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/analytics/analytics_pricing_engine_types_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/analytics/analytics_pricing_model_configs_notify_trigger_create.sql
+++ b/projects/ores.sql/create/analytics/analytics_pricing_model_configs_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/analytics/analytics_pricing_model_product_parameters_notify_trigger_create.sql
+++ b/projects/ores.sql/create/analytics/analytics_pricing_model_product_parameters_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/analytics/analytics_pricing_model_products_notify_trigger_create.sql
+++ b/projects/ores.sql/create/analytics/analytics_pricing_model_products_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/compute/compute_app_version_platforms_notify_trigger_create.sql
+++ b/projects/ores.sql/create/compute/compute_app_version_platforms_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_app_version_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/compute/compute_app_versions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/compute/compute_app_versions_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/compute/compute_apps_notify_trigger_create.sql
+++ b/projects/ores.sql/create/compute/compute_apps_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/compute/compute_batches_notify_trigger_create.sql
+++ b/projects/ores.sql/create/compute/compute_batches_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/compute/compute_hosts_notify_trigger_create.sql
+++ b/projects/ores.sql/create/compute/compute_hosts_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/compute/compute_results_notify_trigger_create.sql
+++ b/projects/ores.sql/create/compute/compute_results_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/compute/compute_workunits_notify_trigger_create.sql
+++ b/projects/ores.sql/create/compute/compute_workunits_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/dq/dq_catalogs_notify_trigger_create.sql
+++ b/projects/ores.sql/create/dq/dq_catalogs_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_name),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/dq/dq_change_reason_categories_notify_trigger_create.sql
+++ b/projects/ores.sql/create/dq/dq_change_reason_categories_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/dq/dq_change_reasons_notify_trigger_create.sql
+++ b/projects/ores.sql/create/dq/dq_change_reasons_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/dq/dq_coding_scheme_authority_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/dq/dq_coding_scheme_authority_types_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/dq/dq_coding_schemes_notify_trigger_create.sql
+++ b/projects/ores.sql/create/dq/dq_coding_schemes_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/dq/dq_data_domains_notify_trigger_create.sql
+++ b/projects/ores.sql/create/dq/dq_data_domains_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_name),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/dq/dq_datasets_notify_trigger_create.sql
+++ b/projects/ores.sql/create/dq/dq_datasets_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/dq/dq_fsm_machines_notify_trigger_create.sql
+++ b/projects/ores.sql/create/dq/dq_fsm_machines_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/dq/dq_fsm_states_notify_trigger_create.sql
+++ b/projects/ores.sql/create/dq/dq_fsm_states_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/dq/dq_fsm_transitions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/dq/dq_fsm_transitions_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/dq/dq_methodologies_notify_trigger_create.sql
+++ b/projects/ores.sql/create/dq/dq_methodologies_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/dq/dq_nature_dimensions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/dq/dq_nature_dimensions_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/dq/dq_origin_dimensions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/dq/dq_origin_dimensions_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/dq/dq_rls_policies_create.sql
+++ b/projects/ores.sql/create/dq/dq_rls_policies_create.sql
@@ -268,4 +268,61 @@ for all
 using (tenant_id = ores_iam_current_tenant_id_fn())
 with check (tenant_id = ores_iam_current_tenant_id_fn());
 
+-- -----------------------------------------------------------------------------
+-- Badge Severities
+-- System-owned global registry: seeded by the system tenant and readable by
+-- all tenants. Tenants may define their own severities but cannot modify the
+-- system set.
+-- -----------------------------------------------------------------------------
+alter table ores_dq_badge_severities_tbl enable row level security;
+
+create policy badge_severities_read_policy on ores_dq_badge_severities_tbl
+for select using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+    or tenant_id = ores_utility_system_tenant_id_fn()
+);
+
+create policy badge_severities_modification_policy on ores_dq_badge_severities_tbl
+for all
+using (tenant_id = ores_iam_current_tenant_id_fn())
+with check (tenant_id = ores_iam_current_tenant_id_fn());
+
+-- -----------------------------------------------------------------------------
+-- Badge Definitions
+-- System-owned global registry: seeded by the system tenant and readable by
+-- all tenants. Tenants may define their own badge definitions but cannot
+-- modify the system set.
+-- -----------------------------------------------------------------------------
+alter table ores_dq_badge_definitions_tbl enable row level security;
+
+create policy badge_definitions_read_policy on ores_dq_badge_definitions_tbl
+for select using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+    or tenant_id = ores_utility_system_tenant_id_fn()
+);
+
+create policy badge_definitions_modification_policy on ores_dq_badge_definitions_tbl
+for all
+using (tenant_id = ores_iam_current_tenant_id_fn())
+with check (tenant_id = ores_iam_current_tenant_id_fn());
+
+-- -----------------------------------------------------------------------------
+-- Badge Mappings
+-- System-owned global registry: seeded by the system tenant and readable by
+-- all tenants. Tenants may define their own mappings but cannot modify the
+-- system set.
+-- -----------------------------------------------------------------------------
+alter table ores_dq_badge_mappings_tbl enable row level security;
+
+create policy badge_mappings_read_policy on ores_dq_badge_mappings_tbl
+for select using (
+    tenant_id = ores_iam_current_tenant_id_fn()
+    or tenant_id = ores_utility_system_tenant_id_fn()
+);
+
+create policy badge_mappings_modification_policy on ores_dq_badge_mappings_tbl
+for all
+using (tenant_id = ores_iam_current_tenant_id_fn())
+with check (tenant_id = ores_iam_current_tenant_id_fn());
+
 \ir ./dq_fsm_rls_policies_create.sql

--- a/projects/ores.sql/create/dq/dq_subject_areas_notify_trigger_create.sql
+++ b/projects/ores.sql/create/dq/dq_subject_areas_notify_trigger_create.sql
@@ -35,7 +35,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_key),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/dq/dq_treatment_dimensions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/dq/dq_treatment_dimensions_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/iam/iam_accounts_notify_trigger_create.sql
+++ b/projects/ores.sql/create/iam/iam_accounts_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_account_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/iam/iam_create.sql
+++ b/projects/ores.sql/create/iam/iam_create.sql
@@ -59,6 +59,7 @@
 \ir ./iam_tenant_reset_create.sql
 \ir ./iam_tenant_bootstrap_reset_create.sql
 \ir ./iam_tenant_activate_create.sql
+\ir ./iam_tenant_purger_create.sql
 \ir ./iam_system_reset_create.sql
 \ir ./iam_tenant_terminator_create.sql
 

--- a/projects/ores.sql/create/iam/iam_permissions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/iam/iam_permissions_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/iam/iam_roles_notify_trigger_create.sql
+++ b/projects/ores.sql/create/iam/iam_roles_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/iam/iam_tenant_functions_create.sql
+++ b/projects/ores.sql/create/iam/iam_tenant_functions_create.sql
@@ -374,12 +374,13 @@ begin
         ores_utility_system_tenant_id_fn()
     );
 
-    -- During bootstrap for this tenant (no user accounts exist yet),
+    -- During bootstrap for this tenant (no active user accounts exist yet),
     -- allow any value and default empty to current_user.
     if not exists (
         select 1 from ores_iam_accounts_tbl
         where tenant_id = v_tenant_id
           and account_type != 'service'
+          and valid_to = ores_utility_infinity_timestamp_fn()
         limit 1
     ) then
         if p_username is null or p_username = '' then

--- a/projects/ores.sql/create/iam/iam_tenants_notify_trigger_create.sql
+++ b/projects/ores.sql/create/iam/iam_tenants_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_account_types_notify_trigger.sql
+++ b/projects/ores.sql/create/refdata/refdata_account_types_notify_trigger.sql
@@ -39,7 +39,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code)
     );
 

--- a/projects/ores.sql/create/refdata/refdata_account_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_account_types_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_asset_classes_notify_trigger.sql
+++ b/projects/ores.sql/create/refdata/refdata_asset_classes_notify_trigger.sql
@@ -39,7 +39,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code)
     );
 

--- a/projects/ores.sql/create/refdata/refdata_asset_classes_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_asset_classes_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_asset_measures_notify_trigger.sql
+++ b/projects/ores.sql/create/refdata/refdata_asset_measures_notify_trigger.sql
@@ -39,7 +39,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code)
     );
 

--- a/projects/ores.sql/create/refdata/refdata_asset_measures_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_asset_measures_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_benchmark_rates_notify_trigger.sql
+++ b/projects/ores.sql/create/refdata/refdata_benchmark_rates_notify_trigger.sql
@@ -39,7 +39,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code)
     );
 

--- a/projects/ores.sql/create/refdata/refdata_benchmark_rates_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_benchmark_rates_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_book_statuses_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_book_statuses_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_books_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_books_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_business_centres_notify_trigger.sql
+++ b/projects/ores.sql/create/refdata/refdata_business_centres_notify_trigger.sql
@@ -39,7 +39,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code)
     );
 

--- a/projects/ores.sql/create/refdata/refdata_business_centres_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_business_centres_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_business_processes_notify_trigger.sql
+++ b/projects/ores.sql/create/refdata/refdata_business_processes_notify_trigger.sql
@@ -39,7 +39,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code)
     );
 

--- a/projects/ores.sql/create/refdata/refdata_business_processes_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_business_processes_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_business_unit_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_business_unit_types_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_business_units_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_business_units_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_cashflow_types_notify_trigger.sql
+++ b/projects/ores.sql/create/refdata/refdata_cashflow_types_notify_trigger.sql
@@ -39,7 +39,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code)
     );
 

--- a/projects/ores.sql/create/refdata/refdata_cashflow_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_cashflow_types_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_cds_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_cds_conventions_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_contact_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_contact_types_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_counterparties_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_counterparties_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_counterparty_contact_informations_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_counterparty_contact_informations_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_counterparty_identifiers_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_counterparty_identifiers_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_countries_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_countries_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_alpha2_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_currencies_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_currencies_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_iso_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_currency_market_tiers_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_currency_market_tiers_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_deposit_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_deposit_conventions_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_entity_classifications_notify_trigger.sql
+++ b/projects/ores.sql/create/refdata/refdata_entity_classifications_notify_trigger.sql
@@ -39,7 +39,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code)
     );
 

--- a/projects/ores.sql/create/refdata/refdata_entity_classifications_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_entity_classifications_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_fra_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_fra_conventions_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_fx_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_fx_conventions_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_ibor_index_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_ibor_index_conventions_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_local_jurisdictions_notify_trigger.sql
+++ b/projects/ores.sql/create/refdata/refdata_local_jurisdictions_notify_trigger.sql
@@ -39,7 +39,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code)
     );
 

--- a/projects/ores.sql/create/refdata/refdata_local_jurisdictions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_local_jurisdictions_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_monetary_natures_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_monetary_natures_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_ois_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_ois_conventions_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_overnight_index_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_overnight_index_conventions_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_parties_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_parties_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_party_categories_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_party_categories_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_party_contact_informations_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_party_contact_informations_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_party_id_schemes_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_party_id_schemes_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_party_identifiers_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_party_identifiers_notify_trigger_create.sql
@@ -36,7 +36,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_party_relationships_notify_trigger.sql
+++ b/projects/ores.sql/create/refdata/refdata_party_relationships_notify_trigger.sql
@@ -39,7 +39,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code)
     );
 

--- a/projects/ores.sql/create/refdata/refdata_party_relationships_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_party_relationships_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_party_roles_notify_trigger.sql
+++ b/projects/ores.sql/create/refdata/refdata_party_roles_notify_trigger.sql
@@ -39,7 +39,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code)
     );
 

--- a/projects/ores.sql/create/refdata/refdata_party_roles_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_party_roles_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_party_statuses_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_party_statuses_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_party_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_party_types_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_person_roles_notify_trigger.sql
+++ b/projects/ores.sql/create/refdata/refdata_person_roles_notify_trigger.sql
@@ -39,7 +39,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code)
     );
 

--- a/projects/ores.sql/create/refdata/refdata_person_roles_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_person_roles_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_portfolios_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_portfolios_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_purpose_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_purpose_types_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_regulatory_corporate_sectors_notify_trigger.sql
+++ b/projects/ores.sql/create/refdata/refdata_regulatory_corporate_sectors_notify_trigger.sql
@@ -39,7 +39,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code)
     );
 

--- a/projects/ores.sql/create/refdata/refdata_regulatory_corporate_sectors_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_regulatory_corporate_sectors_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_reporting_regimes_notify_trigger.sql
+++ b/projects/ores.sql/create/refdata/refdata_reporting_regimes_notify_trigger.sql
@@ -39,7 +39,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code)
     );
 

--- a/projects/ores.sql/create/refdata/refdata_reporting_regimes_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_reporting_regimes_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_supervisory_bodies_notify_trigger.sql
+++ b/projects/ores.sql/create/refdata/refdata_supervisory_bodies_notify_trigger.sql
@@ -39,7 +39,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code)
     );
 

--- a/projects/ores.sql/create/refdata/refdata_supervisory_bodies_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_supervisory_bodies_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_swap_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_swap_conventions_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/refdata/refdata_zero_conventions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_zero_conventions_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/reporting/reporting_concurrency_policies_notify_trigger_create.sql
+++ b/projects/ores.sql/create/reporting/reporting_concurrency_policies_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/reporting/reporting_report_definitions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/reporting/reporting_report_definitions_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/reporting/reporting_report_instances_notify_trigger_create.sql
+++ b/projects/ores.sql/create/reporting/reporting_report_instances_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/reporting/reporting_report_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/reporting/reporting_report_types_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/reporting/reporting_risk_report_configs_notify_trigger_create.sql
+++ b/projects/ores.sql/create/reporting/reporting_risk_report_configs_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/scheduler/scheduler_job_definitions_notify_trigger_create.sql
+++ b/projects/ores.sql/create/scheduler/scheduler_job_definitions_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_activity_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_activity_types_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_balance_guaranteed_swap_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_balance_guaranteed_swap_instruments_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_instrument_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_bond_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_bond_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_business_day_convention_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_business_day_convention_types_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_callable_swap_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_callable_swap_instruments_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_instrument_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_cap_floor_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_cap_floor_instruments_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_instrument_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_commodity_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_commodity_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_composite_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_composite_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_composite_legs_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_composite_legs_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_credit_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_credit_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_day_count_fraction_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_day_count_fraction_types_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_equity_accumulator_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_accumulator_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_equity_asian_option_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_asian_option_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_equity_barrier_option_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_barrier_option_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_equity_digital_option_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_digital_option_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_equity_forward_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_forward_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_equity_option_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_option_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_equity_position_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_position_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_equity_swap_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_swap_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_equity_variance_swap_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_equity_variance_swap_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_floating_index_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_floating_index_types_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_fpml_event_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_fpml_event_types_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_fra_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_fra_instruments_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_instrument_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_fx_accumulator_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_accumulator_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_fx_asian_forward_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_asian_forward_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_fx_barrier_option_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_barrier_option_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_fx_digital_option_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_digital_option_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_fx_forward_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_forward_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_fx_vanilla_option_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_vanilla_option_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_fx_variance_swap_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_fx_variance_swap_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_inflation_swap_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_inflation_swap_instruments_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_instrument_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_knock_out_swap_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_knock_out_swap_instruments_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_instrument_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_leg_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_leg_types_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_lifecycle_events_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_lifecycle_events_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_party_role_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_party_role_types_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_payment_frequency_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_payment_frequency_types_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_rpa_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_rpa_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_scripted_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_scripted_instruments_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_swap_legs_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_swap_legs_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_swaption_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_swaption_instruments_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_instrument_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_trade_id_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_trade_id_types_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_trade_identifiers_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_trade_identifiers_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_trade_party_roles_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_trade_party_roles_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_trade_types_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_trade_types_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_code),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_trades_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_trades_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/trading/trading_vanilla_swap_instruments_notify_trigger_create.sql
+++ b/projects/ores.sql/create/trading/trading_vanilla_swap_instruments_notify_trigger_create.sql
@@ -42,7 +42,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_instrument_id),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/create/variability/variability_system_settings_notify_trigger_create.sql
+++ b/projects/ores.sql/create/variability/variability_system_settings_notify_trigger_create.sql
@@ -37,7 +37,7 @@ begin
 
     notification_payload := jsonb_build_object(
         'entity', entity_name,
-        'timestamp', to_char(change_timestamp, 'YYYY-MM-DD HH24:MI:SS'),
+        'timestamp', to_char(change_timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
         'entity_ids', jsonb_build_array(changed_setting_name),
         'tenant_id', changed_tenant_id
     );

--- a/projects/ores.sql/drop/iam/iam_drop.sql
+++ b/projects/ores.sql/drop/iam/iam_drop.sql
@@ -24,6 +24,7 @@
 \ir ./iam_tenant_reset_drop.sql
 \ir ./iam_tenant_bootstrap_reset_drop.sql
 \ir ./iam_tenant_activate_drop.sql
+\ir ./iam_tenant_purger_drop.sql
 \ir ./iam_system_reset_drop.sql
 \ir ./iam_tenant_provisioner_drop.sql
 

--- a/projects/ores.sql/drop/iam/iam_tenant_purger_drop.sql
+++ b/projects/ores.sql/drop/iam/iam_tenant_purger_drop.sql
@@ -1,0 +1,23 @@
+/* -*- sql-product: postgres; tab-width: 4; indent-tabs-mode: nil -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+drop function if exists ores_iam_purge_test_tenants_fn();
+drop function if exists ores_iam_hard_delete_tenants_fn(uuid[]);
+drop function if exists ores_iam_purge_tenant_fn(uuid);


### PR DESCRIPTION
## Summary

- **pg_notify timestamp format**: All 143 notify triggers now emit ISO 8601 UTC (`YYYY-MM-DDThh:mm:ssZ`); `datetime::from_iso8601_utc` updated to accept both `T` and space date/time separators so the full notification pipeline functions correctly
- **Party cache refresh**: Fixed `ores.refdata.party_changed` → `ores.refdata.party` entity name mismatch in refdata service event registration — party status changes now propagate to the IAM party cache, eliminating the re-appearing party provisioning wizard on login
- **Badge colours**: Added RLS read policies for badge severity, definition and mapping tables so system-tenant badge data is visible to all tenants; removed redundant explicit `tenant_id` filters from badge repository read methods
- **System reset**: Added missing `iam_tenant_purger_create.sql` to the IAM create/drop sequences; fixed bootstrap detection in `ores_iam_validate_account_username_fn` to filter by active accounts only (soft-deleted accounts no longer block re-bootstrap); fixed `nats.sh` to use `tls://` scheme for mTLS connections
- **Event source logging**: `postgres_event_source` now logs registered entity names at startup and in the no-mapping warning path, making future mismatches immediately diagnosable

🤖 Generated with [Claude Code](https://claude.com/claude-code)