### PR TITLE
[doc] v2 information architecture (sprints 08-11)

### DIFF
--- a/doc/v2/versions/v0/sprint_07/observability_and_telemetry/story.org
+++ b/doc/v2/versions/v0/sprint_07/observability_and_telemetry/story.org
@@ -9,8 +9,13 @@
 #+created: 2026-05-19
 #+updated: 2026-05-19
 #+todo: BACKLOG STARTED | DONE ABANDONED
+#+successor: cd9e9d04-44d2-4d0d-95ce-719d55c40da4
 
 Parent sprint: [[id:a79d42af-1b38-43ee-9607-848a4a84c09a][Sprint 07]].
+
+Continued in: [[id:cd9e9d04-44d2-4d0d-95ce-719d55c40da4][Observability follow-up]] (sprint 08) — review pass of
+telemetry, comms analyser, and event viewer; implementations carried
+forward.
 
 * DONE Status
 :PROPERTIES:

--- a/doc/v2/versions/v0/sprint_07/wt_and_http_introduction/story.org
+++ b/doc/v2/versions/v0/sprint_07/wt_and_http_introduction/story.org
@@ -9,8 +9,12 @@
 #+created: 2026-05-19
 #+updated: 2026-05-19
 #+todo: BACKLOG STARTED | DONE ABANDONED
+#+successor: 13fbe901-b255-49f7-88c3-13b2a2506bf3
 
 Parent sprint: [[id:a79d42af-1b38-43ee-9607-848a4a84c09a][Sprint 07]].
+
+Continued in: [[id:13fbe901-b255-49f7-88c3-13b2a2506bf3][Wt and HTTP review]] (sprint 08) — validation of the
+Wt application + HTTP service introduced here.
 
 * DONE Status
 :PROPERTIES:

--- a/doc/v2/versions/v0/sprint_08/books_modelling_analysis/story.org
+++ b/doc/v2/versions/v0/sprint_08/books_modelling_analysis/story.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 77211166-9316-40c0-88d6-c92f983a00b5
+:END:
+#+title: Books domain modelling analysis
+#+description: First-cut analysis of the entities needed to support books; FPML-anchored, iterated with LLMs.
+#+type: story
+#+level: s2
+#+filetags: :modelling:books:analysis:fpml:sprint_08:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:49c4e380-68ee-4d80-839a-41311a99c734][Sprint 08]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Produce a first-cut model of the entities required to support books —
+the next major modelling effort after currencies and countries.
+
+* Acceptance
+
+- FPML-anchored model of the books-supporting entities.
+- Iterated with Gemini and Qwen.
+- Known use cases conform or are explicitly marked as too complex.
+
+* Tasks
+
+In execution order:
+
+- [[id:60722e51-beb9-4221-abb1-95b0e08e9a32][Books entity analysis]]
+
+* Decisions
+
+- /FPML as the anchor/ :: the financial industry's vocabulary; keeps our model interoperable with how other systems describe the same concepts.
+- /LLM triangulation/ :: two models disagreeing is a useful signal that the modelling itself is ambiguous.
+
+* Out of scope
+
+- Implementation. This is analysis; code lands in a later sprint.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_08/books_modelling_analysis/task_books_entity_analysis.org
+++ b/doc/v2/versions/v0/sprint_08/books_modelling_analysis/task_books_entity_analysis.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: 60722e51-beb9-4221-abb1-95b0e08e9a32
+:END:
+#+title: Books entity analysis
+#+description: First-cut model of the entities needed to support books; FPML-anchored, iterated with Gemini and Qwen; ignore items explicitly marked as too complex.
+#+type: task
+#+level: s1
+#+filetags: :modelling:books:fpml:analysis:books_modelling_analysis:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:77211166-9316-40c0-88d6-c92f983a00b5][Books domain modelling analysis]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+First-cut analysis of the entities required to support books, the next major modelling effort after currencies and countries.
+
+* Acceptance
+
+- FPML-anchored model.
+- Iterated with Gemini and Qwen for triangulation.
+- Known use cases either conform or are explicitly marked as too complex for now.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Strategic / S4 analysis rather than S1 implementation; output is a model sketch that future sprints will turn into code.
+
+* Result
+
+Analysis committed; sets the direction for the books work.

--- a/doc/v2/versions/v0/sprint_08/change_management_infrastructure/story.org
+++ b/doc/v2/versions/v0/sprint_08/change_management_infrastructure/story.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: 150e3c44-aadb-48c8-a11e-322b44a0357a
+:END:
+#+title: Change management infrastructure
+#+description: Amendment / deletion reasons base infrastructure plus the Qt UI polish round on top.
+#+type: story
+#+level: s2
+#+filetags: :change_management:audit:iam:qt:sprint_08:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:49c4e380-68ee-4d80-839a-41311a99c734][Sprint 08]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Lay down the change-management substrate: every amend and delete
+must reference a reason category + reason, with optional commentary,
+preserved historically and visible in the UI.
+
+* Acceptance
+
+- Three temporal tables + populate seeds for reason categories and amendment reasons.
+- All temporal entities carry =change_reason_code= + =change_commentary= fields.
+- Qt UI: mandatory reason on save; CRUD for categories and reasons; history shows reason + commentary.
+- Protocol bump (21.1) standardises =list= → =get=, =create=/=update= → =save=.
+
+* Tasks
+
+In execution order:
+
+- [[id:fb3a1834-f76a-4229-8f04-49830a9039cd][Amend and delete reasons base infrastructure]]
+- [[id:6b514406-2fbd-4697-8026-b0cb98a3b93d][Change reasons UI fixes]]
+
+* Decisions
+
+- /Regulatory-anchored taxonomy/ :: BCBS 239, FRTB, FINRA, MiFID II up-front avoids retrofitting reasons later when audit needs them.
+- /Soft delete via INSTEAD OF DELETE/ :: keeps the historical record intact; no destructive deletes on temporal tables.
+- /Mandatory reason at save time/ :: enforced in the UI now; will also be enforced server-side as the protocol settles.
+
+* Out of scope
+
+- Shared save-dialog refactor (raised, deferred).
+- Per-row column tweaks beyond what review surfaced.
+
+* See also
+
+- [[id:D00BEA0D-E501-C534-A013-E6F40C1A6097][ores.iam]] — owns the change-management domain types.

--- a/doc/v2/versions/v0/sprint_08/change_management_infrastructure/task_amend_and_delete_reasons_base.org
+++ b/doc/v2/versions/v0/sprint_08/change_management_infrastructure/task_amend_and_delete_reasons_base.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: fb3a1834-f76a-4229-8f04-49830a9039cd
+:END:
+#+title: Amend and delete reasons base infrastructure
+#+description: Domain + temporal tables for reason_categories, amendment_reasons, entity_reason_categories; populate scripts; Qt UI scaffolding.
+#+type: task
+#+level: s1
+#+filetags: :change_management:audit:iam:sql:change_management_infrastructure:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:150e3c44-aadb-48c8-a11e-322b44a0357a][Change management infrastructure]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-09]
+:END:
+
+** Now
+Completed 2026-01-09.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-09
+
+* Goal
+
+Lay the change-management foundations: temporal tables for =reason_categories=, =amendment_reasons=, =entity_reason_categories=, with a regulatory-compliant taxonomy and idempotent populate scripts.
+
+* Acceptance
+
+- Three temporal tables with =valid_from=/=valid_to=, BEFORE-INSERT triggers, and INSTEAD-OF-DELETE rules for soft deletes.
+- Idempotent populate seeds 3 reason categories (system, common, trade) and 17 amendment reasons.
+- Taxonomy aligned with BCBS 239, FRTB, FINRA, and MiFID II.
+- C++ domain + JSON/Table I/O + repositories + service + protocol + Qt list/detail UI.
+- Build green (895 assertions / 227 test cases).
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+All entity amends and deletes will eventually require a reason + commentary; this lays the schema down so subsequent stories can hang fields off temporal entities.
+
+* Result
+
+Reason taxonomy in place; Qt UI scaffolded; protocol messages 0x2050-0x2055 carry it.

--- a/doc/v2/versions/v0/sprint_08/change_management_infrastructure/task_change_reasons_ui_fixes.org
+++ b/doc/v2/versions/v0/sprint_08/change_management_infrastructure/task_change_reasons_ui_fixes.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 6b514406-2fbd-4697-8026-b0cb98a3b93d
+:END:
+#+title: Change reasons UI fixes
+#+description: Polish the change-reason Qt dialogs based on first-pass review: mandatory reason selection, history visibility, save-dialog refactor, protocol bump to 21.1.
+#+type: task
+#+level: s1
+#+filetags: :change_management:qt:ux:change_management_infrastructure:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:150e3c44-aadb-48c8-a11e-322b44a0357a][Change management infrastructure]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Polish the change-reason dialogs based on first-pass review and propagate change-tracking fields through all temporal entities.
+
+* Acceptance
+
+- Mandatory reason on save via =ChangeReasonDialog=.
+- =change_reason_code= + =change_commentary= present on every temporal entity.
+- Client-side =ChangeReasonCache= refreshed by events.
+- History dialog shows the reason and commentary.
+- Protocol bump to 21.1; rename =list= → =get=, =create=/=update= → =save=.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Long review-fix list in v0; covered icon guidelines, badge usage, recorded-at humanisation, and a long tail of column-width snags. One item deferred: extract a shared save-dialog.
+
+* Result
+
+Change-management workflow lives across all temporal entities; UI conventions consistent with other dialogs.

--- a/doc/v2/versions/v0/sprint_08/comms_substrate_evolution/story.org
+++ b/doc/v2/versions/v0/sprint_08/comms_substrate_evolution/story.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: da77fb50-27e8-4b42-a826-cab289c7826e
+:END:
+#+title: Comms substrate evolution
+#+description: Composable CLI options/parser; rename ores.shell to ores.comms.shell; dynamic notification-channel discovery.
+#+type: story
+#+level: s2
+#+filetags: :comms:cli:shell:refactor:sprint_08:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:49c4e380-68ee-4d80-839a-41311a99c734][Sprint 08]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Continue evolving the comms substrate: composable CLI options across
+binaries, rename =ores.shell= to reflect its scope, and replace the
+hardcoded channel list with server-side discovery.
+
+* Acceptance
+
+- All binaries share the composable options classes; standardised flags.
+- =ores.shell= renamed to =ores.comms.shell= consistently.
+- Channels discovered dynamically; shell consumes the registry.
+
+* Tasks
+
+In execution order:
+
+- [[id:fdeb08b4-fd95-46df-b868-eb57ae4666c6][Refactor options and parser]]
+- [[id:443b546e-357b-4809-8c20-b804e62fa31e][Rename ores.shell to ores.comms.shell]]
+- [[id:410ef5b4-9e13-4357-8b20-d78c63419572][Discover notification channels dynamically]]
+
+* Decisions
+
+- /Compose options rather than inherit/ :: small focused classes keep each binary's option set explicit while sharing the common bits.
+- /Server-side channel registry/ :: clients no longer need code changes when a new channel is added; subscriptions follow the registry.
+
+* Out of scope
+
+- Splitting the shell into per-binary subcommands.
+- Channel-level authorization (covered by RBAC in sprint 07).
+
+* See also
+
+- [[id:D0876A24-69BA-F484-ED9B-71CD3AA8710C][ores.comms.shell]] — the renamed component.
+- [[id:13fbe901-b255-49f7-88c3-13b2a2506bf3][Wt and HTTP review]] — the HTTP entry point that consumes the same dispatch.

--- a/doc/v2/versions/v0/sprint_08/comms_substrate_evolution/task_discover_channels_dynamically.org
+++ b/doc/v2/versions/v0/sprint_08/comms_substrate_evolution/task_discover_channels_dynamically.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 410ef5b4-9e13-4357-8b20-d78c63419572
+:END:
+#+title: Discover notification channels dynamically
+#+description: Server-side event_channel_registry; new list_event_channels protocol messages (0x0015/0x0016); shell 'events channels' and 'events listen *' use discovery.
+#+type: task
+#+level: s1
+#+filetags: :comms:eventing:protocol:comms_substrate_evolution:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:da77fb50-27e8-4b42-a826-cab289c7826e][Comms substrate evolution]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Replace client-side hardcoded channel lists with server-side dynamic discovery.
+
+* Acceptance
+
+- Server-side =event_channel_registry= service.
+- New protocol messages: =list_event_channels_request= (0x0015), =list_event_channels_response= (0x0016).
+- Shell =events channels= queries the registry; =events listen *= subscribes to every discovered channel.
+- Registry covers =country_changed=, =change_reason_changed=, =change_reason_category_changed= alongside existing channels.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Removes the per-feature client edit when a new channel is added on the server.
+
+* Result
+
+Event channels are discoverable; clients self-update when the server adds channels.

--- a/doc/v2/versions/v0/sprint_08/comms_substrate_evolution/task_refactor_options_and_parser.org
+++ b/doc/v2/versions/v0/sprint_08/comms_substrate_evolution/task_refactor_options_and_parser.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: fdeb08b4-fd95-46df-b868-eb57ae4666c6
+:END:
+#+title: Refactor options and parser
+#+description: Composable CLI configuration: common, server, client, compression configurations; standardise -h/-v/--verbose across binaries; add --log-include-pid.
+#+type: task
+#+level: s1
+#+filetags: :cli:refactor:options:comms_substrate_evolution:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:da77fb50-27e8-4b42-a826-cab289c7826e][Comms substrate evolution]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-02]
+:END:
+
+** Now
+Completed 2026-01-02.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-02
+
+* Goal
+
+Refactor the boost-program-options usage across binaries into a composable configuration architecture.
+
+* Acceptance
+
+- =common_configuration=, =server_configuration=, =client_configuration=, =compression_configuration= classes share the common code.
+- Standardised =-h=/=--help=, =-v=/=--version=, =--verbose= across all binaries.
+- =--log-include-pid= added across applications.
+- =ores.comms.service=, =ores.cli=, =ores.qt=, =ores.comms.analyser= migrated.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Tradeoff: =--log-include-pid= is generic enough to justify global treatment rather than per-binary.
+
+* Result
+
+Options consistent across binaries.

--- a/doc/v2/versions/v0/sprint_08/comms_substrate_evolution/task_rename_shell_to_comms_shell.org
+++ b/doc/v2/versions/v0/sprint_08/comms_substrate_evolution/task_rename_shell_to_comms_shell.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: 443b546e-357b-4809-8c20-b804e62fa31e
+:END:
+#+title: Rename ores.shell to ores.comms.shell
+#+description: The shell is specific to the binary comms protocol; namespaces, CMake targets, headers, and docs renamed.
+#+type: task
+#+level: s1
+#+filetags: :shell:comms:rename:refactor:comms_substrate_evolution:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:da77fb50-27e8-4b42-a826-cab289c7826e][Comms substrate evolution]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-03]
+:END:
+
+** Now
+Completed 2026-01-03.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-03
+
+* Goal
+
+Rename =ores.shell= to =ores.comms.shell= so the component name reflects that it is the interactive shell for the binary comms protocol.
+
+* Acceptance
+
+- File paths, CMake targets, header guards, namespaces renamed.
+- Docs (system UML, recipes) updated.
+- No stray references to =ores::shell= or =ores.shell= remain in live code.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Pairs with the broader =ores.comms.*= naming established in earlier sprints; the shell becomes a peer of =ores.comms.service= rather than a top-level component.
+
+* Result
+
+Component renamed; namespace tree consistent.

--- a/doc/v2/versions/v0/sprint_08/database_schema_and_seeding/story.org
+++ b/doc/v2/versions/v0/sprint_08/database_schema_and_seeding/story.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: 42e6c351-795f-48aa-a435-eb3d1c9b6704
+:END:
+#+title: Database schema and seeding overhaul
+#+description: Rerun SQL from scratch with TimescaleDB tier detection; move all seeding from C++ to SQL populate scripts.
+#+type: story
+#+level: s2
+#+filetags: :sql:timescaledb:seeding:refactor:sprint_08:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:49c4e380-68ee-4d80-839a-41311a99c734][Sprint 08]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2025-12-31]
+:END:
+
+** Now
+Completed 2025-12-31.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2025-12-31
+
+* Goal
+
+Take the database story from /works on my dev box/ to /reproducible from
+scratch/. Make TimescaleDB integration adaptive to the available license
+tier, centralise seeding in SQL populate scripts, and document the
+schema.
+
+* Acceptance
+
+- Clean-slate schema bring-up succeeds end-to-end.
+- Apache vs Timescale license detected at runtime; advanced features gated.
+- All seeding lives in SQL; the C++ seeders are gone.
+- Schema and component docs land in =doc/= and =projects/ores.sql/modeling/=.
+
+* Tasks
+
+In execution order:
+
+- [[id:27768a0e-d9dc-4958-9731-adef4385f23e][Rerun SQL scripts from scratch]]
+- [[id:2d4c153b-1aa9-4eb3-b6de-69c409401499][Remove code seeders; seed from SQL populate scripts]]
+
+* Decisions
+
+- /Runtime license detection/ :: keeps the same binaries usable against both Apache TimescaleDB and the Timescale-licensed build.
+- /Per-database extension install/ :: avoids template/database drift when multiple ORES databases coexist on one cluster.
+- /SQL is the single source of truth for seeding/ :: removes the dual seed paths that were quietly diverging.
+
+* Out of scope
+
+- Postgres major-version upgrade automation.
+- Cross-cluster replication.
+
+* See also
+
+- [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]] — the component this story restructures.

--- a/doc/v2/versions/v0/sprint_08/database_schema_and_seeding/task_remove_code_seeders.org
+++ b/doc/v2/versions/v0/sprint_08/database_schema_and_seeding/task_remove_code_seeders.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 2d4c153b-1aa9-4eb3-b6de-69c409401499
+:END:
+#+title: Remove code seeders; seed from SQL populate scripts
+#+description: Replace C++ rbac_seeder and system_flags_seeder with SQL populate scripts; rename sql/data/ to sql/populate/; adapt tests to a pre-seeded database.
+#+type: task
+#+level: s1
+#+filetags: :sql:seeding:refactor:database_schema_and_seeding:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:42e6c351-795f-48aa-a435-eb3d1c9b6704][Database schema and seeding overhaul]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2025-12-31]
+:END:
+
+** Now
+Completed 2025-12-31.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2025-12-31
+
+* Goal
+
+Move all initial seeding (permissions, roles, system flags) out of C++ into SQL populate scripts so the database template is the single source of truth.
+
+* Acceptance
+
+- C++ =rbac_seeder= and =system_flags_seeder= deleted.
+- Dedicated SQL populate scripts in =sql/populate/= (renamed from =sql/data/=) seed the template.
+- =init_instance.sql= no longer calls seeders.
+- Test suites adapted to a pre-seeded database (no more empty-DB assumptions).
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+The original two-source seeding (code + SQL) was the cause of subtle drift; centralising in SQL closes that loop.
+
+* Result
+
+All seeding is SQL; tests pass against the pre-seeded template.

--- a/doc/v2/versions/v0/sprint_08/database_schema_and_seeding/task_rerun_sql_scripts_from_scratch.org
+++ b/doc/v2/versions/v0/sprint_08/database_schema_and_seeding/task_rerun_sql_scripts_from_scratch.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 27768a0e-d9dc-4958-9731-adef4385f23e
+:END:
+#+title: Rerun SQL scripts from scratch
+#+description: Validate schema bring-up from a clean slate; add TimescaleDB license-tier detection and per-database extension install; document the schema.
+#+type: task
+#+level: s1
+#+filetags: :sql:timescaledb:bootstrap:database_schema_and_seeding:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:42e6c351-795f-48aa-a435-eb3d1c9b6704][Database schema and seeding overhaul]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2025-12-31]
+:END:
+
+** Now
+Completed 2025-12-31.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2025-12-31
+
+* Goal
+
+Validate the SQL schema by rebuilding from scratch; in passing, make TimescaleDB integration adaptive to the available license tier and install extensions per-database.
+
+* Acceptance
+
+- Schema bring-up succeeds on a clean database.
+- TimescaleDB license tier (Apache vs Timescale) detected at runtime; advanced features (compression, retention, continuous aggregates) skipped under Apache.
+- PostgreSQL extensions installed per-database, including the template.
+- Schema documentation updated (=ores.sql.org=) plus component docs for =ores.assets= and =ores.comms.analyser=.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+TimescaleDB function calls now use the =public.= schema prefix so they don't break when =search_path= is =ores=.
+
+* Result
+
+Schema fully reproducible from scratch under both Timescale tiers.

--- a/doc/v2/versions/v0/sprint_08/entity_creator_skills/story.org
+++ b/doc/v2/versions/v0/sprint_08/entity_creator_skills/story.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: b302b2b6-13f8-49cc-a6af-88418668be31
+:END:
+#+title: Entity-creator skills suite
+#+description: Skills for adding a new entity end-to-end: Qt, Shell, HTTP (incl. recipes), Wt, CLI.
+#+type: story
+#+level: s2
+#+filetags: :skills:llm:scaffolding:sprint_08:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:49c4e380-68ee-4d80-839a-41311a99c734][Sprint 08]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Land a complete set of /entity creator/ skills so adding a new domain
+entity end-to-end follows a known shape across Qt, shell, HTTP, Wt,
+and CLI surfaces.
+
+* Acceptance
+
+- Skill present for each of: Qt, shell, HTTP, HTTP recipes, Wt, CLI.
+- Each follows a phase-based PR-checkpoint pattern.
+- Cross-references in the skill catalog updated.
+
+* Tasks
+
+In execution order:
+
+- [[id:a6afe796-dcfb-40c1-a9c8-bd7a20091930][Qt entity creator skill]]
+- [[id:0127aa75-dca4-432e-b892-edd1caa334b4][Shell entity creator skill]]
+- [[id:d2ced93a-5642-4374-bd26-0c7d5dc2ca13][HTTP entity creator skill]]
+- [[id:e00e8fd6-82f2-4ab4-9456-c6f44f855129][HTTP recipes skill]]
+- [[id:31a1d475-3941-4429-a7ec-2b52096c07a7][Wt entity creator skill]]
+- [[id:de76313f-3c9e-441a-aa5e-6212a3841eed][CLI entity creator skill]]
+
+* Decisions
+
+- /Phase-based PRs/ :: keeps each PR small enough to review; matches the =domain-type-creator= skill's pattern.
+- /One skill per surface/ :: rather than one monolithic /add an entity/ skill; surfaces have different review priorities and conventions.
+
+* Out of scope
+
+- Cross-surface orchestration skill (a meta-skill that chains the surface-specific skills) — desirable but not in scope here.
+
+* See also
+
+- [[id:501c05b5-aa7f-4807-a4f2-627b857ce2aa][Reference data: countries]] — first real exerciser of the skill set.

--- a/doc/v2/versions/v0/sprint_08/entity_creator_skills/task_cli_entity_creator_skill.org
+++ b/doc/v2/versions/v0/sprint_08/entity_creator_skills/task_cli_entity_creator_skill.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: de76313f-3c9e-441a-aa5e-6212a3841eed
+:END:
+#+title: CLI entity creator skill
+#+description: Skill for adding CLI commands for a domain entity in ores.cli; parsers, options, application logic, recipes.
+#+type: task
+#+level: s1
+#+filetags: :skills:cli:scaffolding:entity_creator_skills:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:b302b2b6-13f8-49cc-a6af-88418668be31][Entity-creator skills suite]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Skill describing how to add CLI commands for a domain entity in =ores.cli=.
+
+* Acceptance
+
+- Three-phase PR strategy mirroring the shell-entity-creator pattern.
+- Parser, options, application logic, recipe documentation.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Completes the entity-creator skill set: Qt, Shell, HTTP (incl. recipes), Wt, CLI.
+
+* Result
+
+Skill present.

--- a/doc/v2/versions/v0/sprint_08/entity_creator_skills/task_http_entity_creator_skill.org
+++ b/doc/v2/versions/v0/sprint_08/entity_creator_skills/task_http_entity_creator_skill.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: d2ced93a-5642-4374-bd26-0c7d5dc2ca13
+:END:
+#+title: HTTP entity creator skill
+#+description: Skill for adding REST endpoints for a domain entity in ores.http.server; coroutine handlers, OpenAPI metadata, JSON via rfl.
+#+type: task
+#+level: s1
+#+filetags: :skills:http:scaffolding:entity_creator_skills:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:b302b2b6-13f8-49cc-a6af-88418668be31][Entity-creator skills suite]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Skill describing how to add HTTP REST endpoints for a domain entity in =ores.http.server=.
+
+* Acceptance
+
+- Three-phase PR strategy: setup, core CRUD, documentation.
+- Coroutine-based handler pattern, OpenAPI metadata, JSON via =rfl=, integration with service layer.
+- URL/log conventions documented.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Used to validate the HTTP entry point landed in sprint 07.
+
+* Result
+
+Skill present.

--- a/doc/v2/versions/v0/sprint_08/entity_creator_skills/task_http_recipes_skill.org
+++ b/doc/v2/versions/v0/sprint_08/entity_creator_skills/task_http_recipes_skill.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: e00e8fd6-82f2-4ab4-9456-c6f44f855129
+:END:
+#+title: HTTP recipes skill
+#+description: Mirror of the shell/cli recipes skill for HTTP endpoints: Emacs verb-mode requests, route source references.
+#+type: task
+#+level: s1
+#+filetags: :skills:http:recipes:entity_creator_skills:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:b302b2b6-13f8-49cc-a6af-88418668be31][Entity-creator skills suite]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Skill for documenting HTTP API recipes — mirror of =ores-shell-recipes= and =ores-cli-recipes=.
+
+* Acceptance
+
+- Pattern aligned with the existing recipes skills.
+- Uses Emacs verb-mode for structured API requests.
+- References =projects/ores.http.server/src/routes/= for verification.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Pairs with the HTTP entity creator skill; the creator skill writes endpoints, this one writes runnable recipes for them.
+
+* Result
+
+Skill present.

--- a/doc/v2/versions/v0/sprint_08/entity_creator_skills/task_qt_entity_creator_skill.org
+++ b/doc/v2/versions/v0/sprint_08/entity_creator_skills/task_qt_entity_creator_skill.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: a6afe796-dcfb-40c1-a9c8-bd7a20091930
+:END:
+#+title: Qt entity creator skill
+#+description: Phase-based skill for adding a Qt UI for a domain entity (list window, detail dialog, history dialog, controller).
+#+type: task
+#+level: s1
+#+filetags: :skills:qt:scaffolding:entity_creator_skills:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:b302b2b6-13f8-49cc-a6af-88418668be31][Entity-creator skills suite]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Skill describing how to add a Qt UI for a domain entity end-to-end.
+
+* Acceptance
+
+- List window, detail dialog, history dialog, controller pattern documented.
+- PR-checkpoint phases for incremental review.
+- Refactoring analysis of existing dialogs to reduce duplication.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Shares the PR-checkpoint phase pattern with the updated =domain-type-creator= skill.
+
+* Result
+
+Skill present and exercisable.

--- a/doc/v2/versions/v0/sprint_08/entity_creator_skills/task_shell_entity_creator_skill.org
+++ b/doc/v2/versions/v0/sprint_08/entity_creator_skills/task_shell_entity_creator_skill.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: 0127aa75-dca4-432e-b892-edd1caa334b4
+:END:
+#+title: Shell entity creator skill
+#+description: Skill for adding shell commands for a domain entity: list/add then history; register with REPL; recipe with runnable examples.
+#+type: task
+#+level: s1
+#+filetags: :skills:shell:scaffolding:entity_creator_skills:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:b302b2b6-13f8-49cc-a6af-88418668be31][Entity-creator skills suite]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Skill describing how to add shell commands for a domain entity.
+
+* Acceptance
+
+- Phase 1: list/add commands with REPL registration.
+- Phase 2: history commands and formatting helpers.
+- Phase 3: recipe documentation with runnable examples.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+First skill exercised on the countries-in-shell task in this sprint.
+
+* Result
+
+Skill present and validated by the countries-in-shell task.

--- a/doc/v2/versions/v0/sprint_08/entity_creator_skills/task_wt_entity_creator_skill.org
+++ b/doc/v2/versions/v0/sprint_08/entity_creator_skills/task_wt_entity_creator_skill.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 31a1d475-3941-4429-a7ec-2b52096c07a7
+:END:
+#+title: Wt entity creator skill
+#+description: Skill for adding Wt list widget + detail dialog + application integration for a domain entity.
+#+type: task
+#+level: s1
+#+filetags: :skills:wt:scaffolding:entity_creator_skills:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:b302b2b6-13f8-49cc-a6af-88418668be31][Entity-creator skills suite]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Skill describing how to add Wt list widget + detail dialog + application integration for a domain entity.
+
+* Acceptance
+
+- Multi-phase guide following the established Wt patterns in =ores.wt=.
+- Feature-branch-manager skill enhanced in parallel: PR-merge verification, automatic stash/restore on phase transitions.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Used implicitly to land the countries Wt UI in this sprint.
+
+* Result
+
+Skill present.

--- a/doc/v2/versions/v0/sprint_08/native_pagination_support/story.org
+++ b/doc/v2/versions/v0/sprint_08/native_pagination_support/story.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 40d153e3-4a87-44b6-b605-1e3e28a44d03
+:END:
+#+title: Native pagination support
+#+description: Adopt sqlgen 0.6.0 native offset/limit; drop the single-connection workaround and expand pagination coverage.
+#+type: story
+#+level: s2
+#+filetags: :sqlgen:pagination:refactor:sprint_08:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:49c4e380-68ee-4d80-839a-41311a99c734][Sprint 08]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-07]
+:END:
+
+** Now
+Completed 2026-01-07.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-07
+
+* Goal
+
+Adopt sqlgen 0.6.0 to land natively what we had hacked around: native
+=offset=/=limit= and sessions that support aggregation.
+
+* Acceptance
+
+- vcpkg sqlgen submodule updated to 0.6.0.
+- Custom overlay ports for sqlgen removed.
+- =single_connection= aggregation hack deleted.
+- Pagination expanded across the repositories that were stubbed without it.
+
+* Tasks
+
+In execution order:
+
+- [[id:422d1b1b-d34c-4aa5-b127-0ff08d627377][Adopt sqlgen 0.6.0 native offset/limit]]
+
+* Decisions
+
+- /Upstream-first/ :: we landed the offset PRs in sqlgen itself and then waited for them to reach vcpkg, rather than carrying indefinite local patches.
+
+* Out of scope
+
+- Cursor-based pagination — offset-based is sufficient at this scale.
+
+* See also
+
+- [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]] — pagination plumbs through the SQL component.

--- a/doc/v2/versions/v0/sprint_08/native_pagination_support/task_adopt_sqlgen_offset.org
+++ b/doc/v2/versions/v0/sprint_08/native_pagination_support/task_adopt_sqlgen_offset.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 422d1b1b-d34c-4aa5-b127-0ff08d627377
+:END:
+#+title: Adopt sqlgen 0.6.0 native offset/limit
+#+description: Update vcpkg submodule to sqlgen 0.6.0; drop custom overlay ports and the single_connection aggregation hack; expand pagination to feature_flags, role, permission, image, tag, login_info repositories.
+#+type: task
+#+level: s1
+#+filetags: :sqlgen:pagination:vcpkg:native_pagination_support:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:40d153e3-4a87-44b6-b605-1e3e28a44d03][Native pagination support]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-07]
+:END:
+
+** Now
+Completed 2026-01-07.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-07
+
+* Goal
+
+Adopt the sqlgen 0.6.0 features that landed natively what we previously worked around: native =offset=/=limit= and aggregation under sessions.
+
+* Acceptance
+
+- vcpkg sqlgen submodule updated to 0.6.0.
+- Custom overlay ports for sqlgen removed.
+- =single_connection= aggregation hack deleted; sessions support aggregation natively now.
+- Pagination expanded to =feature_flags_repository=, =role_repository=, =permission_repository=, =image_repository=, =tag_repository=, =login_info_repository=.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+We landed the upstream offset/limit work ourselves earlier; this is the swap-back-to-vcpkg step.
+
+* Result
+
+All repositories on native sqlgen pagination.

--- a/doc/v2/versions/v0/sprint_08/observability_followup/story.org
+++ b/doc/v2/versions/v0/sprint_08/observability_followup/story.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: cd9e9d04-44d2-4d0d-95ce-719d55c40da4
+:END:
+#+title: Observability follow-up
+#+description: Telemetry review, comms-analyser review, event-viewer review — all postponed within the sprint window.
+#+type: story
+#+level: s2
+#+filetags: :telemetry:observability:review:sprint_08:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+#+predecessor: 8c4c8429-9328-46dd-88ef-27689fb556f2
+
+Parent sprint: [[id:49c4e380-68ee-4d80-839a-41311a99c734][Sprint 08]].
+
+Continued from: [[id:8c4c8429-9328-46dd-88ef-27689fb556f2][Observability and telemetry]] (sprint 07) — sprint 07
+stood up the components; this story is the review pass which deferred
+all three review items to a later sprint.
+
+* BACKLOG Status
+
+** Now
+Review notes captured in sprint 08; all three implementation
+passes carry forward.
+
+** Waiting on
+A sprint with the slot to land the fixes.
+
+** Next
+Schedule the telemetry/comms-analyser/event-viewer fix passes.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Review the telemetry, comms-analyser, and event-viewer surfaces that
+landed in sprint 07. Raise fix lists. All three review items were
+POSTPONED within this sprint — implementation carries forward.
+
+* Acceptance
+
+- Review notes captured for telemetry, comms analyser, and event viewer.
+- Fix lists filed against the appropriate components.
+- All three implementation passes scheduled forward.
+
+* Tasks
+
+In execution order:
+
+- [[id:d7794c1a-496d-491f-9a92-319c1b92d062][Review telemetry work]]
+- [[id:b091715a-ffa2-4716-90d5-3431f5ff4532][Review comms analyser work]]
+- [[id:67fde70e-e08d-4b55-b420-5f2676763e8e][Event viewer review]]
+
+* Decisions
+
+- /Review without fixing/ :: keeps the review pass crisp and lets us defer the work without losing the findings.
+
+* Out of scope
+
+- Implementing any of the raised fixes — they're scheduled for a later sprint.
+
+* See also
+
+- [[id:8c4c8429-9328-46dd-88ef-27689fb556f2][Observability and telemetry]] (sprint 07) — predecessor.

