### PR TITLE
[sql,agile] SQLite shell quality-of-life config (.sqliterc)

### DIFF
--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -36,6 +36,7 @@ In execution order.
 | Story                                                                                       | State   | Start      | End | Theme                                                                           |
 |---------------------------------------------------------------------------------------------+---------+------------+-----+---------------------------------------------------------------------------------|
 | [[id:a4bef88c-1372-46ce-864b-c30ac3be95eb][Inline org-roam export into ores.lisp]] | BACKLOG | 2026-05-22 |     | Vendor =org-roam-export.el= into =ores.lisp= so the CI site build is self-contained. |
+| [[id:0a2cb5bd-67b8-4096-bac4-8e110333893a][SQLite CLI quality-of-life setup]]       | STARTED | 2026-05-24 |     | Committed, commented =.sqliterc= for readable, non-wrapping =sqlite3= shell output.   |
 
 * Retrospective
 

--- a/doc/agile/versions/v0/sprint_18/sqlite_cli_ergonomics/story.org
+++ b/doc/agile/versions/v0/sprint_18/sqlite_cli_ergonomics/story.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: 0a2cb5bd-67b8-4096-bac4-8e110333893a
+:END:
+#+title: Story: SQLite CLI quality-of-life setup
+#+description: Ship a default .sqliterc that gives sensible formatting and ergonomic defaults when connecting to SQLite via the command-line shell.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :sql:sqlite:tooling:developer_experience:sprint_18:v0:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699a8d45-b67e-4d3e-9206-24fa17c51ada][story]] in [[id:1737c00c-699a-475a-bc94-743c6cda1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Connecting to an ORE Studio SQLite database from the =sqlite3= shell
+gives a sane, readable experience out of the box: headed, box-drawn
+output with columns wide enough to show their content (no wrapping),
+visible NULL markers, query timing, and connection-level safety
+defaults — all from a single committed, well-commented rc file.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:1737c00c-699a-475a-bc94-743c6cda1001][Sprint 18]] |
+| Now           | rc file authored and verified against sqlite3 3.46. |
+| Waiting on    | Nothing.                               |
+| Next          | Land via PR.                           |
+| Last touched  | 2026-05-24                               |
+
+* Acceptance
+
+- A committed rc file lives at =projects/ores.sql/utility/sqliterc.sql=.
+- Every active entry carries a comment explaining what it does.
+- Long column values are shown in full on one line (no wrapping); the
+  columns simply grow wider.
+- NULLs are rendered with a visible marker.
+- The file loads via =sqlite3 -init <file>= with no errors.
+
+* Tasks
+
+In execution order:
+
+- [[id:687b46b5-ef84-4016-a699-391edc443072][Task: Add a default sqliterc with formatting and ergonomic defaults]]
+
+* Decisions
+
+- =.mode box --wrap 0= is the lever that fixes wrapping: plain
+  =.mode box= folds long values onto multiple lines, =--wrap 0= lets
+  the column expand to fit instead.
+- =PRAGMA journal_mode = WAL= is left commented: it persists to the
+  database file and affects all connections, so it must be set
+  deliberately, not from an interactive rc.
+
+* Out of scope
+
+- A PostgreSQL =.psqlrc= equivalent (ORE Studio's primary database is
+  PostgreSQL; this story covers the SQLite shell only).

--- a/doc/agile/versions/v0/sprint_18/sqlite_cli_ergonomics/task_add_sqliterc_config.org
+++ b/doc/agile/versions/v0/sprint_18/sqlite_cli_ergonomics/task_add_sqliterc_config.org
@@ -47,9 +47,13 @@ connection-level safety defaults.
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+Reproduce the wrapping complaint against the installed =sqlite3= to
+find the real lever (=.mode box --wrap 0=) rather than guessing, and
+verify each dot-command is real before commenting it. Then rewrite the
+rc file in sections — output formatting, ergonomics, session pragmas,
+handy levers — with a comment on every active entry, enabling only
+per-connection settings and leaving persistent ones commented. Finish
+by smoke-testing with =sqlite3 -init=.
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_18/sqlite_cli_ergonomics/task_add_sqliterc_config.org
+++ b/doc/agile/versions/v0/sprint_18/sqlite_cli_ergonomics/task_add_sqliterc_config.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: 687b46b5-ef84-4016-a699-391edc443072
+:END:
+#+title: Task: Add a default sqliterc with formatting and ergonomic defaults
+#+description: Author projects/ores.sql/utility/sqliterc.sql with commented defaults for output formatting, wide non-wrapping columns, and session settings.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :sql:sqlite:tooling:sqlite_cli_ergonomics:sprint_18:v0:
+#+owner: marco
+#+branch: feature/sqliterc-helper
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31c868b9-306e-4282-ba8c-07e647021b34][task]] in the [[id:0a2cb5bd-67b8-4096-bac4-8e110333893a][SQLite CLI quality-of-life setup]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+A committed, fully-commented =projects/ores.sql/utility/sqliterc.sql=
+that the =sqlite3= shell can load to get headed box output, wide
+non-wrapping columns, a visible NULL marker, query timing, and
+connection-level safety defaults.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:0a2cb5bd-67b8-4096-bac4-8e110333893a][SQLite CLI quality-of-life setup]] |
+| Now          | rc file authored; verified against sqlite3 3.46.1. |
+| Waiting on   | Nothing.                               |
+| Next         | Land via PR.                           |
+| Last touched | 2026-05-24                               |
+
+* Acceptance
+
+- =.mode box --wrap 0= so long values render on one line (verified).
+- =.headers on=, =.nullvalue '∅'=, =.timer on=, =.changes on=.
+- =PRAGMA foreign_keys = ON= and =PRAGMA busy_timeout = 5000= active.
+- Every active entry is commented; =journal_mode= left commented with
+  rationale.
+- =sqlite3 -init projects/ores.sql/utility/sqliterc.sql= loads cleanly.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+- Removed the original =.alias= example — =.alias= is not a real
+  =sqlite3= dot-command (verified against 3.46.1).
+- Plain =.mode box= was confirmed to wrap long values even when no
+  =~/.sqliterc= is present; =--wrap 0= disables it.
+
+* Result
+
+rc file written and smoke-tested with =sqlite3 -init=: a long value
+renders on a single full-width line, NULL shows as =∅=,
+=PRAGMA foreign_keys= reports =1=, and =PRAGMA busy_timeout= reports
+=5000=. No load errors.

