### PR TITLE
Qt menu structure simplification + V2 component documentation

### DIFF
--- a/doc/plans/2026-05-18-menu-structure-simplification.org
+++ b/doc/plans/2026-05-18-menu-structure-simplification.org
@@ -1,7 +1,7 @@
 #+TITLE: Menu Structure Analysis and Simplification
 #+DATE: 2026-05-18
 #+AUTHOR: ORE Studio Team
-#+STATUS: PROPOSED
+#+STATUS: IN PROGRESS
 #+OPTIONS: toc:t num:nil
 
 * Related Plans
@@ -180,11 +180,13 @@ Secondary issues:
 - Organisation Codes (submenu: Party Types, Statuses, ID Schemes, Contact Types,
   Business Unit Types)
 
-*** Data /(renamed from Data Transfer)/
+*** Data Management /(renamed from Data Transfer; absorbs Workspaces)/
 - Data Catalogue (submenu — unchanged)
 - Data Librarian
 - /separator/
 - Import ORE Data...
+- /separator/
+- Manage Workspaces
 
 *** Operations /(replaces Scheduler + Workflows)/
 - Job Definitions, Job Instances
@@ -209,10 +211,10 @@ Secondary issues:
   - Onboard Tenant...
 
 *** Workspaces
-Removed as a top-level menu.  ~Manage Workspaces~ becomes a toolbar action
-and/or accessible from the Window menu (alongside open-window management).
-This is consistent with how workspace switching is expected to work —
-a quick-access affordance rather than a navigation destination.
+Removed as a standalone top-level menu.  ~Manage Workspaces~ moves into
+~Data Management~, where it sits naturally alongside data catalogue,
+librarian, and import functionality — all concerned with organising and
+managing data contexts.
 
 ** Items not moved
 
@@ -234,7 +236,7 @@ inserts between File and System.  The proposed changes affect:
 | ~PartyPlugin~ | No longer creates a top-level menu; contributes to Reference Data. |
 | ~SchedulerPlugin~ | No longer creates a top-level menu; contributes to Operations. |
 | ~WorkflowPlugin~ | No longer creates a top-level menu; contributes to Operations. |