--- a/doc/v2/versions/v0/sprint_08/observability_followup/task_event_viewer_review.org
+++ b/doc/v2/versions/v0/sprint_08/observability_followup/task_event_viewer_review.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: 67fde70e-e08d-4b55-b420-5f2676763e8e
+:END:
+#+title: Event viewer review
+#+description: Dialog reshape; ring buffer for last N events; error highlighting; eventing coverage gaps for accounts/login/feature flags/roles/permissions; non-admin permission gaps.
+#+type: task
+#+level: s1
+#+filetags: :eventing:qt:review:observability_followup:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:cd9e9d04-44d2-4d0d-95ce-719d55c40da4][Observability follow-up]].
+
+* BACKLOG Status
+
+** Now
+POSTPONED in sprint 08; carried forward to a later sprint.
+
+** Waiting on
+Nothing.
+
+** Next
+Return to this once a sprint has the slot.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Review the event viewer and its eventing coverage; raise the fix list for a later sprint.
+
+* Acceptance
+
+- Event details a proper dialog; viewer no longer always-on-top.
+- Ring buffer of last N events captured even when the dialog is closed.
+- Error events marked so they're scannable.
+- Eventing coverage gaps closed: account-created events visible; login/logout decisions made; flag-save events propagate to event viewer.
+- Non-admin permission gaps fixed (roles/feature-flag visibility).
+- Role/permission CRUD gaps in Qt addressed (non-maximisable, eventing).
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+POSTPONED in v0: extensive snag list; deferred for a later, dedicated sprint to address it cleanly.
+
+* Result
+
+Not completed in sprint 08; carried forward.

--- a/doc/v2/versions/v0/sprint_08/observability_followup/task_review_comms_analyser_work.org
+++ b/doc/v2/versions/v0/sprint_08/observability_followup/task_review_comms_analyser_work.org
@@ -1,0 +1,53 @@
+:PROPERTIES:
+:ID: b091715a-ffa2-4716-90d5-3431f5ff4532
+:END:
+#+title: Review comms analyser work
+#+description: Validate the comms analyser; add a UI surface for it.
+#+type: task
+#+level: s1
+#+filetags: :comms:analyser:review:ux:observability_followup:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:cd9e9d04-44d2-4d0d-95ce-719d55c40da4][Observability follow-up]].
+
+* BACKLOG Status
+
+** Now
+POSTPONED in sprint 08; carried forward to a later sprint.
+
+** Waiting on
+Nothing.
+
+** Next
+Return to this once a sprint has the slot.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Review the comms-analyser component: validate the analyser works end-to-end and add a UI surface for it.
+
+* Acceptance
+
+- Analyser exercised against representative comms traffic.
+- UI surface added (Qt panel) to inspect analysed traffic.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+POSTPONED in v0: short clock entry only, deferred to a later sprint.
+
+* Result
+
+Not completed in sprint 08; carried forward.

--- a/doc/v2/versions/v0/sprint_08/observability_followup/task_review_telemetry_work.org
+++ b/doc/v2/versions/v0/sprint_08/observability_followup/task_review_telemetry_work.org
@@ -1,0 +1,55 @@
+:PROPERTIES:
+:ID: d7794c1a-496d-491f-9a92-319c1b92d062
+:END:
+#+title: Review telemetry work
+#+description: Database support for telemetry was missing; persist telemetry log entries with sender identity; fix self-referential telemetry events; UI fixes (event-viewer timestamps, accounts dialog sizing).
+#+type: task
+#+level: s1
+#+filetags: :telemetry:review:qt:observability_followup:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:cd9e9d04-44d2-4d0d-95ce-719d55c40da4][Observability follow-up]].
+
+* BACKLOG Status
+
+** Now
+POSTPONED in sprint 08; carried forward to a later sprint.
+
+** Waiting on
+Nothing.
+
+** Next
+Return to this once a sprint has the slot.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Review the telemetry component landed in sprint 07: validate database persistence, sender identification, and surface fixes around the event viewer.
+
+* Acceptance
+
+- Telemetry events persisted with proper sender identity (not =unknown=).
+- Self-referential telemetry events (logging about telemetry generates telemetry) eliminated.
+- Event viewer timestamps and event-type column legible.
+- Accounts dialog sizing and currency cache refresh issues raised here resolved alongside.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+POSTPONED in v0: review identified the gaps but fixes were scheduled for a later sprint.
+
+* Result
+
+Not completed in sprint 08; carried forward.

--- a/doc/v2/versions/v0/sprint_08/qt_ux_polish/story.org
+++ b/doc/v2/versions/v0/sprint_08/qt_ux_polish/story.org
@@ -1,0 +1,69 @@
+:PROPERTIES:
+:ID: cb564c6a-f248-4740-8d1c-a1be148ce576
+:END:
+#+title: Qt UX polish
+#+description: Validation of features added during the holidays + assorted dialog fixes (currency, currencies, feature flags, accounts, log viewer).
+#+type: story
+#+level: s2
+#+filetags: :qt:ux:polish:sprint_08:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:49c4e380-68ee-4d80-839a-41311a99c734][Sprint 08]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Validate the holiday-period Qt features end-to-end and resolve the
+snag list across the currency, currencies, feature-flags, and accounts
+dialogs. Add a Qt UI for log viewing.
+
+* Acceptance
+
+- Validation pass complete; bug list filed.
+- Currency, currencies, and feature-flags dialogs polished.
+- Log-viewer panel present with runtime log-level controls.
+- Accounts dialog polish carried forward (POSTPONED).
+
+* Tasks
+
+In execution order:
+
+- [[id:56a07d0e-f2d9-4337-819f-1a20cdfc8c26][Run qt client and validate all new features]]
+- [[id:0933396a-54e5-4496-ac82-3ec2b0151f2e][Assorted fixes to currency dialog]]
+- [[id:f1634788-2c13-4635-8ea4-cd9fe80b8b07][Assorted fixes to currencies dialog (flag and history)]]
+- [[id:ca2dd074-9a85-4d05-ac5c-0f4a4586d44c][Assorted fixes to feature flags dialog]]
+- [[id:574998d9-07c8-4c24-8e6a-1a9f97ed74f5][Add UI for log viewing]]
+- [[id:2ad7863b-31f9-4d50-8c47-2decba543013][Assorted fixes to accounts dialog]]
+
+* Decisions
+
+- /Mark stale rather than auto-reload/ :: keeps the UI responsive when external events arrive; user reloads when they're ready.
+- /Common reload logic shared across entity dialogs/ :: removes a copy-paste path that was drifting per entity.
+- /Accounts dialog deferred/ :: too large to land in-sprint without bumping out the change-management work; carried as BACKLOG.
+
+* Out of scope
+
+- Theming / dark mode.
+- Right-to-left support.
+
+* See also
+
+- [[id:150e3c44-aadb-48c8-a11e-322b44a0357a][Change management infrastructure]] — the change-management protocol drove much of the dialog work this sprint.

--- a/doc/v2/versions/v0/sprint_08/qt_ux_polish/task_add_log_viewing_ui.org
+++ b/doc/v2/versions/v0/sprint_08/qt_ux_polish/task_add_log_viewing_ui.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: 574998d9-07c8-4c24-8e6a-1a9f97ed74f5
+:END:
+#+title: Add UI for log viewing
+#+description: Qt-LogViewer-based panel for both client and server logs; runtime log-level controls.
+#+type: task
+#+level: s1
+#+filetags: :qt:logging:ux:qt_ux_polish:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:cb564c6a-f248-4740-8d1c-a1be148ce576][Qt UX polish]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Add a Qt UI for browsing both client and server logs, with runtime log-level controls.
+
+* Acceptance
+
+- Log view present in Qt.
+- Log level adjustable from the UI for both the Qt app and the service.
+- Reference implementation: Qt-LogViewer.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Foundation for letting AI agents browse logs end-to-end (paired with the telemetry ingest from sprint 07).
+
+* Result
+
+Logs visible from Qt; levels adjustable at runtime.

--- a/doc/v2/versions/v0/sprint_08/qt_ux_polish/task_assorted_fixes_accounts_dialog.org
+++ b/doc/v2/versions/v0/sprint_08/qt_ux_polish/task_assorted_fixes_accounts_dialog.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: 2ad7863b-31f9-4d50-8c47-2decba543013
+:END:
+#+title: Assorted fixes to accounts dialog
+#+description: Save-button enable-on-change, my-account dialog reshape, session-history non-maximisable, byte counters, status taxonomy (locked/unlocked/reset), right-click menu.
+#+type: task
+#+level: s1
+#+filetags: :qt:accounts:ux:polish:qt_ux_polish:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:cb564c6a-f248-4740-8d1c-a1be148ce576][Qt UX polish]].
+
+* BACKLOG Status
+
+** Now
+POSTPONED in sprint 08; carried forward to a later sprint.
+
+** Waiting on
+Nothing.
+
+** Next
+Return to this once a sprint has the slot.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Address the long tail of accounts-dialog snags surfaced during the validation pass.
+
+* Acceptance
+
+- Save enable-on-change, disable-on-saved.
+- My-account as a regular dialog (keep-open, interact with rest of app).
+- Session history not maximisable.
+- Real byte counters on sessions; instance-id visible.
+- Last-login column fits the screen; reload available.
+- Status taxonomy: locked / unlocked / reset (separate from age: online / never / recent / unused).
+- Right-click menu mirrors toolbar; reload preserves row position.
+- User cannot lock their own account.
+- Server-side session sweep on start.
+- Unlock-by-whom + when visible.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+POSTPONED in v0: the change-management work and Qt-LogViewer absorbed the slot; this task carries forward.
+
+* Result
+
+Not landed in sprint 08; carried forward.

--- a/doc/v2/versions/v0/sprint_08/qt_ux_polish/task_assorted_fixes_currencies_dialog.org
+++ b/doc/v2/versions/v0/sprint_08/qt_ux_polish/task_assorted_fixes_currencies_dialog.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: f1634788-2c13-4635-8ea4-cd9fe80b8b07
+:END:
+#+title: Assorted fixes to currencies dialog (flag and history)
+#+description: Flag updates propagate after reload; flag changes visible in history; fix incorrect-version error on history revert.
+#+type: task
+#+level: s1
+#+filetags: :qt:currencies:history:polish:qt_ux_polish:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:cb564c6a-f248-4740-8d1c-a1be148ce576][Qt UX polish]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-09]
+:END:
+
+** Now
+Completed 2026-01-09.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-09
+
+* Goal
+
+Address the residual currency-flag and history-revert issues.
+
+* Acceptance
+
+- Flag update propagates after reload.
+- Flag changes visible in history.
+- Revert to a version in history no longer errors with /incorrect version/.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Distinct from the dialog-level fixes; these are data-flow bugs around the flag + history axes.
+
+* Result
+
+Currencies dialog flag and history paths green.

--- a/doc/v2/versions/v0/sprint_08/qt_ux_polish/task_assorted_fixes_currency_dialog.org
+++ b/doc/v2/versions/v0/sprint_08/qt_ux_polish/task_assorted_fixes_currency_dialog.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 0933396a-54e5-4496-ac82-3ec2b0151f2e
+:END:
+#+title: Assorted fixes to currency dialog
+#+description: Non-maximisable details, column trimming, revert-icon fix, attach-flag on creation; refactor reload logic into common entity code.
+#+type: task
+#+level: s1
+#+filetags: :qt:currencies:ux:polish:qt_ux_polish:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:cb564c6a-f248-4740-8d1c-a1be148ce576][Qt UX polish]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-06]
+:END:
+
+** Now
+Completed 2026-01-06.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-06
+
+* Goal
+
+Address the first set of currency-dialog snags surfaced during validation.
+
+* Acceptance
+
+- Details windows non-maximisable.
+- Less-useful columns hidden from the list (symbol, fraction) but kept in the detail view.
+- Wrong revert icon fixed in currency history.
+- Reload available in history.
+- Flag attachable on creation.
+- Common reload logic refactored into shared entity code.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+The reload-logic refactor will continue to pay back as more entity dialogs follow the same shape.
+
+* Result
+
+Currency dialog usable; common reload logic shared.

--- a/doc/v2/versions/v0/sprint_08/qt_ux_polish/task_assorted_fixes_feature_flags_dialog.org
+++ b/doc/v2/versions/v0/sprint_08/qt_ux_polish/task_assorted_fixes_feature_flags_dialog.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: ca2dd074-9a85-4d05-ac5c-0f4a4586d44c
+:END:
+#+title: Assorted fixes to feature flags dialog
+#+description: Real-time subscription, recency pulse, badge column, version + recorded_at columns; protocol bump to 20.0.
+#+type: task
+#+level: s1
+#+filetags: :qt:feature_flags:ux:polish:qt_ux_polish:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:cb564c6a-f248-4740-8d1c-a1be148ce576][Qt UX polish]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-08]
+:END:
+
+** Now
+Completed 2026-01-08.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-08
+
+* Goal
+
+Polish the feature-flags dialog with real-time updates, badges, and richer columns.
+
+* Acceptance
+
+- Subscription to feature-flag change events; UI updates in real time.
+- Recency pulse on recently-changed rows.
+- Green/grey badge for the Enabled column.
+- Version and Recorded At columns.
+- Detail dialog uses a combo box for Enabled and shows Recorded At.
+- Save / external change marks the list stale rather than forcing reload.
+- Protocol bump to 20.0 with =recorded_at= and =version= fields.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Sets the pattern for stale-marking instead of auto-reload across other dialogs.
+
+* Result
+
+Feature flags dialog reactive and informative.

