### PR TITLE
[services] Add missing Windows DLL export macros to all service host …

### DIFF
--- a/projects/ores.analytics.service/include/ores.analytics.service/app/host.hpp
+++ b/projects/ores.analytics.service/include/ores.analytics.service/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.analytics.service/export.hpp"
 
 namespace ores::analytics::service::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_ANALYTICS_SERVICE_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.analytics.service.app.host";
 

--- a/projects/ores.analytics.service/include/ores.analytics.service/export.hpp
+++ b/projects/ores.analytics.service/include/ores.analytics.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_ANALYTICS_SERVICE_EXPORT_HPP
+#define ORES_ANALYTICS_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_ANALYTICS_SERVICE_LIBRARY
+#  define ORES_ANALYTICS_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_ANALYTICS_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.analytics.service/src/CMakeLists.txt
+++ b/projects/ores.analytics.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_ANALYTICS_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.assets.service/include/ores.assets.service/app/host.hpp
+++ b/projects/ores.assets.service/include/ores.assets.service/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.assets.service/export.hpp"
 
 namespace ores::assets::service::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_ASSETS_SERVICE_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.assets.service.app.host";
 

--- a/projects/ores.assets.service/include/ores.assets.service/export.hpp
+++ b/projects/ores.assets.service/include/ores.assets.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_ASSETS_SERVICE_EXPORT_HPP
+#define ORES_ASSETS_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_ASSETS_SERVICE_LIBRARY
+#  define ORES_ASSETS_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_ASSETS_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.assets.service/src/CMakeLists.txt
+++ b/projects/ores.assets.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_ASSETS_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.compute.service/include/ores.compute.service/app/host.hpp
+++ b/projects/ores.compute.service/include/ores.compute.service/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.compute.service/export.hpp"
 
 namespace ores::compute::service::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_COMPUTE_SERVICE_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.compute.service.app.host";
 

