### PR TITLE
[agile,skills] Backlog refinement skills, recipes, and sprint 18 goals

### DIFF
--- a/doc/agile/versions/v0/sprint_18/backlog_refinement/story.org
+++ b/doc/agile/versions/v0/sprint_18/backlog_refinement/story.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 22AA37FA-23A0-406E-B05B-B11BB3E83874
+:END:
+#+title: Story: Product backlog refinement
+#+description: Build the skills and recipes for backlog housekeeping and sprint planning sessions.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :agile:backlog:skills:recipes:sprint_18:v0:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Equip every future session with two Claude Code skills and companion recipes — one for general backlog housekeeping (=backlog-refiner=) and one for sprint planning (=sprint-planner=) — so that backlog work is structured, repeatable, and recorded. As a first use of the new tooling, set sprint 18's mission and select its remaining stories.
+
+* Status
+
+| Field         | Value                                       |
+|---------------+---------------------------------------------|
+| State         | STARTED                                     |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                                   |
+| Branch        | feature/backlog-refinement-skills           |
+| Now           | Authoring backlog-refiner and sprint-planner skills and recipes. |
+| Waiting on    | Nothing.                                    |
+| Next          | Task 2 — set sprint 18 goals and select stories. |
+| Last touched  | 2026-05-24                                  |
+
+* Acceptance
+
+- A =backlog-refiner= skill exists under =doc/llm/skills/backlog-refiner/= and is deployed to =.claude/skills/=.
+- A =sprint-planner= skill exists under =doc/llm/skills/sprint-planner/= and is deployed to =.claude/skills/=.
+- A =how_do_i_refine_the_backlog.org= recipe exists under =doc/recipes/agile/=.
+- A =how_do_i_plan_a_sprint.org= recipe exists under =doc/recipes/agile/=.
+- Sprint 18 has a one-sentence mission and a populated Stories table with at least one additional story beyond those already in flight.
+- The site builds clean after all new documents are committed.
+
+* Tasks
+
+In execution order:
+
+- [[id:C0A295F9-69B0-45AF-A45C-18A813D649A4][Task: Create backlog-refiner and sprint-planner skills and recipes]]
+- [[id:2F0D0382-2230-470E-A481-7A9D5B7326B4][Task: Set sprint goals and select sprint 18 stories]]
+
+* Decisions
+
+- /Two skills, not one./ General refinement (housekeeping, near↔far moves, culling) and sprint planning (goal-directed selection, promotion) have different triggers and outputs. Separating them keeps each skill focused and composable. The existing =agile-product-owner= skill handles atomic operations that both call into.
+- /Recipes alongside skills./ Skills hold the LLM orchestration logic; recipes hold the human-readable checklist and context. Both are needed so the process is transparent and the user can run it without Claude.
+- /Sprint goal-setting is part of task 2, not a third task./ Goals are a precondition of sprint planning; folding them in keeps the task atomic and avoids a blocked state where planning cannot start.
+
+* Out of scope
+
+- Changes to =agile-product-owner= skill (it remains the atomic-operation handler).
+- Backlog estimation or complexity-tagging (a future refinement pass).
+- Automated backlog health checks in CI.