--- a/projects/ores.sql/utility/sqliterc.sql
+++ b/projects/ores.sql/utility/sqliterc.sql
@@ -1,0 +1,22 @@
+-- -----------------------------------------------------
+-- Output Formatting
+-- -----------------------------------------------------
+-- Displays column names in your SELECT output
+.headers on
+-- Uses a clean, bordered grid format for tables
+.mode box
+-- Prints '∅' instead of blank space for NULL values
+.nullvalue '∅'
+-- Measures execution time of SQL queries
+.timer on
+
+-- -----------------------------------------------------
+-- Session Settings
+-- -----------------------------------------------------
+-- PRAGMA foreign_keys = ON; -- Ensures relational integrity (disabled by default)
+-- PRAGMA journal_mode = WAL; -- Sets Write-Ahead Logging for better concurrency & speed
+
+-- -----------------------------------------------------
+-- Command Aliases (Custom Shortcuts)
+-- -----------------------------------------------------
+-- .alias .tables_info 'SELECT tbl_name, sql FROM sqlite_master WHERE type="table"'

--- a/projects/ores.sql/utility/sqliterc.sql
+++ b/projects/ores.sql/utility/sqliterc.sql
@@ -7,7 +7,11 @@
 --
 -- Use it one of two ways:
 --   * Per session:  sqlite3 -init projects/ores.sql/utility/sqliterc.sql my.db
---   * Always on:     ln -s "$PWD/projects/ores.sql/utility/sqliterc.sql" ~/.sqliterc
+--   * Always on:     source it from your global ~/.sqliterc with .read,
+--                    which preserves any settings you already have there:
+--                    echo ".read $PWD/projects/ores.sql/utility/sqliterc.sql" >> ~/.sqliterc
+--
+-- Requires SQLite 3.37.0+ (Nov 2021) for the columnar `--wrap` option below.
 -- =====================================================================
 
 -- ---------------------------------------------------------------------
@@ -20,6 +24,7 @@
 -- wrapping: columns grow to fit their widest value instead of being
 -- folded onto multiple lines. (Plain `.mode box` wraps long values; this
 -- is the "larger columns, no wrapping" behaviour we want.)
+-- Needs SQLite 3.37.0+; older shells reject the `--wrap` option.
 .mode box --wrap 0
 
 -- Print a visible marker for NULL so it is not confused with an empty

--- a/projects/ores.sql/utility/sqliterc.sql
+++ b/projects/ores.sql/utility/sqliterc.sql
@@ -1,22 +1,71 @@
--- -----------------------------------------------------
--- Output Formatting
--- -----------------------------------------------------
--- Displays column names in your SELECT output
+-- =====================================================================
+-- SQLite command-line shell configuration (.sqliterc)
+-- ---------------------------------------------------------------------
+-- Quality-of-life defaults for inspecting ORE Studio's SQLite databases
+-- from the `sqlite3` shell. These are shell *dot-commands* and PRAGMAs,
+-- not SQL DDL, despite the `.sql` extension (project convention).
+--
+-- Use it one of two ways:
+--   * Per session:  sqlite3 -init projects/ores.sql/utility/sqliterc.sql my.db
+--   * Always on:     ln -s "$PWD/projects/ores.sql/utility/sqliterc.sql" ~/.sqliterc
+-- =====================================================================
+
+-- ---------------------------------------------------------------------
+-- Output formatting
+-- ---------------------------------------------------------------------
+-- Show column names as a header row above each result set.
 .headers on
