### PR TITLE
[refdata] Migrate 11 party domain types to utility::uuid::tenant_id strong type

### DIFF
--- a/doc/plans/2026-05-20-refdata-cpp-codegen-activation.org
+++ b/doc/plans/2026-05-20-refdata-cpp-codegen-activation.org
@@ -1,0 +1,194 @@
+:PROPERTIES:
+:ID: 8B4C1D2E-93F7-4A68-C5B9-6D0E1F4A2B83
+:END:
+#+title: Refdata C++ Codegen: Activate Domain/Generator/Repository Generation
+#+STATUS: TODO
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
+#+startup: inlineimages
+
+* Problem
+
+25 =*_domain_entity.json= models and 3 =*_junction.json= models exist in
+=ores.codegen/models/refdata/=.  The C++ templates
+(=cpp_domain_type_class.hpp.mustache=, =cpp_domain_type_mapper.cpp.mustache=,
+=cpp_domain_type_generator.cpp.mustache=, =cpp_domain_type_repository.cpp.mustache=,
+etc.) are fully functional and already in use for trading and workspace
+entities.
+
+However, =generate_refdata_schema.sh= only runs =--profile sql= on
+=*_entity.json= lookup tables.  It never invokes =--profile domain=,
+=--profile generator=, or =--profile repository= for the domain entities.
+As a result, all refdata domain headers, mappers, generators, and repositories
+are hand-written and drift from the templates over time.
+
+The immediate consequence was the =tenant_id= strong-type migration
+(=feature/dq-plan-resume=, 2026-05-20): 11 party-related domain types still
+used =std::string tenant_id= because the codegen template already emitted the
+correct =utility::uuid::tenant_id= type, but the hand-written files were never
+regenerated to pick it up.
+
+* Scope
+
+** Models to cover (25 domain entities + 3 junctions)
+
+| Model | Notes |
+|-------+-------|
+| =book_domain_entity.json= | |
+| =business_unit_domain_entity.json= | |
+| =cds_convention_domain_entity.json= | |
+| =contact_type_domain_entity.json= | |
+| =counterparty_contact_information_domain_entity.json= | |
+| =counterparty_domain_entity.json= | |
+| =counterparty_identifier_domain_entity.json= | |
+| =currency_market_tier_domain_entity.json= | |
+| =deposit_convention_domain_entity.json= | |
+| =fra_convention_domain_entity.json= | |
+| =fx_convention_domain_entity.json= | |
+| =ibor_index_convention_domain_entity.json= | |
+| =monetary_nature_domain_entity.json= | |
+| =ois_convention_domain_entity.json= | |
+| =overnight_index_convention_domain_entity.json= | |
+| =party_contact_information_domain_entity.json= | |
+| =party_domain_entity.json= | Has special =read_system_party= hand-mapped function |
+| =party_identifier_domain_entity.json= | |
+| =party_id_scheme_domain_entity.json= | |
+| =party_status_domain_entity.json= | |
+| =party_type_domain_entity.json= | |
+| =portfolio_domain_entity.json= | |
+| =rounding_type_domain_entity.json= | |
+| =swap_convention_domain_entity.json= | |
+| =zero_convention_domain_entity.json= | |
+| =party_counterparty_junction.json= | Junction type |
+| =party_country_junction.json= | Junction type |
+| =party_currency_junction.json= | Junction type |
+
+** Missing model
+
+=business_unit_type= has no =*_domain_entity.json= model.  Its C++ files are
+entirely hand-written.  A model must be created before its files can be brought
+under codegen.
+
+** Out of scope
+
+- =*_entity.json= lookup tables — already codegen-managed (SQL only, no C++
+  generation planned).
+- Eventing/messaging/protocol types — these are in =ores.refdata.api/eventing/=
+  and =ores.refdata.api/messaging/= and are not domain entities.
+- Any project outside =ores.refdata.api= and =ores.refdata.core=.
+
+* Template Gaps to Fix First
+
+Before running generation, two gaps in the templates must be fixed.  Both are
+in =projects/ores.codegen/library/templates/=.
+
+** Gap 1: Junction section uses =std::string tenant_id=
+
+=cpp_domain_type_class.hpp.mustache= has two sections:
+
+- ={{#domain_entity}}= (line 28): correctly emits =utility::uuid::tenant_id=
+- ={{#junction}}= (line 130): still emits =std::string tenant_id=
+
+The junction section needs the same fix:
+
+#+begin_src diff
+-{{#has_tenant_id}}
+-    /**
+-     * @brief Tenant identifier for multi-tenancy isolation.
+-     */
+-    std::string tenant_id;
+-
+-{{/has_tenant_id}}
++{{#has_tenant_id}}
++    /**
++     * @brief Tenant identifier for multi-tenancy isolation.
++     */
++    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
++
++{{/has_tenant_id}}
+#+end_src
+
+And add the include in the junction section header block alongside the other
+includes (needs =ores.utility/uuid/tenant_id.hpp=).
+
+** Gap 2: Mapper read side uses =.value_or()= instead of =.value()=
+
+=cpp_domain_type_mapper.cpp.mustache= read side (entity→domain) emits:
+
+#+begin_src c++
+r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id)
+    .value_or(utility::uuid::tenant_id::system());
+#+end_src
+
+The convention (see =2026-05-20-refdata-party-tenant-id-migration.org=) is
+=.value()= because a malformed UUID in the DB is a data integrity bug, not an
+expected runtime condition.  The =.value_or= form silently masks corruption.
+
+Fix the mapper template to use =.value()= for the entity→domain read side, and
+verify the junction variant is also consistent.
+
+* Implementation Plan
+
+** Phase 1 — Fix templates
+
+- [ ] Fix =cpp_domain_type_class.hpp.mustache= junction section:
+  add include, change =std::string tenant_id= → =utility::uuid::tenant_id=
+- [ ] Fix =cpp_domain_type_mapper.cpp.mustache= read side:
+  =.value_or()= → =.value()= in the entity→domain mapping
+
+** Phase 2 — Create missing model
+
+- [ ] Create =business_unit_type_domain_entity.json= in
+  =ores.codegen/models/refdata/= modelled on =business_unit_domain_entity.json=
+  (fields: =coding_scheme_code=, =code=, =name=, =level=, =description=)
+
+** Phase 3 — Add generation script
+
+- [ ] Create =generate_refdata_cpp.sh= alongside the existing scripts,
+  mirroring =generate_workspace_entities.sh=:
+  - For each =*_domain_entity.json= and =*_junction.json= in
+    =models/refdata/=: run =--profile domain=, =--profile generator=,
+    =--profile repository=
+  - Output directly into the repo tree (=projects/ores.refdata.api/= and
+    =projects/ores.refdata.core/=), not the =output/= staging directory
+- [ ] Add header =AUTO-GENERATED FILE - DO NOT EDIT MANUALLY= to each output
+  file (handled by the template =cpp_license= block if =generated: true= is
+  set in the model)
+
+** Phase 4 — Run and diff
+
+- [ ] Run =generate_refdata_cpp.sh= against all 28 models
+- [ ] Diff generated output against each existing hand-written file
+- [ ] For each file: either the output matches (replace as-is) or there is a
+  meaningful difference (fix the template or the model before replacing)
+- [ ] Special case: =party_repository.cpp= contains a hand-written
+  =read_system_party= function that maps rows by column index (not via the
+  mapper).  This function is unlikely to be codegen-able — keep it hand-written
+  with a comment, and ensure the codegen output for the rest of the file does
+  not clobber it.
+
+** Phase 5 — Replace and verify
+
+- [ ] Replace hand-written files with codegen output
+- [ ] Build =ores.refdata.api.lib= and =ores.refdata.core.lib= cleanly
+- [ ] All refdata repository tests pass
+- [ ] All synthetic tests pass
+
+* Notes
+
+- Reference for the =generate_workspace_entities.sh= pattern (closest analogue
+  to what this script should do).
+- The =party_repository.cpp= exception: the =read_system_party= function does
+  manual column-index row mapping that the repository template does not support.
+  When generating the repository file, this function must be preserved by hand
+  or the template extended to support manual override sections.
+- Once active, any future field addition or type change to a refdata entity
+  should go through the model JSON, not the C++ files directly.  A CI check
+  (or at minimum a developer discipline) should enforce this.
+- =tenant_id= generation context cleanup: generators currently accept ="system"=
+  as a human-readable shorthand for the system tenant, converting it with
+  =from_string().value_or(system())=.  This is a leaky abstraction — the type is
+  UUID and non-UUID strings should not be silently tolerated even in test/generation
+  contexts.  When the codegen script is active, consider requiring callers to pass a
+  real UUID string (or the =tenant_id= strong type directly) and replacing the
+  =value_or= fallback with =.value()= across all generators.

--- a/doc/plans/2026-05-20-refdata-party-tenant-id-migration.org
+++ b/doc/plans/2026-05-20-refdata-party-tenant-id-migration.org
@@ -193,8 +193,8 @@ that assigned =h.tenant_id().to_string()= to =pc.tenant_id=.
 
 ** Build and test
 - [X] Build =ores.refdata.api.lib= and =ores.refdata.core.lib= cleanly
-- [ ] All refdata repository tests pass (=ores.refdata.core= test suite)
-- [ ] =ores.synthetic.core= tests pass (no more =bad access to std::expected=)
+- [X] All refdata repository tests pass (=ores.refdata.core= test suite)
+- [X] =ores.synthetic.core= tests pass (no more =bad access to std::expected=)
 
 * Notes
 

--- a/doc/plans/2026-05-20-refdata-party-tenant-id-migration.org
+++ b/doc/plans/2026-05-20-refdata-party-tenant-id-migration.org
@@ -2,7 +2,7 @@
 :ID: 3A7F2B1C-84E6-4D59-B2A8-5C9E0F3D1A72
 :END:
 #+title: Refdata Party Domain: tenant_id Strong-Type Migration
-#+STATUS: TODO
+#+STATUS: DONE
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
@@ -134,49 +134,65 @@ Affected generators (all in =ores.refdata.api/src/generators/=):
 * Implementation Checklist
 
 ** Domain headers
-- [ ] =party.hpp= — change field type, add include
-- [ ] =business_unit.hpp= — change field type, add include
-- [ ] =business_unit_type.hpp= — change field type, add include
-- [ ] =counterparty.hpp= — change field type, add include
-- [ ] =counterparty_identifier.hpp= — change field type, add include
-- [ ] =counterparty_contact_information.hpp= — change field type, add include
-- [ ] =party_contact_information.hpp= — change field type, add include
-- [ ] =party_counterparty.hpp= — change field type, add include
-- [ ] =party_country.hpp= — change field type, add include
-- [ ] =party_currency.hpp= — change field type, add include
-- [ ] =party_identifier.hpp= — change field type, add include
+- [X] =party.hpp= — change field type, add include
+- [X] =business_unit.hpp= — change field type, add include
+- [X] =business_unit_type.hpp= — change field type, add include
+- [X] =counterparty.hpp= — change field type, add include
+- [X] =counterparty_identifier.hpp= — change field type, add include
+- [X] =counterparty_contact_information.hpp= — change field type, add include
+- [X] =party_contact_information.hpp= — change field type, add include
+- [X] =party_counterparty.hpp= — change field type, add include
+- [X] =party_country.hpp= — change field type, add include
+- [X] =party_currency.hpp= — change field type, add include
+- [X] =party_identifier.hpp= — change field type, add include
 
 ** Repository mappers (=ores.refdata.core/src/repository/=)
-- [ ] =party_mapper.cpp= — both read and write sides
-- [ ] =business_unit_mapper.cpp= — both read and write sides
-- [ ] =business_unit_type_mapper.cpp= — both read and write sides
-- [ ] =counterparty_mapper.cpp= — both read and write sides
-- [ ] =counterparty_identifier_mapper.cpp= — both read and write sides
-- [ ] =counterparty_contact_information_mapper.cpp= — both read and write sides
-- [ ] =party_contact_information_mapper.cpp= — both read and write sides
-- [ ] =party_counterparty_mapper.cpp= — both read and write sides
-- [ ] =party_country_mapper.cpp= — both read and write sides
-- [ ] =party_currency_mapper.cpp= — both read and write sides
-- [ ] =party_identifier_mapper.cpp= — both read and write sides
+- [X] =party_mapper.cpp= — both read and write sides
+- [X] =business_unit_mapper.cpp= — both read and write sides
+- [X] =business_unit_type_mapper.cpp= — both read and write sides
+- [X] =counterparty_mapper.cpp= — both read and write sides
+- [X] =counterparty_identifier_mapper.cpp= — both read and write sides
+- [X] =counterparty_contact_information_mapper.cpp= — both read and write sides
+- [X] =party_contact_information_mapper.cpp= — both read and write sides
+- [X] =party_counterparty_mapper.cpp= — both read and write sides
+- [X] =party_country_mapper.cpp= — both read and write sides
+- [X] =party_currency_mapper.cpp= — both read and write sides
+- [X] =party_identifier_mapper.cpp= — both read and write sides
 
 ** Special repository cases
-- [ ] =party_repository.cpp= — manual row mapping in =read_system_party= (line 129)
+- [X] =party_repository.cpp= — manual row mapping in =read_system_party= (line 129)
 
 ** Generators (=ores.refdata.api/src/generators/=)
-- [ ] =party_generator.cpp=
-- [ ] =business_unit_generator.cpp=
-- [ ] =business_unit_type_generator.cpp=
-- [ ] =counterparty_generator.cpp=
-- [ ] =counterparty_identifier_generator.cpp=
-- [ ] =counterparty_contact_information_generator.cpp=
-- [ ] =party_contact_information_generator.cpp=
-- [ ] =party_counterparty_generator.cpp=
-- [ ] =party_country_generator.cpp=
-- [ ] =party_currency_generator.cpp=
-- [ ] =party_identifier_generator.cpp=
+- [X] =party_generator.cpp=
+- [X] =business_unit_generator.cpp=
+- [X] =business_unit_type_generator.cpp=
+- [X] =counterparty_generator.cpp=
+- [X] =counterparty_identifier_generator.cpp=
+- [X] =counterparty_contact_information_generator.cpp=
+- [X] =party_contact_information_generator.cpp=
+- [X] =party_counterparty_generator.cpp=
+- [X] =party_country_generator.cpp=
+- [X] =party_currency_generator.cpp=
+- [X] =party_identifier_generator.cpp=
+
+** Test files (=ores.refdata.core/tests/= and =ores.synthetic.core/tests/=)
+
+These were not in the original scope but required fixes to compile after the
+domain header changes.  The pattern in each: update =find_system_party_id=
+helper to take =const ores::utility::uuid::tenant_id&=, remove spurious
+=.to_string()= at call sites, and update =make_pc= / =make_party_*= helpers
+that assigned =h.tenant_id().to_string()= to =pc.tenant_id=.
+
+- [X] =party_rls_isolation_tests.cpp=
+- [X] =repository_party_counterparty_repository_tests.cpp=
+- [X] =repository_party_country_repository_tests.cpp=
+- [X] =repository_party_currency_repository_tests.cpp=
+- [X] =organisation_publisher_integration_tests.cpp= (=ores.synthetic.core=) —
+  moved =from_string()= conversion before the generic =stamp= lambda so all
+  entity types receive the strong type directly
 
 ** Build and test
-- [ ] Build =ores.refdata.api.lib= and =ores.refdata.core.lib= cleanly
+- [X] Build =ores.refdata.api.lib= and =ores.refdata.core.lib= cleanly
 - [ ] All refdata repository tests pass (=ores.refdata.core= test suite)
 - [ ] =ores.synthetic.core= tests pass (no more =bad access to std::expected=)
 
@@ -184,7 +200,9 @@ Affected generators (all in =ores.refdata.api/src/generators/=):
 
 - The mapper read side uses =.value()= (not =.value_or=) because a malformed
   UUID in the DB is a data integrity bug.  The generator uses =.value_or= because
-  the generation context allows ="system"= as a human-readable shorthand.
+  the generation context allows ="system"= as a human-readable shorthand.  This
+  shorthand is a leaky abstraction — cleanup is tracked in
+  =2026-05-20-refdata-cpp-codegen-activation.org= (Notes section).
 - No SQL migration is needed.  The DB column is already =uuid=; only the C++
   representation changes.
 - No eventing or messaging types are touched.  Downstream consumers of

--- a/projects/ores.iam.core/tests/repository_account_party_repository_tests.cpp
+++ b/projects/ores.iam.core/tests/repository_account_party_repository_tests.cpp
@@ -54,7 +54,7 @@ boost::uuids::uuid find_system_party_id(
     party_repository& repo, const ores::utility::uuid::tenant_id& tid) {
     auto parties = repo.read_latest();
     for (const auto& p : parties)
-        if (p.tenant_id == tid)
+        if (p.tenant_id == tid && p.party_category == "System")
             return p.id;
     throw std::runtime_error("No system party for tenant: " + tid.to_string());
 }

--- a/projects/ores.iam.core/tests/repository_account_party_repository_tests.cpp
+++ b/projects/ores.iam.core/tests/repository_account_party_repository_tests.cpp
@@ -34,6 +34,7 @@
 #include "ores.refdata.api/generators/party_generator.hpp"
 #include "ores.testing/database_helper.hpp"
 #include "ores.testing/make_generation_context.hpp"
+#include "ores.utility/uuid/tenant_id.hpp"
 
 using namespace ores::logging;
 using namespace ores::iam::generators;
@@ -50,12 +51,12 @@ const std::string_view test_suite("ores.iam.tests");
 const std::string tags("[repository]");
 
 boost::uuids::uuid find_system_party_id(
-    party_repository& repo, const std::string& tid) {
+    party_repository& repo, const ores::utility::uuid::tenant_id& tid) {
     auto parties = repo.read_latest();
     for (const auto& p : parties)
         if (p.tenant_id == tid)
             return p.id;
-    throw std::runtime_error("No system party for tenant: " + tid);
+    throw std::runtime_error("No system party for tenant: " + tid.to_string());
 }
 
 }
@@ -70,7 +71,7 @@ TEST_CASE("write_single_account_party", tags) {
     account_party_repository repo(h.context());
     party_repository party_repo(h.context());
     const auto party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
 
     auto acc = generate_synthetic_account(ctx);
     acc_repo.write(acc);
@@ -93,7 +94,7 @@ TEST_CASE("write_multiple_account_parties", tags) {
     account_party_repository repo(h.context());
     party_repository party_repo(h.context());
     const auto system_party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
 
     std::vector<account_party> aps;
     for (int i = 0; i < 3; ++i) {
@@ -124,7 +125,7 @@ TEST_CASE("read_latest_account_parties", tags) {
     account_repository acc_repo(h.context());
     party_repository party_repo(h.context());
     const auto system_party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
 
     std::vector<account_party> written;
     for (int i = 0; i < 3; ++i) {
@@ -167,7 +168,7 @@ TEST_CASE("read_latest_account_parties_by_account", tags) {
     account_repository acc_repo(h.context());
     party_repository party_repo(h.context());
     const auto party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
 
     // Construct repo after set_party so its stored context has party IDs.
     h.set_party(party_id);

--- a/projects/ores.qt.api/src/EntityDetailOperations.cpp
+++ b/projects/ores.qt.api/src/EntityDetailOperations.cpp
@@ -26,7 +26,7 @@ namespace ores::qt {
 entity_data to_entity_data(const refdata::domain::counterparty& cpty) {
     entity_data d;
     d.version = cpty.version;
-    d.tenant_id = cpty.tenant_id;
+    d.tenant_id = cpty.tenant_id.to_string();
     d.id = cpty.id;
     d.full_name = cpty.full_name;
     d.short_code = cpty.short_code;
@@ -47,7 +47,7 @@ entity_data to_entity_data(const refdata::domain::counterparty& cpty) {
 entity_data to_entity_data(const refdata::domain::party& p) {
     entity_data d;
     d.version = p.version;
-    d.tenant_id = p.tenant_id;
+    d.tenant_id = p.tenant_id.to_string();
     d.id = p.id;
     d.full_name = p.full_name;
     d.short_code = p.short_code;

--- a/projects/ores.qt.party/src/CounterpartyDetailOperations.cpp
+++ b/projects/ores.qt.party/src/CounterpartyDetailOperations.cpp
@@ -21,6 +21,7 @@
 
 #include <boost/uuid/uuid_io.hpp>
 #include "ores.qt/ClientManager.hpp"
+#include "ores.utility/uuid/tenant_id.hpp"
 #include "ores.refdata.api/domain/counterparty.hpp"
 #include "ores.refdata.api/domain/counterparty_identifier.hpp"
 #include "ores.refdata.api/domain/counterparty_contact_information.hpp"
@@ -43,7 +44,7 @@ operation_result counterparty_detail_operations::save_entity(
 
     refdata::domain::counterparty cpty;
     cpty.version = data.version;
-    cpty.tenant_id = data.tenant_id;
+    cpty.tenant_id = ores::utility::uuid::tenant_id::from_string(data.tenant_id).value();
     cpty.id = data.id;
     cpty.full_name = data.full_name;
     cpty.short_code = data.short_code;

--- a/projects/ores.qt.party/src/PartyDetailOperations.cpp
+++ b/projects/ores.qt.party/src/PartyDetailOperations.cpp
@@ -21,6 +21,7 @@
 
 #include <boost/uuid/uuid_io.hpp>
 #include "ores.qt/ClientManager.hpp"
+#include "ores.utility/uuid/tenant_id.hpp"
 #include "ores.refdata.api/domain/party.hpp"
 #include "ores.refdata.api/domain/party_identifier.hpp"
 #include "ores.refdata.api/domain/party_contact_information.hpp"
@@ -44,7 +45,7 @@ operation_result party_detail_operations::save_entity(
 
     refdata::domain::party p;
     p.version = data.version;
-    p.tenant_id = data.tenant_id;
+    p.tenant_id = ores::utility::uuid::tenant_id::from_string(data.tenant_id).value();
     p.id = data.id;
     p.full_name = data.full_name;
     p.short_code = data.short_code;

--- a/projects/ores.qt/src/TenantProvisioningWizard.cpp
+++ b/projects/ores.qt/src/TenantProvisioningWizard.cpp
@@ -989,7 +989,7 @@ void TenantExecutePage::startPartyAssociation() {
                 iam::domain::account_party ap;
                 ap.account_id         = *accountId;
                 ap.party_id           = party.id;
-                ap.tenant_id          = party.tenant_id;
+                ap.tenant_id          = party.tenant_id.to_string();
                 ap.modified_by        = publishedBy;
                 ap.performed_by       = publishedBy;
                 ap.change_reason_code =

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/business_unit.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/business_unit.hpp
@@ -24,6 +24,7 @@
 #include <optional>
 #include <string>
 #include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
 
 namespace ores::refdata::domain {
 
@@ -43,7 +44,7 @@ struct business_unit final {
     /**
      * @brief Tenant identifier for multi-tenancy isolation.
      */
-    std::string tenant_id;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
      * @brief UUID uniquely identifying this business unit.

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/business_unit_type.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/business_unit_type.hpp
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <string>
 #include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
 
 namespace ores::refdata::domain {
 
@@ -43,7 +44,7 @@ struct business_unit_type final {
     /**
      * @brief Tenant identifier for multi-tenancy isolation.
      */
-    std::string tenant_id;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
      * @brief UUID uniquely identifying this business unit type.

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/counterparty.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/counterparty.hpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <optional>
 #include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
 
 namespace ores::refdata::domain {
 
@@ -43,7 +44,7 @@ struct counterparty final {
     /**
      * @brief Tenant identifier for multi-tenancy isolation.
      */
-    std::string tenant_id;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
      * @brief UUID uniquely identifying this counterparty.

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/counterparty_contact_information.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/counterparty_contact_information.hpp
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <string>
 #include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
 
 namespace ores::refdata::domain {
 
@@ -41,7 +42,7 @@ struct counterparty_contact_information final {
     /**
      * @brief Tenant identifier for multi-tenancy isolation.
      */
-    std::string tenant_id;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
      * @brief UUID uniquely identifying this contact information record.

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/counterparty_identifier.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/counterparty_identifier.hpp
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <string>
 #include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
 
 namespace ores::refdata::domain {
 
@@ -42,7 +43,7 @@ struct counterparty_identifier final {
     /**
      * @brief Tenant identifier for multi-tenancy isolation.
      */
-    std::string tenant_id;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
      * @brief UUID uniquely identifying this counterparty identifier.

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/party.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/party.hpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <optional>
 #include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
 
 namespace ores::refdata::domain {
 
@@ -43,7 +44,7 @@ struct party final {
     /**
      * @brief Tenant identifier for multi-tenancy isolation.
      */
-    std::string tenant_id;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
      * @brief UUID uniquely identifying this party.

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/party_contact_information.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/party_contact_information.hpp
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <string>
 #include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
 
 namespace ores::refdata::domain {
 
@@ -41,7 +42,7 @@ struct party_contact_information final {
     /**
      * @brief Tenant identifier for multi-tenancy isolation.
      */
-    std::string tenant_id;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
      * @brief UUID uniquely identifying this contact information record.

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/party_counterparty.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/party_counterparty.hpp
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <string>
 #include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
 
 namespace ores::refdata::domain {
 
@@ -35,7 +36,7 @@ namespace ores::refdata::domain {
  */
 struct party_counterparty final {
     int version = 0;
-    std::string tenant_id;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
     boost::uuids::uuid party_id;
     boost::uuids::uuid counterparty_id;
     std::string modified_by;

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/party_country.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/party_country.hpp
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <string>
 #include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
 
 namespace ores::refdata::domain {
 
@@ -35,7 +36,7 @@ namespace ores::refdata::domain {
  */
 struct party_country final {
     int version = 0;
-    std::string tenant_id;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
     boost::uuids::uuid party_id;
     std::string country_alpha2_code;
     std::string modified_by;

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/party_currency.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/party_currency.hpp
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <string>
 #include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
 
 namespace ores::refdata::domain {
 
@@ -35,7 +36,7 @@ namespace ores::refdata::domain {
  */
 struct party_currency final {
     int version = 0;
-    std::string tenant_id;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
     boost::uuids::uuid party_id;
     std::string currency_iso_code;
     std::string modified_by;

--- a/projects/ores.refdata.api/include/ores.refdata.api/domain/party_identifier.hpp
+++ b/projects/ores.refdata.api/include/ores.refdata.api/domain/party_identifier.hpp
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <string>
 #include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
 
 namespace ores::refdata::domain {
 
@@ -42,7 +43,7 @@ struct party_identifier final {
     /**
      * @brief Tenant identifier for multi-tenancy isolation.
      */
-    std::string tenant_id;
+    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
 
     /**
      * @brief UUID uniquely identifying this party identifier.

--- a/projects/ores.refdata.api/src/generators/business_unit_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/business_unit_generator.cpp
@@ -38,7 +38,8 @@ domain::business_unit generate_synthetic_business_unit(
 
     domain::business_unit r;
     r.version = 1;
-    r.tenant_id = tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(tenant_id)
+        .value_or(utility::uuid::tenant_id::system());
     r.id = ctx.generate_uuid();
     r.party_id = ctx.generate_uuid();
     r.unit_name = faker::company::companyName() + " Desk " + std::to_string(idx);

--- a/projects/ores.refdata.api/src/generators/business_unit_type_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/business_unit_type_generator.cpp
@@ -38,7 +38,8 @@ domain::business_unit_type generate_synthetic_business_unit_type(
 
     domain::business_unit_type r;
     r.version = 1;
-    r.tenant_id = tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(tenant_id)
+        .value_or(utility::uuid::tenant_id::system());
     r.id = ctx.generate_uuid();
     r.coding_scheme_code = "ORES-ORG";
     r.code = std::string(faker::word::noun()) + "_type_" + std::to_string(idx);

--- a/projects/ores.refdata.api/src/generators/counterparty_contact_information_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/counterparty_contact_information_generator.cpp
@@ -41,7 +41,8 @@ domain::counterparty_contact_information generate_synthetic_counterparty_contact
 
     domain::counterparty_contact_information r;
     r.version = 1;
-    r.tenant_id = tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(tenant_id)
+        .value_or(utility::uuid::tenant_id::system());
     r.id = ctx.generate_uuid();
     r.counterparty_id = ctx.generate_uuid();
     r.contact_type = std::string(contact_types[idx % contact_types.size()]);

--- a/projects/ores.refdata.api/src/generators/counterparty_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/counterparty_generator.cpp
@@ -38,7 +38,8 @@ domain::counterparty generate_synthetic_counterparty(
 
     domain::counterparty r;
     r.version = 1;
-    r.tenant_id = tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(tenant_id)
+        .value_or(utility::uuid::tenant_id::system());
     r.id = ctx.generate_uuid();
     r.full_name = faker::company::companyName() + " " + std::to_string(idx);
     r.short_code = std::string(faker::string::alpha(6)) + std::to_string(idx);

--- a/projects/ores.refdata.api/src/generators/counterparty_identifier_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/counterparty_identifier_generator.cpp
@@ -38,7 +38,8 @@ domain::counterparty_identifier generate_synthetic_counterparty_identifier(
 
     domain::counterparty_identifier r;
     r.version = 1;
-    r.tenant_id = tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(tenant_id)
+        .value_or(utility::uuid::tenant_id::system());
     r.id = ctx.generate_uuid();
     static constexpr std::array<const char*, 10> id_schemes = {
         "LEI", "BIC", "MIC", "NATIONAL_ID", "CEDB",

--- a/projects/ores.refdata.api/src/generators/party_contact_information_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/party_contact_information_generator.cpp
@@ -41,7 +41,8 @@ domain::party_contact_information generate_synthetic_party_contact_information(
 
     domain::party_contact_information r;
     r.version = 1;
-    r.tenant_id = tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(tenant_id)
+        .value_or(utility::uuid::tenant_id::system());
     r.id = ctx.generate_uuid();
     r.party_id = ctx.generate_uuid();
     r.contact_type = std::string(contact_types[idx % contact_types.size()]);

--- a/projects/ores.refdata.api/src/generators/party_counterparty_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/party_counterparty_generator.cpp
@@ -35,7 +35,8 @@ domain::party_counterparty generate_synthetic_party_counterparty(
 
     domain::party_counterparty r;
     r.version = 1;
-    r.tenant_id = tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(tenant_id)
+        .value_or(utility::uuid::tenant_id::system());
     r.party_id = ctx.generate_uuid();
     r.counterparty_id = ctx.generate_uuid();
     r.modified_by = modified_by;

--- a/projects/ores.refdata.api/src/generators/party_country_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/party_country_generator.cpp
@@ -35,7 +35,8 @@ domain::party_country generate_synthetic_party_country(
 
     domain::party_country r;
     r.version = 1;
-    r.tenant_id = tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(tenant_id)
+        .value_or(utility::uuid::tenant_id::system());
     r.party_id = ctx.generate_uuid();
     r.country_alpha2_code = "US";
     r.modified_by = modified_by;

--- a/projects/ores.refdata.api/src/generators/party_currency_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/party_currency_generator.cpp
@@ -35,7 +35,8 @@ domain::party_currency generate_synthetic_party_currency(
 
     domain::party_currency r;
     r.version = 1;
-    r.tenant_id = tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(tenant_id)
+        .value_or(utility::uuid::tenant_id::system());
     r.party_id = ctx.generate_uuid();
     r.currency_iso_code = "USD";
     r.modified_by = modified_by;

--- a/projects/ores.refdata.api/src/generators/party_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/party_generator.cpp
@@ -38,7 +38,8 @@ domain::party generate_synthetic_party(
 
     domain::party r;
     r.version = 1;
-    r.tenant_id = tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(tenant_id)
+        .value_or(utility::uuid::tenant_id::system());
     r.id = ctx.generate_uuid();
     r.full_name = faker::company::companyName() + " " + std::to_string(idx);
     r.short_code = std::string(faker::string::alpha(6)) + std::to_string(idx);

--- a/projects/ores.refdata.api/src/generators/party_identifier_generator.cpp
+++ b/projects/ores.refdata.api/src/generators/party_identifier_generator.cpp
@@ -38,7 +38,8 @@ domain::party_identifier generate_synthetic_party_identifier(
 
     domain::party_identifier r;
     r.version = 1;
-    r.tenant_id = tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(tenant_id)
+        .value_or(utility::uuid::tenant_id::system());
     r.id = ctx.generate_uuid();
     static constexpr std::array<const char*, 10> id_schemes = {
         "LEI", "BIC", "MIC", "NATIONAL_ID", "CEDB",

--- a/projects/ores.refdata.api/tests/generators_tests.cpp
+++ b/projects/ores.refdata.api/tests/generators_tests.cpp
@@ -31,6 +31,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include "ores.logging/make_logger.hpp"
 #include "ores.utility/generation/generation_context.hpp"
+#include "ores.utility/uuid/tenant_id.hpp"
 
 namespace {
 
@@ -53,7 +54,7 @@ TEST_CASE("party_generator_produces_valid_instance", tags) {
     BOOST_LOG_SEV(lg, info) << "Generated party: " << sut.full_name;
 
     CHECK(sut.version == 1);
-    CHECK(sut.tenant_id == "system");
+    CHECK(sut.tenant_id == ores::utility::uuid::tenant_id::system());
     CHECK(!sut.id.is_nil());
     CHECK(!sut.full_name.empty());
     CHECK(!sut.short_code.empty());
@@ -86,7 +87,7 @@ TEST_CASE("counterparty_generator_produces_valid_instance", tags) {
     auto sut = generate_synthetic_counterparty(ctx);
 
     CHECK(sut.version == 1);
-    CHECK(sut.tenant_id == "system");
+    CHECK(sut.tenant_id == ores::utility::uuid::tenant_id::system());
     CHECK(!sut.id.is_nil());
     CHECK(!sut.full_name.empty());
     CHECK(!sut.short_code.empty());
@@ -240,7 +241,7 @@ TEST_CASE("party_identifier_generator_produces_valid_instance", tags) {
     auto sut = generate_synthetic_party_identifier(ctx);
 
     CHECK(sut.version == 1);
-    CHECK(sut.tenant_id == "system");
+    CHECK(sut.tenant_id == ores::utility::uuid::tenant_id::system());
     CHECK(!sut.id.is_nil());
     CHECK(!sut.party_id.is_nil());
     CHECK(!sut.id_scheme.empty());
@@ -272,7 +273,7 @@ TEST_CASE("counterparty_identifier_generator_produces_valid_instance", tags) {
     auto sut = generate_synthetic_counterparty_identifier(ctx);
 
     CHECK(sut.version == 1);
-    CHECK(sut.tenant_id == "system");
+    CHECK(sut.tenant_id == ores::utility::uuid::tenant_id::system());
     CHECK(!sut.id.is_nil());
     CHECK(!sut.counterparty_id.is_nil());
     CHECK(!sut.id_scheme.empty());
@@ -304,7 +305,7 @@ TEST_CASE("party_contact_information_generator_produces_valid_instance", tags) {
     auto sut = generate_synthetic_party_contact_information(ctx);
 
     CHECK(sut.version == 1);
-    CHECK(sut.tenant_id == "system");
+    CHECK(sut.tenant_id == ores::utility::uuid::tenant_id::system());
     CHECK(!sut.id.is_nil());
     CHECK(!sut.party_id.is_nil());
     CHECK(!sut.contact_type.empty());
@@ -339,7 +340,7 @@ TEST_CASE("counterparty_contact_information_generator_produces_valid_instance", 
     auto sut = generate_synthetic_counterparty_contact_information(ctx);
 
     CHECK(sut.version == 1);
-    CHECK(sut.tenant_id == "system");
+    CHECK(sut.tenant_id == ores::utility::uuid::tenant_id::system());
     CHECK(!sut.id.is_nil());
     CHECK(!sut.counterparty_id.is_nil());
     CHECK(!sut.contact_type.empty());

--- a/projects/ores.refdata.core/src/repository/business_unit_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/business_unit_mapper.cpp
@@ -35,7 +35,7 @@ business_unit_mapper::map(const business_unit_entity& v) {
 
     domain::business_unit r;
     r.version = v.version;
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
     r.id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
     r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
     r.unit_name = v.unit_name;
@@ -62,7 +62,7 @@ business_unit_mapper::map(const domain::business_unit& v) {
 
     business_unit_entity r;
     r.id = boost::uuids::to_string(v.id);
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = v.tenant_id.to_string();
     r.version = v.version;
     r.party_id = boost::uuids::to_string(v.party_id);
     r.unit_name = v.unit_name;

--- a/projects/ores.refdata.core/src/repository/business_unit_type_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/business_unit_type_mapper.cpp
@@ -35,7 +35,7 @@ business_unit_type_mapper::map(const business_unit_type_entity& v) {
 
     domain::business_unit_type r;
     r.version = v.version;
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
     r.id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
     r.coding_scheme_code = v.coding_scheme_code;
     r.code = v.code;
@@ -58,7 +58,7 @@ business_unit_type_mapper::map(const domain::business_unit_type& v) {
 
     business_unit_type_entity r;
     r.id = boost::uuids::to_string(v.id);
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = v.tenant_id.to_string();
     r.version = v.version;
     r.coding_scheme_code = v.coding_scheme_code;
     r.code = v.code;

--- a/projects/ores.refdata.core/src/repository/counterparty_contact_information_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/counterparty_contact_information_mapper.cpp
@@ -35,7 +35,7 @@ counterparty_contact_information_mapper::map(const counterparty_contact_informat
 
     domain::counterparty_contact_information r;
     r.version = v.version;
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
     r.id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
     r.counterparty_id = boost::lexical_cast<boost::uuids::uuid>(v.counterparty_id);
     r.contact_type = v.contact_type;
@@ -64,7 +64,7 @@ counterparty_contact_information_mapper::map(const domain::counterparty_contact_
 
     counterparty_contact_information_entity r;
     r.id = boost::uuids::to_string(v.id);
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = v.tenant_id.to_string();
     r.version = v.version;
     r.counterparty_id = boost::uuids::to_string(v.counterparty_id);
     r.contact_type = v.contact_type;

--- a/projects/ores.refdata.core/src/repository/counterparty_identifier_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/counterparty_identifier_mapper.cpp
@@ -35,7 +35,7 @@ counterparty_identifier_mapper::map(const counterparty_identifier_entity& v) {
 
     domain::counterparty_identifier r;
     r.version = v.version;
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
     r.id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
     r.counterparty_id = boost::lexical_cast<boost::uuids::uuid>(v.counterparty_id);
     r.id_scheme = v.id_scheme;
@@ -57,7 +57,7 @@ counterparty_identifier_mapper::map(const domain::counterparty_identifier& v) {
 
     counterparty_identifier_entity r;
     r.id = boost::uuids::to_string(v.id);
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = v.tenant_id.to_string();
     r.version = v.version;
     r.counterparty_id = boost::uuids::to_string(v.counterparty_id);
     r.id_scheme = v.id_scheme;

--- a/projects/ores.refdata.core/src/repository/counterparty_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/counterparty_mapper.cpp
@@ -35,7 +35,7 @@ counterparty_mapper::map(const counterparty_entity& v) {
 
     domain::counterparty r;
     r.version = v.version;
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
     r.id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
     r.full_name = v.full_name;
     r.short_code = v.short_code;
@@ -61,7 +61,7 @@ counterparty_mapper::map(const domain::counterparty& v) {
 
     counterparty_entity r;
     r.id = boost::uuids::to_string(v.id);
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = v.tenant_id.to_string();
     r.version = v.version;
     r.full_name = v.full_name;
     r.short_code = v.short_code;

--- a/projects/ores.refdata.core/src/repository/party_contact_information_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/party_contact_information_mapper.cpp
@@ -35,7 +35,7 @@ party_contact_information_mapper::map(const party_contact_information_entity& v)
 
     domain::party_contact_information r;
     r.version = v.version;
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
     r.id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
     r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
     r.contact_type = v.contact_type;
@@ -64,7 +64,7 @@ party_contact_information_mapper::map(const domain::party_contact_information& v
 
     party_contact_information_entity r;
     r.id = boost::uuids::to_string(v.id);
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = v.tenant_id.to_string();
     r.version = v.version;
     r.party_id = boost::uuids::to_string(v.party_id);
     r.contact_type = v.contact_type;

--- a/projects/ores.refdata.core/src/repository/party_counterparty_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/party_counterparty_mapper.cpp
@@ -35,7 +35,7 @@ party_counterparty_mapper::map(const party_counterparty_entity& v) {
 
     domain::party_counterparty r;
     r.version = v.version;
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
     r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id.value());
     r.counterparty_id = boost::lexical_cast<boost::uuids::uuid>(v.counterparty_id);
     r.modified_by = v.modified_by;
@@ -54,7 +54,7 @@ party_counterparty_mapper::map(const domain::party_counterparty& v) {
 
     party_counterparty_entity r;
     r.party_id = boost::uuids::to_string(v.party_id);
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = v.tenant_id.to_string();
     r.counterparty_id = boost::uuids::to_string(v.counterparty_id);
     r.version = v.version;
     r.modified_by = v.modified_by;

--- a/projects/ores.refdata.core/src/repository/party_country_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/party_country_mapper.cpp
@@ -35,7 +35,7 @@ party_country_mapper::map(const party_country_entity& v) {
 
     domain::party_country r;
     r.version = v.version;
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
     r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id.value());
     r.country_alpha2_code = v.country_alpha2_code;
     r.modified_by = v.modified_by;
@@ -54,7 +54,7 @@ party_country_mapper::map(const domain::party_country& v) {
 
     party_country_entity r;
     r.party_id = boost::uuids::to_string(v.party_id);
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = v.tenant_id.to_string();
     r.country_alpha2_code = v.country_alpha2_code;
     r.version = v.version;
     r.modified_by = v.modified_by;

--- a/projects/ores.refdata.core/src/repository/party_currency_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/party_currency_mapper.cpp
@@ -35,7 +35,7 @@ party_currency_mapper::map(const party_currency_entity& v) {
 
     domain::party_currency r;
     r.version = v.version;
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
     r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id.value());
     r.currency_iso_code = v.currency_iso_code;
     r.modified_by = v.modified_by;
@@ -54,7 +54,7 @@ party_currency_mapper::map(const domain::party_currency& v) {
 
     party_currency_entity r;
     r.party_id = boost::uuids::to_string(v.party_id);
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = v.tenant_id.to_string();
     r.currency_iso_code = v.currency_iso_code;
     r.version = v.version;
     r.modified_by = v.modified_by;

--- a/projects/ores.refdata.core/src/repository/party_identifier_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/party_identifier_mapper.cpp
@@ -35,7 +35,7 @@ party_identifier_mapper::map(const party_identifier_entity& v) {
 
     domain::party_identifier r;
     r.version = v.version;
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
     r.id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
     r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
     r.id_scheme = v.id_scheme;
@@ -57,7 +57,7 @@ party_identifier_mapper::map(const domain::party_identifier& v) {
 
     party_identifier_entity r;
     r.id = boost::uuids::to_string(v.id);
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = v.tenant_id.to_string();
     r.version = v.version;
     r.party_id = boost::uuids::to_string(v.party_id);
     r.id_scheme = v.id_scheme;

--- a/projects/ores.refdata.core/src/repository/party_mapper.cpp
+++ b/projects/ores.refdata.core/src/repository/party_mapper.cpp
@@ -35,7 +35,7 @@ party_mapper::map(const party_entity& v) {
 
     domain::party r;
     r.version = v.version;
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
     r.id = boost::lexical_cast<boost::uuids::uuid>(v.id.value());
     r.full_name = v.full_name;
     r.short_code = v.short_code;
@@ -63,7 +63,7 @@ party_mapper::map(const domain::party& v) {
 
     party_entity r;
     r.id = boost::uuids::to_string(v.id);
-    r.tenant_id = v.tenant_id;
+    r.tenant_id = v.tenant_id.to_string();
     r.version = v.version;
     r.full_name = v.full_name;
     r.short_code = v.short_code;

--- a/projects/ores.refdata.core/src/repository/party_repository.cpp
+++ b/projects/ores.refdata.core/src/repository/party_repository.cpp
@@ -126,7 +126,7 @@ party_repository::read_system_party(const std::string& tenant_id) {
                 [&row](int i) { return static_cast<bool>(row[i]); })) {
             domain::party p;
             p.id = boost::lexical_cast<boost::uuids::uuid>(*row[0]);
-            p.tenant_id = *row[1];
+            p.tenant_id = utility::uuid::tenant_id::from_string(*row[1]).value();
             p.version = std::stoi(*row[2]);
             p.full_name = *row[3];
             p.short_code = *row[4];

--- a/projects/ores.refdata.core/tests/party_rls_isolation_tests.cpp
+++ b/projects/ores.refdata.core/tests/party_rls_isolation_tests.cpp
@@ -34,6 +34,7 @@
 #include "ores.refdata.api/generators/counterparty_generator.hpp"
 #include "ores.testing/scoped_database_helper.hpp"
 #include "ores.testing/make_generation_context.hpp"
+#include "ores.utility/uuid/tenant_id.hpp"
 
 using namespace ores::logging;
 using namespace ores::refdata::generators;
@@ -50,19 +51,19 @@ const std::string_view test_suite("ores.refdata.tests");
 const std::string tags("[rls][party_isolation]");
 
 boost::uuids::uuid find_system_party_id(
-    party_repository& repo, const std::string& tid) {
+    party_repository& repo, const ores::utility::uuid::tenant_id& tid) {
     auto parties = repo.read_latest();
     for (const auto& p : parties)
         if (p.tenant_id == tid && p.party_category == "System")
             return p.id;
-    throw std::runtime_error("No system party for tenant: " + tid);
+    throw std::runtime_error("No system party for tenant: " + tid.to_string());
 }
 
 party_counterparty make_pc(scoped_database_helper& h,
     const boost::uuids::uuid& party_id,
     const boost::uuids::uuid& counterparty_id) {
     party_counterparty pc;
-    pc.tenant_id = h.tenant_id().to_string();
+    pc.tenant_id = h.tenant_id();
     pc.party_id = party_id;
     pc.counterparty_id = counterparty_id;
     pc.modified_by = h.db_user();
@@ -108,7 +109,7 @@ TEST_CASE("system_party_sees_all_assignments", tags) {
 
     // Find system party
     const auto system_party_id = find_system_party_id(
-        party_repo, tid.to_string());
+        party_repo, tid);
 
     // Create two operational parties under the system party
     auto party_a = generate_synthetic_party(gen_ctx);
@@ -171,7 +172,7 @@ TEST_CASE("party_a_sees_only_own_assignments", tags) {
     counterparty_repository cp_repo(ctx);
 
     const auto system_party_id = find_system_party_id(
-        party_repo, tid.to_string());
+        party_repo, tid);
 
     // Create two operational parties
     auto party_a = generate_synthetic_party(gen_ctx);
@@ -232,7 +233,7 @@ TEST_CASE("party_b_sees_only_own_assignments", tags) {
     counterparty_repository cp_repo(ctx);
 
     const auto system_party_id = find_system_party_id(
-        party_repo, tid.to_string());
+        party_repo, tid);
 
     auto party_a = generate_synthetic_party(gen_ctx);
     party_a.party_category = "Operational";
@@ -290,7 +291,7 @@ TEST_CASE("nested_party_hierarchy_visibility", tags) {
     counterparty_repository cp_repo(ctx);
 
     const auto system_party_id = find_system_party_id(
-        party_repo, tid.to_string());
+        party_repo, tid);
 
     // Create parent → child hierarchy
     auto parent = generate_synthetic_party(gen_ctx);

--- a/projects/ores.refdata.core/tests/repository_party_counterparty_repository_tests.cpp
+++ b/projects/ores.refdata.core/tests/repository_party_counterparty_repository_tests.cpp
@@ -33,6 +33,7 @@
 #include "ores.refdata.api/generators/counterparty_generator.hpp"
 #include "ores.testing/scoped_database_helper.hpp"
 #include "ores.testing/make_generation_context.hpp"
+#include "ores.utility/uuid/tenant_id.hpp"
 
 using namespace ores::logging;
 using namespace ores::refdata::generators;
@@ -49,19 +50,19 @@ const std::string_view test_suite("ores.refdata.tests");
 const std::string tags("[repository][party_counterparty]");
 
 boost::uuids::uuid find_system_party_id(
-    party_repository& repo, const std::string& tid) {
+    party_repository& repo, const ores::utility::uuid::tenant_id& tid) {
     auto parties = repo.read_latest();
     for (const auto& p : parties)
         if (p.tenant_id == tid)
             return p.id;
-    throw std::runtime_error("No system party for tenant: " + tid);
+    throw std::runtime_error("No system party for tenant: " + tid.to_string());
 }
 
 party_counterparty make_party_counterparty(scoped_database_helper& h,
     const boost::uuids::uuid& party_id,
     const boost::uuids::uuid& counterparty_id) {
     party_counterparty pc;
-    pc.tenant_id = h.tenant_id().to_string();
+    pc.tenant_id = h.tenant_id();
     pc.party_id = party_id;
     pc.counterparty_id = counterparty_id;
     pc.modified_by = h.db_user();
@@ -84,7 +85,7 @@ TEST_CASE("write_single_party_counterparty", tags) {
     party_counterparty_repository repo(h.context());
 
     const auto party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
 
     auto cp = generate_synthetic_counterparty(ctx);
     cp.change_reason_code = "system.test";
@@ -106,7 +107,7 @@ TEST_CASE("write_multiple_party_counterparties", tags) {
     party_counterparty_repository repo(h.context());
 
     const auto system_party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
 
     std::vector<party_counterparty> pcs;
     for (int i = 0; i < 3; ++i) {
@@ -132,7 +133,7 @@ TEST_CASE("read_latest_party_counterparties_by_party", tags) {
     party_counterparty_repository repo(h.context());
 
     const auto system_party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
 
     auto cp = generate_synthetic_counterparty(ctx);
     cp.change_reason_code = "system.test";
@@ -166,7 +167,7 @@ TEST_CASE("read_latest_party_counterparties_by_counterparty", tags) {
     party_counterparty_repository repo(h.context());
 
     const auto system_party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
 
     auto cp = generate_synthetic_counterparty(ctx);
     cp.change_reason_code = "system.test";
@@ -193,7 +194,7 @@ TEST_CASE("remove_party_counterparty", tags) {
     party_counterparty_repository repo(h.context());
 
     const auto system_party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
 
     auto cp = generate_synthetic_counterparty(ctx);
     cp.change_reason_code = "system.test";

--- a/projects/ores.refdata.core/tests/repository_party_counterparty_repository_tests.cpp
+++ b/projects/ores.refdata.core/tests/repository_party_counterparty_repository_tests.cpp
@@ -53,7 +53,7 @@ boost::uuids::uuid find_system_party_id(
     party_repository& repo, const ores::utility::uuid::tenant_id& tid) {
     auto parties = repo.read_latest();
     for (const auto& p : parties)
-        if (p.tenant_id == tid)
+        if (p.tenant_id == tid && p.party_category == "System")
             return p.id;
     throw std::runtime_error("No system party for tenant: " + tid.to_string());
 }

--- a/projects/ores.refdata.core/tests/repository_party_country_repository_tests.cpp
+++ b/projects/ores.refdata.core/tests/repository_party_country_repository_tests.cpp
@@ -33,6 +33,7 @@
 #include "ores.refdata.api/generators/country_generator.hpp"
 #include "ores.testing/scoped_database_helper.hpp"
 #include "ores.testing/make_generation_context.hpp"
+#include "ores.utility/uuid/tenant_id.hpp"
 
 using namespace ores::logging;
 using namespace ores::refdata::generators;
@@ -55,19 +56,19 @@ const std::string tags("[repository][party_country]");
 constexpr std::size_t total_slots = 10;
 
 boost::uuids::uuid find_system_party_id(
-    party_repository& repo, const std::string& tid) {
+    party_repository& repo, const ores::utility::uuid::tenant_id& tid) {
     auto parties = repo.read_latest();
     for (const auto& p : parties)
         if (p.tenant_id == tid)
             return p.id;
-    throw std::runtime_error("No system party for tenant: " + tid);
+    throw std::runtime_error("No system party for tenant: " + tid.to_string());
 }
 
 party_country make_party_country(scoped_database_helper& h,
     const boost::uuids::uuid& party_id,
     const std::string& alpha2_code) {
     party_country pc;
-    pc.tenant_id = h.tenant_id().to_string();
+    pc.tenant_id = h.tenant_id();
     pc.party_id = party_id;
     pc.country_alpha2_code = alpha2_code;
     pc.modified_by = h.db_user();
@@ -89,7 +90,7 @@ TEST_CASE("write_single_party_country", tags) {
     party_country_repository repo(h.context());
 
     const auto party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
     auto gctx = ores::testing::make_generation_context(h);
     auto all = generate_fictional_countries(total_slots, gctx);
     cty_repo.write(h.context(), {all[0]});
@@ -110,7 +111,7 @@ TEST_CASE("write_multiple_party_countries", tags) {
     party_country_repository repo(h.context());
 
     const auto system_party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
 
     auto gctx = ores::testing::make_generation_context(h);
     auto all = generate_fictional_countries(total_slots, gctx);
@@ -136,7 +137,7 @@ TEST_CASE("read_latest_party_countries_by_party", tags) {
     party_country_repository repo(h.context());
 
     const auto system_party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
     h.set_party(system_party_id);
 
     auto gctx = ores::testing::make_generation_context(h);
@@ -171,7 +172,7 @@ TEST_CASE("read_latest_party_countries_by_country", tags) {
     party_country_repository repo(h.context());
 
     const auto system_party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
     h.set_party(system_party_id);
 
     auto gctx = ores::testing::make_generation_context(h);
@@ -199,7 +200,7 @@ TEST_CASE("remove_party_country", tags) {
     party_country_repository repo(h.context());
 
     const auto system_party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
     auto gctx = ores::testing::make_generation_context(h);
     auto all = generate_fictional_countries(total_slots, gctx);
     cty_repo.write(h.context(), {all[5]});

--- a/projects/ores.refdata.core/tests/repository_party_country_repository_tests.cpp
+++ b/projects/ores.refdata.core/tests/repository_party_country_repository_tests.cpp
@@ -59,7 +59,7 @@ boost::uuids::uuid find_system_party_id(
     party_repository& repo, const ores::utility::uuid::tenant_id& tid) {
     auto parties = repo.read_latest();
     for (const auto& p : parties)
-        if (p.tenant_id == tid)
+        if (p.tenant_id == tid && p.party_category == "System")
             return p.id;
     throw std::runtime_error("No system party for tenant: " + tid.to_string());
 }

--- a/projects/ores.refdata.core/tests/repository_party_currency_repository_tests.cpp
+++ b/projects/ores.refdata.core/tests/repository_party_currency_repository_tests.cpp
@@ -33,6 +33,7 @@
 #include "ores.refdata.api/generators/currency_generator.hpp"
 #include "ores.testing/scoped_database_helper.hpp"
 #include "ores.testing/make_generation_context.hpp"
+#include "ores.utility/uuid/tenant_id.hpp"
 
 using namespace ores::logging;
 using namespace ores::refdata::generators;
@@ -49,19 +50,19 @@ const std::string_view test_suite("ores.refdata.tests");
 const std::string tags("[repository][party_currency]");
 
 boost::uuids::uuid find_system_party_id(
-    party_repository& repo, const std::string& tid) {
+    party_repository& repo, const ores::utility::uuid::tenant_id& tid) {
     auto parties = repo.read_latest();
     for (const auto& p : parties)
         if (p.tenant_id == tid)
             return p.id;
-    throw std::runtime_error("No system party for tenant: " + tid);
+    throw std::runtime_error("No system party for tenant: " + tid.to_string());
 }
 
 party_currency make_party_currency(scoped_database_helper& h,
     const boost::uuids::uuid& party_id,
     const std::string& iso_code) {
     party_currency pc;
-    pc.tenant_id = h.tenant_id().to_string();
+    pc.tenant_id = h.tenant_id();
     pc.party_id = party_id;
     pc.currency_iso_code = iso_code;
     pc.modified_by = h.db_user();
@@ -83,7 +84,7 @@ TEST_CASE("write_single_party_currency", tags) {
     party_currency_repository repo(h.context());
 
     const auto party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
     auto gctx = ores::testing::make_generation_context(h);
     auto test_currency = generate_synthetic_currency(gctx);
     cur_repo.write(h.context(), test_currency);
@@ -104,7 +105,7 @@ TEST_CASE("write_multiple_party_currencies", tags) {
     party_currency_repository repo(h.context());
 
     const auto system_party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
 
     auto gctx = ores::testing::make_generation_context(h);
     auto test_currencies = generate_unique_synthetic_currencies(2, gctx);
@@ -129,7 +130,7 @@ TEST_CASE("read_latest_party_currencies_by_party", tags) {
     party_currency_repository repo(h.context());
 
     const auto system_party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
     h.set_party(system_party_id);
 
     auto gctx = ores::testing::make_generation_context(h);
@@ -164,7 +165,7 @@ TEST_CASE("read_latest_party_currencies_by_currency", tags) {
     party_currency_repository repo(h.context());
 
     const auto system_party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
     h.set_party(system_party_id);
 
     auto gctx = ores::testing::make_generation_context(h);
@@ -192,7 +193,7 @@ TEST_CASE("remove_party_currency", tags) {
     party_currency_repository repo(h.context());
 
     const auto system_party_id = find_system_party_id(
-        party_repo, h.tenant_id().to_string());
+        party_repo, h.tenant_id());
     auto gctx = ores::testing::make_generation_context(h);
     auto test_currency = generate_synthetic_currency(gctx);
     cur_repo.write(h.context(), test_currency);

--- a/projects/ores.refdata.core/tests/repository_party_currency_repository_tests.cpp
+++ b/projects/ores.refdata.core/tests/repository_party_currency_repository_tests.cpp
@@ -53,7 +53,7 @@ boost::uuids::uuid find_system_party_id(
     party_repository& repo, const ores::utility::uuid::tenant_id& tid) {
     auto parties = repo.read_latest();
     for (const auto& p : parties)
-        if (p.tenant_id == tid)
+        if (p.tenant_id == tid && p.party_category == "System")
             return p.id;
     throw std::runtime_error("No system party for tenant: " + tid.to_string());
 }

--- a/projects/ores.synthetic.core/src/service/organisation_generator_service.cpp
+++ b/projects/ores.synthetic.core/src/service/organisation_generator_service.cpp
@@ -177,13 +177,15 @@ std::string make_bic(const std::string& country,
 // ============================================================================
 
 struct audit_fields {
-    std::string tenant_id;
+    utility::uuid::tenant_id tenant_id;
     std::string modified_by;
 };
 
 audit_fields get_audit(generation_context& ctx) {
+    const auto tid = ctx.env().get_or(generation_keys::tenant_id, "system");
     return {
-        ctx.env().get_or(generation_keys::tenant_id, "system"),
+        utility::uuid::tenant_id::from_string(tid)
+            .value_or(utility::uuid::tenant_id::system()),
         ctx.env().get_or(generation_keys::modified_by, "system")
     };
 }
@@ -715,8 +717,7 @@ void generate_portfolios(
 
         refdata::domain::portfolio p;
         p.version = 1;
-        p.tenant_id = utility::uuid::tenant_id::from_string(tenant_id)
-            .value_or(utility::uuid::tenant_id::system());
+        p.tenant_id = tenant_id;
         p.party_id = root_party_id;
         p.id = ctx.generate_uuid();
         p.name = name;
@@ -830,8 +831,7 @@ void generate_books(
         for (std::size_t bi = 0; bi < options.books_per_leaf_portfolio; ++bi) {
             refdata::domain::book bk;
             bk.version = 1;
-            bk.tenant_id = utility::uuid::tenant_id::from_string(tenant_id)
-                .value_or(utility::uuid::tenant_id::system());
+            bk.tenant_id = tenant_id;
             bk.id = ctx.generate_uuid();
             bk.party_id = root_party_id;
             bk.parent_portfolio_id = portfolio.id;

--- a/projects/ores.synthetic.core/tests/organisation_publisher_integration_tests.cpp
+++ b/projects/ores.synthetic.core/tests/organisation_publisher_integration_tests.cpp
@@ -112,9 +112,10 @@ void prepare_for_publish(generated_organisation& org,
     // uniqueness across multiple tests sharing the same tenant.
     const auto prefix = std::to_string(seed);
 
+    const auto tid = ores::utility::uuid::tenant_id::from_string(tenant_id).value();
     const auto stamp = [&](auto& entities) {
         for (auto& e : entities) {
-            e.tenant_id = tenant_id;
+            e.tenant_id = tid;
             e.modified_by = modified_by;
             e.performed_by = modified_by;
         }
@@ -129,7 +130,6 @@ void prepare_for_publish(generated_organisation& org,
     stamp(org.business_unit_types);
     stamp(org.business_units);
 
-    const auto tid = ores::utility::uuid::tenant_id::from_string(tenant_id).value();
     for (auto& p : org.portfolios) {
         p.tenant_id = tid;
         p.modified_by = modified_by;


### PR DESCRIPTION
## Summary

- Replaces `std::string tenant_id` with `utility::uuid::tenant_id` across all 11 party-cluster domain types (`party`, `business_unit`, `business_unit_type`, `counterparty`, `counterparty_identifier`, `counterparty_contact_information`, `party_contact_information`, `party_counterparty`, `party_country`, `party_currency`, `party_identifier`)
- Mapper read side uses `.value()` — a malformed UUID in the DB is a data integrity bug, not a recoverable condition
- Mapper write side uses `.to_string()` for the DB column
- Generators use `.value_or(system())` to tolerate the `"system"` shorthand in generation contexts
- `party_repository::read_system_party` manual row mapping updated accordingly
- Four test files in `ores.refdata.core/tests/` and one in `ores.synthetic.core/tests/` updated to compile and pass with the strong type
- Adds refdata C++ codegen activation plan (`doc/plans/2026-05-20-refdata-cpp-codegen-activation.org`) capturing the broader work needed to bring refdata domain files under codegen

## Root cause

The party/counterparty cluster was implemented before `utility::uuid::tenant_id` was introduced. All other refdata domain types already carried the strong type; this PR closes the gap and makes the domain model internally consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)