-| ~WorkspacePlugin~ | ~Manage Workspaces~ promoted to toolbar action; plugin stops creating a menu. |
+| ~WorkspacePlugin~ | Contributes ~Manage Workspaces~ into ~Data Management~; stops creating its own top-level menu. |
 | ~RefdataPlugin~ | Absorbs Organisation Codes submenu from PartyPlugin. |
 
 The shared-menu mechanism (where MainWindow pre-creates a named menu and
@@ -251,7 +253,7 @@ contributing plugins can locate it without hard-coding creation order:
 |------+-------------|
 | Analytics | ~menu_analytics~ |
 | Reference Data | ~menu_refdata~ |
-| Data | ~menu_data~ |
+| Data Management | ~menu_data_management~ |
 | Operations | ~menu_operations~ |
 | System | ~menu_system~ |
 
@@ -294,17 +296,15 @@ contributing plugins can locate it without hard-coding creation order:
    ~menu_operations~.
 3. Remove ~Scheduler~ and ~Workflows~ as separate top-level entries.
 
-** Phase 6 — Data: rename Data Transfer
+** Phase 6 — Data Management: rename + absorb Workspaces
 
-1. Rename ~Data Transfer~ to ~Data~ (object name ~menu_data~, display name ~&Data~).
-2. No content changes required.
+1. Rename ~Data Transfer~ to ~Data Management~ (object name ~menu_data_management~,
+   display name ~&Data Management~).
+2. Modify ~WorkspacePlugin::create_menus()~ to contribute ~Manage Workspaces~
+   into ~menu_data_management~ instead of creating its own top-level menu.
+3. Remove ~Workspaces~ as a separate top-level entry.
 
-** Phase 7 — Workspaces: toolbar action
-
-1. Add ~Manage Workspaces~ as a toolbar action in ~WorkspacePlugin~.
-2. Remove ~WorkspacePlugin::create_menus()~ (or return ~nullptr~).
-
-** Phase 8 — Final QA
+** Phase 7 — Final QA
 
 1. Walk every menu item in the new structure; confirm no action is missing.
 2. Verify login/logout enable-disable state still works for all items.

--- a/doc/skills/v2-doc-author/SKILL.org
+++ b/doc/skills/v2-doc-author/SKILL.org
@@ -8,7 +8,7 @@
 #+export_exclude_tags: noexport
 #+filetags: :v2_docs:codegen:templates:skill:
 #+created: 2026-05-18
-#+updated: 2026-05-18
+#+updated: 2026-05-20
 
 #+begin_export markdown
 ---
@@ -39,15 +39,26 @@ than hand-written.
    parent document for task/story/sprint, so no UUID typing is
    needed. The recipe at [[id:3153aa4b-23d4-4111-9710-5a4971102edc][How do I create a new v2 doc?]] has copy-
    pasteable invocations per type.
-4. Fill in the skeleton sections in the generated file.
-5. For stories that continue from a previous sprint, update the
+   - For component overviews specifically, always use =--slug
+     component_overview= (not the component name). See
+     [[id:0806c8fb-43d2-497e-900d-5f2e0b3472fd][How do I create a component overview?]].
+4. *When creating multiple inter-linked documents* (e.g. a set of
+   component overviews plus a knowledge doc they all reference):
+   generate all skeleton files first, then collect their IDs with
+   =grep "^:ID:" <file>=, then fill in the content using the actual
+   IDs. Never pre-assign UUIDs — the generator always mints its own.
+   The =--id= flag is for migration of existing documents only.
+5. Fill in the skeleton sections in the generated file.
+6. For stories that continue from a previous sprint, update the
    predecessor story to add =#+successor:= and a =Continued in:=
    note in =* Decisions= (this step is manual).
 
 * Recipes
 
 - [[id:3153aa4b-23d4-4111-9710-5a4971102edc][How do I create a new v2 doc?]] — the master recipe with examples
-  for every type.
+  for every type, including inter-linked document sets.
+- [[id:0806c8fb-43d2-497e-900d-5f2e0b3472fd][How do I create a component overview?]] — component-specific workflow
+  with section-by-section guidance and the correct slug to use.
 - [[id:20d0a77d-e0c0-492e-b0ec-45c7638dd220][How do I run codegen?]] — the C++/SQL generator on the same
   infrastructure.
 

--- a/doc/v2/knowledge/documentation/component_documentation_guide.org
+++ b/doc/v2/knowledge/documentation/component_documentation_guide.org
@@ -1,0 +1,120 @@
+:PROPERTIES:
+:ID: b9d3d469-9e59-465f-8c18-34546b680d13
+:END:
+#+title: Component Documentation Guide
+#+description: Practical guide to writing component_overview.org files: what each section means, how to fill it in, and what makes a good entry.
+#+type: knowledge
+#+level: cross
+#+filetags: :documentation:component:knowledge:
+#+created: 2026-05-20
+#+updated: 2026-05-20
+
+* Summary
+
+Every component in ORE Studio carries a =component_overview.org= co-located
+in its =modeling/= directory. It is a 50–100 line index — not a reference
+manual — that tells a reader what the component does, what it consumes and
+produces, how to enter it, and where to look for deeper material. This
+document explains how to fill in each section and what separates a useful
+entry from a placeholder.
+
+* Detail
+
+** The six required sections
+
+*** Summary (3–5 sentences)
+
+Answer: /What does this component do and why does it exist?/ Do not describe
+the technology stack; describe the /purpose/. A good summary can be read in
+isolation and still convey value.
+
+- Bad :: "This component uses Qt and NATS."
+- Good :: "=ores.qt.trading= provides the Qt UI for managing portfolios, books,
+  and trades. It renders instrument-specific forms for FX, rates, credit,
+  equity, and commodity trades, and drives the Portfolio Explorer and Org
+  Explorer MDI windows."
+
+*** Inputs
+
+What does the component consume? List data sources, dependency contracts,
+configuration, or trigger events — not function signatures. One bullet per
+distinct source.
+
+Examples:
+- NATS responses from a named domain service (note the subject range)
+- PostgreSQL tables owned by the component
+- Configuration loaded at startup (env vars, config files)
+- User interactions or commands
+
+*** Outputs
+
+What does the component produce? This is the symmetric counterpart to Inputs.
+For a Qt plugin: rendered MDI windows, NATS request messages sent. For a
+service: persisted records, NATS response messages, emitted events.
+
+*** Entry points
+
+Key files a developer opens first. Keep to 3–6 items. Prefer:
+- The main plugin/service class header
+- The aggregate include header (=ores.<comp>.hpp= if it exists)
+- The messaging registrar (for services)
+- The application entry point (=main.cpp= for services and apps)
+
+Use repo-relative paths so they remain clickable.
+
+*** Dependencies
+
+List other ORE Studio components and significant third-party libraries this
+component links against. Use the component slug (=ores.refdata.api=) rather
+than the CMake target name (=ores.refdata.api.lib=). Omit ubiquitous
+transitive dependencies (=ores.logging=, =Qt6=) unless there is a specific
+reason to call them out.
+
+The CMakeLists.txt =target_link_libraries= block is the authoritative source
+for direct dependencies; copy the non-transient entries.
+
+*** See also
+
+This is the most valuable section for navigation and the most commonly left
+empty. Link to:
+- Sibling components (=ores.<domain>.api= for Qt plugins; =*.service= for
+  =*.core= components)
+- Knowledge documents that provide architectural depth
+- Recipes for operating on the component
+
+Use org-roam id-links: =[[id:<UUID>][human-readable text]]=. Never use file
+paths; IDs survive renames.
+
+** What makes a good entry vs. a skeleton
+
+A skeleton has placeholder text and empty bullets. A good entry is /closed/:
+a reader who only looks at this file knows where to start and where to go
+next, without digging through the code.
+
+| Section | Skeleton | Good |
+|---------+----------+------|
+| Summary | "does things" | Concrete purpose; mentions domain |
+| Inputs | "-" | Named data source and format |
+| Outputs | "-" | Named artifact and consumer |
+| Entry points | "-" | Real file paths with 1-line annotation |
+| Dependencies | "-" | Named ores.* slugs from CMakeLists |
+| See also | "-" | At least one id-link to a sibling component |
+
+** Common mistakes
+
+- /Over-long entries./ If the component section is growing past 100 lines,
+  extract the depth into a linked knowledge document in =projects/<comp>/docs/=
+  and keep the overview as an index.
+- /See also left empty./ At minimum, link from a Qt plugin to its domain API
+  (=ores.<domain>.api=) and back from the API to the Qt plugin.
+- /File path links instead of id-links./ File paths break on rename.
+  Always use =[[id:UUID][label]]=.
+- /Describing the implementation, not the contract./ Summary should describe
+  /what it does for callers/, not /how it is implemented/.
+
+* See also
+
+- [[id:8b29a8d8-e004-4e87-b81d-abeaf68f2b98][Document types]] — the formal spec for component document structure.
+- [[id:0806c8fb-43d2-497e-900d-5f2e0b3472fd][How do I create a component overview?]] — the recipe that scaffolds the file.
+- [[id:25812E6F-7AD1-36E4-697B-EEC8015C4F1F][ores.qt]] — example of a complete component overview.
+- [[id:D00BEA0D-E501-C534-A013-E6F40C1A6097][ores.iam.core]] — another example with a well-populated See also section.

--- a/doc/v2/knowledge/qt/plugin_architecture.org
+++ b/doc/v2/knowledge/qt/plugin_architecture.org
@@ -1,0 +1,127 @@
+:PROPERTIES:
+:ID: e81c7fea-33e4-400a-839a-9d1618bed211
+:END:
+#+title: Qt Plugin Architecture
+#+description: IPlugin lifecycle, shared_menus_context, load_order, and the two-phase menu-building sequence in ORE Studio.
+#+type: knowledge
+#+level: cross
+#+filetags: :qt:ui:architecture:knowledge:
+#+created: 2026-05-20
+#+updated: 2026-05-20
+
+* Summary
+
+ORE Studio's Qt desktop application is assembled from independently-loaded
+plugins, each implementing the =IPlugin= interface (=ores.qt.api=). Plugins
+follow a four-stage lifecycle: =on_login=, =setup_menus=, =create_menus=, and
+=on_logout=. The =load_order()= integer controls both the setup and creation
+sequences. =MainWindow= runs all =setup_menus()= calls first (one pass), then
+all =create_menus()= calls (a second pass), so every plugin can contribute
+items to a shared menu before any plugin returns its own menu for insertion.
+
+* Detail
+
+** The IPlugin interface
+
+Defined in =projects/ores.qt.api/include/ores.qt/IPlugin.hpp=. Key methods:
+
+| Method | When called | Purpose |
+|--------+-------------+---------|
+| =load_order()= | at sort time | determines call sequence for both phases |
+| =on_login(plugin_context)= | after NATS login | create controllers, cache refs |
+| =setup_menus(shared_menus_context)= | phase 1 | contribute items to shared menus |
+| =create_menus()= | phase 2 | return owned menus for insertion into menu bar |
+| =toolbar_actions()= | after create_menus | return actions to add to the toolbar |
+| =on_logout()= | on logout | destroy controllers, clear state |
+
+Plugins derive from =PluginBase : IPlugin= (which derives from =QObject=) and
+are loaded as Qt plugins via =QPluginLoader=.
+
+** The plugin_context struct
+
+Passed to =on_login=. Contains references that persist for the session:
+
+- =main_window= — the application =QMainWindow=
+- =mdi_area= — the central =QMdiArea=
+- =client_manager= — NATS client wrapper for all domain calls
+- =image_cache=, =badge_cache=, =change_reason_cache= — shared caches
+- =username= — authenticated user handle
+- =http_base_url= — base URL for HTTP fallback (e.g. ORE import)
+
+** The shared_menus_context struct
+
+Passed to =setup_menus=. Contains pointers to pre-created shared menus that
+multiple plugins contribute to:
+
+| Field | Owner plugin | Contributors |
+|-------+---------------+--------------|
+| =system_menu= | =ores.qt= (MainWindow) | AdminPlugin |
+| =account_menu= | =ores.qt= (MainWindow) | AdminPlugin |
+| =telemetry_menu= | =ores.qt= (MainWindow) | AdminPlugin |
+| =reference_data_menu= | RefdataPlugin | PartyPlugin |
+| =data_management_menu= | DataTransferPlugin | RefdataPlugin, TradingPlugin, WorkspacePlugin |
+| =trading_codes_menu= | (pre-created) | TradingPlugin, RefdataPlugin |
+| =analytics_menu= | AnalyticsPlugin | ComputePlugin |
+| =analytics_codes_menu= | AnalyticsPlugin | ComputePlugin |
+| =operations_menu= | SchedulerPlugin | WorkflowPlugin |
+
+A pointer being =nullptr= means the owning plugin has not yet called
+=setup_menus=. Always null-check before using.
+
+** The two-phase dispatch loop
+
+=MainWindow= calls plugins in two separate loops, both ordered by =load_order=:
+
+#+begin_example
+Pass 1 — setup_menus
+  for each plugin (ascending load_order):
+      plugin->setup_menus(smc)         // contribute to shared menus
+
+Pass 2 — create_menus
+  for each plugin (ascending load_order):
+      menus = plugin->create_menus()   // return owned menus
+      for each menu:
+          menuBar()->insertMenu(...)   // insert before System menu
+#+end_example
+
+This guarantees all contributions to a shared menu are complete before any
+plugin returns that menu via =create_menus()=.
+
+** load_order values (current)
+
+| load_order | Plugin |
+|------------+--------|
+| 100 | RefdataPlugin |
+| 105 | PartyPlugin |
+| 200 | TradingPlugin |
+| 210 | WorkspacePlugin |
+| 350 | AnalyticsPlugin |
+| 355 | ComputePlugin |
+| 360 | SchedulerPlugin |
+| 365 | WorkflowPlugin |
+| 375 | DataTransferPlugin |
+| 400 | AdminPlugin |
+| 450 | MktdataPlugin |
+
+** Menu bar insertion order
+
+Menus returned by =create_menus()= are inserted before the System menu using
+=menuBar()->insertMenu(systemAction, menu)=. The System menu itself is
+pre-created by =MainWindow= and is always last. Plugins with lower
+=load_order= have their menus inserted first (leftmost).
+
+** Adding a new plugin
+
+1. Implement =IPlugin= (derive from =PluginBase=).
+2. Add =Q_PLUGIN_METADATA= and =Q_INTERFACES= macros.
+3. Choose a =load_order()= value that places it correctly relative to menus
+   it contributes to (lower = earlier).
+4. Wire =on_login= / =on_logout= to create / destroy controllers.
+5. Wire =setup_menus= to contribute to any shared menus.
+6. Wire =create_menus= to return any owned menus.
+
+* See also
+
+- [[id:25812E6F-7AD1-36E4-697B-EEC8015C4F1F][ores.qt]] — the MainWindow shell that drives the two-phase loop.
+- [[id:30a3a7f4-e1a9-42fb-af9d-ff36fa0f3d21][ores.qt.api]] — defines IPlugin, PluginBase, plugin_context, shared_menus_context.
+- [[id:fc186d19-9421-45a2-bbcc-4355d66aa41f][Entity Controller Pattern]] — how plugins wire their controllers.

--- a/doc/v2/recipes/codegen/how_do_i_create_a_component_overview.org
+++ b/doc/v2/recipes/codegen/how_do_i_create_a_component_overview.org
@@ -1,0 +1,68 @@
+:PROPERTIES:
+:ID: 0806c8fb-43d2-497e-900d-5f2e0b3472fd
+:END:
+#+title: How do I create a component overview?
+#+description: Use generate_v2_doc.sh to scaffold a component_overview.org and fill in each required section.
+#+type: recipe
+#+level: cross
+#+filetags: :codegen:component:documentation:recipe:
+#+created: 2026-05-20
+#+updated: 2026-05-20
+
+See [[id:b9d3d469-9e59-465f-8c18-34546b680d13][Component Documentation Guide]] for what each section should contain
+and what separates a useful entry from a placeholder.
+
+* Question
+
+How do I create a =component_overview.org= for an ORE Studio component
+that is missing one?
+
+* Answer
+
+#+begin_src sh :results verbatim
+projects/ores.codegen/generate_v2_doc.sh \
+  --type component --slug component_overview \
+  --parent-dir projects/<comp>/modeling \
+  --title "<comp>" \
+  --description "<one-liner ≤ 120 chars>" \
+  --tags "qt,component"   # adjust tags to match the domain
+#+end_src
+
+The script writes =projects/<comp>/modeling/component_overview.org=
+with a fresh UUID, today's dates, and skeleton sections.
+
+Then fill in each section (values in parentheses are prompts, not
+literal content):
+
+1. *Summary* — 3–5 sentences: what it does and why it exists.
+2. *Inputs* — named data sources (NATS subjects, DB tables, config).
+3. *Outputs* — what it produces (MDI windows, NATS messages, records).
+4. *Entry points* — 3–6 key file paths with a one-line annotation each.
+5. *Dependencies* — =ores.*= slugs from the component's
+   =target_link_libraries= block; omit ubiquitous transitive deps.
+6. *See also* — at minimum one id-link to a sibling component; more for
+   knowledge docs and recipes. Use =[[id:UUID][label]]=.
+
+Finally, remove the component's =MISSING_OVERVIEW= entry from
+=projects/ores.codegen/docs_exceptions.txt= and run the validation:
+
+#+begin_src sh :results verbatim
+./projects/ores.codegen/validate_docs.sh
+#+end_src
+
+* Script
+
+=projects/ores.codegen/generate_v2_doc.sh= — the Mustache-based v2
+document generator. Full CLI reference at
+=projects/ores.codegen/docs/v2_doc_generator.md=.
+
+* Tested by
+
+Manual: run =validate_docs.sh= after creation and confirm no
+=MISSING_OVERVIEW= errors remain for the target component.
+
+* See also
+
+- [[id:b9d3d469-9e59-465f-8c18-34546b680d13][Component Documentation Guide]] — what each section should contain.
+- [[id:3153aa4b-23d4-4111-9710-5a4971102edc][How do I create a new v2 doc?]] — the general v2 doc creation recipe.
+- [[id:8b29a8d8-e004-4e87-b81d-abeaf68f2b98][Document types]] — the formal spec every component doc follows.

--- a/doc/v2/recipes/codegen/how_do_i_create_a_new_v2_doc.org
+++ b/doc/v2/recipes/codegen/how_do_i_create_a_new_v2_doc.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :codegen:v2_docs:templates:agile:recipe:
 #+created: 2026-05-18
-#+updated: 2026-05-18
+#+updated: 2026-05-20
 
 For the contract every generated document follows (frontmatter,
 sections, TODO vocabulary), see [[id:8b29a8d8-e004-4e87-b81d-abeaf68f2b98][document types]]. For background on
@@ -104,17 +104,20 @@ projects/ores.codegen/generate_v2_doc.sh \
 
 ** New component model
 
+Component overview files are always named =component_overview.org=.
+Use =--slug component_overview= (not the component name):
+
 #+begin_src sh :results verbatim
 projects/ores.codegen/generate_v2_doc.sh \
-  --type component --slug ores.example \
+  --type component --slug component_overview \
   --parent-dir projects/ores.example/modeling \
   --title "ores.example" \
   --description "One-line summary of what the component does." \
-  --tags "example,scaffolding"
+  --tags "example,component"
 #+end_src
 
-The output sits directly at =projects/ores.example/modeling/ores.example.org=
-(no subfolder), matching the existing convention.
+Output: =projects/ores.example/modeling/component_overview.org=.
+See [[id:0806c8fb-43d2-497e-900d-5f2e0b3472fd][How do I create a component overview?]] for how to fill in each section.
 
 ** New recipe
 
@@ -163,6 +166,36 @@ projects/ores.codegen/generate_v2_doc.sh \
 
 Output: =doc/skills/my-new-skill/SKILL.org=.
 
+** Creating a set of inter-linked documents
+
+When creating multiple documents that will link to each other (e.g. a
+knowledge doc and several component overviews that reference it), the
+correct order is:
+
+1. *Generate all skeleton files first.* Each call mints a fresh UUID.
+   Do not pre-assign or guess UUIDs before running the script — they
+   will not match.
+
+   #+begin_src sh :results verbatim
+   projects/ores.codegen/generate_v2_doc.sh --type knowledge ...
+   projects/ores.codegen/generate_v2_doc.sh --type component --slug component_overview ...
+   projects/ores.codegen/generate_v2_doc.sh --type component --slug component_overview ...
+   #+end_src
+
+2. *Collect the generated IDs.*
+
+   #+begin_src sh :results verbatim
+   grep "^:ID:" projects/ores.foo/modeling/component_overview.org \
+                doc/v2/knowledge/topic/my_knowledge.org
+   #+end_src
+
+3. *Fill in the content of each file*, using the actual IDs in
+   =[[id:UUID][label]]= links.
+
+The =--id= flag is for *migration only* — preserving an existing UUID
+when reformatting a document that already has one. Never use it to
+pre-assign an ID to a brand-new document.
+
 * What the script does
 
 - Generates a fresh UUID and puts it in =:ID:=.
@@ -183,6 +216,9 @@ Manual smoke tests during initial development. No automated test yet
 
 * See also
 
+- [[id:0806c8fb-43d2-497e-900d-5f2e0b3472fd][How do I create a component overview?]] — component-specific workflow
+  with section-by-section guidance.
+- [[id:b9d3d469-9e59-465f-8c18-34546b680d13][Component Documentation Guide]] — what makes a good component doc.
 - [[id:20d0a77d-e0c0-492e-b0ec-45c7638dd220][How do I run codegen?]] — the C++ model-driven generator on the same
   infrastructure.
 - [[id:8b29a8d8-e004-4e87-b81d-abeaf68f2b98][document types]] — the contract every generated document follows.

--- a/projects/ores.codegen/docs_exceptions.txt
+++ b/projects/ores.codegen/docs_exceptions.txt
@@ -13,20 +13,6 @@
 # Entries below represent known gaps to be addressed in follow-up work.
 # Remove an entry once the corresponding issue is resolved.
 
-# Qt sub-module components: component_overview.org not yet created.
-MISSING_OVERVIEW ores.qt.admin
-MISSING_OVERVIEW ores.qt.analytics
-MISSING_OVERVIEW ores.qt.api
-MISSING_OVERVIEW ores.qt.compute
-MISSING_OVERVIEW ores.qt.data_transfer
-MISSING_OVERVIEW ores.qt.mktdata
-MISSING_OVERVIEW ores.qt.party
-MISSING_OVERVIEW ores.qt.refdata
-MISSING_OVERVIEW ores.qt.scheduler
-MISSING_OVERVIEW ores.qt.trading
-MISSING_OVERVIEW ores.qt.workflow
-MISSING_OVERVIEW ores.qt.workspace
-
 # Workspace components: component_overview.org not yet created.
 MISSING_OVERVIEW ores.workspace.api
 MISSING_OVERVIEW ores.workspace.core

--- a/projects/ores.qt.admin/modeling/component_overview.org
+++ b/projects/ores.qt.admin/modeling/component_overview.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: db5a4924-8f0a-440c-873e-d823f430043e
+:END:
+#+title: ores.qt.admin
+#+description: Qt plugin for IAM UI — accounts, roles, tenants, system settings, badge types, and tenant onboarding.
+#+type: component
+#+level: cross
+#+filetags: :qt:iam:ui:component:
+#+created: 2026-05-20
+#+updated: 2026-05-20
+
+* Summary
+
+=ores.qt.admin= is the Qt plugin for identity and access management UI.
+It provides MDI windows and dialogs for managing accounts, roles, tenants,
+tenant types, system settings, badge definitions, and badge severities.
+It also provides the Tenant Onboarding Wizard for provisioning new tenants
+and contributes the Configuration and Administration submenus to the System
+menu. Variability (feature flags) are surfaced through the system-settings
+controllers.
+
+* Inputs
+
+- NATS responses from the IAM service (accounts, roles, tenants, tenant types,
+  system settings, badge definitions, badge severities).
+- NATS responses from the controller service (variability/system settings).
+- User interactions: create/edit/delete/view-history on IAM entities.
+
+* Outputs
+
+- Rendered MDI windows for each IAM entity type.
+- NATS request messages sent to the IAM and controller services on user actions.
+- Configuration and Administration submenus injected into the System menu.
+
+* Entry points
+
+- =include/ores.qt/AdminPlugin.hpp= — plugin class; contributes to System menu.
+- =include/ores.qt/AccountController.hpp= — account entity controller.
+- =include/ores.qt/TenantController.hpp= — tenant entity controller.
+- =include/ores.qt/TenantOnboardingWizard.hpp= — multi-step tenant provisioning.
+
+* Dependencies
+
+- =ores.qt.api= — IPlugin, base controller/window/dialog classes, ClientManager.
+- =ores.iam.api= — account, role, tenant, badge domain types and NATS schemas.
+- =ores.controller.api= — system-setting and variability domain types.
+- =ores.variability.api= — variability/feature-flag domain types.
+
+* See also
+
+- [[id:4e0dc581-d74d-4bd1-87d2-7f524a36d20c][ores.iam.api]] — domain types and NATS protocol schemas for IAM.
+- [[id:D00BEA0D-E501-C534-A013-E6F40C1A6097][ores.iam.core]] — server-side IAM logic and NATS handlers.
+- [[id:85d20e29-0ebd-41ff-9f32-10f60af074a8][ores.controller.api]] — system-setting domain types.
+- [[id:26218ad6-c63e-44e8-9b92-7fb51c366566][ores.variability.api]] — variability/feature-flag domain types.
+- [[id:30a3a7f4-e1a9-42fb-af9d-ff36fa0f3d21][ores.qt.api]] — shared Qt infrastructure and base classes.
+- [[id:e81c7fea-33e4-400a-839a-9d1618bed211][Qt Plugin Architecture]] — plugin lifecycle and menu-contribution model.
+- [[id:fc186d19-9421-45a2-bbcc-4355d66aa41f][Entity Controller Pattern]] — controller/window/dialog/model structure.

--- a/projects/ores.qt.admin/src/AdminPlugin.cpp
+++ b/projects/ores.qt.admin/src/AdminPlugin.cpp
@@ -126,68 +126,70 @@ void AdminPlugin::on_login(const plugin_context& ctx) {
 
 void AdminPlugin::setup_menus(const shared_menus_context& smc) {
     BOOST_LOG_SEV(lg(), debug) << "Registering entries in shared menus."
-        << " identity=" << (smc.identity_menu ? "ok" : "null")
+        << " account=" << (smc.account_menu ? "ok" : "null")
         << " system=" << (smc.system_menu ? "ok" : "null")
         << " telemetry=" << (smc.telemetry_menu ? "ok" : "null");
-    // ---- Identity menu (top-level, pre-created by MainWindow) ---------------
-    if (smc.identity_menu) {
-        act_accounts_ = smc.identity_menu->addAction(
-            ico(Icon::PersonAccounts), tr("&Accounts"));
-        connect(act_accounts_, &QAction::triggered, this,
-            [this]() { if (accountController_) accountController_->showListWindow(); });
 
-        auto* actRoles = smc.identity_menu->addAction(tr("&Roles"));
-        connect(actRoles, &QAction::triggered, this,
-            [this]() { if (roleController_) roleController_->showListWindow(); });
+    if (!(smc.system_menu && smc.telemetry_menu))
+        return;
 
-        smc.identity_menu->addSeparator();
+    // ---- System > Configuration (inserted before Telemetry) --------------
+    auto* telemetryAction = smc.telemetry_menu->menuAction();
+    auto* config = new QMenu(tr("&Configuration"), smc.system_menu);
+    smc.system_menu->insertMenu(telemetryAction, config);
 
-        act_tenants_ = smc.identity_menu->addAction(
-            ico(Icon::BuildingSkyscraper), tr("&Tenants"));
-        connect(act_tenants_, &QAction::triggered, this,
-            [this]() { if (tenantController_) tenantController_->showListWindow(); });
+    act_system_settings_ = config->addAction(ico(Icon::Flag), tr("&System Settings"));
+    connect(act_system_settings_, &QAction::triggered, this,
+        [this]() { if (systemSettingController_) systemSettingController_->showListWindow(); });
 
-        auto* actTenantTypes = smc.identity_menu->addAction(tr("Tenant &Types"));
-        connect(actTenantTypes, &QAction::triggered, this,
-            [this]() { if (tenantTypeController_) tenantTypeController_->showListWindow(); });
+    config->addSeparator();
 
-        smc.identity_menu->addSeparator();
+    auto* actBadgeDefs = config->addAction(tr("Badge &Definitions"));
+    connect(actBadgeDefs, &QAction::triggered, this,
+        [this]() { if (badgeDefinitionController_) badgeDefinitionController_->showListWindow(); });
 
-        auto* actOnboardTenant = smc.identity_menu->addAction(tr("&Onboard Tenant..."));
-        connect(actOnboardTenant, &QAction::triggered,
-                this, &AdminPlugin::show_onboarding_wizard);
-    }
+    auto* actBadgeSevs = config->addAction(tr("Badge &Severities"));
+    connect(actBadgeSevs, &QAction::triggered, this,
+        [this]() { if (badgeSeverityController_) badgeSeverityController_->showListWindow(); });
 
-    // ---- System > Configuration ------------------------------------------
-    if (smc.system_menu && smc.telemetry_menu) {
-        auto* telemetryAction = smc.telemetry_menu->menuAction();
-        auto* config = new QMenu(tr("&Configuration"), smc.system_menu);
-        smc.system_menu->insertMenu(telemetryAction, config);
+    // ---- System > Administration (appended at end, admin-only) -----------
+    smc.system_menu->addSeparator();
 
-        act_system_settings_ = config->addAction(ico(Icon::Flag), tr("&System Settings"));
-        connect(act_system_settings_, &QAction::triggered, this,
-            [this]() { if (systemSettingController_) systemSettingController_->showListWindow(); });
+    auto* admin = smc.system_menu->addMenu(tr("&Administration"));
 
-        config->addSeparator();
+    act_accounts_ = admin->addAction(ico(Icon::PersonAccounts), tr("&Accounts"));
+    connect(act_accounts_, &QAction::triggered, this,
+        [this]() { if (accountController_) accountController_->showListWindow(); });
 
-        auto* actBadgeDefs = config->addAction(tr("Badge &Definitions"));
-        connect(actBadgeDefs, &QAction::triggered, this,
-            [this]() { if (badgeDefinitionController_) badgeDefinitionController_->showListWindow(); });
+    auto* actRoles = admin->addAction(tr("&Roles"));
+    connect(actRoles, &QAction::triggered, this,
+        [this]() { if (roleController_) roleController_->showListWindow(); });
 
-        auto* actBadgeSevs = config->addAction(tr("Badge &Severities"));
-        connect(actBadgeSevs, &QAction::triggered, this,
-            [this]() { if (badgeSeverityController_) badgeSeverityController_->showListWindow(); });
-        // Apps and App Versions live in the Compute menu (see ComputePlugin).
+    admin->addSeparator();
 
-        smc.system_menu->addSeparator();
+    act_tenants_ = admin->addAction(ico(Icon::BuildingSkyscraper), tr("&Tenants"));
+    connect(act_tenants_, &QAction::triggered, this,
+        [this]() { if (tenantController_) tenantController_->showListWindow(); });
 
-        act_reset_system_ = smc.system_menu->addAction(
-            ico(Icon::Warning), tr("Reset &System..."));
-        act_reset_system_->setToolTip(
-            tr("Reset the entire system to pre-bootstrap state (SuperAdmin only)"));
-        connect(act_reset_system_, &QAction::triggered,
-                this, &AdminPlugin::on_reset_system);
-    }
+    auto* actTenantTypes = admin->addAction(tr("Tenant &Types"));
+    connect(actTenantTypes, &QAction::triggered, this,
+        [this]() { if (tenantTypeController_) tenantTypeController_->showListWindow(); });
+
+    admin->addSeparator();
+
+    auto* actOnboardTenant = admin->addAction(tr("&Onboard Tenant..."));
+    connect(actOnboardTenant, &QAction::triggered,
+            this, &AdminPlugin::show_onboarding_wizard);
+
+    // ---- Reset System (appended after Administration) --------------------
+    smc.system_menu->addSeparator();
+
+    act_reset_system_ = smc.system_menu->addAction(
+        ico(Icon::Warning), tr("Reset &System..."));
+    act_reset_system_->setToolTip(
+        tr("Reset the entire system to pre-bootstrap state (SuperAdmin only)"));
+    connect(act_reset_system_, &QAction::triggered,
+            this, &AdminPlugin::on_reset_system);
 }
 
 QList<QMenu*> AdminPlugin::create_menus() {

--- a/projects/ores.qt.analytics/include/ores.qt/AnalyticsPlugin.hpp
+++ b/projects/ores.qt.analytics/include/ores.qt/AnalyticsPlugin.hpp
@@ -33,9 +33,10 @@ class PricingModelProductParameterController;
 /**
  * @brief Plugin owning all analytics and pricing model controllers.
  *
- * Provides a top-level Analytics menu with:
- *   - Pricing Models submenu (pricing engine types)
- *   - Configuration submenu (model configs, products, parameters)
+ * Contributes to the shared Analytics menu (pre-created by MainWindow).
+ * setup_menus() populates the model configuration items and seeds the
+ * Analytics Codes submenu; create_menus() finalises the submenu and
+ * returns the pre-created Analytics menu for bar insertion.
  */
 class AnalyticsPlugin : public PluginBase {
     Q_OBJECT
@@ -50,11 +51,15 @@ public:
     int load_order() const override { return 350; }
 
     void on_login(const plugin_context& ctx) override;
+    void setup_menus(const shared_menus_context& ctx) override;
     QList<QMenu*> create_menus() override;
     void on_logout() override;
 
 private:
     plugin_context ctx_;
+
+    QMenu* analytics_menu_{nullptr};
+    QMenu* analytics_codes_menu_{nullptr};
 
     std::unique_ptr<PricingEngineTypeController>            pricingEngineTypeController_;
     std::unique_ptr<PricingModelConfigController>           pricingModelConfigController_;

--- a/projects/ores.qt.analytics/modeling/component_overview.org
+++ b/projects/ores.qt.analytics/modeling/component_overview.org
@@ -1,0 +1,55 @@
+:PROPERTIES:
+:ID: 970667d1-8ba8-4b49-b047-0d6d4c4ce498
+:END:
+#+title: ores.qt.analytics
+#+description: Qt plugin for analytics pricing UI — model configurations, products, parameters, and pricing engine types.
+#+type: component
+#+level: cross
+#+filetags: :qt:analytics:ui:component:
+#+created: 2026-05-20
+#+updated: 2026-05-20
+
+* Summary
+
+=ores.qt.analytics= is the Qt plugin for the analytics pricing domain.
+It provides MDI windows and dialogs for managing pricing model configurations,
+pricing model products, pricing model product parameters, and pricing engine
+types. It owns the Analytics top-level menu and the Analytics Codes submenu;
+=ores.qt.compute= contributes additional reporting code types to that submenu
+during the =setup_menus= phase.
+
+* Inputs
+
+- NATS responses from the analytics service (model configs, products,
+  parameters, engine types).
+- User interactions: create/edit/delete/view-history on analytics entities.
+- =shared_menus_context.analytics_menu= and =analytics_codes_menu= pointers
+  received in =setup_menus=.
+
+* Outputs
+
+- Rendered MDI windows for pricing model entities.
+- NATS request messages sent to the analytics service on user actions.
+- Analytics and Analytics Codes menus (returned via =create_menus=, with
+  items contributed by ComputePlugin already appended).
+
+* Entry points
+
+- =include/ores.qt/AnalyticsPlugin.hpp= — plugin class; owns the Analytics menu.
+- =include/ores.qt/PricingModelConfigController.hpp= — model config controller.
+- =include/ores.qt/PricingEngineTypeController.hpp= — engine type controller.
+
+* Dependencies
+
+- =ores.qt.api= — IPlugin, base controller/window/dialog classes, ClientManager.
+- =ores.analytics.api= — pricing model and engine type domain types and NATS schemas.
+- =ores.refdata.api= — reference data types used in pricing configuration.
+
+* See also
+
+- [[id:66d3f1d6-1926-40cf-bcf5-aa42f14ad6d5][ores.analytics.api]] — domain types and NATS protocol schemas for analytics.
+- [[id:654be6cd-d212-4ee5-a7b4-8af125787522][ores.refdata.api]] — reference data types used in model configuration.
+- [[id:03eae018-5e61-4005-ac9a-eff827a46178][ores.qt.compute]] — contributes report types and concurrency policies to the Analytics Codes submenu.
+- [[id:30a3a7f4-e1a9-42fb-af9d-ff36fa0f3d21][ores.qt.api]] — shared Qt infrastructure and base classes.
+- [[id:e81c7fea-33e4-400a-839a-9d1618bed211][Qt Plugin Architecture]] — plugin lifecycle and the two-phase menu sequence.
+- [[id:fc186d19-9421-45a2-bbcc-4355d66aa41f][Entity Controller Pattern]] — controller/window/dialog/model structure.

--- a/projects/ores.qt.analytics/src/AnalyticsPlugin.cpp
+++ b/projects/ores.qt.analytics/src/AnalyticsPlugin.cpp
@@ -75,46 +75,57 @@ void AnalyticsPlugin::on_login(const plugin_context& ctx) {
     connectControllerSignals(pricingModelProductParameterController_.get());
 }
 
-QList<QMenu*> AnalyticsPlugin::create_menus() {
-    BOOST_LOG_SEV(lg(), debug) << "Building plugin menus.";
-    auto* menuPricing = new QMenu(tr("&Pricing"));
+void AnalyticsPlugin::setup_menus(const shared_menus_context& smc) {
+    BOOST_LOG_SEV(lg(), debug) << "Registering entries in shared menus."
+        << " analytics=" << (smc.analytics_menu ? "ok" : "null")
+        << " analytics_codes=" << (smc.analytics_codes_menu ? "ok" : "null");
+    if (!smc.analytics_menu || !smc.analytics_codes_menu)
+        return;
 
-    // ---- Flat model configuration items at the top ----------------------
-    auto* actModelConfigs = menuPricing->addAction(
+    analytics_menu_ = smc.analytics_menu;
+    analytics_codes_menu_ = smc.analytics_codes_menu;
+
+    auto* actModelConfigs = analytics_menu_->addAction(
         ico(Icon::Chart), tr("Model &Configurations"));
     connect(actModelConfigs, &QAction::triggered, this, [this]() {
         if (pricingModelConfigController_)
             pricingModelConfigController_->showListWindow();
     });
 
-    auto* actModelProducts = menuPricing->addAction(
+    auto* actModelProducts = analytics_menu_->addAction(
         ico(Icon::Table), tr("Model &Products"));
     connect(actModelProducts, &QAction::triggered, this, [this]() {
         if (pricingModelProductController_)
             pricingModelProductController_->showListWindow();
     });
 
-    auto* actModelProductParameters = menuPricing->addAction(
+    auto* actModelProductParameters = analytics_menu_->addAction(
         ico(Icon::Settings), tr("Model Product &Parameters"));
     connect(actModelProductParameters, &QAction::triggered, this, [this]() {
         if (pricingModelProductParameterController_)
             pricingModelProductParameterController_->showListWindow();
     });
 
-    menuPricing->addSeparator();
-
-    // ---- Pricing Codes submenu ------------------------------------------
-    auto* menuPricingCodes = menuPricing->addMenu(tr("Pricing &Codes"));
-
-    auto* actPricingEngineTypes = menuPricingCodes->addAction(
+    auto* actPricingEngineTypes = analytics_codes_menu_->addAction(
         ico(Icon::Tag), tr("&Pricing Engine Types"));
     connect(actPricingEngineTypes, &QAction::triggered, this, [this]() {
         if (pricingEngineTypeController_)
             pricingEngineTypeController_->showListWindow();
     });
+}
+
+QList<QMenu*> AnalyticsPlugin::create_menus() {
+    BOOST_LOG_SEV(lg(), debug) << "Building plugin menus.";
+    if (!analytics_menu_ || !analytics_codes_menu_) {
+        BOOST_LOG_SEV(lg(), warn) << "Analytics menu not initialised via setup_menus.";
+        return {};
+    }
+
+    analytics_menu_->addSeparator();
+    analytics_menu_->addMenu(analytics_codes_menu_);
 
     BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
-    return {menuPricing};
+    return {analytics_menu_};
 }
 
 void AnalyticsPlugin::on_logout() {

--- a/projects/ores.qt.api/docs/entity_controller_pattern.org
+++ b/projects/ores.qt.api/docs/entity_controller_pattern.org
@@ -1,0 +1,114 @@
+:PROPERTIES:
+:ID: fc186d19-9421-45a2-bbcc-4355d66aa41f
+:END:
+#+title: Entity Controller Pattern
+#+description: Four-layer Qt entity UI pattern: controller, list-window, detail-dialog, and table-model — and how they wire to NATS.
+#+type: knowledge
+#+level: cross
+#+filetags: :qt:ui:architecture:knowledge:
+#+created: 2026-05-20
+#+updated: 2026-05-20
+
+* Summary
+
+Every domain entity in ORE Studio's Qt UI is managed by a four-layer stack:
+a *controller* that owns MDI windows and orchestrates NATS calls, a
+*list-window* (=EntityListMdiWindow=) that displays a paginated table of
+records, a *detail-dialog* (=EntityDetailDialog=) for create/edit/view, and
+an *abstract client model* (=AbstractClientModel=) that fetches and caches
+the entity's rows from the NATS service. This pattern is implemented by base
+classes in =ores.qt.api= and followed consistently across all entity types.
+
+* Detail
+
+** The four layers
+
+*** AbstractClientModel
+
+- Subclass of =QAbstractTableModel=.
+- Sends a NATS list request on =refresh()= and populates its row cache on
+  response.
+- Emits =dataReady()= when the initial fetch completes.
+- Provides =entityAt(row)= for the list-window to feed into the detail dialog.
+- Column metadata comes from =ColumnMetadata= structs defined per entity type.
+
+*** EntityListMdiWindow
+
+- MDI sub-window containing a =QTableView= backed by an =AbstractClientModel=.
+- Toolbar: Refresh, New, Edit, View History, Delete (enabled/disabled by
+  selection state and user permissions).
+- Pagination via =PaginationWidget=.
+- Selection changes propagate to the toolbar button states.
+- Opened and closed by the controller; only one instance per entity type lives
+  in the MDI area at a time.
+
+*** EntityDetailDialog
+
+- Modal dialog for create, edit, and read-only view.
+- Opened from the list-window toolbar or via controller action.
+- On accept: sends a NATS create or update request; on completion refreshes
+  the list model.
+- Change reason dialog (=ChangeReasonDialog=) is injected from
+  =ChangeReasonCache= for entities requiring audit trail entries.
+- Temporal entities show bitemporal fields; non-temporal entities omit them.
+
+*** EntityController
+
+- Owns the model, list-window, and dialog lifecycles.
+- Created by the plugin in =on_login=; destroyed in =on_logout=.
+- =showListWindow()= — opens or raises the MDI sub-window.
+- =ClientManager= reference held throughout the session for NATS calls.
+- Emits =statusMessage= for the status bar; connected by the plugin.
+
+** NATS wiring
+
+All domain requests go through =ClientManager=, which wraps the NATS client
+and provides typed request/response helpers. The general flow:
+
+#+begin_example
+User action (button click)
+  → EntityController::onNew/onEdit
+    → EntityDetailDialog::exec()
+      → on accept: ClientManager::send<Request>(payload)
+        → NATS response callback (lambda on Qt event loop)
+          → model->refresh()  or  emit statusMessage
+#+end_example
+
+Responses arrive asynchronously; lambdas captured in the controller marshal
+back to the Qt thread via =QMetaObject::invokeMethod(..., Qt::QueuedConnection)=
+where cross-thread signalling is needed.
+
+** History dialogs
+
+For temporal entities a =HistoryDialog= shows the bitemporal record set.
+Opened via the list-window toolbar's "View History" button. Uses the same
+=ClientManager= infrastructure but sends a history-fetch request and
+displays results in a read-only table.
+
+** Naming conventions
+
+For an entity =Foo=:
+
+| Layer | Class name | File |
+|-------+------------+------|
+| Controller | =FooController= | =FooController.{hpp,cpp}= |
+| List window | =FooMdiWindow= | =FooMdiWindow.{hpp,cpp}= |
+| Detail dialog | =FooDetailDialog= | =FooDetailDialog.{hpp,cpp}= |
+| Table model | =ClientFooModel= | =ClientFooModel.{hpp,cpp}= |
+| History dialog | =FooHistoryDialog= | =FooHistoryDialog.{hpp,cpp}= |
+
+All live in the domain plugin's =include/ores.qt/= and =src/= directories.
+
+** Item delegates
+
+Complex cells (enum drop-downs, date pickers, colour swatches) use
+=QStyledItemDelegate= subclasses. Common ones live in =ores.qt.api=
+(=EntityItemDelegate=, =ClientResultItemDelegate=); entity-specific ones
+live alongside the model.
+
+* See also
+
+- [[id:e81c7fea-33e4-400a-839a-9d1618bed211][Qt Plugin Architecture]] — how controllers are created/destroyed via the
+  plugin lifecycle.
+- [[id:30a3a7f4-e1a9-42fb-af9d-ff36fa0f3d21][ores.qt.api]] — the base classes (EntityController, AbstractClientModel,
+  EntityListMdiWindow, EntityDetailDialog) that implement this pattern.

--- a/projects/ores.qt.api/include/ores.qt/IPlugin.hpp
+++ b/projects/ores.qt.api/include/ores.qt/IPlugin.hpp
@@ -40,9 +40,12 @@ struct shared_menus_context {
     QMenu* system_menu = nullptr;
     QMenu* reference_data_menu = nullptr;
     QMenu* telemetry_menu = nullptr;
-    QMenu* identity_menu = nullptr;
-    QMenu* data_transfer_menu = nullptr;
+    QMenu* account_menu = nullptr;
+    QMenu* data_management_menu = nullptr;
     QMenu* trading_codes_menu = nullptr;
+    QMenu* analytics_menu = nullptr;
+    QMenu* analytics_codes_menu = nullptr;
+    QMenu* operations_menu = nullptr;
 };
 
 /**

--- a/projects/ores.qt.api/modeling/component_overview.org
+++ b/projects/ores.qt.api/modeling/component_overview.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: 30a3a7f4-e1a9-42fb-af9d-ff36fa0f3d21
+:END:
+#+title: ores.qt.api
+#+description: Shared Qt infrastructure — IPlugin interface, base controllers/windows/dialogs, ClientManager, caches, and entity UI patterns.
+#+type: component
+#+level: cross
+#+filetags: :qt:ui:api:component:
+#+created: 2026-05-20
+#+updated: 2026-05-20
+
+* Summary
+
+=ores.qt.api= is the shared infrastructure layer for the ORE Studio Qt
+application. It defines the =IPlugin= interface and =PluginBase= that all
+feature plugins implement, the =plugin_context= and =shared_menus_context=
+structs passed through the plugin lifecycle, and the base classes for the
+entity UI pattern: =EntityController=, =EntityListMdiWindow=,
+=EntityDetailDialog=, and =AbstractClientModel=. It also provides
+=ClientManager= (the NATS client wrapper), shared caches (badge, image,
+change-reason), MDI utilities, icon utilities, and common dialog helpers
+used across all plugins.
+
+* Inputs
+
+- NATS client connection provided by =ores.nats= and =ores.eventing=.
+- Domain type definitions from all linked =ores.*.api= libraries.
+- Qt plugin loader infrastructure (=QPluginLoader=) for the plugin protocol.
+
+* Outputs
+
+- =IPlugin= / =PluginBase= — the interface every Qt plugin implements.
+- =plugin_context= / =shared_menus_context= — lifecycle context structs.
+- =EntityController=, =EntityListMdiWindow=, =EntityDetailDialog=,
+  =AbstractClientModel= — base classes for the entity UI pattern.
+- =ClientManager= — typed NATS request/response wrapper for all domain calls.
+- =BadgeCache=, =ChangeReasonCache=, =ImageCache= — session-scoped caches.
+- Utility headers: =IconUtils=, =MdiUtils=, =FontUtils=, =TextUtils=, etc.
+
+* Entry points
+
+- =include/ores.qt/IPlugin.hpp= — plugin interface with lifecycle methods.
+- =include/ores.qt/PluginBase.hpp= — QObject-based IPlugin implementation base.
+- =include/ores.qt/plugin_context.hpp= — login context passed to =on_login=.
+- =include/ores.qt/EntityController.hpp= — base controller class.
+- =include/ores.qt/ClientManager.hpp= — NATS client wrapper.
+
+* Dependencies
+
+- =ores.nats= — NATS transport client.
+- =ores.eventing= — eventing infrastructure for change notifications.
+- =ores.iam.api= — IAM domain types (session, account).
+- =ores.refdata.api= — refdata domain types used in shared pickers.
+- =ores.trading.api= — trading domain types used in shared pickers.
+- =ores.compute.api=, =ores.scheduler.api=, =ores.dq.api=, =ores.http.api=,
+  =ores.assets.api= — domain types for shared UI helpers.
+- =ores.logging=, =ores.utility=, =ores.platform= — infrastructure.
+
+* See also
+
+- [[id:25812E6F-7AD1-36E4-697B-EEC8015C4F1F][ores.qt]] — the application shell (MainWindow) that loads and drives plugins.
+- [[id:e81c7fea-33e4-400a-839a-9d1618bed211][Qt Plugin Architecture]] — full plugin lifecycle and menu-building sequence.
+- [[id:fc186d19-9421-45a2-bbcc-4355d66aa41f][Entity Controller Pattern]] — detailed description of the base class pattern.
+- [[id:C9C24C99-F16C-45BE-A262-1C0F4502765E][ores.nats]] — NATS transport underlying ClientManager.

--- a/projects/ores.qt.api/modeling/ores.qt.api.puml
+++ b/projects/ores.qt.api/modeling/ores.qt.api.puml
@@ -354,9 +354,12 @@ namespace ores #F2F2F2 {
             +system_menu : QMenu*
             +reference_data_menu : QMenu*
             +telemetry_menu : QMenu*
-            +identity_menu : QMenu*
-            +data_transfer_menu : QMenu*
+            +account_menu : QMenu*
+            +data_management_menu : QMenu*
             +trading_codes_menu : QMenu*
+            +analytics_menu : QMenu*
+            +analytics_codes_menu : QMenu*
+            +operations_menu : QMenu*
         }
         class IPlugin {
         }

--- a/projects/ores.qt.compute/include/ores.qt/ComputePlugin.hpp
+++ b/projects/ores.qt.compute/include/ores.qt/ComputePlugin.hpp
@@ -55,7 +55,7 @@ public:
     ~ComputePlugin() override;
 
     QString name() const override { return QStringLiteral("ores.qt.compute"); }
-    int load_order() const override { return 400; }
+    int load_order() const override { return 355; }
 
     void on_login(const plugin_context& ctx) override;
     void setup_menus(const shared_menus_context& ctx) override;

--- a/projects/ores.qt.compute/modeling/component_overview.org
+++ b/projects/ores.qt.compute/modeling/component_overview.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: 03eae018-5e61-4005-ac9a-eff827a46178
+:END:
+#+title: ores.qt.compute
+#+description: Qt plugin for compute/reporting UI — report definitions, instances, apps, compute dashboard, and concurrency policies.
+#+type: component
+#+level: cross
+#+filetags: :qt:compute:reporting:ui:component:
+#+created: 2026-05-20
+#+updated: 2026-05-20
+
+* Summary
+
+=ores.qt.compute= is the Qt plugin for the compute and reporting domain.
+It provides MDI windows and dialogs for report definitions, report instances,
+apps, app versions, batches, workunits, hosts, and queues, plus a Compute
+Dashboard and Compute Console for monitoring running jobs. It contributes
+report-related items to the Analytics menu (owned by =ores.qt.analytics=) and
+code types (Report Types, Concurrency Policies) to the Analytics Codes submenu.
+It also contributes Service Dashboard and Message Queue views to the System menu.
+
+* Inputs
+
+- NATS responses from the compute, reporting, scheduling, workflow, and
+  controller services.
+- User interactions: submit/cancel reports, launch apps, monitor compute state.
+- =shared_menus_context.analytics_menu= and =analytics_codes_menu= for
+  contributing items during =setup_menus=.
+
+* Outputs
+
+- Rendered MDI windows for compute and reporting entities.
+- NATS request messages to compute, reporting, ore, and controller services.
+- Menu items contributed to the shared Analytics and System menus.
+
+* Entry points
+
+- =include/ores.qt/ComputePlugin.hpp= — plugin class; contributes to Analytics menu.
+- =include/ores.qt/ComputeDashboardController.hpp= — live compute state overview.
+- =include/ores.qt/ComputeConsoleController.hpp= — interactive job console.
+
+* Dependencies
+
+- =ores.qt.api= — IPlugin, base controller/window/dialog classes, ClientManager.
+- =ores.compute.api= — compute domain types and NATS schemas.
+- =ores.scheduler.api= — scheduling domain types.
+- =ores.reporting.api= — report definition/instance domain types and NATS schemas.
+- =ores.workflow.core= — workflow execution types used in compute coordination.
+- =ores.ore.core= — ORE model types for report payload construction.
+- =ores.ore.api= — ORE API types.
+- =ores.controller.api= — service dashboard and system monitor types.
+
+* See also
+
+- [[id:a59e121a-b8fb-43f0-a5cd-1fa5f426e66a][ores.compute.api]] — compute domain types and NATS protocol schemas.
+- [[id:e5ac5738-0694-494e-823e-0322f4902ad2][ores.reporting.api]] — report domain types and NATS protocol schemas.
+- [[id:b49ed6e9-20dc-421f-a0f9-d7eab6b54f9b][ores.scheduler.api]] — scheduling domain types.
+- [[id:0f93b352-f234-4d9d-82e6-05218be645e8][ores.ore.api]] — ORE model integration types.
+- [[id:9a71f1f5-c3ed-4c07-9d7d-c5b42d4a1332][ores.ore.core]] — ORE XML import/export and risk engine integration.
+- [[id:970667d1-8ba8-4b49-b047-0d6d4c4ce498][ores.qt.analytics]] — owns the Analytics menu that compute contributes to.
+- [[id:30a3a7f4-e1a9-42fb-af9d-ff36fa0f3d21][ores.qt.api]] — shared Qt infrastructure and base classes.
+- [[id:e81c7fea-33e4-400a-839a-9d1618bed211][Qt Plugin Architecture]] — plugin lifecycle and menu-contribution model.

--- a/projects/ores.qt.compute/src/ComputePlugin.cpp
+++ b/projects/ores.qt.compute/src/ComputePlugin.cpp
@@ -147,106 +147,112 @@ void ComputePlugin::on_login(const plugin_context& ctx) {
 
 void ComputePlugin::setup_menus(const shared_menus_context& smc) {
     BOOST_LOG_SEV(lg(), debug) << "Registering entries in shared menus."
+        << " analytics=" << (smc.analytics_menu ? "ok" : "null")
         << " system=" << (smc.system_menu ? "ok" : "null")
         << " telemetry=" << (smc.telemetry_menu ? "ok" : "null");
-    if (!smc.system_menu || !smc.telemetry_menu)
-        return;
 
-    auto* telemetryAction = smc.telemetry_menu->menuAction();
+    // ---- Analytics menu: reporting + compute items ----------------------
+    if (smc.analytics_menu) {
+        smc.analytics_menu->addSeparator();
+
+        act_report_definitions_ = smc.analytics_menu->addAction(
+            ico(Icon::ChartMultiple), tr("Report &Definitions"));
+        connect(act_report_definitions_, &QAction::triggered, this, [this]() {
+            if (reportDefinitionController_)
+                reportDefinitionController_->showListWindow();
+        });
+
+        act_report_instances_ = smc.analytics_menu->addAction(
+            ico(Icon::Record), tr("Report &Instances"));
+        connect(act_report_instances_, &QAction::triggered, this, [this]() {
+            if (reportInstanceController_)
+                reportInstanceController_->showListWindow();
+        });
+
+        smc.analytics_menu->addSeparator();
+
+        auto* actDashboard = smc.analytics_menu->addAction(
+            ico(Icon::Chart), tr("&Dashboard"));
+        connect(actDashboard, &QAction::triggered, this, [this]() {
+            if (computeDashboardController_)
+                computeDashboardController_->showDashboard();
+        });
+
+        auto* actConsole = smc.analytics_menu->addAction(
+            ico(Icon::ServerLink), tr("&Console"));
+        connect(actConsole, &QAction::triggered, this, [this]() {
+            if (computeConsoleController_)
+                computeConsoleController_->showConsole();
+        });
+
+        smc.analytics_menu->addSeparator();
+
+        auto* actApps = smc.analytics_menu->addAction(
+            ico(Icon::TasksApp), tr("&Apps"));
+        connect(actApps, &QAction::triggered, this, [this]() {
+            if (appController_) appController_->showListWindow();
+        });
+
+        auto* actAppVersions = smc.analytics_menu->addAction(
+            ico(Icon::TasksApp), tr("App &Versions"));
+        connect(actAppVersions, &QAction::triggered, this, [this]() {
+            if (appVersionController_) appVersionController_->showListWindow();
+        });
+    }
+
+    // ---- Analytics Codes: report types + concurrency policies -----------
+    if (smc.analytics_codes_menu) {
+        auto* actReportTypes = smc.analytics_codes_menu->addAction(
+            ico(Icon::Chart), tr("Report &Types"));
+        connect(actReportTypes, &QAction::triggered, this, [this]() {
+            if (reportTypeController_) reportTypeController_->showListWindow();
+        });
+
+        auto* actConcurrencyPolicies = smc.analytics_codes_menu->addAction(
+            ico(Icon::Settings), tr("&Concurrency Policies"));
+        connect(actConcurrencyPolicies, &QAction::triggered, this, [this]() {
+            if (concurrencyPolicyController_)
+                concurrencyPolicyController_->showListWindow();
+        });
+    }
 
     // ---- System > Message Queue (before Telemetry) -----------------------
-    auto* msgQueue = new QMenu(tr("&Message Queue"), smc.system_menu);
-    smc.system_menu->insertMenu(telemetryAction, msgQueue);
+    if (smc.system_menu && smc.telemetry_menu) {
+        auto* telemetryAction = smc.telemetry_menu->menuAction();
 
-    auto* actQueueMonitor = msgQueue->addAction(ico(Icon::Server), tr("&Queue Monitor"));
-    connect(actQueueMonitor, &QAction::triggered, this, [this]() {
-        if (queueMonitorController_) queueMonitorController_->showListWindow();
-    });
+        auto* msgQueue = new QMenu(tr("&Message Queue"), smc.system_menu);
+        smc.system_menu->insertMenu(telemetryAction, msgQueue);
 
-    // ---- System > Telemetry > Service Dashboard (first item) ------------
-    auto* firstTelemetryAction = smc.telemetry_menu->actions().isEmpty()
-        ? nullptr : smc.telemetry_menu->actions().first();
+        auto* actQueueMonitor = msgQueue->addAction(ico(Icon::Server), tr("&Queue Monitor"));
+        connect(actQueueMonitor, &QAction::triggered, this, [this]() {
+            if (queueMonitorController_) queueMonitorController_->showListWindow();
+        });
 
-    auto* actServiceDashboard = new QAction(ico(Icon::Chart), tr("&Service Dashboard..."), this);
-    connect(actServiceDashboard, &QAction::triggered, this, [this]() {
-        if (serviceDashboardController_) serviceDashboardController_->showDashboard();
-    });
+        // ---- System > Telemetry > Service Dashboard (first item) --------
+        auto* firstTelemetryAction = smc.telemetry_menu->actions().isEmpty()
+            ? nullptr : smc.telemetry_menu->actions().first();
 
-    if (firstTelemetryAction) {
-        smc.telemetry_menu->insertAction(firstTelemetryAction, actServiceDashboard);
-        auto* sep = new QAction(this);
-        sep->setSeparator(true);
-        smc.telemetry_menu->insertAction(firstTelemetryAction, sep);
-    } else {
-        smc.telemetry_menu->addAction(actServiceDashboard);
+        auto* actServiceDashboard = new QAction(
+            ico(Icon::Chart), tr("&Service Dashboard..."), this);
+        connect(actServiceDashboard, &QAction::triggered, this, [this]() {
+            if (serviceDashboardController_)
+                serviceDashboardController_->showDashboard();
+        });
+
+        if (firstTelemetryAction) {
+            smc.telemetry_menu->insertAction(firstTelemetryAction, actServiceDashboard);
+            auto* sep = new QAction(this);
+            sep->setSeparator(true);
+            smc.telemetry_menu->insertAction(firstTelemetryAction, sep);
+        } else {
+            smc.telemetry_menu->addAction(actServiceDashboard);
+        }
     }
 }
 
 QList<QMenu*> ComputePlugin::create_menus() {
-    BOOST_LOG_SEV(lg(), debug) << "Building plugin menus.";
-    QList<QMenu*> menus;
-
-    // ---- Compute --------------------------------------------------------
-    auto* menuCompute = new QMenu(tr("&Compute"));
-
-    auto* actDashboard = menuCompute->addAction(ico(Icon::Chart), tr("&Dashboard"));
-    connect(actDashboard, &QAction::triggered, this, [this]() {
-        if (computeDashboardController_) computeDashboardController_->showDashboard();
-    });
-
-    auto* actConsole = menuCompute->addAction(ico(Icon::ServerLink), tr("&Console"));
-    connect(actConsole, &QAction::triggered, this, [this]() {
-        if (computeConsoleController_) computeConsoleController_->showConsole();
-    });
-
-    menuCompute->addSeparator();
-
-    auto* actApps = menuCompute->addAction(ico(Icon::TasksApp), tr("&Apps"));
-    connect(actApps, &QAction::triggered, this, [this]() {
-        if (appController_) appController_->showListWindow();
-    });
-
-    auto* actAppVersions = menuCompute->addAction(ico(Icon::TasksApp), tr("App &Versions"));
-    connect(actAppVersions, &QAction::triggered, this, [this]() {
-        if (appVersionController_) appVersionController_->showListWindow();
-    });
-
-    // ---- Reporting (inserted before Compute in the menu bar) ------------
-    auto* menuReporting = new QMenu(tr("&Reporting"));
-
-    act_report_definitions_ = menuReporting->addAction(
-        ico(Icon::ChartMultiple), tr("Report &Definitions"));
-    connect(act_report_definitions_, &QAction::triggered, this, [this]() {
-        if (reportDefinitionController_) reportDefinitionController_->showListWindow();
-    });
-
-    act_report_instances_ = menuReporting->addAction(ico(Icon::Record), tr("Report &Instances"));
-    connect(act_report_instances_, &QAction::triggered, this, [this]() {
-        if (reportInstanceController_) reportInstanceController_->showListWindow();
-    });
-
-    menuReporting->addSeparator();
-
-    // ---- Reporting Codes submenu ----------------------------------------
-    auto* menuReportingCodes = menuReporting->addMenu(tr("Reporting &Codes"));
-
-    auto* actReportTypes = menuReportingCodes->addAction(ico(Icon::Chart), tr("Report &Types"));
-    connect(actReportTypes, &QAction::triggered, this, [this]() {
-        if (reportTypeController_) reportTypeController_->showListWindow();
-    });
-
-    auto* actConcurrencyPolicies = menuReportingCodes->addAction(
-        ico(Icon::Settings), tr("&Concurrency Policies"));
-    connect(actConcurrencyPolicies, &QAction::triggered, this, [this]() {
-        if (concurrencyPolicyController_) concurrencyPolicyController_->showListWindow();
-    });
-
-    // Return Reporting before Compute so Reporting appears first in the menu bar.
-    menus.append(menuReporting);
-    menus.append(menuCompute);
-
-    BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
-    return menus;
+    BOOST_LOG_SEV(lg(), debug) << "All items contributed via setup_menus — no standalone menus.";
+    return {};
 }
 
 QList<QAction*> ComputePlugin::toolbar_actions() {

--- a/projects/ores.qt.data_transfer/include/ores.qt/DataTransferPlugin.hpp
+++ b/projects/ores.qt.data_transfer/include/ores.qt/DataTransferPlugin.hpp
@@ -25,11 +25,11 @@
 namespace ores::qt {
 
 /**
- * @brief Qt plugin providing the Data Transfer top-level menu.
+ * @brief Qt plugin providing the Data Management top-level menu.
  *
- * Owns the pre-created data_transfer_menu handle. All menu items are
- * contributed by peer plugins (RefdataPlugin, TradingPlugin) via setup_menus.
- * Loaded as a shared library by QPluginLoader at application startup.
+ * Owns the pre-created data_management_menu handle. Items are contributed
+ * by RefdataPlugin (Data Catalogue + Librarian), TradingPlugin (Import),
+ * and WorkspacePlugin (Manage Workspaces) via setup_menus.
  */
 class DataTransferPlugin : public PluginBase {
     Q_OBJECT
@@ -51,9 +51,9 @@ public:
 private:
     plugin_context ctx_;
 
-    // The data_transfer_menu is pre-created by MainWindow and passed via
+    // The data_management_menu is pre-created by MainWindow and passed via
     // setup_menus context. We hold a reference to return it from create_menus.
-    QMenu* data_transfer_menu_{nullptr};
+    QMenu* data_management_menu_{nullptr};
 };
 
 }

--- a/projects/ores.qt.data_transfer/modeling/component_overview.org
+++ b/projects/ores.qt.data_transfer/modeling/component_overview.org
@@ -1,0 +1,47 @@
+:PROPERTIES:
+:ID: 92492264-b67a-4ac7-8a58-7d706d9f0dab
+:END:
+#+title: ores.qt.data_transfer
+#+description: Qt plugin that owns the Data Management top-level menu and coordinates item contributions from sibling plugins.
+#+type: component
+#+level: cross
+#+filetags: :qt:data_management:ui:component:
+#+created: 2026-05-20
+#+updated: 2026-05-20
+
+* Summary
+
+=ores.qt.data_transfer= is the Qt plugin that owns the Data Management
+top-level menu. It pre-creates the menu handle and passes it via
+=shared_menus_context= to all other plugins during the =setup_menus= phase.
+Sibling plugins contribute their own items: =ores.qt.refdata= adds Data
+Catalogue and Data Librarian, =ores.qt.trading= adds Import ORE Data, and
+=ores.qt.workspace= adds Manage Workspaces. The plugin has no domain entities
+or controllers of its own.
+
+* Inputs
+
+- =shared_menus_context= populated by =MainWindow= with the pre-created
+  =data_management_menu= pointer.
+- Items contributed to the menu by sibling plugins via =setup_menus=.
+
+* Outputs
+
+- Data Management top-level menu (returned via =create_menus=) for insertion
+  into the application menu bar.
+
+* Entry points
+
+- =include/ores.qt/DataTransferPlugin.hpp= — plugin class; menu owner.
+
+* Dependencies
+
+- =ores.qt.api= — IPlugin, PluginBase, shared_menus_context.
+
+* See also
+
+- [[id:621194c4-d438-4215-ae40-21fbe8ff0d85][ores.qt.refdata]] — contributes Data Catalogue and Data Librarian items.
+- [[id:3fa355d1-38fd-4e35-9e05-2185882b8ac1][ores.qt.trading]] — contributes Import ORE Data item.
+- [[id:31d9c75a-de71-4b98-9d33-d8ed86000c94][ores.qt.workspace]] — contributes Manage Workspaces item.
+- [[id:30a3a7f4-e1a9-42fb-af9d-ff36fa0f3d21][ores.qt.api]] — shared Qt infrastructure and base classes.
+- [[id:e81c7fea-33e4-400a-839a-9d1618bed211][Qt Plugin Architecture]] — plugin lifecycle and the two-phase menu sequence.

--- a/projects/ores.qt.data_transfer/src/DataTransferPlugin.cpp
+++ b/projects/ores.qt.data_transfer/src/DataTransferPlugin.cpp
@@ -48,22 +48,19 @@ void DataTransferPlugin::on_login(const plugin_context& ctx) {
 }
 
 void DataTransferPlugin::setup_menus(const shared_menus_context& smc) {
-    BOOST_LOG_SEV(lg(), debug) << "Capturing shared Data Transfer menu handle."
-        << " data_transfer=" << (smc.data_transfer_menu ? "ok" : "null");
-    // Save reference so create_menus() can return the pre-created menu.
-    // RefdataPlugin and TradingPlugin contribute actions during their own
-    // setup_menus calls.
-    data_transfer_menu_ = smc.data_transfer_menu;
+    BOOST_LOG_SEV(lg(), debug) << "Capturing shared Data Management menu handle."
+        << " data_management=" << (smc.data_management_menu ? "ok" : "null");
+    data_management_menu_ = smc.data_management_menu;
 }
 
 QList<QMenu*> DataTransferPlugin::create_menus() {
     BOOST_LOG_SEV(lg(), debug) << "Building plugin menus."
-        << " data_transfer_menu=" << (data_transfer_menu_ ? "ok" : "null");
-    if (!data_transfer_menu_) {
-        BOOST_LOG_SEV(lg(), warn) << "Data Transfer menu handle is missing — no menu will appear.";
+        << " data_management_menu=" << (data_management_menu_ ? "ok" : "null");
+    if (!data_management_menu_) {
+        BOOST_LOG_SEV(lg(), warn) << "Data Management menu handle is missing — no menu will appear.";
         return {};
     }
-    return {data_transfer_menu_};
+    return {data_management_menu_};
 }
 
 void DataTransferPlugin::on_logout() {

--- a/projects/ores.qt.mktdata/CMakeLists.txt
+++ b/projects/ores.qt.mktdata/CMakeLists.txt
@@ -15,4 +15,5 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
 # Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
-add_subdirectory(src)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/modeling)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/projects/ores.qt.mktdata/modeling/component_overview.org
+++ b/projects/ores.qt.mktdata/modeling/component_overview.org
@@ -1,0 +1,52 @@
+:PROPERTIES:
+:ID: 2e83f9b5-67f4-4a1f-95bc-fe1e7ab7d4c0
+:END:
+#+title: ores.qt.mktdata
+#+description: Qt plugin for market data UI — market series, fixings, observations, and currency market tiers.
+#+type: component
+#+level: cross
+#+filetags: :qt:marketdata:ui:component:
+#+created: 2026-05-20
+#+updated: 2026-05-20
+
+* Summary
+
+=ores.qt.mktdata= is the Qt plugin for the market data domain. It provides
+MDI windows and dialogs for browsing and managing market series, market
+fixings, market observations, and currency market tiers. Market data is
+read-heavy; the plugin surfaces time-series data for curves and fixings
+consumed by the analytics and compute layers.
+
+* Inputs
+
+- NATS responses from the market data service (market series, fixings,
+  observations, currency market tiers).
+- User interactions: browse/view market series and fixing history.
+
+* Outputs
+
+- Rendered MDI windows for market data entities.
+- NATS request messages sent to the market data service on user actions.
+
+* Entry points
+
+- =include/ores.qt/MktdataPlugin.hpp= — plugin class.
+- =include/ores.qt/MarketDataController.hpp= — market data entity controller.
+- =include/ores.qt/CurrencyMarketTierController.hpp= — currency tier controller.
+
+* Dependencies
+
+- =ores.qt.api= — IPlugin, base controller/window/dialog classes, ClientManager.
+- =ores.marketdata.api= — market series, fixing, observation domain types and NATS schemas.
+- =ores.refdata.api= — reference data types (currencies) used in market series.
+- =ores.dq.api= — data quality types used in market data validation.
+- =ores.storage= — storage abstraction for market data persistence.
+
+* See also
+
+- [[id:6a62d943-fac9-4b77-9e22-f265557dcf1a][ores.marketdata.api]] — domain types and NATS protocol schemas for market data.
+- [[id:654be6cd-d212-4ee5-a7b4-8af125787522][ores.refdata.api]] — reference data types (currencies) consumed by market data.
+- [[id:ffcfc860-204d-4f48-ae34-d3e382d7a02b][ores.dq.api]] — data quality domain types.
+- [[id:30a3a7f4-e1a9-42fb-af9d-ff36fa0f3d21][ores.qt.api]] — shared Qt infrastructure and base classes.
+- [[id:e81c7fea-33e4-400a-839a-9d1618bed211][Qt Plugin Architecture]] — plugin lifecycle and menu sequence.
+- [[id:fc186d19-9421-45a2-bbcc-4355d66aa41f][Entity Controller Pattern]] — controller/window/dialog/model structure.

--- a/projects/ores.qt.party/CMakeLists.txt
+++ b/projects/ores.qt.party/CMakeLists.txt
@@ -15,4 +15,5 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
 # Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
-add_subdirectory(src)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/modeling)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/projects/ores.qt.party/include/ores.qt/PartyPlugin.hpp
+++ b/projects/ores.qt.party/include/ores.qt/PartyPlugin.hpp
@@ -42,7 +42,7 @@ class BusinessUnitTypeController;
  *        centres, business units, and related type tables.
  *
  * Loaded as a shared library by QPluginLoader at application startup.
- * Owns the Entities top-level menu.
+ * Contributes to the shared Reference Data menu; no standalone menu.
  */
 class PartyPlugin : public PluginBase {
     Q_OBJECT
@@ -54,9 +54,10 @@ public:
     ~PartyPlugin() override;
 
     QString name() const override { return QStringLiteral("ores.qt.party"); }
-    int load_order() const override { return 150; }  // owns the Entities top-level menu
+    int load_order() const override { return 105; }  // after RefdataPlugin (100)
 
     void on_login(const plugin_context& ctx) override;
+    void setup_menus(const shared_menus_context& ctx) override;
     QList<QMenu*> create_menus() override;
     QList<QAction*> toolbar_actions() override;
     void on_logout() override;

--- a/projects/ores.qt.party/modeling/component_overview.org
+++ b/projects/ores.qt.party/modeling/component_overview.org
@@ -1,0 +1,54 @@
+:PROPERTIES:
+:ID: 6de9a7b8-f7ba-4e93-bb93-2fb10c53f9ca
+:END:
+#+title: ores.qt.party
+#+description: Qt plugin for party/organisation UI — parties, counterparties, business units, business centres, and organisation codes.
+#+type: component
+#+level: cross
+#+filetags: :qt:party:organisation:ui:component:
+#+created: 2026-05-20
+#+updated: 2026-05-20
+
+* Summary
+
+=ores.qt.party= is the Qt plugin for the party and organisation domain. It
+provides MDI windows and dialogs for managing parties, counterparties, business
+units, and business centres, and their supporting code types (party types,
+party statuses, party ID schemes, contact types, and business unit types). It
+contributes its entity actions to the Reference Data menu (owned by
+=ores.qt.refdata=) via the =setup_menus= phase.
+
+* Inputs
+
+- NATS responses for party, counterparty, business unit, business centre, and
+  organisation code entities.
+- User interactions: create/edit/delete/view-history on party entities.
+- =shared_menus_context.reference_data_menu= pointer for contributing items.
+
+* Outputs
+
+- Rendered MDI windows for party and organisation entities.
+- NATS request messages sent to the relevant party services on user actions.
+- Parties, Counterparties, Business Centres, Business Units, and Organisation
+  Codes submenu items contributed to the Reference Data menu.
+
+* Entry points
+
+- =include/ores.qt/PartyPlugin.hpp= — plugin class; contributes to Reference Data menu.
+- =include/ores.qt/PartyController.hpp= — party entity controller.
+- =include/ores.qt/CounterpartyController.hpp= — counterparty entity controller.
+- =include/ores.qt/BusinessUnitController.hpp= — business unit controller.
+
+* Dependencies
+
+- =ores.qt.api= — IPlugin, base controller/window/dialog classes, ClientManager.
+- =ores.refdata.api= — reference data domain types used in party classification.
+- =ores.storage= — storage abstraction for party data persistence.
+
+* See also
+
+- [[id:654be6cd-d212-4ee5-a7b4-8af125787522][ores.refdata.api]] — reference data domain types shared with party entities.
+- [[id:621194c4-d438-4215-ae40-21fbe8ff0d85][ores.qt.refdata]] — owns the Reference Data menu that party contributes to.
+- [[id:30a3a7f4-e1a9-42fb-af9d-ff36fa0f3d21][ores.qt.api]] — shared Qt infrastructure and base classes.
+- [[id:e81c7fea-33e4-400a-839a-9d1618bed211][Qt Plugin Architecture]] — plugin lifecycle and menu-contribution model.
+- [[id:fc186d19-9421-45a2-bbcc-4355d66aa41f][Entity Controller Pattern]] — controller/window/dialog/model structure.

--- a/projects/ores.qt.party/src/PartyPlugin.cpp
+++ b/projects/ores.qt.party/src/PartyPlugin.cpp
@@ -107,65 +107,73 @@ void PartyPlugin::on_login(const plugin_context& ctx) {
 }
 
 // ---------------------------------------------------------------------------
-// IPlugin::create_menus — return the standalone Entities menu.
+// IPlugin::setup_menus — contribute Organisation section to Reference Data.
 // ---------------------------------------------------------------------------
-QList<QMenu*> PartyPlugin::create_menus() {
-    BOOST_LOG_SEV(lg(), debug) << "Building plugin menus.";
+void PartyPlugin::setup_menus(const shared_menus_context& smc) {
+    BOOST_LOG_SEV(lg(), debug) << "Registering entries in shared menus."
+        << " reference_data=" << (smc.reference_data_menu ? "ok" : "null");
+    auto* ref = smc.reference_data_menu;
+    if (!ref)
+        return;
+
     using IC = IconUtils;
     auto ico = [](Icon i) { return IC::createRecoloredIcon(i, IC::DefaultIconColor); };
 
-    auto* menuEntities = new QMenu(tr("&Organisation"));
+    ref->addSeparator();
 
-    act_parties_ = menuEntities->addAction(ico(Icon::Organization), tr("&Parties"));
+    act_parties_ = ref->addAction(ico(Icon::Organization), tr("&Parties"));
     connect(act_parties_, &QAction::triggered, this, [this]() {
         if (partyController_) partyController_->showListWindow();
     });
-    act_counterparties_ = menuEntities->addAction(ico(Icon::Handshake), tr("&Counterparties"));
+    act_counterparties_ = ref->addAction(ico(Icon::Handshake), tr("&Counterparties"));
     connect(act_counterparties_, &QAction::triggered, this, [this]() {
         if (counterpartyController_) counterpartyController_->showListWindow();
     });
 
-    menuEntities->addSeparator();
+    ref->addSeparator();
 
-    act_business_centres_ = menuEntities->addAction(
-        ico(Icon::BuildingBank), tr("&Business Centres"));
+    act_business_centres_ = ref->addAction(ico(Icon::BuildingBank), tr("&Business Centres"));
     connect(act_business_centres_, &QAction::triggered, this, [this]() {
         if (businessCentreController_) businessCentreController_->showListWindow();
     });
-    act_business_units_ = menuEntities->addAction(ico(Icon::PeopleTeam), tr("Business &Units"));
+    act_business_units_ = ref->addAction(ico(Icon::PeopleTeam), tr("Business &Units"));
     connect(act_business_units_, &QAction::triggered, this, [this]() {
         if (businessUnitController_) businessUnitController_->showListWindow();
     });
 
-    menuEntities->addSeparator();
+    ref->addSeparator();
 
-    // Organisation code tables
-    auto* menuEntityTypes = menuEntities->addMenu(tr("Organisation &Codes"));
-    auto* actPartyTypes = menuEntityTypes->addAction(ico(Icon::Tag), tr("Party &Types"));
+    auto* menuOrgCodes = ref->addMenu(tr("Organisation &Codes"));
+    auto* actPartyTypes = menuOrgCodes->addAction(ico(Icon::Tag), tr("Party &Types"));
     connect(actPartyTypes, &QAction::triggered, this, [this]() {
         if (partyTypeController_) partyTypeController_->showListWindow();
     });
-    auto* actPartyStatuses = menuEntityTypes->addAction(ico(Icon::Flag), tr("Party &Statuses"));
+    auto* actPartyStatuses = menuOrgCodes->addAction(ico(Icon::Flag), tr("Party &Statuses"));
     connect(actPartyStatuses, &QAction::triggered, this, [this]() {
         if (partyStatusController_) partyStatusController_->showListWindow();
     });
-    auto* actPartyIdSchemes = menuEntityTypes->addAction(ico(Icon::Key), tr("Party &ID Schemes"));
+    auto* actPartyIdSchemes = menuOrgCodes->addAction(ico(Icon::Key), tr("Party &ID Schemes"));
     connect(actPartyIdSchemes, &QAction::triggered, this, [this]() {
         if (partyIdSchemeController_) partyIdSchemeController_->showListWindow();
     });
-    auto* actContactTypes = menuEntityTypes->addAction(
+    auto* actContactTypes = menuOrgCodes->addAction(
         ico(Icon::PersonAccounts), tr("&Contact Types"));
     connect(actContactTypes, &QAction::triggered, this, [this]() {
         if (contactTypeController_) contactTypeController_->showListWindow();
     });
-    auto* actBizUnitTypes = menuEntityTypes->addAction(
+    auto* actBizUnitTypes = menuOrgCodes->addAction(
         ico(Icon::PeopleTeam), tr("Business Unit &Types"));
     connect(actBizUnitTypes, &QAction::triggered, this, [this]() {
         if (businessUnitTypeController_) businessUnitTypeController_->showListWindow();
     });
+}
 
-    BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
-    return {menuEntities};
+// ---------------------------------------------------------------------------
+// IPlugin::create_menus — no standalone menu; all items in Reference Data.
+// ---------------------------------------------------------------------------
+QList<QMenu*> PartyPlugin::create_menus() {
+    BOOST_LOG_SEV(lg(), debug) << "All items contributed via setup_menus — no standalone menus.";
+    return {};
 }
 
 QList<QAction*> PartyPlugin::toolbar_actions() {

--- a/projects/ores.qt.refdata/CMakeLists.txt
+++ b/projects/ores.qt.refdata/CMakeLists.txt
@@ -15,4 +15,5 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
 # Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
-add_subdirectory(src)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/modeling)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/projects/ores.qt.refdata/include/ores.qt/RefdataPlugin.hpp
+++ b/projects/ores.qt.refdata/include/ores.qt/RefdataPlugin.hpp
@@ -92,6 +92,8 @@ private:
 
     plugin_context ctx_;
 
+    QMenu* reference_data_menu_{nullptr};
+
     QAction* act_currencies_{nullptr};
     QAction* act_countries_{nullptr};
     QAction* act_data_librarian_{nullptr};
@@ -125,7 +127,7 @@ private:
     std::unique_ptr<FxConventionController>                fxConventionController_;
     std::unique_ptr<CdsConventionController>               cdsConventionController_;
 
-    // Data Catalogue controllers (owned here, contributed to data_transfer_menu)
+    // Data Catalogue controllers (owned here, contributed to data_management_menu)
     std::unique_ptr<DataDomainController>         dataDomainController_;
     std::unique_ptr<SubjectAreaController>        subjectAreaController_;
     std::unique_ptr<CatalogController>            catalogController_;

--- a/projects/ores.qt.refdata/modeling/component_overview.org
+++ b/projects/ores.qt.refdata/modeling/component_overview.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: 621194c4-d438-4215-ae40-21fbe8ff0d85
+:END:
+#+title: ores.qt.refdata
+#+description: Qt plugin for reference data UI — currencies, countries, trading conventions, coding schemes, datasets, and the data catalogue.
+#+type: component
+#+level: cross
+#+filetags: :qt:refdata:ui:component:
+#+created: 2026-05-20
+#+updated: 2026-05-20
+
+* Summary
+
+=ores.qt.refdata= is the Qt plugin for the reference data domain. It provides
+MDI windows and dialogs for currencies, countries, all trading conventions
+(swap, OIS, FRA, ibor, overnight, CDS, FX, deposit, zero), day count
+fractions, business day convention types, floating index types, payment
+frequency types, coding schemes, datasets, change reasons, and the full data
+catalogue (catalogs, dataset bundles, methodologies, and origin/nature/treatment
+dimensions). It owns the Reference Data top-level menu and the Data Librarian
+window; =ores.qt.party= contributes party-related items to the same menu.
+
+* Inputs
+
+- NATS responses from the refdata and trading services (currencies, countries,
+  conventions, coding schemes, datasets, catalogue entities).
+- User interactions: create/edit/delete/view-history on all refdata entities.
+- =shared_menus_context.reference_data_menu= and =data_management_menu=
+  pointers for menu ownership and contribution.
+
+* Outputs
+
+- Rendered MDI windows for all reference data entities and the Data Librarian.
+- NATS request messages sent to the refdata and trading services on user actions.
+- Reference Data top-level menu (returned via =create_menus=).
+- Data Catalogue and Data Librarian items contributed to the Data Management menu.
+
+* Entry points
+
+- =include/ores.qt/RefdataPlugin.hpp= — plugin class; owns Reference Data menu.
+- =include/ores.qt/CurrencyController.hpp= — currency entity controller.
+- =include/ores.qt/SwapConventionController.hpp= — swap convention controller.
+- =include/ores.qt/CatalogController.hpp= — data catalogue controller.
+
+* Dependencies
+
+- =ores.qt.api= — IPlugin, base controller/window/dialog classes, ClientManager.
+- =ores.refdata.api= — reference data domain types and NATS schemas.
+- =ores.trading.api= — trading convention domain types and NATS schemas.
+- =ores.ore.core= — ORE model types used in convention configuration.
+- =ores.variability.api= — variability types referenced in some refdata entities.
+- =ores.dq.api= — data quality types used in dataset management.
+- =ores.storage= — storage abstraction for refdata persistence.
+
+* See also
+
+- [[id:654be6cd-d212-4ee5-a7b4-8af125787522][ores.refdata.api]] — domain types and NATS protocol schemas for reference data.
+- [[id:fd34a3b5-0e24-467a-a9d7-a2f2e7480e1b][ores.trading.api]] — trading convention domain types and NATS schemas.
+- [[id:9a71f1f5-c3ed-4c07-9d7d-c5b42d4a1332][ores.ore.core]] — ORE model types used in convention configuration.
+- [[id:6de9a7b8-f7ba-4e93-bb93-2fb10c53f9ca][ores.qt.party]] — contributes party items to the Reference Data menu.
+- [[id:92492264-b67a-4ac7-8a58-7d706d9f0dab][ores.qt.data_transfer]] — receives Data Catalogue and Data Librarian items.
+- [[id:30a3a7f4-e1a9-42fb-af9d-ff36fa0f3d21][ores.qt.api]] — shared Qt infrastructure and base classes.
+- [[id:e81c7fea-33e4-400a-839a-9d1618bed211][Qt Plugin Architecture]] — plugin lifecycle and menu-contribution model.
+- [[id:fc186d19-9421-45a2-bbcc-4355d66aa41f][Entity Controller Pattern]] — controller/window/dialog/model structure.

--- a/projects/ores.qt.refdata/src/RefdataPlugin.cpp
+++ b/projects/ores.qt.refdata/src/RefdataPlugin.cpp
@@ -267,13 +267,14 @@ void RefdataPlugin::on_login(const plugin_context& ctx) {
 void RefdataPlugin::setup_menus(const shared_menus_context& smc) {
     BOOST_LOG_SEV(lg(), debug) << "Registering entries in shared menus."
         << " reference_data=" << (smc.reference_data_menu ? "ok" : "null")
-        << " data_transfer=" << (smc.data_transfer_menu ? "ok" : "null")
+        << " data_management=" << (smc.data_management_menu ? "ok" : "null")
         << " trading_codes=" << (smc.trading_codes_menu ? "ok" : "null");
     using IC = IconUtils;
     auto ico = [](Icon i) { return IC::createRecoloredIcon(i, IC::DefaultIconColor); };
 
     // ---- Reference Data menu --------------------------------------------
-    auto* ref = smc.reference_data_menu;
+    reference_data_menu_ = smc.reference_data_menu;
+    auto* ref = reference_data_menu_;
     if (ref) {
         act_currencies_ = ref->addAction(ico(Icon::Currency), tr("&Currencies"));
         connect(act_currencies_, &QAction::triggered, this, [this]() {
@@ -415,8 +416,8 @@ void RefdataPlugin::setup_menus(const shared_menus_context& smc) {
         });
     }
 
-    // ---- Data Transfer menu — contribute Data Catalogue submenu + Data Librarian
-    auto* dt = smc.data_transfer_menu;
+    // ---- Data Management menu — contribute Data Catalogue submenu + Data Librarian
+    auto* dt = smc.data_management_menu;
     if (dt) {
         auto* menuCatalogue = dt->addMenu(tr("Data Ca&talogue"));
 
@@ -515,8 +516,10 @@ void RefdataPlugin::setup_menus(const shared_menus_context& smc) {
 
 // ---------------------------------------------------------------------------
 QList<QMenu*> RefdataPlugin::create_menus() {
-    BOOST_LOG_SEV(lg(), debug) << "No standalone menus — all entries contributed via shared menus.";
-    return {};  // all items contributed to the shared Reference Data menu
+    BOOST_LOG_SEV(lg(), debug) << "Returning pre-created Reference Data menu.";
+    if (!reference_data_menu_)
+        BOOST_LOG_SEV(lg(), warn) << "Reference Data menu not initialised via setup_menus.";
+    return reference_data_menu_ ? QList<QMenu*>{reference_data_menu_} : QList<QMenu*>{};
 }
 
 QList<QAction*> RefdataPlugin::toolbar_actions() {

--- a/projects/ores.qt.scheduler/include/ores.qt/SchedulerPlugin.hpp
+++ b/projects/ores.qt.scheduler/include/ores.qt/SchedulerPlugin.hpp
@@ -30,12 +30,11 @@ class JobInstanceController;
 class SchedulerMonitorController;
 
 /**
- * @brief Qt plugin providing the top-level &Scheduler menu.
+ * @brief Qt plugin providing the Operations menu (job scheduling half).
  *
- * Owns all three scheduler UI controllers:
- *   - JobDefinitionController  — &Job Definitions
- *   - JobInstanceController    — &Job Instances
- *   - SchedulerMonitorController — &Monitor
+ * setup_menus() seeds the pre-created Operations menu with Job items;
+ * create_menus() returns the populated menu for bar insertion.
+ * WorkflowPlugin (load_order 365) appends the Workflow section after.
  */
 class SchedulerPlugin : public PluginBase {
     Q_OBJECT
@@ -50,11 +49,14 @@ public:
     int load_order() const override { return 360; }
 
     void on_login(const plugin_context& ctx) override;
+    void setup_menus(const shared_menus_context& ctx) override;
     QList<QMenu*> create_menus() override;
     void on_logout() override;
 
 private:
     plugin_context ctx_;
+
+    QMenu* operations_menu_{nullptr};
 
     std::unique_ptr<JobDefinitionController>     jobDefinitionController_;
     std::unique_ptr<JobInstanceController>       jobInstanceController_;

--- a/projects/ores.qt.scheduler/modeling/component_overview.org
+++ b/projects/ores.qt.scheduler/modeling/component_overview.org
@@ -1,0 +1,52 @@
+:PROPERTIES:
+:ID: 4092e7e6-c663-4e5e-b330-63bfece7ca51
+:END:
+#+title: ores.qt.scheduler
+#+description: Qt plugin for job scheduling UI — job definitions, job instances, and the scheduler monitor.
+#+type: component
+#+level: cross
+#+filetags: :qt:scheduler:ui:component:
+#+created: 2026-05-20
+#+updated: 2026-05-20
+
+* Summary
+
+=ores.qt.scheduler= is the Qt plugin for the job scheduling domain. It
+provides MDI windows and dialogs for managing job definitions, viewing and
+managing job instances, and the Scheduler Monitor for live job-state
+inspection. It owns the Operations top-level menu and contributes the
+job-related items (Job Definitions, Job Instances, Job Monitor) to it;
+=ores.qt.workflow= contributes workflow items to the same menu.
+
+* Inputs
+
+- NATS responses from the scheduler service (job definitions, job instances,
+  job state events).
+- User interactions: create/edit job definitions, monitor/cancel job instances.
+- =shared_menus_context.operations_menu= pointer for menu ownership.
+
+* Outputs
+
+- Rendered MDI windows for job definition, job instance, and scheduler monitor.
+- NATS request messages sent to the scheduler service on user actions.
+- Operations top-level menu (returned via =create_menus=).
+
+* Entry points
+
+- =include/ores.qt/SchedulerPlugin.hpp= — plugin class; owns Operations menu.
+- =include/ores.qt/JobDefinitionController.hpp= — job definition controller.
+- =include/ores.qt/JobInstanceController.hpp= — job instance controller.
+- =include/ores.qt/SchedulerMonitorController.hpp= — live job-state monitor.
+
+* Dependencies
+
+- =ores.qt.api= — IPlugin, base controller/window/dialog classes, ClientManager.
+- =ores.scheduler.api= — job definition and instance domain types and NATS schemas.
+
+* See also
+
+- [[id:b49ed6e9-20dc-421f-a0f9-d7eab6b54f9b][ores.scheduler.api]] — domain types and NATS protocol schemas for scheduling.
+- [[id:b7269e9c-83b6-4d6c-80de-d796ab89b1bd][ores.qt.workflow]] — contributes workflow items to the Operations menu.
+- [[id:30a3a7f4-e1a9-42fb-af9d-ff36fa0f3d21][ores.qt.api]] — shared Qt infrastructure and base classes.
+- [[id:e81c7fea-33e4-400a-839a-9d1618bed211][Qt Plugin Architecture]] — plugin lifecycle and menu-contribution model.
+- [[id:fc186d19-9421-45a2-bbcc-4355d66aa41f][Entity Controller Pattern]] — controller/window/dialog/model structure.

--- a/projects/ores.qt.scheduler/src/SchedulerPlugin.cpp
+++ b/projects/ores.qt.scheduler/src/SchedulerPlugin.cpp
@@ -73,32 +73,40 @@ void SchedulerPlugin::on_login(const plugin_context& ctx) {
             this, &SchedulerPlugin::statusMessage);
 }
 
-QList<QMenu*> SchedulerPlugin::create_menus() {
-    BOOST_LOG_SEV(lg(), debug) << "Building plugin menus.";
-    auto* menuScheduler = new QMenu(tr("&Scheduler"));
+void SchedulerPlugin::setup_menus(const shared_menus_context& smc) {
+    BOOST_LOG_SEV(lg(), debug) << "Registering entries in shared menus."
+        << " operations=" << (smc.operations_menu ? "ok" : "null");
+    if (!smc.operations_menu)
+        return;
 
-    auto* actJobDefs = menuScheduler->addAction(
+    operations_menu_ = smc.operations_menu;
+
+    auto* actJobDefs = operations_menu_->addAction(
         ico(Icon::TasksApp), tr("&Job Definitions"));
     connect(actJobDefs, &QAction::triggered, this, [this]() {
         if (jobDefinitionController_) jobDefinitionController_->showListWindow();
     });
 
-    auto* actJobInstances = menuScheduler->addAction(
+    auto* actJobInstances = operations_menu_->addAction(
         ico(Icon::Clock), tr("&Job Instances"));
     connect(actJobInstances, &QAction::triggered, this, [this]() {
         if (jobInstanceController_) jobInstanceController_->showListWindow();
     });
 
-    menuScheduler->addSeparator();
+    operations_menu_->addSeparator();
 
-    auto* actMonitor = menuScheduler->addAction(
-        ico(Icon::Clock), tr("&Monitor"));
+    auto* actMonitor = operations_menu_->addAction(
+        ico(Icon::Clock), tr("Job &Monitor"));
     connect(actMonitor, &QAction::triggered, this, [this]() {
         if (schedulerMonitorController_) schedulerMonitorController_->showWindow();
     });
+}
 
-    BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
-    return {menuScheduler};
+QList<QMenu*> SchedulerPlugin::create_menus() {
+    BOOST_LOG_SEV(lg(), debug) << "Returning pre-created Operations menu.";
+    if (!operations_menu_)
+        BOOST_LOG_SEV(lg(), warn) << "Operations menu not initialised via setup_menus.";
+    return operations_menu_ ? QList<QMenu*>{operations_menu_} : QList<QMenu*>{};
 }
 
 void SchedulerPlugin::on_logout() {

--- a/projects/ores.qt.trading/CMakeLists.txt
+++ b/projects/ores.qt.trading/CMakeLists.txt
@@ -15,4 +15,5 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
 # Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
-add_subdirectory(src)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/modeling)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/projects/ores.qt.trading/modeling/component_overview.org
+++ b/projects/ores.qt.trading/modeling/component_overview.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: 3fa355d1-38fd-4e35-9e05-2185882b8ac1
+:END:
+#+title: ores.qt.trading
+#+description: Qt plugin for trading UI — portfolios, books, trades with multi-instrument forms, portfolio/org explorers, and ORE import.
+#+type: component
+#+level: cross
+#+filetags: :qt:trading:ui:component:
+#+created: 2026-05-20
+#+updated: 2026-05-20
+
+* Summary
+
+=ores.qt.trading= is the Qt plugin for the trading domain. It provides MDI
+windows and dialogs for portfolios, books, book statuses, and trades, with
+instrument-specific forms for FX (forwards, options, Asian, barrier, digital,
+accumulator, variance swap), rates (IRS/swap, OIS, FRA), credit, equity,
+commodity, and scripted instruments. It provides a Portfolio Explorer and Org
+Explorer for hierarchical trade browsing, an ORE Import Wizard for bulk trade
+loading, and contributes Import ORE Data to the Data Management menu.
+
+* Inputs
+
+- NATS responses from the trading service (portfolios, books, book statuses, trades).
+- NATS responses from the refdata and market data services for instrument-form
+  pickers and reference look-ups.
+- ORE XML files supplied by the user for import.
+- User interactions: create/edit/delete/view-history on trading entities.
+
+* Outputs
+
+- Rendered MDI windows for portfolios, books, trades, explorers, and import wizard.
+- NATS request messages sent to the trading service on user actions.
+- Import ORE Data menu item contributed to the Data Management menu.
+
+* Entry points
+
+- =include/ores.qt/TradingPlugin.hpp= — plugin class; owns Trading menu.
+- =include/ores.qt/TradeController.hpp= — trade entity controller.
+- =include/ores.qt/PortfolioController.hpp= — portfolio entity controller.
+- =include/ores.qt/PortfolioExplorerMdiWindow.hpp= — tree-based portfolio explorer.
+- =include/ores.qt/OreImportController.hpp= — ORE XML bulk import controller.
+
+* Dependencies
+
+- =ores.qt.api= — IPlugin, base controller/window/dialog classes, ClientManager.
+- =ores.trading.api= — trade, portfolio, book domain types and NATS schemas.
+- =ores.refdata.api= — reference data types used in instrument forms and pickers.
+- =ores.ore.core= — ORE model types for import payload parsing.
+- =ores.ore.api= — ORE API types.
+- =ores.marketdata.api= — market data types used in trade valuation context.
+- =ores.storage= — storage abstraction for trade data persistence.
+
+* See also
+
+- [[id:fd34a3b5-0e24-467a-a9d7-a2f2e7480e1b][ores.trading.api]] — trade, portfolio, book domain types and NATS schemas.
+- [[id:654be6cd-d212-4ee5-a7b4-8af125787522][ores.refdata.api]] — reference data types used in instrument forms.
+- [[id:0f93b352-f234-4d9d-82e6-05218be645e8][ores.ore.api]] — ORE model integration types.
+- [[id:9a71f1f5-c3ed-4c07-9d7d-c5b42d4a1332][ores.ore.core]] — ORE XML import/export for bulk trade loading.
+- [[id:6a62d943-fac9-4b77-9e22-f265557dcf1a][ores.marketdata.api]] — market data types used in trade context.
+- [[id:92492264-b67a-4ac7-8a58-7d706d9f0dab][ores.qt.data_transfer]] — receives Import ORE Data menu contribution.
+- [[id:30a3a7f4-e1a9-42fb-af9d-ff36fa0f3d21][ores.qt.api]] — shared Qt infrastructure and base classes.
+- [[id:e81c7fea-33e4-400a-839a-9d1618bed211][Qt Plugin Architecture]] — plugin lifecycle and menu-contribution model.
+- [[id:fc186d19-9421-45a2-bbcc-4355d66aa41f][Entity Controller Pattern]] — controller/window/dialog/model structure.

--- a/projects/ores.qt.trading/src/TradingPlugin.cpp
+++ b/projects/ores.qt.trading/src/TradingPlugin.cpp
@@ -95,7 +95,7 @@ void TradingPlugin::on_login(const plugin_context& ctx) {
 void TradingPlugin::setup_menus(const shared_menus_context& smc) {
     BOOST_LOG_SEV(lg(), debug) << "Registering entries in shared menus."
         << " trading_codes=" << (smc.trading_codes_menu ? "ok" : "null")
-        << " data_transfer=" << (smc.data_transfer_menu ? "ok" : "null");
+        << " data_management=" << (smc.data_management_menu ? "ok" : "null");
     using IC = IconUtils;
     auto ico = [](Icon i) { return IC::createRecoloredIcon(i, IC::DefaultIconColor); };
 
@@ -111,9 +111,10 @@ void TradingPlugin::setup_menus(const shared_menus_context& smc) {
         });
     }
 
-    // ---- Data Transfer menu — contribute Import ORE Data ----------------
-    if (smc.data_transfer_menu) {
-        auto* actImportOre = smc.data_transfer_menu->addAction(
+    // ---- Data Management menu — contribute Import ORE Data --------------
+    if (smc.data_management_menu) {
+        smc.data_management_menu->addSeparator();
+        auto* actImportOre = smc.data_management_menu->addAction(
             ico(Icon::ImportOre), tr("&Import ORE Data..."));
         connect(actImportOre, &QAction::triggered, this, [this]() {
             if (oreImportController_) oreImportController_->trigger(ctx_.main_window);

--- a/projects/ores.qt.workflow/include/ores.qt/WorkflowPlugin.hpp
+++ b/projects/ores.qt.workflow/include/ores.qt/WorkflowPlugin.hpp
@@ -28,10 +28,11 @@ namespace ores::qt {
 class WorkflowController;
 
 /**
- * @brief Qt plugin providing the top-level Workflows menu.
+ * @brief Qt plugin providing the Workflow section of the Operations menu.
  *
- * Exposes workflow monitoring to end users via a dedicated Workflows menu.
- * Loaded as a shared library by QPluginLoader at application startup.
+ * Contributes Workflow items to the pre-created Operations menu via
+ * setup_menus(); no standalone top-level menu is created.
+ * SchedulerPlugin (load_order 360) owns and returns the Operations menu.
  */
 class WorkflowPlugin : public PluginBase {
     Q_OBJECT
@@ -43,9 +44,10 @@ public:
     ~WorkflowPlugin() override;
 
     QString name() const override { return QStringLiteral("ores.qt.workflow"); }
-    int load_order() const override { return 450; }
+    int load_order() const override { return 365; }  // after SchedulerPlugin (360)
 
     void on_login(const plugin_context& ctx) override;
+    void setup_menus(const shared_menus_context& ctx) override;
     QList<QMenu*> create_menus() override;
     void on_logout() override;
 

--- a/projects/ores.qt.workflow/modeling/component_overview.org
+++ b/projects/ores.qt.workflow/modeling/component_overview.org
@@ -1,0 +1,52 @@
+:PROPERTIES:
+:ID: b7269e9c-83b6-4d6c-80de-d796ab89b1bd
+:END:
+#+title: ores.qt.workflow
+#+description: Qt plugin for workflow UI — workflow executions and workflow definitions with step-log detail.
+#+type: component
+#+level: cross
+#+filetags: :qt:workflow:ui:component:
+#+created: 2026-05-20
+#+updated: 2026-05-20
+
+* Summary
+
+=ores.qt.workflow= is the Qt plugin for the workflow domain. It provides MDI
+windows and dialogs for browsing workflow executions (instances) and workflow
+definitions, with step-log detail views showing per-step progress and output.
+It contributes Workflow Executions and Workflow Definitions items to the
+Operations menu owned by =ores.qt.scheduler=.
+
+* Inputs
+
+- NATS responses from the workflow service (workflow executions, definitions,
+  step logs).
+- User interactions: view workflow execution state and step-level detail.
+- =shared_menus_context.operations_menu= pointer for contributing items.
+
+* Outputs
+
+- Rendered MDI windows for workflow executions and definitions.
+- NATS request messages sent to the workflow service on user actions.
+- Workflow Executions and Workflow Definitions items contributed to the
+  Operations menu.
+
+* Entry points
+
+- =include/ores.qt/WorkflowPlugin.hpp= — plugin class; contributes to Operations menu.
+- =include/ores.qt/WorkflowController.hpp= — workflow execution controller.
+- =include/ores.qt/WorkflowStepsWidget.hpp= — step-log detail widget.
+
+* Dependencies
+
+- =ores.qt.api= — IPlugin, base controller/window/dialog classes, ClientManager.
+- =ores.workflow.api= — workflow execution and definition domain types and NATS schemas.
+
+* See also
+
+- [[id:85319483-4ae9-4162-91f7-d72a8201134b][ores.workflow.api]] — domain types and NATS protocol schemas for workflow.
+- [[id:440294d7-385d-41ee-92cb-cab937e65e81][ores.workflow.core]] — server-side workflow orchestration logic.
+- [[id:4092e7e6-c663-4e5e-b330-63bfece7ca51][ores.qt.scheduler]] — owns the Operations menu that workflow contributes to.
+- [[id:30a3a7f4-e1a9-42fb-af9d-ff36fa0f3d21][ores.qt.api]] — shared Qt infrastructure and base classes.
+- [[id:e81c7fea-33e4-400a-839a-9d1618bed211][Qt Plugin Architecture]] — plugin lifecycle and menu-contribution model.
+- [[id:fc186d19-9421-45a2-bbcc-4355d66aa41f][Entity Controller Pattern]] — controller/window/dialog/model structure.

--- a/projects/ores.qt.workflow/src/WorkflowPlugin.cpp
+++ b/projects/ores.qt.workflow/src/WorkflowPlugin.cpp
@@ -64,24 +64,30 @@ void WorkflowPlugin::on_login(const plugin_context& ctx) {
             this, &WorkflowPlugin::windowDestroyed);
 }
 
-QList<QMenu*> WorkflowPlugin::create_menus() {
-    BOOST_LOG_SEV(lg(), debug) << "Building plugin menus.";
-    auto* menuWorkflows = new QMenu(tr("&Workflows"));
+void WorkflowPlugin::setup_menus(const shared_menus_context& smc) {
+    BOOST_LOG_SEV(lg(), debug) << "Registering entries in shared menus."
+        << " operations=" << (smc.operations_menu ? "ok" : "null");
+    if (!smc.operations_menu)
+        return;
 
-    auto* actExecutionList = menuWorkflows->addAction(
-        ico(Icon::TasksApp), tr("Execution &List"));
-    connect(actExecutionList, &QAction::triggered, this, [this]() {
+    smc.operations_menu->addSeparator();
+
+    auto* actExecutions = smc.operations_menu->addAction(
+        ico(Icon::TasksApp), tr("Workflow &Executions"));
+    connect(actExecutions, &QAction::triggered, this, [this]() {
         if (controller_) controller_->showListWindow();
     });
 
-    auto* actDefinitions = menuWorkflows->addAction(
-        ico(Icon::DocumentTable), tr("&Definitions"));
+    auto* actDefinitions = smc.operations_menu->addAction(
+        ico(Icon::DocumentTable), tr("Workflow &Definitions"));
     connect(actDefinitions, &QAction::triggered, this, [this]() {
         if (controller_) controller_->showDefinitionsWindow();
     });
+}
 
-    BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
-    return {menuWorkflows};
+QList<QMenu*> WorkflowPlugin::create_menus() {
+    BOOST_LOG_SEV(lg(), debug) << "All items contributed via setup_menus — no standalone menus.";
+    return {};
 }
 
 void WorkflowPlugin::on_logout() {

--- a/projects/ores.qt.workspace/CMakeLists.txt
+++ b/projects/ores.qt.workspace/CMakeLists.txt
@@ -15,4 +15,5 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
 # Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
-add_subdirectory(src)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/modeling)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/projects/ores.qt.workspace/include/ores.qt/WorkspacePlugin.hpp
+++ b/projects/ores.qt.workspace/include/ores.qt/WorkspacePlugin.hpp
@@ -32,8 +32,8 @@ class WorkspaceController;
 /**
  * @brief Workspace plugin: manage named data-isolation workspaces.
  *
- * Provides a "Workspaces" menu entry that opens the workspace list window
- * where users can view, create, and archive workspaces.
+ * Contributes "Manage Workspaces" to the shared Data Management menu;
+ * no standalone top-level menu is created.
  */
 class WorkspacePlugin : public PluginBase {
     Q_OBJECT
@@ -45,9 +45,10 @@ public:
     ~WorkspacePlugin() override;
 
     QString name() const override { return QStringLiteral("ores.qt.workspace"); }
-    int load_order() const override { return 110; }
+    int load_order() const override { return 210; }  // after TradingPlugin (200)
 
     void on_login(const plugin_context& ctx) override;
+    void setup_menus(const shared_menus_context& ctx) override;
     QList<QMenu*> create_menus() override;
     void on_logout() override;
 

--- a/projects/ores.qt.workspace/modeling/component_overview.org
+++ b/projects/ores.qt.workspace/modeling/component_overview.org
@@ -1,0 +1,48 @@
+:PROPERTIES:
+:ID: 31d9c75a-de71-4b98-9d33-d8ed86000c94
+:END:
+#+title: ores.qt.workspace
+#+description: Qt plugin for workspace management UI — NATS-persisted workspaces that capture user session context.
+#+type: component
+#+level: cross
+#+filetags: :qt:workspace:ui:component:
+#+created: 2026-05-20
+#+updated: 2026-05-20
+
+* Summary
+
+=ores.qt.workspace= is the Qt plugin for workspace management. Workspaces are
+NATS-persisted records that group a user's session context — active views,
+preferences, and configuration state. The plugin provides an MDI window and
+dialogs for creating, editing, and deleting workspaces. It contributes a
+Manage Workspaces item to the Data Management menu owned by
+=ores.qt.data_transfer=.
+
+* Inputs
+
+- NATS responses from the workspace service (workspace records).
+- User interactions: create/edit/delete workspaces.
+- =shared_menus_context.data_management_menu= pointer for contributing items.
+
+* Outputs
+
+- Rendered MDI window for workspace management.
+- NATS request messages sent to the workspace service on user actions.
+- Manage Workspaces item contributed to the Data Management menu.
+
+* Entry points
+
+- =include/ores.qt/WorkspacePlugin.hpp= — plugin class; contributes to Data Management menu.
+- =include/ores.qt/WorkspaceController.hpp= — workspace entity controller.
+
+* Dependencies
+
+- =ores.qt.api= — IPlugin, base controller/window/dialog classes, ClientManager.
+- =ores.workspace.api= — workspace domain types and NATS schemas.
+
+* See also
+
+- [[id:92492264-b67a-4ac7-8a58-7d706d9f0dab][ores.qt.data_transfer]] — owns the Data Management menu that workspace contributes to.
+- [[id:30a3a7f4-e1a9-42fb-af9d-ff36fa0f3d21][ores.qt.api]] — shared Qt infrastructure and base classes.
+- [[id:e81c7fea-33e4-400a-839a-9d1618bed211][Qt Plugin Architecture]] — plugin lifecycle and menu-contribution model.
+- [[id:fc186d19-9421-45a2-bbcc-4355d66aa41f][Entity Controller Pattern]] — controller/window/dialog/model structure.

--- a/projects/ores.qt.workspace/src/WorkspacePlugin.cpp
+++ b/projects/ores.qt.workspace/src/WorkspacePlugin.cpp
@@ -55,20 +55,26 @@ void WorkspacePlugin::on_login(const plugin_context& ctx) {
             this, &WorkspacePlugin::statusMessage);
 }
 
-QList<QMenu*> WorkspacePlugin::create_menus() {
-    BOOST_LOG_SEV(lg(), debug) << "Building plugin menus.";
-    auto* menu = new QMenu(tr("&Workspaces"));
+void WorkspacePlugin::setup_menus(const shared_menus_context& smc) {
+    BOOST_LOG_SEV(lg(), debug) << "Registering entries in shared menus."
+        << " data_management=" << (smc.data_management_menu ? "ok" : "null");
+    if (!smc.data_management_menu)
+        return;
 
-    act_workspaces_ = menu->addAction(
+    smc.data_management_menu->addSeparator();
+
+    act_workspaces_ = smc.data_management_menu->addAction(
         IconUtils::createRecoloredIcon(Icon::Database, IconUtils::DefaultIconColor),
         tr("&Manage Workspaces"));
     connect(act_workspaces_, &QAction::triggered, this, [this]() {
         if (workspaceController_)
             workspaceController_->showListWindow();
     });
+}
 
-    BOOST_LOG_SEV(lg(), debug) << "Plugin menus ready.";
-    return {menu};
+QList<QMenu*> WorkspacePlugin::create_menus() {
+    BOOST_LOG_SEV(lg(), debug) << "All items contributed via setup_menus — no standalone menus.";
+    return {};
 }
 
 void WorkspacePlugin::on_logout() {

--- a/projects/ores.qt/modeling/component_overview.org
+++ b/projects/ores.qt/modeling/component_overview.org
@@ -48,4 +48,17 @@ housed in sibling projects under =ores.qt.*=.
 
 * See also
 
--
+- [[id:30a3a7f4-e1a9-42fb-af9d-ff36fa0f3d21][ores.qt.api]] — shared infrastructure, IPlugin, and base entity UI classes.
+- [[id:e81c7fea-33e4-400a-839a-9d1618bed211][Qt Plugin Architecture]] — plugin lifecycle and two-phase menu sequence.
+- [[id:fc186d19-9421-45a2-bbcc-4355d66aa41f][Entity Controller Pattern]] — how domain controllers, windows, and dialogs are structured.
+- [[id:db5a4924-8f0a-440c-873e-d823f430043e][ores.qt.admin]] — IAM UI plugin.
+- [[id:970667d1-8ba8-4b49-b047-0d6d4c4ce498][ores.qt.analytics]] — analytics pricing UI plugin.
+- [[id:03eae018-5e61-4005-ac9a-eff827a46178][ores.qt.compute]] — compute/reporting UI plugin.
+- [[id:92492264-b67a-4ac7-8a58-7d706d9f0dab][ores.qt.data_transfer]] — Data Management menu owner.
+- [[id:2e83f9b5-67f4-4a1f-95bc-fe1e7ab7d4c0][ores.qt.mktdata]] — market data UI plugin.
+- [[id:6de9a7b8-f7ba-4e93-bb93-2fb10c53f9ca][ores.qt.party]] — party/organisation UI plugin.
+- [[id:621194c4-d438-4215-ae40-21fbe8ff0d85][ores.qt.refdata]] — reference data UI plugin.
+- [[id:4092e7e6-c663-4e5e-b330-63bfece7ca51][ores.qt.scheduler]] — job scheduling UI plugin.
+- [[id:3fa355d1-38fd-4e35-9e05-2185882b8ac1][ores.qt.trading]] — trading UI plugin.
+- [[id:b7269e9c-83b6-4d6c-80de-d796ab89b1bd][ores.qt.workflow]] — workflow UI plugin.
+- [[id:31d9c75a-de71-4b98-9d33-d8ed86000c94][ores.qt.workspace]] — workspace management UI plugin.

--- a/projects/ores.qt/src/MainWindow.cpp
+++ b/projects/ores.qt/src/MainWindow.cpp
@@ -424,24 +424,36 @@ MainWindow::MainWindow(QWidget* parent) :
     // System, keeping System/Window/Help always last.
     auto* systemAction = ui_->menuSystem->menuAction();
 
-    // Pre-create the shared &Identity menu (before Reference Data).
-    auto* identityMenu = new QMenu(tr("&Identity"), this);
-    menuBar()->insertMenu(systemAction, identityMenu);
-    plugin_menus_.append(identityMenu);
+    // Pre-create the shared &Account menu (personal actions only; inserted
+    // directly so it always appears first after File).
+    auto* accountMenu = new QMenu(tr("&Account"), this);
+    menuBar()->insertMenu(systemAction, accountMenu);
+    plugin_menus_.append(accountMenu);
 
-    // Pre-create the shared &Reference Data menu so RefdataPlugin and
-    // other plugins can populate it during setup_menus().
+    // Pre-create the shared &Reference Data menu. NOT inserted directly —
+    // RefdataPlugin returns it from create_menus() to control bar position.
     auto* referenceDataMenu = new QMenu(tr("&Reference Data"), this);
-    menuBar()->insertMenu(systemAction, referenceDataMenu);
-    plugin_menus_.append(referenceDataMenu);
+
+    // Pre-create &Analytics menu. NOT inserted directly — AnalyticsPlugin
+    // returns it from create_menus() to control bar position.
+    auto* analyticsMenu = new QMenu(tr("&Analytics"), this);
+
+    // Pre-create Analytics Codes submenu. Contributed to by AnalyticsPlugin
+    // and ComputePlugin via setup_menus(); appended to analyticsMenu by
+    // AnalyticsPlugin in create_menus().
+    auto* analyticsCodesMenu = new QMenu(tr("Analytics &Codes"), this);
+
+    // Pre-create &Operations menu. NOT inserted directly — SchedulerPlugin
+    // returns it from create_menus() to control bar position.
+    auto* operationsMenu = new QMenu(tr("&Operations"), this);
 
     // Pre-create trading codes menu (NOT inserted directly; TradingPlugin
     // appends it to its own Trading menu in create_menus()).
     auto* tradingCodesMenu = new QMenu(tr("Trading &Codes"), this);
 
-    // Pre-create data transfer menu (NOT inserted directly; DataTransferPlugin
-    // returns it from create_menus() so it appears in plugin load_order).
-    auto* dataTransferMenu = new QMenu(tr("&Data Transfer"), this);
+    // Pre-create &Data Management menu. NOT inserted directly; DataTransferPlugin
+    // returns it from create_menus() so it appears in plugin load_order.
+    auto* dataManagementMenu = new QMenu(tr("&Data Management"), this);
 
     // Phase 1 — let plugins contribute to shared menus.
     // Phase 2 — collect standalone menus returned by create_menus().
@@ -450,12 +462,15 @@ MainWindow::MainWindow(QWidget* parent) :
     BOOST_LOG_SEV(lg(), info) << plugins.size() << " plugin(s) registered.";
 
     shared_menus_context smc;
-    smc.system_menu        = ui_->menuSystem;
-    smc.reference_data_menu = referenceDataMenu;
-    smc.telemetry_menu     = ui_->menuTelemetry;
-    smc.identity_menu      = identityMenu;
-    smc.data_transfer_menu = dataTransferMenu;
-    smc.trading_codes_menu = tradingCodesMenu;
+    smc.system_menu          = ui_->menuSystem;
+    smc.reference_data_menu  = referenceDataMenu;
+    smc.telemetry_menu       = ui_->menuTelemetry;
+    smc.account_menu         = accountMenu;
+    smc.data_management_menu = dataManagementMenu;
+    smc.trading_codes_menu   = tradingCodesMenu;
+    smc.analytics_menu       = analyticsMenu;
+    smc.analytics_codes_menu = analyticsCodesMenu;
+    smc.operations_menu      = operationsMenu;
 
     BOOST_LOG_SEV(lg(), debug) << "Distributing shared menu handles to plugins.";
     for (auto* plugin : plugins) {
@@ -463,23 +478,12 @@ MainWindow::MainWindow(QWidget* parent) :
         plugin->setup_menus(smc);
     }
 
-    // Prepend My Account / My Sessions to the Identity menu (after plugins
-    // have had a chance to add their items first).
-    auto* firstIdentityAction = identityMenu->actions().isEmpty()
-        ? nullptr : identityMenu->actions().first();
-    if (firstIdentityAction) {
-        auto* sep = new QAction(this);
-        sep->setSeparator(true);
-        identityMenu->insertAction(firstIdentityAction, sep);
-        identityMenu->insertAction(sep, ui_->ActionMySessions);
-        identityMenu->insertAction(ui_->ActionMySessions, ui_->ActionMyAccount);
-    } else {
-        identityMenu->addAction(ui_->ActionMyAccount);
-        identityMenu->addAction(ui_->ActionMySessions);
-    }
+    // Populate the Account menu: personal actions only.
+    // Admin items (Accounts, Roles, Tenants) live under System > Administration.
+    accountMenu->addAction(ui_->ActionMyAccount);
+    accountMenu->addAction(ui_->ActionMySessions);
 
-    // Remove My Account / My Sessions from the File menu (they now live in
-    // Identity).
+    // Remove My Account / My Sessions from the File menu (they now live in Account).
     ui_->menuFile->removeAction(ui_->ActionMyAccount);
     ui_->menuFile->removeAction(ui_->ActionMySessions);
 


### PR DESCRIPTION
## Summary

Two cohesive changes on one branch:

### 1. Qt menu structure simplification (phases 1–5)

Restructures the application menu bar to reduce top-level menus and
group related items more logically:

- **Phase 1** — Admin items moved into System > Configuration and
  System > Administration submenus; Identity renamed to Account
- **Phase 2** — Pricing and Compute merged into a single Analytics menu
  (AnalyticsPlugin owns the menu; ComputePlugin contributes to it)
- **Phase 3** — Reference Data absorbs Organisation (PartyPlugin
  contributes to the Reference Data menu via `setup_menus`)
- **Phase 4** — Operations menu created; Scheduler owns it, Workflow
  contributes to it
- **Phase 5** — Data Transfer renamed to Data Management; Workspace
  plugin contributes to it

Implementation: all plugins now participate in a two-phase dispatch
loop (`setup_menus` then `create_menus`) driven by `load_order()`.
`shared_menus_context` extended with `analytics_menu`,
`analytics_codes_menu`, `operations_menu`, `reference_data_menu`,
`data_management_menu`.

### 2. V2 component documentation for all Qt plugins

Brings the 12 `ores.qt.*` plugin components into full V2 compliance:

- `component_overview.org` created for all 12 plugins (`admin`,
  `analytics`, `api`, `compute`, `data_transfer`, `mktdata`, `party`,
  `refdata`, `scheduler`, `trading`, `workflow`, `workspace`), each
  with cross-references to their corresponding domain API components
- `doc/v2/knowledge/qt/plugin_architecture.org` — IPlugin lifecycle,
  `shared_menus_context`, `load_order`, two-phase menu sequence
- `projects/ores.qt.api/docs/entity_controller_pattern.org` —
  four-layer controller/window/dialog/model pattern
- `doc/v2/knowledge/documentation/component_documentation_guide.org`
  — practical guide to writing good component overviews
- `doc/v2/recipes/codegen/how_do_i_create_a_component_overview.org`
- Updated `how_do_i_create_a_new_v2_doc.org`: correct component slug
  (`component_overview`), inter-linked document workflow, `--id`
  migration-only clarification
- Updated `v2-doc-author` skill with the above
- 12 `MISSING_OVERVIEW ores.qt.*` entries removed from
  `docs_exceptions.txt`; all 88 components pass `validate_docs.sh`
- 5 Qt plugin `CMakeLists.txt` files updated to include
  `add_subdirectory(modeling)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)