--- Uses a clean, bordered grid format for tables
-.mode box
--- Prints '∅' instead of blank space for NULL values
+
+-- Render results as a Unicode box-drawing grid. `--wrap 0` disables line
+-- wrapping: columns grow to fit their widest value instead of being
+-- folded onto multiple lines. (Plain `.mode box` wraps long values; this
+-- is the "larger columns, no wrapping" behaviour we want.)
+.mode box --wrap 0
+
+-- Print a visible marker for NULL so it is not confused with an empty
+-- string or whitespace.
 .nullvalue '∅'
--- Measures execution time of SQL queries
+
+-- ---------------------------------------------------------------------
+-- Interactive ergonomics
+-- ---------------------------------------------------------------------
+-- Report wall-clock / CPU time taken by each statement.
 .timer on
 
--- -----------------------------------------------------
--- Session Settings
--- -----------------------------------------------------
--- PRAGMA foreign_keys = ON; -- Ensures relational integrity (disabled by default)
--- PRAGMA journal_mode = WAL; -- Sets Write-Ahead Logging for better concurrency & speed
+-- After INSERT/UPDATE/DELETE, print how many rows were affected, so a
+-- mistyped WHERE clause is obvious immediately.
+.changes on
 
--- -----------------------------------------------------
--- Command Aliases (Custom Shortcuts)
--- -----------------------------------------------------
--- .alias .tables_info 'SELECT tbl_name, sql FROM sqlite_master WHERE type="table"'
+-- Do not re-echo each command back to the terminal (this is the default;
+-- stated explicitly so it survives an inherited `.echo on`).
+.echo off
+
+-- Branded primary prompt plus an indented continuation prompt, so it is
+-- clear when the shell is waiting for the rest of a multi-line statement.
+.prompt 'ore> ' '  ...> '
+
+-- ---------------------------------------------------------------------
+-- Session settings (per connection)
+-- ---------------------------------------------------------------------
+-- Enforce foreign-key constraints. SQLite leaves these OFF by default;
+-- turning them on catches referential-integrity mistakes during manual
+-- DML. Scoped to this connection only.
+PRAGMA foreign_keys = ON;
+
+-- Wait up to 5s for a lock to clear instead of failing instantly with
+-- "database is locked" — useful when the running app holds the DB open.
+PRAGMA busy_timeout = 5000;
+
+-- PRAGMA journal_mode = WAL; -- Better read/write concurrency, BUT this
+--   is persisted in the database file and affects every connection, so
+--   set it deliberately against the file, not from an interactive rc.
+
+-- ---------------------------------------------------------------------
+-- Handy levers (left off by default)
+-- ---------------------------------------------------------------------
+-- .width N1 N2 ...   Set *minimum* column widths (0 = auto). Pads short
+--                    columns; combine with `--wrap 0` above to never wrap.
+-- .once FILE         Send only the next query's output to FILE.
+-- .output FILE       Redirect all subsequent output to FILE (.output to reset).
+-- .excel             Open the next result set in your spreadsheet app.
+-- .schema ?TABLE?    Show the CREATE statements for the schema (or one table).


### PR DESCRIPTION
## Summary

Turn the placeholder `projects/ores.sql/utility/sqliterc.sql` into a
commented, quality-of-life configuration for the `sqlite3` shell, and
raise the agile story and task that track the work under Sprint 18.

The headline fix: plain `.mode box` wraps long column values onto
multiple lines (reproduced against sqlite3 3.46.1 with no `~/.sqliterc`
present). Switching to `.mode box --wrap 0` lets columns grow to fit
their content instead — larger columns, no wrapping.

## Changes

- **`projects/ores.sql/utility/sqliterc.sql`**
  - `.mode box --wrap 0` for full-width, non-wrapping columns.
  - Added `.changes on`, explicit `.echo off`, and a branded `.prompt`.
  - Added `PRAGMA foreign_keys = ON` and `PRAGMA busy_timeout = 5000`
    (per-connection); left `journal_mode = WAL` commented with rationale
    (it persists to the DB file and affects all connections).
  - Removed the bogus `.alias` example — not a real `sqlite3`
    dot-command.
  - Header comment documenting how to load it (`-init` or `~/.sqliterc`)
    plus a "handy levers" block (`.width`, `.once`, `.output`, `.excel`,
    `.schema`).
  - Every active entry is commented.
- **Agile (Sprint 18)** — raised via codegen (`generate_v2_doc.sh`):
  - Story: *SQLite CLI quality-of-life setup*.
  - Task: *Add a default sqliterc with formatting and ergonomic defaults*.
  - Added the story to the Sprint 18 backlog table.

## Notes

- Smoke-tested with `sqlite3 -init projects/ores.sql/utility/sqliterc.sql`:
  long value on one line, NULL renders as `∅`, `foreign_keys` = 1,
  `busy_timeout` = 5000, no load errors.
- `validate_docs.sh` passes for the new agile docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)