### PR TITLE
[doc] Drop site banner, restore index cards, GitHub icon in nav

### DIFF
--- a/.build-site.el
+++ b/.build-site.el
@@ -77,9 +77,12 @@
 ;; Load the publishing system
 (require 'ox-publish)
 
-;; IMPORTANT: update to href=\"./assets/style.css\"> testing locally.
-(defvar html-header "<link rel=\"stylesheet\" href=\"https://orestudio.github.io/OreStudio/assets/style.css\">
-<link rel=\"icon\" href=\"/assets/images/modern-icon.png\">
+;; Stylesheet uses absolute /OreStudio/ path so it resolves both in
+;; production (orestudio.github.io/OreStudio/) and under the local
+;; preview server, which symlinks the build output to /OreStudio (see
+;; build/scripts/serve-site.sh).
+(defvar html-header "<link rel=\"stylesheet\" href=\"/OreStudio/assets/style.css\">
+<link rel=\"icon\" href=\"/OreStudio/assets/images/modern-icon.png\">
 <script src=\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/highlight.min.js\"></script>
 <script>var hlf=function(){Array.prototype.forEach.call(document.querySelectorAll(\"pre.src\"),function(t){var e;e=t.getAttribute(\"class\"),e=e.replace(/src-(\w+)/,\"src-$1 $1\"),console.log(e),t.setAttribute(\"class\",e),hljs.highlightBlock(t)})};addEventListener(\"DOMContentLoaded\",hlf);</script>
 <link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/styles/googlecode.min.css\" />
@@ -97,13 +100,12 @@
       org-html-head html-header)
 
 (defvar site-html-preamble "<header id='site-header'>
-  <a href='/OreStudio/readme.html'><img id='site-banner' src='/OreStudio/assets/images/ore-studio-banner.png' alt='ORE Studio'/></a>
   <nav id='site-nav'>
     <a href='/OreStudio/readme.html'>Home</a>
     <a href='/OreStudio/doc/doc.html'>Documentation</a>
     <a href='/OreStudio/doc/v2/compass.html'>V2 Compass</a>
     <a href='/OreStudio/doxygen/html/index.html'>Doxygen</a>
-    <a href='https://github.com/OreStudio/OreStudio'>GitHub</a>
+    <a href='https://github.com/OreStudio/OreStudio' aria-label='GitHub' title='GitHub'><i class='fab fa-github'></i></a>
   </nav>
 </header>")
 

--- a/.build-site.el
+++ b/.build-site.el
@@ -84,7 +84,7 @@
 (defvar html-header "<link rel=\"stylesheet\" href=\"/OreStudio/assets/style.css\">
 <link rel=\"icon\" href=\"/OreStudio/assets/images/modern-icon.png\">
 <script src=\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/highlight.min.js\"></script>
-<script>var hlf=function(){Array.prototype.forEach.call(document.querySelectorAll(\"pre.src\"),function(t){var e;e=t.getAttribute(\"class\"),e=e.replace(/src-(\w+)/,\"src-$1 $1\"),console.log(e),t.setAttribute(\"class\",e),hljs.highlightBlock(t)})};addEventListener(\"DOMContentLoaded\",hlf);</script>
+<script>var hlf=function(){Array.prototype.forEach.call(document.querySelectorAll(\"pre.src\"),function(t){var e;e=t.getAttribute(\"class\"),e=e.replace(/src-(\w+)/,\"src-$1 $1\"),t.setAttribute(\"class\",e),hljs.highlightBlock(t)})};addEventListener(\"DOMContentLoaded\",hlf);</script>
 <link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/styles/googlecode.min.css\" />
 <link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css\">")
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -35,7 +35,7 @@ body {
     align-items: center;
 }
 
-/* Site-wide preamble: banner image edge-to-edge, nav below */
+/* Site-wide preamble: top nav band */
 #preamble {
     align-self: stretch;
     margin: 0 -1.5rem 2rem;
@@ -44,15 +44,6 @@ body {
 #site-header {
     display: flex;
     flex-direction: column;
-}
-
-#site-banner {
-    display: block;
-    width: 100%;
-    height: auto;
-    margin: 0;
-    border: none;
-    border-radius: 0;
 }
 
 #site-nav {
@@ -75,6 +66,11 @@ body {
 #site-nav a:hover {
     color: var(--accent);
     text-decoration: none;
+}
+
+#site-nav a i.fab {
+    font-size: 1.05rem;
+    vertical-align: middle;
 }
 
 #content {
@@ -394,4 +390,109 @@ li {
     font-size: 0.85rem;
     color: var(--text-muted);
     text-align: center;
+}
+
+/* Index page: hero section — image flush to the box edges */
+.hero {
+    text-align: center;
+    padding: 0 0 1.75rem;
+    margin: 0 auto 2.5rem;
+    width: 100%;
+    max-width: 964px;       /* splash-screen.png native width */
+    box-sizing: border-box;
+    background-color: var(--bg-secondary);
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    overflow: hidden;
+}
+
+.hero .banner {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    margin: 0 0 1.5rem;
+    border: none;
+    border-radius: 0;
+}
+
+.hero h1 {
+    font-size: 2rem;
+    border-bottom: none;
+    margin: 1rem 0 0.75rem;
+    padding: 0 1rem;
+    line-height: 1.25;
+}
+
+.hero p {
+    color: var(--text-muted);
+    max-width: 36rem;
+    margin: 0 auto 1.5rem;
+    padding: 0 1rem;
+}
+
+.btn {
+    display: inline-block;
+    background-color: var(--accent);
+    color: #0d1117;
+    font-weight: 600;
+    padding: 0.55rem 1.1rem;
+    border-radius: 6px;
+    text-decoration: none;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.btn:hover {
+    background-color: var(--accent-hover);
+    color: #0d1117;
+    text-decoration: none;
+    transform: translateY(-1px);
+}
+
+/* Index page: feature grid */
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.25rem;
+    margin: 2.5rem 0;
+}
+
+.card {
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1.25rem 1.35rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.card:hover {
+    transform: translateY(-2px);
+    border-color: var(--accent-dim);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+}
+
+.card h3 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+    color: var(--accent);
+    font-size: 1.05rem;
+}
+
+.card p {
+    margin-bottom: 0;
+    color: var(--text-muted);
+    font-size: 0.92rem;
+    line-height: 1.55;
+}
+
+/* Index page: footer (inline, distinct from #postamble) */
+footer {
+    width: 100%;
+    max-width: var(--max-width);
+    margin-top: 3rem;
+    padding: 1.25rem 0;
+    border-top: 1px solid var(--border-color);
+    text-align: center;
+    font-size: 0.85rem;
+    color: var(--text-muted);
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -16,6 +16,8 @@
     --accent-dim: #21262d;       /* Subtle decorative accents / borders */
 
     --border-color: #30363d;     /* Clean, thin borders */
+    --on-accent: #0d1117;        /* Text color on an accent background */
+    --shadow-card: rgba(0, 0, 0, 0.35); /* Card / surface drop shadow */
     --max-width: 920px;          /* Optimal reading line length */
 }
 
@@ -434,7 +436,7 @@ li {
 .btn {
     display: inline-block;
     background-color: var(--accent);
-    color: #0d1117;
+    color: var(--on-accent);
     font-weight: 600;
     padding: 0.55rem 1.1rem;
     border-radius: 6px;
@@ -444,7 +446,7 @@ li {
 
 .btn:hover {
     background-color: var(--accent-hover);
-    color: #0d1117;
+    color: var(--on-accent);
     text-decoration: none;
     transform: translateY(-1px);
 }
@@ -468,7 +470,7 @@ li {
 .card:hover {
     transform: translateY(-2px);
     border-color: var(--accent-dim);
-    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+    box-shadow: 0 6px 18px var(--shadow-card);
 }
 
 .card h3 {

--- a/index.org
+++ b/index.org
@@ -9,19 +9,6 @@
 #+options: html-postamble:nil toc:nil num:nil ^:nil title:nil
 #+HTML_DOCTYPE: html5
 
-#+HTML: <header>
-#+HTML: <div class="nav">
-#+HTML:   <ul>
-#+HTML:     <li><a href="./readme.html">Readme</a></li>
-#+HTML:     <li><a href="./doc/doc.html">Documentation</a></li>
-#+HTML:     <li><a href="https://github.com/OreStudio/OreStudio/releases">Releases</a></li>
-#+HTML:     <li><a href="https://discord.com/channels/1254062142626332732/1254062142626332735">Discord</a></li>
-#+HTML:     <li><a href="https://deepwiki.com/OreStudio/OreStudio">DeepWiki</a></li>
-#+HTML:     <li><a href="https://github.com/orestudio/OREStudio" title="GitHub"><i class="fab fa-github"></i></a></li>
-#+HTML:   </ul>
-#+HTML: </div>
-#+HTML: </header>
-
 #+HTML: <section class="hero">
 #+HTML: <img class="banner" src="./assets/images/splash-screen.png" alt="ORE Studio">
 #+HTML: <a class="btn" href="https://github.com/orestudio/OREStudio">Explore on GitHub</a>


### PR DESCRIPTION
## Summary

- Drop the oversized banner image from the site preamble — leaves the nav band alone at the top of every page.
- Restore the dark-theme styles for `.hero`, `.btn`, `.grid`, `.card`, and `footer` that the index page (`index.org`) needs for the splash hero and the three feature cards (QuantLib Inside / ORE Powered / Visual Workflow); these were lost when the site CSS was rewritten in #784.
- Hero box now hugs the splash image edge-to-edge (capped at the image's native 964px, image clipped by the hero's rounded corners).
- Swap the GitHub nav entry to the FontAwesome github mark (CDN already loaded in `html-header`).
- Drop the now-redundant inline `<header><div class="nav">…</div></header>` block from `index.org` since the site-wide preamble nav replaces it.
- Switch the stylesheet href from the hardcoded production URL to `/OreStudio/assets/style.css` so local previews via `build/scripts/serve-site.sh` pick up CSS changes without round-tripping through GitHub Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)