### PR TITLE
[cli] Build ores.cli.lib as a static library

### DIFF
--- a/projects/ores.cli/include/ores.cli/app/application.hpp
+++ b/projects/ores.cli/include/ores.cli/app/application.hpp
@@ -50,13 +50,14 @@
 #include "ores.cli/config/add_floating_index_type_options.hpp"
 #include "ores.cli/config/add_payment_frequency_type_options.hpp"
 #include "ores.cli/config/add_leg_type_options.hpp"
+#include "ores.cli/export.hpp"
 
 namespace ores::cli::app {
 
 /**
  * @brief Entry point for the ores command line application.
  */
-class application final {
+class ORES_CLI_EXPORT application final {
 private:
     inline static std::string_view logger_name =
         "ores.cli.application";

--- a/projects/ores.cli/include/ores.cli/app/application_exception.hpp
+++ b/projects/ores.cli/include/ores.cli/app/application_exception.hpp
@@ -22,13 +22,14 @@
 
 #include <string>
 #include <boost/exception/info.hpp>
+#include "ores.cli/export.hpp"
 
 namespace ores::cli::app {
 
 /**
  * @brief A fatal error has occurred whilst the application was running.
  */
-class application_exception : public virtual std::exception,
+class ORES_CLI_EXPORT application_exception : public virtual std::exception,
                               public virtual boost::exception {
 public:
     explicit application_exception(std::string_view message = "")

--- a/projects/ores.cli/include/ores.cli/app/host.hpp
+++ b/projects/ores.cli/include/ores.cli/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.cli/export.hpp"
 
 namespace ores::cli::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_CLI_EXPORT host {
 private:
     inline static std::string_view logger_name =
         "ores.cli.app.host";

--- a/projects/ores.cli/include/ores.cli/config/parser_exception.hpp
+++ b/projects/ores.cli/include/ores.cli/config/parser_exception.hpp
@@ -22,13 +22,14 @@
 
 #include <string>
 #include <boost/exception/info.hpp>
+#include "ores.cli/export.hpp"
 
 namespace ores::cli::config {
 
 /**
  * @brief A fatal error has occurred during option parsing.
  */
-class parser_exception : public virtual std::exception,
+class ORES_CLI_EXPORT parser_exception : public virtual std::exception,
                          public virtual boost::exception {
 public:
     explicit parser_exception(std::string_view message = "")

--- a/projects/ores.cli/include/ores.cli/config/parser_helpers.hpp
+++ b/projects/ores.cli/include/ores.cli/config/parser_helpers.hpp
@@ -31,6 +31,7 @@
 #include "ores.cli/config/options.hpp"
 #include "ores.cli/config/export_options.hpp"
 #include "ores.cli/config/delete_options.hpp"
+#include "ores.cli/export.hpp"
 
 namespace ores::cli::config::parser_helpers {
 
@@ -50,7 +51,7 @@ struct simple_entity_config {
  *
  * This eliminates boilerplate code for simple entity parsers.
  */
-std::optional<options>
+ORES_CLI_EXPORT std::optional<options>
 handle_simple_entity_command(
     const simple_entity_config& cfg,
     bool has_help,
@@ -61,7 +62,7 @@ handle_simple_entity_command(
 /**
  * @brief Prints the header of the help text, applicable to all cases.
  */
-void print_help_header(std::ostream& s);
+ORES_CLI_EXPORT void print_help_header(std::ostream& s);
 
 /**
  * @brief Prints help text at the command level.
@@ -70,26 +71,26 @@ void print_help_header(std::ostream& s);
  * @param od command options.
  * @param info information stream.
  */
-void print_help_command(const std::string& command_name,
+ORES_CLI_EXPORT void print_help_command(const std::string& command_name,
     const boost::program_options::options_description& od, std::ostream& info);
 
 /**
  * @brief Adds database and logging options to an options_description.
  */
-boost::program_options::options_description
+ORES_CLI_EXPORT boost::program_options::options_description
 add_common_options(boost::program_options::options_description base);
 
 /**
  * @brief Validates that an operation is in the list of allowed operations.
  */
-void validate_operation(const std::string& entity_name,
+ORES_CLI_EXPORT void validate_operation(const std::string& entity_name,
     const std::string& operation,
     const std::vector<std::string>& allowed_operations);
 
 /**
  * @brief Prints entity-level help showing available operations.
  */
-void print_entity_help(const std::string& entity_name,
+ORES_CLI_EXPORT void print_entity_help(const std::string& entity_name,
     const std::string& description,
     const std::vector<std::pair<std::string, std::string>>& operations,
     std::ostream& info);
@@ -97,28 +98,28 @@ void print_entity_help(const std::string& entity_name,
 /**
  * @brief Creates the options related to exporting/listing.
  */
-boost::program_options::options_description make_export_options_description();
+ORES_CLI_EXPORT boost::program_options::options_description make_export_options_description();
 
 /**
  * @brief Creates the options related to deleting entities.
  */
-boost::program_options::options_description make_delete_options_description();
+ORES_CLI_EXPORT boost::program_options::options_description make_delete_options_description();
 
 /**
  * @brief Reads format from the variables map.
  */
-format read_format(const boost::program_options::variables_map& vm);
+ORES_CLI_EXPORT format read_format(const boost::program_options::variables_map& vm);
 
 /**
  * @brief Reads the export configuration from the variables map.
  */
-export_options read_export_options(
+ORES_CLI_EXPORT export_options read_export_options(
     const boost::program_options::variables_map& vm, entity e);
 
 /**
  * @brief Reads the delete configuration from the variables map.
  */
-delete_options read_delete_options(
+ORES_CLI_EXPORT delete_options read_delete_options(
     const boost::program_options::variables_map& vm, entity e);
 
 }

--- a/projects/ores.cli/include/ores.cli/export.hpp
+++ b/projects/ores.cli/include/ores.cli/export.hpp
@@ -17,34 +17,15 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_CLI_CONFIG_PARSER_HPP
-#define ORES_CLI_CONFIG_PARSER_HPP
+#ifndef ORES_CLI_EXPORT_HPP
+#define ORES_CLI_EXPORT_HPP
 
-#include <iosfwd>
-#include <vector>
-#include <string>
-#include <optional>
-#include "ores.cli/config/options.hpp"
-#include "ores.cli/export.hpp"
+#include <boost/config.hpp>
 
-namespace ores::cli::config {
-
-/**
- * @brief Command-line parser implementation using boost program options.
- *
- * Note on logging: we are NOT logging any of the exceptions to the log in this
- * class. This is by design. The logger is only initialised after the options
- * have been parsed; were we to log prior to this, we would dump all the
- * messages into the cli. The output is very confusing users that are accustomed
- * to normal cli applications.
- */
-class ORES_CLI_EXPORT parser final {
-public:
-    std::optional<options>
-    parse(const std::vector<std::string>& arguments, std::ostream& info,
-        std::ostream& error) const;
-};
-
-}
+#ifdef ORES_CLI_LIBRARY
+#  define ORES_CLI_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_CLI_EXPORT BOOST_SYMBOL_IMPORT
+#endif
 
 #endif

--- a/projects/ores.cli/src/CMakeLists.txt
+++ b/projects/ores.cli/src/CMakeLists.txt
@@ -27,9 +27,16 @@ file(GLOB_RECURSE files RELATIVE
 set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
-add_library(${lib_target_name} STATIC ${lib_files})
+add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_CLI_LIBRARY)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(${lib_target_name} PRIVATE
+        -fvisibility=hidden -fvisibility-inlines-hidden)
+endif()
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
+set_target_properties(${lib_target_name}
+    PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 
 target_include_directories(${lib_target_name} PUBLIC
     ${CMAKE_SOURCE_DIR}/projects/ores.cli/include)
@@ -53,7 +60,10 @@ target_link_libraries(${lib_target_name}
         magic_enum::magic_enum
         cli::cli)
 
-install(TARGETS ${lib_target_name} ARCHIVE DESTINATION lib)
+install(TARGETS ${lib_target_name}
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
 
 set(exe_binary_name ${name})
 set(exe_target_name ${name}.exe)

--- a/projects/ores.cli/src/CMakeLists.txt
+++ b/projects/ores.cli/src/CMakeLists.txt
@@ -27,11 +27,9 @@ file(GLOB_RECURSE files RELATIVE
 set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
-add_library(${lib_target_name} ${lib_files})
+add_library(${lib_target_name} STATIC ${lib_files})
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
-set_target_properties(${lib_target_name}
-    PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 
 target_include_directories(${lib_target_name} PUBLIC
     ${CMAKE_SOURCE_DIR}/projects/ores.cli/include)
@@ -55,7 +53,7 @@ target_link_libraries(${lib_target_name}
         magic_enum::magic_enum
         cli::cli)
 
-install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)
+install(TARGETS ${lib_target_name} ARCHIVE DESTINATION lib)
 
 set(exe_binary_name ${name})
 set(exe_target_name ${name}.exe)


### PR DESCRIPTION
## Summary

- Fixes Windows link error: `undefined symbol: ores::cli::app::host::execute`
- Root cause: `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` was removed in the symbol visibility migration but `ores.cli.lib` was never given explicit `ORES_CLI_EXPORT` annotations
- Fix: declare `ores.cli.lib` as `STATIC` — no other component consumes this library (only `ores.cli.exe` and `ores.cli.tests`), so using a shared library was never the right choice here; a static library for exe + testability is the standard pattern and requires no DLL export annotations
- Also updates the install destination from `LIBRARY` to `ARCHIVE` to match static library convention
- Drops the `SOVERSION` property which is meaningless for a static library

🤖 Generated with [Claude Code](https://claude.com/claude-code)