### PR TITLE
[windows] Fix MSVC linker error and C1202 in trade variant

### DIFF
--- a/projects/ores.qt.api/src/ClientManagerTrades.cpp
+++ b/projects/ores.qt.api/src/ClientManagerTrades.cpp
@@ -84,6 +84,15 @@ ClientManager::getTradeDetail(const std::string& trade_id) {
                 << "getTradeDetail server error: " << base->message;
             return std::nullopt;
         }
+        // rfl::internal::no_duplicate_field_names does O(N^2) constexpr
+        // comparisons over all variant alternatives.  trade_instrument has 9
+        // top-level alternatives (two of which are nested variants), which
+        // pushes MSVC past its default 100 000-step constexpr budget (C1202).
+        // Raise the limit for this translation unit only.
+#ifdef _MSC_VER
+#  pragma constexpr_depth(1024)
+#  pragma constexpr_steps(1000000)
+#endif
         auto inst = rfl::json::read<
             trading::messaging::get_trade_detail_instrument_wrapper,
             rfl::AddTagsToVariants>(raw);

--- a/projects/ores.qt.api/src/ClientManagerTrades.cpp
+++ b/projects/ores.qt.api/src/ClientManagerTrades.cpp
@@ -72,41 +72,32 @@ ClientManager::getTradeDetail(const std::string& trade_id) {
             rfl::json::write(request),
             std::chrono::seconds(30));
 
-        auto base = rfl::json::read<
-            trading::messaging::get_trade_detail_response_base>(raw);
-        if (!base) {
-            BOOST_LOG_SEV(lg(), error)
-                << "getTradeDetail deserialize error: " << base.error().what();
-            return std::nullopt;
-        }
-        if (!base->success) {
-            BOOST_LOG_SEV(lg(), error)
-                << "getTradeDetail server error: " << base->message;
-            return std::nullopt;
-        }
-        // rfl::internal::no_duplicate_field_names does O(N^2) constexpr
-        // comparisons over all variant alternatives.  trade_instrument has 9
-        // top-level alternatives (two of which are nested variants), which
-        // pushes MSVC past its default 100 000-step constexpr budget (C1202).
-        // Raise the limit for this translation unit only.
+        // rfl::internal::no_duplicate_field_names does O(N²) constexpr
+        // comparisons over all variant field names.  trade_instrument has 9
+        // top-level alternatives (two of which are nested variants), pushing
+        // MSVC past its default 100 000-step constexpr budget (C1202).
 #ifdef _MSC_VER
 #  pragma constexpr_depth(1024)
 #  pragma constexpr_steps(1000000)
 #endif
-        auto inst = rfl::json::read<
-            trading::messaging::get_trade_detail_instrument_wrapper,
+        auto resp = rfl::json::read<
+            trading::messaging::get_trade_detail_response,
             rfl::AddTagsToVariants>(raw);
-        if (!inst) {
+        if (!resp) {
             BOOST_LOG_SEV(lg(), error)
-                << "getTradeDetail instrument deserialize error: "
-                << inst.error().what();
+                << "getTradeDetail deserialize error: " << resp.error().what();
+            return std::nullopt;
+        }
+        if (!resp->success) {
+            BOOST_LOG_SEV(lg(), error)
+                << "getTradeDetail server error: " << resp->message;
             return std::nullopt;
         }
 
-        trading::messaging::trade_export_item item;
-        item.trade = std::move(base->trade);
-        item.instrument = std::move(inst->instrument);
-        return item;
+        return trading::messaging::trade_export_item{
+            .trade = std::move(resp->trade),
+            .instrument = std::move(resp->instrument)
+        };
     } catch (const ores::nats::service::nats_connect_error&) {
         throw;
     } catch (const ores::nats::service::session_expired_error& e) {

--- a/projects/ores.refdata.service/include/ores.refdata.service/app/host.hpp
+++ b/projects/ores.refdata.service/include/ores.refdata.service/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.refdata.service/export.hpp"
 
 namespace ores::refdata::service::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_REFDATA_SERVICE_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.refdata.service.app.host";
 

--- a/projects/ores.refdata.service/include/ores.refdata.service/export.hpp
+++ b/projects/ores.refdata.service/include/ores.refdata.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REFDATA_SERVICE_EXPORT_HPP
+#define ORES_REFDATA_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_REFDATA_SERVICE_LIBRARY
+#  define ORES_REFDATA_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_REFDATA_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.refdata.service/src/CMakeLists.txt
+++ b/projects/ores.refdata.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_REFDATA_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.trading.api/include/ores.trading.api/messaging/trade_protocol.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/messaging/trade_protocol.hpp
@@ -88,21 +88,6 @@ struct get_trade_detail_response {
     ores::trading::domain::trade_instrument instrument;
 };
 
-// Two-phase deserialization helpers for ClientManager on MSVC.
-// Parsing trade (nested sub-structs) and trade_instrument (8-alternative
-// variant + rfl::AddTagsToVariants) in a single rfl call exceeds MSVC's
-// constexpr depth budget (C1202). Splitting into two independent reads keeps
-// each instantiation within the limit.
-struct get_trade_detail_response_base {
-    bool success = false;
-    std::string message;
-    ores::trading::domain::trade trade;
-};
-
-struct get_trade_detail_instrument_wrapper {
-    ores::trading::domain::trade_instrument instrument;
-};
-
 struct save_trade_request {
     using response_type = struct save_trade_response;
     static constexpr std::string_view nats_subject = "trading.v1.trades.save";


### PR DESCRIPTION
## Summary

- **Error 1 (LNK2001 – `ores.refdata.service`)**: `host::execute` was missing its Windows DLL export annotation. Added `export.hpp` with `ORES_REFDATA_SERVICE_EXPORT` (pattern: `BOOST_SYMBOL_EXPORT`/`BOOST_SYMBOL_IMPORT` guarded by `ORES_REFDATA_SERVICE_LIBRARY`), annotated the `host` class, and added the `target_compile_definitions` to the lib CMake target. Same fix as PR for `ores.shell`.

- **Error 2 (C1202 – `ores.qt.api`)**: `rfl::internal::no_duplicate_field_names` performs O(N²) constexpr field-name comparisons across all alternatives of `trade_instrument` (9 top-level, two of which are nested variants). This exhausts MSVC's default 100 000-step constexpr budget, triggering fatal error C1202. Added `#pragma constexpr_depth(1024)` and `#pragma constexpr_steps(1000000)` under `#ifdef _MSC_VER` before the problematic `rfl::json::read` call in `ClientManagerTrades.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)