### PR TITLE
[shell] Fix missing ORES_SHELL_EXPORT on host class (Windows linker error)

### DIFF
--- a/projects/ores.shell/include/ores.shell/app/host.hpp
+++ b/projects/ores.shell/include/ores.shell/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.shell/export.hpp"
 
 namespace ores::shell::app {
 
 /**
  * @brief Provides hosting clients to the application.
  */
-class host {
+class ORES_SHELL_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.shell.app.host";
 


### PR DESCRIPTION
## Summary

- `ores::shell::app::host` was missing the `ORES_SHELL_EXPORT` macro, so `host::execute` was not exported from the `ores.shell` DLL on Windows
- This caused a linker error when building `ores.shell.exe`: `undefined symbol: ores::shell::app::host::execute`
- Fix: include `ores.shell/export.hpp` and annotate the class with `ORES_SHELL_EXPORT`, consistent with `ores::shell::app::repl` in the same project and `ores::cli::app::host` in `ores.cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)