--- a/doc/agile/versions/v0/sprint_18/backlog_refinement/task_create_backlog_refinement_skills.org
+++ b/doc/agile/versions/v0/sprint_18/backlog_refinement/task_create_backlog_refinement_skills.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: C0A295F9-69B0-45AF-A45C-18A813D649A4
+:END:
+#+title: Task: Create backlog-refiner and sprint-planner skills and recipes
+#+description: Author the backlog-refiner and sprint-planner Claude Code skills and their companion agile recipes.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :agile:backlog:skills:recipes:sprint_18:v0:backlog_refinement:
+#+owner: marco
+#+branch: feature/backlog-refinement-skills
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:22AA37FA-23A0-406E-B05B-B11BB3E83874][Product backlog refinement]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Produce two Claude Code skills (=backlog-refiner=, =sprint-planner=) and two companion agile recipes, so that both types of backlog session are structured, repeatable, and self-documenting.
+
+* Status
+
+| Field        | Value                                                          |
+|--------------+----------------------------------------------------------------|
+| State        | STARTED                                                        |
+| Parent story | [[id:22AA37FA-23A0-406E-B05B-B11BB3E83874][Product backlog refinement]]                                     |
+| Now          | Authoring skills and recipes.                                  |
+| Waiting on   | Nothing.                                                       |
+| Next         | Deploy skills; verify site build; close task.                  |
+| Last touched | 2026-05-24                                                     |
+
+* Acceptance
+
+- =doc/llm/skills/backlog-refiner/SKILL.org= exists and is a valid v2 skill doc.
+- =doc/llm/skills/sprint-planner/SKILL.org= exists and is a valid v2 skill doc.
+- =doc/recipes/agile/how_do_i_refine_the_backlog.org= exists and covers the full housekeeping checklist.
+- =doc/recipes/agile/how_do_i_plan_a_sprint.org= exists and covers the goal-setting and selection workflow.
+- =.claude/skills/backlog-refiner.md= and =.claude/skills/sprint-planner.md= are deployed (=deploy_skills= target passes).
+- Site builds clean with all four new documents.
+
+* Plan
+
+1. Scaffold =backlog-refiner= skill via =generate_v2_doc.sh --type skill=.
+2. Scaffold =sprint-planner= skill via =generate_v2_doc.sh --type skill=.
+3. Author both skills: when-to-use, how-to-use, step-by-step procedure.
+4. Scaffold =how_do_i_refine_the_backlog.org= recipe via codegen.
+5. Scaffold =how_do_i_plan_a_sprint.org= recipe via codegen.
+6. Author both recipes: question, answer (checklist), script, tested-by, see-also.
+7. Run =deploy_skills= and =deploy_site= to confirm clean build.
+
+* Notes
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/backlog_refinement/task_plan_sprint_18_stories.org
+++ b/doc/agile/versions/v0/sprint_18/backlog_refinement/task_plan_sprint_18_stories.org
@@ -1,0 +1,49 @@
+:PROPERTIES:
+:ID: 2F0D0382-2230-470E-A481-7A9D5B7326B4
+:END:
+#+title: Task: Set sprint goals and select sprint 18 stories
+#+description: Define sprint 18 mission and use the sprint-planner skill to identify and promote candidate stories from the backlog.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :agile:sprint_18:sprint_planning:v0:backlog_refinement:
+#+owner: marco
+#+branch: feature/backlog-refinement-skills
+#+pr:
+#+blocked_on: C0A295F9-69B0-45AF-A45C-18A813D649A4
+#+blocked_since:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:22AA37FA-23A0-406E-B05B-B11BB3E83874][Product backlog refinement]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Sprint 18 acquires a clear one-sentence mission and a curated Stories table that reflects actual planned work — produced by running the new =sprint-planner= skill against the near backlog.
+
+* Status
+
+| Field        | Value                                                                      |
+|--------------+----------------------------------------------------------------------------|
+| State        | BACKLOG                                                                    |
+| Parent story | [[id:22AA37FA-23A0-406E-B05B-B11BB3E83874][Product backlog refinement]]                                                 |
+| Now          | Blocked on Task 1 (skills must exist before running the planner).          |
+| Waiting on   | [[id:C0A295F9-69B0-45AF-A45C-18A813D649A4][Task: Create backlog-refiner and sprint-planner skills and recipes]]         |
+| Next         | Set sprint mission; run sprint-planner; promote selected captures.         |
+| Last touched | 2026-05-24                                                                 |
+
+* Acceptance
+
+- =doc/agile/versions/v0/sprint_18/sprint.org= has a non-placeholder one-sentence mission.
+- At least one capture from =doc/agile/product_backlog/near/= has been promoted into a sprint 18 story.
+- All promoted stories appear in the sprint's Stories table.
+- Site builds clean.
+
+* Plan
+
+(Written when task 1 completes and this task starts.)
+
+* Notes
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -2,7 +2,7 @@
 :ID: 1737C00C-699A-475A-BC94-743C6CDA1001
 :END:
 #+title: Sprint 18
-#+description: Sprint 18 — TBD.
+#+description: Sprint 18 — ORE imports, more ORE types, compass tool, and backlog refinement tooling.
 #+type: sprint
 #+version: 2
 #+level: s3
@@ -18,7 +18,14 @@ surrounding context — version goals, sprint order, and product identity — se
 
 * Mission
 
