### PR TITLE
[trading] Export parser symbol for Windows DLL build + codegen export.hpp support

### DIFF
--- a/doc/knowledge/external/shared_library_symbol_visibility.org
+++ b/doc/knowledge/external/shared_library_symbol_visibility.org
@@ -151,9 +151,23 @@ Types shared *across* Qt plugins must live in =ores.qt.api= and be
 exported from there using =ORES_QT_API=.  Plugin-internal types are
 never exported.
 
-** Service executables (=ores.X.service=)
+** Service libraries and executables (=ores.X.service=)
 
-Executables export nothing.  Do not add an export header.
+Each service project produces two targets: a shared library
+(=ores.X.service.lib=) and an executable (=ores.X.service.exe=).
+
+The library target exports any class whose symbols must be visible to
+the test binary or to =main.cpp= after they cross the DLL boundary.
+In practice this means at minimum:
+
+- =config::parser= — called by both =main.cpp= and the test binary.
+- =app::host= — called by =main.cpp=.
+
+Add =export.hpp= to the project and annotate those classes with
+=ORES_X_SERVICE_EXPORT=.  Add =target_compile_definitions(... PRIVATE
+ORES_X_SERVICE_LIBRARY)= to the lib target in =src/CMakeLists.txt=.
+
+The executable target (=main.cpp= only) exports nothing.
 
 ** CLI and test executables
 

--- a/projects/ores.codegen/library/profiles.json
+++ b/projects/ores.codegen/library/profiles.json
@@ -327,6 +327,10 @@
           "output": "projects/{component_full}/modeling/CMakeLists.txt"
         },
         {
+          "template": "cpp_export.hpp.mustache",
+          "output": "projects/{component_full}/include/{component_full}/export.hpp"
+        },
+        {
           "template": "cpp_component_header.hpp.mustache",
           "output": "projects/{component_full}/include/{component_full}/{component_full}.hpp"
         },
@@ -367,6 +371,10 @@
         {
           "template": "cmake_component_modeling.mustache",
           "output": "projects/{component_full}/modeling/CMakeLists.txt"
+        },
+        {
+          "template": "cpp_export.hpp.mustache",
+          "output": "projects/{component_full}/include/{component_full}/export.hpp"
         },
         {
           "template": "cpp_component_header.hpp.mustache",
@@ -411,6 +419,10 @@
           "output": "projects/{component_full}/modeling/CMakeLists.txt"
         },
         {
+          "template": "cpp_export.hpp.mustache",
+          "output": "projects/{component_full}/include/{component_full}/export.hpp"
+        },
+        {
           "template": "cpp_component_header.hpp.mustache",
           "output": "projects/{component_full}/include/{component_full}/{component_full}.hpp"
         },