--- a/doc/v2/versions/v0/sprint_08/qt_ux_polish/task_run_qt_and_validate_features.org
+++ b/doc/v2/versions/v0/sprint_08/qt_ux_polish/task_run_qt_and_validate_features.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 56a07d0e-f2d9-4337-819f-1a20cdfc8c26
+:END:
+#+title: Run qt client and validate all new features
+#+description: End-to-end pass on holiday-period features: session monitoring, flags display, roles/permissions; raise bug list for the fixes that follow.
+#+type: task
+#+level: s1
+#+filetags: :qt:ux:validation:qt_ux_polish:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:cb564c6a-f248-4740-8d1c-a1be148ce576][Qt UX polish]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-02]
+:END:
+
+** Now
+Completed 2026-01-02.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-02
+
+* Goal
+
+End-to-end pass on the holiday-period features that couldn't be validated on the constrained laptop: session monitoring, flags display, roles + permissions.
+
+* Acceptance
+
+- Session monitoring confirmed working for tracking.
+- Feature flags display confirmed.
+- Roles + permissions snags raised (can't edit, display should be tabular).
+- Bug list raised for the assorted-fixes tasks.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Sets the priority list for the rest of the Qt UX polish story.
+
+* Result
+
+Holiday-period features validated; follow-up bugs filed.

--- a/doc/v2/versions/v0/sprint_08/reference_data_countries/story.org
+++ b/doc/v2/versions/v0/sprint_08/reference_data_countries/story.org
@@ -1,0 +1,63 @@
+:PROPERTIES:
+:ID: 501c05b5-aa7f-4807-a4f2-627b857ce2aa
+:END:
+#+title: Reference data: countries
+#+description: ISO 3166-1 countries with bitemporal storage, Wt UI, and shell support.
+#+type: story
+#+level: s2
+#+filetags: :refdata:countries:iso:bitemporal:sprint_08:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:49c4e380-68ee-4d80-839a-41311a99c734][Sprint 08]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Introduce countries as a first-class reference-data entity end-to-end.
+The implementation sets the template the rest of refdata will follow.
+
+* Acceptance
+
+- ISO 3166-1 countries with bitemporal repository and =country_service= in =ores.refdata=.
+- Flag-image linkage in =ores.assets= via =country_images=.
+- Wt CRUD UI present.
+- Shell commands (=countries get=, =countries add=) cover read and write.
+- SQL populate seeds all 249 countries idempotently.
+
+* Tasks
+
+In execution order:
+
+- [[id:00590c50-f119-4e2b-bc43-6fa2bae8543c][Add country support (ISO 3166-1)]]
+- [[id:125b746d-d625-4764-8d1e-ea9d4623880c][Finish country features in shell]]
+
+* Decisions
+
+- /Bitemporal storage/ :: countries change rarely but they /do/ change (new countries, renames); audit-grade history matters.
+- /Flag artwork via images table/ :: keeps countries decoupled from the asset bundle; same pattern applies to other reference data.
+
+* Out of scope
+
+- Non-ISO geographies (regions, sub-divisions). Tracked separately.
+
+* See also
+
+- [[id:b302b2b6-13f8-49cc-a6af-88418668be31][Entity-creator skills suite]] — countries was the first real exerciser of these skills.

--- a/doc/v2/versions/v0/sprint_08/reference_data_countries/task_add_country_support.org
+++ b/doc/v2/versions/v0/sprint_08/reference_data_countries/task_add_country_support.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 00590c50-f119-4e2b-bc43-6fa2bae8543c
+:END:
+#+title: Add country support (ISO 3166-1)
+#+description: Domain model, bitemporal repository, country_service in ores.refdata; country_images linkage in ores.assets; Wt list/dialog UI; SQL populate for all 249 ISO countries.
+#+type: task
+#+level: s1
+#+filetags: :refdata:countries:iso:wt:reference_data_countries:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:501c05b5-aa7f-4807-a4f2-627b857ce2aa][Reference data: countries]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-08]
+:END:
+
+** Now
+Completed 2026-01-08.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-08
+
+* Goal
+
+Add full ISO 3166-1 country support end-to-end: domain types, bitemporal repository, service layer, SQL populate of all 249 countries, country-image linkage in =ores.assets=, and Wt CRUD UI.
+
+* Acceptance
+
+- =country= domain in =ores.refdata= with bitemporal repository.
+- =country_service= wired into =application_context=.
+- =country_images= table + repository + mapper in =ores.assets=.
+- Wt =country_list_widget= + =country_dialog= cover CRUD.
+- SQL populate seeds all 249 ISO countries with idempotent scripts.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+First proper /reference data/ entity; sets the template the rest of refdata will follow.
+
+* Result
+
+Countries are a first-class entity with persistence, service, UI, and flag linkage.

--- a/doc/v2/versions/v0/sprint_08/reference_data_countries/task_finish_country_features_in_shell.org
+++ b/doc/v2/versions/v0/sprint_08/reference_data_countries/task_finish_country_features_in_shell.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: 125b746d-d625-4764-8d1e-ea9d4623880c
+:END:
+#+title: Finish country features in shell
+#+description: Add 'countries get' and 'countries add' commands to ores.comms.shell with formatted table output.
+#+type: task
+#+level: s1
+#+filetags: :shell:countries:cli:reference_data_countries:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:501c05b5-aa7f-4807-a4f2-627b857ce2aa][Reference data: countries]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Cover countries in =ores.comms.shell=: =countries get= to list, =countries add= to create, with formatted table output.
+
+* Acceptance
+
+- =countries= menu registered in the REPL.
+- =countries get= returns the server-side list as a fort-formatted table.
+- =countries add= round-trips client↔server through the country protocol.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+First exercise of the new shell-entity-creator skill on a real entity.
+
+* Result
+
+Countries usable from the shell; further entities follow the same template.

--- a/doc/v2/versions/v0/sprint_08/sprint.org
+++ b/doc/v2/versions/v0/sprint_08/sprint.org
@@ -1,0 +1,104 @@
+:PROPERTIES:
+:ID: 49c4e380-68ee-4d80-839a-41311a99c734
+:END:
+#+title: Sprint 08
+#+description: Database/seeding overhaul, ISO countries, change-management infrastructure, Qt UX polish, Wt/HTTP review, comms substrate evolution, native pagination, entity-creator skills suite, books domain analysis.
+#+type: sprint
+#+level: s3
+#+filetags: :refdata:countries:change_management:qt:comms:skills:sprint_08:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: STARTED | DONE
+
+Parent version: [[id:e6fd30ed-963e-4705-b414-91bf471c23d0][Version 0]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Sprint closed 2026-01-11. Three observability-review items and the
+accounts-dialog polish carry forward.
+
+** Waiting on
+None — carried-forward items are scheduled for sprint 09+.
+
+** Next
+Sprint 09 picks up the deferred items and continues the reference-data
+work (countries → next entity).
+
+** Last touched
+2026-01-11
+
+* Mission
+
+Originally /implement basic reference data/. In practice the sprint
+expanded to cover the substrate beneath that work: database
+reproducibility, change-management infrastructure for amends/deletes,
+Qt UX polish across most dialogs, plus a full set of entity-creator
+skills to make the next entity cheaper.
+
+* Stories
+
+In execution order:
+
+- [[id:f40e0162-a092-4716-a256-206fdba93452][Sprint 08 housekeeping]] — backlog refinement, OCR scans;
+  AI summary deferred.
+- [[id:42e6c351-795f-48aa-a435-eb3d1c9b6704][Database schema and seeding overhaul]] — rerun SQL from
+  scratch with TimescaleDB tier detection; remove code seeders.
+- [[id:cb564c6a-f248-4740-8d1c-a1be148ce576][Qt UX polish]] — validate holiday features; assorted dialog
+  fixes; log-viewer UI; accounts polish deferred.
+- [[id:da77fb50-27e8-4b42-a826-cab289c7826e][Comms substrate evolution]] — composable options, rename
+  =ores.shell= → =ores.comms.shell=, dynamic channel discovery.
+- [[id:40d153e3-4a87-44b6-b605-1e3e28a44d03][Native pagination support]] — adopt sqlgen 0.6.0.
+- [[id:13fbe901-b255-49f7-88c3-13b2a2506bf3][Wt and HTTP review]] — validate the sprint-07 surfaces;
+  document the HTTP service.
+- [[id:150e3c44-aadb-48c8-a11e-322b44a0357a][Change management infrastructure]] — reasons base + UI.
+- [[id:501c05b5-aa7f-4807-a4f2-627b857ce2aa][Reference data: countries]] — first proper refdata entity,
+  end-to-end.
+- [[id:b302b2b6-13f8-49cc-a6af-88418668be31][Entity-creator skills suite]] — Qt, shell, HTTP (incl.
+  recipes), Wt, CLI.
+- [[id:77211166-9316-40c0-88d6-c92f983a00b5][Books domain modelling analysis]] — strategic next-modelling
+  effort.
+- [[id:cd9e9d04-44d2-4d0d-95ce-719d55c40da4][Observability follow-up]] — review pass only; three
+  implementation tasks carry forward.
+
+* Retrospective
+
+** What went well
+
+- The database overhaul (license-tier detection, SQL populate
+  centralisation) was a foundational piece that unlocked subsequent
+  reference-data work; landed early and paid back through the rest of
+  the sprint.
+- Sprint-07 follow-ups (Wt and HTTP review, observability review)
+  arrived on schedule, even if some of the resulting fix work was
+  deferred — separating review from fixes was the right call.
+- Six entity-creator skills landed in parallel; the countries story
+  exercised the shell + Wt skills as their first real workload.
+
+** What hurt
+
+- Ambitious in volume: 11 stories / 31 tasks made it the biggest
+  v0 sprint to date. The cost showed up as four deferred items
+  (AI summary, accounts dialog, all three observability fixes).
+- =ores.refdata= doesn't have a versioned modelling doc with a
+  stable ID; the "see also" linkage from the countries story has
+  to point sideways at the skills story instead of at the component
+  doc.
+- Change-management UI polish ran longer than expected, mostly
+  because the icon / save-dialog / human-time pattern changes
+  touched every existing dialog.
+
+** What changed
+
+- =ores.shell= is now =ores.comms.shell= — the name reflects its
+  binary-protocol scope and frees the =ores.shell= slot for any
+  future protocol-agnostic shell.
+- Seeding centralised in SQL populate scripts; C++ seeders gone.
+- All dialogs mark stale on external change rather than
+  auto-reloading, a pattern that came out of the feature-flags
+  work and was generalised across the codebase.
+- Native sqlgen pagination replaces the offset workarounds and the
+  =single_connection= aggregation hack.

--- a/doc/v2/versions/v0/sprint_08/sprint_08_housekeeping/story.org
+++ b/doc/v2/versions/v0/sprint_08/sprint_08_housekeeping/story.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: f40e0162-a092-4716-a256-206fdba93452
+:END:
+#+title: Sprint 08 housekeeping
+#+description: Sprint backlog refinement, AI summary, notebook OCR scans.
+#+type: story
+#+level: s2
+#+filetags: :agile:housekeeping:sprint_08:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:49c4e380-68ee-4d80-839a-41311a99c734][Sprint 08]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Recurring per-sprint housekeeping: keep the backlog honest,
+continue the notebook OCR thread. AI summary was postponed.
+
+* Acceptance
+
+- Sprint 08 backlog reflects reality at close.
+- Sprint 08's notebook pages OCRed and committed.
+- AI summary scheduled rather than skipped — carried as BACKLOG.
+
+* Tasks
+
+In execution order:
+
+- [[id:06c1cb96-b27d-41cd-9b1e-5b450110bc5f][Sprint and product backlog refinement]]
+- [[id:6777df63-b6f7-4290-9482-d1103749ee7c][OCR scan notebooks for this sprint]]
+- [[id:89d71399-3e8c-4e39-94cf-4f1f173d3ff5][Add AI-generated sprint summary]]
+
+* Decisions
+
+- /AI summary deferred rather than dropped/ :: keeps the recurring story consistent across sprints; the task carries BACKLOG state.
+
+* Out of scope
+
+- Backfilling summaries for prior sprints — out-of-band activity.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_08/sprint_08_housekeeping/task_sprint_08_ai_summary.org
+++ b/doc/v2/versions/v0/sprint_08/sprint_08_housekeeping/task_sprint_08_ai_summary.org
@@ -1,0 +1,53 @@
+:PROPERTIES:
+:ID: 89d71399-3e8c-4e39-94cf-4f1f173d3ff5
+:END:
+#+title: Add AI-generated sprint summary
+#+description: Produce sprint 08's summary via the AI-summary skill.
+#+type: task
+#+level: s1
+#+filetags: :agile:llm:summary:sprint_08_housekeeping:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:f40e0162-a092-4716-a256-206fdba93452][Sprint 08 housekeeping]].
+
+* BACKLOG Status
+
+** Now
+POSTPONED in sprint 08; carried forward to a later sprint.
+
+** Waiting on
+Nothing.
+
+** Next
+Return to this once a sprint has the slot.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Generate sprint 08's AI summary using the sprint-summariser skill.
+
+* Acceptance
+
+- Summary committed alongside the v0 backlog.
+- Highlights notable wins, postponed items, and discovered work.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+POSTPONED in v0: deferred to a later pass because the sprint ran long and review priorities took the slot.
+
+* Result
+
+Not produced during sprint 08; carried forward.

--- a/doc/v2/versions/v0/sprint_08/sprint_08_housekeeping/task_sprint_08_backlog_refinement.org
+++ b/doc/v2/versions/v0/sprint_08/sprint_08_housekeeping/task_sprint_08_backlog_refinement.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 06c1cb96-b27d-41cd-9b1e-5b450110bc5f
+:END:
+#+title: Sprint and product backlog refinement
+#+description: Maintain sprint 08 backlog and groom the product backlog.
+#+type: task
+#+level: s1
+#+filetags: :agile:backlog:sprint_08_housekeeping:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:f40e0162-a092-4716-a256-206fdba93452][Sprint 08 housekeeping]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Maintain the sprint 08 backlog and groom the product backlog as items emerge.
+
+* Acceptance
+
+- Sprint 08 backlog reflects what was actually planned and what landed.
+- Items discovered in flight added to the product backlog rather than smuggled in.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Ongoing during the sprint; the v0 backlog file =sprint_backlog_08.org= was the source of truth.
+
+* Result
+
+Backlog refined at sprint end alongside the AI summary attempt.

--- a/doc/v2/versions/v0/sprint_08/sprint_08_housekeeping/task_sprint_08_ocr_notebooks.org
+++ b/doc/v2/versions/v0/sprint_08/sprint_08_housekeeping/task_sprint_08_ocr_notebooks.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 6777df63-b6f7-4290-9482-d1103749ee7c
+:END:
+#+title: OCR scan notebooks for this sprint
+#+description: Continue the long-running notebook OCR thread for sprint 08.
+#+type: task
+#+level: s1
+#+filetags: :agile:ocr:sprint_08_housekeeping:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:f40e0162-a092-4716-a256-206fdba93452][Sprint 08 housekeeping]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-11]
+:END:
+
+** Now
+Completed 2026-01-11.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-11
+
+* Goal
+
+Continue digitising the paper notebooks for the period covered by sprint 08.
+
+* Acceptance
+
+- Relevant notebook pages OCRed and committed.
+- Cross-references back to sprint items where applicable.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Long-running notebook digitisation strand; one pass per sprint.
+
+* Result
+
+Sprint 08's chunk of notebook content landed.

--- a/doc/v2/versions/v0/sprint_08/wt_and_http_review/story.org
+++ b/doc/v2/versions/v0/sprint_08/wt_and_http_review/story.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: 13fbe901-b255-49f7-88c3-13b2a2506bf3
+:END:
+#+title: Wt and HTTP review
+#+description: Validate the Wt application introduced in sprint 07; review and document the HTTP service (swagger, recipes).
+#+type: story
+#+level: s2
+#+filetags: :wt:http:review:sprint_08:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+#+predecessor: db625c07-811a-4a61-8de8-910b29913744
+
+Parent sprint: [[id:49c4e380-68ee-4d80-839a-41311a99c734][Sprint 08]].
+
+Continued from: [[id:db625c07-811a-4a61-8de8-910b29913744][Wt and HTTP introduction]] (sprint 07) — that story
+put the scaffolding in place; this one validates and documents it.
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-06]
+:END:
+
+** Now
+Completed 2026-01-06.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-06
+
+* Goal
+
+Validate the Wt application and HTTP service introduced in sprint 07.
+Raise the snag lists; write recipes covering the HTTP surface; document
+the OpenAPI generator.
+
+* Acceptance
+
+- Wt application validated; bug list filed for follow-up.
+- HTTP service swagger working; recipes cover the surface.
+- OpenAPI generation documented.
+
+* Tasks
+
+In execution order:
+
+- [[id:331bac68-cf7f-4fc3-97c6-fb7b7a993724][Check functionality in ores.wt]]
+- [[id:a6c3f702-ec89-41db-b662-79ac971d30a9][Review HTTP service]]
+
+* Decisions
+
+- /Validation first, fixes later/ :: keeps the review pass tight; the resulting bug list feeds future sprints.
+
+* Out of scope
+
+- Implementing the Wt bugs raised here (theming, hard-coded currencies, password-in-log).
+
+* See also
+
+- [[id:db625c07-811a-4a61-8de8-910b29913744][Wt and HTTP introduction]] (sprint 07) — predecessor.

--- a/doc/v2/versions/v0/sprint_08/wt_and_http_review/task_check_functionality_in_wt.org
+++ b/doc/v2/versions/v0/sprint_08/wt_and_http_review/task_check_functionality_in_wt.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 331bac68-cf7f-4fc3-97c6-fb7b7a993724
+:END:
+#+title: Check functionality in ores.wt
+#+description: Validate the Wt application end-to-end; raise bugs (theming, hard-coded currencies, password in log, dialog sizing, site logo).
+#+type: task
+#+level: s1
+#+filetags: :wt:review:ux:wt_and_http_review:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:13fbe901-b255-49f7-88c3-13b2a2506bf3][Wt and HTTP review]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-02]
+:END:
+
+** Now
+Completed 2026-01-02.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-02
+
+* Goal
+
+Validate the Wt application end-to-end and raise the snag list.
+
+* Acceptance
+
+- End-to-end smoke test of the Wt UI.
+- Bug list filed for follow-up: dark/light theme support, hard-coded currencies, password leaking to log, missing detail in accounts dialog, tall edit-currency dialog, missing logo imagery.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Reviewing rather than fixing; the bugs themselves land later.
+
+* Result
+
+Wt application validated; follow-up bug list ready for triage.

--- a/doc/v2/versions/v0/sprint_08/wt_and_http_review/task_review_http_service.org
+++ b/doc/v2/versions/v0/sprint_08/wt_and_http_review/task_review_http_service.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: a6c3f702-ec89-41db-b662-79ac971d30a9
+:END:
+#+title: Review HTTP service
+#+description: Validate swagger; write recipes covering the HTTP surface; document the OpenAPI generator.
+#+type: task
+#+level: s1
+#+filetags: :http:review:swagger:recipes:wt_and_http_review:sprint_08:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:13fbe901-b255-49f7-88c3-13b2a2506bf3][Wt and HTTP review]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-06]
+:END:
+
+** Now
+Completed 2026-01-06.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-06
+
+* Goal
+
+Validate the HTTP service introduced in sprint 07: swagger correctness, recipes covering each endpoint, and OpenAPI-generator documentation.
+
+* Acceptance
+
+- Swagger confirmed working end-to-end.
+- Recipes added covering the HTTP surface.
+- OpenAPI generation documented.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Closes the loop on the HTTP entry point landed in sprint 07.
+
+* Result
+
+HTTP service validated and documented.

--- a/doc/v2/versions/v0/sprint_09/cli_entity_coverage/story.org
+++ b/doc/v2/versions/v0/sprint_09/cli_entity_coverage/story.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: 09a8d544-22f3-491a-82a9-306b1aa7c756
+:END:
+#+title: CLI entity coverage
+#+description: Add list/delete CLI commands for roles, permissions, countries, change reasons, change-reason categories; refactor parsers behind a generic helper.
+#+type: story
+#+level: s2
+#+filetags: :cli:refactor:entity_coverage:sprint_09:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:af0b027b-77bf-4794-810d-39ad49a5efad][Sprint 09]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-12]
+:END:
+
+** Now
+Completed 2026-01-12.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-12
+
+* Goal
+
+Bring the CLI up to date with the entities added in earlier sprints,
+then refactor the resulting parsers behind a generic helper to remove
+boilerplate.
+
+* Acceptance
+
+- list + delete commands cover roles, permissions, countries, change_reasons, change_reason_categories.
+- Parsers refactored behind =simple_entity_config= + =handle_simple_entity_command=.
+- Net reduction ~314 lines across the five parsers.
+
+* Tasks
+
+In execution order:
+
+- [[id:3d5f5bb6-056a-4533-9b18-7222d9b9b84f][Add missing entities to CLI]]
+- [[id:61fb71d8-9fd2-4739-a20a-7cadb3f83f4a][Refactor CLI entity parsers with generic helper]]
+
+* Decisions
+
+- /Write all five, then extract the helper/ :: rule-of-three lets us see the shape clearly before generalising.
+
+* Out of scope
+
+- Full CRUD on these entities — only list + delete in this pass.
+
+* See also
+
+- [[id:de76313f-3c9e-441a-aa5e-6212a3841eed][CLI entity creator skill]] (sprint 08) — the skill this story exercises.

--- a/doc/v2/versions/v0/sprint_09/cli_entity_coverage/task_add_missing_entities_to_cli.org
+++ b/doc/v2/versions/v0/sprint_09/cli_entity_coverage/task_add_missing_entities_to_cli.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 3d5f5bb6-056a-4533-9b18-7222d9b9b84f
+:END:
+#+title: Add missing entities to CLI
+#+description: list + delete commands for roles, permissions, countries, change_reasons, change_reason_categories; JSON and table output; lookup by UUID/code/name as appropriate.
+#+type: task
+#+level: s1
+#+filetags: :cli:entity_coverage:cli_entity_coverage:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:09a8d544-22f3-491a-82a9-306b1aa7c756][CLI entity coverage]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-12]
+:END:
+
+** Now
+Completed 2026-01-12.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-12
+
+* Goal
+
+Bring the CLI up to date with the entities added in earlier sprints.
+
+* Acceptance
+
+- list + delete commands for roles, permissions, countries, change_reasons, change_reason_categories.
+- JSON and table output formats for list.
+- Delete lookups by UUID, code, or name depending on the entity.
+- New parser headers + implementations integrated into the existing application.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Direct exerciser of the =cli-entity-creator= skill landed in sprint 08.
+
+* Result
+
+Five new entity verbs available on the CLI.

--- a/doc/v2/versions/v0/sprint_09/cli_entity_coverage/task_refactor_cli_entity_parsers.org
+++ b/doc/v2/versions/v0/sprint_09/cli_entity_coverage/task_refactor_cli_entity_parsers.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: 61fb71d8-9fd2-4739-a20a-7cadb3f83f4a
+:END:
+#+title: Refactor CLI entity parsers with generic helper
+#+description: Introduce simple_entity_config + handle_simple_entity_command in parser_helpers; refactor the five new entity parsers behind it. Net reduction ~314 lines.
+#+type: task
+#+level: s1
+#+filetags: :cli:refactor:helper:cli_entity_coverage:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:09a8d544-22f3-491a-82a9-306b1aa7c756][CLI entity coverage]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-12]
+:END:
+
+** Now
+Completed 2026-01-12.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-12
+
+* Goal
+
+Refactor the five new entity parsers behind a generic helper to remove boilerplate.
+
+* Acceptance
+
+- =simple_entity_config= + =handle_simple_entity_command= in =parser_helpers=.
+- All five entity parsers refactored to use the helper.
+- ~314 line reduction.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Direct response to PR review feedback on the first version of these parsers.
+
+* Result
+
+Boilerplate gone; future list/delete entities follow the helper.

--- a/doc/v2/versions/v0/sprint_09/connection_management/story.org
+++ b/doc/v2/versions/v0/sprint_09/connection_management/story.org
@@ -1,0 +1,71 @@
+:PROPERTIES:
+:ID: aacc71e6-3dee-47d2-b77c-e0b4847260bd
+:END:
+#+title: Connection management
+#+description: ores.connections component, Connection Browser MDI, login-dialog modernisation, prodigy multi-environment support.
+#+type: story
+#+level: s2
+#+filetags: :connections:qt:login:environments:sprint_09:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:af0b027b-77bf-4794-810d-39ad49a5efad][Sprint 09]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-15]
+:END:
+
+** Now
+Completed 2026-01-15.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-15
+
+* Goal
+
+Solve the /which server am I talking to?/ problem the multi-environment
+agent workflow surfaces. Land =ores.connections= as the local-SQLite
+bookmark store, a Connection Browser MDI on top of it, polish the
+browser, and modernise the login dialog to consume saved connections.
+
+* Acceptance
+
+- Prodigy lists all environments in a single buffer.
+- =ores.connections= present with SQLite persistence and AES-256-GCM encryption.
+- Connection Browser MDI covers folders + environments + master password.
+- Drag-reorder, inline rename, password validation, test-connection action all in place.
+- Modernised login + sign-up dialogs consume saved connections; auto-login after sign-up.
+
+* Tasks
+
+In execution order:
+
+- [[id:d769d4f4-97c9-49d6-93ae-850f6755b6e1][Prodigy supports multiple environments]]
+- [[id:15053700-a572-4ab7-b9f8-9cc2405d60c6][Add ores.connections core]]
+- [[id:581b2714-84ae-43ff-99db-f77003e4e0cd][Add Connection Browser MDI window]]
+- [[id:da48504b-2da4-48ae-895c-b8c5017a22c1][Improvements to connection browser]]
+- [[id:b182b9b1-cb77-4751-b36c-75c380e7237b][Modernise login dialog]]
+
+* Decisions
+
+- /Local SQLite, not server Postgres/ :: connection bookmarks belong on the client machine; storing them server-side defeats the purpose.
+- /Modeless login dialog/ :: lets the user keep it open while exploring saved connections, which the modal version blocked.
+- /Master password gates the encrypted store/ :: simple model; everything is encrypted at rest with AES-256-GCM derived from PBKDF2.
+
+* Out of scope
+
+- SSO / federated login.
+- Per-environment role pre-fetch.
+
+* See also
+
+- [[id:8c29b0e8-64ea-4f32-add0-59419769bcd4][Security module]] — supplies the crypto primitives.
+- [[id:b09e0d06-0314-4424-ad57-2da31a335d99][Login and sessions]] (sprint 03) — origin of the login surface modernised here.

--- a/doc/v2/versions/v0/sprint_09/connection_management/task_add_connection_browser_ui.org
+++ b/doc/v2/versions/v0/sprint_09/connection_management/task_add_connection_browser_ui.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 581b2714-84ae-43ff-99db-f77003e4e0cd
+:END:
+#+title: Add Connection Browser MDI window
+#+description: Hierarchical tree view of folders and environments; master-password support; full CRUD for folders and environments; database purge; pre-fill login from saved connection with auto-submit.
+#+type: task
+#+level: s1
+#+filetags: :qt:connections:ux:connection_management:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:aacc71e6-3dee-47d2-b77c-e0b4847260bd][Connection management]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-13]
+:END:
+
+** Now
+Completed 2026-01-13.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-13
+
+* Goal
+
+Provide a Qt UI for managing the saved-connections store.
+
+* Acceptance
+
+- MDI window with hierarchical tree view of folders + environments.
+- Master-password support: create / change / unlock encrypted credentials.
+- Full CRUD for folders and environments.
+- Database purge action.
+- Login dialog pre-fills + auto-submits from a selected entry when credentials available.
+- Icon-guidelines doc extended with Delete-Dismiss / Key-Multiple / Server-Link.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Master password is the thing that gates the encrypted-credentials store; without it the dialog stays empty.
+
+* Result
+
+Connection browser usable from Qt.

--- a/doc/v2/versions/v0/sprint_09/connection_management/task_add_connections_core.org
+++ b/doc/v2/versions/v0/sprint_09/connection_management/task_add_connections_core.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 15053700-a572-4ab7-b9f8-9cc2405d60c6
+:END:
+#+title: Add ores.connections core
+#+description: New component for server connection bookmarks: folder + tag + server_environment + environment_tag domain types; SQLite persistence with AES-256-GCM password encryption and PBKDF2 key derivation; connection_manager service.
+#+type: task
+#+level: s1
+#+filetags: :connections:component:sqlite:encryption:connection_management:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:aacc71e6-3dee-47d2-b77c-e0b4847260bd][Connection management]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-13]
+:END:
+
+** Now
+Completed 2026-01-13.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-13
+
+* Goal
+
+Stand up =ores.connections= as a dedicated component for server-connection bookmarks.
+
+* Acceptance
+
+- Domain types: =folder= (hierarchical), =tag= (categorisation), =server_environment= (connection details), =environment_tag= (M:N).
+- JSON + table I/O for every type.
+- SQLite persistence with foreign keys + cascade-delete rules.
+- AES-256-GCM password encryption with PBKDF2 key derivation.
+- =connection_manager= high-level service.
+- 79 test cases across domain / repository / service.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Local SQLite (not the project Postgres) because connection bookmarks belong on the client machine, not the server.
+
+* Result
+
+=ores.connections= present and tested.

--- a/doc/v2/versions/v0/sprint_09/connection_management/task_improvements_to_connection_browser.org
+++ b/doc/v2/versions/v0/sprint_09/connection_management/task_improvements_to_connection_browser.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: da48504b-2da4-48ae-895c-b8c5017a22c1
+:END:
+#+title: Improvements to connection browser
+#+description: Inline rename, drag-reorder folders, password policy validation, test-connection button, expanded start state, tags support, brighter-disabled-state fix, login-dialog integration.
+#+type: task
+#+level: s1
+#+filetags: :qt:connections:ux:polish:connection_management:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:aacc71e6-3dee-47d2-b77c-e0b4847260bd][Connection management]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-15]
+:END:
+
+** Now
+Completed 2026-01-15.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-15
+
+* Goal
+
+Polish the connection browser based on first-pass review.
+
+* Acceptance
+
+- Drag-reorder folders.
+- Inline rename.
+- Password-policy validation on save.
+- Test-connection button validates credentials.
+- Disabled buttons visually muted (no longer look enabled).
+- Browser starts with expanded tree.
+- Tags support.
+- Login dialog consumes connection-browser entries.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+The visual-state bug (disabled-buttons-look-enabled) was tracked separately because it had the same cause across all dialogs.
+
+* Result
+
+Connection browser usable in anger.

--- a/doc/v2/versions/v0/sprint_09/connection_management/task_modernise_login_dialog.org
+++ b/doc/v2/versions/v0/sprint_09/connection_management/task_modernise_login_dialog.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: b182b9b1-cb77-4751-b36c-75c380e7237b
+:END:
+#+title: Modernise login dialog
+#+description: Dark-themed, modeless LoginDialog and SignUpDialog as MDI subwindows; auto-login after sign-up; saved-connections dropdown.
+#+type: task
+#+level: s1
+#+filetags: :qt:login:ux:refactor:connection_management:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:aacc71e6-3dee-47d2-b77c-e0b4847260bd][Connection management]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-15]
+:END:
+
+** Now
+Completed 2026-01-15.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-15
+
+* Goal
+
+Modernise login and sign-up dialogs: dark theme, modeless MDI subwindows, auto-login after sign-up, saved-connections dropdown.
+
+* Acceptance
+
+- Dark-themed LoginDialog and SignUpDialog widgets.
+- Modeless MDI subwindows rather than modal dialogs.
+- Auto-login after successful registration.
+- Saved-connections dropdown integrated with the new connection browser.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Modeless lets the user keep the login dialog open while exploring saved connections — important for the connection-browser flow.
+
+* Result
+
+Login surface aligned with the connection management story.

--- a/doc/v2/versions/v0/sprint_09/connection_management/task_prodigy_multiple_environments.org
+++ b/doc/v2/versions/v0/sprint_09/connection_management/task_prodigy_multiple_environments.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: d769d4f4-97c9-49d6-93ae-850f6755b6e1
+:END:
+#+title: Prodigy supports multiple environments
+#+description: Prodigy shows all environments in a single buffer for running multiple claudes / qwens / geminis side-by-side.
+#+type: task
+#+level: s1
+#+filetags: :tooling:environments:prodigy:connection_management:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:aacc71e6-3dee-47d2-b77c-e0b4847260bd][Connection management]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-13]
+:END:
+
+** Now
+Completed 2026-01-13.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-13
+
+* Goal
+
+Update prodigy to surface every environment in a single buffer so running multiple LLM-driven sessions (claudes, qwens, geminis) side-by-side is friction-free.
+
+* Acceptance
+
+- Single buffer lists all environments.
+- Selecting an environment runs the relevant service in it.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Comes out of the day-to-day pain of running parallel agents across two repos.
+
+* Result
+
+Multi-environment workflow available in prodigy.

--- a/doc/v2/versions/v0/sprint_09/data_quality_subsystem/story.org
+++ b/doc/v2/versions/v0/sprint_09/data_quality_subsystem/story.org
@@ -9,8 +9,12 @@
 #+created: 2026-05-19
 #+updated: 2026-05-19
 #+todo: BACKLOG STARTED | DONE ABANDONED
+#+successor: 75442a55-dbbb-4bc1-875e-981679e05621
 
 Parent sprint: [[id:af0b027b-77bf-4794-810d-39ad49a5efad][Sprint 09]].
+
+Continued in: [[id:75442a55-dbbb-4bc1-875e-981679e05621][Librarian polish]] (sprint 10) — PR-review feedback on
+the librarian landed here.
 
 * DONE Status
 :PROPERTIES:

--- a/doc/v2/versions/v0/sprint_09/data_quality_subsystem/story.org
+++ b/doc/v2/versions/v0/sprint_09/data_quality_subsystem/story.org
@@ -1,0 +1,82 @@
+:PROPERTIES:
+:ID: 3579ab5e-d5d8-45ae-8cb5-00ad1c58644f
+:END:
+#+title: Data Quality subsystem and Data Librarian
+#+description: Stand up ores.dq as a first-class component: domain types, ER schema, messaging subsystem, Data Librarian UI, publication workflow, fake-world dataset.
+#+type: story
+#+level: s2
+#+filetags: :dq:data_quality:librarian:lineage:fpml:sprint_09:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:af0b027b-77bf-4794-810d-39ad49a5efad][Sprint 09]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-20]
+:END:
+
+** Now
+Completed 2026-01-20.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-20
+
+* Goal
+
+Stand up Data Quality as a first-class subsystem of ORE Studio:
+concept model, domain types + FpML reference data, ER refactor,
+messaging subsystem with breaking protocol bump, Data Librarian UI,
+subject-area surface, circular-dependency resolution, publication
+workflow, and a fake-world validation dataset.
+
+* Acceptance
+
+- =ores.dq= component present with 10 DQ domain types.
+- FpML non-ISO currencies / business centers / business processes integrated.
+- ER diagram standardised on =<component>_<entity>_tbl=.
+- Binary protocol carries DQ subsystem 0x6000-0x6FFF (protocol 22.0).
+- Data Librarian three-panel MDI window exposes the subsystem.
+- Subject areas have dedicated controller + detail + history dialogs.
+- DQ-IAM circular dependency resolved by relocating change-reason constants to =ores.database=.
+- Publication wizard promotes staged datasets with dependency resolution.
+- Fake-world dataset round-trips through the system.
+
+* Tasks
+
+In execution order:
+
+- [[id:b03fee7c-2156-4b80-a2bd-020a9a5b6077][Create Data Quality infrastructure]]
+- [[id:1dc4639c-893d-4cbe-b4ac-a4bc9a04b932][DQ domain types and FpML reference data]]
+- [[id:b1969bed-3c53-42c9-b316-cacc90814ca7][DQ catalog and ER refactor]]
+- [[id:530624ef-e76e-40ce-82be-3efc8420d938][Data Librarian UI]]
+- [[id:293a5704-3138-40d4-9903-6d09b67f3456][DQ subject areas management]]
+- [[id:21dfacf9-f1cc-4c99-9e46-586fd8c6b23c][DQ messaging subsystem]]
+- [[id:808db4f2-2191-4600-983c-f83c7438c11e][Resolve DQ-IAM circular dependency]]
+- [[id:fee9f73a-16b2-4692-9a22-b6c8b23ca451][Data Librarian publication workflow]]
+- [[id:efd5093d-5bf0-43f2-a2c6-443405f849e3][Add fake-world dataset]]
+
+* Decisions
+
+- /FpML as the reference-data anchor/ :: industry vocabulary by default; avoids inventing our own currencies/business-centers terminology.
+- /Lean into the librarian metaphor/ :: /Catalog/, /Volume/, /Formula/, /Accession Card/, /Stacks/ — naming pays back in mental model.
+- /Change-management migrates to DQ subsystem/ :: it's data-quality machinery, not identity machinery; the IAM home was wrong.
+- /Boost.Graph for dependency resolution/ :: well-tested topo-sort is cheaper than rolling our own; we'll consume more graph algorithms as the system grows.
+- /Fake-world dataset as smoke test/ :: deliberately synthetic so we can validate the infrastructure without licensing concerns.
+
+* Out of scope
+
+- Real-world data acquisition (vendor integrations) — separate workstream.
+- DQ scoring / quality gates — covered conceptually but not implemented.
+
+* See also
+
+- [[id:61485635-64ba-4c31-a35b-2f60d7fb41aa][Database naming refactor]] — the ER refactor consumes its naming convention.
+- [[id:150e3c44-aadb-48c8-a11e-322b44a0357a][Change management infrastructure]] (sprint 08) — change-management messages migrate from there into DQ here.

--- a/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_add_fake_world_dataset.org
+++ b/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_add_fake_world_dataset.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: efd5093d-5bf0-43f2-a2c6-443405f849e3
+:END:
+#+title: Add fake-world dataset
+#+description: Use the previously spec'd 'fake world' dataset to validate the dataset infrastructure end-to-end.
+#+type: task
+#+level: s1
+#+filetags: :dq:fake_data:validation:data_quality_subsystem:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:3579ab5e-d5d8-45ae-8cb5-00ad1c58644f][Data Quality subsystem and Data Librarian]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-20]
+:END:
+
+** Now
+Completed 2026-01-20.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-20
+
+* Goal
+
+Exercise the dataset infrastructure end-to-end against the previously spec'd /fake world/ dataset.
+
+* Acceptance
+
+- Fake-world dataset loaded into the system.
+- Lineage, provenance, classification all populated.
+- Dataset visible in the Data Librarian.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Validates the infrastructure by ingesting something deliberately synthetic; if it works for fake world it'll work for the real ones.
+
+* Result
+
+Fake-world dataset present and inspectable.

--- a/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_create_dq_infrastructure.org
+++ b/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_create_dq_infrastructure.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: b03fee7c-2156-4b80-a2bd-020a9a5b6077
+:END:
+#+title: Create Data Quality infrastructure
+#+description: Stand up ores.dq with domain types backing the user-driven sample-data workflow: dataset, lineage, provenance, classification, temporal context, data passport, granularity options.
+#+type: task
+#+level: s1
+#+filetags: :dq:component:domain_types:data_quality_subsystem:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:3579ab5e-d5d8-45ae-8cb5-00ad1c58644f][Data Quality subsystem and Data Librarian]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-15]
+:END:
+
+** Now
+Completed 2026-01-15.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-15
+
+* Goal
+
+Lay out the conceptual foundations for the data-quality subsystem: how the project will manage curated sample data with full lineage and provenance.
+
+* Acceptance
+
+- Concept model documented: dataset, record, provenance, classification, lineage, temporal context, data passport.
+- Metadata-attribute schema covering provenance + classification, lineage + derivation, temporal metadata.
+- Granularity options (dataset vs record level) decided.
+- Validation constraints captured (e.g. synthetic ⇒ generation_method required).
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Heavy use of LLM (Qwen) for the conceptual model; this is the design step ahead of the implementation tasks.
+
+* Result
+
+DQ concept model documented; implementation can follow.

--- a/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_data_librarian_publication_workflow.org
+++ b/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_data_librarian_publication_workflow.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: fee9f73a-16b2-4692-9a22-b6c8b23ca451
+:END:
+#+title: Data Librarian publication workflow
+#+description: Multi-page publication wizard (upsert / insert_only / replace_all) with dependency resolution via Boost.Graph topological sort; stable dataset codes; publication history dialog; UI rename to 'methodology' and 'data passport'.
+#+type: task
+#+level: s1
+#+filetags: :dq:librarian:publication:boost_graph:data_quality_subsystem:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:3579ab5e-d5d8-45ae-8cb5-00ad1c58644f][Data Quality subsystem and Data Librarian]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-20]
+:END:
+
+** Now
+Completed 2026-01-20.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-20
+
+* Goal
+
+Add a publication workflow so curated datasets can be promoted from staging artefact tables into production tables with full dependency resolution.
+
+* Acceptance
+
+- Multi-page publication wizard with progress indication.
+- Publication modes: =upsert=, =insert_only=, =replace_all=.
+- Dependency resolution via Boost.Graph topological sort; stable dataset codes for cross-references.
+- Publication-history dialog.
+- Dataset detail view visualises dependencies.
+- Schema rename: =catalog_dependency= → =dataset_dependency= across the stack; role field on dependencies.
+- Upsert mode in population functions corrected (version increments preserved).
+- UI nomenclature updated: =methods= → =methodology=, =data Ascension= → =data passport=.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Boost.Graph chosen rather than rolling a topo-sort because the graph algorithms are well-tested and we'll use more of them later.
+
+* Result
+
+Publication workflow complete and exercised against the existing curated catalogs.

--- a/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_data_librarian_ui.org
+++ b/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_data_librarian_ui.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: 530624ef-e76e-40ce-82be-3efc8420d938
+:END:
+#+title: Data Librarian UI
+#+description: Three-panel Data Librarian MDI window: dataset browser, accession card details, methodology panel; IP geolocation catalog + iptoasn staging; Visual Assets catalog; TCP_NODELAY for parallel-request latency; menu restructuring (System / Data); Origin 'Source' renamed to 'Primary'.
+#+type: task
+#+level: s1
+#+filetags: :qt:dq:librarian:ux:geo:assets:data_quality_subsystem:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:3579ab5e-d5d8-45ae-8cb5-00ad1c58644f][Data Quality subsystem and Data Librarian]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-19]
+:END:
+
+** Now
+Completed 2026-01-19.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-19
+
+* Goal
+
+Stand up the Data Librarian Qt UI — the user-facing surface of the DQ subsystem.
+
+* Acceptance
+
+- Three-panel MDI window: dataset browser (Stacks), accession card details (Archive), methodology panel.
+- IP-geolocation catalog with iptoasn.com staging + IPv4→country populate.
+- Visual-assets catalog (country flags, crypto icons).
+- TCP_NODELAY on comms to mitigate Nagle for parallel-request UI latency.
+- Menu restructure: Identity + Configuration under /System/; data actions under /Data/.
+- =ClientDatasetModel= grows a Tags column + custom roles rendering Origin / Nature / Treatment as badges.
+- Origin /Source/ renamed to /Primary/ to mean /raw, untransformed/.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+/Data Librarian/ metaphor came from Gemini's UI analysis; lean into it (Catalog, Volume, Formula, Accession Card, Stacks).
+
+* Result
+
+Data Librarian is the visible entry point of the DQ subsystem.

--- a/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_dq_catalog_and_er_refactor.org
+++ b/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_dq_catalog_and_er_refactor.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: b1969bed-3c53-42c9-b316-cacc90814ca7
+:END:
+#+title: DQ catalog and ER refactor
+#+description: dq_catalog_tbl as top-level grouping; ER diagram (ores_schema.puml) standardised to <component>_<entity>_tbl naming and re-packaged by component prefix; missing DQ + telemetry + geo entities integrated.
+#+type: task
+#+level: s1
+#+filetags: :dq:er_diagram:sql:refactor:data_quality_subsystem:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:3579ab5e-d5d8-45ae-8cb5-00ad1c58644f][Data Quality subsystem and Data Librarian]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-15]
+:END:
+
+** Now
+Completed 2026-01-15.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-15
+
+* Goal
+
+Introduce the catalog grouping above datasets and use the moment to do an ER-diagram pass.
+
+* Acceptance
+
+- =dq_catalog_tbl= top-level grouping; existing datasets assigned to ISO-Standards and Cryptocurrency catalogs.
+- ER diagram (=ores_schema.puml=) standardised on =<component>_<entity>_tbl= naming; re-packaged by component prefix.
+- Missing DQ entities + telemetry + geo domains added to the ER diagram.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Pairs naturally with the prefix-database-entities task — the ER refactor consumes the same naming convention.
+
+* Result
+
+Catalog + ER diagram aligned with the new naming.

--- a/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_dq_domain_types_and_fpml.org
+++ b/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_dq_domain_types_and_fpml.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 1dc4639c-893d-4cbe-b4ac-a4bc9a04b932
+:END:
+#+title: DQ domain types and FpML reference data
+#+description: 10 DQ domain types (data_domain, subject_area, catalog, coding_scheme_authority_type, coding_scheme, origin_dimension, nature_dimension, treatment_dimension, methodology, dataset) with JSON + table I/O; FpML non-ISO currencies / business centers / business processes integrated; faker-cxx generators; year_month_day reflector.
+#+type: task
+#+level: s1
+#+filetags: :dq:domain_types:fpml:faker:data_quality_subsystem:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:3579ab5e-d5d8-45ae-8cb5-00ad1c58644f][Data Quality subsystem and Data Librarian]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-15]
+:END:
+
+** Now
+Completed 2026-01-15.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-15
+
+* Goal
+
+Land the C++ domain types and synthetic-data generators for the DQ subsystem; integrate FpML reference data.
+
+* Acceptance
+
+- 10 domain types: =data_domain=, =subject_area=, =catalog=, =coding_scheme_authority_type=, =coding_scheme=, =origin_dimension=, =nature_dimension=, =treatment_dimension=, =methodology=, =dataset= (each with JSON + table I/O).
+- FpML non-ISO currencies, business centers, business processes integrated via SQL populate.
+- faker-cxx generators for all DQ types.
+- =year_month_day= reflector for reflect-cpp.
+- DQ documentation extended with the /DQ 6/ standard dimensions and DAMA-DMBOK / TOGAF references.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+FpML reference data anchors us to industry vocabulary rather than inventing one.
+
+* Result
+
+DQ types + FpML data + synthetic generators all in place.

--- a/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_dq_iam_circular_dependency_fix.org
+++ b/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_dq_iam_circular_dependency_fix.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 808db4f2-2191-4600-983c-f83c7438c11e
+:END:
+#+title: Resolve DQ-IAM circular dependency
+#+description: Relocate change_reason_constants.hpp to the more foundational ores.database module; system models + CMake deps synchronised; deterministic time values via make_timepoint helper for DQ tests; skill docs updated.
+#+type: task
+#+level: s1
+#+filetags: :dq:iam:refactor:dependency:tests:data_quality_subsystem:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:3579ab5e-d5d8-45ae-8cb5-00ad1c58644f][Data Quality subsystem and Data Librarian]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-19]
+:END:
+
+** Now
+Completed 2026-01-19.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-19
+
+* Goal
+
+Resolve the circular dependency between =ores.dq= and =ores.iam= introduced by the change-management migration.
+
+* Acceptance
+
+- =change_reason_constants.hpp= relocated to =ores.database= (the more foundational module).
+- System models + CMake deps synchronised across =ores.cli=, =ores.comms.shell=, =ores.dq=, =ores.iam=.
+- Deterministic time values in DQ tests via a =make_timepoint= helper.
+- DQ tests assert audit fields (=recorded_by=, =change_commentary=) and table-header / field-value details.
+- Skill docs extended with guidance for binary-protocol developers and domain-type creators on auth-service plumbing + comprehensive testing.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Pulling the constants down to the foundational =ores.database= module is the standard /both depend on it/ fix.
+
+* Result
+
+Cycle broken; tests deterministic.

--- a/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_dq_messaging_subsystem.org
+++ b/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_dq_messaging_subsystem.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 21dfacf9-f1cc-4c99-9e46-586fd8c6b23c
+:END:
+#+title: DQ messaging subsystem
+#+description: New 0x6000-0x6FFF subsystem in the binary protocol; CRUD + history for every DQ entity; change-management messages migrated from IAM (0x2050-0x2061) to DQ (0x6070-0x6081); protocol bump 21.3 -> 22.0.
+#+type: task
+#+level: s1
+#+filetags: :dq:comms:protocol:breaking_change:data_quality_subsystem:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:3579ab5e-d5d8-45ae-8cb5-00ad1c58644f][Data Quality subsystem and Data Librarian]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-19]
+:END:
+
+** Now
+Completed 2026-01-19.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-19
+
+* Goal
+
+Open a new subsystem in the binary protocol for DQ messages, and migrate the change-management messages into it.
+
+* Acceptance
+
+- New subsystem 0x6000-0x6FFF reserved for DQ.
+- CRUD + history protocols for catalogs, data domains, subject areas, datasets, methodologies, coding schemes, dimensions (nature, origin, treatment).
+- Change-management messages migrated from IAM (0x2050-0x2061) to DQ (0x6070-0x6081).
+- Protocol bump 21.3 → 22.0 (breaking).
+- =dq_message_handler= + registrar processes incoming DQ traffic.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Breaking change made up-front before too many clients depend on the IAM range for change-management.
+
+* Result
+
+DQ messaging in place; change-management lives in the right place now.

--- a/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_dq_subject_areas.org
+++ b/doc/v2/versions/v0/sprint_09/data_quality_subsystem/task_dq_subject_areas.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 293a5704-3138-40d4-9903-6d09b67f3456
+:END:
+#+title: DQ subject areas management
+#+description: SubjectAreaController + Detail + History dialogs; menu integration; version history with revert; read-only versioned view.
+#+type: task
+#+level: s1
+#+filetags: :dq:subject_areas:qt:history:data_quality_subsystem:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:3579ab5e-d5d8-45ae-8cb5-00ad1c58644f][Data Quality subsystem and Data Librarian]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-19]
+:END:
+
+** Now
+Completed 2026-01-19.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-19
+
+* Goal
+
+Add a dedicated subject-area management surface for the DQ subsystem.
+
+* Acceptance
+
+- =SubjectAreaController= manages the lifecycle of subject-area windows.
+- =SubjectAreaDetailDialog= covers create / view / edit / delete.
+- =SubjectAreaHistoryDialog= shows the version timeline with revert + read-only-at-version views.
+- Main window integration: action enabled on login; status-bar signals wired.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Subject areas sit between domains and catalogs in the hierarchy; the UI mirrors that.
+
+* Result
+
+Subject-area management complete end-to-end.

--- a/doc/v2/versions/v0/sprint_09/database_naming_refactor/story.org
+++ b/doc/v2/versions/v0/sprint_09/database_naming_refactor/story.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: 61485635-64ba-4c31-a35b-2f60d7fb41aa
+:END:
+#+title: Database naming refactor
+#+description: Rename ores.risk to ores.refdata; prefix every SQL entity by component (iam_, refdata_, assets_, etc.).
+#+type: story
+#+level: s2
+#+filetags: :sql:refactor:naming:refdata:sprint_09:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:af0b027b-77bf-4794-810d-39ad49a5efad][Sprint 09]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-14]
+:END:
+
+** Now
+Completed 2026-01-14.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-14
+
+* Goal
+
+Make ownership of every SQL object explicit by prefixing it with the
+component, and use the moment to rename =ores.risk= to =ores.refdata=
+to reflect what the component actually does.
+
+* Acceptance
+
+- =ores.risk= renamed to =ores.refdata= consistently.
+- Every SQL object follows =<component>_<entity>_<suffix>=.
+- C++ =tablename= constants synchronised.
+- =sql-schema-creator= docs extended.
+
+* Tasks
+
+In execution order:
+
+- [[id:aa32b9c6-9c05-4f63-bbc5-51704df4e9b6][Rename ores.risk to ores.refdata]]
+- [[id:6c292f2c-9a0a-479c-9632-59a3f5028da7][Prefix database entities with component]]
+
+* Decisions
+
+- /Rename before prefix/ :: the rename had to land first so the new prefix tree (=refdata_=) was correct from the start.
+- /Prefix + suffix together/ :: =<component>_<entity>_<suffix>= carries both ownership and object kind in the name; no need to grep schema metadata.
+
+* Out of scope
+
+- Postgres role naming convention (already covered).
+- Schema-per-component (single =ores= schema is sufficient at this scale).
+
+* See also
+
+- [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]] — the component this story restructures.

--- a/doc/v2/versions/v0/sprint_09/database_naming_refactor/task_prefix_database_entities.org
+++ b/doc/v2/versions/v0/sprint_09/database_naming_refactor/task_prefix_database_entities.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 6c292f2c-9a0a-479c-9632-59a3f5028da7
+:END:
+#+title: Prefix database entities with component
+#+description: All SQL tables/functions/triggers/rules follow {component}_{entity}_{suffix}: iam_, refdata_, assets_, telemetry_, geo_, variability_, utility_; entity suffixes _tbl, _fn, _trg, _rule, _idx, _uniq_idx, _gist_idx. C++ tablename constants updated.
+#+type: task
+#+level: s1
+#+filetags: :sql:naming:refactor:convention:database_naming_refactor:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:61485635-64ba-4c31-a35b-2f60d7fb41aa][Database naming refactor]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-14]
+:END:
+
+** Now
+Completed 2026-01-14.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-14
+
+* Goal
+
+Apply a consistent =<component>_<entity>_<suffix>= naming pattern across every SQL object so it's obvious which component owns what.
+
+* Acceptance
+
+- Component prefixes: =iam_=, =refdata_=, =assets_=, =telemetry_=, =geo_=, =variability_=, =utility_=.
+- Suffixes: =_tbl= tables, =_fn= functions, =_trg= triggers, =_rule= rules, =_idx= indexes (+ =_uniq_idx=, =_gist_idx= variants).
+- C++ =tablename= constants synchronised.
+- =sql-schema-creator= skill docs extended with the convention + examples + the existing entity catalog.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+A flat schema becomes ambiguous as components multiply; this is the moment the prefix pattern starts paying back.
+
+* Result
+
+Schema-wide naming consistent; future entities follow the convention by default.

--- a/doc/v2/versions/v0/sprint_09/database_naming_refactor/task_rename_risk_to_refdata.org
+++ b/doc/v2/versions/v0/sprint_09/database_naming_refactor/task_rename_risk_to_refdata.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: aa32b9c6-9c05-4f63-bbc5-51704df4e9b6
+:END:
+#+title: Rename ores.risk to ores.refdata
+#+description: Pure rename: include paths, namespaces, CMake targets, header guards, HTTP routes file (risk_routes.cpp -> refdata_routes.cpp); diagrams + docs aligned.
+#+type: task
+#+level: s1
+#+filetags: :refactor:rename:refdata:database_naming_refactor:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:61485635-64ba-4c31-a35b-2f60d7fb41aa][Database naming refactor]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-14]
+:END:
+
+** Now
+Completed 2026-01-14.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-14
+
+* Goal
+
+Rename =ores.risk= to =ores.refdata= so the component name reflects /reference data/ rather than /risk calculation/.
+
+* Acceptance
+
+- Include paths updated from =ores.risk/= to =ores.refdata/=.
+- C++ namespace from =ores::risk= to =ores::refdata=.
+- CMake targets renamed (e.g. =ores.risk.lib= → =ores.refdata.lib=).
+- Header guards from =ORES_RISK_*= to =ORES_REFDATA_*=.
+- HTTP routes file renamed =risk_routes.cpp= → =refdata_routes.cpp=.
+- PlantUML diagrams + docs aligned.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+The =risk= name was a hangover from the original ORE (Open Source Risk Engine) framing; the component had drifted to refdata duty in practice.
+
+* Result
+
+Component renamed; no =risk= references left in live code.

