### PR TITLE
Promote workspace to full standard entity with history, badges, and workspace selector

### DIFF
--- a/doc/meta/document_types.org
+++ b/doc/meta/document_types.org
@@ -10,6 +10,18 @@
 #+created: 2026-05-18
 #+updated: 2026-05-18
 
+* Creating documents
+
+Never hand-write frontmatter or IDs. Use the generator:
+
+#+begin_src sh
+projects/ores.codegen/generate_v2_doc.sh --type <type> --slug <slug> \
+  --parent-dir <dir> --title "..." --description "..." --tags "..."
+#+end_src
+
+See [[id:3153aa4b-23d4-4111-9710-5a4971102edc][How do I create a new v2 doc?]] for copy-pasteable invocations per
+type. The contract each generated file follows is described below.
+
 * Standard frontmatter
 
 Every document under =doc/= begins with this block. Fields marked

--- a/doc/plans/2026-05-21-workspace-full-entity.org
+++ b/doc/plans/2026-05-21-workspace-full-entity.org
@@ -1,0 +1,268 @@
+#+TITLE: Promote Workspace to Full Standard Entity
+#+DATE: 2026-05-21
+#+STATUS: In Progress
+#+OPTIONS: toc:t num:nil
+
+* Overview
+
+The workspace entity was created with ~has_history: false~, ~has_pagination: false~, and
+no ~detail_fields~ — all without documented rationale. The entity lifecycle standard
+requires every entity to have history, pagination, and a generated detail dialog unless a
+written deviation rationale is present. This plan promotes workspace to a full standard
+entity, adding history support and a generated detail dialog, and records the legitimate
+deviations for the remaining non-standard dimensions.
+
+* Justified Deviations (document, do not fix)
+
+The following dimensions legitimately differ from the standard and must have written
+rationale added to the codegen model:
+
+| Dimension           | Value | Rationale |
+|---------------------+-------+-----------|
+| ~has_tenant_id~     | false | Workspace is system-wide; cross-tenant isolation is handled via IAM, not per-tenant row scoping. |
+| ~has_workspace_id~  | false | A workspace cannot belong to a workspace; self-referential membership is undefined. |
+| ~has_pagination~    | false | A tenant holds at most ~20 active workspaces by product design; the tree view displaying the parent-workspace hierarchy does not support standard pagination. |
+| Tree view (not QTableView) | — | ~WorkspaceMdiWindow~ uses ~QTreeWidget~ to display the workspace inheritance chain; a flat paginated list loses that hierarchy. Codegen of the MDI window is skipped; only the detail and history dialogs are generated. |
+
+* What Changes
+
+** Unjustified deviations to fix
+
+- ~has_history: false~ → ~true~: no justification exists; the bitemporal table already
+  stores full version history; the audit trail must be viewable.
+- No ~detail_fields~: replace hand-crafted ~WorkspaceDetailDialog~ with a generated
+  version driven by the model.
+- No generator: add ~workspace_generator.hpp/.cpp~ for test data generation.
+
+* Phase 1 — Model Update and C++ API
+
+** PR title
+
+~[workspace] Add history support and generator to workspace entity~
+
+** 1.1 Update the codegen model
+
+File: ~projects/ores.codegen/models/workspace/workspace_domain_entity.json~
+
+Add to the top-level ~domain_entity~ section (alongside existing ~has_tenant_id~):
+
+#+BEGIN_SRC json
+"deviation_rationale_tenant_id":    "Workspace is system-wide; cross-tenant isolation is handled via IAM, not per-tenant row scoping.",
+"deviation_rationale_workspace_id": "A workspace cannot belong to a workspace; self-referential membership is undefined.",
+#+END_SRC
+
+Add/replace in the ~qt~ section:
+
+#+BEGIN_SRC json
+"has_history": true,
+"has_pagination": false,
+"deviation_rationale_pagination": "A tenant holds at most ~20 active workspaces by product design; the tree view displaying the parent-workspace hierarchy does not support standard pagination.",
+
+"history_request_class":  "workspace::messaging::get_workspace_history_request",
+"history_response_class": "workspace::messaging::get_workspace_history_response",
+"history_message_type":   "get_workspace_history_request",
+
+"detail_fields": [
+  {"field": "name",                "label": "Name",        "widget": "nameEdit",        "type": "line_edit",      "is_key": true, "is_required": true, "placeholder": "Unique workspace name"},
+  {"field": "description",         "label": "Description", "widget": "descriptionEdit", "type": "plain_text_edit"},
+  {"field": "source_path",         "label": "Source Path", "widget": "sourcePathEdit",  "type": "line_edit",      "placeholder": "Optional data source path"},
+  {"field": "parent_workspace_id", "label": "Parent",      "widget": "parentEdit",      "type": "line_edit",      "readonly": true, "placeholder": "Inherited from (UUID)"},
+  {"field": "owner_id",            "label": "Owner",       "widget": "ownerEdit",       "type": "line_edit",      "readonly": true},
+  {"field": "status_code",         "label": "Status",      "widget": "statusEdit",      "type": "line_edit",      "readonly": true}
+]
+#+END_SRC
+
+Remove the explicit ~"has_history": false~ and ~"has_pagination": false~ lines (replacing
+them with the above — pagination keeps false but now has rationale).
+
+** 1.2 Regenerate C++ API
+
+#+BEGIN_SRC sh
+cd projects/ores.codegen
+./run_generator.sh models/workspace/workspace_domain_entity.json --profile all-cpp
+#+END_SRC
+
+Expected new/changed files in ~projects/ores.workspace.api/~:
+
+- ~include/ores.workspace.api/generators/workspace_generator.hpp~ — *new*
+- ~src/generators/workspace_generator.cpp~ — *new*
+- ~include/ores.workspace.api/messaging/workspace_protocol.hpp~ — add ~get_workspace_history_request/response~
+
+** 1.3 CMakeLists integration
+
+File: ~projects/ores.workspace.api/CMakeLists.txt~
+
+Add the generator source files if they are not picked up automatically via GLOB.
+
+** 1.4 Build and verify
+
+Ask user to build ~ores.workspace.api~:
+
+#+BEGIN_SRC sh
+make -C build/output/linux-clang-debug-make -j$(nproc) ores.workspace.api
+#+END_SRC
+
+* Phase 2 — C++ Core (History Method)
+
+** PR title
+
+~[workspace] Add workspace history repository and service methods~
+
+** 2.1 Repository
+
+Files:
+- ~projects/ores.workspace.core/include/ores.workspace.core/repository/workspace_repository.hpp~
+- ~projects/ores.workspace.core/src/repository/workspace_repository.cpp~
+
+The repository already has ~read_all(ctx, id)~ which returns all versions of a single
+workspace. Add the standard-named alias:
+
+#+BEGIN_SRC cpp
+std::vector<domain::workspace>
+read_history(context ctx, const boost::uuids::uuid& id);
+#+END_SRC
+
+Implementation: same bitemporal query as ~read_all(id)~, ordered newest-first by ~valid_from DESC~.
+
+** 2.2 Service
+
+Files:
+- ~projects/ores.workspace.core/include/ores.workspace.core/service/workspace_service.hpp~
+- ~projects/ores.workspace.core/src/service/workspace_service.cpp~
+
+Add:
+
+#+BEGIN_SRC cpp
+std::vector<domain::workspace>
+get_workspace_history(const boost::uuids::uuid& id);
+#+END_SRC
+
+Delegates to ~workspace_repo_.read_history(ctx, id)~.
+
+** 2.3 Handler
+
+Files:
+- ~projects/ores.workspace.core/include/ores.workspace.core/messaging/workspace_handler.hpp~
+- ~projects/ores.workspace.core/src/messaging/workspace_handler.cpp~
+
+Add routing for ~get_workspace_history_request~ → call ~service_.get_workspace_history(id)~,
+return ~get_workspace_history_response{workspaces}~.
+
+** 2.4 Build and verify
+
+Ask user to build ~ores.workspace.core~:
+
+#+BEGIN_SRC sh
+make -C build/output/linux-clang-debug-make -j$(nproc) ores.workspace.core
+#+END_SRC
+
+* Phase 3 — Qt UI
+
+** PR title
+
+~[qt] Add workspace history dialog and replace hand-crafted detail dialog~
+
+** 3.1 Regenerate Qt layer (selectively)
+
+Run codegen for the Qt profile to get the detail dialog and history dialog:
+
+#+BEGIN_SRC sh
+cd projects/ores.codegen
+./run_generator.sh models/workspace/workspace_domain_entity.json --profile qt
+#+END_SRC
+
+This will generate or update all Qt files. *Do not commit the regenerated
+~WorkspaceMdiWindow~ or ~ClientWorkspaceModel~ files* — these are justified deviations
+(tree view, no pagination). Only integrate:
+
+- ~WorkspaceDetailDialog.hpp/.cpp/.ui~ — replaces hand-crafted version
+- ~WorkspaceHistoryDialog.hpp/.cpp/.ui~ — *new*
+
+Review generated ~WorkspaceDetailDialog~ carefully: the existing hand-crafted dialog has a
+Provenance tab showing read-only audit fields. The generated version may or may not include
+this; manually merge the provenance widget if the generator omits it.
+
+** 3.2 Update WorkspaceMdiWindow
+
+Files:
+- ~projects/ores.qt.workspace/include/ores.qt/WorkspaceMdiWindow.hpp~
+- ~projects/ores.qt.workspace/src/WorkspaceMdiWindow.cpp~
+
+Add to the private section of the header:
+
+#+BEGIN_SRC cpp
+QAction* historyAction_{nullptr};
+void onHistoryRequested();
+#+END_SRC
+
+In ~WorkspaceMdiWindow.cpp~, in the toolbar setup block (after ~editAction_~):
+
+#+BEGIN_SRC cpp
+historyAction_ = toolbar_->addAction(
+    QIcon::fromTheme("document-open-recent"), tr("History"));
+historyAction_->setEnabled(false);
+connect(historyAction_, &QAction::triggered,
+        this, &WorkspaceMdiWindow::onHistoryRequested);
+#+END_SRC
+
+Enable/disable ~historyAction_~ alongside ~editAction_~ in the selection-changed handler.
+
+Implement ~onHistoryRequested()~:
+
+#+BEGIN_SRC cpp
+void WorkspaceMdiWindow::onHistoryRequested() {
+    const auto* item = treeWidget_->currentItem();
+    if (!item) return;
+    const auto id = item->data(0, Qt::UserRole).toString();
+    auto* dlg = new WorkspaceHistoryDialog(clientManager_, id, this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->exec();
+}
+#+END_SRC
+
+** 3.3 CMakeLists integration
+
+File: ~projects/ores.qt.workspace/CMakeLists.txt~
+
+Add ~WorkspaceHistoryDialog.hpp~, ~WorkspaceHistoryDialog.cpp~, ~WorkspaceHistoryDialog.ui~
+if not picked up by GLOB.
+
+** 3.4 Build and verify
+
+Ask user to build ~ores.qt.workspace~:
+
+#+BEGIN_SRC sh
+make -C build/output/linux-clang-debug-make -j$(nproc) ores.qt.workspace
+#+END_SRC
+
+Manual smoke test:
+1. Launch the application and open the Workspace MDI window.
+2. Select any workspace → History button becomes enabled.
+3. Click History → ~WorkspaceHistoryDialog~ opens with the full version list.
+4. Click Edit (or Add) → generated ~WorkspaceDetailDialog~ opens with Name, Description,
+   Source Path, Parent, Owner, Status fields.
+
+* Files Changed
+
+| File | Change |
+|------+--------|
+| ~projects/ores.codegen/models/workspace/workspace_domain_entity.json~ | Add history config, detail_fields, deviation rationales |
+| ~projects/ores.workspace.api/include/.../messaging/workspace_protocol.hpp~ | Add ~get_workspace_history_request/response~ |
+| ~projects/ores.workspace.api/include/.../generators/workspace_generator.hpp~ | *New* |
+| ~projects/ores.workspace.api/src/generators/workspace_generator.cpp~ | *New* |
+| ~projects/ores.workspace.api/CMakeLists.txt~ | Add generator sources if needed |
+| ~projects/ores.workspace.core/include/.../repository/workspace_repository.hpp~ | Add ~read_history()~ |
+| ~projects/ores.workspace.core/src/repository/workspace_repository.cpp~ | Implement ~read_history()~ |
+| ~projects/ores.workspace.core/include/.../service/workspace_service.hpp~ | Add ~get_workspace_history()~ |
+| ~projects/ores.workspace.core/src/service/workspace_service.cpp~ | Implement |
+| ~projects/ores.workspace.core/include/.../messaging/workspace_handler.hpp~ | Add history handler |
+| ~projects/ores.workspace.core/src/messaging/workspace_handler.cpp~ | Route history request |
+| ~projects/ores.qt.workspace/include/.../WorkspaceDetailDialog.hpp~ | Replace with generated |
+| ~projects/ores.qt.workspace/src/WorkspaceDetailDialog.cpp~ | Replace with generated |
+| ~projects/ores.qt.workspace/ui/WorkspaceDetailDialog.ui~ | Replace with generated |
+| ~projects/ores.qt.workspace/include/.../WorkspaceHistoryDialog.hpp~ | *New* (generated) |
+| ~projects/ores.qt.workspace/src/WorkspaceHistoryDialog.cpp~ | *New* (generated) |
+| ~projects/ores.qt.workspace/ui/WorkspaceHistoryDialog.ui~ | *New* (generated) |
+| ~projects/ores.qt.workspace/include/.../WorkspaceMdiWindow.hpp~ | Add ~historyAction_~, ~onHistoryRequested()~ |
+| ~projects/ores.qt.workspace/src/WorkspaceMdiWindow.cpp~ | Wire history action → dialog |
+| ~projects/ores.qt.workspace/CMakeLists.txt~ | Add history dialog sources if needed |

--- a/doc/v2/recipes/entity/how_do_i_create_a_new_entity.org
+++ b/doc/v2/recipes/entity/how_do_i_create_a_new_entity.org
@@ -1,0 +1,85 @@
+:PROPERTIES:
+:ID: b6c5d4e3-f2a1-4b0c-8d9e-0f1a2b3c4d5e
+:END:
+#+title: How do I create a new entity?
+#+description: Steps to add a complete domain entity across all layers using codegen-first approach.
+#+type: recipe
+#+level: cross
+#+filetags: :entity:codegen:recipe:
+#+created: 2026-05-21
+#+updated: 2026-05-21
+
+* Question
+
+How do I add a new domain entity to ORE Studio?
+
+* Answer
+
+** 1. Read the standard first
+
+Every entity must conform to [[id:f3a1b2c4-d5e6-4f7a-8b9c-0d1e2f3a4b5c][entity lifecycle]] before writing any code.
+That document specifies what each layer must contain and what the defaults
+are. Partial entities or disabled defaults without written rationale are not
+acceptable.
+
+** 2. Create the codegen model
+
+Create =projects/ores.codegen/models/{component}/{entity}_domain_entity.json=.
+Minimum required content in the =qt= section:
+
+#+begin_src json
+"qt": {
+  "has_uuid_primary_key": true,
+  "has_pagination": true,
+  "has_history": true,
+  "detail_fields": [ ... ],
+  "history_request_class":  "{component}::messaging::get_{entity}_history_request",
+  "history_response_class": "{component}::messaging::get_{entity}_history_response",
+  "history_message_type":   "get_{entity}_history_request",
+  ...
+}
+#+end_src
+
+If any of =has_history=, =has_pagination=, or =detail_fields= is absent
+or disabled, add a =deviation_rationale_{dimension}= key with a one-sentence
+justification before proceeding.
+
+** 3. Generate and integrate each layer
+
+#+begin_src sh
+cd projects/ores.codegen
+
+# SQL (table DDL, trigger, RLS, artefact table)
+./run_generator.sh models/{component}/{entity}_domain_entity.json
+
+# C++ API and core (domain type, repository, service, handler)
+./run_generator.sh models/{component}/{entity}_domain_entity.json --profile all-cpp
+
+# Qt UI (model, MDI window, detail dialog, history dialog, controller)
+./run_generator.sh models/{component}/{entity}_domain_entity.json --profile qt
+#+end_src
+
+Follow the [[id:a9b8c7d6-e5f4-4a3b-9c2d-1e0f9a8b7c6d][entity-creator]] skill for CMakeLists integration, controller
+wiring, and PR checkpoints at each layer boundary.
+
+** 4. Validate
+
+#+begin_src sh
+# SQL schema integrity
+./projects/ores.sql/utility/validate_schemas.sh
+
+# Component documentation
+./projects/ores.codegen/validate_docs.sh
+#+end_src
+
+Ask the user to build the affected targets before raising each PR.
+
+* Script
+
+See [[id:a9b8c7d6-e5f4-4a3b-9c2d-1e0f9a8b7c6d][entity-creator]] skill for the full phase-by-phase execution guide and
+layer-specific skills for deep detail on each layer.
+
+* Tested by
+
+Build and test suite for the component under =cmake --build --preset
+linux-clang-debug-ninja --target {component}.core.tests=.

--- a/projects/ores.codegen/library/templates/cpp_domain_type_generator.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_generator.cpp.mustache
@@ -45,7 +45,13 @@ domain::{{entity_singular}} generate_synthetic_{{entity_singular}}(
     r.{{column}} = ctx.generate_uuid();
 {{/is_uuid}}
 {{^is_uuid}}
+{{#generator_expr}}
     r.{{column}} = {{{generator_expr}}};
+{{/generator_expr}}
+{{^generator_expr}}
+    r.{{column}} = std::string(faker::word::noun()) + "-"
+        + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
+{{/generator_expr}}
 {{/is_uuid}}
 {{/natural_keys}}
 {{#columns}}

--- a/projects/ores.codegen/library/templates/cpp_domain_type_generator.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_generator.cpp.mustache
@@ -46,7 +46,8 @@ domain::{{entity_singular}} generate_synthetic_{{entity_singular}}(
 {{/is_uuid}}
 {{^is_uuid}}
 {{#generator_expr}}
-    r.{{column}} = {{{generator_expr}}};
+    r.{{column}} = {{{generator_expr}}} + "-"
+        + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
 {{/generator_expr}}
 {{^generator_expr}}
     r.{{column}} = std::string(faker::word::noun()) + "-"

--- a/projects/ores.codegen/library/templates/cpp_qt_detail_dialog.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_detail_dialog.cpp.mustache
@@ -13,6 +13,12 @@
 {{/domain_entity.qt.has_combo_fields}}
 {{#domain_entity.qt.has_uuid_primary_key}}
 #include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+{{/domain_entity.qt.has_uuid_primary_key}}
+{{^domain_entity.qt.has_uuid_primary_key}}
+{{#domain_entity.qt.has_uuid_detail_fields}}
+#include <boost/uuid/uuid_io.hpp>
+{{/domain_entity.qt.has_uuid_detail_fields}}
 {{/domain_entity.qt.has_uuid_primary_key}}
 #include "ui_{{domain_entity.entity_pascal}}DetailDialog.h"
 #include "ores.qt/IconUtils.hpp"
@@ -207,6 +213,20 @@ void {{domain_entity.entity_pascal}}DetailDialog::populate{{combo_setter_pascal}
 void {{domain_entity.entity_pascal}}DetailDialog::updateUiFrom{{domain_entity.entity_pascal_short}}() {
 {{#domain_entity.qt.detail_fields}}
 {{#is_line_edit}}
+{{#is_optional_uuid}}
+    {
+        const auto& _opt = {{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}};
+        ui_->{{widget}}->setText(_opt
+            ? QString::fromStdString(boost::uuids::to_string(*_opt))
+            : QString{});
+    }
+{{/is_optional_uuid}}
+{{^is_optional_uuid}}
+{{#is_uuid}}
+    ui_->{{widget}}->setText(QString::fromStdString(
+        boost::uuids::to_string({{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}})));
+{{/is_uuid}}
+{{^is_uuid}}
 {{#is_optional_string}}
     ui_->{{widget}}->setText({{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}}
         ? QString::fromStdString(*{{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}})
@@ -215,6 +235,8 @@ void {{domain_entity.entity_pascal}}DetailDialog::updateUiFrom{{domain_entity.en
 {{^is_optional_string}}
     ui_->{{widget}}->setText(QString::fromStdString({{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}}));
 {{/is_optional_string}}
+{{/is_uuid}}
+{{/is_optional_uuid}}
 {{/is_line_edit}}
 {{#is_text_edit}}
 {{#is_optional_string}}
@@ -289,6 +311,8 @@ void {{domain_entity.entity_pascal}}DetailDialog::update{{domain_entity.entity_p
 {{/is_key}}
 {{^is_key}}
 {{#is_line_edit}}
+{{^is_uuid}}
+{{^is_optional_uuid}}
 {{#is_optional_string}}
     {
         const auto {{field}}_str = ui_->{{widget}}->text().trimmed().toStdString();
@@ -299,6 +323,8 @@ void {{domain_entity.entity_pascal}}DetailDialog::update{{domain_entity.entity_p
 {{^is_optional_string}}
     {{domain_entity.qt.item_var}}_.{{#field_access}}{{field_access}}{{/field_access}}{{^field_access}}{{field}}{{/field_access}} = ui_->{{widget}}->text().trimmed().toStdString();
 {{/is_optional_string}}
+{{/is_optional_uuid}}
+{{/is_uuid}}
 {{/is_line_edit}}
 {{#is_text_edit}}
 {{#is_optional_string}}
@@ -483,13 +509,18 @@ void {{domain_entity.entity_pascal}}DetailDialog::onDeleteClicked() {
     };
 
 {{#domain_entity.qt.has_uuid_primary_key}}
-    auto task = [self, id = {{domain_entity.qt.item_var}}_.{{#domain_entity.qt.id_access}}{{domain_entity.qt.id_access}}{{/domain_entity.qt.id_access}}{{^domain_entity.qt.id_access}}id{{/domain_entity.qt.id_access}}]() -> DeleteResult {
+    auto task = [self, id_str = boost::uuids::to_string({{domain_entity.qt.item_var}}_.{{#domain_entity.qt.id_access}}{{domain_entity.qt.id_access}}{{/domain_entity.qt.id_access}}{{^domain_entity.qt.id_access}}id{{/domain_entity.qt.id_access}})]() -> DeleteResult {
         if (!self || !self->clientManager_) {
             return {false, "Dialog closed"};
         }
 
         {{domain_entity.qt.delete_request_class}} request;
-        request.ids = {id};
+{{#domain_entity.qt.delete_request_id_is_plural}}
+        request.{{domain_entity.qt.delete_request_id_field}} = {id_str};
+{{/domain_entity.qt.delete_request_id_is_plural}}
+{{^domain_entity.qt.delete_request_id_is_plural}}
+        request.{{domain_entity.qt.delete_request_id_field}} = id_str;
+{{/domain_entity.qt.delete_request_id_is_plural}}
         auto response_result = self->clientManager_->
             process_authenticated_request(std::move(request));
 

--- a/projects/ores.codegen/library/templates/cpp_qt_history_dialog.cpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_qt_history_dialog.cpp.mustache
@@ -10,6 +10,14 @@
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "{{domain_entity.qt.protocol_include}}"
+{{#domain_entity.qt.has_uuid_primary_key}}
+#include <boost/uuid/uuid_io.hpp>
+{{/domain_entity.qt.has_uuid_primary_key}}
+{{^domain_entity.qt.has_uuid_primary_key}}
+{{#domain_entity.qt.has_uuid_detail_fields}}
+#include <boost/uuid/uuid_io.hpp>
+{{/domain_entity.qt.has_uuid_detail_fields}}
+{{/domain_entity.qt.has_uuid_primary_key}}
 
 namespace ores::qt {
 
@@ -133,11 +141,11 @@ void {{domain_entity.entity_pascal}}HistoryDialog::loadHistory() {
 
 {{#domain_entity.qt.has_uuid_primary_key}}
     QFuture<HistoryResult> future =
-        QtConcurrent::run([self, id = id_]() -> HistoryResult {
+        QtConcurrent::run([self, id_str = boost::uuids::to_string(id_)]() -> HistoryResult {
         if (!self || !self->clientManager_)
             return std::unexpected("Dialog closed");
         {{domain_entity.qt.history_request_class}} request;
-        request.id = id;
+        request.id = id_str;
         auto result = self->clientManager_->process_authenticated_request(std::move(request));
         if (!result) return std::unexpected(result.error());
         return std::move(*result);
@@ -292,9 +300,26 @@ void {{domain_entity.entity_pascal}}HistoryDialog::updateChangesTable(int curren
 {{^is_optional_string}}
 {{^is_check_box}}
 {{^is_spin_box}}
+{{#is_optional_uuid}}
+        {
+            auto _to_s = [](const std::optional<boost::uuids::uuid>& o) {
+                return o ? QString::fromStdString(boost::uuids::to_string(*o)) : QString{};
+            };
+            addChange("{{label}}", _to_s(previous.{{field}}), _to_s(current.{{field}}));
+        }
+{{/is_optional_uuid}}
+{{^is_optional_uuid}}
+{{#is_uuid}}
+        addChange("{{label}}",
+                  QString::fromStdString(boost::uuids::to_string(previous.{{field}})),
+                  QString::fromStdString(boost::uuids::to_string(current.{{field}})));
+{{/is_uuid}}
+{{^is_uuid}}
         addChange("{{label}}",
                   QString::fromStdString(previous.{{field}}),
                   QString::fromStdString(current.{{field}}));
+{{/is_uuid}}
+{{/is_optional_uuid}}
 {{/is_spin_box}}
 {{/is_check_box}}
 {{/is_optional_string}}
@@ -348,7 +373,20 @@ void {{domain_entity.entity_pascal}}HistoryDialog::updateFullDetails(int version
 {{^is_optional_string}}
 {{^is_check_box}}
 {{^is_spin_box}}
+{{#is_optional_uuid}}
+    ui_->{{value_widget}}->setText(version.{{field}}
+        ? QString::fromStdString(boost::uuids::to_string(*version.{{field}}))
+        : QString{});
+{{/is_optional_uuid}}
+{{^is_optional_uuid}}
+{{#is_uuid}}
+    ui_->{{value_widget}}->setText(
+        QString::fromStdString(boost::uuids::to_string(version.{{field}})));
+{{/is_uuid}}
+{{^is_uuid}}
     ui_->{{value_widget}}->setText(QString::fromStdString(version.{{field}}));
+{{/is_uuid}}
+{{/is_optional_uuid}}
 {{/is_spin_box}}
 {{/is_check_box}}
 {{/is_optional_string}}

--- a/projects/ores.codegen/models/analytics/pricing_model_config_domain_entity.json
+++ b/projects/ores.codegen/models/analytics/pricing_model_config_domain_entity.json
@@ -27,7 +27,7 @@
         "cpp_type": "std::string",
         "description": "Human-readable name for this configuration.",
         "detail": "Unique per tenant. Examples: 'Standard', 'AMC', 'DeltaGamma', 'SABR'.",
-        "generator_expr": "std::string(\"config_\") + std::to_string(++counter)"
+        "generator_expr": "std::string(\"config\")"
       }
     ],
 

--- a/projects/ores.codegen/models/workspace/workspace_domain_entity.json
+++ b/projects/ores.codegen/models/workspace/workspace_domain_entity.json
@@ -128,6 +128,7 @@
       "delete_request_class": "workspace::messaging::archive_workspace_request",
       "delete_response_class": "workspace::messaging::archive_workspace_response",
       "delete_message_type": "archive_workspace_request",
+      "delete_request_id_field": "id",
       "history_request_class":  "workspace::messaging::get_workspace_history_request",
       "history_response_class": "workspace::messaging::get_workspace_history_response",
       "history_message_type":   "get_workspace_history_request",

--- a/projects/ores.codegen/models/workspace/workspace_domain_entity.json
+++ b/projects/ores.codegen/models/workspace/workspace_domain_entity.json
@@ -7,6 +7,8 @@
     "component_core": "workspace.core",
     "has_tenant_id": false,
     "has_workspace_id": false,
+    "deviation_rationale_tenant_id": "Workspace is system-wide; cross-tenant isolation is handled via IAM, not per-tenant row scoping.",
+    "deviation_rationale_workspace_id": "A workspace cannot belong to a workspace; self-referential membership is undefined.",
     "entity_singular": "workspace",
     "entity_plural": "workspaces",
     "entity_title": "Workspace",
@@ -111,7 +113,8 @@
       "has_uuid_primary_key": true,
       "has_integer_primary_key": false,
       "has_pagination": false,
-      "has_history": false,
+      "deviation_rationale_pagination": "A tenant holds at most ~20 active workspaces by product design; the tree view displaying the parent-workspace hierarchy does not support standard pagination.",
+      "has_history": true,
       "has_description_column": true,
 
       "get_request_class": "workspace::messaging::list_workspaces_request",
@@ -124,6 +127,18 @@
       "delete_request_class": "workspace::messaging::archive_workspace_request",
       "delete_response_class": "workspace::messaging::archive_workspace_response",
       "delete_message_type": "archive_workspace_request",
+      "history_request_class":  "workspace::messaging::get_workspace_history_request",
+      "history_response_class": "workspace::messaging::get_workspace_history_response",
+      "history_message_type":   "get_workspace_history_request",
+
+      "detail_fields": [
+        {"field": "name",                "label": "Name",        "widget": "nameEdit",        "type": "line_edit",      "is_key": true, "is_required": true, "placeholder": "Unique workspace name"},
+        {"field": "description",         "label": "Description", "widget": "descriptionEdit", "type": "plain_text_edit"},
+        {"field": "source_path",         "label": "Source Path", "widget": "sourcePathEdit",  "type": "line_edit",      "placeholder": "Optional data source path"},
+        {"field": "parent_workspace_id", "label": "Parent",      "widget": "parentEdit",      "type": "line_edit",      "readonly": true, "placeholder": "Inherited from (UUID)"},
+        {"field": "owner_id",            "label": "Owner",       "widget": "ownerEdit",       "type": "line_edit",      "readonly": true},
+        {"field": "status_code",         "label": "Status",      "widget": "statusEdit",      "type": "line_edit",      "readonly": true}
+      ],
 
       "columns": [
         {"enum_name": "Name",        "field": "name",        "header": "Name",        "is_string": true, "width": 200},

--- a/projects/ores.codegen/models/workspace/workspace_domain_entity.json
+++ b/projects/ores.codegen/models/workspace/workspace_domain_entity.json
@@ -30,7 +30,7 @@
         "type": "text",
         "cpp_type": "std::string",
         "description": "Unique workspace name.",
-        "generator_expr": "std::string(faker::word::noun()) + \"-\" + std::to_string(counter.fetch_add(1, std::memory_order_relaxed))"
+        "generator_expr": "std::string(faker::word::noun())"
       }
     ],
 

--- a/projects/ores.codegen/models/workspace/workspace_domain_entity.json
+++ b/projects/ores.codegen/models/workspace/workspace_domain_entity.json
@@ -29,7 +29,8 @@
         "column": "name",
         "type": "text",
         "cpp_type": "std::string",
-        "description": "Unique workspace name."
+        "description": "Unique workspace name.",
+        "generator_expr": "std::string(faker::word::noun()) + \"-\" + std::to_string(counter.fetch_add(1, std::memory_order_relaxed))"
       }
     ],
 

--- a/projects/ores.codegen/src/generator.py
+++ b/projects/ores.codegen/src/generator.py
@@ -1486,7 +1486,7 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
             }
             for i, f in enumerate(detail_fields):
                 f['is_line_edit'] = f.get('type') == 'line_edit'
-                f['is_text_edit'] = f.get('type') == 'text_edit'
+                f['is_text_edit'] = f.get('type') in ('text_edit', 'plain_text_edit')
                 f['is_static_combo'] = f.get('type') == 'static_combo'
                 f['is_dynamic_combo'] = f.get('type') == 'dynamic_combo'
                 f['is_check_box'] = f.get('type') == 'check_box'
@@ -1496,6 +1496,10 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
                     field_cpp.startswith('std::optional<std::string>')
                     and (f['is_line_edit'] or f['is_text_edit'])
                 )
+                # UUID type detection — needed for boost::uuids::to_string() conversions
+                _is_any_uuid = 'boost::uuids::uuid' in field_cpp
+                f['is_optional_uuid'] = 'std::optional<boost::uuids::uuid>' in field_cpp
+                f['is_uuid'] = _is_any_uuid and not f['is_optional_uuid']
                 # Tri-state checkbox for optional<bool>; normal two-state
                 # for plain bool. Nullable spin box uses minimum as sentinel.
                 f['is_tristate'] = (
@@ -1546,7 +1550,7 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
             # Default has_pagination to False if not set
             qt['has_pagination'] = qt.get('has_pagination', False)
             qt['has_text_edit_fields'] = any(
-                f.get('type') == 'text_edit' for f in detail_fields
+                f.get('type') in ('text_edit', 'plain_text_edit') for f in detail_fields
             )
             qt['has_combo_fields'] = any(
                 f.get('type') in ('static_combo', 'dynamic_combo') for f in detail_fields
@@ -1557,6 +1561,14 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
             qt['has_static_combo_fields'] = any(
                 f.get('type') == 'static_combo' for f in detail_fields
             )
+            qt['has_uuid_detail_fields'] = any(
+                f.get('is_uuid') or f.get('is_optional_uuid') for f in detail_fields
+            )
+            # Delete request id field config for UUID PK entities
+            if qt.get('has_uuid_primary_key', False):
+                qt.setdefault('delete_request_id_field', 'ids')
+                qt['delete_request_id_is_plural'] = (
+                    qt['delete_request_id_field'] != 'id')
             qt['metadata_start_row'] = len(detail_fields)
             qt['metadata_start_row_plus_1'] = len(detail_fields) + 1
             qt['metadata_start_row_plus_2'] = len(detail_fields) + 2

--- a/projects/ores.qt.api/include/ores.qt/EntityListMdiWindow.hpp
+++ b/projects/ores.qt.api/include/ores.qt/EntityListMdiWindow.hpp
@@ -37,6 +37,7 @@
 namespace ores::qt {
 
 class ClientManager;
+class PaginationWidget;
 
 /**
  * @brief Base class for entity list MDI windows providing stale indicator support.
@@ -195,16 +196,28 @@ protected:
     void connectModel(AbstractClientModel* model);
 
     /**
+     * @brief Create a bottom bar: optional workspace selector (left) + pagination (right).
+     *
+     * Call once in setupUi() after creating the pagination widget. Pass the
+     * returned widget to layout->addWidget() instead of adding paginationWidget_
+     * directly.
+     *
+     * The workspace selector is opt-in: pass a non-null ClientManager to include it.
+     * Subclasses that include the selector should override onWindowWorkspaceChanged
+     * to update their model before calling the base implementation.
+     *
+     * @param pagination  Pagination widget to place on the right (may be null).
+     * @param cm          If non-null, adds a workspace selector on the left.
+     * @return            A new QWidget owned by this window.
+     */
+    QWidget* createBottomBar(class PaginationWidget* pagination,
+                             ClientManager* cm = nullptr);
+
+    /**
      * @brief Create a workspace selector widget bound to this window.
      *
-     * The selector fetches the workspace list from the server, shows a
-     * searchable QComboBox, and emits workspaceChanged. Connect its signal
-     * to the window's onWindowWorkspaceChanged to propagate changes. Add the
-     * returned widget to the window's toolbar with an expanding spacer on its
-     * left so it sits flush-right.
-     *
-     * The window's windowWorkspaceContext_ is initialised to cm->workspaceContext()
-     * and kept in sync automatically as the user makes changes.
+     * Prefer createBottomBar() for new code. Use this only when embedding the
+     * selector in a non-standard location (e.g. inside a splitter panel).
      *
      * @param cm  The ClientManager (must outlive the returned widget).
      * @return    A new WorkspaceSelector* owned by this widget.

--- a/projects/ores.qt.api/src/EntityListMdiWindow.cpp
+++ b/projects/ores.qt.api/src/EntityListMdiWindow.cpp
@@ -20,6 +20,7 @@
 #include "ores.qt/EntityListMdiWindow.hpp"
 
 #include <QHeaderView>
+#include <QHBoxLayout>
 #include <QMenu>
 #include <QProgressBar>
 #include <QWidget>
@@ -27,6 +28,7 @@
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/PaginationWidget.hpp"
 #include "ores.qt/UiPersistence.hpp"
 #include "ores.qt/WorkspaceSelector.hpp"
 
@@ -233,6 +235,19 @@ void EntityListMdiWindow::connectModel(AbstractClientModel* model) {
             this, &EntityListMdiWindow::endLoading);
     connect(model, &AbstractClientModel::loadError,
             this, [this](const QString&, const QString&) { endLoading(); });
+}
+
+QWidget* EntityListMdiWindow::createBottomBar(PaginationWidget* pagination,
+                                               ClientManager* cm) {
+    auto* bar = new QWidget(this);
+    auto* h = new QHBoxLayout(bar);
+    h->setContentsMargins(0, 0, 0, 0);
+    h->setSpacing(4);
+    if (cm)
+        h->addWidget(createWorkspaceSelector(cm));
+    if (pagination)
+        h->addWidget(pagination, 1);
+    return bar;
 }
 
 WorkspaceSelector* EntityListMdiWindow::createWorkspaceSelector(ClientManager* cm) {

--- a/projects/ores.qt.compute/src/ReportDefinitionMdiWindow.cpp
+++ b/projects/ores.qt.compute/src/ReportDefinitionMdiWindow.cpp
@@ -21,7 +21,6 @@
 
 #include <QVBoxLayout>
 #include <QHeaderView>
-#include <QSizePolicy>
 #include <QMessageBox>
 #include <QtConcurrent>
 #include <QFutureWatcher>
@@ -29,7 +28,6 @@
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/EntityItemDelegate.hpp"
 #include "ores.qt/BadgeCache.hpp"
-#include "ores.qt/WorkspaceSelector.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
 #include "ores.qt/ColorConstants.hpp"
 #include "ores.reporting.api/messaging/report_definition_protocol.hpp"
@@ -81,7 +79,7 @@ void ReportDefinitionMdiWindow::setupUi() {
     layout->addWidget(tableView_);
 
     paginationWidget_ = new PaginationWidget(this);
-    layout->addWidget(paginationWidget_);
+    layout->addWidget(createBottomBar(paginationWidget_, clientManager_));
 }
 
 void ReportDefinitionMdiWindow::setupToolbar() {
@@ -156,10 +154,6 @@ void ReportDefinitionMdiWindow::setupToolbar() {
     connect(unscheduleAction_, &QAction::triggered, this,
             &ReportDefinitionMdiWindow::unscheduleSelected);
 
-    auto* spacer = new QWidget(this);
-    spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-    toolbar_->addWidget(spacer);
-    toolbar_->addWidget(createWorkspaceSelector(clientManager_));
 }
 
 void ReportDefinitionMdiWindow::setupTable() {

--- a/projects/ores.qt.mktdata/include/ores.qt/CurrencyMarketTierMdiWindow.hpp
+++ b/projects/ores.qt.mktdata/include/ores.qt/CurrencyMarketTierMdiWindow.hpp
@@ -82,6 +82,8 @@ private slots:
     void onDoubleClicked(const QModelIndex& index);
 
 protected:
+    void onWindowWorkspaceChanged(const WorkspaceContext& ctx) override;
+
     QString normalRefreshTooltip() const override {
         return tr("Refresh currency market tiers");
     }

--- a/projects/ores.qt.mktdata/include/ores.qt/MarketFixingsMdiWindow.hpp
+++ b/projects/ores.qt.mktdata/include/ores.qt/MarketFixingsMdiWindow.hpp
@@ -71,6 +71,8 @@ signals:
     void showMarketFixings(const marketdata::domain::market_series& series);
 
 protected:
+    void onWindowWorkspaceChanged(const WorkspaceContext& ctx) override;
+
     QString normalRefreshTooltip() const override {
         return tr("Refresh fixing series");
     }

--- a/projects/ores.qt.mktdata/include/ores.qt/MarketSeriesMdiWindow.hpp
+++ b/projects/ores.qt.mktdata/include/ores.qt/MarketSeriesMdiWindow.hpp
@@ -74,6 +74,8 @@ signals:
     void showMarketObservations(const marketdata::domain::market_series& series);
 
 protected:
+    void onWindowWorkspaceChanged(const WorkspaceContext& ctx) override;
+
     QString normalRefreshTooltip() const override {
         return tr("Refresh market series");
     }

--- a/projects/ores.qt.mktdata/src/CurrencyMarketTierMdiWindow.cpp
+++ b/projects/ores.qt.mktdata/src/CurrencyMarketTierMdiWindow.cpp
@@ -69,7 +69,7 @@ void CurrencyMarketTierMdiWindow::setupUi() {
     layout->addWidget(tableView_);
 
     paginationWidget_ = new PaginationWidget(this);
-    layout->addWidget(paginationWidget_);
+    layout->addWidget(createBottomBar(paginationWidget_, clientManager_));
 }
 
 void CurrencyMarketTierMdiWindow::setupToolbar() {
@@ -181,7 +181,13 @@ void CurrencyMarketTierMdiWindow::setupConnections() {
 void CurrencyMarketTierMdiWindow::doReload() {
     BOOST_LOG_SEV(lg(), debug) << "Reloading currency market tiers";
     emit statusChanged(tr("Loading currency market tiers..."));
+    model_->setWorkspaceContext(windowWorkspaceContext_);
     model_->refresh();
+}
+
+void CurrencyMarketTierMdiWindow::onWindowWorkspaceChanged(const WorkspaceContext& ctx) {
+    model_->setWorkspaceContext(ctx);
+    EntityListMdiWindow::onWindowWorkspaceChanged(ctx);
 }
 
 void CurrencyMarketTierMdiWindow::onDataLoaded() {

--- a/projects/ores.qt.mktdata/src/MarketFixingsMdiWindow.cpp
+++ b/projects/ores.qt.mktdata/src/MarketFixingsMdiWindow.cpp
@@ -72,7 +72,7 @@ void MarketFixingsMdiWindow::setupUi() {
         "MarketFixingsListWindow", {}, {1100, 600}, 1);
 
     verticalLayout_->addWidget(tableView_);
-    verticalLayout_->addWidget(paginationWidget_);
+    verticalLayout_->addWidget(createBottomBar(paginationWidget_, clientManager_));
 
     // Connections
     connect(model_.get(), &ClientMarketSeriesModel::dataLoaded,
@@ -150,7 +150,13 @@ void MarketFixingsMdiWindow::updateActionStates() {
 
 void MarketFixingsMdiWindow::doReload() {
     clearStaleIndicator();
+    model_->setWorkspaceContext(windowWorkspaceContext_);
     model_->refresh();
+}
+
+void MarketFixingsMdiWindow::onWindowWorkspaceChanged(const WorkspaceContext& ctx) {
+    model_->setWorkspaceContext(ctx);
+    EntityListMdiWindow::onWindowWorkspaceChanged(ctx);
 }
 
 void MarketFixingsMdiWindow::onDataLoaded() {

--- a/projects/ores.qt.mktdata/src/MarketSeriesMdiWindow.cpp
+++ b/projects/ores.qt.mktdata/src/MarketSeriesMdiWindow.cpp
@@ -80,7 +80,7 @@ void MarketSeriesMdiWindow::setupUi() {
         "MarketSeriesListWindow", {}, {1100, 600}, 1);
 
     verticalLayout_->addWidget(tableView_);
-    verticalLayout_->addWidget(paginationWidget_);
+    verticalLayout_->addWidget(createBottomBar(paginationWidget_, clientManager_));
 
     // Connections
     connect(model_.get(), &ClientMarketSeriesModel::dataLoaded,
@@ -177,7 +177,13 @@ void MarketSeriesMdiWindow::updateActionStates() {
 
 void MarketSeriesMdiWindow::doReload() {
     clearStaleIndicator();
+    model_->setWorkspaceContext(windowWorkspaceContext_);
     model_->refresh();
+}
+
+void MarketSeriesMdiWindow::onWindowWorkspaceChanged(const WorkspaceContext& ctx) {
+    model_->setWorkspaceContext(ctx);
+    EntityListMdiWindow::onWindowWorkspaceChanged(ctx);
 }
 
 void MarketSeriesMdiWindow::onDataLoaded() {

--- a/projects/ores.qt.trading/include/ores.qt/PortfolioMdiWindow.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/PortfolioMdiWindow.hpp
@@ -85,6 +85,8 @@ private slots:
     void onDoubleClicked(const QModelIndex& index);
 
 protected:
+    void onWindowWorkspaceChanged(const WorkspaceContext& ctx) override;
+
     QString normalRefreshTooltip() const override {
         return tr("Refresh portfolios");
     }

--- a/projects/ores.qt.trading/include/ores.qt/TradeMdiWindow.hpp
+++ b/projects/ores.qt.trading/include/ores.qt/TradeMdiWindow.hpp
@@ -84,6 +84,8 @@ private slots:
     void onDoubleClicked(const QModelIndex& index);
 
 protected:
+    void onWindowWorkspaceChanged(const WorkspaceContext& ctx) override;
+
     QString normalRefreshTooltip() const override {
         return tr("Refresh trades");
     }

--- a/projects/ores.qt.trading/src/BookMdiWindow.cpp
+++ b/projects/ores.qt.trading/src/BookMdiWindow.cpp
@@ -21,7 +21,6 @@
 
 #include <QVBoxLayout>
 #include <QHeaderView>
-#include <QSizePolicy>
 #include <QMessageBox>
 #include <optional>
 #include <QFile>
@@ -36,7 +35,6 @@
 #include "ores.qt/MessageBoxHelper.hpp"
 #include "ores.qt/ColorConstants.hpp"
 #include "ores.qt/WidgetUtils.hpp"
-#include "ores.qt/WorkspaceSelector.hpp"
 #include "ores.qt/ImportTradeDialog.hpp"
 #include "ores.ore.core/xml/importer.hpp"
 #include "ores.ore.core/xml/exporter.hpp"
@@ -90,7 +88,7 @@ void BookMdiWindow::setupUi() {
     layout->addWidget(tableView_);
 
     paginationWidget_ = new PaginationWidget(this);
-    layout->addWidget(paginationWidget_);
+    layout->addWidget(createBottomBar(paginationWidget_, clientManager_));
 }
 
 void BookMdiWindow::setupToolbar() {
@@ -167,11 +165,6 @@ void BookMdiWindow::setupToolbar() {
     connect(exportXmlAction_, &QAction::triggered, this,
             &BookMdiWindow::exportToXml);
 
-    // Workspace selector — flush-right in the toolbar
-    auto* spacer = new QWidget(this);
-    spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-    toolbar_->addWidget(spacer);
-    toolbar_->addWidget(createWorkspaceSelector(clientManager_));
 }
 
 void BookMdiWindow::setupTable() {

--- a/projects/ores.qt.trading/src/ClientPortfolioModel.cpp
+++ b/projects/ores.qt.trading/src/ClientPortfolioModel.cpp
@@ -218,7 +218,10 @@ void ClientPortfolioModel::fetch_portfolios(
         QtConcurrent::run([self, offset, limit]() -> FetchResult {
             return exception_helper::wrap_async_fetch<FetchResult>([&]() -> FetchResult {
                 BOOST_LOG_SEV(lg(), debug) << "Making portfolios request with offset="
-                                           << offset << ", limit=" << limit;
+                                           << offset << ", limit=" << limit
+                                           << " (model workspace_id="
+                                           << self->workspaceContext().id.toStdString()
+                                           << ")";
                 if (!self || !self->clientManager_) {
                     return {.success = false, .portfolios = {},
                             .total_available_count = 0,
@@ -230,8 +233,9 @@ void ClientPortfolioModel::fetch_portfolios(
                 request.offset = offset;
                 request.limit = limit;
 
+                const auto ws_id = self->workspaceContext().id.toStdString();
                 auto result = self->clientManager_->
-                    process_authenticated_request(std::move(request));
+                    process_authenticated_request(std::move(request), ws_id);
 
                 if (!result) {
                     BOOST_LOG_SEV(lg(), error) << "Failed to fetch portfolios: "
@@ -283,6 +287,9 @@ void ClientPortfolioModel::onPortfoliosLoaded() {
             BOOST_LOG_SEV(lg(), debug) << "Found " << recencyTracker_.recent_count()
                                        << " portfolios newer than last reload";
         }
+    } else {
+        BOOST_LOG_SEV(lg(), warn) << "Server returned 0 portfolios"
+                                  << " (total_available_count=" << total_available_count_ << ")";
     }
 
     BOOST_LOG_SEV(lg(), info) << "Loaded " << new_count << " portfolios."

--- a/projects/ores.qt.trading/src/PortfolioExplorerMdiWindow.cpp
+++ b/projects/ores.qt.trading/src/PortfolioExplorerMdiWindow.cpp
@@ -207,7 +207,7 @@ void PortfolioExplorerMdiWindow::setupTradePanel() {
     right_layout->addWidget(tradeTableView_, 1);
 
     paginationWidget_ = new PaginationWidget(right_panel);
-    right_layout->addWidget(paginationWidget_);
+    right_layout->addWidget(createBottomBar(paginationWidget_, clientManager_));
 
     splitter_->addWidget(right_panel);
     splitter_->setStretchFactor(0, 1);

--- a/projects/ores.qt.trading/src/PortfolioMdiWindow.cpp
+++ b/projects/ores.qt.trading/src/PortfolioMdiWindow.cpp
@@ -78,7 +78,7 @@ void PortfolioMdiWindow::setupUi() {
     layout->addWidget(tableView_);
 
     paginationWidget_ = new PaginationWidget(this);
-    layout->addWidget(paginationWidget_);
+    layout->addWidget(createBottomBar(paginationWidget_, clientManager_));
 }
 
 void PortfolioMdiWindow::setupToolbar() {
@@ -218,7 +218,13 @@ void PortfolioMdiWindow::setupConnections() {
 void PortfolioMdiWindow::doReload() {
     BOOST_LOG_SEV(lg(), debug) << "Reloading portfolios";
     emit statusChanged(tr("Loading portfolios..."));
+    model_->setWorkspaceContext(windowWorkspaceContext_);
     model_->refresh();
+}
+
+void PortfolioMdiWindow::onWindowWorkspaceChanged(const WorkspaceContext& ctx) {
+    model_->setWorkspaceContext(ctx);
+    EntityListMdiWindow::onWindowWorkspaceChanged(ctx);
 }
 
 void PortfolioMdiWindow::onDataLoaded() {

--- a/projects/ores.qt.trading/src/TradeMdiWindow.cpp
+++ b/projects/ores.qt.trading/src/TradeMdiWindow.cpp
@@ -73,7 +73,7 @@ void TradeMdiWindow::setupUi() {
     layout->addWidget(tableView_);
 
     paginationWidget_ = new PaginationWidget(this);
-    layout->addWidget(paginationWidget_);
+    layout->addWidget(createBottomBar(paginationWidget_, clientManager_));
 }
 
 void TradeMdiWindow::setupToolbar() {
@@ -196,7 +196,13 @@ void TradeMdiWindow::setupConnections() {
 void TradeMdiWindow::doReload() {
     BOOST_LOG_SEV(lg(), debug) << "Reloading trades";
     emit statusChanged(tr("Loading trades..."));
+    model_->setWorkspaceContext(windowWorkspaceContext_);
     model_->refresh();
+}
+
+void TradeMdiWindow::onWindowWorkspaceChanged(const WorkspaceContext& ctx) {
+    model_->setWorkspaceContext(ctx);
+    EntityListMdiWindow::onWindowWorkspaceChanged(ctx);
 }
 
 void TradeMdiWindow::onDataLoaded() {

--- a/projects/ores.qt.workspace/include/ores.qt/ClientWorkspaceModel.hpp
+++ b/projects/ores.qt.workspace/include/ores.qt/ClientWorkspaceModel.hpp
@@ -55,11 +55,11 @@ public:
      * @brief Enumeration of table columns for type-safe column access.
      */
     enum Column {
-        Id,
         Name,
-        Description,
         Status,
+        Version,
         ModifiedBy,
+        RecordedAt,
         ColumnCount
     };
 

--- a/projects/ores.qt.workspace/include/ores.qt/WorkspaceController.hpp
+++ b/projects/ores.qt.workspace/include/ores.qt/WorkspaceController.hpp
@@ -74,11 +74,16 @@ protected:
 private slots:
     void onShowDetails(const workspace::domain::workspace& workspace);
     void onAddNewRequested();
+    void onShowHistory(const workspace::domain::workspace& workspace);
     void onWorkspaceActivated(const workspace::domain::workspace& workspace);
+    void onRevertVersion(const workspace::domain::workspace& workspace);
+    void onOpenVersion(const workspace::domain::workspace& workspace,
+                       int versionNumber);
 
 private:
     void showAddWindow();
     void showDetailWindow(const workspace::domain::workspace& workspace);
+    void showHistoryWindow(const workspace::domain::workspace& workspace);
 
     WorkspaceMdiWindow* listWindow_;
     DetachableMdiSubWindow* listMdiSubWindow_;

--- a/projects/ores.qt.workspace/include/ores.qt/WorkspaceController.hpp
+++ b/projects/ores.qt.workspace/include/ores.qt/WorkspaceController.hpp
@@ -30,6 +30,7 @@
 
 namespace ores::qt {
 
+class BadgeCache;
 class WorkspaceMdiWindow;
 class DetachableMdiSubWindow;
 
@@ -58,6 +59,7 @@ public:
         QMdiArea* mdiArea,
         ClientManager* clientManager,
         const QString& username,
+        BadgeCache* badgeCache = nullptr,
         QObject* parent = nullptr);
 
     void showListWindow() override;
@@ -85,6 +87,7 @@ private:
     void showDetailWindow(const workspace::domain::workspace& workspace);
     void showHistoryWindow(const workspace::domain::workspace& workspace);
 
+    BadgeCache* badgeCache_;
     WorkspaceMdiWindow* listWindow_;
     DetachableMdiSubWindow* listMdiSubWindow_;
 };

--- a/projects/ores.qt.workspace/include/ores.qt/WorkspaceHistoryDialog.hpp
+++ b/projects/ores.qt.workspace/include/ores.qt/WorkspaceHistoryDialog.hpp
@@ -1,0 +1,100 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_WORKSPACE_HISTORY_DIALOG_HPP
+#define ORES_QT_WORKSPACE_HISTORY_DIALOG_HPP
+
+#include <QWidget>
+#include <QToolBar>
+#include <QTableWidget>
+#include <boost/uuid/uuid.hpp>
+#include "ores.qt/ClientManager.hpp"
+#include "ores.logging/make_logger.hpp"
+#include "ores.workspace.api/domain/workspace.hpp"
+
+namespace Ui {
+class WorkspaceHistoryDialog;
+}
+
+namespace ores::qt {
+
+/**
+ * @brief Dialog for viewing the version history of a workspace.
+ *
+ * Shows all historical versions of a workspace with ability
+ * to view details or revert to a previous version.
+ */
+class WorkspaceHistoryDialog final : public QWidget {
+    Q_OBJECT
+
+private:
+    inline static std::string_view logger_name =
+        "ores.qt.workspace_history_dialog";
+
+    [[nodiscard]] static auto& lg() {
+        using namespace ores::logging;
+        static auto instance = make_logger(logger_name);
+        return instance;
+    }
+
+public:
+    explicit WorkspaceHistoryDialog(
+        const boost::uuids::uuid& id,
+        const QString& code,
+        ClientManager* clientManager,
+        QWidget* parent = nullptr);
+    ~WorkspaceHistoryDialog() override;
+
+    void loadHistory();
+
+signals:
+    void statusChanged(const QString& message);
+    void errorOccurred(const QString& error_message);
+    void openVersionRequested(const workspace::domain::workspace& workspace,
+                              int versionNumber);
+    void revertVersionRequested(const workspace::domain::workspace& workspace);
+
+private slots:
+    void onVersionSelected();
+    void onOpenVersionClicked();
+    void onRevertClicked();
+
+private:
+    void setupUi();
+    void setupToolbar();
+    void setupConnections();
+    void updateVersionList();
+    void updateChangesTable(int currentVersionIndex);
+    void updateFullDetails(int versionIndex);
+    void updateActionStates();
+
+    Ui::WorkspaceHistoryDialog* ui_;
+    boost::uuids::uuid id_;
+    QString code_;
+    ClientManager* clientManager_;
+    std::vector<workspace::domain::workspace> versions_;
+
+    QToolBar* toolbar_;
+    QAction* openVersionAction_;
+    QAction* revertAction_;
+};
+
+}
+
+#endif

--- a/projects/ores.qt.workspace/include/ores.qt/WorkspaceMdiWindow.hpp
+++ b/projects/ores.qt.workspace/include/ores.qt/WorkspaceMdiWindow.hpp
@@ -24,6 +24,7 @@
 #include <QToolBar>
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
+#include "ores.qt/BadgeCache.hpp"
 #include "ores.qt/EntityListMdiWindow.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/ClientWorkspaceModel.hpp"
@@ -55,6 +56,7 @@ public:
     explicit WorkspaceMdiWindow(
         ClientManager* clientManager,
         const QString& username,
+        BadgeCache* badgeCache = nullptr,
         QWidget* parent = nullptr);
     ~WorkspaceMdiWindow() override = default;
 
@@ -99,6 +101,7 @@ private:
 
     ClientManager* clientManager_;
     QString username_;
+    BadgeCache* badgeCache_;
 
     QToolBar* toolbar_;
     QTreeWidget* treeWidget_;

--- a/projects/ores.qt.workspace/include/ores.qt/WorkspaceMdiWindow.hpp
+++ b/projects/ores.qt.workspace/include/ores.qt/WorkspaceMdiWindow.hpp
@@ -28,6 +28,7 @@
 #include "ores.qt/EntityListMdiWindow.hpp"
 #include "ores.qt/ClientManager.hpp"
 #include "ores.qt/ClientWorkspaceModel.hpp"
+#include "ores.qt/PaginationWidget.hpp"
 #include "ores.logging/make_logger.hpp"
 #include "ores.workspace.api/domain/workspace.hpp"
 
@@ -106,6 +107,7 @@ private:
     QToolBar* toolbar_;
     QTreeWidget* treeWidget_;
     ClientWorkspaceModel* model_;
+    PaginationWidget* paginationWidget_;
 
     // Toolbar actions
     QAction* reloadAction_;

--- a/projects/ores.qt.workspace/include/ores.qt/WorkspaceMdiWindow.hpp
+++ b/projects/ores.qt.workspace/include/ores.qt/WorkspaceMdiWindow.hpp
@@ -62,6 +62,7 @@ signals:
     void statusChanged(const QString& message);
     void errorOccurred(const QString& error_message);
     void showWorkspaceDetails(const workspace::domain::workspace& workspace);
+    void showWorkspaceHistory(const workspace::domain::workspace& workspace);
     void addNewRequested();
     void workspaceDeleted(const QString& code);
     void workspaceActivated(const workspace::domain::workspace& workspace);
@@ -81,6 +82,7 @@ private slots:
     void onLoadError(const QString& error_message, const QString& details = {});
     void onSelectionChanged();
     void onItemDoubleClicked(QTreeWidgetItem* item, int column);
+    void onHistoryRequested();
 
 protected:
     QString normalRefreshTooltip() const override {
@@ -107,6 +109,7 @@ private:
     QAction* addAction_;
     QAction* openAction_;
     QAction* editAction_;
+    QAction* historyAction_;
     QAction* archiveAction_;
     QAction* deleteAction_;
 };

--- a/projects/ores.qt.workspace/src/ClientWorkspaceModel.cpp
+++ b/projects/ores.qt.workspace/src/ClientWorkspaceModel.cpp
@@ -83,16 +83,16 @@ QVariant ClientWorkspaceModel::data(
 
     if (role == Qt::DisplayRole) {
         switch (index.column()) {
-        case Id:
-            return QString::fromStdString(boost::uuids::to_string(workspace.id));
         case Name:
             return QString::fromStdString(workspace.name);
-        case Description:
-            return QString::fromStdString(workspace.description);
         case Status:
             return QString::fromStdString(workspace.status_code);
+        case Version:
+            return workspace.version;
         case ModifiedBy:
             return QString::fromStdString(workspace.modified_by);
+        case RecordedAt:
+            return relative_time_helper::format(workspace.recorded_at);
         default:
             return {};
         }
@@ -111,16 +111,16 @@ QVariant ClientWorkspaceModel::headerData(
         return {};
 
     switch (section) {
-    case Id:
-        return tr("ID");
     case Name:
         return tr("Name");
-    case Description:
-        return tr("Description");
     case Status:
         return tr("Status");
+    case Version:
+        return tr("Version");
     case ModifiedBy:
         return tr("Modified By");
+    case RecordedAt:
+        return tr("Recorded At");
     default:
         return {};
     }

--- a/projects/ores.qt.workspace/src/WorkspaceController.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceController.cpp
@@ -84,7 +84,7 @@ void WorkspaceController::showListWindow() {
     listMdiSubWindow_->setWidget(listWindow_);
     listMdiSubWindow_->setWindowTitle("Workspaces");
     listMdiSubWindow_->setWindowIcon(IconUtils::createRecoloredIcon(
-        Icon::Layers, IconUtils::DefaultIconColor));
+        Icon::Database, IconUtils::DefaultIconColor));
     listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
     listMdiSubWindow_->resize(listWindow_->sizeHint());
 
@@ -235,7 +235,7 @@ void WorkspaceController::showAddWindow() {
     detailWindow->setWidget(detailDialog);
     detailWindow->setWindowTitle("New Workspace");
     detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
-        Icon::Layers, IconUtils::DefaultIconColor));
+        Icon::Database, IconUtils::DefaultIconColor));
 
     register_detachable_window(detailWindow);
 
@@ -284,7 +284,7 @@ void WorkspaceController::showDetailWindow(
     detailWindow->setWidget(detailDialog);
     detailWindow->setWindowTitle(QString("Workspace: %1").arg(identifier));
     detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
-        Icon::Layers, IconUtils::DefaultIconColor));
+        Icon::Database, IconUtils::DefaultIconColor));
 
     // Track window
     track_window(key, detailWindow);

--- a/projects/ores.qt.workspace/src/WorkspaceController.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceController.cpp
@@ -27,11 +27,12 @@
 #include <QFutureWatcher>
 #include <boost/uuid/uuid_io.hpp>
 #include "ores.qt/IconUtils.hpp"
-#include "ores.utility/uuid/tenant_id.hpp"
 #include "ores.qt/WorkspaceContext.hpp"
 #include "ores.qt/WorkspaceMdiWindow.hpp"
 #include "ores.qt/WorkspaceDetailDialog.hpp"
+#include "ores.qt/WorkspaceHistoryDialog.hpp"
 #include "ores.qt/DetachableMdiSubWindow.hpp"
+#include "ores.utility/uuid/tenant_id.hpp"
 #include "ores.workspace.api/messaging/workspace_protocol.hpp"
 
 namespace ores::qt {
@@ -73,6 +74,8 @@ void WorkspaceController::showListWindow() {
             this, &WorkspaceController::onShowDetails);
     connect(listWindow_, &WorkspaceMdiWindow::addNewRequested,
             this, &WorkspaceController::onAddNewRequested);
+    connect(listWindow_, &WorkspaceMdiWindow::showWorkspaceHistory,
+            this, &WorkspaceController::onShowHistory);
     connect(listWindow_, &WorkspaceMdiWindow::workspaceActivated,
             this, &WorkspaceController::onWorkspaceActivated);
 
@@ -81,7 +84,7 @@ void WorkspaceController::showListWindow() {
     listMdiSubWindow_->setWidget(listWindow_);
     listMdiSubWindow_->setWindowTitle("Workspaces");
     listMdiSubWindow_->setWindowIcon(IconUtils::createRecoloredIcon(
-        Icon::Database, IconUtils::DefaultIconColor));
+        Icon::Layers, IconUtils::DefaultIconColor));
     listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
     listMdiSubWindow_->resize(listWindow_->sizeHint());
 
@@ -127,8 +130,7 @@ void WorkspaceController::reloadListWindow() {
 
 void WorkspaceController::onShowDetails(
     const workspace::domain::workspace& workspace) {
-    BOOST_LOG_SEV(lg(), debug) << "Show details for: "
-                               << boost::uuids::to_string(workspace.id);
+    BOOST_LOG_SEV(lg(), debug) << "Show details for: " << workspace.name;
     showDetailWindow(workspace);
 }
 
@@ -137,106 +139,14 @@ void WorkspaceController::onAddNewRequested() {
     showAddWindow();
 }
 
-void WorkspaceController::showAddWindow() {
-    BOOST_LOG_SEV(lg(), debug) << "Creating add window for new workspace";
-
-    auto* detailDialog = new WorkspaceDetailDialog(mainWindow_);
-    detailDialog->setClientManager(clientManager_);
-    detailDialog->setUsername(username_.toStdString());
-    detailDialog->setCreateMode(true);
-
-    connect(detailDialog, &WorkspaceDetailDialog::statusMessage,
-            this, &WorkspaceController::statusMessage);
-    connect(detailDialog, &WorkspaceDetailDialog::errorMessage,
-            this, &WorkspaceController::errorMessage);
-    connect(detailDialog, &WorkspaceDetailDialog::workspaceSaved,
-            this, [self = QPointer<WorkspaceController>(this)](const QString& code) {
-        if (!self) return;
-        BOOST_LOG_SEV(lg(), info) << "Workspace saved: " << code.toStdString();
-        self->handleEntitySaved();
-    });
-
-    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
-    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
-    detailWindow->setWidget(detailDialog);
-    detailWindow->setWindowTitle("New Workspace");
-    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
-        Icon::Database, IconUtils::DefaultIconColor));
-
-    register_detachable_window(detailWindow);
-
-    connect_dialog_close(detailDialog, detailWindow);
-    show_managed_window(detailWindow, listMdiSubWindow_);
-}
-
-void WorkspaceController::showDetailWindow(
-    const workspace::domain::workspace& workspace) {
-
-    const QString identifier =
-        QString::fromStdString(boost::uuids::to_string(workspace.id));
-    const QString key = build_window_key("details", identifier);
-
-    if (try_reuse_window(key)) {
-        BOOST_LOG_SEV(lg(), debug) << "Reusing existing detail window";
-        return;
-    }
-
-    BOOST_LOG_SEV(lg(), debug) << "Creating detail window for id: "
-                               << identifier.toStdString();
-
-    auto* detailDialog = new WorkspaceDetailDialog(mainWindow_);
-    detailDialog->setClientManager(clientManager_);
-    detailDialog->setUsername(username_.toStdString());
-    detailDialog->setCreateMode(false);
-    detailDialog->setWorkspace(workspace);
-
-    connect(detailDialog, &WorkspaceDetailDialog::statusMessage,
-            this, &WorkspaceController::statusMessage);
-    connect(detailDialog, &WorkspaceDetailDialog::errorMessage,
-            this, &WorkspaceController::errorMessage);
-    connect(detailDialog, &WorkspaceDetailDialog::workspaceSaved,
-            this, [self = QPointer<WorkspaceController>(this)](const QString& code) {
-        if (!self) return;
-        BOOST_LOG_SEV(lg(), info) << "Workspace saved: " << code.toStdString();
-        self->handleEntitySaved();
-    });
-    connect(detailDialog, &WorkspaceDetailDialog::workspaceDeleted,
-            this, [self = QPointer<WorkspaceController>(this), key](const QString& code) {
-        if (!self) return;
-        BOOST_LOG_SEV(lg(), info) << "Workspace deleted: " << code.toStdString();
-        self->handleEntityDeleted();
-    });
-
-    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
-    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
-    detailWindow->setWidget(detailDialog);
-    detailWindow->setWindowTitle(QString("Workspace: %1").arg(identifier));
-    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
-        Icon::Database, IconUtils::DefaultIconColor));
-
-    // Track window
-    track_window(key, detailWindow);
-    register_detachable_window(detailWindow);
-
-    QPointer<WorkspaceController> self = this;
-    connect(detailWindow, &QObject::destroyed, this,
-            [self, key]() {
-        if (self) {
-            self->untrack_window(key);
-        }
-    });
-
-    connect_dialog_close(detailDialog, detailWindow);
-    show_managed_window(detailWindow, listMdiSubWindow_);
-}
-
 void WorkspaceController::onWorkspaceActivated(
     const workspace::domain::workspace& ws) {
 
-    BOOST_LOG_SEV(lg(), debug) << "Workspace activation requested: "
-                               << boost::uuids::to_string(ws.id);
+    const std::string ws_id = boost::uuids::to_string(ws.id);
+    BOOST_LOG_SEV(lg(), debug) << "Workspace activation requested: " << ws_id;
 
-    if (ws.id == ores::utility::uuid::live_workspace_id()) {
+    constexpr std::string_view live_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    if (ws_id == live_id) {
         WorkspaceContext ctx;
         mdiArea_->setProperty("ores_workspace_context",
             QVariant::fromValue(ctx));
@@ -245,7 +155,6 @@ void WorkspaceController::onWorkspaceActivated(
     }
 
     QPointer<WorkspaceController> self = this;
-    const std::string ws_id = boost::uuids::to_string(ws.id);
     const std::string ws_name = ws.name;
 
     struct ResolveResult {
@@ -294,6 +203,257 @@ void WorkspaceController::onWorkspaceActivated(
 
     QFuture<ResolveResult> future = QtConcurrent::run(task);
     watcher->setFuture(future);
+}
+
+void WorkspaceController::onShowHistory(
+    const workspace::domain::workspace& workspace) {
+    BOOST_LOG_SEV(lg(), debug) << "Show history requested for: " << workspace.name;
+    showHistoryWindow(workspace);
+}
+
+void WorkspaceController::showAddWindow() {
+    BOOST_LOG_SEV(lg(), debug) << "Creating add window for new workspace";
+
+    auto* detailDialog = new WorkspaceDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(true);
+
+    connect(detailDialog, &WorkspaceDetailDialog::statusMessage,
+            this, &WorkspaceController::statusMessage);
+    connect(detailDialog, &WorkspaceDetailDialog::errorMessage,
+            this, &WorkspaceController::errorMessage);
+    connect(detailDialog, &WorkspaceDetailDialog::workspaceSaved,
+            this, [self = QPointer<WorkspaceController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "Workspace saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle("New Workspace");
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Layers, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void WorkspaceController::showDetailWindow(
+    const workspace::domain::workspace& workspace) {
+
+    const QString identifier = QString::fromStdString(workspace.name);
+    const QString key = build_window_key("details", identifier);
+
+    if (try_reuse_window(key)) {
+        BOOST_LOG_SEV(lg(), debug) << "Reusing existing detail window";
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Creating detail window for: " << workspace.name;
+
+    auto* detailDialog = new WorkspaceDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setCreateMode(false);
+    detailDialog->setWorkspace(workspace);
+
+    connect(detailDialog, &WorkspaceDetailDialog::statusMessage,
+            this, &WorkspaceController::statusMessage);
+    connect(detailDialog, &WorkspaceDetailDialog::errorMessage,
+            this, &WorkspaceController::errorMessage);
+    connect(detailDialog, &WorkspaceDetailDialog::workspaceSaved,
+            this, [self = QPointer<WorkspaceController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "Workspace saved: " << code.toStdString();
+        self->handleEntitySaved();
+    });
+    connect(detailDialog, &WorkspaceDetailDialog::workspaceDeleted,
+            this, [self = QPointer<WorkspaceController>(this), key](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "Workspace deleted: " << code.toStdString();
+        self->handleEntityDeleted();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Workspace: %1").arg(identifier));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::Layers, IconUtils::DefaultIconColor));
+
+    // Track window
+    track_window(key, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<WorkspaceController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, key]() {
+        if (self) {
+            self->untrack_window(key);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
+}
+
+void WorkspaceController::showHistoryWindow(
+    const workspace::domain::workspace& workspace) {
+    const QString code = QString::fromStdString(workspace.name);
+    BOOST_LOG_SEV(lg(), info) << "Opening history window for workspace: "
+                              << workspace.name;
+
+    const QString windowKey = build_window_key("history", code);
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing history window for: "
+                                  << workspace.name;
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), info) << "Creating new history window for: "
+                              << workspace.name;
+
+    auto* historyDialog = new WorkspaceHistoryDialog(
+        workspace.id, code, clientManager_, mainWindow_);
+
+    connect(historyDialog, &WorkspaceHistoryDialog::statusChanged,
+            this, [self = QPointer<WorkspaceController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(historyDialog, &WorkspaceHistoryDialog::errorOccurred,
+            this, [self = QPointer<WorkspaceController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+    connect(historyDialog, &WorkspaceHistoryDialog::revertVersionRequested,
+            this, &WorkspaceController::onRevertVersion);
+    connect(historyDialog, &WorkspaceHistoryDialog::openVersionRequested,
+            this, &WorkspaceController::onOpenVersion);
+
+    // Load history data
+    historyDialog->loadHistory();
+
+    auto* historyWindow = new DetachableMdiSubWindow(mainWindow_);
+    historyWindow->setAttribute(Qt::WA_DeleteOnClose);
+    historyWindow->setWidget(historyDialog);
+    historyWindow->setWindowTitle(QString("Workspace History: %1").arg(code));
+    historyWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    // Track this history window
+    track_window(windowKey, historyWindow);
+    register_detachable_window(historyWindow);
+
+    QPointer<WorkspaceController> self = this;
+    connect(historyWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    show_managed_window(historyWindow, listMdiSubWindow_);
+}
+
+void WorkspaceController::onOpenVersion(
+    const workspace::domain::workspace& workspace, int versionNumber) {
+    BOOST_LOG_SEV(lg(), info) << "Opening historical version " << versionNumber
+                              << " for workspace: " << workspace.name;
+
+    const QString code = QString::fromStdString(workspace.name);
+    const QString windowKey = build_window_key("version", QString("%1_v%2")
+        .arg(code).arg(versionNumber));
+
+    // Try to reuse existing window
+    if (try_reuse_window(windowKey)) {
+        BOOST_LOG_SEV(lg(), info) << "Reusing existing version window";
+        return;
+    }
+
+    auto* detailDialog = new WorkspaceDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setWorkspace(workspace);
+    detailDialog->setReadOnly(true);
+
+    connect(detailDialog, &WorkspaceDetailDialog::statusMessage,
+            this, [self = QPointer<WorkspaceController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->statusMessage(message);
+    });
+    connect(detailDialog, &WorkspaceDetailDialog::errorMessage,
+            this, [self = QPointer<WorkspaceController>(this)](const QString& message) {
+        if (!self) return;
+        emit self->errorMessage(message);
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Workspace: %1 (Version %2)")
+        .arg(code).arg(versionNumber));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::History, IconUtils::DefaultIconColor));
+
+    track_window(windowKey, detailWindow);
+    register_detachable_window(detailWindow);
+
+    QPointer<WorkspaceController> self = this;
+    connect(detailWindow, &QObject::destroyed, this,
+            [self, windowKey]() {
+        if (self) {
+            self->untrack_window(windowKey);
+        }
+    });
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_, QPoint(60, 60));
+}
+
+void WorkspaceController::onRevertVersion(
+    const workspace::domain::workspace& workspace) {
+    BOOST_LOG_SEV(lg(), info) << "Reverting workspace to version: "
+                              << workspace.version;
+
+    // Open detail dialog with the old version data for editing
+    auto* detailDialog = new WorkspaceDetailDialog(mainWindow_);
+    detailDialog->setClientManager(clientManager_);
+    detailDialog->setUsername(username_.toStdString());
+    detailDialog->setWorkspace(workspace);
+    detailDialog->setCreateMode(false);
+
+    connect(detailDialog, &WorkspaceDetailDialog::statusMessage,
+            this, &WorkspaceController::statusMessage);
+    connect(detailDialog, &WorkspaceDetailDialog::errorMessage,
+            this, &WorkspaceController::errorMessage);
+    connect(detailDialog, &WorkspaceDetailDialog::workspaceSaved,
+            this, [self = QPointer<WorkspaceController>(this)](const QString& code) {
+        if (!self) return;
+        BOOST_LOG_SEV(lg(), info) << "Workspace reverted: " << code.toStdString();
+        emit self->statusMessage(QString("Workspace '%1' reverted successfully").arg(code));
+        self->handleEntitySaved();
+    });
+
+    auto* detailWindow = new DetachableMdiSubWindow(mainWindow_);
+    detailWindow->setAttribute(Qt::WA_DeleteOnClose);
+    detailWindow->setWidget(detailDialog);
+    detailWindow->setWindowTitle(QString("Revert Workspace: %1")
+        .arg(QString::fromStdString(workspace.name)));
+    detailWindow->setWindowIcon(IconUtils::createRecoloredIcon(
+        Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor));
+
+    register_detachable_window(detailWindow);
+
+    connect_dialog_close(detailDialog, detailWindow);
+    show_managed_window(detailWindow, listMdiSubWindow_);
 }
 
 EntityListMdiWindow* WorkspaceController::listWindow() const {

--- a/projects/ores.qt.workspace/src/WorkspaceController.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceController.cpp
@@ -26,7 +26,9 @@
 #include <QtConcurrent>
 #include <QFutureWatcher>
 #include <boost/uuid/uuid_io.hpp>
+#include "ores.qt/BadgeCache.hpp"
 #include "ores.qt/IconUtils.hpp"
+#include "ores.qt/UiPersistence.hpp"
 #include "ores.qt/WorkspaceContext.hpp"
 #include "ores.qt/WorkspaceMdiWindow.hpp"
 #include "ores.qt/WorkspaceDetailDialog.hpp"
@@ -44,9 +46,11 @@ WorkspaceController::WorkspaceController(
     QMdiArea* mdiArea,
     ClientManager* clientManager,
     const QString& username,
+    BadgeCache* badgeCache,
     QObject* parent)
     : EntityController(mainWindow, mdiArea, clientManager, username,
           std::string_view{}, parent),
+      badgeCache_(badgeCache),
       listWindow_(nullptr),
       listMdiSubWindow_(nullptr) {
 
@@ -63,7 +67,7 @@ void WorkspaceController::showListWindow() {
     }
 
     // Create new window
-    listWindow_ = new WorkspaceMdiWindow(clientManager_, username_);
+    listWindow_ = new WorkspaceMdiWindow(clientManager_, username_, badgeCache_);
 
     // Connect signals
     connect(listWindow_, &WorkspaceMdiWindow::statusChanged,
@@ -86,9 +90,10 @@ void WorkspaceController::showListWindow() {
     listMdiSubWindow_->setWindowIcon(IconUtils::createRecoloredIcon(
         Icon::Database, IconUtils::DefaultIconColor));
     listMdiSubWindow_->setAttribute(Qt::WA_DeleteOnClose);
-    listMdiSubWindow_->resize(listWindow_->sizeHint());
-
+    listMdiSubWindow_->setGeometryKey("WorkspaceListWindow");
     mdiArea_->addSubWindow(listMdiSubWindow_);
+    if (!UiPersistence::restoreMdiGeometry("WorkspaceListWindow", listMdiSubWindow_))
+        listMdiSubWindow_->resize(900, 400);
     listMdiSubWindow_->show();
 
     // Track window
@@ -240,6 +245,9 @@ void WorkspaceController::showAddWindow() {
     register_detachable_window(detailWindow);
 
     connect_dialog_close(detailDialog, detailWindow);
+    detailWindow->setGeometryKey("WorkspaceDetailDialog");
+    if (!UiPersistence::restoreMdiGeometry("WorkspaceDetailDialog", detailWindow))
+        detailWindow->resize(600, 450);
     show_managed_window(detailWindow, listMdiSubWindow_);
 }
 
@@ -299,6 +307,9 @@ void WorkspaceController::showDetailWindow(
     });
 
     connect_dialog_close(detailDialog, detailWindow);
+    detailWindow->setGeometryKey("WorkspaceDetailDialog");
+    if (!UiPersistence::restoreMdiGeometry("WorkspaceDetailDialog", detailWindow))
+        detailWindow->resize(600, 450);
     show_managed_window(detailWindow, listMdiSubWindow_);
 }
 
@@ -360,6 +371,9 @@ void WorkspaceController::showHistoryWindow(
         }
     });
 
+    historyWindow->setGeometryKey("WorkspaceHistoryDialog");
+    if (!UiPersistence::restoreMdiGeometry("WorkspaceHistoryDialog", historyWindow))
+        historyWindow->resize(750, 500);
     show_managed_window(historyWindow, listMdiSubWindow_);
 }
 
@@ -453,6 +467,9 @@ void WorkspaceController::onRevertVersion(
     register_detachable_window(detailWindow);
 
     connect_dialog_close(detailDialog, detailWindow);
+    detailWindow->setGeometryKey("WorkspaceDetailDialog");
+    if (!UiPersistence::restoreMdiGeometry("WorkspaceDetailDialog", detailWindow))
+        detailWindow->resize(600, 450);
     show_managed_window(detailWindow, listMdiSubWindow_);
 }
 

--- a/projects/ores.qt.workspace/src/WorkspaceDetailDialog.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceDetailDialog.cpp
@@ -22,8 +22,7 @@
 #include <QMessageBox>
 #include <QtConcurrent>
 #include <QFutureWatcher>
-#include <QPlainTextEdit>
-#include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/random_generator.hpp>
 #include "ui_WorkspaceDetailDialog.h"
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
@@ -65,14 +64,10 @@ void WorkspaceDetailDialog::setupUi() {
     ui_->saveButton->setEnabled(false);
 
     ui_->deleteButton->setIcon(
-        IconUtils::createRecoloredIcon(Icon::Archive, IconUtils::DefaultIconColor));
+        IconUtils::createRecoloredIcon(Icon::Delete, IconUtils::DefaultIconColor));
 
     ui_->closeButton->setIcon(
         IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
-
-    // ID is always auto-generated — hide the id field entirely
-    ui_->labelId->setVisible(false);
-    ui_->codeEdit->setVisible(false);
 }
 
 void WorkspaceDetailDialog::setupConnections() {
@@ -84,8 +79,14 @@ void WorkspaceDetailDialog::setupConnections() {
             &WorkspaceDetailDialog::onCloseClicked);
 
     connect(ui_->nameEdit, &QLineEdit::textChanged, this,
+            &WorkspaceDetailDialog::onCodeChanged);
+    connect(ui_->sourcePathEdit, &QLineEdit::textChanged, this,
             &WorkspaceDetailDialog::onFieldChanged);
-    connect(ui_->descriptionEdit, &QPlainTextEdit::textChanged, this,
+    connect(ui_->parentEdit, &QLineEdit::textChanged, this,
+            &WorkspaceDetailDialog::onFieldChanged);
+    connect(ui_->ownerEdit, &QLineEdit::textChanged, this,
+            &WorkspaceDetailDialog::onFieldChanged);
+    connect(ui_->statusEdit, &QLineEdit::textChanged, this,
             &WorkspaceDetailDialog::onFieldChanged);
 }
 
@@ -105,54 +106,54 @@ void WorkspaceDetailDialog::setWorkspace(
 
 void WorkspaceDetailDialog::setCreateMode(bool createMode) {
     createMode_ = createMode;
+    ui_->nameEdit->setReadOnly(!createMode);
     ui_->deleteButton->setVisible(!createMode);
-    setProvenanceEnabled(false);
+    setProvenanceEnabled(!createMode);
+    if (createMode) {
+        workspace_.id = boost::uuids::random_generator()();
+    }
     hasChanges_ = false;
     updateSaveButtonState();
 }
 
 void WorkspaceDetailDialog::setReadOnly(bool readOnly) {
     readOnly_ = readOnly;
-    ui_->nameEdit->setReadOnly(readOnly);
-    ui_->descriptionEdit->setReadOnly(readOnly);
+    ui_->nameEdit->setReadOnly(true);
+    ui_->sourcePathEdit->setReadOnly(readOnly);
+    ui_->parentEdit->setReadOnly(readOnly);
+    ui_->ownerEdit->setReadOnly(readOnly);
+    ui_->statusEdit->setReadOnly(readOnly);
     ui_->saveButton->setVisible(!readOnly);
     ui_->deleteButton->setVisible(!readOnly);
 }
 
 void WorkspaceDetailDialog::updateUiFromWorkspace() {
     ui_->nameEdit->setText(QString::fromStdString(workspace_.name));
-    ui_->descriptionEdit->setPlainText(QString::fromStdString(workspace_.description));
+    ui_->sourcePathEdit->setText(QString::fromStdString(workspace_.source_path));
+    ui_->parentEdit->setText(QString::fromStdString(workspace_.parent_workspace_id));
+    ui_->ownerEdit->setText(QString::fromStdString(workspace_.owner_id));
+    ui_->statusEdit->setText(QString::fromStdString(workspace_.status_code));
 
-    if (workspace_.parent_workspace_id) {
-        ui_->inheritsFromEdit->setText(QString::fromStdString(
-            boost::uuids::to_string(*workspace_.parent_workspace_id)));
-    } else {
-        ui_->inheritsFromEdit->setText(QString());
-    }
-
-    if (workspace_.version > 0 && provenanceWidget()) {
-        provenanceWidget()->populate(
-            workspace_.version,
-            workspace_.modified_by,
-            workspace_.performed_by,
-            workspace_.recorded_at,
-            workspace_.change_reason_code,
-            workspace_.change_commentary);
-        setProvenanceEnabled(true);
-    } else {
-        clearProvenance();
-    }
+    populateProvenance(workspace_.version,
+                       workspace_.modified_by,
+                       workspace_.performed_by,
+                       workspace_.recorded_at,
+                       workspace_.change_reason_code,
+                       workspace_.change_commentary);
 
     hasChanges_ = false;
     updateSaveButtonState();
 }
 
 void WorkspaceDetailDialog::updateWorkspaceFromUi() {
-    workspace_.name = ui_->nameEdit->text().trimmed().toStdString();
-    workspace_.description = ui_->descriptionEdit->toPlainText().trimmed().toStdString();
+    if (createMode_) {
+        workspace_.name = ui_->nameEdit->text().trimmed().toStdString();
+    }
+    workspace_.source_path = ui_->sourcePathEdit->text().trimmed().toStdString();
+    workspace_.parent_workspace_id = ui_->parentEdit->text().trimmed().toStdString();
+    workspace_.owner_id = ui_->ownerEdit->text().trimmed().toStdString();
+    workspace_.status_code = ui_->statusEdit->text().trimmed().toStdString();
     workspace_.modified_by = username_;
-    if (workspace_.change_reason_code.empty())
-        workspace_.change_reason_code = "system.new_record";
 }
 
 void WorkspaceDetailDialog::onCodeChanged(const QString& /* text */) {
@@ -171,7 +172,11 @@ void WorkspaceDetailDialog::updateSaveButtonState() {
 }
 
 bool WorkspaceDetailDialog::validateInput() {
-    return !ui_->nameEdit->text().trimmed().isEmpty();
+    const QString name_val = ui_->nameEdit->text().trimmed();
+
+    return true
+        && !name_val.isEmpty()
+    ;
 }
 
 void WorkspaceDetailDialog::onSaveClicked() {
@@ -189,14 +194,14 @@ void WorkspaceDetailDialog::onSaveClicked() {
 
     updateWorkspaceFromUi();
 
-    BOOST_LOG_SEV(lg(), info) << "Creating workspace: " << workspace_.name;
+    BOOST_LOG_SEV(lg(), info) << "Saving workspace: "
+        << workspace_.name;
 
     QPointer<WorkspaceDetailDialog> self = this;
 
     struct SaveResult {
         bool success;
         std::string message;
-        std::string id;
     };
 
     auto task = [self, workspace = workspace_]() -> SaveResult {
@@ -213,7 +218,7 @@ void WorkspaceDetailDialog::onSaveClicked() {
             return {false, "Failed to communicate with server"};
         }
 
-        return {response_result->success, response_result->message, response_result->id};
+        return {response_result->success, response_result->message};
     };
 
     auto* watcher = new QFutureWatcher<SaveResult>(self);
@@ -223,12 +228,13 @@ void WorkspaceDetailDialog::onSaveClicked() {
         watcher->deleteLater();
 
         if (result.success) {
-            BOOST_LOG_SEV(lg(), info) << "Workspace created with id: " << result.id;
-            QString code = QString::fromStdString(result.id);
+            BOOST_LOG_SEV(lg(), info) << "Workspace saved successfully";
+            QString code = QString::fromStdString(
+                self->workspace_.name);
             self->hasChanges_ = false;
             self->updateSaveButtonState();
             emit self->workspaceSaved(code);
-            self->notifySaveSuccess(tr("Workspace '%1' created").arg(code));
+            self->notifySaveSuccess(tr("Workspace '%1' saved").arg(code));
         } else {
             BOOST_LOG_SEV(lg(), error) << "Save failed: " << result.message;
             QString errorMsg = QString::fromStdString(result.message);
@@ -244,41 +250,37 @@ void WorkspaceDetailDialog::onSaveClicked() {
 void WorkspaceDetailDialog::onDeleteClicked() {
     if (!clientManager_ || !clientManager_->isConnected()) {
         MessageBoxHelper::warning(this, "Disconnected",
-            "Cannot archive workspace while disconnected from server.");
+            "Cannot delete workspace while disconnected from server.");
         return;
     }
 
-    QString name = QString::fromStdString(workspace_.name);
-    auto reply = MessageBoxHelper::question(this, "Archive Workspace",
-        QString("Are you sure you want to archive workspace '%1'?").arg(name),
+    QString code = QString::fromStdString(
+        workspace_.name);
+    auto reply = MessageBoxHelper::question(this, "Delete Workspace",
+        QString("Are you sure you want to delete workspace '%1'?").arg(code),
         QMessageBox::Yes | QMessageBox::No);
 
     if (reply != QMessageBox::Yes) {
         return;
     }
 
-    BOOST_LOG_SEV(lg(), info) << "Archiving workspace id: "
-                              << boost::uuids::to_string(workspace_.id);
+    BOOST_LOG_SEV(lg(), info) << "Deleting workspace: "
+        << workspace_.name;
 
     QPointer<WorkspaceDetailDialog> self = this;
 
-    struct ArchiveResult {
+    struct DeleteResult {
         bool success;
         std::string message;
     };
 
-    const std::string ws_id = boost::uuids::to_string(workspace_.id);
-    const std::string actor = username_;
-    auto task = [self, ws_id, actor]() -> ArchiveResult {
+    auto task = [self, id = workspace_.id]() -> DeleteResult {
         if (!self || !self->clientManager_) {
             return {false, "Dialog closed"};
         }
 
         workspace::messaging::archive_workspace_request request;
-        request.id = ws_id;
-        request.modified_by = actor;
-        request.change_reason_code = "user.archive";
-        request.change_commentary = "Archived by user";
+        request.ids = {id};
         auto response_result = self->clientManager_->
             process_authenticated_request(std::move(request));
 
@@ -289,27 +291,27 @@ void WorkspaceDetailDialog::onDeleteClicked() {
         return {response_result->success, response_result->message};
     };
 
-    auto* watcher = new QFutureWatcher<ArchiveResult>(self);
-    connect(watcher, &QFutureWatcher<ArchiveResult>::finished,
-            self, [self, name, watcher]() {
+    auto* watcher = new QFutureWatcher<DeleteResult>(self);
+    connect(watcher, &QFutureWatcher<DeleteResult>::finished,
+            self, [self, code, watcher]() {
         auto result = watcher->result();
         watcher->deleteLater();
 
         if (result.success) {
-            BOOST_LOG_SEV(lg(), info) << "Workspace archived successfully";
+            BOOST_LOG_SEV(lg(), info) << "Workspace deleted successfully";
             emit self->statusMessage(
-                QString("Workspace '%1' archived").arg(name));
-            emit self->workspaceDeleted(name);
+                QString("Workspace '%1' deleted").arg(code));
+            emit self->workspaceDeleted(code);
             self->requestClose();
         } else {
-            BOOST_LOG_SEV(lg(), error) << "Archive failed: " << result.message;
+            BOOST_LOG_SEV(lg(), error) << "Delete failed: " << result.message;
             QString errorMsg = QString::fromStdString(result.message);
             emit self->errorMessage(errorMsg);
-            MessageBoxHelper::critical(self, "Archive Failed", errorMsg);
+            MessageBoxHelper::critical(self, "Delete Failed", errorMsg);
         }
     });
 
-    QFuture<ArchiveResult> future = QtConcurrent::run(task);
+    QFuture<DeleteResult> future = QtConcurrent::run(task);
     watcher->setFuture(future);
 }
 

--- a/projects/ores.qt.workspace/src/WorkspaceDetailDialog.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceDetailDialog.cpp
@@ -22,7 +22,9 @@
 #include <QMessageBox>
 #include <QtConcurrent>
 #include <QFutureWatcher>
+#include <QPlainTextEdit>
 #include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include "ui_WorkspaceDetailDialog.h"
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
@@ -80,6 +82,8 @@ void WorkspaceDetailDialog::setupConnections() {
 
     connect(ui_->nameEdit, &QLineEdit::textChanged, this,
             &WorkspaceDetailDialog::onCodeChanged);
+    connect(ui_->descriptionEdit, &QPlainTextEdit::textChanged, this,
+            &WorkspaceDetailDialog::onFieldChanged);
     connect(ui_->sourcePathEdit, &QLineEdit::textChanged, this,
             &WorkspaceDetailDialog::onFieldChanged);
     connect(ui_->parentEdit, &QLineEdit::textChanged, this,
@@ -119,6 +123,7 @@ void WorkspaceDetailDialog::setCreateMode(bool createMode) {
 void WorkspaceDetailDialog::setReadOnly(bool readOnly) {
     readOnly_ = readOnly;
     ui_->nameEdit->setReadOnly(true);
+    ui_->descriptionEdit->setReadOnly(readOnly);
     ui_->sourcePathEdit->setReadOnly(readOnly);
     ui_->parentEdit->setReadOnly(readOnly);
     ui_->ownerEdit->setReadOnly(readOnly);
@@ -129,9 +134,16 @@ void WorkspaceDetailDialog::setReadOnly(bool readOnly) {
 
 void WorkspaceDetailDialog::updateUiFromWorkspace() {
     ui_->nameEdit->setText(QString::fromStdString(workspace_.name));
+    ui_->descriptionEdit->setPlainText(QString::fromStdString(workspace_.description));
     ui_->sourcePathEdit->setText(QString::fromStdString(workspace_.source_path));
-    ui_->parentEdit->setText(QString::fromStdString(workspace_.parent_workspace_id));
-    ui_->ownerEdit->setText(QString::fromStdString(workspace_.owner_id));
+    {
+        const auto& _opt = workspace_.parent_workspace_id;
+        ui_->parentEdit->setText(_opt
+            ? QString::fromStdString(boost::uuids::to_string(*_opt))
+            : QString{});
+    }
+    ui_->ownerEdit->setText(QString::fromStdString(
+        boost::uuids::to_string(workspace_.owner_id)));
     ui_->statusEdit->setText(QString::fromStdString(workspace_.status_code));
 
     populateProvenance(workspace_.version,
@@ -149,9 +161,8 @@ void WorkspaceDetailDialog::updateWorkspaceFromUi() {
     if (createMode_) {
         workspace_.name = ui_->nameEdit->text().trimmed().toStdString();
     }
+    workspace_.description = ui_->descriptionEdit->toPlainText().trimmed().toStdString();
     workspace_.source_path = ui_->sourcePathEdit->text().trimmed().toStdString();
-    workspace_.parent_workspace_id = ui_->parentEdit->text().trimmed().toStdString();
-    workspace_.owner_id = ui_->ownerEdit->text().trimmed().toStdString();
     workspace_.status_code = ui_->statusEdit->text().trimmed().toStdString();
     workspace_.modified_by = username_;
 }
@@ -274,13 +285,13 @@ void WorkspaceDetailDialog::onDeleteClicked() {
         std::string message;
     };
 
-    auto task = [self, id = workspace_.id]() -> DeleteResult {
+    auto task = [self, id_str = boost::uuids::to_string(workspace_.id)]() -> DeleteResult {
         if (!self || !self->clientManager_) {
             return {false, "Dialog closed"};
         }
 
         workspace::messaging::archive_workspace_request request;
-        request.ids = {id};
+        request.id = id_str;
         auto response_result = self->clientManager_->
             process_authenticated_request(std::move(request));
 

--- a/projects/ores.qt.workspace/src/WorkspaceDetailDialog.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceDetailDialog.cpp
@@ -24,6 +24,7 @@
 #include <QFutureWatcher>
 #include <QPlainTextEdit>
 #include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/string_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include "ui_WorkspaceDetailDialog.h"
 #include "ores.qt/IconUtils.hpp"
@@ -165,6 +166,13 @@ void WorkspaceDetailDialog::updateWorkspaceFromUi() {
     workspace_.source_path = ui_->sourcePathEdit->text().trimmed().toStdString();
     workspace_.status_code = ui_->statusEdit->text().trimmed().toStdString();
     workspace_.modified_by = username_;
+
+    const auto owner_str = ui_->ownerEdit->text().trimmed().toStdString();
+    if (!owner_str.empty()) {
+        try {
+            workspace_.owner_id = boost::uuids::string_generator{}(owner_str);
+        } catch (...) {}
+    }
 }
 
 void WorkspaceDetailDialog::onCodeChanged(const QString& /* text */) {

--- a/projects/ores.qt.workspace/src/WorkspaceHistoryDialog.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceHistoryDialog.cpp
@@ -27,6 +27,7 @@
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.workspace.api/messaging/workspace_protocol.hpp"
+#include <boost/uuid/uuid_io.hpp>
 
 namespace ores::qt {
 
@@ -128,11 +129,11 @@ void WorkspaceHistoryDialog::loadHistory() {
     using HistoryResult = std::expected<workspace::messaging::get_workspace_history_response, std::string>;
 
     QFuture<HistoryResult> future =
-        QtConcurrent::run([self, id = id_]() -> HistoryResult {
+        QtConcurrent::run([self, id_str = boost::uuids::to_string(id_)]() -> HistoryResult {
         if (!self || !self->clientManager_)
             return std::unexpected("Dialog closed");
         workspace::messaging::get_workspace_history_request request;
-        request.id = id;
+        request.id = id_str;
         auto result = self->clientManager_->process_authenticated_request(std::move(request));
         if (!result) return std::unexpected(result.error());
         return std::move(*result);
@@ -259,15 +260,18 @@ void WorkspaceHistoryDialog::updateChangesTable(int currentVersionIndex) {
     }
 
     if (current.parent_workspace_id != previous.parent_workspace_id) {
-        addChange("Parent",
-                  QString::fromStdString(previous.parent_workspace_id),
-                  QString::fromStdString(current.parent_workspace_id));
+        {
+            auto _to_s = [](const std::optional<boost::uuids::uuid>& o) {
+                return o ? QString::fromStdString(boost::uuids::to_string(*o)) : QString{};
+            };
+            addChange("Parent", _to_s(previous.parent_workspace_id), _to_s(current.parent_workspace_id));
+        }
     }
 
     if (current.owner_id != previous.owner_id) {
         addChange("Owner",
-                  QString::fromStdString(previous.owner_id),
-                  QString::fromStdString(current.owner_id));
+                  QString::fromStdString(boost::uuids::to_string(previous.owner_id)),
+                  QString::fromStdString(boost::uuids::to_string(current.owner_id)));
     }
 
     if (current.status_code != previous.status_code) {
@@ -297,8 +301,11 @@ void WorkspaceHistoryDialog::updateFullDetails(int versionIndex) {
     ui_->nameValue->setText(QString::fromStdString(version.name));
     ui_->descriptionValue->setText(QString::fromStdString(version.description));
     ui_->sourcePathValue->setText(QString::fromStdString(version.source_path));
-    ui_->parentValue->setText(QString::fromStdString(version.parent_workspace_id));
-    ui_->ownerValue->setText(QString::fromStdString(version.owner_id));
+    ui_->parentValue->setText(version.parent_workspace_id
+        ? QString::fromStdString(boost::uuids::to_string(*version.parent_workspace_id))
+        : QString{});
+    ui_->ownerValue->setText(
+        QString::fromStdString(boost::uuids::to_string(version.owner_id)));
     ui_->statusValue->setText(QString::fromStdString(version.status_code));
     ui_->versionNumberValue->setText(QString::number(version.version));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));

--- a/projects/ores.qt.workspace/src/WorkspaceHistoryDialog.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceHistoryDialog.cpp
@@ -1,0 +1,339 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/WorkspaceHistoryDialog.hpp"
+
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include "ui_WorkspaceHistoryDialog.h"
+#include "ores.qt/IconUtils.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
+#include "ores.workspace.api/messaging/workspace_protocol.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+WorkspaceHistoryDialog::WorkspaceHistoryDialog(
+    const boost::uuids::uuid& id,
+    const QString& code,
+    ClientManager* clientManager,
+    QWidget* parent)
+    : QWidget(parent),
+      ui_(new Ui::WorkspaceHistoryDialog),
+      id_(id),
+      code_(code),
+      clientManager_(clientManager),
+      toolbar_(nullptr),
+      openVersionAction_(nullptr),
+      revertAction_(nullptr) {
+
+    ui_->setupUi(this);
+    setupUi();
+    setupToolbar();
+    setupConnections();
+}
+
+WorkspaceHistoryDialog::~WorkspaceHistoryDialog() {
+    delete ui_;
+}
+
+void WorkspaceHistoryDialog::setupUi() {
+    ui_->closeButton->setIcon(
+        IconUtils::createRecoloredIcon(Icon::Dismiss, IconUtils::DefaultIconColor));
+
+    ui_->titleLabel->setText(QString("History for: %1").arg(code_));
+
+    // Setup version list table
+    ui_->versionListWidget->setColumnCount(5);
+    ui_->versionListWidget->setHorizontalHeaderLabels(
+        {"Version", "Recorded At", "Modified By", "Performed By", "Commentary"});
+    ui_->versionListWidget->horizontalHeader()->setStretchLastSection(true);
+    ui_->versionListWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui_->versionListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    // Setup changes table
+    ui_->changesTableWidget->setColumnCount(3);
+    ui_->changesTableWidget->setHorizontalHeaderLabels(
+        {"Field", "Old Value", "New Value"});
+    ui_->changesTableWidget->horizontalHeader()->setStretchLastSection(true);
+}
+
+void WorkspaceHistoryDialog::setupToolbar() {
+    toolbar_ = new QToolBar(this);
+    toolbar_->setMovable(false);
+    toolbar_->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolbar_->setIconSize(QSize(20, 20));
+
+    openVersionAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(Icon::Open, IconUtils::DefaultIconColor),
+        tr("Open"));
+    openVersionAction_->setToolTip(tr("Open this version (read-only)"));
+    openVersionAction_->setEnabled(false);
+
+    revertAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::ArrowRotateCounterclockwise, IconUtils::DefaultIconColor),
+        tr("Revert"));
+    revertAction_->setToolTip(tr("Revert to this version"));
+    revertAction_->setEnabled(false);
+
+    // Insert toolbar at the top of the layout
+    auto* layout = qobject_cast<QVBoxLayout*>(this->layout());
+    if (layout) {
+        layout->insertWidget(0, toolbar_);
+    }
+}
+
+void WorkspaceHistoryDialog::setupConnections() {
+    connect(ui_->versionListWidget, &QTableWidget::itemSelectionChanged,
+            this, &WorkspaceHistoryDialog::onVersionSelected);
+    connect(openVersionAction_, &QAction::triggered,
+            this, &WorkspaceHistoryDialog::onOpenVersionClicked);
+    connect(revertAction_, &QAction::triggered,
+            this, &WorkspaceHistoryDialog::onRevertClicked);
+    connect(ui_->closeButton, &QPushButton::clicked,
+            this, [this]() { if (window()) window()->close(); });
+}
+
+void WorkspaceHistoryDialog::loadHistory() {
+    if (!clientManager_ || !clientManager_->isConnected()) {
+        emit errorOccurred("Not connected to server");
+        return;
+    }
+
+    BOOST_LOG_SEV(lg(), debug) << "Loading history for workspace: " << code_.toStdString();
+    emit statusChanged(tr("Loading history..."));
+
+    QPointer<WorkspaceHistoryDialog> self = this;
+
+    using HistoryResult = std::expected<workspace::messaging::get_workspace_history_response, std::string>;
+
+    QFuture<HistoryResult> future =
+        QtConcurrent::run([self, id = id_]() -> HistoryResult {
+        if (!self || !self->clientManager_)
+            return std::unexpected("Dialog closed");
+        workspace::messaging::get_workspace_history_request request;
+        request.id = id;
+        auto result = self->clientManager_->process_authenticated_request(std::move(request));
+        if (!result) return std::unexpected(result.error());
+        return std::move(*result);
+    });
+
+    auto* watcher = new QFutureWatcher<HistoryResult>(self);
+    connect(watcher, &QFutureWatcher<HistoryResult>::finished,
+            self, [self, watcher]() {
+        auto result = watcher->result();
+        watcher->deleteLater();
+
+        if (!result) {
+            BOOST_LOG_SEV(lg(), error) << "History load failed: " << result.error();
+            emit self->errorOccurred(QString::fromStdString(result.error()));
+            return;
+        }
+        if (!result->success) {
+            emit self->errorOccurred(QString::fromStdString(result->message));
+            return;
+        }
+        self->versions_ = std::move(result->workspaces);
+        self->updateVersionList();
+        emit self->statusChanged(
+            QString("Loaded %1 versions").arg(self->versions_.size()));
+    });
+    watcher->setFuture(future);
+}
+
+void WorkspaceHistoryDialog::updateVersionList() {
+    ui_->versionListWidget->setRowCount(0);
+
+    for (const auto& version : versions_) {
+        int row = ui_->versionListWidget->rowCount();
+        ui_->versionListWidget->insertRow(row);
+
+        auto* versionItem = new QTableWidgetItem(QString::number(version.version));
+        versionItem->setTextAlignment(Qt::AlignCenter);
+        ui_->versionListWidget->setItem(row, 0, versionItem);
+
+        auto* recordedAtItem = new QTableWidgetItem(
+            relative_time_helper::format(version.recorded_at));
+        ui_->versionListWidget->setItem(row, 1, recordedAtItem);
+
+        auto* modifiedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.modified_by));
+        ui_->versionListWidget->setItem(row, 2, modifiedByItem);
+
+        auto* performedByItem = new QTableWidgetItem(
+            QString::fromStdString(version.performed_by));
+        ui_->versionListWidget->setItem(row, 3, performedByItem);
+
+        auto* commentaryItem = new QTableWidgetItem(
+            QString::fromStdString(version.change_commentary));
+        ui_->versionListWidget->setItem(row, 4, commentaryItem);
+    }
+
+    // Select the first (most recent) version
+    if (!versions_.empty()) {
+        ui_->versionListWidget->selectRow(0);
+    }
+}
+
+void WorkspaceHistoryDialog::onVersionSelected() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) {
+        updateActionStates();
+        return;
+    }
+
+    int row = selected.first()->row();
+    updateChangesTable(row);
+    updateFullDetails(row);
+    updateActionStates();
+}
+
+void WorkspaceHistoryDialog::updateChangesTable(int currentVersionIndex) {
+    ui_->changesTableWidget->setRowCount(0);
+
+    if (currentVersionIndex < 0 ||
+        static_cast<size_t>(currentVersionIndex) >= versions_.size()) {
+        return;
+    }
+
+    // Get the next older version to compare against
+    int previousVersionIndex = currentVersionIndex + 1;
+    if (static_cast<size_t>(previousVersionIndex) >= versions_.size()) {
+        // This is the first version, no changes to show
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(Initial version)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+        return;
+    }
+
+    const auto& current = versions_[currentVersionIndex];
+    const auto& previous = versions_[previousVersionIndex];
+
+    auto addChange = [this](const QString& field,
+                            const QString& oldVal, const QString& newVal) {
+        int row = ui_->changesTableWidget->rowCount();
+        ui_->changesTableWidget->insertRow(row);
+        ui_->changesTableWidget->setItem(row, 0, new QTableWidgetItem(field));
+        ui_->changesTableWidget->setItem(row, 1, new QTableWidgetItem(oldVal));
+        ui_->changesTableWidget->setItem(row, 2, new QTableWidgetItem(newVal));
+    };
+
+    if (current.name != previous.name) {
+        addChange("Name",
+                  QString::fromStdString(previous.name),
+                  QString::fromStdString(current.name));
+    }
+
+    if (current.description != previous.description) {
+        addChange("Description",
+                  QString::fromStdString(previous.description),
+                  QString::fromStdString(current.description));
+    }
+
+    if (current.source_path != previous.source_path) {
+        addChange("Source Path",
+                  QString::fromStdString(previous.source_path),
+                  QString::fromStdString(current.source_path));
+    }
+
+    if (current.parent_workspace_id != previous.parent_workspace_id) {
+        addChange("Parent",
+                  QString::fromStdString(previous.parent_workspace_id),
+                  QString::fromStdString(current.parent_workspace_id));
+    }
+
+    if (current.owner_id != previous.owner_id) {
+        addChange("Owner",
+                  QString::fromStdString(previous.owner_id),
+                  QString::fromStdString(current.owner_id));
+    }
+
+    if (current.status_code != previous.status_code) {
+        addChange("Status",
+                  QString::fromStdString(previous.status_code),
+                  QString::fromStdString(current.status_code));
+    }
+
+
+    if (ui_->changesTableWidget->rowCount() == 0) {
+        ui_->changesTableWidget->insertRow(0);
+        ui_->changesTableWidget->setItem(0, 0,
+            new QTableWidgetItem("(No field changes)"));
+        ui_->changesTableWidget->setItem(0, 1, new QTableWidgetItem("-"));
+        ui_->changesTableWidget->setItem(0, 2, new QTableWidgetItem("-"));
+    }
+}
+
+void WorkspaceHistoryDialog::updateFullDetails(int versionIndex) {
+    if (versionIndex < 0 ||
+        static_cast<size_t>(versionIndex) >= versions_.size()) {
+        return;
+    }
+
+    const auto& version = versions_[versionIndex];
+
+    ui_->nameValue->setText(QString::fromStdString(version.name));
+    ui_->descriptionValue->setText(QString::fromStdString(version.description));
+    ui_->sourcePathValue->setText(QString::fromStdString(version.source_path));
+    ui_->parentValue->setText(QString::fromStdString(version.parent_workspace_id));
+    ui_->ownerValue->setText(QString::fromStdString(version.owner_id));
+    ui_->statusValue->setText(QString::fromStdString(version.status_code));
+    ui_->versionNumberValue->setText(QString::number(version.version));
+    ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
+    ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
+    ui_->changeCommentaryValue->setText(
+        QString::fromStdString(version.change_commentary));
+}
+
+void WorkspaceHistoryDialog::updateActionStates() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    bool hasSelection = !selected.isEmpty();
+    bool isNotLatest = hasSelection && selected.first()->row() > 0;
+
+    openVersionAction_->setEnabled(hasSelection);
+    revertAction_->setEnabled(isNotLatest);
+}
+
+void WorkspaceHistoryDialog::onOpenVersionClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit openVersionRequested(versions_[row], versions_[row].version);
+}
+
+void WorkspaceHistoryDialog::onRevertClicked() {
+    auto selected = ui_->versionListWidget->selectedItems();
+    if (selected.isEmpty()) return;
+
+    int row = selected.first()->row();
+    if (static_cast<size_t>(row) >= versions_.size()) return;
+
+    emit revertVersionRequested(versions_[row]);
+}
+
+}

--- a/projects/ores.qt.workspace/src/WorkspaceMdiWindow.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceMdiWindow.cpp
@@ -30,6 +30,7 @@
 #include "ores.qt/IconUtils.hpp"
 #include "ores.qt/MessageBoxHelper.hpp"
 #include "ores.qt/ColorConstants.hpp"
+#include "ores.qt/EntityItemDelegate.hpp"
 #include "ores.workspace.api/messaging/workspace_protocol.hpp"
 
 namespace ores::qt {
@@ -39,10 +40,12 @@ using namespace ores::logging;
 WorkspaceMdiWindow::WorkspaceMdiWindow(
     ClientManager* clientManager,
     const QString& username,
+    BadgeCache* badgeCache,
     QWidget* parent)
     : EntityListMdiWindow(parent),
       clientManager_(clientManager),
       username_(username),
+      badgeCache_(badgeCache),
       toolbar_(nullptr),
       treeWidget_(nullptr),
       model_(nullptr),
@@ -60,6 +63,8 @@ WorkspaceMdiWindow::WorkspaceMdiWindow(
 }
 
 void WorkspaceMdiWindow::setupUi() {
+    setMinimumSize(700, 300);
+
     auto* layout = new QVBoxLayout(this);
 
     setupToolbar();
@@ -67,7 +72,7 @@ void WorkspaceMdiWindow::setupUi() {
     layout->addWidget(loadingBar());
 
     setupTree();
-    layout->addWidget(treeWidget_);
+    layout->addWidget(treeWidget_, 1);
 }
 
 void WorkspaceMdiWindow::setupToolbar() {
@@ -157,6 +162,24 @@ void WorkspaceMdiWindow::setupTree() {
     treeWidget_->setSelectionMode(QAbstractItemView::SingleSelection);
     treeWidget_->header()->setStretchLastSection(false);
     treeWidget_->header()->setSectionResizeMode(0, QHeaderView::Stretch);
+    treeWidget_->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
+    treeWidget_->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+
+    using cs = column_style;
+    auto* delegate = new EntityItemDelegate({
+        cs::text_left,       // Name
+        cs::badge_centered,  // Status
+        cs::text_left        // Modified By
+    }, treeWidget_);
+    delegate->set_badge_color_resolver(1, [cache = badgeCache_](const QString& value) -> badge_color_pair {
+        static const badge_color_pair default_gray{QColor(0x6B, 0x72, 0x80), Qt::white};
+        if (!cache) return default_gray;
+        auto* def = cache->resolve("workspace_status", value.toStdString());
+        if (!def) return default_gray;
+        return {QColor(QString::fromStdString(def->background_colour)),
+                QColor(QString::fromStdString(def->text_colour))};
+    });
+    treeWidget_->setItemDelegate(delegate);
 }
 
 void WorkspaceMdiWindow::setupConnections() {

--- a/projects/ores.qt.workspace/src/WorkspaceMdiWindow.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceMdiWindow.cpp
@@ -31,6 +31,8 @@
 #include "ores.qt/MessageBoxHelper.hpp"
 #include "ores.qt/ColorConstants.hpp"
 #include "ores.qt/EntityItemDelegate.hpp"
+#include "ores.qt/PaginationWidget.hpp"
+#include "ores.qt/RelativeTimeHelper.hpp"
 #include "ores.workspace.api/messaging/workspace_protocol.hpp"
 
 namespace ores::qt {
@@ -49,6 +51,7 @@ WorkspaceMdiWindow::WorkspaceMdiWindow(
       toolbar_(nullptr),
       treeWidget_(nullptr),
       model_(nullptr),
+      paginationWidget_(nullptr),
       reloadAction_(nullptr),
       addAction_(nullptr),
       openAction_(nullptr),
@@ -73,6 +76,9 @@ void WorkspaceMdiWindow::setupUi() {
 
     setupTree();
     layout->addWidget(treeWidget_, 1);
+
+    paginationWidget_ = new PaginationWidget(this);
+    layout->addWidget(createBottomBar(paginationWidget_));
 }
 
 void WorkspaceMdiWindow::setupToolbar() {
@@ -153,8 +159,9 @@ void WorkspaceMdiWindow::setupTree() {
     model_ = new ClientWorkspaceModel(clientManager_, this);
 
     treeWidget_ = new QTreeWidget(this);
-    treeWidget_->setColumnCount(3);
-    treeWidget_->setHeaderLabels({tr("Name"), tr("Status"), tr("Modified By")});
+    treeWidget_->setColumnCount(5);
+    treeWidget_->setHeaderLabels({
+        tr("Name"), tr("Status"), tr("Version"), tr("Modified By"), tr("Recorded At")});
     treeWidget_->setRootIsDecorated(true);
     treeWidget_->setAnimated(true);
     treeWidget_->setAlternatingRowColors(true);
@@ -164,12 +171,16 @@ void WorkspaceMdiWindow::setupTree() {
     treeWidget_->header()->setSectionResizeMode(0, QHeaderView::Stretch);
     treeWidget_->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
     treeWidget_->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+    treeWidget_->header()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
+    treeWidget_->header()->setSectionResizeMode(4, QHeaderView::ResizeToContents);
 
     using cs = column_style;
     auto* delegate = new EntityItemDelegate({
         cs::text_left,       // Name
         cs::badge_centered,  // Status
-        cs::text_left        // Modified By
+        cs::mono_center,     // Version
+        cs::text_left,       // Modified By
+        cs::mono_left        // Recorded At
     }, treeWidget_);
     delegate->set_badge_color_resolver(1, [cache = badgeCache_](const QString& value) -> badge_color_pair {
         static const badge_color_pair default_gray{QColor(0x6B, 0x72, 0x80), Qt::white};
@@ -193,12 +204,29 @@ void WorkspaceMdiWindow::setupConnections() {
     connect(treeWidget_, &QTreeWidget::itemDoubleClicked,
             this, &WorkspaceMdiWindow::onItemDoubleClicked);
 
+    connect(paginationWidget_, &PaginationWidget::page_size_changed,
+            this, [this](std::uint32_t size) {
+        model_->set_page_size(size);
+        model_->refresh();
+    });
+    connect(paginationWidget_, &PaginationWidget::load_all_requested,
+            this, [this]() {
+        const auto total = model_->total_available_count();
+        if (total > 0 && total <= 1000) {
+            model_->set_page_size(total);
+            model_->refresh();
+        }
+    });
+    connect(paginationWidget_, &PaginationWidget::page_requested,
+            this, [this](std::uint32_t offset, std::uint32_t limit) {
+        model_->load_page(offset, limit);
+    });
+
     connectModel(model_);
 }
 
 void WorkspaceMdiWindow::doReload() {
     BOOST_LOG_SEV(lg(), debug) << "Reloading workspaces";
-    clearStaleIndicator();
     emit statusChanged(tr("Loading workspaces..."));
     model_->refresh();
 }
@@ -223,7 +251,9 @@ void addTreeItems(QTreeWidgetItem* parent,
         auto* item = new QTreeWidgetItem(parent);
         item->setText(0, QString::fromStdString(ws->name));
         item->setText(1, QString::fromStdString(ws->status_code));
-        item->setText(2, QString::fromStdString(ws->modified_by));
+        item->setText(2, QString::number(ws->version));
+        item->setText(3, QString::fromStdString(ws->modified_by));
+        item->setText(4, relative_time_helper::format(ws->recorded_at));
         item->setData(0, Qt::UserRole, id_str);
         addTreeItems(item, ws->id, children_map);
     }
@@ -263,7 +293,9 @@ void WorkspaceMdiWindow::buildTree() {
         auto* item = new QTreeWidgetItem(treeWidget_);
         item->setText(0, QString::fromStdString(ws->name));
         item->setText(1, QString::fromStdString(ws->status_code));
-        item->setText(2, QString::fromStdString(ws->modified_by));
+        item->setText(2, QString::number(ws->version));
+        item->setText(3, QString::fromStdString(ws->modified_by));
+        item->setText(4, relative_time_helper::format(ws->recorded_at));
         item->setData(0, Qt::UserRole, id_str);
         addTreeItems(item, ws->id, children_map);
     }
@@ -275,6 +307,10 @@ void WorkspaceMdiWindow::onDataLoaded() {
     const auto loaded = static_cast<int>(model_->workspaces().size());
     const auto total = model_->total_available_count();
     emit statusChanged(tr("Loaded %1 of %2 workspaces").arg(loaded).arg(total));
+
+    paginationWidget_->update_state(loaded, total);
+    paginationWidget_->set_load_all_enabled(
+        loaded < static_cast<int>(total) && total > 0 && total <= 1000);
 
     buildTree();
 }

--- a/projects/ores.qt.workspace/src/WorkspaceMdiWindow.cpp
+++ b/projects/ores.qt.workspace/src/WorkspaceMdiWindow.cpp
@@ -50,6 +50,7 @@ WorkspaceMdiWindow::WorkspaceMdiWindow(
       addAction_(nullptr),
       openAction_(nullptr),
       editAction_(nullptr),
+      historyAction_(nullptr),
       archiveAction_(nullptr),
       deleteAction_(nullptr) {
 
@@ -113,6 +114,15 @@ void WorkspaceMdiWindow::setupToolbar() {
     editAction_->setEnabled(false);
     connect(editAction_, &QAction::triggered, this,
             &WorkspaceMdiWindow::editSelected);
+
+    historyAction_ = toolbar_->addAction(
+        IconUtils::createRecoloredIcon(
+            Icon::History, IconUtils::DefaultIconColor),
+        tr("History"));
+    historyAction_->setToolTip(tr("View workspace version history"));
+    historyAction_->setEnabled(false);
+    connect(historyAction_, &QAction::triggered, this,
+            &WorkspaceMdiWindow::onHistoryRequested);
 
     archiveAction_ = toolbar_->addAction(
         IconUtils::createRecoloredIcon(
@@ -275,6 +285,7 @@ void WorkspaceMdiWindow::updateActionStates() {
     const bool has_selection = !treeWidget_->selectedItems().isEmpty();
     openAction_->setEnabled(has_selection);
     editAction_->setEnabled(has_selection);
+    historyAction_->setEnabled(has_selection);
     archiveAction_->setEnabled(has_selection);
     deleteAction_->setEnabled(has_selection);
 }
@@ -297,6 +308,24 @@ void WorkspaceMdiWindow::openSelected() {
     }
     BOOST_LOG_SEV(lg(), warn) << "Could not find workspace for id: "
                               << id_str.toStdString();
+}
+
+void WorkspaceMdiWindow::onHistoryRequested() {
+    auto selected = treeWidget_->selectedItems();
+    if (selected.isEmpty()) {
+        BOOST_LOG_SEV(lg(), warn) << "History requested but no item selected";
+        return;
+    }
+
+    const auto target_id = boost::uuids::string_generator()(
+        selected.first()->data(0, Qt::UserRole).toString().toStdString());
+    for (const auto& ws : model_->workspaces()) {
+        if (ws.id == target_id) {
+            emit showWorkspaceHistory(ws);
+            return;
+        }
+    }
+    BOOST_LOG_SEV(lg(), warn) << "Could not find workspace for history request";
 }
 
 void WorkspaceMdiWindow::addNew() {

--- a/projects/ores.qt.workspace/src/WorkspacePlugin.cpp
+++ b/projects/ores.qt.workspace/src/WorkspacePlugin.cpp
@@ -47,7 +47,8 @@ void WorkspacePlugin::on_login(const plugin_context& ctx) {
     ctx_ = ctx;
 
     workspaceController_ = std::make_unique<WorkspaceController>(
-        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager, ctx_.username, this);
+        ctx_.main_window, ctx_.mdi_area, ctx_.client_manager, ctx_.username,
+        ctx_.badge_cache, this);
 
     connect(workspaceController_.get(), &WorkspaceController::statusMessage,
             this, &WorkspacePlugin::statusMessage);

--- a/projects/ores.qt.workspace/ui/WorkspaceDetailDialog.ui
+++ b/projects/ores.qt.workspace/ui/WorkspaceDetailDialog.ui
@@ -39,73 +39,81 @@
          </property>
          <layout class="QFormLayout" name="formLayout">
           <item row="0" column="0">
-           <widget class="QLabel" name="labelId">
-            <property name="text">
-             <string>Id:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="codeEdit">
-            <property name="placeholderText">
-             <string>Enter workspace id</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
            <widget class="QLabel" name="labelName">
             <property name="text">
              <string>Name:</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="0" column="1">
            <widget class="QLineEdit" name="nameEdit">
             <property name="placeholderText">
-             <string>Enter display name</string>
+             <string>Unique workspace name</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="1" column="0">
            <widget class="QLabel" name="labelDescription">
             <property name="text">
              <string>Description:</string>
             </property>
            </widget>
           </item>
+          <item row="1" column="1">
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelSourcePath">
+            <property name="text">
+             <string>Source Path:</string>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="1">
-           <widget class="QPlainTextEdit" name="descriptionEdit">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>80</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>150</height>
-             </size>
-            </property>
+           <widget class="QLineEdit" name="sourcePathEdit">
             <property name="placeholderText">
-             <string>Enter a description</string>
+             <string>Optional data source path</string>
             </property>
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QLabel" name="labelInheritsFrom">
+           <widget class="QLabel" name="labelParentWorkspaceId">
             <property name="text">
-             <string>Inherits from:</string>
+             <string>Parent:</string>
             </property>
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="QLineEdit" name="inheritsFromEdit">
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
+           <widget class="QLineEdit" name="parentEdit">
             <property name="placeholderText">
-             <string>Live (root workspace)</string>
+             <string>Inherited from (UUID)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelOwnerId">
+            <property name="text">
+             <string>Owner:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="ownerEdit">
+            <property name="placeholderText">
+             <string></string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="labelStatusCode">
+            <property name="text">
+             <string>Status:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLineEdit" name="statusEdit">
+            <property name="placeholderText">
+             <string></string>
             </property>
            </widget>
           </item>

--- a/projects/ores.qt.workspace/ui/WorkspaceDetailDialog.ui
+++ b/projects/ores.qt.workspace/ui/WorkspaceDetailDialog.ui
@@ -60,6 +60,23 @@
            </widget>
           </item>
           <item row="1" column="1">
+           <widget class="QPlainTextEdit" name="descriptionEdit">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>80</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>150</height>
+             </size>
+            </property>
+            <property name="placeholderText">
+             <string></string>
+            </property>
+           </widget>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="labelSourcePath">

--- a/projects/ores.qt.workspace/ui/WorkspaceHistoryDialog.ui
+++ b/projects/ores.qt.workspace/ui/WorkspaceHistoryDialog.ui
@@ -175,6 +175,9 @@
                  <property name="text">
                   <string/>
                  </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
                 </widget>
                </item>
                <item row="2" column="0">

--- a/projects/ores.qt.workspace/ui/WorkspaceHistoryDialog.ui
+++ b/projects/ores.qt.workspace/ui/WorkspaceHistoryDialog.ui
@@ -1,0 +1,332 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>WorkspaceHistoryDialog</class>
+ <widget class="QWidget" name="WorkspaceHistoryDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>900</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Workspace History</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Workspace History</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QTableWidget" name="versionListWidget">
+      <property name="minimumHeight">
+       <number>150</number>
+      </property>
+      <property name="maximumHeight">
+       <number>250</number>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="editTriggers">
+       <set>QAbstractItemView::NoEditTriggers</set>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+      <column>
+       <property name="text">
+        <string>Version</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Recorded At</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Modified By</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Commentary</string>
+       </property>
+      </column>
+     </widget>
+     <widget class="QWidget" name="detailWidget">
+      <layout class="QVBoxLayout" name="detailLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTabWidget" name="tabWidget">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="changesTab">
+          <attribute name="title">
+           <string>Changes</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="changesTabLayout">
+           <item>
+            <widget class="QTableWidget" name="changesTableWidget">
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="alternatingRowColors">
+              <bool>true</bool>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::SingleSelection</enum>
+             </property>
+             <property name="selectionBehavior">
+              <enum>QAbstractItemView::SelectRows</enum>
+             </property>
+             <column>
+              <property name="text">
+               <string>Field</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Old Value</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>New Value</string>
+              </property>
+             </column>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="fullDetailsTab">
+          <attribute name="title">
+           <string>Full Details</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="fullDetailsTabLayout">
+           <item>
+            <widget class="QScrollArea" name="scrollArea">
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="scrollAreaWidgetContents">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>560</width>
+                <height>450</height>
+               </rect>
+              </property>
+              <layout class="QFormLayout" name="formLayout">
+               <item row="0" column="0">
+                <widget class="QLabel" name="nameLabel">
+                 <property name="text">
+                  <string>Name:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="nameValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="descriptionLabel">
+                 <property name="text">
+                  <string>Description:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="descriptionValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="source_pathLabel">
+                 <property name="text">
+                  <string>Source Path:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QLabel" name="sourcePathValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="parent_workspace_idLabel">
+                 <property name="text">
+                  <string>Parent:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLabel" name="parentValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="owner_idLabel">
+                 <property name="text">
+                  <string>Owner:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QLabel" name="ownerValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="status_codeLabel">
+                 <property name="text">
+                  <string>Status:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QLabel" name="statusValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="versionNumberLabel">
+                 <property name="text">
+                  <string>Version:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
+                <widget class="QLabel" name="versionNumberValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QLabel" name="modifiedByLabel">
+                 <property name="text">
+                  <string>Modified By:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QLabel" name="modifiedByValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="0">
+                <widget class="QLabel" name="recordedAtLabel">
+                 <property name="text">
+                  <string>Recorded At:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="1">
+                <widget class="QLabel" name="recordedAtValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0">
+                <widget class="QLabel" name="changeCommentaryLabel">
+                 <property name="text">
+                  <string>Change Commentary:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QLabel" name="changeCommentaryValue">
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size><width>40</width><height>20</height></size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/projects/ores.refdata.core/include/ores.refdata.core/messaging/portfolio_handler.hpp
+++ b/projects/ores.refdata.core/include/ores.refdata.core/messaging/portfolio_handler.hpp
@@ -65,6 +65,9 @@ public:
             return;
         }
         const auto& ctx = *ctx_expected;
+        BOOST_LOG_SEV(portfolio_handler_lg(), debug)
+            << "Listing portfolios: tenant_id=" << ctx.tenant_id().to_string()
+            << " workspace_id=" << ctx.workspace_id();
         service::portfolio_service svc(ctx);
         get_portfolios_response resp;
         try {
@@ -72,7 +75,8 @@ public:
             resp.total_available_count =
                 static_cast<int>(resp.portfolios.size());
             BOOST_LOG_SEV(portfolio_handler_lg(), debug)
-                << "Completed " << msg.subject;
+                << "Completed " << msg.subject
+                << ": returned " << resp.total_available_count << " portfolios";
         } catch (const std::exception& e) {
             BOOST_LOG_SEV(portfolio_handler_lg(), error)
                 << msg.subject << " failed: " << e.what();

--- a/projects/ores.sql/create/workspace/workspace_create.sql
+++ b/projects/ores.sql/create/workspace/workspace_create.sql
@@ -22,7 +22,7 @@ create table if not exists ores_workspaces_tbl (
     version             integer      not null,
     name                text         not null,
     description         text         not null default '',
-    source_path         text         not null default '',
+    source_path         text         null,
     parent_workspace_id uuid         null,
     scope_portfolio_id  uuid         null,
     owner_id            uuid         not null,

--- a/projects/ores.workspace.api/include/ores.workspace.api/generators/workspace_generator.hpp
+++ b/projects/ores.workspace.api/include/ores.workspace.api/generators/workspace_generator.hpp
@@ -17,20 +17,28 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_WORKSPACE_DOMAIN_WORKSPACE_TABLE_HPP
-#define ORES_WORKSPACE_DOMAIN_WORKSPACE_TABLE_HPP
+#ifndef ORES_WORKSPACE_GENERATORS_WORKSPACE_GENERATOR_HPP
+#define ORES_WORKSPACE_GENERATORS_WORKSPACE_GENERATOR_HPP
 
-#include <string>
 #include <vector>
-#include "ores.workspace.api/domain/workspace.hpp"
 #include "ores.workspace.api/export.hpp"
+#include "ores.workspace.api/domain/workspace.hpp"
+#include "ores.utility/generation/generation_context.hpp"
 
-namespace ores::workspace::domain {
+namespace ores::workspace::generators {
 
 /**
- * @brief Converts workspaces to the table format.
+ * @brief Generates a synthetic workspace.
  */
-ORES_WORKSPACE_API_EXPORT std::string convert_to_table(const std::vector<workspace>& v);
+ORES_WORKSPACE_API_EXPORT domain::workspace generate_synthetic_workspace(
+    utility::generation::generation_context& ctx);
+
+/**
+ * @brief Generates N synthetic workspaces.
+ */
+ORES_WORKSPACE_API_EXPORT std::vector<domain::workspace>
+generate_synthetic_workspaces(std::size_t n,
+    utility::generation::generation_context& ctx);
 
 }
 

--- a/projects/ores.workspace.api/include/ores.workspace.api/messaging/workspace_protocol.hpp
+++ b/projects/ores.workspace.api/include/ores.workspace.api/messaging/workspace_protocol.hpp
@@ -138,6 +138,23 @@ struct clear_trade_scope_response {
     std::string message;
 };
 
+// ---------------------------------------------------------------------------
+// Get workspace history
+// ---------------------------------------------------------------------------
+
+struct get_workspace_history_request {
+    using response_type = struct get_workspace_history_response;
+    static constexpr std::string_view nats_subject =
+        "workspace.v1.workspaces.history";
+    std::string id;  // UUID string
+};
+
+struct get_workspace_history_response {
+    std::vector<ores::workspace::domain::workspace> workspaces;
+    bool success = false;
+    std::string message;
+};
+
 }
 
 #endif

--- a/projects/ores.workspace.api/src/CMakeLists.txt
+++ b/projects/ores.workspace.api/src/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${lib_target_name}
         ores.platform.lib
     PRIVATE
         ores.utility.lib
-        libfort::fort)
+        libfort::fort
+        faker-cxx::faker-cxx)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.workspace.api/src/generators/workspace_generator.cpp
+++ b/projects/ores.workspace.api/src/generators/workspace_generator.cpp
@@ -1,0 +1,60 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.workspace.api/generators/workspace_generator.hpp"
+
+#include <atomic>
+#include <string>
+#include <faker-cxx/faker.h> // IWYU pragma: keep.
+#include "ores.utility/generation/generation_keys.hpp"
+
+namespace ores::workspace::generators {
+
+using ores::utility::generation::generation_keys;
+
+domain::workspace generate_synthetic_workspace(
+    utility::generation::generation_context& ctx) {
+    static std::atomic<int> counter{0};
+    const auto modified_by = ctx.env().get_or(
+        std::string(generation_keys::modified_by), "system");
+
+    domain::workspace r;
+    r.version = 1;
+    r.id = ctx.generate_uuid();
+    r.name = ;
+    r.owner_id = ctx.generate_uuid();
+    r.modified_by = modified_by;
+    r.performed_by = modified_by;
+    r.change_reason_code = "system.test";
+    r.change_commentary = "Synthetic test data";
+    r.recorded_at = ctx.past_timepoint();
+    return r;
+}
+
+std::vector<domain::workspace>
+generate_synthetic_workspaces(std::size_t n,
+    utility::generation::generation_context& ctx) {
+    std::vector<domain::workspace> r;
+    r.reserve(n);
+    while (r.size() < n)
+        r.push_back(generate_synthetic_workspace(ctx));
+    return r;
+}
+
+}

--- a/projects/ores.workspace.api/src/generators/workspace_generator.cpp
+++ b/projects/ores.workspace.api/src/generators/workspace_generator.cpp
@@ -37,7 +37,7 @@ domain::workspace generate_synthetic_workspace(
     domain::workspace r;
     r.version = 1;
     r.id = ctx.generate_uuid();
-    r.name = ;
+    r.name = std::string(faker::word::noun()) + "-" + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
     r.owner_id = ctx.generate_uuid();
     r.modified_by = modified_by;
     r.performed_by = modified_by;

--- a/projects/ores.workspace.core/include/ores.workspace.core/messaging/workspace_handler.hpp
+++ b/projects/ores.workspace.core/include/ores.workspace.core/messaging/workspace_handler.hpp
@@ -22,6 +22,7 @@
 
 #include <optional>
 #include <string>
+#include <thread>
 #include <vector>
 #include <boost/uuid/string_generator.hpp>
 #include <boost/uuid/uuid.hpp>
@@ -329,26 +330,28 @@ public:
             error_reply(nats_, msg, ores::service::error_code::forbidden);
             return;
         }
-        service::workspace_service svc(ctx);
-        get_workspace_history_response resp;
         auto req = decode<get_workspace_history_request>(msg);
         if (!req) {
             BOOST_LOG_SEV(workspace_handler_lg(), warn)
                 << "Failed to decode: " << msg.subject;
-            reply(nats_, msg, resp);
+            reply(nats_, msg, get_workspace_history_response{});
             return;
         }
-        try {
-            resp.workspaces = svc.get_workspace_history(req->id);
-            resp.success = true;
-            BOOST_LOG_SEV(workspace_handler_lg(), debug)
-                << "Completed " << msg.subject;
-        } catch (const std::exception& e) {
-            BOOST_LOG_SEV(workspace_handler_lg(), error)
-                << msg.subject << " failed: " << e.what();
-            resp.message = e.what();
-        }
-        reply(nats_, msg, resp);
+        std::thread([this, msg = std::move(msg), ctx, id = req->id]() mutable {
+            service::workspace_service svc(ctx);
+            get_workspace_history_response resp;
+            try {
+                resp.workspaces = svc.get_workspace_history(id);
+                resp.success = true;
+                BOOST_LOG_SEV(workspace_handler_lg(), debug)
+                    << "Completed " << msg.subject;
+            } catch (const std::exception& e) {
+                BOOST_LOG_SEV(workspace_handler_lg(), error)
+                    << msg.subject << " failed: " << e.what();
+                resp.message = e.what();
+            }
+            reply(nats_, msg, resp);
+        }).detach();
     }
 
     void clear_trade_scope(ores::nats::message msg) {

--- a/projects/ores.workspace.core/include/ores.workspace.core/messaging/workspace_handler.hpp
+++ b/projects/ores.workspace.core/include/ores.workspace.core/messaging/workspace_handler.hpp
@@ -315,6 +315,42 @@ public:
         }
     }
 
+    void history(ores::nats::message msg) {
+        [[maybe_unused]] const auto correlation_id =
+            log_handler_entry(workspace_handler_lg(), msg);
+        auto ctx_expected = ores::service::service::make_request_context(
+            ctx_, msg, verifier_);
+        if (!ctx_expected) {
+            error_reply(nats_, msg, ctx_expected.error());
+            return;
+        }
+        const auto& ctx = *ctx_expected;
+        if (!has_permission(ctx, "workspace::workspaces:read")) {
+            error_reply(nats_, msg, ores::service::error_code::forbidden);
+            return;
+        }
+        service::workspace_service svc(ctx);
+        get_workspace_history_response resp;
+        auto req = decode<get_workspace_history_request>(msg);
+        if (!req) {
+            BOOST_LOG_SEV(workspace_handler_lg(), warn)
+                << "Failed to decode: " << msg.subject;
+            reply(nats_, msg, resp);
+            return;
+        }
+        try {
+            resp.workspaces = svc.get_workspace_history(req->id);
+            resp.success = true;
+            BOOST_LOG_SEV(workspace_handler_lg(), debug)
+                << "Completed " << msg.subject;
+        } catch (const std::exception& e) {
+            BOOST_LOG_SEV(workspace_handler_lg(), error)
+                << msg.subject << " failed: " << e.what();
+            resp.message = e.what();
+        }
+        reply(nats_, msg, resp);
+    }
+
     void clear_trade_scope(ores::nats::message msg) {
         [[maybe_unused]] const auto correlation_id =
             log_handler_entry(workspace_handler_lg(), msg);

--- a/projects/ores.workspace.core/include/ores.workspace.core/repository/workspace_mapper.hpp
+++ b/projects/ores.workspace.core/include/ores.workspace.core/repository/workspace_mapper.hpp
@@ -23,13 +23,14 @@
 #include "ores.workspace.api/domain/workspace.hpp"
 #include "ores.workspace.core/repository/workspace_entity.hpp"
 #include "ores.logging/make_logger.hpp"
+#include "ores.workspace.core/export.hpp"
 
 namespace ores::workspace::repository {
 
 /**
  * @brief Maps workspace domain entities to data storage layer and vice-versa.
  */
-class workspace_mapper {
+class ORES_WORKSPACE_CORE_EXPORT workspace_mapper {
 private:
     inline static std::string_view logger_name =
         "ores.workspace.repository.workspace_mapper";

--- a/projects/ores.workspace.core/include/ores.workspace.core/repository/workspace_mapper.hpp
+++ b/projects/ores.workspace.core/include/ores.workspace.core/repository/workspace_mapper.hpp
@@ -23,14 +23,13 @@
 #include "ores.workspace.api/domain/workspace.hpp"
 #include "ores.workspace.core/repository/workspace_entity.hpp"
 #include "ores.logging/make_logger.hpp"
-#include "ores.workspace.core/export.hpp"
 
 namespace ores::workspace::repository {
 
 /**
  * @brief Maps workspace domain entities to data storage layer and vice-versa.
  */
-class ORES_WORKSPACE_CORE_EXPORT workspace_mapper {
+class workspace_mapper {
 private:
     inline static std::string_view logger_name =
         "ores.workspace.repository.workspace_mapper";

--- a/projects/ores.workspace.core/include/ores.workspace.core/repository/workspace_repository.hpp
+++ b/projects/ores.workspace.core/include/ores.workspace.core/repository/workspace_repository.hpp
@@ -61,6 +61,9 @@ public:
 
     void remove(context ctx, const std::string& id);
 
+    std::vector<domain::workspace>
+    read_history(context ctx, const std::string& id);
+
     /**
      * @brief Returns all active workspaces ordered by name.
      */

--- a/projects/ores.workspace.core/include/ores.workspace.core/service/workspace_service.hpp
+++ b/projects/ores.workspace.core/include/ores.workspace.core/service/workspace_service.hpp
@@ -103,6 +103,9 @@ public:
      */
     void clear_trade_scope(const std::string& workspace_id);
 
+    std::vector<domain::workspace>
+    get_workspace_history(const std::string& id);
+
 private:
     context ctx_;
     repository::workspace_repository repo_{};

--- a/projects/ores.workspace.core/src/messaging/registrar.cpp
+++ b/projects/ores.workspace.core/src/messaging/registrar.cpp
@@ -65,6 +65,9 @@ registrar::register_handlers(ores::nats::service::client& nats,
         subs.push_back(nats.queue_subscribe(
             clear_trade_scope_request::nats_subject, queue_group,
             [h](ores::nats::message msg) { h->clear_trade_scope(std::move(msg)); }));
+        subs.push_back(nats.queue_subscribe(
+            get_workspace_history_request::nats_subject, queue_group,
+            [h](ores::nats::message msg) { h->history(std::move(msg)); }));
     }
 
     return subs;

--- a/projects/ores.workspace.core/src/repository/workspace_repository.cpp
+++ b/projects/ores.workspace.core/src/repository/workspace_repository.cpp
@@ -101,6 +101,11 @@ void workspace_repository::remove(context ctx, const std::string& id) {
 }
 
 std::vector<domain::workspace>
+workspace_repository::read_history(context ctx, const std::string& id) {
+    return read_all(ctx, id);
+}
+
+std::vector<domain::workspace>
 workspace_repository::list_active(context ctx) {
     BOOST_LOG_SEV(lg(), debug) << "Listing active workspaces.";
     static auto max(make_timestamp(MAX_TIMESTAMP, lg()));

--- a/projects/ores.workspace.core/src/service/workspace_service.cpp
+++ b/projects/ores.workspace.core/src/service/workspace_service.cpp
@@ -61,6 +61,7 @@ std::string workspace_service::create_workspace(const domain::workspace& ws) {
     }
     if (to_create.status_code.empty())
         to_create.status_code = "active";
+    to_create.modified_by = ctx_.actor();
 
     BOOST_LOG_SEV(lg(), debug) << "Creating workspace: " << to_create.name;
     repo_.write(ctx_, to_create);
@@ -73,7 +74,7 @@ void workspace_service::archive_workspace(const std::string& id,
     const std::string& change_commentary) {
 
     BOOST_LOG_SEV(lg(), debug) << "Archiving workspace: " << id;
-    repo_.archive(ctx_, id, modified_by, change_reason_code, change_commentary);
+    repo_.archive(ctx_, id, ctx_.actor(), change_reason_code, change_commentary);
 }
 
 void workspace_service::remove_workspace(const std::string& id) {

--- a/projects/ores.workspace.core/src/service/workspace_service.cpp
+++ b/projects/ores.workspace.core/src/service/workspace_service.cpp
@@ -101,4 +101,10 @@ void workspace_service::clear_trade_scope(const std::string& workspace_id) {
     repo_.clear_trade_scope(ctx_, workspace_id);
 }
 
+std::vector<domain::workspace>
+workspace_service::get_workspace_history(const std::string& id) {
+    BOOST_LOG_SEV(lg(), debug) << "Getting history for workspace: " << id;
+    return repo_.read_history(ctx_, id);
+}
+
 }


### PR DESCRIPTION
## Summary

- Promotes the workspace entity to a full standard entity: adds history support (bitemporal audit trail), a generated detail dialog replacing the hand-crafted one, and a generated `workspace_generator`
- Adds status badge rendering to the workspace tree window using `EntityItemDelegate` + `BadgeCache` (`active` → green, `archived` → red)
- Adds history toolbar action and geometry persistence for all workspace dialogs
- Security fix: `workspace_service` now derives `modified_by` from `ctx_.actor()` (JWT-authenticated username) instead of trusting the client-supplied value
- Introduces `createBottomBar(PaginationWidget*, ClientManager* = nullptr)` on `EntityListMdiWindow` — workspace selector is opt-in (pass `clientManager_` to enable); previously it was ad-hoc and missing from most windows
- Wires workspace selector to all applicable list windows: Book, Portfolio, Trade, PortfolioExplorer, ReportDefinition, MarketFixings, MarketSeries, CurrencyMarketTier
- Moves workspace selector from toolbar flush-right to a bottom bar left of the pagination widget, consistent across all windows
- Fixes codegen template gaps: `plain_text_edit` widget support, UUID field handling, delete request generation

## Justified deviations (workspace entity)

| Deviation | Rationale |
|---|---|
| `has_tenant_id: false` | Workspace is system-wide; cross-tenant isolation handled via IAM |
| `has_workspace_id: false` | A workspace cannot belong to a workspace |
| `has_pagination: false` | ≤ ~20 active workspaces by design; tree view does not support pagination |

🤖 Generated with [Claude Code](https://claude.com/claude-code)