-(One sentence — what this sprint exists to achieve.)
+Enable end-to-end [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][ORE]] imports into workspaces, expand supported ORE types, and equip the LLM with a compass tool for orientation.
+
+* Goals
+
+- *ORE imports into workspaces* — users can load ORE input files directly into a workspace and have them processed end-to-end.
+- *More ORE types* — expand the set of ORE instrument/trade types that ORE Studio recognises and can round-trip.
+- *Compass tool* — implement the basic compass skill so the LLM can orient itself in the doc graph and codebase without manual exploration.
+- *Backlog refinement tooling* — build the =backlog-refiner= and =sprint-planner= skills and recipes to make future sprint planning repeatable.
 
 * Status
 
@@ -29,9 +36,9 @@ surrounding context — version goals, sprint order, and product identity — se
 | Previous       | [[id:A2B8A670-3B02-11F1-BCE2-4B06F4BBA5D7][Sprint 17]]                              |
 | Now            | Sprint in flight.                      |
 | Waiting on     | Nothing.                               |
-| Next           | Inline org-roam export into ores.lisp. |
+| Next           | Backlog refinement skills; ORE imports. |
 | Release Notes  | Added at end of sprint.                |
-| Last touched   | 2026-05-23                             |
+| Last touched   | 2026-05-24                             |
 
 * Stories
 

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -44,6 +44,7 @@ In execution order.
 | [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D8][Resolve RFL complexity issues]]         | STARTED | 2026-05-23 |            | Permanently resolve MSVC C1202 and Clang expression nesting limits via structural isolation.    |
 | [[id:0A2CB5BD-67B8-4096-BAC4-8E110333893A][SQLite CLI quality-of-life setup]]       | STARTED | 2026-05-24 |            | Committed, commented =.sqliterc= for readable, non-wrapping =sqlite3= shell output.             |
 | [[id:BAF1DEAE-59DF-49AB-BFCD-E6D09496DA43][Lock down uppercase UUID invariant]]    | DONE    | 2026-05-24 | 2026-05-24 | Close the remaining code paths that can emit lowercase UUIDs into the doc graph.                |
+| [[id:22AA37FA-23A0-406E-B05B-B11BB3E83874][Product backlog refinement]]            | STARTED | 2026-05-24 |            | Build backlog-refiner and sprint-planner skills/recipes; set sprint 18 mission.                 |
 
 * Retrospective
 

