### PR TITLE
[doc] Site theme: dark CSS + sidebar TOC + preamble + Pages enablement

### DIFF
--- a/.build-site.el
+++ b/.build-site.el
@@ -96,15 +96,27 @@
       org-html-head-include-default-style nil ;; Use our own styles
       org-html-head html-header)
 
+(defvar site-html-preamble "<header id='site-header'>
+  <a href='/OreStudio/readme.html'><img id='site-banner' src='/OreStudio/assets/images/ore-studio-banner.png' alt='ORE Studio'/></a>
+  <nav id='site-nav'>
+    <a href='/OreStudio/readme.html'>Home</a>
+    <a href='/OreStudio/doc/doc.html'>Documentation</a>
+    <a href='/OreStudio/doc/v2/compass.html'>V2 Compass</a>
+    <a href='/OreStudio/doxygen/html/index.html'>Doxygen</a>
+    <a href='https://github.com/OreStudio/OreStudio'>GitHub</a>
+  </nav>
+</header>")
+
 ;; Define the publishing project
 (setq org-publish-project-alist
-      '(
+      `(
         ("site:pages"
          :recursive t
          :base-directory "./"
          :exclude "\\(^\\|/\\)\\(\\.packages\\|vcpkg\\|build\\)/"
          :publishing-function org-html-publish-to-html
          :publishing-directory "./build/output/site"
+         :html-preamble ,site-html-preamble
          :with-author nil
          :with-creator t
          :with-toc t

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -48,6 +48,8 @@ jobs:
           emacs -Q --script .build-site.el
       - name: Setup Pages
         uses: actions/configure-pages@v6
+        with:
+          enablement: true
       - name: Doxygen
         run: |
           sudo apt-get install graphviz doxygen

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,300 +1,397 @@
-/*
- * ORE Studio Website Stylesheet
- * Featuring Dark and Light Themes
- */
-
-/* --- Theme Variables and Base Styles --- */
+/* ==========================================================================
+   ORE Studio — Dark theme for Emacs Org-mode exports
+   Adapted from mcraveiro.github.io
+   ========================================================================== */
 
 :root {
-    /* Default to Light Theme */
-    --background-color: #ffffff;
-    --text-color: #333333;
-    --heading-color: #1a1a1a;
-    --link-color: #007bff;
-    --link-hover-color: #0056b3;
-    --accent-color: #007bff;
-    --accent-hover-color: #0056b3;
-    --code-bg: #f8f8f8;
-    --code-text: #d63384;
-    --border-color: #eeeeee;
-    --card-bg: #f8f9fa;
-    --footer-bg: #f4f4f4;
+    --bg-primary: #121214;       /* Deep matte background */
+    --bg-secondary: #1a1a1e;     /* Section/card background */
+    --bg-accent: #26262b;        /* Table headers / code blocks */
+
+    --text-primary: #e3e3e6;     /* High-contrast off-white body text */
+    --text-muted: #a1a1aa;       /* Muted gray for captions, subtitles */
+
+    --accent: #58a6ff;           /* Crisp blue for primary links */
+    --accent-hover: #8ab4f8;     /* Brighter blue for interactive states */
+    --accent-dim: #21262d;       /* Subtle decorative accents / borders */
+
+    --border-color: #30363d;     /* Clean, thin borders */
+    --max-width: 920px;          /* Optimal reading line length */
 }
 
-/* Dark Theme Preference */
-@media (prefers-color-scheme: dark) {
-    :root {
-        --background-color: #1e1e1e;
-        --text-color: #dddddd;
-        --heading-color: #ffffff;
-        --link-color: #90caf9;
-        --link-hover-color: #64b5f6;
-        --accent-color: #0056b3;
-        --accent-hover-color: #0056b3;
-        --code-bg: #2d2d2d;
-        --code-text: #ff6347;
-        --border-color: #333333;
-        --card-bg: #2d2d2d;
-        --footer-bg: #111111;
-    }
+html {
+    font-size: 17px;
 }
 
-/* Global Reset and Body Styles */
 body {
-    font-family: 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
-    line-height: 1.6;
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    line-height: 1.75;
     margin: 0;
-    padding: 0;
-    background-color: var(--background-color);
-    color: var(--text-color);
-    transition: background-color 0.3s, color 0.3s;
-    font-size: 1.1em;
+    padding: 0 1.5rem 2rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
-/* Ensure content is centered and readable */
+/* Site-wide preamble: banner image edge-to-edge, nav below */
+#preamble {
+    align-self: stretch;
+    margin: 0 -1.5rem 2rem;
+}
+
+#site-header {
+    display: flex;
+    flex-direction: column;
+}
+
+#site-banner {
+    display: block;
+    width: 100%;
+    height: auto;
+    margin: 0;
+    border: none;
+    border-radius: 0;
+}
+
+#site-nav {
+    display: flex;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding: 0.85rem 1.5rem;
+    background-color: var(--bg-secondary);
+    border-bottom: 1px solid var(--border-color);
+}
+
+#site-nav a {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    text-decoration: none;
+    letter-spacing: 0.02em;
+}
+
+#site-nav a:hover {
+    color: var(--accent);
+    text-decoration: none;
+}
+
 #content {
-    max-width: 960px;
-    margin: 0 auto;
-    padding: 20px;
+    max-width: var(--max-width);
+    width: 100%;
 }
 
-/* Headings */
+/* Typography */
 h1, h2, h3, h4, h5, h6 {
-    color: var(--heading-color);
+    color: #ffffff;
     font-weight: 600;
-    margin-top: 1.5em;
-    margin-bottom: 0.5em;
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+    letter-spacing: -0.02em;
 }
 
-h1 { font-size: 2.5em; }
-h2 { font-size: 2em; border-bottom: 2px solid var(--border-color); padding-bottom: 5px; }
-h3 { font-size: 1.5em; }
+h1.title {
+    font-size: 2.25rem;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 1rem;
+    margin-top: 0;
+    text-align: left;
+}
+
+h2 {
+    font-size: 1.5rem;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 0.3rem;
+}
+
+p {
+    margin-bottom: 1.5rem;
+}
 
 /* Links */
 a {
-    color: var(--link-color);
+    color: var(--accent);
     text-decoration: none;
-    transition: color 0.2s;
+    transition: color 0.2s ease;
 }
 
 a:hover {
-    color: var(--link-hover-color);
+    color: var(--accent-hover);
     text-decoration: underline;
 }
 
-/* Emphasis and Code */
-strong, b {
-    font-weight: bold;
-    color: var(--heading-color); /* Slightly more emphasis */
-}
-
-code {
-    font-family: 'Consolas', 'Monaco', monospace;
-    background-color: var(--code-bg);
-    padding: 2px 4px;
-    border-radius: 3px;
-    color: var(--code-text);
-    font-size: 0.95em;
-}
-
-/* Images and Lists */
+/* Images and figures */
 img {
     max-width: 100%;
     height: auto;
-    display: block;
-    margin: 2em auto;
     border-radius: 6px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* Subtle shadow for images */
-}
-
-ul {
-    list-style-type: disc;
-    padding-left: 25px;
-}
-
-ul li {
-    margin-bottom: 0.5em;
-}
-
-/* --- Navigation and Header (Your Custom HTML) --- */
-
-header {
-    background-color: var(--background-color);
-    border-bottom: 1px solid var(--border-color);
-    padding: 10px 0;
-    position: sticky;
-    top: 0;
-    z-index: 100;
-}
-
-.nav {
-    max-width: 960px;
-    margin: 0 auto;
-    padding: 0 20px;
-}
-
-.nav ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    justify-content: flex-end;
-}
-
-.nav ul li {
-    margin-left: 20px;
-}
-
-.nav ul li a {
-    color: var(--heading-color);
-    font-weight: 500;
-    padding: 5px 10px;
-    text-transform: uppercase;
-    font-size: 0.9em;
-    border-bottom: 2px solid transparent;
-}
-
-.nav ul li a:hover {
-    color: var(--link-color);
-    text-decoration: none;
-    border-bottom: 2px solid var(--link-color);
-}
-
-/* --- Hero Section (Your Custom HTML) --- */
-
-.hero {
-    text-align: center;
-    padding: 40px 20px;
-    background-color: var(--card-bg); /* Use card-bg for a slight visual pop */
-    margin-bottom: 3em;
-}
-
-.hero .banner {
-    max-width: 80%;
-    margin-bottom: 1.5em;
-    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
-}
-
-.hero h1 {
-    font-size: 2.8em;
-    margin-top: 0.5em;
-    line-height: 1.2;
-}
-
-.hero p {
-    font-size: 1.3em;
-    max-width: 700px;
-    margin: 1em auto 2em;
-    color: var(--text-color);
-}
-
-/* --- Button Styling --- */
-
-.btn {
-    display: inline-block;
-    padding: 10px 25px;
-    margin-top: 20px;
-    background-color: var(--accent-color);
-    color: #ffffff;
-    border-radius: 5px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    transition: background-color 0.3s, transform 0.1s;
-    text-decoration: none !important;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
-}
-
-.btn:hover {
-    background-color: var(--accent-hover-color);
-    color: var(--background-color);
-    text-decoration: none;
-    transform: translateY(-2px);
-}
-
-/* --- Feature Grid and Cards (Your Custom HTML) --- */
-
-.grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 20px;
-    margin: 2em 0;
-    padding: 10px;
-}
-
-.card {
-    background-color: var(--card-bg);
     border: 1px solid var(--border-color);
-    border-radius: 8px;
-    padding: 20px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-    transition: box-shadow 0.3s, transform 0.3s;
+    display: block;
+    margin: 1.5rem auto;
 }
 
-.card:hover {
-    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
-    transform: translateY(-5px);
+figure.hero {
+    margin: 0 0 2rem;
 }
 
-.card h3 {
-    margin-top: 0;
-    color: var(--accent-color);
+img.hero {
+    border: none;
+    border-radius: 0;
+    margin: 0;
+    width: 100%;
 }
 
-/* --- Footer --- */
-footer {
-    background-color: var(--footer-bg);
-    color: var(--text-color);
+figure.hero figcaption {
+    margin-top: 0.5rem;
+}
+
+.figure-number, caption, figcaption {
+    color: var(--text-muted);
+    font-size: 0.9rem;
     text-align: center;
-    padding: 20px;
-    font-size: 0.9em;
-    margin-top: 40px;
-    border-top: 1px solid var(--border-color);
+    margin-top: -0.5rem;
+    margin-bottom: 1.5rem;
+    font-style: italic;
 }
 
-/* --- Badge/Shield Styling Fix --- */
+/* Blockquotes */
+blockquote {
+    margin: 1.5rem 0;
+    padding: 0.5rem 1.25rem;
+    border-left: 3px solid var(--accent);
+    background-color: rgba(255, 255, 255, 0.025);
+    color: var(--text-muted);
+}
 
-/* 1. Center the entire container */
+blockquote p:last-child {
+    margin-bottom: 0;
+}
+
+/* Tables */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 2rem 0;
+    font-size: 0.95rem;
+}
+
+th, td {
+    padding: 0.75rem 1rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border-color);
+}
+
+th {
+    background-color: var(--bg-accent);
+    color: #ffffff;
+    font-weight: 600;
+}
+
+tbody tr:nth-child(even) {
+    background-color: rgba(255, 255, 255, 0.025);
+}
+
+tbody tr:hover {
+    background-color: var(--bg-secondary);
+}
+
+td img {
+    margin: 0;
+    max-width: 240px;
+}
+
+/* Code blocks & monospace */
+code, pre {
+    font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+    font-size: 0.875rem;
+    background-color: var(--bg-secondary);
+    border-radius: 4px;
+}
+
+code {
+    padding: 0.15rem 0.4rem;
+    color: #e3b341;
+    background-color: rgba(255, 255, 255, 0.04);
+}
+
+pre {
+    padding: 1rem;
+    overflow-x: auto;
+    border: 1px solid var(--border-color);
+    line-height: 1.45;
+}
+
+/* Lists */
+ul, ol {
+    padding-left: 2rem;
+    margin-bottom: 1.25rem;
+}
+
+li {
+    margin-bottom: 0.5rem;
+}
+
+/* Table of Contents — sidebar layout (only on pages that have a TOC) */
+#content:has(#table-of-contents) {
+    max-width: calc(var(--max-width) + 18rem);
+    display: grid;
+    grid-template-columns: 15rem 1fr;
+    column-gap: 3rem;
+    align-items: start;
+}
+
+#content:has(#table-of-contents) > *:not(#table-of-contents) {
+    grid-column: 2;
+}
+
+#table-of-contents {
+    grid-column: 1;
+    grid-row: 1 / span 100;
+    align-self: start;
+    position: sticky;
+    top: 1.5rem;
+    max-height: calc(100vh - 3rem);
+    overflow-y: auto;
+    padding-right: 1.25rem;
+    border-right: 1px solid var(--border-color);
+    font-size: 0.82rem;
+}
+
+#table-of-contents h2 {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: none;
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+}
+
+#table-of-contents ul {
+    list-style: none;
+    padding-left: 0;
+    margin-bottom: 0;
+}
+
+#table-of-contents ul ul {
+    padding-left: 0.9rem;
+    margin-top: 0.25rem;
+}
+
+#table-of-contents li {
+    margin-bottom: 0.3rem;
+    line-height: 1.4;
+}
+
+#table-of-contents a {
+    color: var(--text-muted);
+}
+
+#table-of-contents a:hover {
+    color: var(--accent);
+}
+
+@media (max-width: 768px) {
+    #content:has(#table-of-contents) {
+        display: block;
+        max-width: var(--max-width);
+    }
+
+    #table-of-contents {
+        position: static;
+        border-right: none;
+        padding-right: 0;
+        padding-bottom: 1rem;
+        margin-bottom: 1.5rem;
+        max-height: 16rem;
+        border-bottom: 1px solid var(--border-color);
+    }
+}
+
+/* Footnotes */
+#footnotes {
+    margin-top: 3rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border-color);
+    font-size: 0.875rem;
+    color: var(--text-muted);
+}
+
+#footnotes h2.footnotes {
+    font-size: 1rem;
+    color: var(--text-muted);
+    border-bottom: none;
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+}
+
+.footdef {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.footdef .footpara {
+    flex: 1;
+}
+
+.footdef .footpara p {
+    margin-bottom: 0;
+}
+
+/* Info / note admonition box */
+.note {
+    background-color: rgba(88, 166, 255, 0.07);
+    border: 1px solid rgba(88, 166, 255, 0.25);
+    border-left: 3px solid var(--accent);
+    border-radius: 0 6px 6px 0;
+    padding: 1rem 1.25rem;
+    margin: 1.5rem 0;
+    font-size: 0.95rem;
+}
+
+.note p:last-child {
+    margin-bottom: 0;
+}
+
+/* Badges / shields */
 .badge-wrapper {
     text-align: left;
-    margin: 2em 0;
+    margin: 1.5rem 0;
 }
 
-/* 2. *** FIX: Target the ANCHOR tag (the link) directly *** */
 .badge-wrapper a {
-    /* Override general link styles (e.g., in case you added padding/border on <a>) */
-    text-decoration: none !important; /* Force no underline */
+    text-decoration: none !important;
     border: none;
     padding: 0;
     margin: 0;
-    display: inline-block; /* Ensure they are treated as blocks for vertical-align and margin */
+    display: inline-block;
 }
 
 .badge-wrapper a:hover {
-    text-decoration: none !important; /* Keep underline off on hover */
-    /* You might want to remove link color changes on hover for these badges */
-    color: inherit; /* Inherit color from the parent, which shouldn't affect the badge image */
+    text-decoration: none !important;
+    color: inherit;
 }
 
-/* 3. Target the image inside the link */
 .badge-wrapper img {
-    /* Revert display property to allow horizontal flow */
     display: inline-block;
-
-    /* Remove the huge vertical margin and add a small, balanced margin */
-    margin: 0px 0px;
-
-    /* Remove the box shadow which looks bad on small shields */
+    margin: 0;
+    border: none;
+    border-radius: 0;
     box-shadow: none;
-
-    /* Ensure no vertical offset issues */
     vertical-align: middle;
 }
 
-.note {
-    background: #fff9e6;
-    border-left: 4px solid #ffeb3b;
-    padding: 10px;
-    margin: 10px 0;
-    border-radius: 4px;
+/* Footer / Postamble */
+#postamble {
+    width: 100%;
+    max-width: var(--max-width);
+    margin-top: 4rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border-color);
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    text-align: center;
 }

--- a/build/scripts/serve-site.sh
+++ b/build/scripts/serve-site.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Serve the published org-mode site locally for previewing.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BUILD_DIR="$REPO_ROOT/build/output/site"
+PORT="${PORT:-8000}"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [--compile] [--port PORT]
+
+  --compile   Rebuild the site (emacs -Q --script .build-site.el) before serving.
+  --port      Port to serve on (default: 8000; can also be set via PORT env var).
+  -h, --help  Show this help.
+EOF
+    exit 1
+}
+
+COMPILE=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --compile) COMPILE=1; shift ;;
+        --port)    PORT="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+if [[ $COMPILE -eq 1 ]]; then
+    echo "Building site..."
+    (cd "$REPO_ROOT" && emacs -Q --script .build-site.el)
+fi
+
+if [[ ! -d "$BUILD_DIR" ]]; then
+    echo "Build directory not found: $BUILD_DIR" >&2
+    echo "Run with --compile, or build first via: emacs -Q --script .build-site.el" >&2
+    exit 1
+fi
+
+echo "Serving $BUILD_DIR on http://localhost:$PORT"
+cd "$BUILD_DIR"
+exec python3 -m http.server "$PORT"

--- a/build/scripts/serve-site.sh
+++ b/build/scripts/serve-site.sh
@@ -39,7 +39,15 @@ COMPILE=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --compile) COMPILE=1; shift ;;
-        --port)    PORT="$2"; shift 2 ;;
+        --port)
+            if [[ -n "${2:-}" && "${2:-}" != -* ]]; then
+                PORT="$2"
+                shift 2
+            else
+                echo "Error: --port requires a non-option argument" >&2
+                usage
+            fi
+            ;;
         -h|--help) usage ;;
         *) echo "Unknown option: $1" >&2; usage ;;
     esac
@@ -56,6 +64,14 @@ if [[ ! -d "$BUILD_DIR" ]]; then
     exit 1
 fi
 
-echo "Serving $BUILD_DIR on http://localhost:$PORT"
-cd "$BUILD_DIR"
+# The site preamble uses absolute /OreStudio/ paths (matches the GitHub
+# Pages URL structure: orestudio.github.io/OreStudio/). To make local
+# preview links resolve, serve from a tmpdir that mirrors that prefix
+# via a symlink to the build output.
+PREVIEW_TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$PREVIEW_TMP_DIR"' EXIT
+ln -s "$BUILD_DIR" "$PREVIEW_TMP_DIR/OreStudio"
+
+echo "Serving $BUILD_DIR on http://localhost:$PORT/OreStudio/"
+cd "$PREVIEW_TMP_DIR"
 exec python3 -m http.server "$PORT"

--- a/doc/agile/agile.org
+++ b/doc/agile/agile.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Agile
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 Task and time tracking activities. If you want a bit of background on how we use

--- a/doc/agile/product_backlog.org
+++ b/doc/agile/product_backlog.org
@@ -1,7 +1,7 @@
 :PROPERTIES:
 :ID: 558650A4-C3E5-8964-4193-7D9125E29B83
 :END:
-#+options: date:nil toc:nil author:nil num:nil
+#+options: date:nil toc:t author:nil num:nil
 #+title: Product Backlog
 #+tags: { reviewing(r) }
 #+tags: { code(c) infra(i) doc(d) agile(a) }

--- a/doc/agile/sprint_backlog.org
+++ b/doc/agile/sprint_backlog.org
@@ -1,7 +1,7 @@
 :PROPERTIES:
 :ID: 57A7FABC-21FE-5124-45EB-9685D0712176
 :END:
-#+options: date:nil toc:nil author:nil num:nil
+#+options: date:nil toc:t author:nil num:nil
 #+title: Sprint Backlog
 
 All work undertaken is captured into stories, and these are grouped into

--- a/doc/agile/v0/sprint_backlog_01.org
+++ b/doc/agile/v0/sprint_backlog_01.org
@@ -2,7 +2,7 @@
 :ID: 34EDDBB5-CB52-35C4-E123-E0A70FB32799
 :END:
 #+title: Sprint Backlog 01
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) doc(d) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/sprint_backlog_02.org
+++ b/doc/agile/v0/sprint_backlog_02.org
@@ -2,7 +2,7 @@
 :ID: 0DFDAF4D-E299-98E4-25C3-5BB6500E5BA8
 :END:
 #+title: Sprint Backlog 02
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/sprint_backlog_03.org
+++ b/doc/agile/v0/sprint_backlog_03.org
@@ -2,7 +2,7 @@
 :ID: D35D43C9-46BF-9A94-F03B-A3B706020498
 :END:
 #+title: Sprint Backlog 03
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/sprint_backlog_04.org
+++ b/doc/agile/v0/sprint_backlog_04.org
@@ -2,7 +2,7 @@
 :ID: 5A85BDB5-E915-3A44-04AB-771ACE91992B
 :END:
 #+title: Sprint Backlog 04
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/sprint_backlog_05.org
+++ b/doc/agile/v0/sprint_backlog_05.org
@@ -2,7 +2,7 @@
 :ID: 2A3C7481-0984-D344-575B-7BFBB8D5A98B
 :END:
 #+title: Sprint Backlog 05
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/sprint_backlog_06.org
+++ b/doc/agile/v0/sprint_backlog_06.org
@@ -2,7 +2,7 @@
 :ID: DBBD0C4F-EA14-4684-7583-D78AAF7AABFF
 :END:
 #+title: Sprint Backlog 06
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED#
 +tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/sprint_backlog_07.org
+++ b/doc/agile/v0/sprint_backlog_07.org
@@ -2,7 +2,7 @@
 :ID: 44AD3D04-EC5A-4039-91DD-7CEA0A18CA92
 :END:
 #+title: Sprint Backlog 07
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/sprint_backlog_08.org
+++ b/doc/agile/v0/sprint_backlog_08.org
@@ -2,7 +2,7 @@
 :ID: A9FB22A0-E067-46D4-A217-AF10C20DFB90
 :END:
 #+title: Sprint Backlog 08
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/sprint_backlog_09.org
+++ b/doc/agile/v0/sprint_backlog_09.org
@@ -2,7 +2,7 @@
 :ID: B13DD349-0341-416E-8A31-6765A9EFCD6F
 :END:
 #+title: Sprint Backlog 09
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/sprint_backlog_10.org
+++ b/doc/agile/v0/sprint_backlog_10.org
@@ -2,7 +2,7 @@
 :ID: A734018F-A4A7-F8A4-8F5B-DE0C74344940
 :END:
 #+title: Sprint Backlog 10
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/sprint_backlog_11.org
+++ b/doc/agile/v0/sprint_backlog_11.org
@@ -2,7 +2,7 @@
 :ID: 98E12E24-FC8E-11F0-8B62-40B0768014EB
 :END:
 #+title: Sprint Backlog 11
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/sprint_backlog_12.org
+++ b/doc/agile/v0/sprint_backlog_12.org
@@ -1,7 +1,7 @@
 :PROPERTIES:
 :ID: 1B387E8C-8EC1-4C2A-A321-1593C35A9A77
 :END:
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/sprint_backlog_13.org
+++ b/doc/agile/v0/sprint_backlog_13.org
@@ -2,7 +2,7 @@
 :ID: 9A4009E7-0E6C-11F1-852D-40B0768014EB
 :END:
 #+title: Sprint Backlog 13
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/sprint_backlog_14.org
+++ b/doc/agile/v0/sprint_backlog_14.org
@@ -2,7 +2,7 @@
 :ID: 93CE19DF-1501-11F1-8EF4-40B0768014EB
 :END:
 #+title: Sprint Backlog 14
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/sprint_backlog_15.org
+++ b/doc/agile/v0/sprint_backlog_15.org
@@ -2,7 +2,7 @@
 :ID: 0B23D554-23BA-11F1-9F0E-40B0768014EB
 :END:
 #+title: Sprint Backlog 15
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/sprint_backlog_16.org
+++ b/doc/agile/v0/sprint_backlog_16.org
@@ -2,7 +2,7 @@
 :ID: 9CE4BE1F-0D57-4927-8344-E66CBC72D882
 :END:
 #+title: Sprint Backlog 16
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/sprint_backlog_17.org
+++ b/doc/agile/v0/sprint_backlog_17.org
@@ -2,7 +2,7 @@
 :ID: A2B8A670-3B02-11F1-BCE2-4B06F4BBA5D7
 :END:
 #+title: Sprint Backlog 17
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/agile/v0/version_zero.org
+++ b/doc/agile/v0/version_zero.org
@@ -2,7 +2,7 @@
 :ID: 154212FF-BB02-8D84-1E33-9338B458380A
 :ROAM_ALIASES: V0
 :END:
-#+options: date:nil toc:nil author:nil num:nil
+#+options: date:nil toc:t author:nil num:nil
 #+title: Version Zero
 #+property: Effort_ALL 1d 2d 5d 10d 20d 30d 35d 50d
 #+property: allocate_ALL dev

--- a/doc/domain/coding_schemes.org
+++ b/doc/domain/coding_schemes.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Coding Schemes
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/domain/data_quality.org
+++ b/doc/domain/data_quality.org
@@ -4,7 +4,7 @@
 :END:
 #+title: Data Quality
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 Data Quality (DQ) is the measure of how well a dataset satisfies the

--- a/doc/domain/domain.org
+++ b/doc/domain/domain.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Domain
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 Project-specific notes on industry standards and data conventions the codebase
 relies upon. Broader speculative musings on the finance domain have moved out

--- a/doc/domain/financial_products_markup_language.org
+++ b/doc/domain/financial_products_markup_language.org
@@ -4,7 +4,7 @@
 :END:
 #+title: Financial products Markup Language
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/knowledge/identity_and_access_management.org
+++ b/doc/knowledge/identity_and_access_management.org
@@ -4,7 +4,7 @@
 :END:
 #+title: Identity and Access Management
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 /Identity and Access Management (IAM)/ is the core security component of a
 system responsible for governing and enforcing access to all system resources.

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -4,7 +4,7 @@
 #+title: Knowledge
 #+author: Marco Craveiro
 #+startup: inlineimages
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 This folder contains assorted knowledge we picked up as part of implementing
 this project. It is mainly made up of short definitions created by LLMs (Gemini,

--- a/doc/knowledge/ore_model_configuration.org
+++ b/doc/knowledge/ore_model_configuration.org
@@ -3,7 +3,7 @@
 :END:
 #+title: ORE Model Configuration
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 This document analyses the model configuration files used by [[https://github.com/OpenSourceRisk/Engine][Open Source Risk
 Engine (ORE)]] and proposes how to represent them as persisted domain entities in

--- a/doc/knowledge/postgresql_row-level_security.org
+++ b/doc/knowledge/postgresql_row-level_security.org
@@ -5,7 +5,7 @@
 #+title: PostgreSQL Row-Level Security
 #+author: Marco Craveiro
 #+startup: inlineimages
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 This document describes RLS in general, not the specifics of how we use it.
 

--- a/doc/knowledge/role_based_access_control.org
+++ b/doc/knowledge/role_based_access_control.org
@@ -4,7 +4,7 @@
 :END:
 #+title: Role-Based Access Control
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 Role-based access control (RBAC) is a security method that restricts system
 access to authorised users based on their job roles, rather than individual user

--- a/doc/knowledge/standing_settlement_instructions.org
+++ b/doc/knowledge/standing_settlement_instructions.org
@@ -4,7 +4,7 @@
 :END:
 #+title: Standing Settlement Instructions
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 In the financial world, *SSI* stands for *Standing Settlement Instructions*.
 

--- a/doc/plans/2026-02-07-party-sql-support-design.org
+++ b/doc/plans/2026-02-07-party-sql-support-design.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Party & Counterparty SQL Support Design
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: COMPLETED
 

--- a/doc/plans/2026-02-08-gleif-librarian-integration-design.org
+++ b/doc/plans/2026-02-08-gleif-librarian-integration-design.org
@@ -3,7 +3,7 @@
 :END:
 #+title: GLEIF Dataset Librarian Integration Design
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 * Overview

--- a/doc/plans/2026-02-09-party-isolation-and-tenant-types-design.org
+++ b/doc/plans/2026-02-09-party-isolation-and-tenant-types-design.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Party-Level Isolation and Tenant Types Design
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: COMPLETED
 

--- a/doc/plans/2026-02-11-librarian-party-counterparty-publication-design.org
+++ b/doc/plans/2026-02-11-librarian-party-counterparty-publication-design.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Librarian Party & Counterparty Publication Design
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 * Overview

--- a/doc/plans/2026-02-14-generation-context-design.org
+++ b/doc/plans/2026-02-14-generation-context-design.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Generation Context Design
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: COMPLETED
 

--- a/doc/plans/2026-02-15-iam-generators-and-test-migration.org
+++ b/doc/plans/2026-02-15-iam-generators-and-test-migration.org
@@ -3,7 +3,7 @@
 :END:
 #+title: IAM Generators and Test Migration
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: COMPLETED
 

--- a/doc/plans/2026-02-22-cli-domain-submenus-design.org
+++ b/doc/plans/2026-02-22-cli-domain-submenus-design.org
@@ -3,7 +3,7 @@
 :END:
 #+title: CLI Domain Sub-menus Design
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: COMPLETED
 

--- a/doc/plans/2026-02-22-currency-taxonomy-enhancement.org
+++ b/doc/plans/2026-02-22-currency-taxonomy-enhancement.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Currency Taxonomy Enhancement: Asset Class and Market Tier
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: COMPLETED
 

--- a/doc/plans/2026-02-27-ore-import-wizard-design.org
+++ b/doc/plans/2026-02-27-ore-import-wizard-design.org
@@ -3,7 +3,7 @@
 :END:
 #+title: ORE Import Wizard Design
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: COMPLETED
 

--- a/doc/plans/2026-03-01-reporting-component-design.org
+++ b/doc/plans/2026-03-01-reporting-component-design.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Reporting Component Design
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 * Overview

--- a/doc/plans/2026-03-03-party-codename-queue-isolation.org
+++ b/doc/plans/2026-03-03-party-codename-queue-isolation.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Party Codename and Queue Isolation Design
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 * Overview

--- a/doc/plans/2026-03-16-nats-monitor-design.org
+++ b/doc/plans/2026-03-16-nats-monitor-design.org
@@ -3,7 +3,7 @@
 :END:
 #+title: NATS Monitor Design
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 * Overview

--- a/doc/plans/2026-03-16-nats-multitenancy-design.org
+++ b/doc/plans/2026-03-16-nats-multitenancy-design.org
@@ -3,7 +3,7 @@
 :END:
 #+title: NATS Multi-Tenancy and Multi-Party Design
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: COMPLETED
 

--- a/doc/plans/2026-03-20-compute-wrapper-design.org
+++ b/doc/plans/2026-03-20-compute-wrapper-design.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Compute Wrapper Design
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: COMPLETED
 

--- a/doc/plans/2026-03-21-compute-e2e-improvements.org
+++ b/doc/plans/2026-03-21-compute-e2e-improvements.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Compute Grid End-to-End Improvements
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: COMPLETED
 

--- a/doc/plans/2026-03-21-compute-grid-telemetry-design.org
+++ b/doc/plans/2026-03-21-compute-grid-telemetry-design.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Compute Grid Telemetry Design
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: COMPLETED
 

--- a/doc/plans/2026-03-22-messaging-architecture-migration.org
+++ b/doc/plans/2026-03-22-messaging-architecture-migration.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Service Architecture Migration
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: COMPLETED
 

--- a/doc/plans/2026-03-22-secure-stamping.org
+++ b/doc/plans/2026-03-22-secure-stamping.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Secure Provenance Stamping
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: COMPLETED
 

--- a/doc/plans/2026-03-23-move-generators-to-api.org
+++ b/doc/plans/2026-03-23-move-generators-to-api.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Move Synthetic Generators to API Layer
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: COMPLETED
 

--- a/doc/plans/2026-03-28-badge-system-design.org
+++ b/doc/plans/2026-03-28-badge-system-design.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Database-Driven Badge System Design
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 * Overview

--- a/doc/plans/2026-03-31-ore-marketdata-domain-model.org
+++ b/doc/plans/2026-03-31-ore-marketdata-domain-model.org
@@ -3,7 +3,7 @@
 :END:
 #+title: ORE Market Data Domain Model
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 * Overview

--- a/doc/plans/2026-04-01-asset-class-unification.org
+++ b/doc/plans/2026-04-01-asset-class-unification.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Asset Class Unification
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 * Overview

--- a/doc/plans/2026-04-05-report-definition-to-instance.org
+++ b/doc/plans/2026-04-05-report-definition-to-instance.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Report Definition to Instance Pipeline
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: COMPLETED
 

--- a/doc/plans/2026-04-05-report-execution.org
+++ b/doc/plans/2026-04-05-report-execution.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Report Execution Pipeline
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: DRAFT
 

--- a/doc/plans/2026-04-05-workflow-engine-generalisation.org
+++ b/doc/plans/2026-04-05-workflow-engine-generalisation.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Workflow Engine Generalisation
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: IN-PROGRESS
 

--- a/doc/plans/2026-04-06-report-execution-workflow-implementation.org
+++ b/doc/plans/2026-04-06-report-execution-workflow-implementation.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Report Execution Workflow — Implementation Plan
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 #+status: IN-PROGRESS
 

--- a/doc/prompts/prompts.org
+++ b/doc/prompts/prompts.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Prompts
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 This file is a repository for useful prompts we may want to reuse. They are not

--- a/doc/recipes/cli_recipes.org
+++ b/doc/recipes/cli_recipes.org
@@ -4,7 +4,7 @@
 :END:
 #+title: Command Line Interface Recipes
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 Demonstrates commands available in the [[id:F0DAACD0-8EAB-46C4-6B53-640921E3F225][ORE Studio CLI Component]].
 

--- a/doc/recipes/comms_analyser_recipes.org
+++ b/doc/recipes/comms_analyser_recipes.org
@@ -4,7 +4,7 @@
 #+title: Comms Analyser Recipes
 #+author: Marco Craveiro
 #+startup: inlineimages
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 Demonstrates the functionality of the ORE Studio Comms Analyser Component,
 which reads and analyses session recording files (.ores) created by

--- a/doc/recipes/git_recipes.org
+++ b/doc/recipes/git_recipes.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Git Recipes
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: showeverything
 
 Recipes related to git.

--- a/doc/recipes/http_recipes.org
+++ b/doc/recipes/http_recipes.org
@@ -4,7 +4,7 @@
 #+title: HTTP Recipes
 #+author: Marco Craveiro
 #+startup: inlineimages
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 Recipes for exercising the ORE Studio HTTP API using Emacs [[https://github.com/federicotdn/verb][verb mode]].
 

--- a/doc/recipes/recipes.org
+++ b/doc/recipes/recipes.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Recipes
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 Notebooks on how to use ORE Studio.

--- a/doc/recipes/shell_recipes.org
+++ b/doc/recipes/shell_recipes.org
@@ -4,7 +4,7 @@
 #+title: ORE Studio Shell Recipes
 #+author: Marco Craveiro
 #+startup: inlineimages
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 Demonstrates all of the functionality available on the [[id:D0876A24-69BA-F484-ED9B-71CD3AA8710C][ORE Studio Comms Shell
 Component]].

--- a/doc/recipes/sql_recipes.org
+++ b/doc/recipes/sql_recipes.org
@@ -4,7 +4,7 @@
 #+title: SQL Recipes
 #+author: Marco Craveiro
 #+startup: inlineimages
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 SQL recipes for directly querying and managing the [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ORES Database Schema]].
 

--- a/doc/skills/agile-product-owner/SKILL.org
+++ b/doc/skills/agile-product-owner/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Agile Product Owner
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/autonomous-developer/SKILL.org
+++ b/doc/skills/autonomous-developer/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Autonomous Developer
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/binary-protocol-developer/SKILL.org
+++ b/doc/skills/binary-protocol-developer/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Binary Protocol Developer
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/brainstorming/SKILL.org
+++ b/doc/skills/brainstorming/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Brainstorming Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 
@@ -150,7 +150,7 @@ Example structure:
 :END:
 #+title: Feature Name Design
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 ,* Overview

--- a/doc/skills/claude-design-skill/SKILL.org
+++ b/doc/skills/claude-design-skill/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Claude Design Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/claude_code_skills.org
+++ b/doc/skills/claude_code_skills.org
@@ -3,7 +3,7 @@
 :END:
 #+title: ORE Claude Code Skill Catalogue
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 Contains all of the [[id:F663DF66-4F62-0884-DB23-BB2D6A42B644][Claude Code Skills]] used with ORE Studio. They are generated

--- a/doc/skills/cli-entity-creator/SKILL.org
+++ b/doc/skills/cli-entity-creator/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: CLI Entity Creator
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/cmake-runner/SKILL.org
+++ b/doc/skills/cmake-runner/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: CMake Runner Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/code-review-component/SKILL.org
+++ b/doc/skills/code-review-component/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Code Review Component Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/code-review-pr/SKILL.org
+++ b/doc/skills/code-review-pr/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Code Review PR Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/component-creator/SKILL.org
+++ b/doc/skills/component-creator/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Component Creator
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/component-model-creator/SKILL.org
+++ b/doc/skills/component-model-creator/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Component Model Creator Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 
@@ -51,7 +51,7 @@ Create =projects/COMPONENT/modeling/COMPONENT.org= with this structure:
 :END:
 #+title: ORE Studio COMPONENT_TITLE Component
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 Brief description paragraph for [[id:D04D3476-D7C5-3954-A33B-C641EBCB43F6][ORE Studio]].

--- a/doc/skills/domain-type-creator/SKILL.org
+++ b/doc/skills/domain-type-creator/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Domain Type Creator
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/domain-type-creator/domain_type_class_definition_facet.org
+++ b/doc/skills/domain-type-creator/domain_type_class_definition_facet.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Domain Type Class Definition Facet
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil title:t
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t title:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/domain-type-creator/domain_type_cmakelists_facet.org
+++ b/doc/skills/domain-type-creator/domain_type_cmakelists_facet.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Domain Type CMakeLists Update Facet
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil title:t
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t title:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/domain-type-creator/domain_type_generator_facet.org
+++ b/doc/skills/domain-type-creator/domain_type_generator_facet.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Domain Type Generator Support Facet
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil title:t
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t title:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/domain-type-creator/domain_type_json_io_facet.org
+++ b/doc/skills/domain-type-creator/domain_type_json_io_facet.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Domain Type JSON I/O Facet
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil title:t
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t title:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/domain-type-creator/domain_type_repository_crud_operations_facet.org
+++ b/doc/skills/domain-type-creator/domain_type_repository_crud_operations_facet.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Domain Type Repository CRUD Operations Facet
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil title:t
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t title:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/domain-type-creator/domain_type_repository_entity_and_mapper_facet.org
+++ b/doc/skills/domain-type-creator/domain_type_repository_entity_and_mapper_facet.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Domain Type Repository Entity and Mapper Facet
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil title:t
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t title:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/domain-type-creator/domain_type_table_io_facet.org
+++ b/doc/skills/domain-type-creator/domain_type_table_io_facet.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Domain Type Table I/O Facet
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil title:t
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t title:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/domain-type-creator/domain_type_test_facet.org
+++ b/doc/skills/domain-type-creator/domain_type_test_facet.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Domain Type Test Creation Facet
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil title:t
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t title:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/feature-branch-manager/SKILL.org
+++ b/doc/skills/feature-branch-manager/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Feature Branch Manager
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/http-entity-creator/SKILL.org
+++ b/doc/skills/http-entity-creator/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: HTTP Entity Creator
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/icon-guidelines/SKILL.org
+++ b/doc/skills/icon-guidelines/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Icon Guidelines
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/new-sprint/SKILL.org
+++ b/doc/skills/new-sprint/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: New Sprint Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 
@@ -234,7 +234,7 @@ gh pr create --title "[agile] Open Sprint NN" --body "Opens Sprint NN for develo
 :ID: GUID
 :END:
 #+title: Sprint Backlog 05
-#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+todo: STARTED | COMPLETED CANCELLED POSTPONED BLOCKED
 #+tags: { code(c) infra(i) analysis(n) agile(a) }
 #+startup: inlineimages

--- a/doc/skills/ores-cli-recipes/SKILL.org
+++ b/doc/skills/ores-cli-recipes/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: ORE CLI Recipes Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/ores-comms-analyser-recipes/SKILL.org
+++ b/doc/skills/ores-comms-analyser-recipes/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: ORE Comms Analyser Recipes Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/ores-http-recipes/SKILL.org
+++ b/doc/skills/ores-http-recipes/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: ORE HTTP Recipes Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/ores-shell-recipes/SKILL.org
+++ b/doc/skills/ores-shell-recipes/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: ORE Shell Recipes Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/plantuml-class-modeler/SKILL.org
+++ b/doc/skills/plantuml-class-modeler/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: PlantUML Class Modeler Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/plantuml-er-modeler/SKILL.org
+++ b/doc/skills/plantuml-er-modeler/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: PlantUML ER Modeler Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/pr-manager/SKILL.org
+++ b/doc/skills/pr-manager/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: PR Manager Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/pr-shepherd/SKILL.org
+++ b/doc/skills/pr-shepherd/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: PR Shepherd Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/qt-entity-creator/SKILL.org
+++ b/doc/skills/qt-entity-creator/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Qt Entity Creator
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/recipe-author/SKILL.org
+++ b/doc/skills/recipe-author/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Recipe Author Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 
@@ -62,7 +62,7 @@ Create =doc/recipes/TOPIC_recipes.org= with this structure:
 #+title: TOPIC Recipes
 #+author: Marco Craveiro
 #+startup: inlineimages
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 Brief description of what these recipes demonstrate.
 
@@ -188,7 +188,7 @@ Create =doc/skills/ores-TOPIC-recipes/skill.org=:
 :END:
 #+title: ORE TOPIC Recipes Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/relese-notes-generator/SKILL.org
+++ b/doc/skills/relese-notes-generator/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Release Notes Generator
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/semi-autonomous-developer/SKILL.org
+++ b/doc/skills/semi-autonomous-developer/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Semi Autonomous Developer
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/shell-entity-creator/SKILL.org
+++ b/doc/skills/shell-entity-creator/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Shell Entity Creator
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/skill-manager/SKILL.org
+++ b/doc/skills/skill-manager/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Skill Manager Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 #+filetags: :skills:claude_code:codegen:

--- a/doc/skills/skill-review/SKILL.org
+++ b/doc/skills/skill-review/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Skill Review Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/sql-schema-creator/SKILL.org
+++ b/doc/skills/sql-schema-creator/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: SQL Schema Creator
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/system-architect/SKILL.org
+++ b/doc/skills/system-architect/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: System Architect
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/test-failure-investigator/skill.org
+++ b/doc/skills/test-failure-investigator/skill.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Test Failure Investigator Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/unit-test-writer/SKILL.org
+++ b/doc/skills/unit-test-writer/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Unit Test Writer
 #+author: Marco Craveiro
-#+options: title:nil <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: title:nil <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/doc/skills/v2-doc-author/SKILL.org
+++ b/doc/skills/v2-doc-author/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: V2 Document Author Skill
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 #+filetags: :v2_docs:codegen:templates:skill:

--- a/doc/skills/wt-entity-creator/SKILL.org
+++ b/doc/skills/wt-entity-creator/SKILL.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Wt Entity Creator
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 

--- a/projects/modeling/claude_code_skills.org
+++ b/projects/modeling/claude_code_skills.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Claude Code Skills
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 As per [[https://code.claude.com/docs/en/skills][Claude documentation]]:
 

--- a/projects/modeling/masd.org
+++ b/projects/modeling/masd.org
@@ -4,7 +4,7 @@
 :END:
 #+title: Model Assisted Software Development
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 MASD is the [[https://uhra.herts.ac.uk/id/eprint/17031/][Model Assisted Software Development]] methodology I developed as part

--- a/projects/modeling/system_model.org
+++ b/projects/modeling/system_model.org
@@ -3,7 +3,7 @@
 :END:
 #+title: System Model
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 This file documents the architecture of the [[id:D04D3476-D7C5-3954-A33B-C641EBCB43F6][ORE Studio]] system. ORE Studio

--- a/projects/modeling/type_definition_facet.org
+++ b/projects/modeling/type_definition_facet.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Type definition facet
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 The type definition facet is a type of facet which implements the conceptual

--- a/projects/ores.codegen/library/templates/v2_doc_skill.org.mustache
+++ b/projects/ores.codegen/library/templates/v2_doc_skill.org.mustache
@@ -3,7 +3,7 @@
 :END:
 #+title: {{title}}
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
 #+startup: inlineimages
 #+export_exclude_tags: noexport
 #+filetags: {{filetags}}

--- a/projects/ores.iam.core/modeling/iam_account.org
+++ b/projects/ores.iam.core/modeling/iam_account.org
@@ -3,7 +3,7 @@
 :END:
 #+title: IAM Account
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 An Account is the fundamental digital identity and record within the [[id:D00BEA0D-E501-C534-A013-E6F40C1A6097][IAM system]]

--- a/projects/ores.iam.core/modeling/multi_party.org
+++ b/projects/ores.iam.core/modeling/multi_party.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Multi-Party Login Flow
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 * Overview

--- a/projects/ores.iam.core/modeling/multi_tenancy.org
+++ b/projects/ores.iam.core/modeling/multi_tenancy.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Multi-Tenancy Architecture
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 * Overview

--- a/projects/ores.refdata.core/modeling/multi_party.org
+++ b/projects/ores.refdata.core/modeling/multi_party.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Multi-Party Architecture
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 * Overview

--- a/projects/ores.refdata.core/modeling/trading_structure.org
+++ b/projects/ores.refdata.core/modeling/trading_structure.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Trading Structure: Party, Book, Portfolio, Business Unit, Business Centre
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 * Overview

--- a/projects/ores.sql/modeling/database_lifecycle.org
+++ b/projects/ores.sql/modeling/database_lifecycle.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Database Lifecycle and Script Reference
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 Operational reference for database creation, population, and teardown in

--- a/projects/ores.trading.core/modeling/trade_state_machine.org
+++ b/projects/ores.trading.core/modeling/trade_state_machine.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Trade Status State Machine
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 * Overview

--- a/projects/ores.workspace.core/modeling/multi_workspace.org
+++ b/projects/ores.workspace.core/modeling/multi_workspace.org
@@ -3,7 +3,7 @@
 :END:
 #+title: Multi-Workspace Architecture
 #+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil html-postamble:nil
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages
 
 * Overview


### PR DESCRIPTION
## Summary

Adopts the dark CSS + sidebar-TOC approach from
`mcraveiro.github.io` for the ORE Studio product website, adds a
site-wide preamble (banner + nav), fixes the missing GitHub Pages
enablement flag, and adds a local-preview script.

## Changes

### CSS (`assets/style.css`)

- Replaces the dual light/dark theme with a single dark theme (deep
  matte background, crisp blue accent, system font stack).
- Sidebar TOC layout via `#content:has(#table-of-contents)` — TOC
  sits sticky on the left, content fills the right column. Falls
  back to single-column under 768px.
- Tightened typography, table styling, code blocks, footnotes,
  blockquotes, note admonitions, badge wrapper.

### `.build-site.el`

- Adds `site-html-preamble` with the ORE Studio banner image + nav
  (Home / Documentation / V2 Compass / Doxygen / GitHub).
- Backquotes the publishing alist so the preamble variable
  substitutes in cleanly.

### `.github/workflows/build-site.yml`

- Adds `with: enablement: true` on `actions/configure-pages`. This is
  the missing setting vs `mcraveiro.github.io`'s yml — auto-enables
  GitHub Pages on first run.

### TOC default flip

- Flips `toc:nil` → `toc:t` across 124 org files in `doc/` +
  `projects/`, plus the `v2_doc_skill.org.mustache` template.
- `doc/doc.org` + `readme.org` stay `toc:nil` (top-level indexes).
- Files without explicit `#+options:` continue to inherit
  `:with-toc t` from the build script.
- Org's TOC renders conditionally on whether the document has
  headlines, so pure-list index files (e.g. `doc/recipes/recipes.org`)
  still render without a TOC even with `toc:t` set.

### `build/scripts/serve-site.sh`

- Adapted from `mcraveiro.github.io/serve.sh`. Wraps
  `python3 -m http.server` over `build/output/site/`. Supports
  `--compile` to rebuild first and `--port` (or `PORT` env var) to
  pick the port.

## Notes for review

- Site builds clean locally.
- Banner image is `assets/images/ore-studio-banner.png`, served at
  `/OreStudio/assets/images/ore-studio-banner.png` via the preamble.
- Other diffs vs `mcraveiro.github.io`'s yml (license header,
  Doxygen step, `ubuntu-24.04` pin, `@v5.0.0` action pins) are
  intentional / kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)