--- a/doc/v2/versions/v0/sprint_09/engineering_hygiene/story.org
+++ b/doc/v2/versions/v0/sprint_09/engineering_hygiene/story.org
@@ -1,0 +1,67 @@
+:PROPERTIES:
+:ID: e7ddb653-ceaa-4922-b0f9-8bd5393a747e
+:END:
+#+title: Engineering hygiene
+#+description: System-model refresh, PR-skill consolidation, valgrind fixes; documentation refactor postponed.
+#+type: story
+#+level: s2
+#+filetags: :modeling:skills:qa:documentation:sprint_09:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:af0b027b-77bf-4794-810d-39ad49a5efad][Sprint 09]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-14]
+:END:
+
+** Now
+Completed 2026-01-14.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-14
+
+* Goal
+
+Three independent hygiene strands: bring system + component models
+back in sync; consolidate PR-handling skills behind a single
+=pr-manager=; resolve the valgrind regressions. A fourth strand —
+documentation refactor — is postponed.
+
+* Acceptance
+
+- System + component models refreshed and a skill in place to keep them so.
+- PR-handling skills consolidated into =pr-manager=.
+- Nightly valgrind green.
+- Documentation refactor scoped and parked as BACKLOG.
+
+* Tasks
+
+In execution order:
+
+- [[id:49bd7089-c2dd-4349-807b-57646076c043][Clean up system models and component models]]
+- [[id:c8d1e83a-d4c7-4b40-9fd1-210c9af0ecf2][Refactor PR-related skills into pr-manager]]
+- [[id:251a6ed5-33f1-4a9b-b450-1eb91c7c7b49][Fix valgrind errors in nightly]]
+- [[id:1bc0f53e-529a-4b38-a428-41ee1da7581d][Refactor documentation per entity]]
+
+* Decisions
+
+- /Skill-as-process for new components/ :: the =component-model-creator= skill ensures that every new component lands with a model rather than being added retroactively.
+- /One PR skill, not five/ :: removes the drift between the multiple skills that all knew how to draft a PR.
+- /Documentation refactor merges into v2/ :: rather than landing the split-recipes-per-entity work twice (once in v0, again in v2), let v2 carry it.
+
+* Out of scope
+
+- Per-entity documentation layout — superseded by v2.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_09/engineering_hygiene/task_clean_up_system_models.org
+++ b/doc/v2/versions/v0/sprint_09/engineering_hygiene/task_clean_up_system_models.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 49bd7089-c2dd-4349-807b-57646076c043
+:END:
+#+title: Clean up system models and component models
+#+description: Refresh system + component models out of sync with recent refactorings; introduce component-model-creator skill; new component docs for ores.logging, ores.http, ores.http.server, ores.wt.
+#+type: task
+#+level: s1
+#+filetags: :modeling:components:skills:documentation:engineering_hygiene:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:e7ddb653-ceaa-4922-b0f9-8bd5393a747e][Engineering hygiene]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-12]
+:END:
+
+** Now
+Completed 2026-01-12.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-12
+
+* Goal
+
+Bring the system and component models back in sync with recent refactorings; introduce a skill to keep them that way.
+
+* Acceptance
+
+- New =component-model-creator= skill standardises org-mode + PlantUML for new components.
+- Component docs land for =ores.logging=, =ores.http=, =ores.http.server=, =ores.wt=.
+- =ores.puml= updated to include the new components and their dependencies.
+- =skill-manager= guidelines extended to require updating the skill-dependencies diagram.
+- Doxygen main page slimmed and linked back to the website.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Modelling-as-skill: the skill ensures the next new component lands documented; the model-refresh task is a one-shot catch-up.
+
+* Result
+
+Models in sync; skill in place to keep them so.

--- a/doc/v2/versions/v0/sprint_09/engineering_hygiene/task_fix_valgrind_errors_nightly.org
+++ b/doc/v2/versions/v0/sprint_09/engineering_hygiene/task_fix_valgrind_errors_nightly.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 251a6ed5-33f1-4a9b-b450-1eb91c7c7b49
+:END:
+#+title: Fix valgrind errors in nightly
+#+description: Eventing tests fail under clang valgrind; one new possible leak on both clang and gcc.
+#+type: task
+#+level: s1
+#+filetags: :qa:valgrind:nightly:bug_fix:engineering_hygiene:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:e7ddb653-ceaa-4922-b0f9-8bd5393a747e][Engineering hygiene]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-14]
+:END:
+
+** Now
+Completed 2026-01-14.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-14
+
+* Goal
+
+Address the valgrind regressions surfaced in the nightly run.
+
+* Acceptance
+
+- Eventing-test errors under clang valgrind resolved.
+- New possible leak (clang + gcc) identified and fixed.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Nightly was the canary here; valgrind catches what unit tests don't.
+
+* Result
+
+Nightly valgrind green again.

--- a/doc/v2/versions/v0/sprint_09/engineering_hygiene/task_refactor_documentation.org
+++ b/doc/v2/versions/v0/sprint_09/engineering_hygiene/task_refactor_documentation.org
@@ -1,0 +1,54 @@
+:PROPERTIES:
+:ID: 1bc0f53e-529a-4b38-a428-41ee1da7581d
+:END:
+#+title: Refactor documentation per entity
+#+description: Split recipes per entity; create a top-level domain document per entity that cross-references recipes, component model, entity implementation files (SQL included), and skills. Recipes attach to components rather than being global.
+#+type: task
+#+level: s1
+#+filetags: :documentation:refactor:structure:engineering_hygiene:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:e7ddb653-ceaa-4922-b0f9-8bd5393a747e][Engineering hygiene]].
+
+* BACKLOG Status
+
+** Now
+POSTPONED in sprint 09; carried forward.
+
+** Waiting on
+A sprint with the slot to land it.
+
+** Next
+Return to this once a sprint has the budget.
+
+** Last touched
+2026-01-20
+
+* Goal
+
+Restructure documentation so it composes per-entity rather than across global recipe files.
+
+* Acceptance
+
+- Recipes split per entity.
+- Top-level domain document per entity cross-referencing recipes, component model, implementation files (SQL included), and skills.
+- Recipes attach to the component they belong to, not the global =doc/recipes/=.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+POSTPONED in v0: substantially overlaps with the v2 cybernetic information architecture work happening on the v2 branch. Some of this already lands in v2; the rest carries forward into v2 directly.
+
+* Result
+
+Not landed in sprint 09; superseded by the v2 information-architecture work.

--- a/doc/v2/versions/v0/sprint_09/engineering_hygiene/task_refactor_pr_related_skills.org
+++ b/doc/v2/versions/v0/sprint_09/engineering_hygiene/task_refactor_pr_related_skills.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: c8d1e83a-d4c7-4b40-9fd1-210c9af0ecf2
+:END:
+#+title: Refactor PR-related skills into pr-manager
+#+description: Rename pr-summary -> pr-manager; consolidate the 5-step PR lifecycle; remove duplicated PR creation logic from autonomous developer skills.
+#+type: task
+#+level: s1
+#+filetags: :skills:pr:refactor:llm:engineering_hygiene:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:e7ddb653-ceaa-4922-b0f9-8bd5393a747e][Engineering hygiene]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-12]
+:END:
+
+** Now
+Completed 2026-01-12.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-12
+
+* Goal
+
+Consolidate PR-handling guidance into a single =pr-manager= skill covering the full PR lifecycle.
+
+* Acceptance
+
+- =pr-summary= renamed to =pr-manager= and expanded.
+- Five-step workflow: summary, draft PR, wait for CI, mark ready, merge.
+- Standard PR-body template included.
+- =autonomous-developer= and =semi-autonomous-developer= refactored to delegate to =pr-manager=.
+- =skill_dependencies.puml= updated.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Removes drift between the multiple skills that all knew how to /file a PR/.
+
+* Result
+
+Single PR-lifecycle skill in place.

--- a/doc/v2/versions/v0/sprint_09/party_database_groundwork/story.org
+++ b/doc/v2/versions/v0/sprint_09/party_database_groundwork/story.org
@@ -9,8 +9,13 @@
 #+created: 2026-05-19
 #+updated: 2026-05-19
 #+todo: BACKLOG STARTED | DONE ABANDONED
+#+successor: 700d4325-2ad1-4e0d-b6af-900abbe1a66e
 
 Parent sprint: [[id:af0b027b-77bf-4794-810d-39ad49a5efad][Sprint 09]].
+
+Continued in: [[id:700d4325-2ad1-4e0d-b6af-900abbe1a66e][Party schemes and FPML reference data]] (sprint 10) —
+lands the 13 reference-data types needed before party can be
+implemented.
 
 * BACKLOG Status
 

--- a/doc/v2/versions/v0/sprint_09/party_database_groundwork/story.org
+++ b/doc/v2/versions/v0/sprint_09/party_database_groundwork/story.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: ef555d10-3fd3-4928-8e43-e63284d7706f
+:END:
+#+title: Party database groundwork
+#+description: First-cut party table structure at the database layer; FpML business-center anchored.
+#+type: story
+#+level: s2
+#+filetags: :party:sql:fpml:sprint_09:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:af0b027b-77bf-4794-810d-39ad49a5efad][Sprint 09]].
+
+* BACKLOG Status
+
+** Now
+Postponed in sprint 09; carried forward.
+
+** Waiting on
+A sprint with the slot to land the table + domain layer together.
+
+** Next
+Return alongside the party domain layer work.
+
+** Last touched
+2026-01-20
+
+* Goal
+
+Lay the first SQL table for =party= so subsequent sprints can build
+the domain layer + UI on top. Postponed within sprint 09.
+
+* Acceptance
+
+- =party_tbl= column list documented and reviewed.
+- FK targets identified (tenant, party_type scheme, business_center).
+- Task ready to pick up in a later sprint.
+
+* Tasks
+
+In execution order:
+
+- [[id:992aad62-c371-4e93-b3d2-311d250aa41a][Party table structure]]
+
+* Decisions
+
+- /Postpone rather than half-do/ :: only 20 minutes of v0 work landed; better to roll the table-creation into the sprint that also tackles the domain layer.
+
+* Out of scope
+
+- Party domain layer (C++).
+- Party UI.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_09/party_database_groundwork/task_party_table_structure.org
+++ b/doc/v2/versions/v0/sprint_09/party_database_groundwork/task_party_table_structure.org
@@ -1,0 +1,53 @@
+:PROPERTIES:
+:ID: 992aad62-c371-4e93-b3d2-311d250aa41a
+:END:
+#+title: Party table structure
+#+description: First-cut SQL table for party (LEI, tenant_id, party_type_id, business_center_id, status, etc.). Foundation for later domain layer + UI.
+#+type: task
+#+level: s1
+#+filetags: :party:sql:fpml:party_database_groundwork:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:ef555d10-3fd3-4928-8e43-e63284d7706f][Party database groundwork]].
+
+* BACKLOG Status
+
+** Now
+POSTPONED in sprint 09; carried forward.
+
+** Waiting on
+A sprint with the slot to land it.
+
+** Next
+Return to this once a sprint has the budget.
+
+** Last touched
+2026-01-20
+
+* Goal
+
+Lay the first SQL table for =party= so subsequent sprints can build the domain layer + UI on top.
+
+* Acceptance
+
+- =party_tbl= with: =party_id= PK, =tenant_id= FK, =party_name=, =short_name= unique, =lei= ISO 17442, =is_internal= bool, =party_type_id= FK, =postal_address=, =business_center_id= FK (FpML), =status= enum, =created_at=.
+- Domain documented; FK targets identified.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+POSTPONED in v0: only 20 minutes of v0 work landed; the full table-creation work was rolled forward to a later sprint where party-related entities are tackled together.
+
+* Result
+
+Not landed in sprint 09; carried forward as the foundation for party work.

--- a/doc/v2/versions/v0/sprint_09/qt_visual_refresh/story.org
+++ b/doc/v2/versions/v0/sprint_09/qt_visual_refresh/story.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: abd80ec4-e7e4-4bb2-b5ae-4fc7f8c46fd3
+:END:
+#+title: Qt visual refresh
+#+description: Centralise Qt icon handling behind a semantic enum + theme system.
+#+type: story
+#+level: s2
+#+filetags: :qt:icons:refactor:theming:sprint_09:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:af0b027b-77bf-4794-810d-39ad49a5efad][Sprint 09]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-20]
+:END:
+
+** Now
+Completed 2026-01-20.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-20
+
+* Goal
+
+Centralise icon handling behind a semantic enum + theme system so
+icon-set or theme changes don't require editing every UI file.
+
+* Acceptance
+
+- =enum class Icon= + =enum class IconTheme= drive icon lookup.
+- All UI files migrated off scattered SVG-path string literals.
+- Standard icon colours defined in one place.
+- Solarized (Linear + Bold) icon set available.
+
+* Tasks
+
+In execution order:
+
+- [[id:41a9ccc5-8a2b-4f0c-a403-8641c2d0318a][Refactor Qt icon implementation]]
+
+* Decisions
+
+- /Enum, not string lookup/ :: the compiler catches typos; the IDE autocompletes; renaming an icon is a single-site change.
+
+* Out of scope
+
+- Switching the default theme — refactor only.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_09/qt_visual_refresh/task_refactor_qt_icon_implementation.org
+++ b/doc/v2/versions/v0/sprint_09/qt_visual_refresh/task_refactor_qt_icon_implementation.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 41a9ccc5-8a2b-4f0c-a403-8641c2d0318a
+:END:
+#+title: Refactor Qt icon implementation
+#+description: Introduce enum class Icon + enum class IconTheme in IconUtils; centralise iconPath / createRecoloredIcon; standardise icon colours (DefaultIconColor, ConnectedColor, DisconnectedColor); add Solarized Linear + Bold icon set.
+#+type: task
+#+level: s1
+#+filetags: :qt:icons:refactor:theming:qt_visual_refresh:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:abd80ec4-e7e4-4bb2-b5ae-4fc7f8c46fd3][Qt visual refresh]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-20]
+:END:
+
+** Now
+Completed 2026-01-20.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-20
+
+* Goal
+
+Replace scattered SVG-path string literals with a semantic icon-enum + theme-aware retrieval.
+
+* Acceptance
+
+- =enum class Icon= and =enum class IconTheme= in =IconUtils.hpp=.
+- =IconUtils::iconPath()= + overloaded =createRecoloredIcon= consume the enums.
+- Standard icon-colour constants (=DefaultIconColor=, =ConnectedColor=, =DisconnectedColor=).
+- Codebase-wide migration: controllers, dialogs, MDI windows.
+- Solarized (Linear + Bold) SVG set added to =resources.qrc=.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Enables a future theme switch without touching every file; the icon-set choice becomes a single change.
+
+* Result
+
+Icon usage centralised; theme switching becomes feasible.

--- a/doc/v2/versions/v0/sprint_09/security_module/story.org
+++ b/doc/v2/versions/v0/sprint_09/security_module/story.org
@@ -1,0 +1,63 @@
+:PROPERTIES:
+:ID: 8c29b0e8-64ea-4f32-add0-59419769bcd4
+:END:
+#+title: Security module
+#+description: Extract shared security primitives into ores.security with RAII OpenSSL contexts.
+#+type: story
+#+level: s2
+#+filetags: :security:refactor:component:sprint_09:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:af0b027b-77bf-4794-810d-39ad49a5efad][Sprint 09]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-13]
+:END:
+
+** Now
+Completed 2026-01-13.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-13
+
+* Goal
+
+Consolidate shared security primitives into a dedicated
+=ores.security= component so future audits look at one component,
+not three.
+
+* Acceptance
+
+- =ores.security= component scaffolded.
+- Password and encryption code migrated from =ores.iam= + =ores.connections=.
+- OpenSSL contexts managed via RAII.
+- Downstream components linked through the new library.
+
+* Tasks
+
+In execution order:
+
+- [[id:91c1e06d-5307-4f45-803d-dea3e841ee84][Create ores.security module]]
+
+* Decisions
+
+- /RAII for OpenSSL/ :: =std::unique_ptr= with a custom =EVP_CIPHER_CTX_free= deleter eliminates the long error-path cleanup that was the source of leak reports.
+- /Clearer naming/ :: =password_hasher= and =encryption= name what they do; =password_manager= and =encryption_service= were vague.
+
+* Out of scope
+
+- Key-rotation tooling (planned separately).
+- Hardware security module integration.
+
+* See also
+
+- [[id:aacc71e6-3dee-47d2-b77c-e0b4847260bd][Connection management]] — primary consumer alongside IAM.

--- a/doc/v2/versions/v0/sprint_09/security_module/task_create_security_module.org
+++ b/doc/v2/versions/v0/sprint_09/security_module/task_create_security_module.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 91c1e06d-5307-4f45-803d-dea3e841ee84
+:END:
+#+title: Create ores.security module
+#+description: Extract shared security primitives from ores.iam and ores.connections into a new ores.security component; rename password_manager -> password_hasher, encryption_service -> encryption; apply RAII to OpenSSL cipher contexts.
+#+type: task
+#+level: s1
+#+filetags: :security:component:refactor:openssl:security_module:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:8c29b0e8-64ea-4f32-add0-59419769bcd4][Security module]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-13]
+:END:
+
+** Now
+Completed 2026-01-13.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-13
+
+* Goal
+
+Extract the shared security primitives that =ores.iam= and =ores.connections= both need into a dedicated =ores.security= component.
+
+* Acceptance
+
+- =password_manager= renamed to =password_hasher=; =encryption_service= to =encryption=.
+- RAII for OpenSSL =EVP_CIPHER_CTX= via =std::unique_ptr= + =EVP_CIPHER_CTX_free= deleter.
+- =ores.iam=, =ores.connections=, =ores.cli= link against the new library.
+- Build green; tests pass.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Moves the OpenSSL-handling rules into one place so future audits look at one component, not three.
+
+* Result
+
+Component in place; downstream components linked through it.

--- a/doc/v2/versions/v0/sprint_09/sprint.org
+++ b/doc/v2/versions/v0/sprint_09/sprint.org
@@ -1,0 +1,102 @@
+:PROPERTIES:
+:ID: af0b027b-77bf-4794-810d-39ad49a5efad
+:END:
+#+title: Sprint 09
+#+description: Data Quality subsystem + Data Librarian; connection management; database naming refactor; security module; CLI entity coverage; engineering hygiene.
+#+type: sprint
+#+level: s3
+#+filetags: :dq:librarian:connections:refdata:security:sprint_09:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: STARTED | DONE
+
+Parent version: [[id:e6fd30ed-963e-4705-b414-91bf471c23d0][Version 0]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-20]
+:END:
+
+** Now
+Sprint closed 2026-01-20. Two items carry forward: the per-entity
+documentation refactor (already mostly absorbed into v2) and the
+party-table groundwork.
+
+** Waiting on
+None.
+
+** Next
+Sprint 10 takes the next refdata entity and starts the party domain
+layer on top of the table-structure groundwork from this sprint.
+
+** Last touched
+2026-01-20
+
+* Mission
+
+Originally /implement data management infrastructure/. Delivered:
+stood up Data Quality as a first-class subsystem (=ores.dq=) end to
+end — concept model, domain types + FpML, ER refactor, breaking
+protocol bump, Data Librarian UI, publication workflow, validated
+against a fake-world dataset. Around it: connection management (so the
+multi-environment agent workflow stops being painful), database
+naming made component-explicit, a dedicated security module, and CLI
+coverage of the entities that landed in earlier sprints.
+
+* Stories
+
+In execution order:
+
+- [[id:1e7a8abc-1abc-4a37-bdce-1d8dfb9d21ff][Sprint 09 housekeeping]] — backlog + OCR.
+- [[id:09a8d544-22f3-491a-82a9-306b1aa7c756][CLI entity coverage]] — list/delete commands for the five
+  entities the CLI was missing; helper-driven refactor.
+- [[id:e7ddb653-ceaa-4922-b0f9-8bd5393a747e][Engineering hygiene]] — model refresh + pr-manager skill +
+  valgrind fixes; documentation refactor postponed.
+- [[id:8c29b0e8-64ea-4f32-add0-59419769bcd4][Security module]] — ores.security with RAII OpenSSL.
+- [[id:aacc71e6-3dee-47d2-b77c-e0b4847260bd][Connection management]] — ores.connections + Connection
+  Browser MDI + modernised login dialog.
+- [[id:61485635-64ba-4c31-a35b-2f60d7fb41aa][Database naming refactor]] — ores.risk → ores.refdata;
+  =<component>_<entity>_<suffix>= across the schema.
+- [[id:3579ab5e-d5d8-45ae-8cb5-00ad1c58644f][Data Quality subsystem and Data Librarian]] — the
+  flagship of the sprint.
+- [[id:abd80ec4-e7e4-4bb2-b5ae-4fc7f8c46fd3][Qt visual refresh]] — icon-enum + theme refactor.
+- [[id:ef555d10-3fd3-4928-8e43-e63284d7706f][Party database groundwork]] — table structure only;
+  postponed.
+
+* Retrospective
+
+** What went well
+
+- Data Quality landed as a coherent subsystem rather than piecemeal:
+  concept first, then domain types + FpML, then ER refactor, messaging,
+  UI, publication, and finally a fake-world validation pass.
+- Connection management unblocked the multi-environment agent workflow
+  the project has been operating under for the last few sprints.
+- Two big refactors — rename risk→refdata and the schema-wide naming
+  pass — landed cleanly thanks to the prefix pattern being mechanical.
+- The DQ subsystem migration of change-management messages out of IAM
+  forced a circular-dependency fix that improved layering more
+  broadly.
+
+** What hurt
+
+- The DQ protocol bump (21.3 → 22.0) is genuinely breaking; the cost
+  is paid up-front while client count is small, but it's still a cost.
+- Documentation-refactor scope overlapped substantially with v2; we
+  ended up postponing the v0 task because doing both would have been
+  duplicate work.
+- Boost.Graph as a build-time dependency is heavy for the one
+  topological-sort we need today; justified by the more-graphs-coming
+  argument but worth revisiting if that doesn't materialise.
+
+** What changed
+
+- =ores.security= is now the only place that knows about OpenSSL
+  primitives; =ores.iam= and =ores.connections= consume it.
+- =ores.risk= is gone — =ores.refdata= replaces it everywhere.
+- Schema-wide =<component>_<entity>_<suffix>= naming is now the
+  rule; new entities follow it by default.
+- =ores.dq= is the home of data-quality and change-management
+  machinery; messaging migrated accordingly.
+- Connection bookmarks live on the client (SQLite + AES-256-GCM)
+  rather than mixed into the server schema.

--- a/doc/v2/versions/v0/sprint_09/sprint_09_housekeeping/story.org
+++ b/doc/v2/versions/v0/sprint_09/sprint_09_housekeeping/story.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 1e7a8abc-1abc-4a37-bdce-1d8dfb9d21ff
+:END:
+#+title: Sprint 09 housekeeping
+#+description: Sprint backlog refinement and notebook OCR scans.
+#+type: story
+#+level: s2
+#+filetags: :agile:housekeeping:sprint_09:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:af0b027b-77bf-4794-810d-39ad49a5efad][Sprint 09]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-20]
+:END:
+
+** Now
+Completed 2026-01-20.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-20
+
+* Goal
+
+Recurring per-sprint housekeeping: keep the backlog honest and
+continue the notebook OCR thread.
+
+* Acceptance
+
+- Sprint 09 backlog reflects reality at close.
+- Sprint 09's notebook pages OCRed and committed.
+
+* Tasks
+
+In execution order:
+
+- [[id:69888c3d-64d0-44ce-ae77-6d9a83dc17d8][Sprint and product backlog refinement]]
+- [[id:f3187f2d-d903-4674-8338-d83af02736ec][OCR scan notebooks for this sprint]]
+
+* Decisions
+
+- /AI summary omitted this sprint/ :: v0 didn't carry an explicit AI-summary task for sprint 09, so it isn't migrated as a task.
+
+* Out of scope
+
+- Backfilling AI summaries for prior sprints.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_09/sprint_09_housekeeping/task_sprint_09_backlog_refinement.org
+++ b/doc/v2/versions/v0/sprint_09/sprint_09_housekeeping/task_sprint_09_backlog_refinement.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 69888c3d-64d0-44ce-ae77-6d9a83dc17d8
+:END:
+#+title: Sprint and product backlog refinement
+#+description: Maintain sprint 09 backlog and groom the product backlog.
+#+type: task
+#+level: s1
+#+filetags: :agile:backlog:sprint_09_housekeeping:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:1e7a8abc-1abc-4a37-bdce-1d8dfb9d21ff][Sprint 09 housekeeping]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-20]
+:END:
+
+** Now
+Completed 2026-01-20.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-20
+
+* Goal
+
+Maintain the sprint 09 backlog and groom the product backlog as items emerge.
+
+* Acceptance
+
+- Sprint 09 backlog reflects what was actually planned and what landed.
+- Items discovered in flight added to the product backlog rather than smuggled in.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Ongoing through the sprint; the v0 backlog file =sprint_backlog_09.org= was the source of truth.
+
+* Result
+
+Backlog refined at sprint end.

--- a/doc/v2/versions/v0/sprint_09/sprint_09_housekeeping/task_sprint_09_ocr_notebooks.org
+++ b/doc/v2/versions/v0/sprint_09/sprint_09_housekeeping/task_sprint_09_ocr_notebooks.org
@@ -1,0 +1,55 @@
+:PROPERTIES:
+:ID: f3187f2d-d903-4674-8338-d83af02736ec
+:END:
+#+title: OCR scan notebooks for this sprint
+#+description: Continue notebook OCR thread for sprint 09.
+#+type: task
+#+level: s1
+#+filetags: :agile:ocr:sprint_09_housekeeping:sprint_09:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:1e7a8abc-1abc-4a37-bdce-1d8dfb9d21ff][Sprint 09 housekeeping]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-20]
+:END:
+
+** Now
+Completed 2026-01-20.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-20
+
+* Goal
+
+Continue digitising the paper notebooks for the period covered by sprint 09.
+
+* Acceptance
+
+- Relevant notebook pages OCRed and committed.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Long-running notebook digitisation strand; one pass per sprint.
+
+* Result
+
+Sprint 09's chunk of notebook content landed.

--- a/doc/v2/versions/v0/sprint_10/codegen_infrastructure/story.org
+++ b/doc/v2/versions/v0/sprint_10/codegen_infrastructure/story.org
@@ -1,0 +1,63 @@
+:PROPERTIES:
+:ID: 49a3b815-b5e9-4b3d-9213-100bf96c266d
+:END:
+#+title: Codegen infrastructure
+#+description: Stand up a simple in-tree code generator; cover domain-types SQL; auto-generate the ER diagram from SQL.
+#+type: story
+#+level: s2
+#+filetags: :codegen:sql:er_diagram:plantuml:sprint_10:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:4bac3b0f-819f-43f3-8a59-2b48abe56938][Sprint 10]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-24]
+:END:
+
+** Now
+Completed 2026-01-24.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-24
+
+* Goal
+
+Stand up a simple in-tree code generator and use it on the two
+highest-leverage workloads: domain-types SQL, and the ER diagram
+(which had been drifting against the schema).
+
+* Acceptance
+
+- Simple codegen infrastructure in place; templates + runner pattern.
+- Domain-types SQL emitted from codegen.
+- ER diagram generated from the SQL schema with convention validation.
+
+* Tasks
+
+In execution order:
+
+- [[id:c6879b22-210b-43b3-8463-c84d44105c93][Create a simple code generator]]
+- [[id:8d7be70d-aeef-443e-8a8e-4f078feff833][Add code generation support for domain types SQL]]
+- [[id:3b04427d-b956-4bd0-97e8-b68f445bd5ae][Code-generate ER diagram from SQL]]
+
+* Decisions
+
+- /Codegen pays back tokens/ :: the immediate motivator was the Claude Code token ceiling; the long-run motivator is that generated artefacts can't drift.
+- /ER diagram as derived artefact/ :: a Python parser + Mustache template + validation engine is cheap insurance against schema drift; the validator caught real issues immediately.
+
+* Out of scope
+
+- C++ domain-types codegen — covered in a later sprint.
+
+* See also
+
+- [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] — the component this story extends.

--- a/doc/v2/versions/v0/sprint_10/codegen_infrastructure/task_code_generate_er_diagram.org
+++ b/doc/v2/versions/v0/sprint_10/codegen_infrastructure/task_code_generate_er_diagram.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 3b04427d-b956-4bd0-97e8-b68f445bd5ae
+:END:
+#+title: Code-generate ER diagram from SQL
+#+description: Python SQL parser produces PlantUML ER diagrams; convention-validation engine; Mustache template; orchestration script.
+#+type: task
+#+level: s1
+#+filetags: :codegen:er_diagram:plantuml:python:codegen_infrastructure:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:49a3b815-b5e9-4b3d-9213-100bf96c266d][Codegen infrastructure]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-24]
+:END:
+
+** Now
+Completed 2026-01-24.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-24
+
+* Goal
+
+Generate the PlantUML ER diagram directly from the SQL schema so it can't drift out of date.
+
+* Acceptance
+
+- Python SQL parser (=plantuml_er_parse_sql.py=) extracts tables, columns, PKs, unique indexes, FKs.
+- Tables auto-classified as =temporal=, =junction=, or =artefact= and stereotyped.
+- Convention validation: naming, temporal-table shape, drop-script completeness, file organisation (strict-mode option).
+- Mustache template (=plantuml_er.mustache=) renders the diagram.
+- Shell orchestration: =plantuml_er_generate.sh= + =validate_schema.sh=.
+- 22 existing SQL tables annotated with descriptions for diagram context.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+The convention-validation engine fell out of the parser for free; cheap insurance against schema drift.
+
+* Result
+
+ER diagram is now a derived artefact, not a manually-edited one.

--- a/doc/v2/versions/v0/sprint_10/codegen_infrastructure/task_codegen_domain_types_sql.org
+++ b/doc/v2/versions/v0/sprint_10/codegen_infrastructure/task_codegen_domain_types_sql.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 8d7be70d-aeef-443e-8a8e-4f078feff833
+:END:
+#+title: Add code generation support for domain types SQL
+#+description: Generate the SQL for domain types from the central model rather than hand-writing them.
+#+type: task
+#+level: s1
+#+filetags: :codegen:sql:domain_types:codegen_infrastructure:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:49a3b815-b5e9-4b3d-9213-100bf96c266d][Codegen infrastructure]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-22]
+:END:
+
+** Now
+Completed 2026-01-22.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-22
+
+* Goal
+
+Use the new codegen to emit the SQL for domain types from the central model rather than hand-writing each table.
+
+* Acceptance
+
+- SQL for domain types comes out of codegen.
+- Output respects the =<component>_<entity>_<suffix>= convention.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+First real workload for the simple-code-generator; pays back with every new domain type.
+
+* Result
+
+Domain-type SQL is generated.

--- a/doc/v2/versions/v0/sprint_10/codegen_infrastructure/task_create_simple_code_generator.org
+++ b/doc/v2/versions/v0/sprint_10/codegen_infrastructure/task_create_simple_code_generator.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: c6879b22-210b-43b3-8463-c84d44105c93
+:END:
+#+title: Create a simple code generator
+#+description: Stand up basic codegen infrastructure to save Claude Code tokens; generate scaffolds locally and use Claude only to fix issues.
+#+type: task
+#+level: s1
+#+filetags: :codegen:infrastructure:llm:codegen_infrastructure:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:49a3b815-b5e9-4b3d-9213-100bf96c266d][Codegen infrastructure]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-21]
+:END:
+
+** Now
+Completed 2026-01-21.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-21
+
+* Goal
+
+Stand up basic codegen infrastructure so the project stops burning Claude Code tokens on scaffold-only work.
+
+* Acceptance
+
+- Codegen scaffolds the boilerplate; Claude is used only for the fix-up.
+- Reusable template + runner pattern in place.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Driven by the Claude Code token budget — the project hit the limit often enough to make the codegen pay off.
+
+* Result
+
+Codegen infra in place; subsequent codegen tasks build on it.

--- a/doc/v2/versions/v0/sprint_10/compute_grid_analysis/story.org
+++ b/doc/v2/versions/v0/sprint_10/compute_grid_analysis/story.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 85f8dc6c-1acd-4610-a877-b0fdba871254
+:END:
+#+title: Compute grid analysis (BOINC-based)
+#+description: First-pass design for a BOINC-style distributed compute grid using Postgres + PGMQ + TimescaleDB.
+#+type: story
+#+level: s2
+#+filetags: :compute:distributed:boinc:analysis:sprint_10:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:4bac3b0f-819f-43f3-8a59-2b48abe56938][Sprint 10]].
+
+* BACKLOG Status
+
+** Now
+Postponed in sprint 10; carried forward.
+
+** Waiting on
+A sprint with the slot.
+
+** Next
+Return alongside the related work.
+
+** Last touched
+2026-01-27
+
+* Goal
+
+First-pass design for a BOINC-style distributed compute grid for
+running ORE / ledger / LLM workloads across multiple locations.
+
+* Acceptance
+
+- BOINC lexicon mapped to our domain.
+- Postgres state-machine entities sketched.
+- PGMQ for hot dispatch; TimescaleDB for telemetry.
+- Constraints documented.
+
+* Tasks
+
+In execution order:
+
+- [[id:3e644071-c68b-4a54-9623-87e09bd81d73][BOINC-based compute grid analysis]]
+
+* Decisions
+
+- /Postgres as the central state machine/ :: we already operate Postgres heavily; one fewer system to learn.
+- /Postgres BYTEA for input/output bundles/ :: sub-optimal but sufficient until we hit resource issues.
+
+* Out of scope
+
+- Actually implementing the compute grid — analysis only.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_10/compute_grid_analysis/task_boinc_compute_analysis.org
+++ b/doc/v2/versions/v0/sprint_10/compute_grid_analysis/task_boinc_compute_analysis.org
@@ -1,0 +1,54 @@
+:PROPERTIES:
+:ID: 3e644071-c68b-4a54-9623-87e09bd81d73
+:END:
+#+title: BOINC-based compute grid analysis
+#+description: Design pass for a distributed compute grid: Postgres as central state machine, PGMQ for hot dispatch, TimescaleDB for telemetry. Entities sketched: hosts, apps + app_versions, workunits, results, batches + batch_dependencies, assimilated_data (hypertable).
+#+type: task
+#+level: s1
+#+filetags: :compute:boinc:analysis:postgres:pgmq:compute_grid_analysis:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:85f8dc6c-1acd-4610-a877-b0fdba871254][Compute grid analysis (BOINC-based)]].
+
+* BACKLOG Status
+
+** Now
+POSTPONED in sprint 10; carried forward.
+
+** Waiting on
+A sprint with the slot to land it.
+
+** Next
+Return to this once a sprint has the budget.
+
+** Last touched
+2026-01-27
+
+* Goal
+
+First-pass design for a BOINC-style distributed compute grid: Postgres central state machine, PGMQ hot dispatch, TimescaleDB telemetry.
+
+* Acceptance
+
+- BOINC lexicon mapped to our domain: Host, Wrapper, App Executable, Workunit, Result, Batch.
+- Postgres entities sketched: =hosts=, =apps=, =app_versions=, =workunits=, =results=, =batches=, =batch_dependencies=, =assimilated_data= hypertable.
+- Constraints captured (Result/output_uri invariant, batch_state derivation, side-by-side app versions).
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+POSTPONED in v0: strategic / S4 analysis; no implementation work this sprint.
+
+* Result
+
+Design document only; implementation deferred.

