### PR TITLE
[site] Inline org-roam export utilities into ores.lisp

### DIFF
--- a/.build-site.el
+++ b/.build-site.el
@@ -209,8 +209,8 @@
             "\\(^\\|/\\)\\(\\.packages\\|vcpkg\\|build\\|tmp\\)/\\|external/org-roam-ui")
       (require 'org-roam)
       (org-roam-db-sync)
-      (load-file (expand-file-name "~/.emacs.d/config/org-roam-export.el"))
-      (cunene/org-roam-export-graph-json
+      (load-file (expand-file-name "./projects/ores.lisp/ores-org-roam-export.el"))
+      (ores/org-roam-export-graph-json
        (expand-file-name "./.org-roam.db")
        (expand-file-name "./build/output/site/OreStudio/graph/graphdata.json")
        (expand-file-name "./")

--- a/doc/agile/versions/v0/sprint_18/inline_org_roam_export/story.org
+++ b/doc/agile/versions/v0/sprint_18/inline_org_roam_export/story.org
@@ -1,0 +1,54 @@
+:PROPERTIES:
+:ID: a4bef88c-1372-46ce-864b-c30ac3be95eb
+:END:
+#+title: Story: Inline org-roam export into ores.lisp
+#+description: Vendor org-roam-export.el so the CI site build no longer depends on a file in /home/runner/.emacs.d/config/.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :site:ci:build:bug_fix:org_roam:sprint_18:v0:
+#+created: 2026-05-22
+#+updated: 2026-05-22
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699a8d45-b67e-4d3e-9206-24fa17c51ada][story]] in [[id:1737c00c-699a-475a-bc94-743c6cda1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+The CI site build no longer fails with =Cannot open load file: No such
+file or directory, /home/runner/.emacs.d/config/org-roam-export.el=.
+The org-roam export code lives in the repository (in =ores.lisp=) so
+the build is self-contained — no dependency on a file under the
+runner's Emacs config directory.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:1737c00c-699a-475a-bc94-743c6cda1001][Sprint 18]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-05-22                               |
+
+* Acceptance
+
+- The CI site build (=continuous-*= site workflow) passes without
+  loading any file from =~/.emacs.d/config/=.
+- =ores.lisp= contains the org-roam export functions previously
+  loaded from =org-roam-export.el=.
+- Local site build via =build/scripts/serve-site.sh= (or equivalent)
+  continues to work.
+
+* Tasks
+
+In execution order:
+
+- [[id:167c48a3-957b-4b58-92a5-e2938f925760][Task: Copy org-roam-export.el code into ores.lisp]]
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_18/inline_org_roam_export/task_copy_org_roam_export_code.org
+++ b/doc/agile/versions/v0/sprint_18/inline_org_roam_export/task_copy_org_roam_export_code.org
@@ -1,0 +1,54 @@
+:PROPERTIES:
+:ID: 167c48a3-957b-4b58-92a5-e2938f925760
+:END:
+#+title: Task: Copy org-roam-export.el code into ores.lisp
+#+description: Inline the org-roam-export functions from ~/.emacs.d/config/org-roam-export.el into projects/ores.lisp (or wherever ores.lisp lives) so the site build does not depend on the runner's emacs config.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :site:ci:build:bug_fix:inline_org_roam_export:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-22
+#+updated: 2026-05-22
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31c868b9-306e-4282-ba8c-07e647021b34][task]] in the [[id:a4bef88c-1372-46ce-864b-c30ac3be95eb][Inline org-roam export into ores.lisp]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Inline the org-roam export functions from
+=~/.emacs.d/config/org-roam-export.el= into =ores.lisp= so the
+CI site build no longer depends on a file outside the repository.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:a4bef88c-1372-46ce-864b-c30ac3be95eb][Inline org-roam export into ores.lisp]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-05-22                               |
+
+* Acceptance
+
+- =org-roam-export.el='s contents are copied into =ores.lisp= (or a
+  sibling file loaded by =ores.lisp=).
+- The site-build script no longer =load=s
+  =~/.emacs.d/config/org-roam-export.el=.
+- CI site build is green.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -25,7 +25,7 @@ This page documents a [[id:0820b7fd-147c-4832-ac25-c043d38d5b61][sprint]] (*Spri
 | Parent version | [[id:e6fd30ed-963e-4705-b414-91bf471c23d0][Version 0]] |
 | Now            | Sprint in flight.                      |
 | Waiting on     | Nothing.                               |
-| Next           | Pick the first story.                  |
+| Next           | Inline org-roam export into ores.lisp. |
 | Last touched   | 2026-05-22                               |
 
 * Stories
@@ -33,9 +33,9 @@ This page documents a [[id:0820b7fd-147c-4832-ac25-c043d38d5b61][sprint]] (*Spri
 In execution order.
 
 #+ATTR_HTML: :class hug-leading
-| Story | State | Start | End | Theme |
-|-------+-------+-------+-----+-------|
-|       |       |       |     |       |
+| Story                                                                                       | State   | Start      | End | Theme                                                                           |
+|---------------------------------------------------------------------------------------------+---------+------------+-----+---------------------------------------------------------------------------------|
+| [[id:a4bef88c-1372-46ce-864b-c30ac3be95eb][Inline org-roam export into ores.lisp]] | BACKLOG | 2026-05-22 |     | Vendor =org-roam-export.el= into =ores.lisp= so the CI site build is self-contained. |
 
 * Retrospective
 

--- a/projects/ores.lisp/ores-org-roam-export.el
+++ b/projects/ores.lisp/ores-org-roam-export.el
@@ -1,0 +1,129 @@
+;;; ores-org-roam-export.el --- org-roam static export utilities for the ORE Studio site. -*- lexical-binding: t -*-
+;; Author: Marco Craveiro <marco_craveiro@gmail.com>
+;; Keywords: org-roam, export, static-site
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Utilities for exporting org-roam graph data to JSON for static site
+;; integration (e.g. org-roam-ui static mode).  Requires Emacs 29+ for
+;; built-in SQLite support; works in both interactive and batch mode
+;; without loading the full org-roam package.
+
+;; Originally lifted from cunene's emacs config so the site build no
+;; longer depends on a file under ~/.emacs.d/ on the CI runner.
+
+;;; License:
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'json)
+
+(defun ores/org-roam-export-graph-json (db-path output-file &optional repo-root site-prefix)
+  "Export org-roam graph from DB-PATH to OUTPUT-FILE as org-roam-ui JSON.
+Optional REPO-ROOT strips the local filesystem prefix from file paths.
+Optional SITE-PREFIX (e.g. \"/OreStudio/\") is prepended so paths become
+site-relative HTML URLs.  Works in batch mode without loading org-roam.
+Requires Emacs 29+ built-in SQLite support."
+  (cond
+   ((not (fboundp 'sqlite-open))
+    (error "ores/org-roam-export-graph-json: Emacs built-in SQLite unavailable (needs Emacs 29+)"))
+   ((not (file-exists-p db-path))
+    (message "ores/org-roam-export-graph-json: %s not found, skipping" db-path))
+   (t
+    (make-directory (file-name-directory (expand-file-name output-file)) t)
+    (let* ((db       (sqlite-open db-path))
+           (nodes-q  "SELECT id, file, level, pos, title, properties, olp FROM nodes")
+           (tags-q   "SELECT \"node-id\", tag FROM tags")
+           (links-q  "SELECT source, dest, type FROM links")
+           (node-rows (sqlite-select db nodes-q))
+           (tag-rows  (sqlite-select db tags-q))
+           (link-rows (sqlite-select db links-q))
+           ;; node-id -> list of tag strings
+           (tag-map   (make-hash-table :test 'equal))
+           ;; unique tag set
+           (all-tags-set (make-hash-table :test 'equal))
+           ;; file path -> org source (read once per file)
+           (file-cache  (make-hash-table :test 'equal)))
+      ;; emacsql stores all scalars as prin1 strings: "foo" -> the string foo.
+      (cl-flet ((unpack (s) (if s (condition-case nil (read s) (error s)) ""))
+                (to-url (f)
+                  (let* ((rel (if repo-root (file-relative-name f repo-root) f))
+                         (html (replace-regexp-in-string "\\.org$" ".html" rel)))
+                    (if site-prefix (concat site-prefix html) html)))
+                (file-content (path)
+                  (or (gethash path file-cache)
+                      (let ((c (when (and path (file-exists-p path))
+                                 (condition-case nil
+                                     (with-temp-buffer
+                                       (insert-file-contents path)
+                                       (buffer-string))
+                                   (error nil)))))
+                        (puthash path c file-cache)
+                        c))))
+        ;; build tag index
+        (dolist (row tag-rows)
+          (let ((nid (unpack (nth 0 row))) (tag (unpack (nth 1 row))))
+            (puthash nid (cons tag (gethash nid tag-map '())) tag-map)
+            (puthash tag t all-tags-set)))
+        ;; build output structures
+        (let* ((nodes
+                (mapcar
+                 (lambda (row)
+                   (let* ((id       (unpack (nth 0 row)))
+                          (raw-path (unpack (nth 1 row)))
+                          (file     (to-url raw-path))
+                          (level    (or (nth 2 row) 0))
+                          (pos      (or (nth 3 row) 0))
+                          (title    (unpack (nth 4 row)))
+                          (props    (let ((raw (nth 5 row)))
+                                      (when raw
+                                        (condition-case nil (read raw) (error nil)))))
+                          (olp      (let ((raw (nth 6 row)))
+                                      (when raw
+                                        (condition-case nil (read raw) (error nil)))))
+                          (tags     (apply #'vector (gethash id tag-map '())))
+                          (content  (or (file-content raw-path) :json-null)))
+                     (list :id id :file file :level level :pos pos :title title
+                           :tags tags :content content
+                           :properties (or props :json-null)
+                           :olp (if (listp olp) (apply #'vector olp) []))))
+                 node-rows))
+               (links
+                (mapcar (lambda (row)
+                          (list :source (unpack (nth 0 row))
+                                :target (unpack (nth 1 row))
+                                :type   (unpack (nth 2 row))))
+                        link-rows))
+             (all-tags
+              (let (ts)
+                (maphash (lambda (k _) (push k ts)) all-tags-set)
+                (apply #'vector ts)))
+             (graph (list :nodes (apply #'vector nodes)
+                          :links (apply #'vector links)
+                          :tags  all-tags)))
+        (sqlite-close db)
+        (with-temp-file output-file
+          (insert (json-encode graph)))
+        (message "ores/org-roam-export-graph-json: wrote %s (%d nodes, %d links)"
+                 output-file (length nodes) (length links))))))))
+
+(provide 'ores-org-roam-export)
+;;; ores-org-roam-export.el ends here


### PR DESCRIPTION
## Summary

- Fixes the CI site build, which was failing with `Cannot open load file: No such file or directory, /home/runner/.emacs.d/config/org-roam-export.el`.
- Copies the org-roam → JSON exporter from the cunene Emacs config into `projects/ores.lisp/ores-org-roam-export.el` (renaming `cunene/org-roam-export-graph-json` → `ores/org-roam-export-graph-json` to match the project's `ores/` namespace).
- Rewires `.build-site.el` to `load-file` the in-repo copy instead of `~/.emacs.d/config/org-roam-export.el`, so the build no longer depends on anything outside the checkout.
- Also adds the Sprint 18 story + task scaffolding that drove this work.

## Test plan

- [x] Byte-compile clean: `emacs --batch -L projects/ores.lisp -f batch-byte-compile projects/ores.lisp/ores-org-roam-export.el`
- [x] `check-parens` on `.build-site.el` passes
- [x] `(require 'ores-org-roam-export)` smoke test: `ores/org-roam-export-graph-json` is `fboundp`
- [ ] CI site workflow goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)