@@ -451,6 +463,10 @@
         {
           "template": "cmake_component_modeling.mustache",
           "output": "projects/{component_full}/modeling/CMakeLists.txt"
+        },
+        {
+          "template": "cpp_export.hpp.mustache",
+          "output": "projects/{component_full}/include/{component_full}/export.hpp"
         },
         {
           "template": "cpp_component_header.hpp.mustache",

--- a/projects/ores.codegen/library/templates/cmake_component_api_src.mustache
+++ b/projects/ores.codegen/library/templates/cmake_component_api_src.mustache
@@ -11,6 +11,7 @@ file(GLOB_RECURSE files RELATIVE
 
 set(lib_files ${files})
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE {{full_name_upper}}_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.codegen/library/templates/cmake_component_core_src.mustache
+++ b/projects/ores.codegen/library/templates/cmake_component_core_src.mustache
@@ -11,6 +11,7 @@ file(GLOB_RECURSE files RELATIVE
 
 set(lib_files ${files})
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE {{full_name_upper}}_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.codegen/library/templates/cmake_component_service_src.mustache
+++ b/projects/ores.codegen/library/templates/cmake_component_service_src.mustache
@@ -13,6 +13,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE {{full_name_upper}}_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.codegen/library/templates/cmake_component_src.mustache
+++ b/projects/ores.codegen/library/templates/cmake_component_src.mustache
@@ -11,6 +11,7 @@ file(GLOB_RECURSE files RELATIVE
 
 set(lib_files ${files})
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE {{full_name_upper}}_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.codegen/library/templates/cmake_service_src.mustache
+++ b/projects/ores.codegen/library/templates/cmake_service_src.mustache
@@ -13,6 +13,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE {{full_name_upper}}_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}

--- a/projects/ores.codegen/library/templates/cpp_export.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_export.hpp.mustache
@@ -1,0 +1,15 @@
+{{{cpp_license}}}
+{{#component}}
+#ifndef {{full_name_upper}}_EXPORT_HPP
+#define {{full_name_upper}}_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef {{full_name_upper}}_LIBRARY
+#  define {{full_name_upper}}_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define {{full_name_upper}}_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif
+{{/component}}

--- a/projects/ores.codegen/library/templates/cpp_service_app_host.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_service_app_host.hpp.mustache
@@ -8,13 +8,14 @@
 #include <ostream>
 #include <boost/asio/awaitable.hpp>
 #include "ores.logging/make_logger.hpp"
+#include "{{full_name}}/export.hpp"
 
 namespace {{namespace}}::app {
 
 /**
  * @brief Provides hosting services to the application.
  */
-class host {
+class {{full_name_upper}}_EXPORT host {
 private:
     inline static std::string_view logger_name = "{{full_name}}.app.host";
 

--- a/projects/ores.codegen/library/templates/cpp_service_config_parser.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_service_config_parser.hpp.mustache
@@ -7,6 +7,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "{{full_name}}/export.hpp"
 #include "{{full_name}}/config/options.hpp"
 
 namespace {{namespace}}::config {
@@ -17,7 +18,7 @@ namespace {{namespace}}::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class {{full_name_upper}}_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.codegen/modeling/component_overview.org
+++ b/projects/ores.codegen/modeling/component_overview.org
@@ -137,10 +137,10 @@ harness.  See [[id:f27e5df7-6223-4b6f-80a5-cefbeb1bc756][Component architecture]
 
 | Profile | Part | Files |
 |---|---|---|
-| =--profile component-api= | =ores.COMPONENT.api= | 9 (CMakeLists ×4, header, stub header+impl, test main+stub) |
-| =--profile component-core= | =ores.COMPONENT.core= | 9 (same set, core CMake deps) |
-| =--profile component-service= | =ores.COMPONENT.service= | 18 (core set + app/config headers+impls + main.cpp) |
-| =--profile component= | standalone (no split) | 9 (generic CMake deps) |
+| =--profile component-api= | =ores.COMPONENT.api= | 10 (CMakeLists ×4, export.hpp, header, stub header+impl, test main+stub) |
+| =--profile component-core= | =ores.COMPONENT.core= | 10 (same set, core CMake deps) |
+| =--profile component-service= | =ores.COMPONENT.service= | 19 (core set + export.hpp + app/config headers+impls + main.cpp) |
+| =--profile component= | standalone (no split) | 10 (generic CMake deps + export.hpp) |
 
 * Entry points
 

--- a/projects/ores.trading.service/include/ores.trading.service/config/parser.hpp
+++ b/projects/ores.trading.service/include/ores.trading.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.trading.service/export.hpp"
 #include "ores.trading.service/config/options.hpp"
 
 namespace ores::trading::service::config {
@@ -34,7 +35,7 @@ namespace ores::trading::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_TRADING_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.trading.service/include/ores.trading.service/export.hpp
+++ b/projects/ores.trading.service/include/ores.trading.service/export.hpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_TRADING_SERVICE_EXPORT_HPP
+#define ORES_TRADING_SERVICE_EXPORT_HPP
+
+#include <boost/config.hpp>
+
+#ifdef ORES_TRADING_SERVICE_LIBRARY
+#  define ORES_TRADING_SERVICE_EXPORT BOOST_SYMBOL_EXPORT
+#else
+#  define ORES_TRADING_SERVICE_EXPORT BOOST_SYMBOL_IMPORT
+#endif
+
+#endif

--- a/projects/ores.trading.service/src/CMakeLists.txt
+++ b/projects/ores.trading.service/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(lib_files ${files})
 list(FILTER lib_files EXCLUDE REGEX "main.cpp")
 
 add_library(${lib_target_name} ${lib_files})
+target_compile_definitions(${lib_target_name} PRIVATE ORES_TRADING_SERVICE_LIBRARY)
 set_target_properties(${lib_target_name} PROPERTIES
     OUTPUT_NAME ${lib_binary_name})
 set_target_properties(${lib_target_name}


### PR DESCRIPTION
## Summary

- Fixes Windows link error: `undefined symbol: ores::trading::service::config::parser::parse` when linking `ores.trading.service.tests.exe`
- Root cause: `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` was removed in the symbol visibility migration but `ores.trading.service` was never given `ORES_TRADING_SERVICE_EXPORT` annotations on `parser` and `host`
- Creates `export.hpp`, annotates `config::parser` with `ORES_TRADING_SERVICE_EXPORT`, adds `ORES_TRADING_SERVICE_LIBRARY` compile definition to the lib target
- Wires the same pattern into the codegen system (all four component CMake templates + `cpp_export.hpp.mustache` template + `profiles.json`) so new components are scaffolded correctly
- Updates the symbol visibility knowledge doc to document the service lib export requirement

## Test plan

- [ ] Windows clang-debug-ninja: `ores.trading.service.tests.exe` links without undefined symbol errors
- [ ] Linux/macOS builds unaffected (export macros expand to `__attribute__((visibility("default")))` on GCC/Clang)
- [ ] Codegen: running `component-service` profile generates `export.hpp`, `config/parser.hpp` with export macro, and `src/CMakeLists.txt` with `ORES_TRADING_SERVICE_LIBRARY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)