--- a/doc/v2/versions/v0/sprint_10/dataset_bundles_and_provisioning/story.org
+++ b/doc/v2/versions/v0/sprint_10/dataset_bundles_and_provisioning/story.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: 2d3d3854-748e-4df7-8bbe-e6498c598c2d
+:END:
+#+title: Dataset bundles and provisioning
+#+description: Separate catalog metadata from production data; introduce dataset bundles; add the System Provisioner Wizard in Qt.
+#+type: story
+#+level: s2
+#+filetags: :dq:bundles:provisioning:wizard:qt:sprint_10:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:4bac3b0f-819f-43f3-8a59-2b48abe56938][Sprint 10]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-27]
+:END:
+
+** Now
+Completed 2026-01-27.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-27
+
+* Goal
+
+Make /spin up a fresh ORE Studio/ a one-click experience. Split the
+schema so catalog metadata can exist before provisioning; introduce
+bundles; build the wizard.
+
+* Acceptance
+
+- metadata vs production schema split lands cleanly.
+- Bundles defined with members + audit trail + lifecycle functions.
+- System Provisioner Wizard guides the user end-to-end.
+- Bootstrap mode atomic via =create_initial_admin_request=.
+
+* Tasks
+
+In execution order:
+
+- [[id:1b78d767-89d3-4646-93db-c8297a66b093][Separate catalog metadata schema from production data]]
+- [[id:03c2977e-ca76-43a1-9cf6-46a5648be40a][Add dataset bundles]]
+- [[id:8aa7657f-a37f-4ab7-85f0-95868cdfd8f3][Add System Provisioner Wizard to Qt]]
+
+* Decisions
+
+- /Schema split, not separate database/ :: lighter operational footprint and the data flow remains unidirectional.
+- /Layer-aligned wizard pages/ :: matches how the population scripts are layered after the schema-polish work.
+- /Localhost-only bootstrap endpoint/ :: lets the wizard work over the network without exposing a remote-bootstrap attack surface.
+
+* Out of scope
+
+- Multi-tenant provisioning — single-tenant first.
+- Migrate between bundle sets in the same database.
+
+* See also
+
+- [[id:5bafbeb2-c875-4655-bb78-801a3bf65022][Schema polish]] — the layer cleanup the wizard consumes.

--- a/doc/v2/versions/v0/sprint_10/dataset_bundles_and_provisioning/task_add_dataset_bundles.org
+++ b/doc/v2/versions/v0/sprint_10/dataset_bundles_and_provisioning/task_add_dataset_bundles.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 03c2977e-ca76-43a1-9cf6-46a5648be40a
+:END:
+#+title: Add dataset bundles
+#+description: dq_dataset_bundles_tbl + bundle_members + bundle_publications audit; PL/pgSQL: dq_list_bundles_fn, dq_list_bundle_datasets_fn, dq_preview_bundle_publication_fn, dq_populate_bundle_fn, dq_get_bundle_publication_history_fn; seed solvaris / base / crypto bundles.
+#+type: task
+#+level: s1
+#+filetags: :dq:bundles:sql:publication:dataset_bundles_and_provisioning:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:2d3d3854-748e-4df7-8bbe-e6498c598c2d][Dataset bundles and provisioning]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-27]
+:END:
+
+** Now
+Completed 2026-01-27.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-27
+
+* Goal
+
+Group datasets into named bundles so the system can be brought into a coherent state in one step.
+
+* Acceptance
+
+- Tables: =dq_dataset_bundles_tbl=, =dq_dataset_bundle_members_tbl=, =dq_bundle_publications_tbl=.
+- Functions: =dq_list_bundles_fn=, =dq_list_bundle_datasets_fn=, =dq_preview_bundle_publication_fn=, =dq_populate_bundle_fn=, =dq_get_bundle_publication_history_fn=.
+- =dq_populate_bundle_fn= orchestrates member publication in display order, respecting dependencies.
+- =upsert_dq_dataset_bundle= + =upsert_dq_dataset_bundle_member= for idempotent seeding.
+- Seed bundles: =solvaris=, =base=, =crypto=.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Pairs with the wizard: each layer offers a list of bundles, then the wizard publishes them.
+
+* Result
+
+Bundles in place; ready for the wizard.

--- a/doc/v2/versions/v0/sprint_10/dataset_bundles_and_provisioning/task_separate_catalog_metadata_schema.org
+++ b/doc/v2/versions/v0/sprint_10/dataset_bundles_and_provisioning/task_separate_catalog_metadata_schema.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 1b78d767-89d3-4646-93db-c8297a66b093
+:END:
+#+title: Separate catalog metadata schema from production data
+#+description: Split the monolithic ores schema into metadata (dq_*, change_control) and production (refdata_*, iam_*, assets_*, geo_*, variability_*, telemetry_*); schema-qualified references; ER generator updated; data-flow documented (unidirectional metadata → production).
+#+type: task
+#+level: s1
+#+filetags: :sql:schema:refactor:bootstrap:dataset_bundles_and_provisioning:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:2d3d3854-748e-4df7-8bbe-e6498c598c2d][Dataset bundles and provisioning]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-27]
+:END:
+
+** Now
+Completed 2026-01-27.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-27
+
+* Goal
+
+Split the monolithic =ores= PostgreSQL schema into =metadata=, =production=, and =public= to resolve the bootstrap chicken-and-egg.
+
+* Acceptance
+
+- =metadata= schema: governance + classification + staging (=dq_*=, change_control).
+- =production= schema: operational data (=refdata_*=, =iam_*=, =assets_*=, =geo_*=, =variability_*=, =telemetry_*=).
+- All SQL uses schema-qualified names; cross-schema FK validations work.
+- Population functions correctly reference tables across schemas.
+- ER diagram generator updated for multi-schema.
+- Data-flow documented: unidirectional from metadata → production.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Without this split the bootstrap wizard can't work — catalog definitions have to exist before provisioning fills the production tables.
+
+* Result
+
+Schema split landed; bootstrap paradox resolved.

--- a/doc/v2/versions/v0/sprint_10/dataset_bundles_and_provisioning/task_system_provisioner_wizard.org
+++ b/doc/v2/versions/v0/sprint_10/dataset_bundles_and_provisioning/task_system_provisioner_wizard.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 8aa7657f-a37f-4ab7-85f0-95868cdfd8f3
+:END:
+#+title: Add System Provisioner Wizard to Qt
+#+description: Multi-page wizard: admin account, foundation bundle, data-governance bundle, data-catalogues bundle, provisioning execution; replaces the shell-only bootstrap; localhost-only create_initial_admin_request atomically creates admin + exits bootstrap mode.
+#+type: task
+#+level: s1
+#+filetags: :qt:bootstrap:wizard:provisioning:dataset_bundles_and_provisioning:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:2d3d3854-748e-4df7-8bbe-e6498c598c2d][Dataset bundles and provisioning]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-27]
+:END:
+
+** Now
+Completed 2026-01-27.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-27
+
+* Goal
+
+Replace the shell-only bootstrap with a guided Qt wizard.
+
+* Acceptance
+
+- Multi-page wizard: =AdminAccountPage=, =FoundationLayerPage=, =DataGovernanceLayerPage=, =DataCataloguesLayerPage=, =ProvisioningPage=.
+- Bootstrap-mode detection: LoginDialog emits signal; MainWindow shows the wizard instead.
+- =create_initial_admin_request= localhost-only (127.0.0.1 / ::1); atomically creates admin and exits bootstrap mode.
+- Bundle selection per layer; mandatory vs optional flagged in the UI.
+- Per-layer progress + logging on the final page.
+- First-time only — not re-runnable.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Subsumes the older /Add screen in qt to exit bootstrap mode/ idea — the wizard is the screen.
+
+* Result
+
+Bootstrap is now a guided UI flow.

--- a/doc/v2/versions/v0/sprint_10/external_data_reorganisation/story.org
+++ b/doc/v2/versions/v0/sprint_10/external_data_reorganisation/story.org
@@ -1,0 +1,63 @@
+:PROPERTIES:
+:ID: ebc22454-356d-4b6c-a3be-e8edfd858fca
+:END:
+#+title: External data reorganisation
+#+description: Consolidate external/ + populate/ into domain-specific subdirectories with manifests; route ISO + FpML coding schemes through the DQ artefact pipeline.
+#+type: story
+#+level: s2
+#+filetags: :data:external:manifests:coding_schemes:sprint_10:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:4bac3b0f-819f-43f3-8a59-2b48abe56938][Sprint 10]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-24]
+:END:
+
+** Now
+Completed 2026-01-24.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-24
+
+* Goal
+
+Get the project's external data into a tidy, provenanced home and
+route coding schemes through the DQ artefact pipeline like every
+other dataset.
+
+* Acceptance
+
+- External data physically under =external/= with methodology docs.
+- populate/ split into domain-specific subdirectories with manifests.
+- Code generators for flags / crypto / solvaris metadata SQL.
+- ISO + FpML coding schemes flow through the DQ artefact pipeline (party schemes excepted).
+
+* Tasks
+
+In execution order:
+
+- [[id:3038f1e7-97b6-4b5b-bda0-50fcb71c0810][Tidy up external data storage]]
+- [[id:43667103-8a31-45f3-b1fa-b18af8297256][Move coding schemes through DQ artefact pipeline]]
+
+* Decisions
+
+- /Manifest.json per domain/ :: provenance is grep-able.
+- /Party schemes stay direct-insert/ :: small, manually-defined, and they don't benefit from the artefact-pipeline overhead.
+
+* Out of scope
+
+- Live vendor integrations — out of scope.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_10/external_data_reorganisation/task_coding_schemes_via_dq_pipeline.org
+++ b/doc/v2/versions/v0/sprint_10/external_data_reorganisation/task_coding_schemes_via_dq_pipeline.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 43667103-8a31-45f3-b1fa-b18af8297256
+:END:
+#+title: Move coding schemes through DQ artefact pipeline
+#+description: ISO + FpML coding schemes now flow through dq_coding_schemes_artefact_tbl with preview / upsert / insert_only / replace_all modes; party schemes (LEI, BIC, MIC) remain direct inserts.
+#+type: task
+#+level: s1
+#+filetags: :dq:coding_schemes:artefact:pipeline:external_data_reorganisation:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:ebc22454-356d-4b6c-a3be-e8edfd858fca][External data reorganisation]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-24]
+:END:
+
+** Now
+Completed 2026-01-24.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-24
+
+* Goal
+
+Route ISO + FpML coding schemes through the DQ artefact pipeline rather than direct database inserts.
+
+* Acceptance
+
+- =dq_coding_schemes_artefact_tbl= staging table.
+- =dq_preview_coding_scheme_population()= + =dq_populate_coding_schemes()=.
+- Preview / upsert / insert_only / replace_all modes supported.
+- Codegen for ISO + FpML coding schemes emits artefact inserts.
+- ISO countries + currencies depend on =iso.coding_schemes= dataset (correct ordering).
+- Party schemes (LEI, BIC, MIC) remain direct inserts (small, manually defined).
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Consistency win: the same governance rules apply to coding schemes that already apply to every other dataset.
+
+* Result
+
+Coding schemes governed through DQ.

--- a/doc/v2/versions/v0/sprint_10/external_data_reorganisation/task_tidy_external_data_storage.org
+++ b/doc/v2/versions/v0/sprint_10/external_data_reorganisation/task_tidy_external_data_storage.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 3038f1e7-97b6-4b5b-bda0-50fcb71c0810
+:END:
+#+title: Tidy up external data storage
+#+description: Restructure populate/ into domain-specific subdirectories (fpml/, crypto/, flags/, solvaris/); manifest.json files; code generators for flags/crypto/solvaris; relocate external data to external/.
+#+type: task
+#+level: s1
+#+filetags: :data:external:manifests:structure:external_data_reorganisation:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:ebc22454-356d-4b6c-a3be-e8edfd858fca][External data reorganisation]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-23]
+:END:
+
+** Now
+Completed 2026-01-23.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-23
+
+* Goal
+
+Consolidate the scattered external data under =external/= and reorganise =populate/= into domain-specific subdirectories with manifests.
+
+* Acceptance
+
+- =populate/= split into =fpml/=, =crypto/=, =flags/=, =solvaris/=.
+- =manifest.json= per domain (external sources tracked, internal sources tracked).
+- Dedicated code generators for flags / crypto / solvaris metadata SQL.
+- External data physically moved to =external/= with methodology docs.
+- Master include files: =fpml.sql=, =crypto.sql=, =flags.sql=, =solvaris.sql=.
+- Population ordering fixes (dataset dependency resolution).
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Provenance becomes greppable: every chunk of external data has a manifest naming its source.
+
+* Result
+
+External data is organised + tracked; populate scripts modular.

--- a/doc/v2/versions/v0/sprint_10/fpml_export_import_groundwork/story.org
+++ b/doc/v2/versions/v0/sprint_10/fpml_export_import_groundwork/story.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: 4c7782d0-1382-4fed-a9f3-c209a45caf7e
+:END:
+#+title: FPML export and import groundwork
+#+description: ores.fpml component scaffolded for future FPML export/import; full implementation deferred.
+#+type: story
+#+level: s2
+#+filetags: :fpml:component:export_import:sprint_10:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:4bac3b0f-819f-43f3-8a59-2b48abe56938][Sprint 10]].
+
+* BACKLOG Status
+
+** Now
+Postponed in sprint 10; carried forward.
+
+** Waiting on
+A sprint with the slot.
+
+** Next
+Return alongside the related work.
+
+** Last touched
+2026-01-27
+
+* Goal
+
+Scaffold =ores.fpml= as the home for FPML common infrastructure.
+Full export/import implementation is postponed.
+
+* Acceptance
+
+- =ores.fpml= component scaffolded.
+- Reporting view downloaded and configured.
+- Schema repository pattern in place.
+- Partial-validation wrapper documented.
+
+* Tasks
+
+In execution order:
+
+- [[id:b7c0605a-7b13-440b-8099-e628ff5bb0e9][Create ores.fpml component]]
+
+* Decisions
+
+- /Component first, implementation later/ :: lets the next sprint pick up where this one left off without a setup step.
+
+* Out of scope
+
+- Actual FPML export and import — postponed.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_10/fpml_export_import_groundwork/task_create_fpml_component.org
+++ b/doc/v2/versions/v0/sprint_10/fpml_export_import_groundwork/task_create_fpml_component.org
@@ -1,0 +1,55 @@
+:PROPERTIES:
+:ID: b7c0605a-7b13-440b-8099-e628ff5bb0e9
+:END:
+#+title: Create ores.fpml component
+#+description: Scaffold the ores.fpml component to host shared FPML infrastructure (XSD validation via libxml2, reporting-view schema set, partial-validation wrappers); export and import implementations carry forward to a later sprint.
+#+type: task
+#+level: s1
+#+filetags: :fpml:component:xml:validation:fpml_export_import_groundwork:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:4c7782d0-1382-4fed-a9f3-c209a45caf7e][FPML export and import groundwork]].
+
+* BACKLOG Status
+
+** Now
+POSTPONED in sprint 10; carried forward.
+
+** Waiting on
+A sprint with the slot to land it.
+
+** Next
+Return to this once a sprint has the budget.
+
+** Last touched
+2026-01-27
+
+* Goal
+
+Scaffold =ores.fpml= as the home for FPML common infrastructure (XSD validation via libxml2, reporting-view schema set, partial-validation wrappers); export and import implementations carry forward.
+
+* Acceptance
+
+- Component scaffolded: source + tests + modelling + CMake.
+- Reporting view downloaded under =/schemas/fpml-5-11/=.
+- Schema repository pattern in place.
+- Partial-validation wrapper documented.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+POSTPONED in v0: the full export/import work was deferred. The component itself was created as a placeholder.
+
+* Result
+
+Component scaffold present; export/import implementation carried forward.

--- a/doc/v2/versions/v0/sprint_10/image_cache_polish/story.org
+++ b/doc/v2/versions/v0/sprint_10/image_cache_polish/story.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: 2a572d8a-644c-40d9-87d2-7a49a9c07d1b
+:END:
+#+title: Image cache polish
+#+description: Reload on new datasets; incremental loading via =modified_since=.
+#+type: story
+#+level: s2
+#+filetags: :qt:assets:images:protocol:sprint_10:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:4bac3b0f-819f-43f3-8a59-2b48abe56938][Sprint 10]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-23]
+:END:
+
+** Now
+Completed 2026-01-23.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-23
+
+* Goal
+
+Fix the image cache surfaced by DQ publication: it didn't reload on
+new datasets, and a full reload was expensive.
+
+* Acceptance
+
+- Cache reloads on image dataset publication.
+- Reload is incremental via =modified_since=.
+- No UI flashing on reload.
+- Backward-compatible protocol change.
+
+* Tasks
+
+In execution order:
+
+- [[id:8153e98e-839f-4c19-9517-8fd41ac7052b][Image cache reloads on new datasets]]
+- [[id:f8794373-3e9c-4ee2-912a-43f7bf33a446][Incremental image cache loading with modified_since]]
+
+* Decisions
+
+- /=modified_since= as the incremental key/ :: =recorded_at= was already on every image; =modified_since= is the natural pairing.
+- /Optional protocol field, server defaults to all/ :: backward compatible by construction.
+
+* Out of scope
+
+- Generalising the pattern to other caches — handled when the next cache needs it.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_10/image_cache_polish/task_image_cache_reload_on_datasets.org
+++ b/doc/v2/versions/v0/sprint_10/image_cache_polish/task_image_cache_reload_on_datasets.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 8153e98e-839f-4c19-9517-8fd41ac7052b
+:END:
+#+title: Image cache reloads on new datasets
+#+description: When publishing images the image cache must reload; current behaviour leaves it stale.
+#+type: task
+#+level: s1
+#+filetags: :qt:assets:bug_fix:image_cache_polish:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:2a572d8a-644c-40d9-87d2-7a49a9c07d1b][Image cache polish]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-22]
+:END:
+
+** Now
+Completed 2026-01-22.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-22
+
+* Goal
+
+When publishing images via the DQ pipeline, the image cache must reload — the current behaviour leaves it stale.
+
+* Acceptance
+
+- Reload triggered on image dataset publication.
+- Cache reflects the published images immediately.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+First fix; the better incremental-load implementation follows in the next task.
+
+* Result
+
+Cache no longer stale after publishing.

--- a/doc/v2/versions/v0/sprint_10/image_cache_polish/task_incremental_image_cache_modified_since.org
+++ b/doc/v2/versions/v0/sprint_10/image_cache_polish/task_incremental_image_cache_modified_since.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: f8794373-3e9c-4ee2-912a-43f7bf33a446
+:END:
+#+title: Incremental image cache loading with modified_since
+#+description: Protocol: add optional modified_since to list_images_request and recorded_at to image_info; client tracks last_load_time and only fetches changed images.
+#+type: task
+#+level: s1
+#+filetags: :qt:assets:protocol:performance:image_cache_polish:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:2a572d8a-644c-40d9-87d2-7a49a9c07d1b][Image cache polish]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-22]
+:END:
+
+** Now
+Completed 2026-01-22.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-22
+
+* Goal
+
+Make the reload incremental — only fetch images modified since the last successful load.
+
+* Acceptance
+
+- Protocol: optional =modified_since= on =list_images_request=; =recorded_at= on =image_info=.
+- Server filters by =recorded_at >= modified_since= when the parameter is set.
+- Client tracks =last_load_time_=; on reload uses it as =modified_since= and doesn't clear cache.
+- Backward compatible: server handles missing =modified_since= (returns all).
+- No UI flashing for unchanged images.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Foundation pattern; the next entity that needs incremental loading uses the same shape.
+
+* Result
+
+Image-cache reload is now incremental.

--- a/doc/v2/versions/v0/sprint_10/librarian_polish/story.org
+++ b/doc/v2/versions/v0/sprint_10/librarian_polish/story.org
@@ -1,0 +1,68 @@
+:PROPERTIES:
+:ID: 75442a55-dbbb-4bc1-875e-981679e05621
+:END:
+#+title: Librarian polish
+#+description: Address PR-review feedback on the Data Librarian landed in sprint 09.
+#+type: story
+#+level: s2
+#+filetags: :librarian:qt:polish:dq:sprint_10:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+#+predecessor: 3579ab5e-d5d8-45ae-8cb5-00ad1c58644f
+
+Parent sprint: [[id:4bac3b0f-819f-43f3-8a59-2b48abe56938][Sprint 10]].
+
+Continued from: [[id:3579ab5e-d5d8-45ae-8cb5-00ad1c58644f][Data Quality subsystem and Data Librarian]] (sprint 09)
+— polishes the librarian based on PR-review feedback from the sprint
+09 work.
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-27]
+:END:
+
+** Now
+Completed 2026-01-27.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-27
+
+* Goal
+
+Address the PR-review feedback on the Data Librarian landed in
+sprint 09. Some of the review work ran out of token budget last
+sprint and was carried into this one.
+
+* Acceptance
+
+- Domain view + edit work.
+- Dimension nodes in the tree as filters.
+- Dependency diagram consumes the new message.
+- Country flags load reliably after restart.
+- Outstanding items raised as follow-up stories.
+
+* Tasks
+
+In execution order:
+
+- [[id:d7653a18-e5b2-4bf4-851d-539f5b827f36][Fix code review comments for librarian]]
+
+* Decisions
+
+- /Raise visual-polish items as follow-ups/ :: header/row colour and the crypto/country flag clash are separately scoped; not worth holding the librarian-polish PR for them.
+
+* Out of scope
+
+- Publish-failure error visibility (raised separately).
+- Crypto-vs-country flag namespace clash (raised separately).
+
+* See also
+
+- [[id:3579ab5e-d5d8-45ae-8cb5-00ad1c58644f][Data Quality subsystem and Data Librarian]] (sprint 09) — predecessor.

--- a/doc/v2/versions/v0/sprint_10/librarian_polish/task_fix_librarian_review_comments.org
+++ b/doc/v2/versions/v0/sprint_10/librarian_polish/task_fix_librarian_review_comments.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: d7653a18-e5b2-4bf4-851d-539f5b827f36
+:END:
+#+title: Fix code review comments for librarian
+#+description: PR review fixes: domain viewing/editing; dimension nodes in the tree as filters; dependency-message diagram check; country flags load after restart; header colour vs row colour; namespace crypto icons vs country flags (AE clash); publish-failure error visibility (raised as separate story).
+#+type: task
+#+level: s1
+#+filetags: :librarian:qt:review:polish:librarian_polish:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:75442a55-dbbb-4bc1-875e-981679e05621][Librarian polish]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-27]
+:END:
+
+** Now
+Completed 2026-01-27.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-27
+
+* Goal
+
+Address the PR-review feedback on the Data Librarian landed in sprint 09.
+
+* Acceptance
+
+- Domain view + edit work.
+- Tree exposes dimension nodes as filters.
+- Dependency diagram consumes the new message.
+- Country-flag mapping loads correctly after restart (force-load on first use).
+- Header colour distinct from row colour (raised as follow-up).
+- Publish-failure errors visible (raised as follow-up story).
+- Crypto vs country flag namespace clash (e.g. =AE=) raised.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Some review items raised in PR #348 ran out of Claude Code token budget; this task closes most of them, raises follow-ups for the rest.
+
+* Result
+
+Most review feedback addressed; the rest carry forward as named stories.

--- a/doc/v2/versions/v0/sprint_10/ore_xml_codegen/story.org
+++ b/doc/v2/versions/v0/sprint_10/ore_xml_codegen/story.org
@@ -1,0 +1,68 @@
+:PROPERTIES:
+:ID: a1571428-c1bd-4fd1-9434-21ce5b1a6154
+:END:
+#+title: ORE XML codegen
+#+description: New ores.ore component; generate C++ for ORE via xsdcpp; round-trip tests; Windows MSVC build fix.
+#+type: story
+#+level: s2
+#+filetags: :ore:xml:xsdcpp:codegen:windows:sprint_10:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:4bac3b0f-819f-43f3-8a59-2b48abe56938][Sprint 10]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-27]
+:END:
+
+** Now
+Completed 2026-01-27.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-27
+
+* Goal
+
+Add a dedicated =ores.ore= component and generate the C++ for ORE
+XML configuration via xsdcpp, with the fixes needed to make real ORE
+samples round-trip.
+
+* Acceptance
+
+- =ores.ore= component present.
+- xsdcpp integrated; manually-written types replaced.
+- xs:group ref expansion + xs:choice maxOccurs unbounded handled.
+- XML round-trip tests against real ORE sample files.
+- Windows MSVC build green (/bigobj).
+
+* Tasks
+
+In execution order:
+
+- [[id:27b76a70-df1d-4c66-89a9-fba3cb801353][Add ores.ore component for import/export]]
+- [[id:2a497ceb-40e2-47ad-8cf5-cfb40226dfbd][Generate C++ code for ORE via xsdcpp]]
+- [[id:755c3e7e-372b-4014-8698-41f6404255f2][Fix issues with xsdcpp when generating ORE code]]
+- [[id:9c3c142a-92b0-4771-9bb5-725e62a9b870][Fix Windows CI break due to XSD codegen]]
+
+* Decisions
+
+- /xsdcpp over codesynthesis/ :: vcpkg availability tips the balance; codesynthesis would have introduced a runtime library we don't want.
+- /Round-trip tests as the regression net/ :: cheap to author, catches both schema and generator regressions.
+- /Document remaining gaps explicitly/ :: =ore_xsd_schema_gaps.md= becomes the work list rather than leaving the gaps invisible.
+
+* Out of scope
+
+- FPML XSD codegen — separate story.
+- Streaming XML parser support.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_10/ore_xml_codegen/task_add_ore_component.org
+++ b/doc/v2/versions/v0/sprint_10/ore_xml_codegen/task_add_ore_component.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: 27b76a70-df1d-4c66-89a9-fba3cb801353
+:END:
+#+title: Add ores.ore component for import/export
+#+description: Dedicated component for ORE (Open Source Risk Engine) import/export work; directory + CMake + stubs + arch docs updated.
+#+type: task
+#+level: s1
+#+filetags: :ore:component:import_export:ore_xml_codegen:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:a1571428-c1bd-4fd1-9434-21ce5b1a6154][ORE XML codegen]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-25]
+:END:
+
+** Now
+Completed 2026-01-25.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-25
+
+* Goal
+
+Add a dedicated =ores.ore= component to host ORE (Open Source Risk Engine) import + export work.
+
+* Acceptance
+
+- Component scaffolded: directory + CMake + modeling + test stubs.
+- Build green from the start.
+- System architecture diagrams updated.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+FPML analysis found that import/export code scattered across components; concentrating it here makes the boundaries cleaner.
+
+* Result
+
+Component in place, ready for the xsdcpp work.

--- a/doc/v2/versions/v0/sprint_10/ore_xml_codegen/task_fix_windows_ci_xsd.org
+++ b/doc/v2/versions/v0/sprint_10/ore_xml_codegen/task_fix_windows_ci_xsd.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 9c3c142a-92b0-4771-9bb5-725e62a9b870
+:END:
+#+title: Fix Windows CI break due to XSD codegen
+#+description: MSVC C1128 on domain_xsd.hpp; add /bigobj to the ores.ore target for MSVC builds.
+#+type: task
+#+level: s1
+#+filetags: :ore:windows:msvc:bug_fix:ore_xml_codegen:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:a1571428-c1bd-4fd1-9434-21ce5b1a6154][ORE XML codegen]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-26]
+:END:
+
+** Now
+Completed 2026-01-26.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-26
+
+* Goal
+
+Resolve the MSVC C1128 break on =domain_xsd.hpp= introduced by the larger generated object files.
+
+* Acceptance
+
+- =/bigobj= added to the =ores.ore= target for MSVC builds.
+- Windows CI green.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Predictable consequence of XSD-generated code being template-heavy on Windows.
+
+* Result
+
+Windows CI green again.

--- a/doc/v2/versions/v0/sprint_10/ore_xml_codegen/task_fix_xsdcpp_issues.org
+++ b/doc/v2/versions/v0/sprint_10/ore_xml_codegen/task_fix_xsdcpp_issues.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 755c3e7e-372b-4014-8698-41f6404255f2
+:END:
+#+title: Fix issues with xsdcpp when generating ORE code
+#+description: xs:group ref expansion (trade data types: SwapData, FxForwardData); xs:choice maxOccurs='unbounded' → xsd::vector<T> (LGM in InterestRateModels); domain regenerated; XML round-trip tests; ore_xsd_schema_gaps.md analysis.
+#+type: task
+#+level: s1
+#+filetags: :ore:xsdcpp:bug_fix:xml:ore_xml_codegen:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:a1571428-c1bd-4fd1-9434-21ce5b1a6154][ORE XML codegen]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-27]
+:END:
+
+** Now
+Completed 2026-01-27.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-27
+
+* Goal
+
+Address the xsdcpp limitations that block parsing real ORE XML samples.
+
+* Acceptance
+
+- =xs:group ref= expansion (trade data types: =SwapData=, =FxForwardData=).
+- =xs:choice= with =maxOccurs='unbounded'= → =xsd::vector<T>= (LGM cardinality in =InterestRateModels=).
+- Domain regenerated: =domain.hpp= (+10,752), =domain.cpp= (+17,459).
+- XML round-trip tests for currency, conventions, curveconfiguration, todaysmarket, pricingengines, simulation, portfolio.
+- =doc/analysis/ore_xsd_schema_gaps.md= captures the residual gaps (e.g. =NettingSetId= substitution group).
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Upstream issue: =github.com/craflin/xsdcpp/issues/11= filed for the ORE schema.
+
+* Result
+
+Real ORE samples now round-trip through the generated code (modulo the still-documented gaps).

--- a/doc/v2/versions/v0/sprint_10/ore_xml_codegen/task_generate_cpp_for_ore.org
+++ b/doc/v2/versions/v0/sprint_10/ore_xml_codegen/task_generate_cpp_for_ore.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 2a497ceb-40e2-47ad-8cf5-cfb40226dfbd
+:END:
+#+title: Generate C++ code for ORE via xsdcpp
+#+description: xsdcpp integrated; manually-crafted CurrencyConfig/CurrencyElement replaced by generated types; artefact_type domain centralises target_table + populate_function lookup; dq_populate_*_fn naming convention enforced; currency rounding-type values corrected.
+#+type: task
+#+level: s1
+#+filetags: :ore:xsdcpp:codegen:xml:ore_xml_codegen:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:a1571428-c1bd-4fd1-9434-21ce5b1a6154][ORE XML codegen]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-25]
+:END:
+
+** Now
+Completed 2026-01-25.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-25
+
+* Goal
+
+Generate C++ types for ORE XML configuration via xsdcpp; centralise publication metadata via an =artefact_type= domain.
+
+* Acceptance
+
+- xsdcpp integrated into the build.
+- Manually-written =CurrencyConfig= / =CurrencyElement= replaced by generated =currencyConfig= / =currencyDefinition=.
+- =artefact_type= domain centralises =target_table= + =populate_function= lookup (removed from =dataset=).
+- =dq_populate_*_fn= naming convention enforced across the SQL functions.
+- Currency rounding-type values corrected: =standard=/=swedish= → =Closest=, =none= → =Down=.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+xsdcpp evaluation: =codesynthesis xsd/xsde= work but need their library at runtime and aren't in vcpkg; xsdcpp wins.
+
+* Result
+
+ORE C++ types now generated; manual-craft path retired.

--- a/doc/v2/versions/v0/sprint_10/party_schemes_and_fpml_data/story.org
+++ b/doc/v2/versions/v0/sprint_10/party_schemes_and_fpml_data/story.org
@@ -1,0 +1,69 @@
+:PROPERTIES:
+:ID: 700d4325-2ad1-4e0d-b6af-900abbe1a66e
+:END:
+#+title: Party schemes and FPML reference data
+#+description: Implement the 13 party-related reference-data types via FPML codegen + DQ artefact workflow; ingest GLEIF subset.
+#+type: story
+#+level: s2
+#+filetags: :party:fpml:refdata:codegen:gleif:sprint_10:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+#+predecessor: ef555d10-3fd3-4928-8e43-e63284d7706f
+
+Parent sprint: [[id:4bac3b0f-819f-43f3-8a59-2b48abe56938][Sprint 10]].
+
+Continued from: [[id:ef555d10-3fd3-4928-8e43-e63284d7706f][Party database groundwork]] (sprint 09) — that story
+documented the party table; this one lands the 13 reference-data
+types needed before party can be implemented.
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-23]
+:END:
+
+** Now
+Completed 2026-01-23.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-23
+
+* Goal
+
+Implement the 13 reference-data types party requires before its
+domain layer can land. Drive the work from FpML XML through codegen
+and the DQ artefact workflow.
+
+* Acceptance
+
+- Party-identifier schemes catalogued.
+- 13 reference-data types implemented end-to-end via FpML codegen + DQ artefact workflow.
+- GLEIF Golden Copy subset available for development.
+- Business centres linked to country flags for visual identity.
+
+* Tasks
+
+In execution order:
+
+- [[id:53b62f83-fb48-42ed-aa25-851259b0341c][Party identifier scheme analysis]]
+- [[id:99881550-e3d4-4692-a07d-a63ef5e2fd03][Implement party-related schemes via FPML codegen]]
+- [[id:c4a49d31-7c01-477f-b988-63ada3be4c64][Download and split GLEIF data]]
+
+* Decisions
+
+- /Drive from FpML XML/ :: hand-writing 13 reference tables wasn't realistic in one sprint; codegen makes it tractable.
+- /Per-entity SQL files, not concatenated/ :: improves modularity and matches the prefix-naming convention.
+
+* Out of scope
+
+- Party domain layer itself — this story unblocks it but doesn't implement it.
+
+* See also
+
+- [[id:ef555d10-3fd3-4928-8e43-e63284d7706f][Party database groundwork]] (sprint 09) — predecessor (party table structure).

--- a/doc/v2/versions/v0/sprint_10/party_schemes_and_fpml_data/task_download_split_gleif_data.org
+++ b/doc/v2/versions/v0/sprint_10/party_schemes_and_fpml_data/task_download_split_gleif_data.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: c4a49d31-7c01-477f-b988-63ada3be4c64
+:END:
+#+title: Download and split GLEIF data
+#+description: Script to fetch the GLEIF Golden Copy and produce a representative subset for development use.
+#+type: task
+#+level: s1
+#+filetags: :party:gleif:data:scripts:party_schemes_and_fpml_data:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:700d4325-2ad1-4e0d-b6af-900abbe1a66e][Party schemes and FPML reference data]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-23]
+:END:
+
+** Now
+Completed 2026-01-23.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-23
+
+* Goal
+
+Script the download + split of the GLEIF Golden Copy so we have a representative LEI dataset for development.
+
+* Acceptance
+
+- Script fetches the GLEIF Golden Copy.
+- Produces a representative subset (the full dataset is too large for dev use).
+- Documented and runnable from =external/=.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Foundation for populating party tables with realistic LEI data.
+
+* Result
+
+GLEIF subset available for dev.

