### PR TITLE
[qt] Remove non-existent MSVC constexpr pragmas

### DIFF
--- a/projects/ores.qt.api/src/ClientManager.cpp
+++ b/projects/ores.qt.api/src/ClientManager.cpp
@@ -19,13 +19,6 @@
  */
 #include "ores.qt/ClientManager.hpp"
 
-// rfl::internal::no_duplicate_field_names does O(N²) constexpr comparisons
-// over all variant field names.  Raise the MSVC constexpr budget for this TU.
-#ifdef _MSC_VER
-#  pragma constexpr_depth(1024)
-#  pragma constexpr_steps(1000000)
-#endif
-
 #include <QDateTime>
 #include <QTimeZone>
 #include <boost/uuid/uuid_io.hpp>

--- a/projects/ores.qt.api/src/ClientManagerTrades.cpp
+++ b/projects/ores.qt.api/src/ClientManagerTrades.cpp
@@ -72,14 +72,6 @@ ClientManager::getTradeDetail(const std::string& trade_id) {
             rfl::json::write(request),
             std::chrono::seconds(30));
 
-        // rfl::internal::no_duplicate_field_names does O(N²) constexpr
-        // comparisons over all variant field names.  trade_instrument has 9
-        // top-level alternatives (two of which are nested variants), pushing
-        // MSVC past its default 100 000-step constexpr budget (C1202).
-#ifdef _MSC_VER
-#  pragma constexpr_depth(1024)
-#  pragma constexpr_steps(1000000)
-#endif
         auto resp = rfl::json::read<
             trading::messaging::get_trade_detail_response,
             rfl::AddTagsToVariants>(raw);


### PR DESCRIPTION
## Summary

- Remove `#pragma constexpr_depth` and `#pragma constexpr_steps` from `ClientManager.cpp` and `ClientManagerTrades.cpp`
- These pragma directives do not exist in MSVC — `constexpr:depth` and `constexpr:steps` are command-line flags, not pragma names
- MSVC emits C4068 (unknown pragma warning) which `/WX` promotes to a hard build error
- The global CMake config already sets `/constexpr:depth100000 /constexpr:steps10000000` project-wide, so no per-TU adjustment is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)