--- a/doc/llm/skills/backlog-refiner/SKILL.org
+++ b/doc/llm/skills/backlog-refiner/SKILL.org
@@ -1,0 +1,119 @@
+:PROPERTIES:
+:ID: 5358EC5A-F7FD-473A-A8AB-AF77E4D83A58
+:END:
+#+title: Backlog Refiner
+#+description: Run a backlog housekeeping session: scan, clarify, cull, and re-prioritise captures in the near/far buckets.
+#+type: skill
+#+version: 2
+#+level: cross
+#+filetags: :skills:claude_code:agile:backlog:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+
+#+begin_export markdown
+---
+name: backlog-refiner
+description: Run a backlog housekeeping session: scan the near/far captures, clarify descriptions, cull stale items, and re-prioritise between buckets.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+When the user asks to tidy, groom, or review the product backlog —
+not to plan a specific sprint (use [[id:FB451B15-9674-4B61-A9F8-7DAEEB4B365A][sprint-planner]] for that) but to keep the
+backlog healthy: pruning stale captures, clarifying vague ones,
+moving items between [[id:9A17E8DF-7E94-4F55-8A14-BCB7D9A16D6B][near]] and [[id:C1BF2C4F-2DB3-49C1-94E9-7D2B3E4F1AB8][far]], or filing new ideas as they
+come up.
+
+* How to use this skill
+
+1. /List both buckets/ to get a full picture before changing anything:
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.codegen/doc_list.sh --type capture --sort path | grep near
+   ./projects/ores.codegen/doc_list.sh --type capture --sort path | grep far
+   #+end_src
+
+   Note the total count — near should stay manageable (≤ 20 is a
+   useful heuristic). A crowded near bucket signals drift; a sparse
+   one may mean work is being under-captured.
+
+2. /Read each capture/ in the target bucket. For each one assess:
+
+   - *Validity* — is the idea still relevant? If the work was done
+     in a past sprint or the need has gone away, mark =ABANDONED=
+     and commit.
+   - *Clarity* — is the =#+title= and =#+description= specific
+     enough that someone could act on it without back-channel
+     context? If not, sharpen both in place.
+   - *Bucket fit* — does this item belong in =near/= (candidate for
+     the next version) or =far/= (longer-horizon)? Move by
+     renaming the file path; the =:ID:= stays unchanged so
+     existing links keep working.
+   - *Duplicates* — if two captures describe the same idea, merge
+     them: keep the richer one, absorb the other's notes, mark the
+     absorbed one =ABANDONED=.
+
+3. /File new captures/ as they surface during the review. Use the
+   [[id:2DF8ADAF-20C9-4757-9399-798EEC6DF828][agile-product-owner]] skill's codegen step to scaffold each one:
+
+   #+begin_src sh :results verbatim
+   projects/ores.codegen/generate_v2_doc.sh \
+     --type capture --slug <slug> \
+     --parent-dir doc/agile/product_backlog/near \
+     --title "<title>" --description "<one-liner>"
+   #+end_src
+
+4. /Re-prioritise/ by moving files between =near/= and =far/=:
+
+   #+begin_src sh :results verbatim
+   git mv doc/agile/product_backlog/near/<slug>.org \
+          doc/agile/product_backlog/far/<slug>.org
+   #+end_src
+
+5. /Commit/ the full sweep in one atomic commit per bucket (or one
+   combined commit if the changes are small):
+
+   #+begin_src sh :results verbatim
+   git add doc/agile/product_backlog/
+   git commit -m "[agile] Backlog refinement — near bucket housekeeping"
+   #+end_src
+
+* Recipes
+
+- [[id:7870BDC8-839B-4E46-9E32-F0EA9F7D5936][How do I refine the backlog?]] — the human-readable checklist for
+  this skill's procedure.
+- [[id:3153AA4B-23D4-4111-9710-5A4971102EDC][How do I create a new v2 doc?]] — codegen invocations for new
+  captures.
+
+* Reference
+
+- [[id:D4219199-7B17-4A89-B4BC-6019738642DA][Product backlog]] — the near/far structure and its invariants.
+- [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][Capture]] — the document type contract.
+- [[id:8B29A8D8-E004-4E87-B81D-ABEAF68F2B98][Document types]] — full frontmatter contract for all types.
+- [[id:2DF8ADAF-20C9-4757-9399-798EEC6DF828][Agile product owner]] — atomic operations (file, promote, scaffold)
+  this skill orchestrates.
+- [[id:FB451B15-9674-4B61-A9F8-7DAEEB4B365A][Sprint planner]] — use instead when the goal is to select stories
+  for a specific sprint.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENCE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/llm/skills/sprint-planner/SKILL.org
+++ b/doc/llm/skills/sprint-planner/SKILL.org
@@ -1,0 +1,146 @@
+:PROPERTIES:
+:ID: FB451B15-9674-4B61-A9F8-7DAEEB4B365A
+:END:
+#+title: Sprint Planner
+#+description: Run a sprint planning session: read sprint goals, score near-backlog captures against them, and promote selected ones into stories.
+#+type: skill
+#+version: 2
+#+level: cross
+#+filetags: :skills:claude_code:agile:sprint:planning:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+
+#+begin_export markdown
+---
+name: sprint-planner
+description: Run a sprint planning session: read the sprint mission, score near-backlog captures against sprint goals, present ranked candidates, and promote the selected ones into stories.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+When the user asks to plan a sprint — select which backlog items
+will become stories in the current [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprint]]. Requires a mission to be
+set on the sprint document; if none exists, establish it with the
+user before scoring. For general backlog housekeeping without a
+sprint-selection goal, use [[id:5358EC5A-F7FD-473A-A8AB-AF77E4D83A58][backlog-refiner]] instead.
+
+* How to use this skill
+
+1. /Read the current sprint and its mission/:
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.codegen/doc_list.sh --type sprint --sort path | tail -3
+   #+end_src
+
+   Open =sprint.org= and read =* Mission= and =* Goals=. If the
+   mission placeholder is still unfilled, stop and ask the user for
+   a one-sentence mission before proceeding — goal-less planning
+   produces low-signal rankings.
+
+2. /Understand what is already committed/. Read the =* Stories= table
+   in =sprint.org= to know which stories are already STARTED or
+   BACKLOG — these are not candidates for selection; they are
+   already planned.
+
+3. /List the near-bucket captures/:
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.codegen/doc_list.sh --type capture --sort path | grep near
+   #+end_src
+
+   Read each capture's title and description. Ignore captures that
+   are already =DONE= or =ABANDONED=.
+
+4. /Score each candidate/ against the sprint goals using three
+   criteria — present results as a ranked table:
+
+   | Criterion | Question |
+   |-----------+----------|
+   | *Fit* | Does this directly advance the sprint mission? |
+   | *Size* | Can it plausibly fit in one sprint as a single story (one PR or a small set)? |
+   | *Dependency* | Does it depend on in-flight work that isn't done yet? |
+
+   High-fit, right-sized, unblocked items rank first.
+
+5. /Present the ranked list to the user/ and agree on which to
+   promote. Do not promote without explicit confirmation — sprint
+   scope is the user's decision.
+
+6. /Promote each confirmed capture to a story/:
+
+   a. Scaffold the story doc in the sprint folder, preserving the
+      capture's =:ID:=:
+
+      #+begin_src sh :results verbatim
+      projects/ores.codegen/generate_v2_doc.sh \
+        --type story --slug <slug> \
+        --id <capture-uuid> \
+        --parent-dir doc/agile/versions/v0/sprint_NN \
+        --title "<title>" --description "<description>"
+      #+end_src
+
+   b. Move the capture file into the sprint folder (or delete the
+      original after scaffolding if the ID was preserved):
+
+      #+begin_src sh :results verbatim
+      git rm doc/agile/product_backlog/near/<slug>.org
+      #+end_src
+
+   c. Fill in the story's =* Goal=, =* Acceptance=, and =* Tasks=
+      sections. At minimum scaffold one task.
+
+7. /Update the sprint's =* Stories= table/ with each newly added
+   story row (State: BACKLOG, Start: today).
+
+8. /Commit all changes/:
+
+   #+begin_src sh :results verbatim
+   git add doc/agile/versions/v0/sprint_NN/ \
+           doc/agile/product_backlog/near/ \
+           doc/agile/versions/v0/sprint_NN/sprint.org
+   git commit -m "[agile] Sprint NN planning — promote N stories from backlog"
+   #+end_src
+
+* Recipes
+
+- [[id:2C2E794B-7565-4FD8-BD26-E7949C874E43][How do I plan a sprint?]] — the human-readable checklist for this
+  skill's procedure.
+- [[id:3153AA4B-23D4-4111-9710-5A4971102EDC][How do I create a new v2 doc?]] — codegen invocations for story
+  scaffolding.
+- [[id:DA003A23-1604-43E7-A98F-A305148FBCF4][How do I start work on a story?]] — once planning is done, this
+  recipe covers BACKLOG → STARTED transition.
+
+* Reference
+
+- [[id:E5635EAC-CCE9-C0A4-A00B-C1780FF4A88E][Agile]] — top of the operational tree.
+- [[id:46DFE47F-967B-4C24-95BF-3E21F97CFD20][Agile process]] — planning phase owns this skill.
+- [[id:D4219199-7B17-4A89-B4BC-6019738642DA][Product backlog]] — the near/far structure.
+- [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][Capture]] — document type being promoted.
+- [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][Story]] — document type being created.
+- [[id:8B29A8D8-E004-4E87-B81D-ABEAF68F2B98][Document types]] — full frontmatter contracts.
+- [[id:2DF8ADAF-20C9-4757-9399-798EEC6DF828][Agile product owner]] — atomic operations this skill orchestrates.
+- [[id:5358EC5A-F7FD-473A-A8AB-AF77E4D83A58][Backlog refiner]] — use instead for general housekeeping without a
+  sprint-selection goal.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENCE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/recipes/agile/how_do_i_plan_a_sprint.org
+++ b/doc/recipes/agile/how_do_i_plan_a_sprint.org
@@ -1,0 +1,115 @@
+:PROPERTIES:
+:ID: 2C2E794B-7565-4FD8-BD26-E7949C874E43
+:END:
+#+title: How do I plan a sprint?
+#+description: Procedure for a sprint planning session: set the mission, score near-backlog captures against sprint goals, and promote winners into stories.
+#+type: recipe
+#+version: 2
+#+level: cross
+#+filetags: :agile:sprint:planning:recipe:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+
+Sprint planning operates on the current [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprint]] document and the
+[[id:D4219199-7B17-4A89-B4BC-6019738642DA][product backlog]]. For automated orchestration, use the [[id:FB451B15-9674-4B61-A9F8-7DAEEB4B365A][sprint-planner]]
+skill. For general backlog housekeeping without sprint selection,
+use [[id:7870BDC8-839B-4E46-9E32-F0EA9F7D5936][How do I refine the backlog?]] first.
+
+* Question
+
+How do I plan a sprint — set its mission, score backlog candidates
+against it, and promote selected captures into stories?
+
+* Answer
+
+1. /Open the current sprint document/ and confirm or set the mission:
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.codegen/doc_list.sh --type sprint --sort path | tail -3
+   #+end_src
+
+   The =* Mission= must be a single sentence before scoring can
+   proceed. If it reads =(One sentence — what this sprint exists to
+   achieve.)= it is unset — agree on it with the user now.
+
+2. /Note what is already committed/ — read the sprint's =* Stories=
+   table. STARTED and BACKLOG stories are already in scope; do not
+   re-select them.
+
+3. /List near-bucket candidates/:
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.codegen/doc_list.sh --type capture --sort path | grep near
+   #+end_src
+
+4. /Score each candidate/ on three axes — record results as a table
+   before presenting to the user:
+
+   | Criterion | Scoring guidance |
+   |-----------+-----------------|
+   | *Fit* | Direct mission advance = high; tangential = low |
+   | *Size* | One sprint / one story = high; multi-sprint = low |
+   | *Ready* | No blockers, no unresolved dependencies = high |
+
+5. /Present the ranked candidates/ and get the user's confirmation
+   on which to promote. Sprint scope is always the user's decision.
+
+6. /Promote each confirmed capture to a story/:
+
+   a. Scaffold the story in the sprint folder, preserving the
+      capture's =:ID:= with =--id=:
+
+      #+begin_src sh :results verbatim
+      projects/ores.codegen/generate_v2_doc.sh \
+        --type story --slug <slug> \
+        --id <capture-uuid> \
+        --parent-dir doc/agile/versions/v0/sprint_NN \
+        --title "<title>" --description "<description>"
+      #+end_src
+
+   b. Remove the capture from the backlog:
+
+      #+begin_src sh :results verbatim
+      git rm doc/agile/product_backlog/near/<slug>.org
+      #+end_src
+
+   c. Fill in the story's =* Goal=, =* Acceptance=, and at least
+      one task skeleton.
+
+7. /Add each promoted story to the sprint's =* Stories= table/:
+
+   #+begin_example
+   | [[id:<uuid>][<title>]] | BACKLOG | YYYY-MM-DD | | <one-line theme> |
+   #+end_example
+
+8. /Commit/:
+
+   #+begin_src sh :results verbatim
+   git add doc/agile/versions/v0/sprint_NN/ \
+           doc/agile/product_backlog/ \
+           doc/agile/versions/v0/sprint_NN/sprint.org
+   git commit -m "[agile] Sprint NN — promote N stories from backlog"
+   #+end_src
+
+After planning, use [[id:DA003A23-1604-43E7-A98F-A305148FBCF4][How do I start work on a story?]] to move the
+first story from BACKLOG → STARTED and create its feature branch.
+
+* Script
+
+No single script — the [[id:FB451B15-9674-4B61-A9F8-7DAEEB4B365A][sprint-planner]] Claude Code skill orchestrates
+this procedure interactively.
+
+* Tested by
+
+Manual. Run once per sprint, at the start of the planning phase.
+
+* See also
+
+- [[id:FB451B15-9674-4B61-A9F8-7DAEEB4B365A][Sprint planner]] — Claude Code skill for this procedure.
+- [[id:7870BDC8-839B-4E46-9E32-F0EA9F7D5936][How do I refine the backlog?]] — run before planning to ensure
+  candidates are clean.
+- [[id:DA003A23-1604-43E7-A98F-A305148FBCF4][How do I start work on a story?]] — next step after planning.
+- [[id:1E666848-A785-437E-A463-3D5A0DA0765F][How do I open a new sprint?]] — use this first if the sprint
+  has not been scaffolded yet.
+- [[id:3153AA4B-23D4-4111-9710-5A4971102EDC][How do I create a new v2 doc?]] — codegen reference for story
+  scaffolding.