--- a/doc/v2/versions/v0/sprint_10/party_schemes_and_fpml_data/task_implement_party_related_schemes.org
+++ b/doc/v2/versions/v0/sprint_10/party_schemes_and_fpml_data/task_implement_party_related_schemes.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 99881550-e3d4-4692-a07d-a63ef5e2fd03
+:END:
+#+title: Implement party-related schemes via FPML codegen
+#+description: 13 reference-data types (entity_type, party_role, business_center, person_role, account_types, entity_classifications, local_jurisdictions, party_relationships, regulatory_corporate_sectors, reporting_regimes, supervisory_bodies, etc.); codegen parses FpML XML to SQL; per-entity SQL files; business centres linked to country flags.
+#+type: task
+#+level: s1
+#+filetags: :party:fpml:refdata:codegen:party_schemes_and_fpml_data:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:700d4325-2ad1-4e0d-b6af-900abbe1a66e][Party schemes and FPML reference data]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-22]
+:END:
+
+** Now
+Completed 2026-01-22.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-22
+
+* Goal
+
+Implement the 13 reference-data types party requires, end-to-end, via FpML codegen and the DQ artefact workflow.
+
+* Acceptance
+
+- DQ artefact workflow covers 15 FpML entity types across 18 datasets.
+- Automated SQL schema generation: bi-temporal tables, notification triggers, artefact staging tables.
+- Business centres linked to country flags for visual identity.
+- SQL generation produces per-entity files (not concatenated scripts).
+- Dataset records carry =target_table= + =populate_function= directly (consumed later by the artefact_type domain).
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+The /codegen reads FpML XML/ part is the load-bearing piece — it's what makes the 13-types-in-one-PR scale work.
+
+* Result
+
+Party reference-data layer present; party domain layer unblocked.

--- a/doc/v2/versions/v0/sprint_10/party_schemes_and_fpml_data/task_party_identifier_scheme_analysis.org
+++ b/doc/v2/versions/v0/sprint_10/party_schemes_and_fpml_data/task_party_identifier_scheme_analysis.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: 53b62f83-fb48-42ed-aa25-851259b0341c
+:END:
+#+title: Party identifier scheme analysis
+#+description: Analysis pass: catalogue the party identifier schemes we need (LEI, BIC, MIC, CEDB, Natural Person, National ID, Internal, ACER, DTCC, AII/MPID).
+#+type: task
+#+level: s1
+#+filetags: :party:analysis:fpml:schemes:party_schemes_and_fpml_data:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:700d4325-2ad1-4e0d-b6af-900abbe1a66e][Party schemes and FPML reference data]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-21]
+:END:
+
+** Now
+Completed 2026-01-21.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-21
+
+* Goal
+
+Catalogue the party-identifier schemes the system needs to support before party can be modelled.
+
+* Acceptance
+
+- LEI, BIC, MIC, CEDB, Natural Person, National ID, Internal, ACER Code, DTCC Participant ID, AII/MPID documented.
+- FpML scheme URIs captured for each.
+- Regulatory context (MiFID II, REMIT, FINRA, US clearing) noted where relevant.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Pure analysis; the implementation lands in the next task.
+
+* Result
+
+Scheme catalogue complete and ready for codegen.

--- a/doc/v2/versions/v0/sprint_10/schema_polish/story.org
+++ b/doc/v2/versions/v0/sprint_10/schema_polish/story.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: 5bafbeb2-c875-4655-bb78-801a3bf65022
+:END:
+#+title: Schema polish
+#+description: Clean up data-population layers, add rounding type table, add CSV/ORE/FPML labels to icons, add mapping artefact to population functions.
+#+type: story
+#+level: s2
+#+filetags: :sql:schema:polish:refdata:icons:sprint_10:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:4bac3b0f-819f-43f3-8a59-2b48abe56938][Sprint 10]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-26]
+:END:
+
+** Now
+Completed 2026-01-26.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-26
+
+* Goal
+
+Four independent polish strands on the schema and the UI: layer the
+population scripts, add rounding types, label the import/export
+icons, and route the mapping data through the artefact pipeline.
+
+* Acceptance
+
+- Population scripts structured by layer (Foundation / Data Governance / Data Catalogues / Production).
+- Rounding-type table aligned with FpML.
+- Import/export icons carry CSV/ORE/FPML badges.
+- Mapping data routed through artefacts.
+
+* Tasks
+
+In execution order:
+
+- [[id:f2062027-b1fa-4b51-84e8-f589f4e14849][Clean up data layers]]
+- [[id:850e10f2-d84c-4a25-b30b-0328edb33ae8][Add rounding type table]]
+- [[id:47bf0f41-5e6b-4da9-b99d-e73ad80686a5][Add labels (CSV/ORE/FPML) to import/export icons]]
+- [[id:bd7f39d4-46b1-41ce-992b-7feedf0cc59d][Add mapping artefact to population functions]]
+
+* Decisions
+
+- /Layer model first/ :: cleans up population before the wizard consumes it, so the wizard is much simpler.
+- /Track FpML on rounding/ :: avoids translation cost on export.
+
+* Out of scope
+
+- Half-up / banker's rounding — explicitly omitted to stay FpML-aligned.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_10/schema_polish/task_add_mapping_artefact_to_population.org
+++ b/doc/v2/versions/v0/sprint_10/schema_polish/task_add_mapping_artefact_to_population.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: bd7f39d4-46b1-41ce-992b-7feedf0cc59d
+:END:
+#+title: Add mapping artefact to population functions
+#+description: Hard-coded mapping moved into the artefact pipeline.
+#+type: task
+#+level: s1
+#+filetags: :sql:populate:artefact:schema_polish:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:5bafbeb2-c875-4655-bb78-801a3bf65022][Schema polish]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-25]
+:END:
+
+** Now
+Completed 2026-01-25.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-25
+
+* Goal
+
+Remove the hard-coded mapping in population functions; route it through the artefact pipeline.
+
+* Acceptance
+
+- Mapping data ingested as an artefact.
+- Population functions consume the mapping from the artefact table.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Closes a /TODO: hard-coded/ noted earlier in the DQ work.
+
+* Result
+
+Mapping data is governed like everything else.

--- a/doc/v2/versions/v0/sprint_10/schema_polish/task_add_rounding_type_table.org
+++ b/doc/v2/versions/v0/sprint_10/schema_polish/task_add_rounding_type_table.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: 850e10f2-d84c-4a25-b30b-0328edb33ae8
+:END:
+#+title: Add rounding type table
+#+description: Rounding values aligned with FpML RoundingDirectionEnum: Up, Down, Closest, Floor, Ceiling. Currency validates against this table.
+#+type: task
+#+level: s1
+#+filetags: :refdata:rounding:fpml:currency:schema_polish:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:5bafbeb2-c875-4655-bb78-801a3bf65022][Schema polish]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-26]
+:END:
+
+** Now
+Completed 2026-01-26.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-26
+
+* Goal
+
+Add a reference table for currency rounding types, aligned with FpML's =RoundingDirectionEnum=.
+
+* Acceptance
+
+- Values: Up, Down, Closest, Floor, Ceiling.
+- Currency validates =rounding_type= against the table.
+- Mapping table consumed by mappers.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Considered banker's rounding / half-up; kept the FpML enum's tight set so we don't have to translate when we export FpML.
+
+* Result
+
+Rounding types are a first-class reference-data entity.

--- a/doc/v2/versions/v0/sprint_10/schema_polish/task_add_words_to_icons.org
+++ b/doc/v2/versions/v0/sprint_10/schema_polish/task_add_words_to_icons.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 47bf0f41-5e6b-4da9-b99d-e73ad80686a5
+:END:
+#+title: Add labels (CSV/ORE/FPML) to import/export icons
+#+description: Two well-defined import/export icons get textual badges (CSV, ORE, FPML) so the toolbar is readable.
+#+type: task
+#+level: s1
+#+filetags: :qt:icons:ux:toolbar:schema_polish:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:5bafbeb2-c875-4655-bb78-801a3bf65022][Schema polish]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-24]
+:END:
+
+** Now
+Completed 2026-01-24.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-24
+
+* Goal
+
+Add textual badges (CSV / ORE / FPML) to the import/export icons so the toolbar reads at a glance.
+
+* Acceptance
+
+- Two well-defined icons for import + export.
+- Format badges on top: CSV, ORE, FPML.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Saves us from inventing a separate icon for every combination.
+
+* Result
+
+Toolbar self-explanatory.

--- a/doc/v2/versions/v0/sprint_10/schema_polish/task_clean_up_data_layers.org
+++ b/doc/v2/versions/v0/sprint_10/schema_polish/task_clean_up_data_layers.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: f2062027-b1fa-4b51-84e8-f589f4e14849
+:END:
+#+title: Clean up data layers
+#+description: Restructure data population around explicit layers (Foundation, Data Governance, Data Catalogues, Production).
+#+type: task
+#+level: s1
+#+filetags: :sql:data:layers:refactor:schema_polish:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:5bafbeb2-c875-4655-bb78-801a3bf65022][Schema polish]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-26]
+:END:
+
+** Now
+Completed 2026-01-26.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-26
+
+* Goal
+
+Restructure data population around explicit layers (Foundation, Data Governance, Data Catalogues, Production).
+
+* Acceptance
+
+- Each layer has clear scope and ordering.
+- Population scripts respect layer boundaries.
+- Foundation for the System Provisioner Wizard, which provisions layer by layer.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Layer model came out of the wizard analysis; cleaning the population scripts first makes the wizard much simpler.
+
+* Result
+
+Population structured by layer.

--- a/doc/v2/versions/v0/sprint_10/sprint.org
+++ b/doc/v2/versions/v0/sprint_10/sprint.org
@@ -1,0 +1,108 @@
+:PROPERTIES:
+:ID: 4bac3b0f-819f-43f3-8a59-2b48abe56938
+:END:
+#+title: Sprint 10
+#+description: Codegen infrastructure; party schemes + FPML reference data; ORE XML codegen via xsdcpp; metadata/production schema split; dataset bundles; System Provisioner Wizard.
+#+type: sprint
+#+level: s3
+#+filetags: :codegen:dq:party:fpml:xsdcpp:bundles:wizard:sprint_10:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: STARTED | DONE
+
+Parent version: [[id:e6fd30ed-963e-4705-b414-91bf471c23d0][Version 0]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-27]
+:END:
+
+** Now
+Sprint closed 2026-01-27. Two stories carry forward: the FPML
+export/import implementation and the BOINC compute-grid design.
+
+** Waiting on
+None — carried items scheduled forward.
+
+** Next
+Sprint 11 picks up from the dataset-bundles + provisioning work; the
+party domain layer also has its prerequisites now.
+
+** Last touched
+2026-01-27
+
+* Mission
+
+Originally /data quality and code generation work/. Delivered exactly
+that: a simple in-tree codegen that emits domain-types SQL and the ER
+diagram; xsdcpp-based codegen for ORE XML inside a dedicated
+=ores.ore= component; the 13 reference-data types party needs landed
+through FpML codegen; a metadata/production schema split that resolves
+the bootstrap paradox; dataset bundles and a Qt System Provisioner
+Wizard that uses them.
+
+* Stories
+
+In execution order:
+
+- [[id:61f6ab0b-bb2e-43e7-9735-447a7e3d55de][Sprint 10 housekeeping]] — backlog + OCR + misspell-CI fix.
+- [[id:49a3b815-b5e9-4b3d-9213-100bf96c266d][Codegen infrastructure]] — simple in-tree codegen;
+  domain-types SQL; ER diagram from SQL.
+- [[id:700d4325-2ad1-4e0d-b6af-900abbe1a66e][Party schemes and FPML reference data]] — 13 types via
+  FpML codegen + DQ artefact workflow; GLEIF subset. Continues from
+  sprint 09 party-database groundwork.
+- [[id:2a572d8a-644c-40d9-87d2-7a49a9c07d1b][Image cache polish]] — reload on new datasets; incremental
+  loading via =modified_since=.
+- [[id:ebc22454-356d-4b6c-a3be-e8edfd858fca][External data reorganisation]] — domain-specific
+  subdirectories + manifests; coding schemes via DQ pipeline.
+- [[id:38b6dddf-c02b-4072-b599-41ab3bcc9c28][SQL directory refactor]] — create/, drop/, populate/ by
+  component; safer teardown; admin naming convention.
+- [[id:a1571428-c1bd-4fd1-9434-21ce5b1a6154][ORE XML codegen]] — =ores.ore= + xsdcpp + Windows MSVC fix.
+- [[id:5bafbeb2-c875-4655-bb78-801a3bf65022][Schema polish]] — layer cleanup, rounding types, icon
+  labels, mapping artefact.
+- [[id:2d3d3854-748e-4df7-8bbe-e6498c598c2d][Dataset bundles and provisioning]] — metadata/production
+  schema split, bundles, System Provisioner Wizard.
+- [[id:75442a55-dbbb-4bc1-875e-981679e05621][Librarian polish]] — sprint-09 PR-review fix-up.
+- [[id:4c7782d0-1382-4fed-a9f3-c209a45caf7e][FPML export and import groundwork]] — =ores.fpml=
+  scaffolded; export/import postponed.
+- [[id:85f8dc6c-1acd-4610-a877-b0fdba871254][Compute grid analysis (BOINC-based)]] — design pass;
+  implementation deferred.
+
+* Retrospective
+
+** What went well
+
+- The codegen-first approach paid back immediately: domain-types SQL,
+  ER diagram, party reference data (13 entity types in one PR) all
+  landed cleanly thanks to the new infra.
+- xsdcpp got us from /manually writing ORE types/ to /real ORE
+  samples round-trip through generated code/ inside a single sprint,
+  including the upstream issue + the Windows MSVC follow-up.
+- The metadata/production schema split was the right shape for the
+  bootstrap wizard — the wizard could be much simpler than it would
+  have been before the split.
+- Three SQL-directory refactor PRs landed back-to-back without
+  breaking the world, thanks to git-history-preserving moves.
+
+** What hurt
+
+- The PR for party-related schemes was huge (15 entity types, 18
+  datasets). It landed but the review surface was unfriendly.
+- Claude Code token budget was the precipitating cause of the codegen
+  story — felt like a forced move rather than a deliberate
+  investment. Still worth doing; just worth noting.
+- The misspell-action fix was annoying out of proportion to its
+  size — GLM 4.7 kept suggesting unhelpful approaches before manual
+  fix-up.
+- xsdcpp gaps surfaced late (sub-elements / substitution groups);
+  documented in =ore_xsd_schema_gaps.md= rather than fixed in-sprint.
+
+** What changed
+
+- Codegen is now a load-bearing part of the workflow, not a one-off.
+- =ores.ore= is the new home for ORE-specific import/export.
+- =ores.fpml= is scaffolded for the FPML side, even though its
+  implementation carries forward.
+- Database schema is split into =metadata= and =production=; the
+  bootstrap chicken-and-egg is resolved.
+- Bootstrap is a Qt wizard, not a shell ritual.

--- a/doc/v2/versions/v0/sprint_10/sprint_10_housekeeping/story.org
+++ b/doc/v2/versions/v0/sprint_10/sprint_10_housekeeping/story.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: 61f6ab0b-bb2e-43e7-9735-447a7e3d55de
+:END:
+#+title: Sprint 10 housekeeping
+#+description: Sprint backlog refinement, OCR scans, misspell-action fix.
+#+type: story
+#+level: s2
+#+filetags: :agile:housekeeping:sprint_10:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:4bac3b0f-819f-43f3-8a59-2b48abe56938][Sprint 10]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-27]
+:END:
+
+** Now
+Completed 2026-01-27.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-27
+
+* Goal
+
+Recurring per-sprint housekeeping plus the misspell-CI fix that
+external data brought to a head.
+
+* Acceptance
+
+- Sprint 10 backlog reflects reality at close.
+- Notebook OCR continued.
+- Misspell action no longer trips on vendor data.
+
+* Tasks
+
+In execution order:
+
+- [[id:f752c290-2a7a-4bf7-a615-4cdc2a3e0de6][Sprint and product backlog refinement]]
+- [[id:09918430-9725-4129-96fd-52aff4c52ece][OCR scan notebooks for this sprint]]
+- [[id:ede64638-ddc0-45b3-a1db-185d48a68114][Fix issues with misspell action]]
+
+* Decisions
+
+- /Misspell ignores at folder level, not file level/ :: vendor content arrives in bulk; folder-level ignore is the right granularity.
+
+* Out of scope
+
+- AI summary for this sprint — v0 doesn't carry one.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_10/sprint_10_housekeeping/task_fix_misspell_action.org
+++ b/doc/v2/versions/v0/sprint_10/sprint_10_housekeeping/task_fix_misspell_action.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: ede64638-ddc0-45b3-a1db-185d48a68114
+:END:
+#+title: Fix issues with misspell action
+#+description: FPML and GLEIF data break the misspell action; configure folder ignores.
+#+type: task
+#+level: s1
+#+filetags: :ci:misspell:bug_fix:sprint_10_housekeeping:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:61f6ab0b-bb2e-43e7-9735-447a7e3d55de][Sprint 10 housekeeping]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-23]
+:END:
+
+** Now
+Completed 2026-01-23.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-23
+
+* Goal
+
+FPML and GLEIF data trip the misspell GitHub action; configure folder ignores so the CI stays green.
+
+* Acceptance
+
+- Misspell action skips =external/= subdirectories that contain vendor data.
+- CI green.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Tried to solve it via GLM 4.7 first; the model kept suggesting unhelpful approaches; fixed manually in the end.
+
+* Result
+
+CI green; misspell action no longer trips on vendor data.

--- a/doc/v2/versions/v0/sprint_10/sprint_10_housekeeping/task_sprint_10_backlog_refinement.org
+++ b/doc/v2/versions/v0/sprint_10/sprint_10_housekeeping/task_sprint_10_backlog_refinement.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: f752c290-2a7a-4bf7-a615-4cdc2a3e0de6
+:END:
+#+title: Sprint and product backlog refinement
+#+description: Maintain sprint 10 backlog and groom the product backlog.
+#+type: task
+#+level: s1
+#+filetags: :agile:backlog:sprint_10_housekeeping:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:61f6ab0b-bb2e-43e7-9735-447a7e3d55de][Sprint 10 housekeeping]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-27]
+:END:
+
+** Now
+Completed 2026-01-27.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-27
+
+* Goal
+
+Maintain the sprint 10 backlog and groom the product backlog as items emerge.
+
+* Acceptance
+
+- Sprint 10 backlog reflects what was actually planned and what landed.
+- Items discovered in flight added to the product backlog.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Backlog headline was still STARTED at sprint close (=2026-01-27 23:52= clocktable) — refinement is ongoing in spirit, /done enough/ in practice.
+
+* Result
+
+Backlog kept current; v0 sprint backlog file is the source of truth.

--- a/doc/v2/versions/v0/sprint_10/sprint_10_housekeeping/task_sprint_10_ocr_notebooks.org
+++ b/doc/v2/versions/v0/sprint_10/sprint_10_housekeeping/task_sprint_10_ocr_notebooks.org
@@ -1,0 +1,55 @@
+:PROPERTIES:
+:ID: 09918430-9725-4129-96fd-52aff4c52ece
+:END:
+#+title: OCR scan notebooks for this sprint
+#+description: Continue notebook OCR thread.
+#+type: task
+#+level: s1
+#+filetags: :agile:ocr:sprint_10_housekeeping:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:61f6ab0b-bb2e-43e7-9735-447a7e3d55de][Sprint 10 housekeeping]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-26]
+:END:
+
+** Now
+Completed 2026-01-26.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-26
+
+* Goal
+
+Continue digitising the paper notebooks for the period covered by sprint 10.
+
+* Acceptance
+
+- Notebook pages OCRed and committed.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Long-running notebook digitisation strand; one pass per sprint.
+
+* Result
+
+Sprint 10's chunk of notebook content landed.

--- a/doc/v2/versions/v0/sprint_10/sql_directory_refactor/story.org
+++ b/doc/v2/versions/v0/sprint_10/sql_directory_refactor/story.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: 38b6dddf-c02b-4072-b599-41ab3bcc9c28
+:END:
+#+title: SQL directory refactor
+#+description: Reorganise create/, drop/, populate/ into component-based subdirectories; safer teardown; admin object naming convention.
+#+type: story
+#+level: s2
+#+filetags: :sql:refactor:structure:teardown:sprint_10:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:4bac3b0f-819f-43f3-8a59-2b48abe56938][Sprint 10]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-24]
+:END:
+
+** Now
+Completed 2026-01-24.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-24
+
+* Goal
+
+Reorganise =create/=, =drop/=, =populate/= into component-based
+subdirectories with consistent naming; harden teardown; clean up
+deprecated files.
+
+* Acceptance
+
+- =create/=, =drop/=, =populate/= follow the same component layout.
+- Production teardown requires explicit reviewable scripts.
+- Admin objects follow =admin_*_fn= / =admin_*_view= convention.
+- 56 files moved with git-history preserved.
+- Stale entries removed.
+
+* Tasks
+
+In execution order:
+
+- [[id:68a57f63-81a6-4c75-b05b-46979ffd9981][Restructure SQL create/, drop/, teardown]]
+- [[id:5a5507a2-f855-4825-b91a-99fb957c7d51][Refactor drop/ and populate/ directory structure]]
+- [[id:37e6dbd7-8117-4cd9-a31a-527bc006e0c4][Refactor coding schemes and clean up ores.sql]]
+
+* Decisions
+
+- /Three PRs, not one/ :: each refactor stands on its own; merging them would have produced an unreviewable diff.
+- /Explicit teardown scripts/ :: removed the pattern-match path that was the source of accidental-drop risk.
+
+* Out of scope
+
+- Schema-per-component (the metadata/production split is enough).
+
+* See also
+
+- [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]] — the component this story restructures.

--- a/doc/v2/versions/v0/sprint_10/sql_directory_refactor/task_refactor_coding_schemes_cleanup.org
+++ b/doc/v2/versions/v0/sprint_10/sql_directory_refactor/task_refactor_coding_schemes_cleanup.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 37e6dbd7-8117-4cd9-a31a-527bc006e0c4
+:END:
+#+title: Refactor coding schemes and clean up ores.sql
+#+description: Schema/ renamed to create/; deprecated files removed; admin objects follow admin_*_fn/admin_*_view convention; database_name_service updated to the new function names.
+#+type: task
+#+level: s1
+#+filetags: :sql:refactor:coding_schemes:admin:sql_directory_refactor:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:38b6dddf-c02b-4072-b599-41ab3bcc9c28][SQL directory refactor]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-24]
+:END:
+
+** Now
+Completed 2026-01-24.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-24
+
+* Goal
+
+Final cleanup pass on =ores.sql=: integrate FPML coding schemes into the DQ pipeline; standardise admin-object naming.
+
+* Acceptance
+
+- FPML coding schemes flow through the DQ artefact pipeline (with ordering + URI escape fixes).
+- =schema/= renamed to =create/=; obsolete files removed.
+- =utility/= folder for developer tools.
+- Admin objects use =admin_*_fn= / =admin_*_view= suffixes.
+- C++ =database_name_service= updated to the new admin function names.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Closes the cycle on the three SQL-directory refactor PRs.
+
+* Result
+
+ores.sql cleaned up; admin naming consistent.

--- a/doc/v2/versions/v0/sprint_10/sql_directory_refactor/task_refactor_drop_populate_directories.org
+++ b/doc/v2/versions/v0/sprint_10/sql_directory_refactor/task_refactor_drop_populate_directories.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 5a5507a2-f855-4825-b91a-99fb957c7d51
+:END:
+#+title: Refactor drop/ and populate/ directory structure
+#+description: 56 files relocated into component subdirectories with git-history preserved; consistent naming (drop_COMPONENT.sql, populate_COMPONENT.sql); monolithic seed_upsert_functions split per component.
+#+type: task
+#+level: s1
+#+filetags: :sql:refactor:structure:convention:sql_directory_refactor:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:38b6dddf-c02b-4072-b599-41ab3bcc9c28][SQL directory refactor]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-24]
+:END:
+
+** Now
+Completed 2026-01-24.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-24
+
+* Goal
+
+Apply the same component-subdirectory pattern to =drop/= and =populate/=.
+
+* Acceptance
+
+- =drop/= split into =assets/=, =dq/=, =geo/=, =iam/=, =refdata/=, =seed/=, =telemetry/=, =utility/=, =variability/=.
+- 56 files relocated with git-history preserved.
+- Master files named =drop_COMPONENT.sql= / =populate_COMPONENT.sql=.
+- =drop_all.sql= removed; =drop/drop.sql= replaces it.
+- Monolithic =seed_upsert_functions_drop.sql= split per component.
+- All =populate/= masters renamed to the new convention.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Pairs naturally with the =create/= refactor; the trio is now consistent.
+
+* Result
+
+drop/ + populate/ aligned with create/.

--- a/doc/v2/versions/v0/sprint_10/sql_directory_refactor/task_refactor_sql_create_drop_teardown.org
+++ b/doc/v2/versions/v0/sprint_10/sql_directory_refactor/task_refactor_sql_create_drop_teardown.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 68a57f63-81a6-4c75-b05b-46979ffd9981
+:END:
+#+title: Restructure SQL create/, drop/, teardown
+#+description: create/ reorganised into component-based subdirectories with master scripts; safer teardown (admin_teardown_instances_generate.sql for production); ER diagram updated with the new tables.
+#+type: task
+#+level: s1
+#+filetags: :sql:refactor:structure:teardown:sql_directory_refactor:sprint_10:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:38b6dddf-c02b-4072-b599-41ab3bcc9c28][SQL directory refactor]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-24]
+:END:
+
+** Now
+Completed 2026-01-24.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-24
+
+* Goal
+
+Reorganise =create/= into component-based subdirectories and harden the teardown path.
+
+* Acceptance
+
+- =create/= split into =iam/=, =dq/=, =refdata/=, =assets/= subdirectories with master scripts.
+- Production drops require explicit reviewable scripts from =admin/admin_teardown_instances_generate.sql= (no more pattern matching on critical names).
+- =drop/drop_database.sql= handles single-DB teardown.
+- =teardown_all.sql= covers cluster-wide cleanup with confirmation.
+- ER diagram updated with 15 new refdata + 19 new DQ tables.
+- 13 stale drop-script entries removed.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Teardown safety is the big win — too many critical-DB names had been distinguished only by string pattern.
+
+* Result
+
+Create + teardown reorganised; safer.

--- a/doc/v2/versions/v0/sprint_11/database_role_split_and_schema_consolidation/story.org
+++ b/doc/v2/versions/v0/sprint_11/database_role_split_and_schema_consolidation/story.org
@@ -1,0 +1,63 @@
+:PROPERTIES:
+:ID: b726d4ea-4e80-4d54-a5cc-0cd895ce883c
+:END:
+#+title: Database role split and schema consolidation
+#+description: Split the 'god' admin account into RBAC roles; collapse metadata/production schemas back into public; SQL directory + naming cleanup.
+#+type: story
+#+level: s2
+#+filetags: :iam:rbac:sql:schema:refactor:sprint_11:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:a48c03ec-395b-4842-b60d-de93dd24bf57][Sprint 11]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-31]
+:END:
+
+** Now
+Completed 2026-01-31.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-31
+
+* Goal
+
+Get the database into the shape multi-tenant work needs:
+Principle-of-Least-Privilege RBAC roles, a single =public= schema
+(reversing the sprint-10 split), and a tidy SQL directory tree.
+
+* Acceptance
+
+- Single all-rights admin account gone; RBAC group roles + LOGIN service users in place.
+- All entities back in =public= with =ores_<component>_<entity>_<suffix>= prefix.
+- SQL files follow =[name]_[purpose].sql=; change_control merged into dq/; orphans removed.
+
+* Tasks
+
+In execution order:
+
+- [[id:41c5a11e-0633-4112-9335-ec7ed684682f][Split god admin account into RBAC roles]]
+- [[id:18d627fb-9eea-4e3b-bd84-744ef0d8ef2e][Move all database entities back to public schema]]
+- [[id:2accc003-a494-4687-bc9b-446653511658][Check SQL directory structure]]
+
+* Decisions
+
+- /Reverse the sprint-10 schema split/ :: Odoo-style prefix naming gives the organisational benefits of schemas without the operational debt of cross-schema management.
+- /Group roles + inheritance, not per-user grants/ :: keeps the permission surface manageable as services multiply.
+
+* Out of scope
+
+- Per-tenant database roles — single set of service users serves all tenants via RLS.
+
+* See also
+
+- [[id:1b78d767-89d3-4646-93db-c8297a66b093][Separate catalog metadata schema from production data]] (sprint 10) — the split this story reverses.