--- a/projects/ores.compute.service/include/ores.compute.service/export.hpp
+++ b/projects/ores.compute.service/include/ores.compute.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_COMPUTE_SERVICE_EXPORT_HPP
+#define ORES_COMPUTE_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_COMPUTE_SERVICE_LIBRARY
+#  define ORES_COMPUTE_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_COMPUTE_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.compute.service/src/CMakeLists.txt
+++ b/projects/ores.compute.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_COMPUTE_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.compute.wrapper/include/ores.compute.wrapper/app/host.hpp
+++ b/projects/ores.compute.wrapper/include/ores.compute.wrapper/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.compute.wrapper/export.hpp"
 
 namespace ores::compute::wrapper::app {
 
 /**
  * @brief Provides hosting services to the wrapper application.
  */
-class host {
+class ORES_COMPUTE_WRAPPER_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.compute.wrapper.app.host";
 

--- a/projects/ores.compute.wrapper/include/ores.compute.wrapper/export.hpp
+++ b/projects/ores.compute.wrapper/include/ores.compute.wrapper/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_COMPUTE_WRAPPER_EXPORT_HPP
+#define ORES_COMPUTE_WRAPPER_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_COMPUTE_WRAPPER_LIBRARY
+#  define ORES_COMPUTE_WRAPPER_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_COMPUTE_WRAPPER_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.compute.wrapper/src/CMakeLists.txt
+++ b/projects/ores.compute.wrapper/src/CMakeLists.txt
@@ -28,6 +28,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_COMPUTE_WRAPPER_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.controller.service/include/ores.controller.service/app/host.hpp
+++ b/projects/ores.controller.service/include/ores.controller.service/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.controller.service/export.hpp"
 
 namespace ores::controller::service::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_CONTROLLER_SERVICE_EXPORT host {
 private:
     inline static std::string_view logger_name =
         "ores.controller.service.app.host";

--- a/projects/ores.controller.service/include/ores.controller.service/export.hpp
+++ b/projects/ores.controller.service/include/ores.controller.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_CONTROLLER_SERVICE_EXPORT_HPP
+#define ORES_CONTROLLER_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_CONTROLLER_SERVICE_LIBRARY
+#  define ORES_CONTROLLER_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_CONTROLLER_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.controller.service/src/CMakeLists.txt
+++ b/projects/ores.controller.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_CONTROLLER_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.dq.service/include/ores.dq.service/app/host.hpp
+++ b/projects/ores.dq.service/include/ores.dq.service/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.dq.service/export.hpp"
 
 namespace ores::dq::service::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_DQ_SERVICE_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.dq.service.app.host";
 

--- a/projects/ores.dq.service/include/ores.dq.service/export.hpp
+++ b/projects/ores.dq.service/include/ores.dq.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_DQ_SERVICE_EXPORT_HPP
+#define ORES_DQ_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_DQ_SERVICE_LIBRARY
+#  define ORES_DQ_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_DQ_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.dq.service/src/CMakeLists.txt
+++ b/projects/ores.dq.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_DQ_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.http.server/include/ores.http.server/app/host.hpp
+++ b/projects/ores.http.server/include/ores.http.server/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.http.server/export.hpp"
 
 namespace ores::http_server::app {
 
 /**
  * @brief Provides hosting services to the HTTP server application.
  */
-class host {
+class ORES_HTTP_SERVER_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.http.server.app.host";
 

--- a/projects/ores.http.server/include/ores.http.server/export.hpp
+++ b/projects/ores.http.server/include/ores.http.server/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_HTTP_SERVER_EXPORT_HPP
+#define ORES_HTTP_SERVER_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_HTTP_SERVER_LIBRARY
+#  define ORES_HTTP_SERVER_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_HTTP_SERVER_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.http.server/src/CMakeLists.txt
+++ b/projects/ores.http.server/src/CMakeLists.txt
@@ -28,6 +28,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_HTTP_SERVER_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.iam.service/include/ores.iam.service/app/host.hpp
+++ b/projects/ores.iam.service/include/ores.iam.service/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.iam.service/export.hpp"
 
 namespace ores::iam::service::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_IAM_SERVICE_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.iam.service.app.host";
 

--- a/projects/ores.iam.service/include/ores.iam.service/export.hpp
+++ b/projects/ores.iam.service/include/ores.iam.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_IAM_SERVICE_EXPORT_HPP
+#define ORES_IAM_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_IAM_SERVICE_LIBRARY
+#  define ORES_IAM_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_IAM_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.iam.service/src/CMakeLists.txt
+++ b/projects/ores.iam.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_IAM_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.marketdata.service/include/ores.marketdata.service/app/host.hpp
+++ b/projects/ores.marketdata.service/include/ores.marketdata.service/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.marketdata.service/export.hpp"
 
 namespace ores::marketdata::service::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_MARKETDATA_SERVICE_EXPORT host {
 private:
     inline static std::string_view logger_name =
         "ores.marketdata.service.app.host";

--- a/projects/ores.marketdata.service/include/ores.marketdata.service/export.hpp
+++ b/projects/ores.marketdata.service/include/ores.marketdata.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_MARKETDATA_SERVICE_EXPORT_HPP
+#define ORES_MARKETDATA_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_MARKETDATA_SERVICE_LIBRARY
+#  define ORES_MARKETDATA_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_MARKETDATA_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.marketdata.service/src/CMakeLists.txt
+++ b/projects/ores.marketdata.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_MARKETDATA_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.ore.service/include/ores.ore.service/app/host.hpp
+++ b/projects/ores.ore.service/include/ores.ore.service/app/host.hpp
@@ -26,6 +26,7 @@
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/io_context.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.ore.service/export.hpp"
 
 namespace ores::ore::service::app {
 
@@ -35,7 +36,7 @@ namespace ores::ore::service::app {
  * Parses command-line arguments, initialises logging, and drives the
  * application coroutine.
  */
-class host final {
+class ORES_ORE_SERVICE_EXPORT host final {
 private:
     inline static std::string_view logger_name = "ores.ore.service.app.host";
 

--- a/projects/ores.ore.service/include/ores.ore.service/export.hpp
+++ b/projects/ores.ore.service/include/ores.ore.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_ORE_SERVICE_EXPORT_HPP
+#define ORES_ORE_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_ORE_SERVICE_LIBRARY
+#  define ORES_ORE_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_ORE_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.ore.service/src/CMakeLists.txt
+++ b/projects/ores.ore.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_ORE_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.reporting.service/include/ores.reporting.service/app/host.hpp
+++ b/projects/ores.reporting.service/include/ores.reporting.service/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.reporting.service/export.hpp"
 
 namespace ores::reporting::service::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_REPORTING_SERVICE_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.reporting.service.app.host";
 

--- a/projects/ores.reporting.service/include/ores.reporting.service/export.hpp
+++ b/projects/ores.reporting.service/include/ores.reporting.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_REPORTING_SERVICE_EXPORT_HPP
+#define ORES_REPORTING_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_REPORTING_SERVICE_LIBRARY
+#  define ORES_REPORTING_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_REPORTING_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.reporting.service/src/CMakeLists.txt
+++ b/projects/ores.reporting.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_REPORTING_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.scheduler.service/include/ores.scheduler.service/app/host.hpp
+++ b/projects/ores.scheduler.service/include/ores.scheduler.service/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.scheduler.service/export.hpp"
 
 namespace ores::scheduler::service::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_SCHEDULER_SERVICE_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.scheduler.service.app.host";
 

--- a/projects/ores.scheduler.service/include/ores.scheduler.service/export.hpp
+++ b/projects/ores.scheduler.service/include/ores.scheduler.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SCHEDULER_SERVICE_EXPORT_HPP
+#define ORES_SCHEDULER_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_SCHEDULER_SERVICE_LIBRARY
+#  define ORES_SCHEDULER_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_SCHEDULER_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.scheduler.service/src/CMakeLists.txt
+++ b/projects/ores.scheduler.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_SCHEDULER_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.synthetic.service/include/ores.synthetic.service/app/host.hpp
+++ b/projects/ores.synthetic.service/include/ores.synthetic.service/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.synthetic.service/export.hpp"
 
 namespace ores::synthetic::service::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_SYNTHETIC_SERVICE_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.synthetic.service.app.host";
 

--- a/projects/ores.synthetic.service/include/ores.synthetic.service/export.hpp
+++ b/projects/ores.synthetic.service/include/ores.synthetic.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_SYNTHETIC_SERVICE_EXPORT_HPP
+#define ORES_SYNTHETIC_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_SYNTHETIC_SERVICE_LIBRARY
+#  define ORES_SYNTHETIC_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_SYNTHETIC_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.synthetic.service/src/CMakeLists.txt
+++ b/projects/ores.synthetic.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_SYNTHETIC_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.telemetry.service/include/ores.telemetry.service/app/host.hpp
+++ b/projects/ores.telemetry.service/include/ores.telemetry.service/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.telemetry.service/export.hpp"
 
 namespace ores::telemetry::service::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_TELEMETRY_SERVICE_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.telemetry.service.app.host";
 

--- a/projects/ores.telemetry.service/include/ores.telemetry.service/export.hpp
+++ b/projects/ores.telemetry.service/include/ores.telemetry.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TELEMETRY_SERVICE_EXPORT_HPP
+#define ORES_TELEMETRY_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_TELEMETRY_SERVICE_LIBRARY
+#  define ORES_TELEMETRY_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_TELEMETRY_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.telemetry.service/src/CMakeLists.txt
+++ b/projects/ores.telemetry.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_TELEMETRY_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.trading.service/include/ores.trading.service/app/host.hpp
+++ b/projects/ores.trading.service/include/ores.trading.service/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.trading.service/export.hpp"
 
 namespace ores::trading::service::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_TRADING_SERVICE_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.trading.service.app.host";
 

--- a/projects/ores.trading.service/include/ores.trading.service/export.hpp
+++ b/projects/ores.trading.service/include/ores.trading.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_EXPORT_HPP
+#define ORES_TRADING_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_TRADING_SERVICE_LIBRARY
+#  define ORES_TRADING_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_TRADING_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.trading.service/src/CMakeLists.txt
+++ b/projects/ores.trading.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_TRADING_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.variability.service/include/ores.variability.service/app/host.hpp
+++ b/projects/ores.variability.service/include/ores.variability.service/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.variability.service/export.hpp"
 
 namespace ores::variability::service::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_VARIABILITY_SERVICE_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.variability.service.app.host";
 

--- a/projects/ores.variability.service/include/ores.variability.service/export.hpp
+++ b/projects/ores.variability.service/include/ores.variability.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_VARIABILITY_SERVICE_EXPORT_HPP
+#define ORES_VARIABILITY_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_VARIABILITY_SERVICE_LIBRARY
+#  define ORES_VARIABILITY_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_VARIABILITY_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.variability.service/src/CMakeLists.txt
+++ b/projects/ores.variability.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_VARIABILITY_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.workflow.service/include/ores.workflow.service/app/host.hpp
+++ b/projects/ores.workflow.service/include/ores.workflow.service/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.workflow.service/export.hpp"
 
 namespace ores::workflow::service::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_WORKFLOW_SERVICE_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.workflow.service.app.host";
 

--- a/projects/ores.workflow.service/include/ores.workflow.service/export.hpp
+++ b/projects/ores.workflow.service/include/ores.workflow.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_WORKFLOW_SERVICE_EXPORT_HPP
+#define ORES_WORKFLOW_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_WORKFLOW_SERVICE_LIBRARY
+#  define ORES_WORKFLOW_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_WORKFLOW_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.workflow.service/src/CMakeLists.txt
+++ b/projects/ores.workflow.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_WORKFLOW_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.workspace.service/include/ores.workspace.service/app/host.hpp
+++ b/projects/ores.workspace.service/include/ores.workspace.service/app/host.hpp
@@ -25,13 +25,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "ores.workspace.service/export.hpp"
 
 namespace ores::workspace::service::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class ORES_WORKSPACE_SERVICE_EXPORT host {
 private:
     inline static std::string_view logger_name = "ores.workspace.service.app.host";
 

--- a/projects/ores.workspace.service/include/ores.workspace.service/export.hpp
+++ b/projects/ores.workspace.service/include/ores.workspace.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_WORKSPACE_SERVICE_EXPORT_HPP
+#define ORES_WORKSPACE_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_WORKSPACE_SERVICE_LIBRARY
+#  define ORES_WORKSPACE_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_WORKSPACE_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.workspace.service/src/CMakeLists.txt
+++ b/projects/ores.workspace.service/src/CMakeLists.txt
@@ -28,6 +28,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_WORKSPACE_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}


### PR DESCRIPTION
…classes

All service host classes with a static execute() method were missing __declspec(dllexport/dllimport) on Windows, causing LNK2001 when main.cpp links against the service lib. Add export.hpp + EXPORT macro to the host class and the LIBRARY compile definition to the lib target for all affected services.