--- a/doc/recipes/agile/how_do_i_refine_the_backlog.org
+++ b/doc/recipes/agile/how_do_i_refine_the_backlog.org
@@ -1,0 +1,93 @@
+:PROPERTIES:
+:ID: 7870BDC8-839B-4E46-9E32-F0EA9F7D5936
+:END:
+#+title: How do I refine the backlog?
+#+description: Checklist and procedure for a general backlog housekeeping session: scan, clarify, cull, and re-prioritise captures.
+#+type: recipe
+#+version: 2
+#+level: cross
+#+filetags: :agile:backlog:recipe:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+
+Backlog refinement operates on the [[id:D4219199-7B17-4A89-B4BC-6019738642DA][product backlog]] — the =near/= and
+=far/= capture buckets under =doc/agile/product_backlog/=. For
+automated orchestration, use the [[id:5358EC5A-F7FD-473A-A8AB-AF77E4D83A58][backlog-refiner]] skill. For sprint
+selection specifically, use [[id:2C2E794B-7565-4FD8-BD26-E7949C874E43][How do I plan a sprint?]].
+
+* Question
+
+How do I tidy the product backlog — pruning stale captures,
+sharpening vague ones, and re-prioritising between =near/= and
+=far/=?
+
+* Answer
+
+1. /List both buckets/:
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.codegen/doc_list.sh --type capture --sort path | grep near
+   ./projects/ores.codegen/doc_list.sh --type capture --sort path | grep far
+   #+end_src
+
+2. /For each capture, apply the VBCD checklist/:
+
+   - *V — Valid?* Is the need still real? If the work shipped or
+     the idea was abandoned, mark =ABANDONED= in the capture's
+     status table and commit.
+   - *B — Bucket?* Does it belong in =near/= (next version) or
+     =far/= (longer horizon)? Move by renaming the file; =:ID:=
+     stays unchanged.
+   - *C — Clear?* Is the title a complete thought and the
+     description specific enough to act on? Sharpen both in place
+     if not.
+   - *D — Duplicate?* Is a similar capture already in the backlog?
+     Merge by absorbing content into the richer one and marking
+     the absorbed one =ABANDONED=.
+
+3. /File new captures/ that surface during the review:
+
+   #+begin_src sh :results verbatim
+   projects/ores.codegen/generate_v2_doc.sh \
+     --type capture --slug <slug> \
+     --parent-dir doc/agile/product_backlog/near \
+     --title "<title>" --description "<one-liner>"
+   #+end_src
+
+4. /Move items between buckets/:
+
+   #+begin_src sh :results verbatim
+   git mv doc/agile/product_backlog/near/<slug>.org \
+          doc/agile/product_backlog/far/<slug>.org
+   #+end_src
+
+5. /Commit the sweep/:
+
+   #+begin_src sh :results verbatim
+   git add doc/agile/product_backlog/
+   git commit -m "[agile] Backlog refinement — near/far housekeeping"
+   #+end_src
+
+** Healthy backlog heuristics
+
+- Near bucket ≤ 20 items. More than that signals drift — push low-priority items to far.
+- Every near capture has a one-line =#+description= a newcomer could act on.
+- No capture has been untouched for more than two sprints without a decision.
+
+* Script
+
+No single script — the [[id:5358EC5A-F7FD-473A-A8AB-AF77E4D83A58][backlog-refiner]] Claude Code skill orchestrates
+this procedure interactively.
+
+* Tested by
+
+Manual. Run at the start of each sprint planning cycle or whenever
+the near bucket exceeds 20 items.
+
+* See also
+
+- [[id:5358EC5A-F7FD-473A-A8AB-AF77E4D83A58][Backlog refiner]] — Claude Code skill for this procedure.
+- [[id:2C2E794B-7565-4FD8-BD26-E7949C874E43][How do I plan a sprint?]] — use after refinement to select stories.
+- [[id:3153AA4B-23D4-4111-9710-5A4971102EDC][How do I create a new v2 doc?]] — codegen invocations for new
+  captures.
+- [[id:D4219199-7B17-4A89-B4BC-6019738642DA][Product backlog]] — the near/far structure and its invariants.


### PR DESCRIPTION
## Summary

- Scaffolds the **Product backlog refinement** story and its two tasks in Sprint 18 (`22AA37FA`).
- Sets the **Sprint 18 mission and goals**: ORE imports into workspaces, more ORE types, compass tool, and backlog refinement tooling.
- Adds two new **Claude Code skills**: `backlog-refiner` (housekeeping sessions) and `sprint-planner` (goal-directed selection and promotion).
- Adds two new **agile recipes**: `how_do_i_refine_the_backlog.org` (VBCD checklist) and `how_do_i_plan_a_sprint.org` (score, confirm, promote, commit).

Both skills cross-link to `agile-product-owner` for atomic operations. Site builds clean at 1680 nodes / 7215 links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)