--- a/doc/v2/versions/v0/sprint_11/database_role_split_and_schema_consolidation/task_check_sql_directory_structure.org
+++ b/doc/v2/versions/v0/sprint_11/database_role_split_and_schema_consolidation/task_check_sql_directory_structure.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: 2accc003-a494-4687-bc9b-446653511658
+:END:
+#+title: Check SQL directory structure
+#+description: Standardise SQL file names to [name]_[purpose].sql; consolidate change_control/ into dq/; remove ~45 orphaned refdata SQL files.
+#+type: task
+#+level: s1
+#+filetags: :sql:naming:structure:cleanup:database_role_split_and_schema_consolidation:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:b726d4ea-4e80-4d54-a5cc-0cd895ce883c][Database role split and schema consolidation]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-31]
+:END:
+
+** Now
+Completed 2026-01-31.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-31
+
+* Goal
+
+Standardise SQL file naming and folder organisation; remove dead files.
+
+* Acceptance
+
+- All SQL files follow =[name]_[purpose].sql= (e.g. =iam_create.sql= not =create_iam.sql=).
+- =change_control/= merged into =dq/= (it's data-governance work, not its own concern).
+- ~45 orphaned refdata SQL files removed.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Caught misclassified files (=dq_account_types_artefact= sitting under =refdata/=) and fixed.
+
+* Result
+
+SQL tree consistent and free of cruft.

--- a/doc/v2/versions/v0/sprint_11/database_role_split_and_schema_consolidation/task_move_to_public_schema.org
+++ b/doc/v2/versions/v0/sprint_11/database_role_split_and_schema_consolidation/task_move_to_public_schema.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 18d627fb-9eea-4e3b-bd84-744ef0d8ef2e
+:END:
+#+title: Move all database entities back to public schema
+#+description: Reverse the metadata/production split landed in sprint 10; adopt Odoo-style ores_<component>_<entity> prefix in a single public schema. /We traded the illusion of cleanliness for the reality of speed./
+#+type: task
+#+level: s1
+#+filetags: :sql:schema:refactor:public:database_role_split_and_schema_consolidation:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:b726d4ea-4e80-4d54-a5cc-0cd895ce883c][Database role split and schema consolidation]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-31]
+:END:
+
+** Now
+Completed 2026-01-31.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-31
+
+* Goal
+
+Reverse the metadata/production schema split landed in sprint 10; collapse everything into =public= with =ores_<component>_<entity>_<suffix>= naming.
+
+* Acceptance
+
+- All entities live in =public=.
+- Component prefix (=ores_iam_=, =ores_dq_=, =ores_refdata_=, etc.) carries the namespacing that was previously done with separate schemas.
+- search_path complexity gone; foreign keys + migrations simplified.
+- ER diagram regenerated for the single-schema layout.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+/We traded the illusion of cleanliness for the reality of speed./ The Odoo-style namespacing turned out to be the right shape; the schema walls were operational overhead without commensurate benefit.
+
+* Result
+
+Single public schema; one fewer thing for the codebase to fight.

--- a/doc/v2/versions/v0/sprint_11/database_role_split_and_schema_consolidation/task_split_god_admin_account.org
+++ b/doc/v2/versions/v0/sprint_11/database_role_split_and_schema_consolidation/task_split_god_admin_account.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 41c5a11e-0633-4112-9335-ec7ed684682f
+:END:
+#+title: Split god admin account into RBAC roles
+#+description: Introduce ores_owner / ores_rw / ores_ro group roles + LOGIN service users (ores_http_user, etc.); ALTER DEFAULT PRIVILEGES; schema ownership held by the DDL user. Postgres passwords removed from GitHub workflows as part of this.
+#+type: task
+#+level: s1
+#+filetags: :iam:rbac:postgres:security:database_role_split_and_schema_consolidation:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:b726d4ea-4e80-4d54-a5cc-0cd895ce883c][Database role split and schema consolidation]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-31]
+:END:
+
+** Now
+Completed 2026-01-31.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-31
+
+* Goal
+
+Split the single all-rights admin account into the Principle-of-Least-Privilege RBAC roles the project should have always had.
+
+* Acceptance
+
+- Group roles: =ores_owner= (DDL), =ores_rw= (DML), =ores_ro= (read-only).
+- Service LOGIN users (=ores_http_user=, etc.) inherit from group roles.
+- =ALTER DEFAULT PRIVILEGES= so future DDL grants flow naturally.
+- Public schema owned by the DDL user.
+- Dev passwords removed from GitHub workflows as part of this work (= /Remove postgres passwords from github workflows/= done here).
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Gemini analysis steered the role hierarchy; the implementation is the standard Postgres pattern.
+
+* Result
+
+Single-role era ends; RBAC is in place ready for tenancy.

--- a/doc/v2/versions/v0/sprint_11/engineering_hygiene/story.org
+++ b/doc/v2/versions/v0/sprint_11/engineering_hygiene/story.org
@@ -1,0 +1,63 @@
+:PROPERTIES:
+:ID: 0a69cb02-19df-4df7-bedd-81c57a604737
+:END:
+#+title: Engineering hygiene
+#+description: Past PR-review comments, CI apt-get retries, vcpkg cache backend fix.
+#+type: story
+#+level: s2
+#+filetags: :review:ci:vcpkg:polish:sprint_11:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:a48c03ec-395b-4842-b60d-de93dd24bf57][Sprint 11]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-06]
+:END:
+
+** Now
+Completed 2026-02-06.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-06
+
+* Goal
+
+Three independent hygiene strands: clear the backlog of past PR review
+comments, harden apt-get against transient failures, and restore vcpkg
+binary caching after the =x-gha= backend was silently removed upstream.
+
+* Acceptance
+
+- Past review comments cleared.
+- apt-get has exponential-backoff retry.
+- vcpkg cache hit-rate restored.
+
+* Tasks
+
+In execution order:
+
+- [[id:12f3d5ed-fb2b-41e6-8cc5-15392522c2c0][Address past review comments]]
+- [[id:1f64c879-3cca-42da-b16c-9f0194346964][Fix apt-get failures on nightly build]]
+- [[id:760fa2b8-3005-494c-aced-53c2d605351d][Fix vcpkg caching (x-gha removed upstream)]]
+
+* Decisions
+
+- /Clear review comments first/ :: technical-debt headwind would have interfered with the multi-tenant work; better to flush it first.
+- /Files-based cache via actions/cache@v4/ :: the =x-gha= upstream removal was silent; this is the recommended replacement and survives upstream churn better.
+
+* Out of scope
+
+- Migrating off =install_debian_packages.sh= to a container image.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_11/engineering_hygiene/task_address_past_review_comments.org
+++ b/doc/v2/versions/v0/sprint_11/engineering_hygiene/task_address_past_review_comments.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: 12f3d5ed-fb2b-41e6-8cc5-15392522c2c0
+:END:
+#+title: Address past review comments
+#+description: Clear backlog of review comments from PRs #389 and #387: header-state restoration, DataLibrarianWindow optimisation, bundle validation messages, dataset_protocol helpers extracted, ORE CMake dependency cleanup, doc pruning.
+#+type: task
+#+level: s1
+#+filetags: :review:qt:dq:ore:polish:engineering_hygiene:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:0a69cb02-19df-4df7-bedd-81c57a604737][Engineering hygiene]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-01-29]
+:END:
+
+** Now
+Completed 2026-01-29.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-01-29
+
+* Goal
+
+Clear the backlog of review comments from PRs #389 and #387 across Qt, DQ, and ORE.
+
+* Acceptance
+
+- Qt MDI windows (ChangeReasonCategory, ChangeReason, Country, Currency, DataLibrarian, DatasetBundle, OriginDimension) restore header state robustly; fall back gracefully when settings are corrupted.
+- =DataLibrarianWindow::getDatasetsUnderNode= optimised to avoid redundant iterations.
+- Dataset-bundle validation pinpoints the missing field.
+- Batch-delete error messages include the failing bundle codes.
+- DQ =write_dataset= / =read_dataset= helpers moved from anonymous namespace into =dataset_protocol.hpp= (200 lines of duplicated serialisation gone).
+- ORE CMake deps cleaned up: removed =ores.variability.lib=, =ores.comms.lib=, =sqlgen::sqlgen=, =faker-cxx=, =libfort::fort=; added =ores.logging.lib= + =ores.platform.lib=.
+- Doc/agile cleanup: pruned outdated entries from =product_backlog.org=.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+First task of the sprint; clears the technical-debt headwind before the multi-tenant work starts.
+
+* Result
+
+Past review comments addressed; codebase ready for the tenancy work.

--- a/doc/v2/versions/v0/sprint_11/engineering_hygiene/task_fix_apt_get_failures_nightly.org
+++ b/doc/v2/versions/v0/sprint_11/engineering_hygiene/task_fix_apt_get_failures_nightly.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 1f64c879-3cca-42da-b16c-9f0194346964
+:END:
+#+title: Fix apt-get failures on nightly build
+#+description: Exponential-backoff retry loop in install_debian_packages.sh (5 retries, 5s start); Acquire::Retries=3; --with-valgrind flag for nightly.
+#+type: task
+#+level: s1
+#+filetags: :ci:nightly:apt:retry:engineering_hygiene:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:0a69cb02-19df-4df7-bedd-81c57a604737][Engineering hygiene]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-05]
+:END:
+
+** Now
+Completed 2026-02-05.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-05
+
+* Goal
+
+Make the apt-get step in =install_debian_packages.sh= robust against transient network failures.
+
+* Acceptance
+
+- Exponential-backoff retry: 5 retries starting at 5s.
+- =Acquire::Retries=3= for the apt fetch step itself.
+- =--with-valgrind= flag; nightly enables it.
+- Cleanup: packages as array, =apt-get clean= and =apt-get autoremove= no longer on the same line.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Nightly was failing about once a week; this brings it close to zero.
+
+* Result
+
+Nightly green; valgrind installs via the new flag.

--- a/doc/v2/versions/v0/sprint_11/engineering_hygiene/task_fix_vcpkg_caching.org
+++ b/doc/v2/versions/v0/sprint_11/engineering_hygiene/task_fix_vcpkg_caching.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: 760fa2b8-3005-494c-aced-53c2d605351d
+:END:
+#+title: Fix vcpkg caching (x-gha removed upstream)
+#+description: Replace the silently-removed x-gha vcpkg binary-cache backend with the files provider backed by actions/cache@v4 across 5 workflow files; saves ~21 min per build.
+#+type: task
+#+level: s1
+#+filetags: :ci:vcpkg:cache:build:engineering_hygiene:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:0a69cb02-19df-4df7-bedd-81c57a604737][Engineering hygiene]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-06]
+:END:
+
+** Now
+Completed 2026-02-06.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-06
+
+* Goal
+
+Restore vcpkg binary caching across all five CI workflows after the =x-gha= backend was silently removed upstream.
+
+* Acceptance
+
+- =x-gha= backend replaced with =files= provider backed by =actions/cache@v4=.
+- All 5 workflows updated: canary-linux, continuous-linux, continuous-windows, continuous-macos, nightly-linux.
+- First run populates the cache; subsequent runs drop =vcpkg install= from ~21 min to seconds.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Silent upstream removal meant /every/ CI run was rebuilding 120 packages from source. The cache hit-rate is the load-bearing piece of CI speed.
+
+* Result
+
+CI back to expected times; no more 21-min vcpkg installs.

--- a/doc/v2/versions/v0/sprint_11/per_request_tenant_context/story.org
+++ b/doc/v2/versions/v0/sprint_11/per_request_tenant_context/story.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: 976a2745-6728-435e-970e-d1205d46dc7a
+:END:
+#+title: Per-request tenant context
+#+description: Refactor message handlers to create per-request database contexts from session tenant_id; type-safe tenant_id wrapper; system tenant moves from nil UUID to max UUID.
+#+type: story
+#+level: s2
+#+filetags: :tenancy:security:handlers:rls:sprint_11:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:a48c03ec-395b-4842-b60d-de93dd24bf57][Sprint 11]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-06]
+:END:
+
+** Now
+Completed 2026-02-06.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-06
+
+* Goal
+
+Close the cross-tenant data-leakage risk: message handlers must build
+their database context from the session's =tenant_id= /per request/,
+not at construction time.
+
+* Acceptance
+
+- Tenant lookup functions take =const context&=.
+- =tenant_aware_handler= base class handles per-request context creation.
+- Type-safe =tenant_id= wrapper.
+- System tenant identifier changed from nil UUID to max UUID.
+- All handlers refactored; ThreadSanitizer green.
+
+* Tasks
+
+In execution order:
+
+- [[id:db80603b-eb19-4c36-bf8c-e997c250766b][Refactor tenant lookup functions to accept const context]]
+- [[id:f4793f16-278e-4274-8727-b33c7062e1a6][Refactor message handlers for per-request tenant context]]
+
+* Decisions
+
+- /Per-request context, not construction-time/ :: real security bug — the cached construction-time context could leak data from one tenant to another.
+- /System tenant = max UUID, not nil UUID/ :: nil UUID is the default-construct value; using it as the system tenant invited accidental confusion. RFC 9562's max UUID is the right pick.
+- /Strong-typed tenant_id wrapper/ :: refuses to construct from a nil UUID; catches a category of bugs at the type system.
+
+* Out of scope
+
+- Pool-per-tenant — pool is shared; tenant context lives on the connection.
+
+* See also
+
+- [[id:f6748da4-e8d7-48b6-b91f-bc05e68f53d8][Tenancy foundation]] — supplies the session.tenant_id this story consumes.

--- a/doc/v2/versions/v0/sprint_11/per_request_tenant_context/task_refactor_handlers_per_request_context.org
+++ b/doc/v2/versions/v0/sprint_11/per_request_tenant_context/task_refactor_handlers_per_request_context.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: f4793f16-278e-4274-8727-b33c7062e1a6
+:END:
+#+title: Refactor message handlers for per-request tenant context
+#+description: tenant_aware_handler base class; per-request database contexts from session.tenant_id; type-safe utility::uuid::tenant_id wrapper; system tenant changes from nil UUID to max UUID (RFC 9562); fixes cross-tenant data leakage.
+#+type: task
+#+level: s1
+#+filetags: :tenancy:security:handlers:rls:refactor:per_request_tenant_context:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:976a2745-6728-435e-970e-d1205d46dc7a][Per-request tenant context]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-06]
+:END:
+
+** Now
+Completed 2026-02-06.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-06
+
+* Goal
+
+Fix the cross-tenant data-leakage risk: message handlers must build their database context from the session's tenant_id per request, not at construction time.
+
+* Acceptance
+
+- =tenant_aware_handler= base class encapsulates per-request context creation.
+- Type-safe =utility::uuid::tenant_id= wrapper with factories =system()=, =from_uuid()=, =from_string()= that reject nil UUIDs.
+- System tenant identifier changes from nil UUID (=00000000...=) to max UUID (=ffffffff...=) per RFC 9562 to avoid confusion with uninitialised =boost::uuids::uuid= values.
+- Serialisation helpers for =tenant_id= in binary protocol + JSON.
+- All handlers refactored: accounts, risk, dq, assets, telemetry, variability.
+- Multi-tenant concurrent integration test + ThreadSanitizer build.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Real security bug — without per-request context, any user from tenant B making a request could end up reading tenant A's data via the cached context. The max-UUID switch came up here because nil-UUID's default-construct semantics kept biting.
+
+* Result
+
+Tenant isolation hardened across the protocol surface.

--- a/doc/v2/versions/v0/sprint_11/per_request_tenant_context/task_refactor_tenant_lookup_const_context.org
+++ b/doc/v2/versions/v0/sprint_11/per_request_tenant_context/task_refactor_tenant_lookup_const_context.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: db80603b-eb19-4c36-bf8c-e997c250766b
+:END:
+#+title: Refactor tenant lookup functions to accept const context
+#+description: resolve_tenant_id, lookup_by_code, lookup_by_hostname take const context& (they're read-only); eliminates unnecessary mutable copies.
+#+type: task
+#+level: s1
+#+filetags: :tenancy:cpp:refactor:const_correctness:per_request_tenant_context:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:976a2745-6728-435e-970e-d1205d46dc7a][Per-request tenant context]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-05]
+:END:
+
+** Now
+Completed 2026-02-05.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-05
+
+* Goal
+
+Make the read-only tenant-lookup functions actually take =const context&=.
+
+* Acceptance
+
+- =resolve_tenant_id=, =lookup_by_code=, =lookup_by_hostname= take =const context&=.
+- Callers no longer create unnecessary mutable copies just to satisfy the signature.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Came out of seeing =ctx.with_tenant(ctx.tenant_id())= in =tenant_context.cpp= — clearly a workaround.
+
+* Result
+
+Const-correctness restored; copies eliminated.

--- a/doc/v2/versions/v0/sprint_11/service_accounts_and_audit/story.org
+++ b/doc/v2/versions/v0/sprint_11/service_accounts_and_audit/story.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: b23bfd60-4604-4d43-92b3-3ef3e1d5dbe6
+:END:
+#+title: Service accounts and audit
+#+description: Service / algorithm / LLM account types; performed_by audit field across 42 tables; telemetry async-sink deadlock fix; tenant-aware pool fail-fast.
+#+type: story
+#+level: s2
+#+filetags: :iam:audit:services:telemetry:sprint_11:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:a48c03ec-395b-4842-b60d-de93dd24bf57][Sprint 11]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-04]
+:END:
+
+** Now
+Completed 2026-02-04.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-04
+
+* Goal
+
+Give services their own identities and separate audit fields for
+/who/ at the database layer (=modified_by=) from /who/ at the
+application layer (=performed_by=).
+
+* Acceptance
+
+- Account types: user / service / algorithm / LLM.
+- Service accounts authenticate via session, no password.
+- =performed_by= on 42 domain tables via codegen.
+- Telemetry async-sink deadlock fixed.
+- Tenant-aware pool fails fast on missing tenant.
+
+* Tasks
+
+In execution order:
+
+- [[id:8125d266-84df-495f-a344-47d6d0649940][Add system accounts for services]]
+
+* Decisions
+
+- /Split modified_by from performed_by/ :: =modified_by= is the database user (often shared); =performed_by= is the actual application actor (the human via Qt, or the service account). Audit needs both.
+
+* Out of scope
+
+- Per-service rate limits or quotas.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_11/service_accounts_and_audit/task_add_system_accounts_for_services.org
+++ b/doc/v2/versions/v0/sprint_11/service_accounts_and_audit/task_add_system_accounts_for_services.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 8125d266-84df-495f-a344-47d6d0649940
+:END:
+#+title: Add system accounts for services
+#+description: account_type classifications (user / service / algorithm / LLM); session-only authentication for service accounts; performed_by audit field across 42 tables (codegen-driven); telemetry async-sink deadlock fix; tenant_aware_pool fail-fast.
+#+type: task
+#+level: s1
+#+filetags: :iam:audit:services:telemetry:deadlock:service_accounts_and_audit:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:b23bfd60-4604-4d43-92b3-3ef3e1d5dbe6][Service accounts and audit]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-04]
+:END:
+
+** Now
+Completed 2026-02-04.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-04
+
+* Goal
+
+Give services proper identities — they /login/ and start sessions — and split =modified_by= (database user) from =performed_by= (application account).
+
+* Acceptance
+
+- =account_type= classifications: user / service / algorithm / LLM.
+- Service accounts authenticate via session, no password.
+- =performed_by= column on 42 domain tables; codegen-driven rollout across C++ domain classes, mappers, protocol serialisation, Qt UI.
+- Telemetry async-sink deadlock resolved via =skip_telemetry_guard= + filter to prevent recursive logging during DB ops.
+- =tenant_aware_pool= fail-fast on acquisition without tenant context.
+- SQL bootstrap fixes: tenant termination versioning, system tenant context set on service startup.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+/=performed_by= vs =modified_by=/ matters more than it looks: audit needs the application-level actor (the user via Qt), not the database role (which is shared by many users).
+
+* Result
+
+Service identities + audit trail substantially improved.

--- a/doc/v2/versions/v0/sprint_11/sprint.org
+++ b/doc/v2/versions/v0/sprint_11/sprint.org
@@ -1,0 +1,112 @@
+:PROPERTIES:
+:ID: a48c03ec-395b-4842-b60d-de93dd24bf57
+:END:
+#+title: Sprint 11
+#+description: Multi-tenant support end-to-end: RBAC + schema consolidation; tenancy foundation, codegen, and test isolation; per-request tenant context; sqlgen improvements; telemetry database sink; tenant validation across surfaces.
+#+type: sprint
+#+level: s3
+#+filetags: :tenancy:rbac:iam:sqlgen:telemetry:rls:sprint_11:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: STARTED | DONE
+
+Parent version: [[id:e6fd30ed-963e-4705-b414-91bf471c23d0][Version 0]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-06]
+:END:
+
+** Now
+Sprint closed 2026-02-06. One task carries forward: the sqlgen
+bound-parameters work, BLOCKED on upstream =getml/sqlgen#119=.
+
+** Waiting on
+Upstream sqlgen bound-parameter support.
+
+** Next
+Sprint 12 picks up the tenancy work in any surface that needs it
+(Qt, Wt, HTTP all benefit) and exercises the system end-to-end under
+a realistic multi-tenant load.
+
+** Last touched
+2026-02-06
+
+* Mission
+
+/Add multi-tenant support./ Delivered: a complete multi-tenant
+foundation that touches every layer. Schema (tenant_id on ~70 tables,
+RBAC roles, RLS), seeding (system tenant), test isolation
+(tenant-per-test), codegen (tenant-aware by default), C++ entities
+(strong-typed tenant_id), handlers (per-request context to close the
+data-leakage risk), and validation (shell, librarian publication, DQ
+metadata, eventing).
+
+* Stories
+
+In execution order:
+
+- [[id:572c63f9-9a87-40fb-8609-8d4d7c1ccd39][Sprint 11 housekeeping]] — backlog + OCR.
+- [[id:0a69cb02-19df-4df7-bedd-81c57a604737][Engineering hygiene]] — past review comments; apt-get
+  retry; vcpkg cache fix.
+- [[id:b726d4ea-4e80-4d54-a5cc-0cd895ce883c][Database role split and schema consolidation]] —
+  preconditions: RBAC, single public schema, SQL tree tidy-up.
+- [[id:f6748da4-e8d7-48b6-b91f-bc05e68f53d8][Tenancy foundation]] — schema, seeding, login/test plumbing.
+- [[id:1eff8c9c-e4c2-49cc-a563-bb91923ec406][Tenancy-based test isolation]] — tenant_context service,
+  per-test tenants, RLS.
+- [[id:467e909e-ceac-4829-8688-d43179d38f18][Tenancy codegen and entity types]] — Mustache templates,
+  pgTAP, C++ tenant entities, protocol bump 26.1.
+- [[id:18ccf6c9-7d23-48b3-9d4d-2a8aeb4ee30d][sqlgen improvements]] — libpq audit; upstream notice +
+  bound-params work.
+- [[id:2920a00e-538d-455e-9013-44a1c3a7ed36][Telemetry database sink]] — ores.telemetry.database;
+  test logging; three-tier tenant lifecycle.
+- [[id:b23bfd60-4604-4d43-92b3-3ef3e1d5dbe6][Service accounts and audit]] — account_type +
+  performed_by audit field + telemetry deadlock fix.
+- [[id:976a2745-6728-435e-970e-d1205d46dc7a][Per-request tenant context]] — security fix; tenant_id
+  wrapper; system tenant nil → max UUID.
+- [[id:52bbea16-0344-4299-88ba-ec6a341fbd21][Validate tenancy across surfaces]] — shell, librarian,
+  DQ metadata, eventing.
+
+* Retrospective
+
+** What went well
+
+- Multi-tenant landed end-to-end inside one sprint window. Schema
+  → seeding → tests → codegen → C++ entities → handlers → validation
+  all in nine days.
+- /Tenant-per-test/ was the right call — order of magnitude faster
+  than tear-down + recreate, and far closer to production reality.
+- The reversal of the sprint-10 metadata/production schema split was
+  uneventful; the prefix-naming convention carried the namespacing
+  without the operational overhead.
+- The per-request tenant-context refactor caught a real cross-tenant
+  leakage risk that had been silently present.
+- Three sqlgen issues filed upstream cleanly; one PR landed for review.
+
+** What hurt
+
+- The bound-parameters story is blocked on upstream sqlgen — we still
+  have libpq escapes we want to retire and can't.
+- The system-tenant nil-UUID confusion (default-construct collides
+  with system identity) was caught only when the handler refactor
+  forced explicit construction. Could have been spotted earlier.
+- Reversing the sprint-10 schema split is a /good/ outcome but it's
+  also evidence that we got the previous decision wrong; the cost is
+  real even when it's the right call.
+- Tenancy touched almost everything in the codebase; the PR queue
+  felt long this sprint.
+
+** What changed
+
+- =public= schema is back as the single SQL home; sprint-10's
+  metadata/production split is gone.
+- Database access goes through RBAC group roles + LOGIN service
+  users; no more single all-rights admin account.
+- =tenant_id= is on every entity table; the system tenant is the
+  max UUID per RFC 9562 (no longer nil).
+- Codegen is tenant-aware by default; tenant-less tables are the
+  exception.
+- Handlers build their database context per request from the
+  session's tenant_id.
+- Services authenticate via session and have their own
+  =account_type=; audit splits =performed_by= from =modified_by=.

--- a/doc/v2/versions/v0/sprint_11/sprint_11_housekeeping/story.org
+++ b/doc/v2/versions/v0/sprint_11/sprint_11_housekeeping/story.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 572c63f9-9a87-40fb-8609-8d4d7c1ccd39
+:END:
+#+title: Sprint 11 housekeeping
+#+description: Sprint backlog refinement and notebook OCR scans.
+#+type: story
+#+level: s2
+#+filetags: :agile:housekeeping:sprint_11:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:a48c03ec-395b-4842-b60d-de93dd24bf57][Sprint 11]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-06]
+:END:
+
+** Now
+Completed 2026-02-06.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-06
+
+* Goal
+
+Recurring per-sprint housekeeping.
+
+* Acceptance
+
+- Sprint 11 backlog reflects reality at close.
+- Notebook OCR continued.
+
+* Tasks
+
+In execution order:
+
+- [[id:caba009d-8b9b-4809-bdbe-419de756a36e][Sprint and product backlog refinement]]
+- [[id:b0f7d3a2-056b-46ac-8402-d0ba2c20fbb9][OCR scan notebooks for this sprint]]
+
+* Decisions
+
+- /AI summary not in v0 for this sprint/ :: so it isn't migrated.
+
+* Out of scope
+
+- Backfilling AI summaries.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_11/sprint_11_housekeeping/task_sprint_11_backlog_refinement.org
+++ b/doc/v2/versions/v0/sprint_11/sprint_11_housekeeping/task_sprint_11_backlog_refinement.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: caba009d-8b9b-4809-bdbe-419de756a36e
+:END:
+#+title: Sprint and product backlog refinement
+#+description: Maintain sprint 11 backlog and groom the product backlog.
+#+type: task
+#+level: s1
+#+filetags: :agile:backlog:sprint_11_housekeeping:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:572c63f9-9a87-40fb-8609-8d4d7c1ccd39][Sprint 11 housekeeping]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-06]
+:END:
+
+** Now
+Completed 2026-02-06.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-06
+
+* Goal
+
+Maintain the sprint 11 backlog and groom the product backlog as items emerge.
+
+* Acceptance
+
+- Sprint 11 backlog reflects what was actually planned and what landed.
+- Items discovered in flight added to the product backlog.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Bigger sprint than most; the backlog file became important for tracking the multi-tenant cascade.
+
+* Result
+
+Backlog kept current.

--- a/doc/v2/versions/v0/sprint_11/sprint_11_housekeeping/task_sprint_11_ocr_notebooks.org
+++ b/doc/v2/versions/v0/sprint_11/sprint_11_housekeeping/task_sprint_11_ocr_notebooks.org
@@ -1,0 +1,55 @@
+:PROPERTIES:
+:ID: b0f7d3a2-056b-46ac-8402-d0ba2c20fbb9
+:END:
+#+title: OCR scan notebooks for this sprint
+#+description: Continue notebook OCR thread.
+#+type: task
+#+level: s1
+#+filetags: :agile:ocr:sprint_11_housekeeping:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:572c63f9-9a87-40fb-8609-8d4d7c1ccd39][Sprint 11 housekeeping]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-06]
+:END:
+
+** Now
+Completed 2026-02-06.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-06
+
+* Goal
+
+Continue digitising the paper notebooks for the period covered by sprint 11.
+
+* Acceptance
+
+- Notebook pages OCRed and committed.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Long-running notebook digitisation strand.
+
+* Result
+
+Sprint 11's chunk of notebook content landed.

--- a/doc/v2/versions/v0/sprint_11/sqlgen_improvements/story.org
+++ b/doc/v2/versions/v0/sprint_11/sqlgen_improvements/story.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: 18ccf6c9-7d23-48b3-9d4d-2a8aeb4ee30d
+:END:
+#+title: sqlgen improvements
+#+description: Audit raw libpq use; upstream NOTICE logging support to sqlgen; bound parameters proposed (blocked upstream).
+#+type: story
+#+level: s2
+#+filetags: :sqlgen:sql:upstream:refactor:sprint_11:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:a48c03ec-395b-4842-b60d-de93dd24bf57][Sprint 11]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-06]
+:END:
+
+** Now
+Completed 2026-02-06.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-06
+
+* Goal
+
+Tighten the sqlgen surface so the project doesn't need to keep raw
+libpq for the cases sqlgen doesn't yet cover.
+
+* Acceptance
+
+- Codebase swept for raw libpq use; remaining cases moved to ores.database.
+- NOTICE logging support raised upstream and PR opened.
+- Bound-parameter support tracked upstream (blocked on the fix landing).
+
+* Tasks
+
+In execution order:
+
+- [[id:f0c71fe7-1920-44aa-b98f-9147aaa00032][Audit for uses of raw libpq]]
+- [[id:db4461dd-a98e-4847-9b16-a76cfd1afcbe][Add NOTICE logging support to sqlgen]]
+- [[id:a6d63825-d592-47bb-a1c6-b6e9564fd55c][Add bound parameters to sqlgen]]
+
+* Decisions
+
+- /Upstream-first for sqlgen gaps/ :: avoid carrying long-running local patches.
+
+* Out of scope
+
+- Forking sqlgen.
+
+* See also
+
+None.

--- a/doc/v2/versions/v0/sprint_11/sqlgen_improvements/task_add_bound_parameters_sqlgen.org
+++ b/doc/v2/versions/v0/sprint_11/sqlgen_improvements/task_add_bound_parameters_sqlgen.org
@@ -1,0 +1,53 @@
+:PROPERTIES:
+:ID: a6d63825-d592-47bb-a1c6-b6e9564fd55c
+:END:
+#+title: Add bound parameters to sqlgen
+#+description: Replace remaining libpq escapes for SQL-injection-safe queries with native sqlgen bound parameters.
+#+type: task
+#+level: s1
+#+filetags: :sqlgen:upstream:security:bound_params:sqlgen_improvements:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: getml/sqlgen#119
+#+blocked_since: 2026-02-01
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:18ccf6c9-7d23-48b3-9d4d-2a8aeb4ee30d][sqlgen improvements]].
+
+* BLOCKED Status
+
+** Now
+BLOCKED on upstream sqlgen support.
+
+** Waiting on
+=getml/sqlgen#119= to merge.
+
+** Next
+Pick up once upstream lands the feature.
+
+** Last touched
+2026-02-06
+
+* Goal
+
+Add native bound-parameter support to sqlgen so we can stop using libpq escapes for SQL-injection safety.
+
+* Acceptance
+
+- Bound parameters supported across sqlgen sessions and connections.
+- Existing libpq escape sites migrated.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+BLOCKED on upstream sqlgen feature: =getml/sqlgen#119=. Once it ships we can finally retire the libpq escapes.
+
+* Result
+
+Not landed; waiting on upstream.

--- a/doc/v2/versions/v0/sprint_11/sqlgen_improvements/task_add_notice_logging_sqlgen.org
+++ b/doc/v2/versions/v0/sprint_11/sqlgen_improvements/task_add_notice_logging_sqlgen.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: db4461dd-a98e-4847-9b16-a76cfd1afcbe
+:END:
+#+title: Add NOTICE logging support to sqlgen
+#+description: Upstream PR getml/sqlgen#120 + proposal #118 — Postgres notice processor hook.
+#+type: task
+#+level: s1
+#+filetags: :sqlgen:upstream:logging:postgres:sqlgen_improvements:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:18ccf6c9-7d23-48b3-9d4d-2a8aeb4ee30d][sqlgen improvements]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-01]
+:END:
+
+** Now
+Completed 2026-02-01.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-01
+
+* Goal
+
+Add Postgres NOTICE-processor support to sqlgen so PL/pgSQL =RAISE NOTICE= surfaces in client logs.
+
+* Acceptance
+
+- Upstream proposal raised: =getml/sqlgen#118=.
+- Implementation PR open upstream: =getml/sqlgen#120=.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Closes a long-standing visibility gap — PL/pgSQL functions were emitting useful diagnostic NOTICEs that nothing on the client side ever saw.
+
+* Result
+
+Upstream PR open; waiting for review.

--- a/doc/v2/versions/v0/sprint_11/sqlgen_improvements/task_check_raw_libpq_uses.org
+++ b/doc/v2/versions/v0/sprint_11/sqlgen_improvements/task_check_raw_libpq_uses.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: f0c71fe7-1920-44aa-b98f-9147aaa00032
+:END:
+#+title: Audit for uses of raw libpq
+#+description: Sweep the codebase for libpq escapes Claude has snuck in; move all into ores.database; raise tickets on sqlgen for the gaps.
+#+type: task
+#+level: s1
+#+filetags: :sqlgen:libpq:audit:cleanup:sqlgen_improvements:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:18ccf6c9-7d23-48b3-9d4d-2a8aeb4ee30d][sqlgen improvements]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-01]
+:END:
+
+** Now
+Completed 2026-02-01.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-01
+
+* Goal
+
+Sweep the codebase for raw libpq escapes (Claude has a habit of sneaking these in) and route everything through ores.database.
+
+* Acceptance
+
+- All raw-libpq sites identified.
+- Code moved into =ores.database= where appropriate.
+- Remaining gaps raised as upstream sqlgen tickets.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Particularly attentive on bitemporal operations — that's where the temptation is highest.
+
+* Result
+
+Audit done; tickets filed against sqlgen for the gaps.

--- a/doc/v2/versions/v0/sprint_11/telemetry_database_sink/story.org
+++ b/doc/v2/versions/v0/sprint_11/telemetry_database_sink/story.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: 2920a00e-538d-455e-9013-44a1c3a7ed36
+:END:
+#+title: Telemetry database sink
+#+description: Split ores.telemetry.database to resolve circular deps; database logging sink for tests; three-tier tenant lifecycle (terminate / deprovision / purge); recursive-logging guard.
+#+type: story
+#+level: s2
+#+filetags: :telemetry:database:tests:refactor:sprint_11:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:a48c03ec-395b-4842-b60d-de93dd24bf57][Sprint 11]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-03]
+:END:
+
+** Now
+Completed 2026-02-03.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-03
+
+* Goal
+
+Make unit-test logs available to subsequent analysis: split off
+=ores.telemetry.database= to break the circular dependency, and add a
+Boost.Log sink that writes telemetry directly to the database.
+
+* Acceptance
+
+- =ores.telemetry.database= component present; circular dep broken.
+- Database sink backend implemented.
+- =ORES_TEST_LOG_DATABASE= CMake option toggles test logging.
+- Three-tier tenant lifecycle: =terminate= / =deprovision= / =purge=.
+- Recursive-logging guard prevents telemetry-about-telemetry loops.
+
+* Tasks
+
+In execution order:
+
+- [[id:7edc04f8-907e-4230-bd82-23e9e979ffb1][Add ores.telemetry.database component]]
+- [[id:6888a023-d626-44ce-b6c7-d0d92d31cbe1][Add database logging for tests]]
+
+* Decisions
+
+- /Three-tier lifecycle/ :: terminate keeps the data, deprovision soft-deletes the temporal data, purge is the hard delete. Lets us look at past test runs without keeping everything forever.
+- /RAII =skip_telemetry_guard=/ :: prevents the recursive log → telemetry → log loop.
+
+* Out of scope
+
+- Telemetry retention policy enforcement (separate story).
+
+* See also
+
+- [[id:8c4c8429-9328-46dd-88ef-27689fb556f2][Observability and telemetry]] (sprint 07) — predecessor work establishing the components.

--- a/doc/v2/versions/v0/sprint_11/telemetry_database_sink/task_add_database_logging_for_tests.org
+++ b/doc/v2/versions/v0/sprint_11/telemetry_database_sink/task_add_database_logging_for_tests.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 6888a023-d626-44ce-b6c7-d0d92d31cbe1
+:END:
+#+title: Add database logging for tests
+#+description: ORES_TEST_LOG_DATABASE CMake option enables direct DB logging from unit tests; three-tier tenant lifecycle (terminate / deprovision / purge); skip_telemetry_guard prevents recursive logging.
+#+type: task
+#+level: s1
+#+filetags: :telemetry:tests:tenancy:lifecycle:telemetry_database_sink:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:2920a00e-538d-455e-9013-44a1c3a7ed36][Telemetry database sink]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-03]
+:END:
+
+** Now
+Completed 2026-02-03.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-03
+
+* Goal
+
+Make the database sink usable from the test framework so unit-test logs land in Postgres alongside the tenant data the test produces.
+
+* Acceptance
+
+- =ORES_TEST_LOG_DATABASE= CMake option toggles the sink.
+- Tenant provisioning fix: =tenant_id= now reliably stored in the database context (was using the wrong column).
+- Three-tier tenant lifecycle: =terminate= (inactive, preserves all), =deprovision= (soft-delete temporal, preserve non-temporal), =purge= (hard-delete everything). New =ores_iam_terminate_tenant_fn=.
+- RAII =skip_telemetry_guard= prevents recursive logging when telemetry operations themselves emit logs.
+- Unit tests cover the sink backend and =telemetry_repository=.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+The three-tier lifecycle is /the/ piece that lets us look at past test runs without keeping every byte forever.
+
+* Result
+
+Test logs persist to DB; tenant lifecycle granular.

--- a/doc/v2/versions/v0/sprint_11/telemetry_database_sink/task_add_telemetry_database_component.org
+++ b/doc/v2/versions/v0/sprint_11/telemetry_database_sink/task_add_telemetry_database_component.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 7edc04f8-907e-4230-bd82-23e9e979ffb1
+:END:
+#+title: Add ores.telemetry.database component
+#+description: Split telemetry repository/mapper/entity into ores.telemetry.database to resolve the ores.telemetry ↔ ores.database circular dependency; Boost.Log database_sink_backend.
+#+type: task
+#+level: s1
+#+filetags: :telemetry:database:component:refactor:telemetry_database_sink:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:2920a00e-538d-455e-9013-44a1c3a7ed36][Telemetry database sink]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-03]
+:END:
+
+** Now
+Completed 2026-02-03.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-03
+
+* Goal
+
+Resolve the =ores.telemetry= ↔ =ores.database= circular dependency by extracting a dedicated =ores.telemetry.database= library.
+
+* Acceptance
+
+- Repository / mapper / entity files moved from =ores.telemetry= to =ores.telemetry.database=.
+- Boost.Log =database_sink_backend= for direct DB logging.
+- Messaging components in =ores.comms.service= reference the new library + namespace.
+- Examples + CMake configurations updated.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Circular dep was the blocker; the sink itself was the easy part.
+
+* Result
+
+Dependency cycle broken; database sink available.

