### PR TITLE
[workspace] Phase 3+4: controller wiring and Data Workshop UI

### DIFF
--- a/CTest.cmake
+++ b/CTest.cmake
@@ -349,9 +349,14 @@ endif()
 #
 # Step: submit build results
 #
-# Always submit results to CDash, even if there were failures. This ensures
-# compilation errors and test failures are visible in the dashboard.
-ctest_submit(RETRY_COUNT ${retry_count} RETRY_DELAY ${retry_delay})
+# Always attempt to submit results to CDash, even if there were failures.
+# Capture the return value so that CDash being unreachable does not fail CI.
+ctest_submit(RETRY_COUNT ${retry_count} RETRY_DELAY ${retry_delay}
+    RETURN_VALUE submit_result)
+if(submit_result)
+    message(WARNING "CDash submission failed (exit code: ${submit_result}). "
+        "Build and test results are unaffected.")
+endif()
 
 #
 # Exit with error if any step failed

--- a/doc/plans/2026-05-17-workspace-design.org
+++ b/doc/plans/2026-05-17-workspace-design.org
@@ -725,7 +725,29 @@ remains Live-only; non-live workspace report definitions run on-demand only.
 10. Add indexes on ~workspace_id~; enforce cycle-prevention trigger on
     ~parent_workspace_id~ inserts/updates (updated for UUID FK).
 11. Extend ~ores_reporting_report_definitions_tbl~ with ~workspace_id~.
-12. Run ~recreate_database.sh -k -y~; validate schemas.
+12. FK validation inventory and trigger wiring:
+    a. Create ~ores_workspace_validate_fn(p_workspace_id uuid) returns uuid~
+       as ~SECURITY DEFINER~ (service users hold no SELECT on
+       ~ores_workspaces_tbl~; this mirrors the pattern of
+       ~ores_iam_validate_tenant_fn~).  Function must accept the Live sentinel
+       UUID unconditionally (it has no row in ~ores_workspaces_tbl~ that can be
+       checked via the normal active-row predicate).
+    b. Inventory every insert trigger on workspace-aware tables (the ~28+
+       entities from the codegen model list in
+       ~2026-05-19-workspace-id-codegen-propagation.org~) and add a
+       ~ores_workspace_validate_fn(NEW.workspace_id)~ call alongside the
+       existing ~ores_iam_validate_tenant_fn~ call.
+    c. Because most of these triggers are codegen-generated, add
+       ~has_workspace_id~ support to the trigger template
+       (~cpp_domain_type_create.sql.mustache~ or equivalent) so the call is
+       regenerated automatically rather than hand-wired per entity.
+13. Run ~recreate_database.sh -k -y~; validate schemas.
+
+Note on workspace visibility: all authenticated users within a tenant hold
+~workspace::workspaces:read~ by default, so workspaces are not private ACL
+objects.  Data restriction is handled by the ~scope_portfolio_id~ on the
+workspace itself (portfolio tree scoping), not by per-workspace read grants.
+This keeps the permission model simple and avoids over-engineering.
 
 ** Phase 2: Service layer
 

--- a/doc/plans/2026-05-19-workspace-id-codegen-propagation.org
+++ b/doc/plans/2026-05-19-workspace-id-codegen-propagation.org
@@ -1,6 +1,6 @@
 #+TITLE: Workspace ID Codegen Propagation
 #+DATE: 2026-05-19
-#+STATUS: In Progress
+#+STATUS: Complete
 
 * Overview
 

--- a/projects/ores.qt.api/include/ores.qt/EntityController.hpp
+++ b/projects/ores.qt.api/include/ores.qt/EntityController.hpp
@@ -86,11 +86,19 @@ public:
      * @brief Updates the client manager and username (e.g. after re-login).
      */
     void setClientManager(ClientManager* clientManager, const QString& username);
-    
+
     /**
      * @brief Updates just the username.
      */
     void setUsername(const QString& username) { username_ = username; }
+
+    /**
+     * @brief Pushes a new workspace context into the shared ClientManager.
+     *
+     * Called automatically when the MDI area's ores_workspace_context property
+     * changes.  May also be called directly by tests or subclasses.
+     */
+    void setWorkspaceContext(const WorkspaceContext& ctx);
 
     /**
      * @brief Shows the main list window for this entity.
@@ -231,6 +239,9 @@ protected:
      * Call this from derived class signal handlers connected to entity deleted signals.
      */
     void handleEntityDeleted();
+
+protected:
+    bool eventFilter(QObject* watched, QEvent* event) override;
 
 private slots:
     /**

--- a/projects/ores.qt.api/src/EntityController.cpp
+++ b/projects/ores.qt.api/src/EntityController.cpp
@@ -19,8 +19,10 @@
  */
 #include "ores.qt/EntityController.hpp"
 
+#include <QEvent>
 #include <QPointer>
 #include <QVariant>
+#include <QDynamicPropertyChangeEvent>
 #include "ores.qt/DetachableMdiSubWindow.hpp"
 #include "ores.qt/EntityListMdiWindow.hpp"
 #include "ores.qt/WorkspaceContext.hpp"
@@ -45,6 +47,14 @@ EntityController::EntityController(
 
     if (!eventName_.empty()) {
         setupEventSubscription();
+    }
+
+    // Watch the MDI area for workspace context changes and forward them to
+    // the client manager so every NATS request carries the right X-Workspace-Id.
+    mdiArea_->installEventFilter(this);
+    const auto wvar = mdiArea_->property("ores_workspace_context");
+    if (wvar.isValid()) {
+        setWorkspaceContext(wvar.value<WorkspaceContext>());
     }
 }
 
