### PR TITLE
[build] Ignore stray Node.js artefacts at repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ build/nats/
 .ripgreprc
 .zprofile
 .zshrc
+node_modules/
+package.json
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -84,5 +84,5 @@ build/nats/
 .zprofile
 .zshrc
 node_modules/
-package.json
-package-lock.json
+/package.json
+/package-lock.json


### PR DESCRIPTION
## Summary

Adds three entries to `.gitignore` to prevent stray Node.js artefacts
from appearing as untracked files at the repository root.

## Changes

- `node_modules/` — dependency tree generated by npm/yarn/pnpm.
- `package.json` — npm package manifest.
- `package-lock.json` — npm lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)