### PR TITLE
Add export macro to parser class for DLL visibility

### DIFF
--- a/projects/ores.refdata.service/include/ores.refdata.service/config/parser.hpp
+++ b/projects/ores.refdata.service/include/ores.refdata.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.refdata.service/export.hpp"
 #include "ores.refdata.service/config/options.hpp"
 
 namespace ores::refdata::service::config {
@@ -34,7 +35,7 @@ namespace ores::refdata::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_REFDATA_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,


### PR DESCRIPTION
## Summary
Add the `ORES_REFDATA_SERVICE_EXPORT` macro to the `parser` class declaration to ensure proper symbol visibility when building as a shared library.

## Changes
- Include `ores.refdata.service/export.hpp` header in parser.hpp
- Apply `ORES_REFDATA_SERVICE_EXPORT` macro to the `parser` class definition

## Details
This change ensures that the `parser` class symbols are properly exported when the refdata service is built as a dynamic library, allowing external consumers to link against and use the parser class. The export macro is a standard pattern for managing symbol visibility across library boundaries.

https://claude.ai/code/session_01SiZDbJn3cgBNFDBbQy1wxq