@@ -118,6 +128,26 @@ void EntityController::setClientManager(ClientManager* clientManager,
     const QString& username) {
     clientManager_ = clientManager;
     username_ = username;
+}
+
+void EntityController::setWorkspaceContext(const WorkspaceContext& ctx) {
+    if (clientManager_) {
+        clientManager_->setWorkspaceContext(ctx);
+    }
+}
+
+bool EntityController::eventFilter(QObject* watched, QEvent* event) {
+    if (watched == mdiArea_ &&
+        event->type() == QEvent::DynamicPropertyChange) {
+        const auto* pe = static_cast<QDynamicPropertyChangeEvent*>(event);
+        if (pe->propertyName() == "ores_workspace_context") {
+            const auto wvar = mdiArea_->property("ores_workspace_context");
+            if (wvar.isValid()) {
+                setWorkspaceContext(wvar.value<WorkspaceContext>());
+            }
+        }
+    }
+    return QObject::eventFilter(watched, event);
 }
 
 QString EntityController::build_window_key(const QString& windowType,

--- a/projects/ores.qt.workspace/include/ores.qt/ClientWorkspaceModel.hpp
+++ b/projects/ores.qt.workspace/include/ores.qt/ClientWorkspaceModel.hpp
@@ -80,6 +80,15 @@ public:
     void refresh();
 
     /**
+     * @brief Get all loaded workspaces.
+     *
+     * @return All workspaces currently loaded in the model.
+     */
+    const std::vector<workspace::domain::workspace>& workspaces() const {
+        return workspaces_;
+    }
+
+    /**
      * @brief Get workspace at the specified row.
      *
      * @param row The row index.

--- a/projects/ores.qt.workspace/include/ores.qt/WorkspaceController.hpp
+++ b/projects/ores.qt.workspace/include/ores.qt/WorkspaceController.hpp
@@ -74,6 +74,7 @@ protected:
 private slots:
     void onShowDetails(const workspace::domain::workspace& workspace);
     void onAddNewRequested();
+    void onWorkspaceActivated(const workspace::domain::workspace& workspace);
 
 private:
     void showAddWindow();

--- a/projects/ores.qt.workspace/include/ores.qt/WorkspaceMdiWindow.hpp
+++ b/projects/ores.qt.workspace/include/ores.qt/WorkspaceMdiWindow.hpp
@@ -21,11 +21,12 @@
 #define ORES_QT_WORKSPACE_MDI_WINDOW_HPP
 
 #include <vector>
-#include <string>
 #include <unordered_map>
 #include <QToolBar>
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_hash.hpp>
 #include "ores.qt/EntityListMdiWindow.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/ClientWorkspaceModel.hpp"
@@ -97,9 +98,10 @@ private:
     void updateActionStates();
     void buildTree();
     void addTreeItems(QTreeWidgetItem* parent,
-        const QString& parent_id_str,
-        const std::unordered_map<std::string,
-            std::vector<const workspace::domain::workspace*>>& children_map);
+        const boost::uuids::uuid& parent_id,
+        const std::unordered_map<boost::uuids::uuid,
+            std::vector<const workspace::domain::workspace*>,
+            boost::hash<boost::uuids::uuid>>& children_map);
 
     ClientManager* clientManager_;
     QString username_;

--- a/projects/ores.qt.workspace/include/ores.qt/WorkspaceMdiWindow.hpp
+++ b/projects/ores.qt.workspace/include/ores.qt/WorkspaceMdiWindow.hpp
@@ -20,13 +20,15 @@
 #ifndef ORES_QT_WORKSPACE_MDI_WINDOW_HPP
 #define ORES_QT_WORKSPACE_MDI_WINDOW_HPP
 
+#include <vector>
+#include <string>
+#include <unordered_map>
 #include <QToolBar>
-#include <QTableView>
-#include <QSortFilterProxyModel>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
 #include "ores.qt/EntityListMdiWindow.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/ClientWorkspaceModel.hpp"
-#include "ores.qt/PaginationWidget.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.workspace.api/domain/workspace.hpp"
 
@@ -35,8 +37,8 @@ namespace ores::qt {
 /**
  * @brief MDI window for displaying and managing workspaces.
  *
- * Provides a table view of workspaces with toolbar actions
- * for reload, add, edit, archive, and delete.
+ * Provides a tree view of workspaces with toolbar actions
+ * for reload, add, open, edit, archive, and delete.
  */
 class WorkspaceMdiWindow final : public EntityListMdiWindow {
     Q_OBJECT
@@ -64,12 +66,14 @@ signals:
     void showWorkspaceDetails(const workspace::domain::workspace& workspace);
     void addNewRequested();
     void workspaceDeleted(const QString& code);
+    void workspaceActivated(const workspace::domain::workspace& workspace);
 
 public slots:
     void addNew();
     void editSelected();
     void archiveSelected();
     void deleteSelected();
+    void openSelected();
 
 protected:
     void doReload() override;
@@ -78,7 +82,7 @@ private slots:
     void onDataLoaded();
     void onLoadError(const QString& error_message, const QString& details = {});
     void onSelectionChanged();
-    void onDoubleClicked(const QModelIndex& index);
+    void onItemDoubleClicked(QTreeWidgetItem* item, int column);
 
 protected:
     QString normalRefreshTooltip() const override {
@@ -88,22 +92,26 @@ protected:
 private:
     void setupUi();
     void setupToolbar();
-    void setupTable();
+    void setupTree();
     void setupConnections();
     void updateActionStates();
+    void buildTree();
+    void addTreeItems(QTreeWidgetItem* parent,
+        const QString& parent_id_str,
+        const std::unordered_map<std::string,
+            std::vector<const workspace::domain::workspace*>>& children_map);
 
     ClientManager* clientManager_;
     QString username_;
 
     QToolBar* toolbar_;
-    QTableView* tableView_;
+    QTreeWidget* treeWidget_;
     ClientWorkspaceModel* model_;
-    QSortFilterProxyModel* proxyModel_;
-    PaginationWidget* paginationWidget_;
 
     // Toolbar actions
     QAction* reloadAction_;
     QAction* addAction_;
+    QAction* openAction_;
     QAction* editAction_;
     QAction* archiveAction_;
     QAction* deleteAction_;

--- a/projects/ores.qt.workspace/include/ores.qt/WorkspaceMdiWindow.hpp
+++ b/projects/ores.qt.workspace/include/ores.qt/WorkspaceMdiWindow.hpp
@@ -21,7 +21,6 @@
 #define ORES_QT_WORKSPACE_MDI_WINDOW_HPP
 
 #include <vector>
-#include <unordered_map>
 #include <QToolBar>
 #include <QTreeWidget>
 #include <QTreeWidgetItem>

--- a/projects/ores.qt.workspace/include/ores.qt/WorkspaceMdiWindow.hpp
+++ b/projects/ores.qt.workspace/include/ores.qt/WorkspaceMdiWindow.hpp
@@ -25,8 +25,6 @@
 #include <QToolBar>
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_hash.hpp>
 #include "ores.qt/EntityListMdiWindow.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/ClientWorkspaceModel.hpp"
@@ -97,11 +95,6 @@ private:
     void setupConnections();
     void updateActionStates();
     void buildTree();
-    void addTreeItems(QTreeWidgetItem* parent,
-        const boost::uuids::uuid& parent_id,
-        const std::unordered_map<boost::uuids::uuid,
-            std::vector<const workspace::domain::workspace*>,
-            boost::hash<boost::uuids::uuid>>& children_map);
 
     ClientManager* clientManager_;
     QString username_;

--- a/projects/ores.qt.workspace/src/WorkspaceController.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceController.cpp
@@ -22,11 +22,16 @@
 #include <QMdiSubWindow>
 #include <QMessageBox>
 #include <QPointer>
+#include <QVariant>
+#include <QtConcurrent>
+#include <QFutureWatcher>
 #include <boost/uuid/uuid_io.hpp>
 #include "ores.qt/IconUtils.hpp"
+#include "ores.qt/WorkspaceContext.hpp"
 #include "ores.qt/WorkspaceMdiWindow.hpp"
 #include "ores.qt/WorkspaceDetailDialog.hpp"
 #include "ores.qt/DetachableMdiSubWindow.hpp"
+#include "ores.workspace.api/messaging/workspace_protocol.hpp"
 
 namespace ores::qt {
 
@@ -67,6 +72,8 @@ void WorkspaceController::showListWindow() {
             this, &WorkspaceController::onShowDetails);
     connect(listWindow_, &WorkspaceMdiWindow::addNewRequested,
             this, &WorkspaceController::onAddNewRequested);
+    connect(listWindow_, &WorkspaceMdiWindow::workspaceActivated,
+            this, &WorkspaceController::onWorkspaceActivated);
 
     // Create MDI subwindow
     listMdiSubWindow_ = new DetachableMdiSubWindow(mainWindow_);
@@ -220,6 +227,72 @@ void WorkspaceController::showDetailWindow(
 
     connect_dialog_close(detailDialog, detailWindow);
     show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void WorkspaceController::onWorkspaceActivated(
+    const workspace::domain::workspace& ws) {
+
+    const std::string ws_id = boost::uuids::to_string(ws.id);
+    BOOST_LOG_SEV(lg(), debug) << "Workspace activation requested: " << ws_id;
+
+    constexpr std::string_view live_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    if (ws_id == live_id) {
+        WorkspaceContext ctx;
+        mdiArea_->setProperty("ores_workspace_context",
+            QVariant::fromValue(ctx));
+        emit statusMessage(tr("Active workspace: Live"));
+        return;
+    }
+
+    QPointer<WorkspaceController> self = this;
+    const std::string ws_name = ws.name;
+
+    struct ResolveResult {
+        bool success;
+        std::vector<std::string> resolution_order;
+        std::string error;
+    };
+
+    auto task = [self, ws_id]() -> ResolveResult {
+        if (!self) return {false, {}, "Controller destroyed"};
+        workspace::messaging::resolve_workspace_request request;
+        request.workspace_id = ws_id;
+        auto result = self->clientManager_->process_authenticated_request(
+            std::move(request));
+        if (!result) return {false, {}, "Failed to communicate with server"};
+        return {true, result->resolution_order, {}};
+    };
+
+    auto* watcher = new QFutureWatcher<ResolveResult>(self);
+    connect(watcher, &QFutureWatcher<ResolveResult>::finished,
+            self, [self, watcher, ws_id, ws_name]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (!self) return;
+
+        if (!result.success) {
+            BOOST_LOG_SEV(lg(), error) << "Resolve failed for workspace "
+                                       << ws_id << ": " << result.error;
+            emit self->errorMessage(QString::fromStdString(result.error));
+            return;
+        }
+
+        WorkspaceContext ctx;
+        ctx.id = QString::fromStdString(ws_id);
+        ctx.name = QString::fromStdString(ws_name);
+        ctx.resolution_order.clear();
+        for (const auto& uuid_str : result.resolution_order)
+            ctx.resolution_order.push_back(QString::fromStdString(uuid_str));
+
+        self->mdiArea_->setProperty("ores_workspace_context",
+            QVariant::fromValue(ctx));
+        emit self->statusMessage(
+            tr("Active workspace: %1").arg(QString::fromStdString(ws_name)));
+    });
+
+    QFuture<ResolveResult> future = QtConcurrent::run(task);
+    watcher->setFuture(future);
 }
 
 EntityListMdiWindow* WorkspaceController::listWindow() const {

--- a/projects/ores.qt.workspace/src/WorkspaceController.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceController.cpp
@@ -27,6 +27,7 @@
 #include <QFutureWatcher>
 #include <boost/uuid/uuid_io.hpp>
 #include "ores.qt/IconUtils.hpp"
+#include "ores.utility/uuid/tenant_id.hpp"
 #include "ores.qt/WorkspaceContext.hpp"
 #include "ores.qt/WorkspaceMdiWindow.hpp"
 #include "ores.qt/WorkspaceDetailDialog.hpp"
@@ -232,11 +233,10 @@ void WorkspaceController::showDetailWindow(
 void WorkspaceController::onWorkspaceActivated(
     const workspace::domain::workspace& ws) {
 
-    const std::string ws_id = boost::uuids::to_string(ws.id);
-    BOOST_LOG_SEV(lg(), debug) << "Workspace activation requested: " << ws_id;
+    BOOST_LOG_SEV(lg(), debug) << "Workspace activation requested: "
+                               << boost::uuids::to_string(ws.id);
 
-    constexpr std::string_view live_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
-    if (ws_id == live_id) {
+    if (ws.id == ores::utility::uuid::live_workspace_id()) {
         WorkspaceContext ctx;
         mdiArea_->setProperty("ores_workspace_context",
             QVariant::fromValue(ctx));
@@ -245,6 +245,7 @@ void WorkspaceController::onWorkspaceActivated(
     }
 
     QPointer<WorkspaceController> self = this;
+    const std::string ws_id = boost::uuids::to_string(ws.id);
     const std::string ws_name = ws.name;
 
     struct ResolveResult {

--- a/projects/ores.qt.workspace/src/WorkspaceDetailDialog.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceDetailDialog.cpp
@@ -123,6 +123,13 @@ void WorkspaceDetailDialog::updateUiFromWorkspace() {
     ui_->nameEdit->setText(QString::fromStdString(workspace_.name));
     ui_->descriptionEdit->setPlainText(QString::fromStdString(workspace_.description));
 
+    if (workspace_.parent_workspace_id) {
+        ui_->inheritsFromEdit->setText(QString::fromStdString(
+            boost::uuids::to_string(*workspace_.parent_workspace_id)));
+    } else {
+        ui_->inheritsFromEdit->setText(QString());
+    }
+
     if (workspace_.version > 0 && provenanceWidget()) {
         provenanceWidget()->populate(
             workspace_.version,

--- a/projects/ores.qt.workspace/src/WorkspaceMdiWindow.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceMdiWindow.cpp
@@ -171,12 +171,16 @@ void WorkspaceMdiWindow::doReload() {
     model_->refresh();
 }
 
-void WorkspaceMdiWindow::addTreeItems(
-    QTreeWidgetItem* parent,
+namespace {
+
+using children_map_t = std::unordered_map<
+    boost::uuids::uuid,
+    std::vector<const workspace::domain::workspace*>,
+    boost::hash<boost::uuids::uuid>>;
+
+void addTreeItems(QTreeWidgetItem* parent,
     const boost::uuids::uuid& parent_id,
-    const std::unordered_map<boost::uuids::uuid,
-        std::vector<const workspace::domain::workspace*>,
-        boost::hash<boost::uuids::uuid>>& children_map) {
+    const children_map_t& children_map) {
 
     auto it = children_map.find(parent_id);
     if (it == children_map.end())
@@ -194,6 +198,8 @@ void WorkspaceMdiWindow::addTreeItems(
     }
 }
 
+} // namespace
+
 void WorkspaceMdiWindow::buildTree() {
     treeWidget_->clear();
 
@@ -207,9 +213,7 @@ void WorkspaceMdiWindow::buildTree() {
     for (const auto& ws : all)
         by_id[ws.id] = &ws;
 
-    std::unordered_map<boost::uuids::uuid,
-        std::vector<const workspace::domain::workspace*>,
-        boost::hash<boost::uuids::uuid>> children_map;
+    children_map_t children_map;
 
     std::vector<const workspace::domain::workspace*> roots;
     for (const auto& ws : all) {

--- a/projects/ores.qt.workspace/src/WorkspaceMdiWindow.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceMdiWindow.cpp
@@ -19,6 +19,7 @@
  */
 #include "ores.qt/WorkspaceMdiWindow.hpp"
 
+#include <unordered_map>
 #include <QVBoxLayout>
 #include <QHeaderView>
 #include <QMessageBox>
@@ -42,12 +43,11 @@ WorkspaceMdiWindow::WorkspaceMdiWindow(
       clientManager_(clientManager),
       username_(username),
       toolbar_(nullptr),
-      tableView_(nullptr),
+      treeWidget_(nullptr),
       model_(nullptr),
-      proxyModel_(nullptr),
-      paginationWidget_(nullptr),
       reloadAction_(nullptr),
       addAction_(nullptr),
+      openAction_(nullptr),
       editAction_(nullptr),
       archiveAction_(nullptr),
       deleteAction_(nullptr) {
@@ -64,11 +64,8 @@ void WorkspaceMdiWindow::setupUi() {
     layout->addWidget(toolbar_);
     layout->addWidget(loadingBar());
 
-    setupTable();
-    layout->addWidget(tableView_);
-
-    paginationWidget_ = new PaginationWidget(this);
-    layout->addWidget(paginationWidget_);
+    setupTree();
+    layout->addWidget(treeWidget_);
 }
 
 void WorkspaceMdiWindow::setupToolbar() {
@@ -96,6 +93,17 @@ void WorkspaceMdiWindow::setupToolbar() {
     connect(addAction_, &QAction::triggered, this,
             &WorkspaceMdiWindow::addNew);
 
+    toolbar_->addSeparator();
+
+    openAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::FolderOpen, IconUtils::DefaultIconColor),
+        tr("Open"));
+    openAction_->setToolTip(tr("Open selected workspace (make it the active context)"));
+    openAction_->setEnabled(false);
+    connect(openAction_, &QAction::triggered, this,
+            &WorkspaceMdiWindow::openSelected);
+
     editAction_ = toolbar_->addAction(
         IconUtils::createRecoloredIcon(
             Icon::Edit, IconUtils::DefaultIconColor),
@@ -118,31 +126,26 @@ void WorkspaceMdiWindow::setupToolbar() {
         IconUtils::createRecoloredIcon(
             Icon::Delete, IconUtils::DefaultIconColor),
         tr("Delete"));
-    deleteAction_->setToolTip(tr("Permanently soft-delete selected workspace and associated data"));
+    deleteAction_->setToolTip(
+        tr("Permanently soft-delete selected workspace and associated data"));
     deleteAction_->setEnabled(false);
     connect(deleteAction_, &QAction::triggered, this,
             &WorkspaceMdiWindow::deleteSelected);
-
 }
 
-void WorkspaceMdiWindow::setupTable() {
+void WorkspaceMdiWindow::setupTree() {
     model_ = new ClientWorkspaceModel(clientManager_, this);
-    proxyModel_ = new QSortFilterProxyModel(this);
-    proxyModel_->setSourceModel(model_);
-    proxyModel_->setSortCaseSensitivity(Qt::CaseInsensitive);
 
-    tableView_ = new QTableView(this);
-    tableView_->setModel(proxyModel_);
-    tableView_->setSelectionBehavior(QAbstractItemView::SelectRows);
-    tableView_->setSelectionMode(QAbstractItemView::SingleSelection);
-    tableView_->setSortingEnabled(true);
-    tableView_->setAlternatingRowColors(true);
-    tableView_->verticalHeader()->setVisible(false);
-
-    initializeTableSettings(tableView_, model_,
-        "WorkspaceListWindow",
-        {ClientWorkspaceModel::Description},
-        {900, 400}, 1);
+    treeWidget_ = new QTreeWidget(this);
+    treeWidget_->setColumnCount(3);
+    treeWidget_->setHeaderLabels({tr("Name"), tr("Status"), tr("Modified By")});
+    treeWidget_->setRootIsDecorated(true);
+    treeWidget_->setAnimated(true);
+    treeWidget_->setAlternatingRowColors(true);
+    treeWidget_->setSelectionBehavior(QAbstractItemView::SelectRows);
+    treeWidget_->setSelectionMode(QAbstractItemView::SingleSelection);
+    treeWidget_->header()->setStretchLastSection(false);
+    treeWidget_->header()->setSectionResizeMode(0, QHeaderView::Stretch);
 }
 
 void WorkspaceMdiWindow::setupConnections() {
@@ -151,30 +154,10 @@ void WorkspaceMdiWindow::setupConnections() {
     connect(model_, &ClientWorkspaceModel::loadError,
             this, &WorkspaceMdiWindow::onLoadError);
 
-    connect(tableView_->selectionModel(), &QItemSelectionModel::selectionChanged,
+    connect(treeWidget_, &QTreeWidget::itemSelectionChanged,
             this, &WorkspaceMdiWindow::onSelectionChanged);
-    connect(tableView_, &QTableView::doubleClicked,
-            this, &WorkspaceMdiWindow::onDoubleClicked);
-
-    connect(paginationWidget_, &PaginationWidget::page_size_changed,
-            this, [this](std::uint32_t size) {
-        model_->set_page_size(size);
-        model_->refresh();
-    });
-
-    connect(paginationWidget_, &PaginationWidget::load_all_requested,
-            this, [this]() {
-        const auto total = model_->total_available_count();
-        if (total > 0 && total <= 1000) {
-            model_->set_page_size(total);
-            model_->refresh();
-        }
-    });
-
-    connect(paginationWidget_, &PaginationWidget::page_requested,
-            this, [this](std::uint32_t offset, std::uint32_t limit) {
-        model_->load_page(offset, limit);
-    });
+    connect(treeWidget_, &QTreeWidget::itemDoubleClicked,
+            this, &WorkspaceMdiWindow::onItemDoubleClicked);
 
     connectModel(model_);
 }
@@ -186,14 +169,77 @@ void WorkspaceMdiWindow::doReload() {
     model_->refresh();
 }
 
+void WorkspaceMdiWindow::addTreeItems(
+    QTreeWidgetItem* parent,
+    const QString& parent_id_str,
+    const std::unordered_map<std::string,
+        std::vector<const workspace::domain::workspace*>>& children_map) {
+
+    auto it = children_map.find(parent_id_str.toStdString());
+    if (it == children_map.end())
+        return;
+
+    for (const auto* ws : it->second) {
+        const QString id_str =
+            QString::fromStdString(boost::uuids::to_string(ws->id));
+        auto* item = new QTreeWidgetItem(parent);
+        item->setText(0, QString::fromStdString(ws->name));
+        item->setText(1, QString::fromStdString(ws->status_code));
+        item->setText(2, QString::fromStdString(ws->modified_by));
+        item->setData(0, Qt::UserRole, id_str);
+        addTreeItems(item, id_str, children_map);
+    }
+}
+
+void WorkspaceMdiWindow::buildTree() {
+    treeWidget_->clear();
+
+    const auto& all = model_->workspaces();
+    if (all.empty())
+        return;
+
+    std::unordered_map<std::string, const workspace::domain::workspace*> by_id;
+    for (const auto& ws : all)
+        by_id[boost::uuids::to_string(ws.id)] = &ws;
+
+    std::unordered_map<std::string,
+        std::vector<const workspace::domain::workspace*>> children_map;
+
+    std::vector<const workspace::domain::workspace*> roots;
+    for (const auto& ws : all) {
+        if (!ws.parent_workspace_id) {
+            roots.push_back(&ws);
+        } else {
+            const std::string parent_str =
+                boost::uuids::to_string(*ws.parent_workspace_id);
+            if (by_id.count(parent_str)) {
+                children_map[parent_str].push_back(&ws);
+            } else {
+                roots.push_back(&ws);
+            }
+        }
+    }
+
+    for (const auto* ws : roots) {
+        const QString id_str =
+            QString::fromStdString(boost::uuids::to_string(ws->id));
+        auto* item = new QTreeWidgetItem(treeWidget_);
+        item->setText(0, QString::fromStdString(ws->name));
+        item->setText(1, QString::fromStdString(ws->status_code));
+        item->setText(2, QString::fromStdString(ws->modified_by));
+        item->setData(0, Qt::UserRole, id_str);
+        addTreeItems(item, id_str, children_map);
+    }
+
+    treeWidget_->expandAll();
+}
+
 void WorkspaceMdiWindow::onDataLoaded() {
-    const auto loaded = model_->rowCount();
+    const auto loaded = static_cast<int>(model_->workspaces().size());
     const auto total = model_->total_available_count();
     emit statusChanged(tr("Loaded %1 of %2 workspaces").arg(loaded).arg(total));
 
-    paginationWidget_->update_state(loaded, total);
-    paginationWidget_->set_load_all_enabled(
-        loaded < static_cast<int>(total) && total > 0 && total <= 1000);
+    buildTree();
 }
 
 void WorkspaceMdiWindow::onLoadError(const QString& error_message,
@@ -207,21 +253,43 @@ void WorkspaceMdiWindow::onSelectionChanged() {
     updateActionStates();
 }
 
-void WorkspaceMdiWindow::onDoubleClicked(const QModelIndex& index) {
-    if (!index.isValid())
+void WorkspaceMdiWindow::onItemDoubleClicked(QTreeWidgetItem* item, int /*column*/) {
+    if (!item)
         return;
 
-    auto sourceIndex = proxyModel_->mapToSource(index);
-    if (auto* workspace = model_->getWorkspace(sourceIndex.row())) {
-        emit showWorkspaceDetails(*workspace);
+    const QString id_str = item->data(0, Qt::UserRole).toString();
+    for (const auto& ws : model_->workspaces()) {
+        if (QString::fromStdString(boost::uuids::to_string(ws.id)) == id_str) {
+            emit showWorkspaceDetails(ws);
+            return;
+        }
     }
 }
 
 void WorkspaceMdiWindow::updateActionStates() {
-    const bool hasSelection = tableView_->selectionModel()->hasSelection();
-    editAction_->setEnabled(hasSelection);
-    archiveAction_->setEnabled(hasSelection);
-    deleteAction_->setEnabled(hasSelection);
+    const bool has_selection = !treeWidget_->selectedItems().isEmpty();
+    openAction_->setEnabled(has_selection);
+    editAction_->setEnabled(has_selection);
+    archiveAction_->setEnabled(has_selection);
+    deleteAction_->setEnabled(has_selection);
+}
+
+void WorkspaceMdiWindow::openSelected() {
+    auto selected = treeWidget_->selectedItems();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "Open requested but no item selected";
+        return;
+    }
+
+    const QString id_str = selected.first()->data(0, Qt::UserRole).toString();
+    for (const auto& ws : model_->workspaces()) {
+        if (QString::fromStdString(boost::uuids::to_string(ws.id)) == id_str) {
+            emit workspaceActivated(ws);
+            return;
+        }
+    }
+    BOOST_LOG_SEV(lg(), warn) << "Could not find workspace for id: "
+                              << id_str.toStdString();
 }
 
 void WorkspaceMdiWindow::addNew() {
@@ -230,22 +298,25 @@ void WorkspaceMdiWindow::addNew() {
 }
 
 void WorkspaceMdiWindow::editSelected() {
-    const auto selected = tableView_->selectionModel()->selectedRows();
+    auto selected = treeWidget_->selectedItems();
     if (selected.isEmpty()) {
-        BOOST_LOG_SEV(lg(), warn) << "Edit requested but no row selected";
+        BOOST_LOG_SEV(lg(), warn) << "Edit requested but no item selected";
         return;
     }
 
-    auto sourceIndex = proxyModel_->mapToSource(selected.first());
-    if (auto* workspace = model_->getWorkspace(sourceIndex.row())) {
-        emit showWorkspaceDetails(*workspace);
+    const QString id_str = selected.first()->data(0, Qt::UserRole).toString();
+    for (const auto& ws : model_->workspaces()) {
+        if (QString::fromStdString(boost::uuids::to_string(ws.id)) == id_str) {
+            emit showWorkspaceDetails(ws);
+            return;
+        }
     }
 }
 
 void WorkspaceMdiWindow::archiveSelected() {
-    const auto selected = tableView_->selectionModel()->selectedRows();
+    auto selected = treeWidget_->selectedItems();
     if (selected.isEmpty()) {
-        BOOST_LOG_SEV(lg(), warn) << "Archive requested but no row selected";
+        BOOST_LOG_SEV(lg(), warn) << "Archive requested but no item selected";
         return;
     }
 
@@ -255,12 +326,15 @@ void WorkspaceMdiWindow::archiveSelected() {
         return;
     }
 
+    const QString id_str = selected.first()->data(0, Qt::UserRole).toString();
     std::string workspace_id;
     QString workspace_name;
-    auto sourceIndex = proxyModel_->mapToSource(selected.first());
-    if (auto* ws = model_->getWorkspace(sourceIndex.row())) {
-        workspace_id = boost::uuids::to_string(ws->id);
-        workspace_name = QString::fromStdString(ws->name);
+    for (const auto& ws : model_->workspaces()) {
+        if (QString::fromStdString(boost::uuids::to_string(ws.id)) == id_str) {
+            workspace_id = boost::uuids::to_string(ws.id);
+            workspace_name = QString::fromStdString(ws.name);
+            break;
+        }
     }
 
     if (workspace_id.empty()) {
@@ -268,7 +342,8 @@ void WorkspaceMdiWindow::archiveSelected() {
         return;
     }
 
-    BOOST_LOG_SEV(lg(), debug) << "Archive requested for workspace id: " << workspace_id;
+    BOOST_LOG_SEV(lg(), debug) << "Archive requested for workspace id: "
+                               << workspace_id;
 
     const std::string actor = username_.toStdString();
 
@@ -286,13 +361,15 @@ void WorkspaceMdiWindow::archiveSelected() {
 
     auto task = [self, workspace_id, actor]() -> OpResult {
         if (!self) return {};
-        BOOST_LOG_SEV(lg(), debug) << "Sending archive request for workspace id: " << workspace_id;
+        BOOST_LOG_SEV(lg(), debug) << "Sending archive request for workspace id: "
+                                   << workspace_id;
         workspace::messaging::archive_workspace_request request;
         request.id = workspace_id;
         request.modified_by = actor;
         request.change_reason_code = "user.archive";
         request.change_commentary = "Archived by user";
-        auto result = self->clientManager_->process_authenticated_request(std::move(request));
+        auto result = self->clientManager_->process_authenticated_request(
+            std::move(request));
         if (!result) return {false, "Failed to communicate with server"};
         return {result->success, result->message};
     };
@@ -310,8 +387,8 @@ void WorkspaceMdiWindow::archiveSelected() {
             emit self->statusChanged(
                 tr("Workspace '%1' archived successfully").arg(workspace_name));
         } else {
-            BOOST_LOG_SEV(lg(), error) << "Archive failed for workspace " << workspace_id
-                                       << ": " << message;
+            BOOST_LOG_SEV(lg(), error) << "Archive failed for workspace "
+                                       << workspace_id << ": " << message;
             auto msg = QString::fromStdString(message);
             emit self->errorOccurred(msg);
             MessageBoxHelper::critical(self, tr("Archive Failed"), msg);
@@ -323,9 +400,9 @@ void WorkspaceMdiWindow::archiveSelected() {
 }
 
 void WorkspaceMdiWindow::deleteSelected() {
-    const auto selected = tableView_->selectionModel()->selectedRows();
+    auto selected = treeWidget_->selectedItems();
     if (selected.isEmpty()) {
-        BOOST_LOG_SEV(lg(), warn) << "Delete requested but no row selected";
+        BOOST_LOG_SEV(lg(), warn) << "Delete requested but no item selected";
         return;
     }
 
@@ -335,12 +412,15 @@ void WorkspaceMdiWindow::deleteSelected() {
         return;
     }
 
+    const QString id_str = selected.first()->data(0, Qt::UserRole).toString();
     std::string workspace_id;
     QString workspace_name;
-    auto sourceIndex = proxyModel_->mapToSource(selected.first());
-    if (auto* ws = model_->getWorkspace(sourceIndex.row())) {
-        workspace_id = boost::uuids::to_string(ws->id);
-        workspace_name = QString::fromStdString(ws->name);
+    for (const auto& ws : model_->workspaces()) {
+        if (QString::fromStdString(boost::uuids::to_string(ws.id)) == id_str) {
+            workspace_id = boost::uuids::to_string(ws.id);
+            workspace_name = QString::fromStdString(ws.name);
+            break;
+        }
     }
 
     if (workspace_id.empty()) {
@@ -348,7 +428,8 @@ void WorkspaceMdiWindow::deleteSelected() {
         return;
     }
 
-    BOOST_LOG_SEV(lg(), debug) << "Delete requested for workspace id: " << workspace_id;
+    BOOST_LOG_SEV(lg(), debug) << "Delete requested for workspace id: "
+                               << workspace_id;
 
     const std::string actor = username_.toStdString();
 
@@ -367,13 +448,15 @@ void WorkspaceMdiWindow::deleteSelected() {
 
     auto task = [self, workspace_id, actor]() -> OpResult {
         if (!self) return {};
-        BOOST_LOG_SEV(lg(), debug) << "Sending delete request for workspace id: " << workspace_id;
+        BOOST_LOG_SEV(lg(), debug) << "Sending delete request for workspace id: "
+                                   << workspace_id;
         workspace::messaging::remove_workspace_request request;
         request.id = workspace_id;
         request.modified_by = actor;
         request.change_reason_code = "user.delete";
         request.change_commentary = "Deleted by user";
-        auto result = self->clientManager_->process_authenticated_request(std::move(request));
+        auto result = self->clientManager_->process_authenticated_request(
+            std::move(request));
         if (!result) return {false, "Failed to communicate with server"};
         return {result->success, result->message};
     };
@@ -391,8 +474,8 @@ void WorkspaceMdiWindow::deleteSelected() {
             emit self->statusChanged(
                 tr("Workspace '%1' deleted successfully").arg(workspace_name));
         } else {
-            BOOST_LOG_SEV(lg(), error) << "Delete failed for workspace " << workspace_id
-                                       << ": " << message;
+            BOOST_LOG_SEV(lg(), error) << "Delete failed for workspace "
+                                       << workspace_id << ": " << message;
             auto msg = QString::fromStdString(message);
             emit self->errorOccurred(msg);
             MessageBoxHelper::critical(self, tr("Delete Failed"), msg);

--- a/projects/ores.qt.workspace/src/WorkspaceMdiWindow.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceMdiWindow.cpp
@@ -19,14 +19,13 @@
  */
 #include "ores.qt/WorkspaceMdiWindow.hpp"
 
-#include <unordered_map>
+#include <map>
 #include <QVBoxLayout>
 #include <QHeaderView>
 #include <QMessageBox>
 #include <QtConcurrent>
 #include <QFutureWatcher>
 #include <boost/uuid/uuid_io.hpp>
-#include <boost/uuid/uuid_hash.hpp>
 #include <boost/uuid/string_generator.hpp>
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
@@ -173,10 +172,9 @@ void WorkspaceMdiWindow::doReload() {
 
 namespace {
 
-using children_map_t = std::unordered_map<
+using children_map_t = std::map<
     boost::uuids::uuid,
-    std::vector<const workspace::domain::workspace*>,
-    boost::hash<boost::uuids::uuid>>;
+    std::vector<const workspace::domain::workspace*>>;
 
 void addTreeItems(QTreeWidgetItem* parent,
     const boost::uuids::uuid& parent_id,
@@ -207,9 +205,7 @@ void WorkspaceMdiWindow::buildTree() {
     if (all.empty())
         return;
 
-    std::unordered_map<boost::uuids::uuid,
-        const workspace::domain::workspace*,
-        boost::hash<boost::uuids::uuid>> by_id;
+    std::map<boost::uuids::uuid, const workspace::domain::workspace*> by_id;
     for (const auto& ws : all)
         by_id[ws.id] = &ws;
 

--- a/projects/ores.qt.workspace/src/WorkspaceMdiWindow.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceMdiWindow.cpp
@@ -26,6 +26,8 @@
 #include <QtConcurrent>
 #include <QFutureWatcher>
 #include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/uuid_hash.hpp>
+#include <boost/uuid/string_generator.hpp>
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
 #include "ores.qt/ColorConstants.hpp"
@@ -171,11 +173,12 @@ void WorkspaceMdiWindow::doReload() {
 
 void WorkspaceMdiWindow::addTreeItems(
     QTreeWidgetItem* parent,
-    const QString& parent_id_str,
-    const std::unordered_map<std::string,
-        std::vector<const workspace::domain::workspace*>>& children_map) {
+    const boost::uuids::uuid& parent_id,
+    const std::unordered_map<boost::uuids::uuid,
+        std::vector<const workspace::domain::workspace*>,
+        boost::hash<boost::uuids::uuid>>& children_map) {
 
-    auto it = children_map.find(parent_id_str.toStdString());
+    auto it = children_map.find(parent_id);
     if (it == children_map.end())
         return;
 
@@ -187,7 +190,7 @@ void WorkspaceMdiWindow::addTreeItems(
         item->setText(1, QString::fromStdString(ws->status_code));
         item->setText(2, QString::fromStdString(ws->modified_by));
         item->setData(0, Qt::UserRole, id_str);
-        addTreeItems(item, id_str, children_map);
+        addTreeItems(item, ws->id, children_map);
     }
 }
 
@@ -198,22 +201,23 @@ void WorkspaceMdiWindow::buildTree() {
     if (all.empty())
         return;
 
-    std::unordered_map<std::string, const workspace::domain::workspace*> by_id;
+    std::unordered_map<boost::uuids::uuid,
+        const workspace::domain::workspace*,
+        boost::hash<boost::uuids::uuid>> by_id;
     for (const auto& ws : all)
-        by_id[boost::uuids::to_string(ws.id)] = &ws;
+        by_id[ws.id] = &ws;
 
-    std::unordered_map<std::string,
-        std::vector<const workspace::domain::workspace*>> children_map;
+    std::unordered_map<boost::uuids::uuid,
+        std::vector<const workspace::domain::workspace*>,
+        boost::hash<boost::uuids::uuid>> children_map;
 
     std::vector<const workspace::domain::workspace*> roots;
     for (const auto& ws : all) {
         if (!ws.parent_workspace_id) {
             roots.push_back(&ws);
         } else {
-            const std::string parent_str =
-                boost::uuids::to_string(*ws.parent_workspace_id);
-            if (by_id.count(parent_str)) {
-                children_map[parent_str].push_back(&ws);
+            if (by_id.count(*ws.parent_workspace_id)) {
+                children_map[*ws.parent_workspace_id].push_back(&ws);
             } else {
                 roots.push_back(&ws);
             }
@@ -228,7 +232,7 @@ void WorkspaceMdiWindow::buildTree() {
         item->setText(1, QString::fromStdString(ws->status_code));
         item->setText(2, QString::fromStdString(ws->modified_by));
         item->setData(0, Qt::UserRole, id_str);
-        addTreeItems(item, id_str, children_map);
+        addTreeItems(item, ws->id, children_map);
     }
 
     treeWidget_->expandAll();
@@ -257,9 +261,10 @@ void WorkspaceMdiWindow::onItemDoubleClicked(QTreeWidgetItem* item, int /*column
     if (!item)
         return;
 
-    const QString id_str = item->data(0, Qt::UserRole).toString();
+    const auto target_id = boost::uuids::string_generator()(
+        item->data(0, Qt::UserRole).toString().toStdString());
     for (const auto& ws : model_->workspaces()) {
-        if (QString::fromStdString(boost::uuids::to_string(ws.id)) == id_str) {
+        if (ws.id == target_id) {
             emit showWorkspaceDetails(ws);
             return;
         }
@@ -281,9 +286,11 @@ void WorkspaceMdiWindow::openSelected() {
         return;
     }
 
-    const QString id_str = selected.first()->data(0, Qt::UserRole).toString();
+    const auto id_str = selected.first()->data(0, Qt::UserRole).toString();
+    const auto target_id =
+        boost::uuids::string_generator()(id_str.toStdString());
     for (const auto& ws : model_->workspaces()) {
-        if (QString::fromStdString(boost::uuids::to_string(ws.id)) == id_str) {
+        if (ws.id == target_id) {
             emit workspaceActivated(ws);
             return;
         }
@@ -304,9 +311,10 @@ void WorkspaceMdiWindow::editSelected() {
         return;
     }
 
-    const QString id_str = selected.first()->data(0, Qt::UserRole).toString();
+    const auto target_id = boost::uuids::string_generator()(
+        selected.first()->data(0, Qt::UserRole).toString().toStdString());
     for (const auto& ws : model_->workspaces()) {
-        if (QString::fromStdString(boost::uuids::to_string(ws.id)) == id_str) {
+        if (ws.id == target_id) {
             emit showWorkspaceDetails(ws);
             return;
         }
@@ -326,11 +334,13 @@ void WorkspaceMdiWindow::archiveSelected() {
         return;
     }
 
-    const QString id_str = selected.first()->data(0, Qt::UserRole).toString();
+    const auto id_str = selected.first()->data(0, Qt::UserRole).toString();
+    const auto target_id =
+        boost::uuids::string_generator()(id_str.toStdString());
     std::string workspace_id;
     QString workspace_name;
     for (const auto& ws : model_->workspaces()) {
-        if (QString::fromStdString(boost::uuids::to_string(ws.id)) == id_str) {
+        if (ws.id == target_id) {
             workspace_id = boost::uuids::to_string(ws.id);
             workspace_name = QString::fromStdString(ws.name);
             break;
@@ -412,11 +422,13 @@ void WorkspaceMdiWindow::deleteSelected() {
         return;
     }
 
-    const QString id_str = selected.first()->data(0, Qt::UserRole).toString();
+    const auto id_str = selected.first()->data(0, Qt::UserRole).toString();
+    const auto target_id =
+        boost::uuids::string_generator()(id_str.toStdString());
     std::string workspace_id;
     QString workspace_name;
     for (const auto& ws : model_->workspaces()) {
-        if (QString::fromStdString(boost::uuids::to_string(ws.id)) == id_str) {
+        if (ws.id == target_id) {
             workspace_id = boost::uuids::to_string(ws.id);
             workspace_name = QString::fromStdString(ws.name);
             break;

--- a/projects/ores.qt.workspace/ui/WorkspaceDetailDialog.ui
+++ b/projects/ores.qt.workspace/ui/WorkspaceDetailDialog.ui
@@ -92,6 +92,23 @@
             </property>
            </widget>
           </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelInheritsFrom">
+            <property name="text">
+             <string>Inherits from:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="inheritsFromEdit">
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+            <property name="placeholderText">
+             <string>Live (root workspace)</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/projects/ores.refdata.core/modeling/multi_party.org
+++ b/projects/ores.refdata.core/modeling/multi_party.org
@@ -620,6 +620,7 @@ Party isolation is a strict refinement of tenant isolation:
 |-----------+-----------------------------------------------------------------------------------+--------------------------------------|
 | design    | [[proj:doc/plans/2026-02-09-party-isolation-and-tenant-types-design.org]]         | Design rationale and decisions       |
 | iam       | [[id:0FF2B4E7-473D-A754-A893-C4C70E636C76][Multi-Tenancy Architecture]]           | Companion tenant isolation document  |
+| workspace | [[id:7C2F8A41-3B91-4D82-B7E0-9E1A5D6C4F82][Multi-Workspace Architecture]]         | Companion workspace isolation document |
 | iam       | [[id:AAD74D7C-4789-4E54-8B02-EC60231D78A5][Multi-Party Login Flow]]               | Account-party rules and login flow   |
 | utility   | [[proj:projects/ores.utility/include/ores.utility/uuid/tenant_id.hpp]]            | Tenant ID wrapper type               |
 | database  | [[proj:projects/ores.database/include/ores.database/domain/tenant_aware_pool.hpp]] | Connection pool with tenant context |

--- a/projects/ores.workspace.core/modeling/multi_workspace.org
+++ b/projects/ores.workspace.core/modeling/multi_workspace.org
@@ -1,0 +1,528 @@
+:PROPERTIES:
+:ID: 7C2F8A41-3B91-4D82-B7E0-9E1A5D6C4F82
+:END:
+#+title: Multi-Workspace Architecture
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+startup: inlineimages
+
+* Overview
+
+ORE Studio implements workspace-level data isolation as a third, orthogonal
+layer on top of tenant and party isolation. While tenant isolation separates
+organisations from each other (see [[id:0FF2B4E7-473D-A754-A893-C4C70E636C76][Multi-Tenancy Architecture]]) and party
+isolation separates business units within a tenant (see [[id:BAE3AA18-6027-10A4-965B-2C174C237195][Multi-Party Architecture]]),
+workspace isolation separates data contexts within a party. This document
+describes how workspace context flows through the system and how it differs
+fundamentally from the security layers beneath it.
+
+This is a companion document to =projects/ores.iam.core/modeling/multi_tenancy.org=
+and =projects/ores.refdata.core/modeling/multi_party.org=.
+
+* Core Concepts
+
+** Workspace
+
+A workspace is a named, isolated data context within OreStudio. It contains a
+complete or partial set of data — trades, market data, conventions, curve
+configs, pricing engine configs, today's market definitions — and can
+optionally inherit missing data from a single parent workspace.
+
+Key properties:
+
+- *Isolated by default*: data in workspace A is not visible to workspace B
+  unless an explicit parent relationship links them.
+- *Layered (single-parent)*: a workspace may declare one parent workspace. Any
+  data not present in the workspace is resolved from the parent, then the
+  grandparent, and so on — the same model as Docker image layers. The
+  resolution order is the chain from the current workspace to the root.
+- *Trade-scoped via portfolio*: a workspace optionally declares a portfolio
+  scope. Only trades in the scoped books are visible; all other inherited
+  trades are hidden. A trade whitelist can further narrow the scope to
+  specific trade IDs within those books.
+- *Non-trade data follows trades*: conventions, market data, curve configs,
+  and pricing engine configs are either stored locally (overriding the
+  parent's version for the same natural key) or inherited transparently.
+- *Durable*: workspaces are long-lived; not deleted when the session ends.
+- *Non-promotable directly*: data cannot be directly promoted from a workspace
+  to live. A deliberate copy operation is used instead.
+
+** Workspace vs Scenario
+
+These two concepts must not be confused.
+
+A *workspace* is a *data context*: a stable, named collection of trades and
+market data. It answers "what data are we working with?" It is long-lived;
+multiple users can share it; its data does not change unless someone
+explicitly edits or imports into it.
+
+A *scenario* (in the OreStudio sense) is a *computation*: one execution of a
+report definition against a workspace. Scenarios are ephemeral — they produce
+results (NPVs, sensitivities, PFE profiles) but do not change the
+workspace's data.
+
+The common risk-system usage of "scenario" (a set of market data shocks) maps
+to OreStudio as a *child workspace that inherits from a parent and overrides
+specific curves or rates*. The shocks live in the workspace; the scenario is
+the report execution that prices the trades against those shocks.
+
+** Live Workspace — Dedicated Sentinel UUID
+
+The Live workspace uses the well-known sentinel UUID
+=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa= (returned by
+=ores_utility_live_workspace_id_fn()=) as its stable identifier. It always
+exists, is the root of all inheritance chains, and cannot be archived without
+=workspace::live_workspace:archive= (SuperAdmin only).
+
+The nil UUID (=00000000-0000-0000-0000-000000000000=) is deliberately *not*
+used as the sentinel: it is the default C++ value for an uninitialised
+=boost::uuids::uuid=, so using it for Live would cause an unset =workspace_id=
+to silently resolve to the Live data space. The sentinel =aaaaaaaa-...= has
+version nibble =a= (decimal 10), which falls outside the valid UUID version
+range 1–8; no UUID generator will ever emit it.
+
+** Workspace Hierarchy
+
+Workspaces form a tree via =parent_workspace_id=. The Live workspace is always
+the root. Resolution follows the chain from the active workspace to the root:
+
+#+begin_example
+workspace 0 (Live)
+  └─ workspace 5 (EUR shock +50bps)     parent = Live
+       └─ workspace 8 (EUR+credit shock) parent = 5
+
+Resolution order for workspace 8: [8, 5, Live]
+- Data in workspace 8 wins.
+- Data absent from 8 falls through to workspace 5.
+- Data absent from 5 falls through to Live.
+#+end_example
+
+Cycle prevention is enforced by a trigger that walks the parent chain before
+any insert or update of =parent_workspace_id=.
+
+* Isolation Layers
+
+Workspace isolation is orthogonal to, and does not replace, tenant and party
+isolation. All three layers are enforced simultaneously:
+
+#+begin_example
+┌──────────────────────────────────────────────────────────────────────┐
+│                       PostgreSQL Database                             │
+│                                                                      │
+│  ┌────────────────────────────────────────────────────────────────┐  │
+│  │ Tenant RLS Layer (app.current_tenant_id)                       │  │
+│  │   Isolates organisations from each other                       │  │
+│  │                                                                │  │
+│  │  ┌──────────────────────────────────────────────────────────┐  │  │
+│  │  │ Party RLS Layer (app.visible_party_ids)                  │  │  │
+│  │  │   Isolates business units within a tenant                │  │  │
+│  │  │                                                          │  │  │
+│  │  │  ┌────────────────────────────────────────────────────┐  │  │  │
+│  │  │  │ Workspace Query Layer (workspace_id column)        │  │  │  │
+│  │  │  │   Scopes data to the active data context           │  │  │  │
+│  │  │  │   Applied via WHERE, not RLS                       │  │  │  │
+│  │  │  │   Resolution order enables inheritance             │  │  │  │
+│  │  │  └────────────────────────────────────────────────────┘  │  │  │
+│  │  └──────────────────────────────────────────────────────────┘  │  │
+│  └────────────────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────┘
+#+end_example
+
+** Why workspace_id is Not in RLS
+
+Tenant and party isolation are *security* boundaries: a user must never see
+another tenant's data, and a user must only see the party hierarchy they
+belong to. These are enforced at the RLS layer using session variables.
+
+Workspace isolation is a *data context* boundary, not a security boundary.
+A user legitimately has read access to data in any workspace within their
+tenant and party scope — they want to view it scoped to a particular context.
+More importantly, the workspace inheritance model *requires* querying across
+multiple workspace IDs simultaneously:
+
+#+begin_src sql
+WHERE workspace_id = ANY(:resolution_order)
+ORDER BY array_position(:resolution_order, workspace_id)
+#+end_src
+
+If =workspace_id= were baked into RLS as
+=workspace_id = current_setting('app.current_workspace_id')=, this
+inheritance query would break — you cannot resolve a parent chain through a
+policy that restricts rows to exactly one workspace.
+
+The correct split is:
+| Concern         | Mechanism    | Handles                                  |
+|-----------------+--------------+------------------------------------------|
+| Tenant security | RLS          | Cross-organisation data leakage          |
+| Party security  | RLS          | Cross-business-unit data leakage         |
+| Data context    | WHERE clause | Workspace scoping + inheritance          |
+
+** Workspace Visibility
+
+All authenticated users within a tenant hold =workspace::workspaces:read= by
+default. Workspaces are not private ACL objects; any user within the tenant
+can see any workspace. Data restriction within a workspace is handled by the
+=scope_portfolio_id= on the workspace itself (portfolio tree scoping), not by
+per-workspace read grants. This keeps the permission model simple.
+
+* Data Model
+
+** workspace_id Column
+
+Every table that holds user or import data gains a =workspace_id= column:
+
+#+begin_src sql
+alter table <table_name>
+    add column workspace_id uuid not null
+        default ores_utility_live_workspace_id_fn();
+
+create index on <table_name> (workspace_id);
+#+end_src
+
+Tables that are genuinely global — users, IAM, parties, DQ FSM definitions,
+workflow definitions, the workspace table itself — do *not* get =workspace_id=.
+
+Affected categories:
+
+| Category        | Representative tables                                    |
+|-----------------+----------------------------------------------------------|
+| Trading         | trades, books, instruments, lifecycle events             |
+| Reference data  | conventions (all types), book, portfolio                 |
+| Market data     | fixings, yield curves, vol surfaces                      |
+| Curve config    | yield curve configs, vol configs                         |
+| Pricing engine  | engine configs                                           |
+| Today's market  | today's market definitions                               |
+| Reporting       | report definitions                                       |
+
+** Resolution Order Computation
+
+When a workspace is opened, its full ancestor chain is computed once via a
+recursive CTE and cached in the application session as an ordered UUID array:
+
+#+begin_src sql
+with recursive chain(id, depth) as (
+    select id, 0
+    from ores_workspaces_tbl
+    where id = :target_workspace_id
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    union all
+    select w.parent_workspace_id, c.depth + 1
+    from ores_workspaces_tbl w
+    join chain c on c.id = w.id
+    where w.parent_workspace_id is not null
+      and w.valid_to = ores_utility_infinity_timestamp_fn()
+)
+select id from chain order by depth;
+-- Returns e.g. [ws-8, ws-5, live-uuid] for a workspace two levels deep
+#+end_src
+
+This array is passed as =:resolution_order= to all workspace-aware queries.
+
+** Query Patterns
+
+*Non-trade data* (conventions, market data, curve configs, etc.) uses the
+resolution order only — no portfolio or trade filtering:
+
+#+begin_src sql
+-- List query with deduplication on natural key
+select distinct on (name) *
+from ores_curveconfig_yieldcurve_tbl
+where workspace_id = any(:resolution_order)
+order by name, array_position(:resolution_order, workspace_id);
+#+end_src
+
+*Trade queries* additionally filter by portfolio scope and (if present) the
+trade whitelist:
+
+#+begin_src sql
+select distinct on (t.id) t.*
+from ores_trading_trades_tbl t
+join ores_trading_books_tbl b on b.id = t.book_id
+left join ores_trading_portfolio_books_tbl pb
+    on pb.book_id = b.id
+    and pb.portfolio_id = (
+        select scope_portfolio_id from ores_workspaces_tbl where id = :ws_id)
+where t.workspace_id = any(:resolution_order)
+  and (
+      (select scope_portfolio_id from ores_workspaces_tbl where id = :ws_id) is null
+      or pb.book_id is not null
+  )
+  and (
+      not exists (select 1 from ores_workspace_trade_scope_tbl
+                  where workspace_id = :ws_id)
+      or t.id in (select trade_id from ores_workspace_trade_scope_tbl
+                  where workspace_id = :ws_id)
+  )
+order by t.id, array_position(:resolution_order, t.workspace_id);
+#+end_src
+
+Note: Phase 2 repositories currently use an exact-match =workspace_id = :wid=
+predicate. Phase 5 will upgrade these to the == ANY(:resolution_order)= pattern
+with =DISTINCT ON= deduplication for full inheritance support.
+
+** FK Validation
+
+Every insert trigger on a workspace-aware table must validate that
+=NEW.workspace_id= references an active workspace. Because service users hold
+no =SELECT= on =ores_workspaces_tbl= (service table isolation invariant), the
+validation function must be =SECURITY DEFINER=:
+
+#+begin_src sql
+create function ores_workspace_validate_fn(p_workspace_id uuid)
+returns uuid
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+    -- The Live sentinel always passes; it has no ordinary active row.
+    if p_workspace_id = ores_utility_live_workspace_id_fn() then
+        return p_workspace_id;
+    end if;
+
+    if not exists (
+        select 1 from ores_workspaces_tbl
+        where id = p_workspace_id
+          and status_code = 'active'
+          and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
+        raise exception 'workspace_id % does not reference an active workspace',
+            p_workspace_id
+            using errcode = '23503';
+    end if;
+
+    return p_workspace_id;
+end;
+$$;
+#+end_src
+
+This mirrors the pattern of =ores_iam_validate_tenant_fn=. The call is added
+to every =has_workspace_id= entity's insert trigger alongside the existing
+=ores_iam_validate_tenant_fn= call, and is generated automatically via the
+=has_workspace_id= codegen template flag.
+
+* Context Propagation
+
+** database::context
+
+The database context carries =workspace_id_= alongside =tenant_id_= and
+=party_id_=:
+
+#+begin_src cpp
+class context {
+public:
+    const std::string& workspace_id() const { return workspace_id_; }
+
+    // Returns a copy with workspace set; does not rebuild the pool.
+    [[nodiscard]] context with_workspace(std::string workspace_id) const {
+        auto copy = *this;
+        copy.workspace_id_ = std::move(workspace_id);
+        return copy;
+    }
+
+private:
+    // Defaults to the Live sentinel.
+    std::string workspace_id_ = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+};
+#+end_src
+
+The chain =with_tenant()= → =with_party()= → =with_workspace()= is applied in
+=make_request_context()= so that workspace is set last and is never lost by
+earlier builder calls.
+
+** make_request_context
+
+After JWT validation, =make_request_context()= reads the =X-Workspace-Id=
+NATS header and chains =with_workspace()=:
+
+#+begin_src cpp
+const auto ws_it = msg.headers.find(
+    std::string(ores::nats::headers::x_workspace_id));
+if (ws_it != msg.headers.end() && !ws_it->second.empty()) {
+    ctx = ctx.with_workspace(ws_it->second);
+}
+return ctx;
+#+end_src
+
+Absence of the header means Live workspace — the default value on
+=context::workspace_id_= ensures backwards compatibility.
+
+** NATS Header
+
+=X-Workspace-Id= is defined in =ores.nats/include/ores.nats/domain/headers.hpp=:
+
+#+begin_src cpp
+/// Active workspace for this request.
+/// Set by the Qt client from WorkspaceContext.id; forwarded on inter-service
+/// calls. Absence means Live workspace.
+inline constexpr std::string_view x_workspace_id = "X-Workspace-Id";
+#+end_src
+
+** Qt Client — WorkspaceContext
+
+The Qt client carries the active workspace in =WorkspaceContext=
+(=projects/ores.qt.api/include/ores.qt/WorkspaceContext.hpp=):
+
+#+begin_src cpp
+struct WorkspaceContext {
+    inline static const QString live_workspace_id =
+        QStringLiteral("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    QString id = live_workspace_id;
+    QString name = QStringLiteral("Live");
+    QVector<QString> resolution_order = {live_workspace_id};
+
+    bool is_live() const { return id == live_workspace_id; }
+};
+#+end_src
+
+The =resolution_order= vector is populated at activation time by calling the
+=workspace.v1.workspaces.resolve= NATS endpoint, which runs the recursive CTE
+and returns the ancestor chain.
+
+=ClientManager= holds a =WorkspaceContext= and injects =X-Workspace-Id= into
+every authenticated NATS request via =with_workspace_id()= on the scoped
+client.
+
+* Session Management
+
+** Workspace Activation Flow
+
+#+begin_example
+┌─────────────────────────┐
+│  User selects workspace  │
+│  in Data Workshop        │
+└────────────┬────────────┘
+             │
+             ▼
+┌─────────────────────────┐
+│ WorkspaceMdiWindow       │
+│ emits workspaceActivated │
+└────────────┬────────────┘
+             │
+             ▼
+┌─────────────────────────────────┐
+│ WorkspaceController             │
+│ onWorkspaceActivated()          │
+│                                 │
+│  Live sentinel?                 │
+│  → set default WorkspaceContext │
+│  → emit statusMessage           │
+│                                 │
+│  Other workspace?               │
+│  → resolve_workspace_request    │
+│    (async, QtConcurrent)        │
+│  → build WorkspaceContext with  │
+│    id, name, resolution_order   │
+└────────────┬────────────────────┘
+             │
+             ▼
+┌─────────────────────────────────────────────────────────┐
+│ mdiArea_->setProperty("ores_workspace_context", ctx)     │
+│   → QEvent::DynamicPropertyChange fires                  │
+│   → EntityController::eventFilter() on every controller │
+│   → clientManager_->setWorkspaceContext(ctx)             │
+│   → all subsequent requests carry X-Workspace-Id        │
+└─────────────────────────────────────────────────────────┘
+#+end_example
+
+** Current Scope: Application-Level Context
+
+The current implementation switches workspace for the entire session. All MDI
+windows share the same =ClientManager= and therefore the same workspace
+context. When the user activates workspace B, every open window immediately
+uses workspace B on its next request.
+
+Per-window workspace context (each MDI subwindow having an independent
+workspace selector, enabling side-by-side comparison of the same data in two
+different workspaces) is a planned future phase. See the UI section below.
+
+* UI Considerations
+
+** Workspace Badge in Window Titles
+
+Windows opened while a non-live workspace is active display the workspace
+name in their title bar:
+
+#+begin_example
+Trades [EUR shock +50bps]
+Market Data [EUR shock +50bps]
+#+end_example
+
+Live workspace windows show no badge — it is the default and adding a badge
+to every window would be noisy. This is applied in
+=EntityController::show_managed_window()=.
+
+** Data Workshop
+
+The =WorkspaceMdiWindow= provides a tree view of all workspaces in the tenant,
+grouped by parent/child relationships. Actions:
+
+| Action  | Description                                          |
+|---------+------------------------------------------------------|
+| Open    | Activates the selected workspace session-wide        |
+| Add     | Creates a new workspace via =WorkspaceDetailDialog=  |
+| Edit    | Opens the detail dialog for an existing workspace    |
+| Archive | Soft-closes the workspace (bitemporal close)         |
+| Delete  | Permanently removes the workspace record             |
+
+** Per-Window Workspace Selector (Future)
+
+The design calls for each MDI subwindow to carry its own workspace context,
+selectable via a compact combo box in the window toolbar:
+
+#+begin_example
++-------------------------------------------------------+
+|  TRADES  [EUR shock ▼]               [Filter] [Cols]  |
++-------------------------------------------------------+
+|  ...trade grid scoped to EUR shock workspace...        |
++-------------------------------------------------------+
+#+end_example
+
+This enables side-by-side comparison:
+
+#+begin_example
++-----------------------------+  +-----------------------------+
+|  TRADES  [Live ▼]           |  |  TRADES  [EUR shock ▼]       |
+|-----------------------------|  |-----------------------------|
+|  IRS_001  NPV:  1,234,500   |  |  IRS_001  NPV:  1,189,200   |
+|  FXF_002  NPV:    456,100   |  |  FXF_002  NPV:    455,900   |
++-----------------------------+  +-----------------------------+
+#+end_example
+
+Implementation requires either per-window =ClientManager= scopes or passing
+workspace context through individual request calls rather than storing it on
+the shared manager. This is deferred; the current MDI-area property mechanism
+is designed as a foundation for this extension.
+
+* Permissions
+
+Three tiers of workspace permission are enforced in =workspace_handler.hpp=:
+
+| Permission                          | Default holders                |
+|-------------------------------------+--------------------------------|
+| =workspace::workspaces:read=        | All authenticated users        |
+| =workspace::workspaces:write=       | All authenticated users        |
+| =workspace::workspaces:archive=     | All authenticated users (own)  |
+| =workspace::workspaces:archive_any= | TenantAdmin                    |
+| =workspace::live_workspace:archive= | SuperAdmin only                |
+
+Archive is ownership-aware: a user may archive their own workspace with
+=workspaces:archive=; archiving another user's workspace requires
+=workspaces:archive_any=.
+
+* Related Components
+
+| Component  | File                                                                               | Purpose                                     |
+|------------+------------------------------------------------------------------------------------+---------------------------------------------|
+| design     | [[proj:doc/plans/2026-05-17-workspace-design.org]]                                 | Full design rationale, phases, and SQL      |
+| codegen    | [[proj:doc/plans/2026-05-19-workspace-id-codegen-propagation.org]]                 | Template changes and affected entity list   |
+| iam        | [[id:0FF2B4E7-473D-A754-A893-C4C70E636C76][Multi-Tenancy Architecture]]            | Companion tenant isolation document         |
+| refdata    | [[id:BAE3AA18-6027-10A4-965B-2C174C237195][Multi-Party Architecture]]              | Companion party isolation document          |
+| utility    | [[proj:projects/ores.utility/include/ores.utility/uuid/tenant_id.hpp]]             | live_workspace_id() sentinel function       |
+| database   | [[proj:projects/ores.database/include/ores.database/domain/context.hpp]]           | Database context with workspace_id_         |
+| nats       | [[proj:projects/ores.nats/include/ores.nats/domain/headers.hpp]]                   | X-Workspace-Id header constant              |
+| qt.api     | [[proj:projects/ores.qt.api/include/ores.qt/WorkspaceContext.hpp]]                 | Qt workspace context struct                 |
+| qt.api     | [[proj:projects/ores.qt.api/include/ores.qt/ClientManager.hpp]]                    | setWorkspaceContext() and header injection  |
+| qt.api     | [[proj:projects/ores.qt.api/src/EntityController.cpp]]                             | MDI area event filter, context propagation  |
+| workspace  | [[proj:projects/ores.workspace.core/include/ores.workspace.core/service/workspace_service.hpp]] | Workspace service                |


### PR DESCRIPTION
## Summary

Completes the remaining workspace propagation work after PR #773 (codegen) was merged.

### Step 11 — EntityController workspace wiring
- `EntityController` installs an event filter on its `mdiArea_` at construction time
- When `mdiArea_->setProperty("ores_workspace_context", ...)` is called anywhere, every plugin controller automatically forwards the new context to `clientManager_->setWorkspaceContext()`
- This makes the `X-Workspace-Id` NATS header active without any per-controller boilerplate

### Phase 4 — Data Workshop UI
- **WorkspaceMdiWindow**: replaces flat `QTableView` with `QTreeWidget` showing parent/child workspace hierarchy; adds "Open" toolbar action
- **WorkspaceController**: `onWorkspaceActivated` resolves the resolution order via `workspace.v1.workspaces.resolve`, builds a `WorkspaceContext`, and sets it on the MDI area property — triggering the Step 11 event filter across all open plugin controllers
- **WorkspaceDetailDialog**: adds "Inherits from:" read-only field showing the parent workspace UUID
- **ClientWorkspaceModel**: exposes `workspaces()` accessor for tree building

### End-to-end flow
1. User opens Workspaces window, selects a workspace, clicks Open
2. `WorkspaceController` resolves the ancestor chain via NATS
3. Sets `ores_workspace_context` on the MDI area
4. `EntityController` event filter fires in all plugin controllers → `clientManager_->setWorkspaceContext()`
5. All subsequent NATS requests carry `X-Workspace-Id: <uuid>`
6. Repository `read_latest()` filters data by `workspace_id`

Marks `2026-05-19-workspace-id-codegen-propagation.org` as Complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)