--- a/doc/v2/versions/v0/sprint_11/tenancy_codegen_and_entity_types/story.org
+++ b/doc/v2/versions/v0/sprint_11/tenancy_codegen_and_entity_types/story.org
@@ -1,0 +1,67 @@
+:PROPERTIES:
+:ID: 467e909e-ceac-4829-8688-d43179d38f18
+:END:
+#+title: Tenancy codegen and entity types
+#+description: Update codegen templates for tenant-aware tables; introduce pgTAP; C++ tenant entities; protocol bump 26.1.
+#+type: story
+#+level: s2
+#+filetags: :codegen:tenancy:pgtap:protocol:sprint_11:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:a48c03ec-395b-4842-b60d-de93dd24bf57][Sprint 11]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-03]
+:END:
+
+** Now
+Completed 2026-02-03.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-03
+
+* Goal
+
+Take the schema-level tenancy plumbed in by the foundation story and
+push it through the rest of the stack: codegen, C++ entities, shell
+commands, protocol bump.
+
+* Acceptance
+
+- Codegen templates emit tenant-aware tables by default.
+- pgTAP testing skill section + per-entity pgTAP tests.
+- Utility scripts for refdata schema gen + entity recreate.
+- C++ tenant + tenant_status + tenant_type entities present.
+- Protocol 26.1 bump.
+- Shell tenants command + tenant-aware bootstrap/login.
+- Principal parsing supports =username@hostname=.
+
+* Tasks
+
+In execution order:
+
+- [[id:4bec02dc-52c4-4d2d-b2cb-6142dfd4ff70][Update codegen for tenancy]]
+- [[id:eec6cea6-4f37-4f23-b88a-1f505eb9cbc0][Add entity types for tenants]]
+
+* Decisions
+
+- /Tenancy is the codegen default/ :: tenant-less tables are the exception now, not the rule.
+- /Enum/lookup tables on tenant 0/ :: consistent data model rather than carving out a separate /tenant-less/ category.
+- /pgTAP for database-level tests/ :: complements C++-level tests with a layer that catches schema-only regressions.
+
+* Out of scope
+
+- Per-component C++ enum codegen rollout — the message-types enum is the proof.
+
+* See also
+
+- [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] — the component this story extends.

--- a/doc/v2/versions/v0/sprint_11/tenancy_codegen_and_entity_types/task_add_entity_types_for_tenants.org
+++ b/doc/v2/versions/v0/sprint_11/tenancy_codegen_and_entity_types/task_add_entity_types_for_tenants.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: eec6cea6-4f37-4f23-b88a-1f505eb9cbc0
+:END:
+#+title: Add entity types for tenants
+#+description: C++ tenant + tenant_status + tenant_type + currency + rounding_type entities tenant-aware; primary key types handled (UUID / text); protocol bump 26.1; shell tenants command + bootstrap/login tenant awareness; principal parsing username@hostname.
+#+type: task
+#+level: s1
+#+filetags: :tenancy:cpp:codegen:protocol:shell:tenancy_codegen_and_entity_types:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:467e909e-ceac-4829-8688-d43179d38f18][Tenancy codegen and entity types]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-03]
+:END:
+
+** Now
+Completed 2026-02-03.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-03
+
+* Goal
+
+Bring tenants into the C++ side: domain entities, shell commands, protocol bump.
+
+* Acceptance
+
+- C++ tenant + tenant_status + tenant_type entities with JSON + table I/O.
+- New tenant-aware JSON models: =artefact_type=, =tenant_status=, =tenant_type=, =currency=, =rounding_type= (with =has_tenant_id: true= and =system_tenant_validation: true= where appropriate).
+- PK type handling for both UUID and text PKs.
+- Protocol version 26.1 bump.
+- Shell commands: =tenants=, plus tenant-aware =bootstrap= and =login=.
+- Principal parsing supports =username@hostname= → tenant lookup.
+- =ores.iam::client::login=/=logout= helpers added (sets up the next story).
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+First full vertical slice — tenants visible from SQL through codegen through shell.
+
+* Result
+
+Tenants are a first-class entity throughout the stack.

--- a/doc/v2/versions/v0/sprint_11/tenancy_codegen_and_entity_types/task_update_codegen_for_tenancy.org
+++ b/doc/v2/versions/v0/sprint_11/tenancy_codegen_and_entity_types/task_update_codegen_for_tenancy.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 4bec02dc-52c4-4d2d-b2cb-6142dfd4ff70
+:END:
+#+title: Update codegen for tenancy
+#+description: Mustache templates (sql_schema_domain_entity_create, sql_schema_table_create) conditionally include tenant_id; PK + exclusion constraints incorporate tenant_id; pgTAP testing skill section; generate_refdata_schema.sh + recreate_entity.sh.
+#+type: task
+#+level: s1
+#+filetags: :codegen:mustache:tenancy:pgtap:scripts:tenancy_codegen_and_entity_types:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:467e909e-ceac-4829-8688-d43179d38f18][Tenancy codegen and entity types]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-02]
+:END:
+
+** Now
+Completed 2026-02-02.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-02
+
+* Goal
+
+Update the codegen templates so tenant-aware tables are generated correctly out of the box.
+
+* Acceptance
+
+- =sql_schema_domain_entity_create.mustache= + =sql_schema_table_create.mustache= conditionally include the =tenant_id= column.
+- PK + exclusion constraints incorporate =tenant_id=.
+- Insert functions emit tenant validation.
+- Detailed plan for consolidating enum/lookup tables onto the system tenant (=tenant 0=).
+- pgTAP testing skill section added; pgTAP test files for =artefact_type=, =tenant_status=, =tenant_type=, =currencies=, refdata validations.
+- =generate_refdata_schema.sh= + =recreate_entity.sh= utilities.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Tenancy is now /the default/ in codegen; tenant-less tables are the exception, not the rule.
+
+* Result
+
+Codegen tenant-aware; pgTAP in place for database-level tests.

--- a/doc/v2/versions/v0/sprint_11/tenancy_foundation/story.org
+++ b/doc/v2/versions/v0/sprint_11/tenancy_foundation/story.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: f6748da4-e8d7-48b6-b91f-bc05e68f53d8
+:END:
+#+title: Tenancy foundation
+#+description: Tenant_id on every entity table; system tenant; validation function; seeding scoped to system tenant; auto-populate triggers and test infrastructure.
+#+type: story
+#+level: s2
+#+filetags: :tenancy:sql:iam:seeding:sprint_11:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:a48c03ec-395b-4842-b60d-de93dd24bf57][Sprint 11]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-01]
+:END:
+
+** Now
+Completed 2026-02-01.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-01
+
+* Goal
+
+Lay multi-tenant support at the schema and seeding layer, with the
+trigger machinery that lets existing C++ code 'just work'.
+
+* Acceptance
+
+- Tenant tables (types, statuses, tenants) in place.
+- =tenant_id= on ~70 entity tables; unique indexes + tenant_id indexes updated.
+- All INSERT triggers validate via =ores_iam_validate_tenant_fn=.
+- All upsert + populate functions scoped to system tenant.
+- BEFORE INSERT triggers auto-populate =tenant_id= from session.
+- Test users default to the system tenant.
+
+* Tasks
+
+In execution order:
+
+- [[id:59582d45-b4f4-47b9-8cf2-06e597f9651c][Initial tenant setup (schema)]]
+- [[id:27aeb340-b98c-4b6d-aa92-d4da2dc5c629][Tenancy and seeding]]
+- [[id:73a005de-626e-4b62-8fed-f385aecdf02a][Tenancy, login and tests]]
+
+* Decisions
+
+- /System tenant is a real row/ :: gives a stable target for platform-level data and seed code paths.
+- /Triggers populate tenant_id from session variable/ :: keeps the pre-existing C++ code working without per-call audits.
+
+* Out of scope
+
+- RLS policies (handled in the test-isolation story).
+- C++ tenant entity (handled in the codegen story).
+
+* See also
+
+- [[id:D00BEA0D-E501-C534-A013-E6F40C1A6097][ores.iam]] — owns the tenancy schema.

--- a/doc/v2/versions/v0/sprint_11/tenancy_foundation/task_tenancy_login_and_tests.org
+++ b/doc/v2/versions/v0/sprint_11/tenancy_foundation/task_tenancy_login_and_tests.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 73a005de-626e-4b62-8fed-f385aecdf02a
+:END:
+#+title: Tenancy, login and tests
+#+description: BEFORE INSERT triggers populate tenant_id from session variable; ores_iam_validate_tenant_fn coalesces with current session tenant; ores_test_ddl/dml_user default tenant set to system tenant; database_helper::set_system_tenant_context().
+#+type: task
+#+level: s1
+#+filetags: :tenancy:sql:iam:tests:tenancy_foundation:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:f6748da4-e8d7-48b6-b91f-bc05e68f53d8][Tenancy foundation]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-01]
+:END:
+
+** Now
+Completed 2026-02-01.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-01
+
+* Goal
+
+Wire tenancy into login + session creation, and prepare the C++ test infrastructure to set tenant context transparently.
+
+* Acceptance
+
+- BEFORE INSERT triggers on =iam_login_info_tbl= + =iam_sessions_tbl= populate =tenant_id= from =app.current_tenant_id= when not supplied explicitly.
+- =ores_iam_validate_tenant_fn= uses =coalesce(p_tenant_id, ores_iam_current_tenant_id_fn())=.
+- =ores_test_ddl_user= and =ores_test_dml_user= default =app.current_tenant_id= to the system tenant in =setup_template.sql=.
+- C++ =database_helper::set_system_tenant_context()= callable from test constructors.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+The triggers are what make pre-existing C++ code 'just work' under tenancy — it doesn't have to know about tenant_id everywhere.
+
+* Result
+
+Tenancy plumbed through login + tests transparently.

--- a/doc/v2/versions/v0/sprint_11/tenancy_foundation/task_tenancy_seeding.org
+++ b/doc/v2/versions/v0/sprint_11/tenancy_foundation/task_tenancy_seeding.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 27aeb340-b98c-4b6d-aa92-d4da2dc5c629
+:END:
+#+title: Tenancy and seeding
+#+description: All populate scripts pass ores_iam_system_tenant_id_fn() as the first upsert parameter so foundational data is scoped to the system tenant.
+#+type: task
+#+level: s1
+#+filetags: :tenancy:sql:populate:seeding:tenancy_foundation:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:f6748da4-e8d7-48b6-b91f-bc05e68f53d8][Tenancy foundation]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-01]
+:END:
+
+** Now
+Completed 2026-02-01.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-01
+
+* Goal
+
+Update every populate script so foundational data is scoped to the system tenant.
+
+* Acceptance
+
+- All =upsert_*= calls pass =ores_iam_system_tenant_id_fn()= as the first argument.
+- Reference data, configurations, and metadata correctly seeded against the system tenant.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Mechanical change but high-impact; one missed call surfaces as a validation-trigger failure on the next run.
+
+* Result
+
+All seed data tenant-scoped.

--- a/doc/v2/versions/v0/sprint_11/tenancy_foundation/task_tenant_setup_schema.org
+++ b/doc/v2/versions/v0/sprint_11/tenancy_foundation/task_tenant_setup_schema.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: 59582d45-b4f4-47b9-8cf2-06e597f9651c
+:END:
+#+title: Initial tenant setup (schema)
+#+description: ores_iam_tenant_types_tbl + tenant_statuses + tenants (bitemporal); tenant_id on ~70 entity tables; unique indexes + tenant_id-indexes; ores_iam_validate_tenant_fn on all relevant INSERT triggers; SuperAdmin + TenantAdmin roles; system tenant UUID; session.tenant_id lookup.
+#+type: task
+#+level: s1
+#+filetags: :tenancy:sql:iam:schema:tenancy_foundation:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:f6748da4-e8d7-48b6-b91f-bc05e68f53d8][Tenancy foundation]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-01]
+:END:
+
+** Now
+Completed 2026-02-01.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-01
+
+* Goal
+
+Lay the multi-tenant foundation at the schema level.
+
+* Acceptance
+
+- =ores_iam_tenant_types_tbl=, =ores_iam_tenant_statuses_tbl=, =ores_iam_tenants_tbl= (bitemporal).
+- =tenant_id= on ~70 existing entity tables across assets / dq / geo / iam / refdata / telemetry / variability.
+- Unique indexes + constraints extended with =tenant_id=; tenant_id indexes added for query performance.
+- INSERT triggers call =ores_iam_validate_tenant_fn= to reject invalid or inactive tenants.
+- Upsert functions take =tenant_id= as the first parameter.
+- System tenant has a well-known UUID; SuperAdmin + TenantAdmin roles introduced.
+- Session-tenant lookup functions (=ores_iam_current_tenant_id_fn=, =ores_iam_lookup_tenant_by_hostname_fn=).
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+One PR (#395) handled the schema; subsequent PRs in this story handled seeding and triggers.
+
+* Result
+
+Schema is multi-tenant aware end-to-end.

--- a/doc/v2/versions/v0/sprint_11/tenancy_test_isolation/story.org
+++ b/doc/v2/versions/v0/sprint_11/tenancy_test_isolation/story.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: 1eff8c9c-e4c2-49cc-a563-bb91923ec406
+:END:
+#+title: Tenancy-based test isolation
+#+description: Centralised tenant_context C++ service; per-test tenant provisioning + deprovisioning; RLS policies; --tenant CLI flag; psqlrc support.
+#+type: story
+#+level: s2
+#+filetags: :tenancy:tests:rls:cli:sprint_11:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:a48c03ec-395b-4842-b60d-de93dd24bf57][Sprint 11]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-01]
+:END:
+
+** Now
+Completed 2026-02-01.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-01
+
+* Goal
+
+Use tenants as the unit of test isolation: same database, different
+tenant per test. Faster than tear-down + recreate; closer to how the
+system actually runs in production.
+
+* Acceptance
+
+- C++ tenant_context service in =ores.database=.
+- Per-test tenant provisioning + deprovisioning.
+- RLS policies allow the system tenant cross-tenant access.
+- CLI gains =--tenant= + =ORES_TENANT=.
+- =psqlrc= shows the current tenant in the prompt.
+- Provision + deprovision SQL functions in place.
+
+* Tasks
+
+In execution order:
+
+- [[id:9e2e5ca9-31a7-4527-bb9b-3b767ddac0ab][Use tenancy to isolate tests]]
+
+* Decisions
+
+- /Tenant-per-test, not database-per-test/ :: order-of-magnitude faster and more representative of production.
+- /RLS lets the system tenant cross boundaries/ :: necessary for admin / provisioning ops; deliberate widening, not a leak.
+
+* Out of scope
+
+- Per-test connection pools.
+
+* See also
+
+- [[id:f6748da4-e8d7-48b6-b91f-bc05e68f53d8][Tenancy foundation]] — supplies the schema this story builds on.

--- a/doc/v2/versions/v0/sprint_11/tenancy_test_isolation/task_use_tenancy_for_test_isolation.org
+++ b/doc/v2/versions/v0/sprint_11/tenancy_test_isolation/task_use_tenancy_for_test_isolation.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 9e2e5ca9-31a7-4527-bb9b-3b767ddac0ab
+:END:
+#+title: Use tenancy to isolate tests
+#+description: tenant_context C++ service in ores.database; per-test tenant provision + deprovision; RLS policies allow system tenant; --tenant CLI flag + ORES_TENANT env; psqlrc tenant prompt; ores_iam_provision_tenant_fn + ores_iam_deprovision_tenant_fn.
+#+type: task
+#+level: s1
+#+filetags: :tenancy:tests:rls:cli:context:tenancy_test_isolation:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:1eff8c9c-e4c2-49cc-a563-bb91923ec406][Tenancy-based test isolation]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-01]
+:END:
+
+** Now
+Completed 2026-02-01.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-01
+
+* Goal
+
+Use tenants to give every test run its own isolated slice of the database — same DB, different tenant.
+
+* Acceptance
+
+- C++ =tenant_context= service in =ores.database= centralises tenant-context management.
+- Each test run provisions a unique tenant + reference-data copies; deprovisions on completion.
+- RLS policies on assets / dq / iam / refdata / telemetry / variability allow the system tenant to access all tenant data for admin/provisioning.
+- =--tenant= CLI flag + =ORES_TENANT= env on =ores.cli=.
+- =psqlrc.sql= sets the system tenant context on load, shows the current tenant in the prompt, exposes =:tenant= / =:tenants= macros.
+- SQL: =ores_iam_provision_tenant_fn= + =ores_iam_deprovision_tenant_fn= for programmatic tenant lifecycle.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Same database / different tenant is much faster than tearing the database down per test, and far more realistic.
+
+* Result
+
+Tests now run in isolated tenants on a shared database.

--- a/doc/v2/versions/v0/sprint_11/validate_tenancy_across_surfaces/story.org
+++ b/doc/v2/versions/v0/sprint_11/validate_tenancy_across_surfaces/story.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: 52bbea16-0344-4299-88ba-ec6a341fbd21
+:END:
+#+title: Validate tenancy across surfaces
+#+description: Shell, Data Librarian publication, DQ metadata indexes, and event-bus subscriptions all checked for correct tenant isolation; gaps fixed.
+#+type: story
+#+level: s2
+#+filetags: :tenancy:validation:shell:librarian:eventing:sprint_11:v0:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+Parent sprint: [[id:a48c03ec-395b-4842-b60d-de93dd24bf57][Sprint 11]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-06]
+:END:
+
+** Now
+Completed 2026-02-06.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-06
+
+* Goal
+
+Validate that tenancy actually works across every surface that could leak: shell, Data Librarian publication, DQ metadata indexes,
+event bus. Fix the gaps.
+
+* Acceptance
+
+- Shell scenarios green: super-admin login, tenant-admin creation+login, tenant-user creation+login.
+- DQ metadata unique indexes include =tenant_id=.
+- Data Librarian publication works across tenants; image_id resolution handled.
+- Eventing carries tenant_id end-to-end and filters at the subscription manager.
+
+* Tasks
+
+In execution order:
+
+- [[id:94a87d79-bae3-46a1-b1b3-81784f3d8c2b][Test shell functionality with tenancy enabled]]
+- [[id:d1b73897-ed9a-49a8-9fc6-8d77b941d1d2][Review DQ metadata tables for multi-tenancy]]
+- [[id:27ee7d4c-c59e-4b9f-a6c6-3920dcce5c77][Check Data Librarian can publish across tenants]]
+- [[id:10f2ee08-c4c4-4b2d-af8a-10898ff2d309][Check eventing across tenants]]
+
+* Decisions
+
+- /Validate before declaring victory/ :: easy to think /tenancy is done/ once the schema and handlers compile; the surfaces that would leak silently get checked here.
+- /Backward-compatible event broadcast when tenant absent/ :: keeps pre-login sessions and unconfigured-session-service paths working without a special case.
+
+* Out of scope
+
+- Wt + HTTP tenant validation (handled separately when Wt is exercised in anger).
+
+* See also
+
+- [[id:976a2745-6728-435e-970e-d1205d46dc7a][Per-request tenant context]] — must land before this validation can trust the handler layer.

--- a/doc/v2/versions/v0/sprint_11/validate_tenancy_across_surfaces/task_check_data_librarian_publish_across_tenants.org
+++ b/doc/v2/versions/v0/sprint_11/validate_tenancy_across_surfaces/task_check_data_librarian_publish_across_tenants.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: 27ee7d4c-c59e-4b9f-a6c6-3920dcce5c77
+:END:
+#+title: Check Data Librarian can publish across tenants
+#+description: Add tenant_id to unique version indexes on 11 DQ metadata + asset + refdata tables; image_id resolution looks up by key in DQ images then by key in target-tenant assets; ImageCache::clear() before reload; connection-browser UI polish; permissions suggest shell command; ores_iam_generate_role_commands_fn SECURITY DEFINER.
+#+type: task
+#+level: s1
+#+filetags: :dq:librarian:tenancy:publishing:assets:validate_tenancy_across_surfaces:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:52bbea16-0344-4299-88ba-ec6a341fbd21][Validate tenancy across surfaces]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-06]
+:END:
+
+** Now
+Completed 2026-02-06.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-06
+
+* Goal
+
+Get cross-tenant Data Librarian publication working correctly; close the DQ metadata unique-index gap.
+
+* Acceptance
+
+- =tenant_id= added to unique version indexes on 11 DQ metadata tables + asset (images, tags) + refdata (countries).
+- Image-publishing functions look up =image_key= in DQ images, then resolve the corresponding image in the target tenant's =assets_images_tbl= (UUIDs differ across tenants).
+- =ImageCache::clear()= before reload prevents stale-UUID issues.
+- Qt connection browser: alphabetical sort, tree expansion preserved across save/edit/delete, inline edit fields populated, dialog closes its MDI sub-window not the main window.
+- New shell command =permissions suggest <user>= emits a sequence of =accounts assign-role= commands.
+- =ores_iam_generate_role_commands_fn= marked =SECURITY DEFINER= so it can do cross-tenant lookups when needed.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+The error log was very specific — duplicate-key violations on =image_id, version= that wouldn't have been violations if =tenant_id= were part of the index.
+
+* Result
+
+Cross-tenant publication green; supporting UX polish landed too.

--- a/doc/v2/versions/v0/sprint_11/validate_tenancy_across_surfaces/task_check_eventing_across_tenants.org
+++ b/doc/v2/versions/v0/sprint_11/validate_tenancy_across_surfaces/task_check_eventing_across_tenants.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 10f2ee08-c4c4-4b2d-af8a-10898ff2d309
+:END:
+#+title: Check eventing across tenants
+#+description: tenant_id propagated through SQL triggers → JSONB payloads → event bus → subscription_manager; subscription_manager::notify() filters by session tenant; backward-compatible broadcast when tenant absent; 5 new test cases.
+#+type: task
+#+level: s1
+#+filetags: :eventing:tenancy:validation:subscription:validate_tenancy_across_surfaces:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:52bbea16-0344-4299-88ba-ec6a341fbd21][Validate tenancy across surfaces]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-06]
+:END:
+
+** Now
+Completed 2026-02-06.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-06
+
+* Goal
+
+Make sure events stay inside their tenant — a database trigger in tenant A must not reach subscribers in tenant B.
+
+* Acceptance
+
+- SQL triggers embed =tenant_id= in JSONB notification payloads.
+- Event-bus + domain-event types carry =tenant_id= end-to-end.
+- =subscription_manager::notify()= filters by session tenant.
+- Backward-compatible broadcast when =tenant_id= is empty (pre-login sessions, unconfigured session service).
+- Five new test cases cover tenant matching, broadcast, cross-tenant isolation, pre-login, and no-session-service scenarios.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Final piece of /tenancy actually works/ — the eventing path was the easiest to leak through without anyone noticing.
+
+* Result
+
+Eventing tenant-aware end-to-end.

--- a/doc/v2/versions/v0/sprint_11/validate_tenancy_across_surfaces/task_review_dq_metadata_multitenancy.org
+++ b/doc/v2/versions/v0/sprint_11/validate_tenancy_across_surfaces/task_review_dq_metadata_multitenancy.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: d1b73897-ed9a-49a8-9fc6-8d77b941d1d2
+:END:
+#+title: Review DQ metadata tables for multi-tenancy
+#+description: Audit: 11 DQ metadata tables have unique version indexes without tenant_id, blocking cross-tenant duplication; decision recorded; fix lands as part of the publish-across-tenants task.
+#+type: task
+#+level: s1
+#+filetags: :dq:tenancy:analysis:sql:validate_tenancy_across_surfaces:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:52bbea16-0344-4299-88ba-ec6a341fbd21][Validate tenancy across surfaces]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-06]
+:END:
+
+** Now
+Completed 2026-02-06.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-06
+
+* Goal
+
+Analyse the DQ metadata tables for multi-tenant correctness: their unique version indexes don't include =tenant_id=, which would block different tenants from carrying the same metadata.
+
+* Acceptance
+
+- 11 DQ tables identified: =catalogs=, =change_reason_categories=, =change_reasons=, =coding_scheme_authority_types=, =data_domains=, =datasets=, =methodologies=, =nature_dimensions=, =origin_dimensions=, =subject_areas=, =treatment_dimensions=.
+- Design decision: DQ metadata is tenant-specific; add =tenant_id= to all version unique indexes.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Analysis pass; the fix lands as part of the Data Librarian publication task in the same story.
+
+* Result
+
+Issue scoped; fix scheduled.

--- a/doc/v2/versions/v0/sprint_11/validate_tenancy_across_surfaces/task_test_shell_with_tenancy.org
+++ b/doc/v2/versions/v0/sprint_11/validate_tenancy_across_surfaces/task_test_shell_with_tenancy.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: 94a87d79-bae3-46a1-b1b3-81784f3d8c2b
+:END:
+#+title: Test shell functionality with tenancy enabled
+#+description: Scenarios: super-admin login, tenant-admin creation + login, tenant-user creation + login; bootstrap mode replay. ores.iam::client login() + logout() helpers; messaging enum refactoring; C++ enum codegen.
+#+type: task
+#+level: s1
+#+filetags: :shell:tenancy:validation:iam:codegen:validate_tenancy_across_surfaces:sprint_11:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-19
+#+updated: 2026-05-19
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+Parent story: [[id:52bbea16-0344-4299-88ba-ec6a341fbd21][Validate tenancy across surfaces]].
+
+* DONE Status
+:PROPERTIES:
+:CLOSED: [2026-02-05]
+:END:
+
+** Now
+Completed 2026-02-05.
+
+** Waiting on
+None.
+
+** Next
+None.
+
+** Last touched
+2026-02-05
+
+* Goal
+
+Verify the shell behaves correctly under tenancy across the realistic scenarios.
+
+* Acceptance
+
+- Super-admin login works.
+- Super-admin can create a tenant-admin and log in as that admin.
+- Tenant-admin can create a tenant-user and log in as that user.
+- Bootstrap re-entry after restart works.
+- Client-side =ores.iam::client::login()= + =logout()= helpers reduce boilerplate.
+- Messaging enums refactored: =message_types.hpp= split into =message_type.hpp= + =compression_type.hpp= + =protocol.hpp=.
+- C++ enum codegen profile + template (=cpp_enum.hpp.mustache=) added to =ores.codegen=.
+
+* Plan
+
+Captured during execution; cleared into the parent story on close.
+
+* Notes
+
+Restart-bootstrap-mode bug surfaced here; fixed in the system-accounts task.
+
+* Result
+
+Shell validated under tenancy; client login helpers landed.

--- a/doc/v2/versions/v0/version.org
+++ b/doc/v2/versions/v0/version.org
@@ -76,6 +76,10 @@ is the current sprint; the rest are closed.
   reference data; ORE XML codegen via xsdcpp; metadata /
   production schema split; dataset bundles + System
   Provisioner Wizard.
+- [[id:a48c03ec-395b-4842-b60d-de93dd24bf57][Sprint 11]] — Multi-tenant support end-to-end: RBAC + schema
+  consolidation; tenancy foundation, codegen, and test isolation;
+  per-request tenant context; sqlgen improvements; telemetry
+  database sink; tenant validation across surfaces.
 - ... through Sprint 16.
 
 * Release scope

--- a/doc/v2/versions/v0/version.org
+++ b/doc/v2/versions/v0/version.org
@@ -69,6 +69,9 @@ is the current sprint; the rest are closed.
 - [[id:49c4e380-68ee-4d80-839a-41311a99c734][Sprint 08]] — Database overhaul; ISO countries; change-
   management infrastructure; Qt UX polish; comms substrate
   evolution; entity-creator skills; Wt + observability review.
+- [[id:af0b027b-77bf-4794-810d-39ad49a5efad][Sprint 09]] — Data Quality subsystem + Data Librarian;
+  connection management; database naming refactor;
+  =ores.security=; CLI entity coverage; Qt icon refactor.
 - ... through Sprint 16.
 
 * Release scope

--- a/doc/v2/versions/v0/version.org
+++ b/doc/v2/versions/v0/version.org
@@ -72,6 +72,10 @@ is the current sprint; the rest are closed.
 - [[id:af0b027b-77bf-4794-810d-39ad49a5efad][Sprint 09]] — Data Quality subsystem + Data Librarian;
   connection management; database naming refactor;
   =ores.security=; CLI entity coverage; Qt icon refactor.
+- [[id:4bac3b0f-819f-43f3-8a59-2b48abe56938][Sprint 10]] — Codegen infrastructure; party schemes + FPML
+  reference data; ORE XML codegen via xsdcpp; metadata /
+  production schema split; dataset bundles + System
+  Provisioner Wizard.
 - ... through Sprint 16.
 
 * Release scope

--- a/doc/v2/versions/v0/version.org
+++ b/doc/v2/versions/v0/version.org
@@ -66,6 +66,9 @@ is the current sprint; the rest are closed.
 - [[id:a79d42af-1b38-43ee-9607-848a4a84c09a][Sprint 07]] — Accounts → IAM rename; RBAC; Wt + HTTP
   introduction; observability and telemetry components; build
   platform follow-up.
+- [[id:49c4e380-68ee-4d80-839a-41311a99c734][Sprint 08]] — Database overhaul; ISO countries; change-
+  management infrastructure; Qt UX polish; comms substrate
+  evolution; entity-creator skills; Wt + observability review.
 - ... through Sprint 16.
 
 * Release scope


### PR DESCRIPTION
## Summary

Migrates sprints 08-11 of v0 into the v2 cybernetic information architecture
landed in PR #771. Four sprints, 43 stories, 114 tasks under
=doc/v2/versions/v0/sprint_{08,09,10,11}/=.

### Sprint 08

11 stories / 31 tasks. The biggest v0 sprint to date.

- =database_schema_and_seeding= — rerun SQL from scratch with TimescaleDB
  license-tier detection; move all seeding from C++ to SQL populate.
- =reference_data_countries= — first proper refdata entity end-to-end
  (ISO 3166-1, bitemporal, Wt CRUD UI, shell).
- =change_management_infrastructure= — reason taxonomy (BCBS 239 / FRTB /
  FINRA / MiFID II); Qt UI; protocol bump to 21.1.
- =qt_ux_polish= — currency / currencies-history / feature-flags / log-viewer
  dialogs; accounts dialog deferred.
- =wt_and_http_review= — validation of sprint-07 surfaces; HTTP recipes.
- =comms_substrate_evolution= — composable options across binaries; rename
  =ores.shell= → =ores.comms.shell=; dynamic event-channel discovery.
- =native_pagination_support= — adopt sqlgen 0.6.0; drop the
  single_connection aggregation hack.
- =entity_creator_skills= — six skills (Qt, shell, HTTP, HTTP recipes, Wt,
  CLI) for adding domain entities end-to-end.
- =books_modelling_analysis= — first-cut FpML-anchored entities for books.
- =observability_followup= — review-only pass; three implementations
  carried forward.

### Sprint 09

9 stories / 27 tasks.

- =data_quality_subsystem= — stand up =ores.dq= end-to-end: concept model,
  10 domain types + FpML, ER refactor with catalog grouping, DQ messaging
  subsystem (0x6000-0x6FFF, protocol 22.0 breaking), Data Librarian
  three-panel MDI, subject-area management, DQ-IAM circular dependency fix,
  publication wizard with Boost.Graph dependency resolution, fake-world
  validation dataset.
- =connection_management= — =ores.connections= (SQLite + AES-256-GCM),
  Connection Browser MDI, modeless modernised login/sign-up dialogs.
- =database_naming_refactor= — rename =ores.risk= → =ores.refdata=; apply
  =<component>_<entity>_<suffix>= naming across the schema.
- =security_module= — extract shared crypto primitives into =ores.security=
  with RAII OpenSSL contexts.
- =cli_entity_coverage= — list/delete for five entities; helper-driven
  refactor.
- =qt_visual_refresh= — centralise icons behind =enum class Icon=.
- =engineering_hygiene= — system-model refresh, pr-manager consolidation,
  nightly valgrind.
- =party_database_groundwork= — party table structure documented; postponed.

### Sprint 10

12 stories / 30 tasks.

- =codegen_infrastructure= — simple in-tree codegen; domain-types SQL; ER
  diagram from SQL with convention validation.
- =party_schemes_and_fpml_data= — 13 reference-data types party requires,
  via FpML codegen + DQ artefact workflow; GLEIF Golden Copy subset.
  Continues from sprint 09 party-database groundwork.
- =sql_directory_refactor= — create/, drop/, populate/ reorganised by
  component; safer teardown; =admin_*_fn=/=admin_*_view= convention.
- =ore_xml_codegen= — new =ores.ore= component; xsdcpp integration;
  xs:group ref expansion + xs:choice maxOccurs handling; Windows MSVC fix.
- =dataset_bundles_and_provisioning= — metadata/production schema split;
  dataset bundles + lifecycle functions; System Provisioner Wizard with
  localhost-only bootstrap.
- =external_data_reorganisation=, =image_cache_polish=, =schema_polish=,
  =librarian_polish=, =fpml_export_import_groundwork= (BACKLOG),
  =compute_grid_analysis= (BACKLOG).

### Sprint 11

11 stories / 26 tasks. The multi-tenancy sprint.

- =database_role_split_and_schema_consolidation= — preconditions: split
  the god admin account into RBAC roles; reverse sprint-10's schema split
  back to a single =public= schema; SQL tree tidy-up.
- =tenancy_foundation= — tenant tables + =tenant_id= on ~70 entity tables;
  ores_iam_validate_tenant_fn; seeding scoped to system tenant; BEFORE
  INSERT triggers populate tenant_id from session.
- =tenancy_test_isolation= — tenant_context C++ service; per-test tenant
  provisioning + deprovisioning; RLS policies; =--tenant= CLI flag; psqlrc
  tenant prompt.
- =tenancy_codegen_and_entity_types= — codegen Mustache templates emit
  tenant-aware tables by default; pgTAP; C++ tenant entities; protocol
  26.1.
- =sqlgen_improvements= — libpq audit; upstream PRs for NOTICE logging and
  bound parameters (latter BLOCKED on =getml/sqlgen#119=).
- =telemetry_database_sink= — break the =ores.telemetry= ↔
  =ores.database= circular dep; Boost.Log database sink; three-tier
  tenant lifecycle (terminate / deprovision / purge); recursive-logging
  guard.
- =service_accounts_and_audit= — account_type classifications; session-only
  auth for services; =performed_by= audit field across 42 tables;
  telemetry async-sink deadlock fix.
- =per_request_tenant_context= — tenant_aware_handler base class;
  per-request database context from session tenant_id; type-safe
  =tenant_id= wrapper; system tenant changes from nil UUID to max UUID
  (RFC 9562). Closes a real cross-tenant data-leakage risk.
- =validate_tenancy_across_surfaces= — shell scenarios; DQ metadata
  unique indexes; Data Librarian cross-tenant publication; eventing
  tenant_id propagation + subscription filtering.

### Notes for review

- Cross-sprint linkage is bidirectional (=#+predecessor= / =#+successor=
  with prose "Continued from/in:" lines):
  - sprint 09 =party_database_groundwork= → sprint 10
    =party_schemes_and_fpml_data=.
  - sprint 09 =data_quality_subsystem= → sprint 10 =librarian_polish=.
- =BLOCKED= TODO state used for the first time on
  =add_bound_parameters_sqlgen= (sprint 11) with =blocked_on= /
  =blocked_since= frontmatter.
- The metadata/production schema split landed in sprint 10 is reversed in
  sprint 11. Both stories cross-reference each other so the trace is
  preserved.
- All v2 references use org-roam =[[id:UUID][text]]= form; no file-path
  links.
- Site builds clean after the rebase from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)