### PR TITLE
Add system bootstrapping concepts chapter and manual-updater skill

### DIFF
--- a/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/story.org
+++ b/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/story.org
@@ -24,11 +24,11 @@ build themselves.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                                |
 | Parent sprint | [[id:1737c00c-699a-475a-bc94-743c6cda1001][Sprint 18]] |
-| Now           | Not yet started; blocked on merge of #807. |
-| Waiting on    | PR #807 (user manual restructure) merged. |
-| Next          | Add CMake target following =deploy_site= pattern. |
+| Now           | Chapter 1 (login/connection manager) merged in PR #811. System bootstrapping concepts + manual-updater skill pushed on feature/user-manual-system-bootstrapping (PR pending). |
+| Waiting on    | PR review for system bootstrapping concepts branch. Screenshots for all TODO_ placeholders. |
+| Next          | Raise PR for feature/user-manual-system-bootstrapping; capture screenshots. |
 | Last touched  | 2026-05-24                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/story.org
+++ b/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/story.org
@@ -44,7 +44,9 @@ In execution order:
 
 - [[id:30AFB759-D3F2-4DD9-A5C7-209735F35B38][Task: User manual restructure]] (DONE — PR #807; prerequisite for PDF build)
 - [[id:001f63b6-c4e8-4dd2-b680-364393b15d51][Task: Add CMake target to build user manual PDF and commit it]] (DONE — PR #810)
-- [[id:63BF06CF-B61E-4163-A017-0E2D13586510][Task: Write Chapter 1: Login and Connection Manager]]
+- [[id:63BF06CF-B61E-4163-A017-0E2D13586510][Task: Write Chapter 1: Login and Connection Manager]] (PR #811)
+- [[id:4834460E-0799-4379-ADD7-462A4BCF9FDF][Task: Write Chapter 1: System bootstrapping concepts and provisioning wizards]]
+- [[id:29379454-1B29-4BB5-905D-F129E0AC41FD][Task: Create documentation update skill]]
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_chapter_01_system_bootstrapping_concepts.org
+++ b/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_chapter_01_system_bootstrapping_concepts.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: 4834460E-0799-4379-ADD7-462A4BCF9FDF
+:END:
+#+title: Task: Write Chapter 1: System bootstrapping concepts and provisioning wizards
+#+description: Explain the multi-tenant/multi-party model and walk through the system, tenant, and party provisioner wizards with screenshot placeholders.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :doc:manual:chapter_01:bootstrapping:user_manual_pdf_build:sprint_18:v0:
+#+owner: marco
+#+branch: feature/user-manual-system-bootstrapping
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:C42C3563-671F-4721-8CE8-5EE05925255F][Build and publish user manual PDF via CMake]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Extend =system_bootstrapping.org= with a conceptual section on the
+multi-tenant/multi-party model and step-by-step walkthroughs of the
+three provisioning wizards (System Provisioner, Tenant Provisioner,
+Party Provisioner), with screenshot placeholders throughout.
+
+* Status
+
+| Field        | Value                                                       |
+|--------------+-------------------------------------------------------------|
+| State        | STARTED                                                     |
+| Parent story | [[id:C42C3563-671F-4721-8CE8-5EE05925255F][Build and publish user manual PDF via CMake]] |
+| Now          | Writing chapter content.                                    |
+| Waiting on   | Nothing.                                                    |
+| Next         | Author takes screenshots per placeholders; rebuild PDF.     |
+| Last touched | 2026-05-24                                                  |
+
+* Acceptance
+
+- Conceptual section explains tenants, tenant types, parties, and
+  party hierarchy in plain language for a non-technical audience.
+- System Provisioner wizard is documented page-by-page.
+- Tenant Provisioner wizard is documented page-by-page.
+- Party Provisioner wizard is documented page-by-page.
+- Every wizard page has a screenshot placeholder with capture
+  instructions.
+- Chapter builds without errors via =deploy_manual=.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_chapter_01_system_bootstrapping_concepts.org
+++ b/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_chapter_01_system_bootstrapping_concepts.org
@@ -9,7 +9,7 @@
 #+filetags: :doc:manual:chapter_01:bootstrapping:user_manual_pdf_build:sprint_18:v0:
 #+owner: marco
 #+branch: feature/user-manual-system-bootstrapping
-#+pr:
+#+pr: 814
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-24
@@ -57,8 +57,10 @@ task closes. Plans do not outlive their task.)
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                           | File                             | Decision | Notes                                                                 |
+|---+-------------------------------------------+----------------------------------+----------+-----------------------------------------------------------------------|
+| 1 | LICENCE.txt vs LICENSE.txt in metadata    | manual-updater/SKILL.org:18      | Accepted | Fixed in 4c40c8776; British spelling matches the tangle block         |
+| 2 | Screenshot path uses 4 traversals, needs 5 | manual-updater/SKILL.org:63     | Accepted | Fixed in 4c40c8776; chapters are 5 levels below repo root             |
+| 3 | Same path depth error on all 16 image links | system_bootstrapping_concepts.org | Accepted | Fixed in 4c40c8776; also fixed 14 occurrences in system_bootstrapping.org (PR #811 oversight) |
 
 * Result

--- a/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_create_documentation_update_skill.org
+++ b/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_create_documentation_update_skill.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: 29379454-1B29-4BB5-905D-F129E0AC41FD
+:END:
+#+title: Task: Create documentation update skill
+#+description: A Claude Code skill that instructs the LLM to update the user manual whenever functionality is added or changed.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :doc:manual:skill:llm:user_manual_pdf_build:sprint_18:v0:
+#+owner: marco
+#+branch: feature/user-manual-system-bootstrapping
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:C42C3563-671F-4721-8CE8-5EE05925255F][Build and publish user manual PDF via CMake]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+A =manual-updater= Claude Code skill that instructs the LLM to keep
+the user manual current: when a feature is added or changed in the
+codebase, the skill guides updating the relevant chapter, adding
+screenshot placeholders, and rebuilding the PDF.
+
+* Status
+
+| Field        | Value                                                       |
+|--------------+-------------------------------------------------------------|
+| State        | BACKLOG                                                     |
+| Parent story | [[id:C42C3563-671F-4721-8CE8-5EE05925255F][Build and publish user manual PDF via CMake]] |
+| Now          | Not yet started.                                            |
+| Waiting on   | Nothing.                                                    |
+| Next         | Scaffold skill via codegen; write skill body.               |
+| Last touched | 2026-05-24                                                  |
+
+* Acceptance
+
+- =doc/llm/skills/manual-updater/SKILL.org= exists and is deployed.
+- Skill describes when to trigger (feature added/changed), which
+  chapter to find/update, how to add screenshot placeholders, and
+  when to rebuild the PDF.
+- Skill is linked from the skills catalogue.
+- =deploy_skills= target picks it up.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_create_documentation_update_skill.org
+++ b/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_create_documentation_update_skill.org
@@ -29,11 +29,11 @@ screenshot placeholders, and rebuilding the PDF.
 
 | Field        | Value                                                       |
 |--------------+-------------------------------------------------------------|
-| State        | BACKLOG                                                     |
+| State        | DONE                                                        |
 | Parent story | [[id:C42C3563-671F-4721-8CE8-5EE05925255F][Build and publish user manual PDF via CMake]] |
-| Now          | Not yet started.                                            |
+| Now          | Skill written and added to skills catalogue.                |
 | Waiting on   | Nothing.                                                    |
-| Next         | Scaffold skill via codegen; write skill body.               |
+| Next         | —                                                           |
 | Last touched | 2026-05-24                                                  |
 
 * Acceptance
@@ -47,10 +47,6 @@ screenshot placeholders, and rebuilding the PDF.
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
-
 * Notes
 
 * Review
@@ -60,3 +56,11 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+Skill created at =doc/llm/skills/manual-updater/SKILL.org= on branch
+=feature/user-manual-system-bootstrapping= (same commit as the system
+bootstrapping concepts chapter). Added to the skills catalogue
+(=doc/llm/skills/claude_code_skills.org=) under the Documentation
+section. The skill covers: when to trigger (UI feature added/changed),
+chapter mapping table, prose editing conventions, screenshot placeholder
+format, PDF rebuild command, and commit guidance.

--- a/doc/llm/skills/claude_code_skills.org
+++ b/doc/llm/skills/claude_code_skills.org
@@ -28,6 +28,9 @@ See [[id:654D4A70-E63D-4C18-B5A5-886066E36314][CMake Runner]] for the deployment
 
 - [[id:2DF8ADAF-20C9-4757-9399-798EEC6DF828][Agile Product Owner]] — manage the team through story creation,
   prioritisation, sprint planning.
+- [[id:00F85A2F-547A-4F11-99EB-A46A7DE5AB1C][Manual Updater]] — update the user manual when UI features are
+  added or changed: find the chapter, edit prose, add screenshot
+  placeholders, rebuild the PDF.
 - [[id:7357C672-A49F-4974-9399-A166F761D222][ORES Memory]] — decide when to write a project-scope memory and
   scaffold it into =doc/llm/memory/=.
 - [[id:D6D86317-4961-6754-A6DB-9C12B5FAC997][PlantUML Class Modeler]] — class diagrams for C++ components.

--- a/doc/llm/skills/manual-updater/SKILL.org
+++ b/doc/llm/skills/manual-updater/SKILL.org
@@ -15,7 +15,7 @@
 ---
 name: manual-updater
 description: When to update the user manual and how: find the right chapter, update prose, add screenshot placeholders, and rebuild the PDF.
-license: Complete terms in LICENSE.txt
+license: Complete terms in LICENCE.txt
 ---
 #+end_export
 
@@ -60,7 +60,7 @@ behaviour, even if the user did not explicitly ask for a manual update.
    #+begin_example
    #+caption: [SCREENSHOT NEEDED] <what to show>.
    # Capture: <precise instruction for what to capture and how>.
-   [[../../../../assets/images/TODO_descriptive_name.png]]
+   [[../../../../../assets/images/TODO_descriptive_name.png]]
    #+end_example
 
    Name placeholder files with the =TODO_= prefix so they stand out in

--- a/doc/llm/skills/manual-updater/SKILL.org
+++ b/doc/llm/skills/manual-updater/SKILL.org
@@ -1,0 +1,128 @@
+:PROPERTIES:
+:ID: 00F85A2F-547A-4F11-99EB-A46A7DE5AB1C
+:END:
+#+title: Manual Updater
+#+version: 1
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+filetags: :skill:manual:doc:pdf:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+
+#+begin_export markdown
+---
+name: manual-updater
+description: When to update the user manual and how: find the right chapter, update prose, add screenshot placeholders, and rebuild the PDF.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+Use this skill whenever a user-facing feature is added, changed, or
+removed: a new wizard, a renamed menu item, a new toolbar button, a
+changed workflow, or a new command-line option. The user manual must
+reflect what the application actually does; stale documentation is a
+defect.
+
+Also use it proactively at the end of any task that changes UI
+behaviour, even if the user did not explicitly ask for a manual update.
+
+* How to use this skill
+
+1. *Identify the affected chapter.* The manual lives under
+   =doc/manual/user_guide/=. The root file is =user_manual.org=; chapters
+   are under =chapters/=. Map the changed feature to its chapter:
+
+   | Feature area                       | Chapter file                          |
+   |------------------------------------+---------------------------------------|
+   | Login, connections, status bar, CLI | =chapter_01/system_bootstrapping.org= |
+   | Bootstrapping, tenants, parties    | =chapter_01/system_bootstrapping_concepts.org= |
+   | Reference data (currencies, etc.)  | (future chapter)                      |
+   | Instruments and trades             | (future chapter)                      |
+   | Market data                        | (future chapter)                      |
+   | Analytics                          | (future chapter)                      |
+
+   If the feature does not map to an existing chapter, note it so a new
+   chapter can be planned.
+
+2. *Update the prose.* Edit the relevant =.org= file to reflect the new
+   or changed behaviour. Keep the tone consistent: plain language,
+   second person ("you"), British English, non-programmer audience.
+   Describe /what the user does and sees/, not /how the code works/.
+
+3. *Add screenshot placeholders for any new UI.* Every new dialog, page,
+   or significant UI state needs a =#+caption:= block and a
+   =TODO_= placeholder link:
+
+   #+begin_example
+   #+caption: [SCREENSHOT NEEDED] <what to show>.
+   # Capture: <precise instruction for what to capture and how>.
+   [[../../../../assets/images/TODO_descriptive_name.png]]
+   #+end_example
+
+   Name placeholder files with the =TODO_= prefix so they stand out in
+   the file list and are easy to search for.
+
+4. *Update existing screenshot captions* if the UI changed enough that
+   an existing screenshot is now wrong or misleading. Mark it:
+
+   #+begin_example
+   #+caption: [SCREENSHOT OUTDATED — retake needed] <updated description>.
+   #+end_example
+
+5. *Rebuild the PDF* to verify the chapter compiles without errors:
+
+   #+begin_src sh
+   cmake --build --preset linux-clang-debug-ninja --target deploy_manual
+   #+end_src
+
+   Fix any LaTeX errors before committing.
+
+6. *Commit the updated chapter* on the relevant feature branch as part
+   of the same PR as the code change. Documentation and code ship
+   together; a PR that changes UI without updating the manual is
+   incomplete.
+
+7. *Rebuild and commit the PDF* if the content changed substantially
+   enough to warrant an updated binary:
+
+   #+begin_src sh
+   cmake --build --preset linux-clang-debug-ninja --target deploy_manual
+   git add doc/manual/user_guide/user_manual.pdf
+   git commit -m "[doc] Rebuild user manual PDF"
+   #+end_src
+
+* Recipes
+
+- [[id:26C1DC06-82D2-46C4-94D6-DF9231BA171B][How do I address PR review comments?]] — the review loop that follows
+  the PR containing manual updates.
+
+* Reference
+
+- [[id:6A1A333C-A83A-8954-B9C3-C3AB1AEC3046][ORE Studio User Manual]] — the root manual file.
+- =doc/manual/user_guide/chapters/= — all chapter source files.
+- =deploy_manual= CMake target — builds the PDF via =.build-manual.el=.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENCE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/manual/user_guide/chapters/chapter_01/system_bootstrapping.org
+++ b/doc/manual/user_guide/chapters/chapter_01/system_bootstrapping.org
@@ -36,7 +36,7 @@ This chapter covers:
 # main window. The toolbar should be visible with both the Connect
 # button (plug icon) and the Connections button (list icon) clearly
 # visible. No workspace panels should be open.
-[[../../../../assets/images/ores_qt_non_logged_in_window.png]]
+[[../../../../../assets/images/ores_qt_non_logged_in_window.png]]
 
 In the disconnected state most of the application is inactive. The menu
 bar and toolbar are present but workspace panels, trade lists, and
@@ -63,7 +63,7 @@ Open it at any time from the toolbar *Connections* button or from the
 # Capture: open the Connection Manager with no connections configured.
 # The list area should be blank. The Add button (or "+" icon) must be
 # visible along with Edit and Delete buttons in their disabled state.
-[[../../../../assets/images/TODO_connection_manager_empty.png]]
+[[../../../../../assets/images/TODO_connection_manager_empty.png]]
 
 *** Adding a new connection
 
@@ -89,7 +89,7 @@ in the fields:
 # Capture: open Add Connection dialog. Fill in realistic example values
 # as described. Show the full form with all fields visible before
 # clicking Save/OK.
-[[../../../../assets/images/TODO_new_connection_form.png]]
+[[../../../../../assets/images/TODO_new_connection_form.png]]
 
 Click *Save* (or *OK*) to add the connection to the list. The new entry
 appears immediately in the Connection Manager list. No network contact
@@ -106,7 +106,7 @@ updates immediately.
 # Capture: select a saved connection and click Edit. The form should
 # show the existing values. Highlight or focus the Name field to show
 # editing is in progress.
-[[../../../../assets/images/TODO_edit_connection_form.png]]
+[[../../../../../assets/images/TODO_edit_connection_form.png]]
 
 *** Deleting a connection
 
@@ -116,7 +116,7 @@ the Delete key). A confirmation dialog asks you to confirm the removal.
 #+caption: [SCREENSHOT NEEDED] The delete confirmation dialog asking "Are you sure you want to delete the selected connection(s)?" with Yes and No buttons.
 # Capture: select a connection and click Delete. Screenshot the
 # confirmation dialog before clicking Yes.
-[[../../../../assets/images/TODO_delete_connection_confirm.png]]
+[[../../../../../assets/images/TODO_delete_connection_confirm.png]]
 
 Deleting a connection removes only the saved configuration; it has no
 effect on the running backend or any data stored there.
@@ -139,7 +139,7 @@ environment badge prevents that.
 # Capture: create three connections with different environments assigned.
 # Open the Connection Manager so the list shows all three, with the
 # environment badge visible on each row.
-[[../../../../assets/images/TODO_connection_manager_env_badges.png]]
+[[../../../../../assets/images/TODO_connection_manager_env_badges.png]]
 
 To manage the available environment names, open the /Environments/
 section within the Connection Manager settings (or the dedicated menu
@@ -154,7 +154,7 @@ item). From there you can:
 #+caption: [SCREENSHOT NEEDED] The Environments management panel showing a list of defined environments (Development, Staging, Production) with their colours, and Add/Edit/Delete controls.
 # Capture: open the Environments management view. Show at least three
 # environments with distinct colours and the controls for managing them.
-[[../../../../assets/images/TODO_environments_management.png]]
+[[../../../../../assets/images/TODO_environments_management.png]]
 
 *** Tags
 
@@ -171,7 +171,7 @@ or select a tag to show only the connections that carry it.
 # Capture: assign tags to several connections. Open the Connection
 # Manager and type a tag name into the filter bar. Show the filtered
 # result with the unmatched connections hidden.
-[[../../../../assets/images/TODO_connection_manager_tag_filter.png]]
+[[../../../../../assets/images/TODO_connection_manager_tag_filter.png]]
 
 To add or remove tags on a connection, open the Edit form for that
 connection and use the tag input field. Type a new tag name and press
@@ -199,7 +199,7 @@ full Connection Manager.
 # Capture: click the Connect button dropdown (or the equivalent
 # quick-select). Show the list of saved connections in the dropdown
 # before selecting one.
-[[../../../../assets/images/TODO_connect_button_dropdown.png]]
+[[../../../../../assets/images/TODO_connect_button_dropdown.png]]
 
 *** The login screen
 
@@ -211,7 +211,7 @@ dialog appears.
 # Capture: click Connect with a reachable backend. Screenshot the login
 # dialog before entering credentials. The connection name should be
 # visible in the dialog header or subtitle.
-[[../../../../assets/images/login_screen.png]]
+[[../../../../../assets/images/login_screen.png]]
 
 Enter your *username* and *password* and click *Log In*. ORE Studio
 authenticates against the backend's user database. On success the dialog
@@ -243,7 +243,7 @@ or port is needed — only your password.
 # Capture: while logged in, stop or restart the backend service.
 # Screenshot the moment ORE Studio detects the disconnection and shows
 # the warning indicator. The Reconnect affordance should be visible.
-[[../../../../assets/images/TODO_connection_lost_banner.png]]
+[[../../../../../assets/images/TODO_connection_lost_banner.png]]
 
 ** The status bar
 
@@ -256,7 +256,7 @@ visible regardless of what is open in the workspace.
 # bottom of the main window. Crop tightly so all zones are clearly
 # legible. Annotate the zones if possible (or describe them in the
 # caption).
-[[../../../../assets/images/TODO_status_bar_connected.png]]
+[[../../../../../assets/images/TODO_status_bar_connected.png]]
 
 The status bar is divided into zones from left to right:
 
@@ -290,7 +290,7 @@ The status bar changes appearance to reflect the connection state:
 # Capture: three separate screenshots of the status bar — one with no
 # connection configured, one while logged in, one after stopping the
 # backend. Arrange them vertically or present as three separate figures.
-[[../../../../assets/images/TODO_status_bar_states.png]]
+[[../../../../../assets/images/TODO_status_bar_states.png]]
 
 ** Starting ORE Studio from the command line
 
@@ -321,7 +321,7 @@ The =--color= spelling (without the 'u') is accepted as an alias.
 # Capture: launch with --colour light and take a screenshot. Relaunch
 # with --colour dark and take the same screenshot. Place them side by
 # side or present as two figures.
-[[../../../../assets/images/TODO_colour_themes.png]]
+[[../../../../../assets/images/TODO_colour_themes.png]]
 
 *** Configuration directory
 

--- a/doc/manual/user_guide/chapters/chapter_01/system_bootstrapping_concepts.org
+++ b/doc/manual/user_guide/chapters/chapter_01/system_bootstrapping_concepts.org
@@ -1,0 +1,381 @@
+:PROPERTIES:
+:ID: A9F2C3E1-74B5-4D8A-9C6E-3B1F7D2E5A04
+:END:
+#+title: System Bootstrapping Concepts and Provisioning
+#+description: Conceptual overview of the multi-tenant/multi-party model and step-by-step guide to the provisioning wizards.
+#+type: manual
+#+version: 2
+#+level: cross
+#+filetags: :knowledge:chapter:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+
+** Understanding the multi-tenant, multi-party model
+
+Before you can use ORE Studio for the first time, the system must be
+bootstrapped — meaning the initial administrative structure must be
+established. Understanding why this step exists requires a brief
+introduction to how ORE Studio organises data.
+
+*** Tenants
+
+A /tenant/ is a fully isolated organisational space within an ORE
+Studio deployment. Each tenant has its own users, its own reference
+data (currencies, counterparties, books), and its own analytics
+results. Data belonging to one tenant is completely invisible to
+another tenant; there is no cross-tenant data leakage by design.
+
+A typical deployment has one tenant per organisation. If you are
+running ORE Studio for your own firm, you will create one tenant
+representing your organisation. A managed-service provider running ORE
+Studio on behalf of multiple clients might create one tenant per
+client.
+
+ORE Studio supports four tenant types, each with different operational
+controls:
+
+| Type         | Purpose                                                 | Controls      |
+|--------------+---------------------------------------------------------+---------------|
+| System       | Platform administration; one per deployment             | Platform-managed |
+| Production   | Real customer organisations with live data              | Strict        |
+| Evaluation   | Demos, UAT, training, and exploratory testing           | Relaxed       |
+| Automation   | Programmatic test infrastructure; not for human use     | None          |
+
+The *system tenant* is special — it is created automatically during
+bootstrapping and cannot be deleted. It is the home of the platform
+administrator accounts. There is exactly one system tenant per
+deployment. All other tenants are created by platform administrators
+working from the system tenant.
+
+*Production tenants* are for live operations. They enforce strict
+controls including four-eyes authorisation for sensitive operations and
+KYC-gated counterparty onboarding.
+
+*Evaluation tenants* provide a realistic but relaxed environment for
+demonstrations, user acceptance testing, and training. Bulk data
+import from external sources (such as the GLEIF/LEI registry) is
+available in evaluation tenants but not in production tenants.
+
+*** Parties
+
+Within a tenant, a /party/ is a business unit — a legal entity, a
+branch, a trading desk, or any other organisational subdivision.
+Parties form a hierarchy: a parent party can see all data belonging to
+its children and grandchildren; a child party sees only its own data
+and that of its own descendants.
+
+Every tenant has exactly one *system party*, created automatically
+when the tenant is provisioned. The system party is the administrative
+home for tenant administrator accounts. It is not a business entity
+and should not be used for trading activity.
+
+Business parties — the entities that actually own trades,
+counterparties, and analytics results — are *operational parties*.
+You create these after the tenant is provisioned, using the Party
+Provisioner.
+
+#+caption: [SCREENSHOT NEEDED] A diagram of a simple party hierarchy: the system party at the top, one root operational party below it (e.g. "Acme Group"), and two child operational parties beneath that (e.g. "Acme London", "Acme New York"). Arrows show the parent-child relationship.
+# Capture: draw or screenshot a simple tree diagram showing the
+# system party and a two-level operational hierarchy. This can be
+# a PlantUML diagram rendered to PNG, or a hand-drawn/tool-drawn
+# illustration.
+[[../../../../assets/images/TODO_party_hierarchy_diagram.png]]
+
+A user logs in to a specific party within a tenant. Their data
+visibility is determined by their position in the hierarchy: a user
+logged in at "Acme Group" sees data from both "Acme London" and
+"Acme New York"; a user logged in at "Acme London" sees only their
+own data.
+
+*** The bootstrapping sequence
+
+A freshly installed ORE Studio backend goes through a fixed sequence
+before it is ready for normal use:
+
+1. *System bootstrap* — the first platform administrator account is
+   created and the system tenant is initialised. Until this step
+   completes, the backend runs in /bootstrap mode/ and accepts no
+   normal user logins.
+2. *Tenant provisioning* — one or more tenants are created by the
+   platform administrator.
+3. *Party provisioning* — within each tenant, the operational party
+   hierarchy is established by the tenant administrator.
+
+Each step has a corresponding wizard in the ORE Studio UI. The
+following sections walk through each one.
+
+** The System Provisioner wizard
+
+The System Provisioner runs automatically when you connect to a
+backend that has never been initialised. It is a one-time wizard; once
+completed, it cannot be launched again from the same backend.
+
+*** Welcome page
+
+#+caption: [SCREENSHOT NEEDED] The System Provisioner welcome page. Show the full dialog with its title, a brief description of what the wizard will do, and the Next button.
+# Capture: connect to a freshly installed backend. The System
+# Provisioner should launch automatically. Screenshot the welcome
+# page before clicking Next.
+[[../../../../assets/images/TODO_system_provisioner_welcome.png]]
+
+The welcome page confirms that the backend is in bootstrap mode and
+explains that you are about to create the first platform administrator
+account. Read it carefully — this account will have unrestricted
+access to the entire deployment.
+
+Click *Next* to proceed.
+
+*** Administrator account
+
+#+caption: [SCREENSHOT NEEDED] The System Provisioner administrator account page. Show the username and password fields, the password confirmation field, and any password-strength indicator.
+# Capture: on the administrator account step, fill in example
+# credentials (use a placeholder username, hide the password field
+# or use a dummy value). Show the full page with all fields visible.
+[[../../../../assets/images/TODO_system_provisioner_admin_account.png]]
+
+Fill in the fields:
+
+- *Username* — the login name for the platform administrator (e.g.
+  =admin=). This is case-sensitive. Choose something memorable; it
+  cannot be changed after creation without database-level access.
+- *Password* — a strong password for the administrator account. ORE
+  Studio enforces a minimum length and complexity; the strength
+  indicator shows the current rating as you type.
+- *Confirm password* — re-enter the password to confirm. The Next
+  button remains disabled until both fields match.
+
+Click *Next*.
+
+*** Review and confirm
+
+#+caption: [SCREENSHOT NEEDED] The System Provisioner review page. Show the summary of choices made (username shown, password shown as asterisks), with Back and Finish buttons.
+# Capture: after filling in credentials, reach the review page.
+# Screenshot it with the username visible and password masked.
+[[../../../../assets/images/TODO_system_provisioner_review.png]]
+
+The review page shows a summary of what will be created. Verify the
+username. Click *Back* to correct any mistake, or *Finish* to
+complete the bootstrap.
+
+*** Completion
+
+#+caption: [SCREENSHOT NEEDED] The System Provisioner completion page (or success dialog). Show the confirmation message and the button to close the wizard and proceed to login.
+# Capture: after clicking Finish, the wizard completes and shows a
+# success message. Screenshot this final state before dismissing.
+[[../../../../assets/images/TODO_system_provisioner_complete.png]]
+
+Once the wizard completes, the backend exits bootstrap mode. The
+System Provisioner closes and the Connection Manager or login dialog
+appears. Log in with the administrator credentials you just created.
+
+** The Tenant Provisioner wizard
+
+After logging in as the platform administrator, you can create one or
+more tenants. Open the Tenant Provisioner from the *Administration*
+menu → /Provision Tenant/, or from the system dashboard if one is
+shown.
+
+#+caption: [SCREENSHOT NEEDED] The Administration menu open, with the "Provision Tenant" item highlighted.
+# Capture: while logged in as the platform administrator, open the
+# Administration menu. Show the menu with "Provision Tenant" visible
+# and highlighted (hover or focus it).
+[[../../../../assets/images/TODO_admin_menu_provision_tenant.png]]
+
+*** Welcome page
+
+#+caption: [SCREENSHOT NEEDED] The Tenant Provisioner welcome page. Show the full dialog with its title, a description of what provisioning will create, and the Next button.
+# Capture: open the Tenant Provisioner. Screenshot the welcome page
+# before interacting with any controls.
+[[../../../../assets/images/TODO_tenant_provisioner_welcome.png]]
+
+The welcome page explains that provisioning creates a new isolated
+tenant with its own system party and an initial administrator account
+for that tenant.
+
+*** Tenant details
+
+#+caption: [SCREENSHOT NEEDED] The Tenant Provisioner tenant details page. Show all fields: tenant name, tenant type dropdown (with options visible or selected), and description.
+# Capture: on the tenant details step, fill in an example tenant name
+# (e.g. "Acme Group"), select a tenant type (e.g. "Production"), and
+# optionally add a description. Show the full page.
+[[../../../../assets/images/TODO_tenant_provisioner_details.png]]
+
+Fill in the fields:
+
+- *Tenant name* — a human-readable name for the organisation this
+  tenant represents (e.g. "Acme Group", "Client A"). This appears in
+  the UI wherever the tenant is referenced.
+- *Tenant type* — choose from /Production/, /Evaluation/, or
+  /Automation/. See the table in [[*Tenants][Tenants]] above for the implications
+  of each type. For a first-time setup representing a real
+  organisation, choose /Production/. For a demo or test environment,
+  choose /Evaluation/.
+- *Description* — optional free-text notes about this tenant's
+  purpose.
+
+Click *Next*.
+
+*** Tenant administrator account
+
+#+caption: [SCREENSHOT NEEDED] The Tenant Provisioner administrator account page. Show username, password, and confirm password fields with a partially filled-in example.
+# Capture: on the administrator account step, enter example
+# credentials for the new tenant's admin. Show all fields.
+[[../../../../assets/images/TODO_tenant_provisioner_admin.png]]
+
+Create the initial administrator account for the new tenant:
+
+- *Username* — the login name for this tenant's administrator. This
+  is independent of the platform administrator account; each tenant
+  maintains its own user database.
+- *Password* / *Confirm password* — as with the system bootstrap,
+  subject to the same strength requirements.
+
+This account is associated with the new tenant's system party and is
+given the =TenantAdmin= role, which grants full control within the
+tenant but no cross-tenant access.
+
+Click *Next*.
+
+*** Review and confirm
+
+#+caption: [SCREENSHOT NEEDED] The Tenant Provisioner review page. Show tenant name, type, and administrator username summarised, with Back and Finish buttons.
+# Capture: reach the review page after filling in all details.
+# Show the summary with all provided information visible.
+[[../../../../assets/images/TODO_tenant_provisioner_review.png]]
+
+The review page summarises the tenant and administrator that will be
+created. Click *Back* to correct any detail, or *Finish* to provision.
+
+*** Completion
+
+#+caption: [SCREENSHOT NEEDED] The Tenant Provisioner completion page confirming that the tenant and its administrator were created successfully.
+# Capture: after clicking Finish, screenshot the success confirmation
+# before dismissing the wizard.
+[[../../../../assets/images/TODO_tenant_provisioner_complete.png]]
+
+Provisioning creates the tenant record, the system party, and the
+administrator account. It also copies the standard set of system-wide
+permissions and roles into the new tenant so administrators can
+immediately assign roles to new users.
+
+The new tenant now appears in the tenant list visible to the platform
+administrator. To begin setting up business parties, log out and log
+back in with the new tenant's administrator credentials, then run the
+Party Provisioner.
+
+** The Party Provisioner wizard
+
+The Party Provisioner is run by the tenant administrator after initial
+tenant provisioning. It establishes the operational party hierarchy —
+the business units that will own trades, counterparties, and
+analytics. Open it from the *Administration* menu → /Provision
+Parties/, or from the tenant welcome screen on first login.
+
+*** Welcome page
+
+#+caption: [SCREENSHOT NEEDED] The Party Provisioner welcome page. Show the full dialog with a description of what it will set up and the Next button.
+# Capture: log in as the tenant administrator and open the Party
+# Provisioner. Screenshot the welcome page.
+[[../../../../assets/images/TODO_party_provisioner_welcome.png]]
+
+The welcome page explains that you are about to define the
+organisational structure your tenant will use. Unlike the system and
+tenant provisioners, the Party Provisioner can be run multiple times
+— you can always add more parties later via the main Reference Data
+→ Parties screen.
+
+*** Root party
+
+#+caption: [SCREENSHOT NEEDED] The Party Provisioner root party page. Show the name, description, and LEI (Legal Entity Identifier) fields, with an example filled in.
+# Capture: on the root party step, fill in a realistic example (e.g.
+# name = "Acme Group Holdings", LEI = a 20-character alphanumeric
+# code, description optional). Show the full page.
+[[../../../../assets/images/TODO_party_provisioner_root.png]]
+
+The root party is the top of your operational hierarchy — typically
+your holding company, group entity, or the single legal entity if
+your organisation has no subsidiaries.
+
+- *Name* — the full legal or trading name of the root entity.
+- *LEI* — the Legal Entity Identifier (a 20-character code issued by
+  the GLEIF). Optional but strongly recommended for production
+  tenants, where KYC workflows use the LEI to verify counterparty
+  identity.
+- *Description* — optional free-text notes.
+
+Click *Next*.
+
+*** Child parties
+
+#+caption: [SCREENSHOT NEEDED] The Party Provisioner child parties page. Show the list of parties added so far (including the root) and controls to add, edit, or remove child parties. At least one child should be shown.
+# Capture: on the child parties step, add one or two child parties
+# (e.g. "Acme London", "Acme New York") under the root. Show the
+# party tree with the children visible.
+[[../../../../assets/images/TODO_party_provisioner_children.png]]
+
+The child parties page lets you add operational parties beneath the
+root. This is optional — you can run the provisioner with just a root
+party and add children later through Reference Data → Parties.
+
+To add a child party:
+
+1. Select the parent in the tree (initially only the root is shown).
+2. Click *Add child*.
+3. Fill in the same fields as the root party (name, optional LEI,
+   optional description).
+4. Click *OK* to add it to the tree.
+
+Repeat for as many parties as you need. Parties can be nested to any
+depth — branches under divisions under the holding company, for
+example.
+
+To remove a party from the tree before provisioning, select it and
+click *Remove*. Note: parties that have already been provisioned to
+the database can only be deleted through the main Parties screen,
+which enforces referential integrity checks.
+
+Click *Next* when the hierarchy looks correct.
+
+*** Review and confirm
+
+#+caption: [SCREENSHOT NEEDED] The Party Provisioner review page showing the full party tree (root + children) in a tree view, with Back and Finish buttons.
+# Capture: on the review page, show the full party hierarchy as it
+# will be created. The tree should show parent-child relationships
+# clearly.
+[[../../../../assets/images/TODO_party_provisioner_review.png]]
+
+The review page shows the full hierarchy as it will be created. Each
+party is shown with its name, level in the hierarchy, and LEI if
+provided. Click *Back* to modify the structure, or *Finish* to
+provision all parties in one operation.
+
+*** Completion
+
+#+caption: [SCREENSHOT NEEDED] The Party Provisioner completion page confirming how many parties were created and providing a link or button to navigate to the Parties screen.
+# Capture: after clicking Finish, screenshot the completion message.
+# Show the count of parties created and any navigation options.
+[[../../../../assets/images/TODO_party_provisioner_complete.png]]
+
+Provisioning creates all parties in the correct parent-child order.
+The system party remains at the top of the hierarchy as the
+administrative root; all operational parties appear beneath it as its
+children or descendants.
+
+Once provisioning is complete, users can be created and assigned to
+parties through the main Administration → Accounts screen. Trades,
+counterparties, and other business data are then entered or imported
+within the context of the party they belong to.
+
+** What comes next
+
+With the system bootstrapped, at least one tenant provisioned, and
+the party hierarchy established, ORE Studio is ready for normal use.
+The next chapters cover:
+
+- *Reference data* — currencies, calendars, and market conventions
+  that must be set up before pricing can begin.
+- *Instruments and trades* — defining and entering financial
+  instruments.
+- *Market data* — yield curves, volatility surfaces, and fixing
+  histories.
+- *Analytics* — running calculations and reviewing results.

--- a/doc/manual/user_guide/chapters/chapter_01/system_bootstrapping_concepts.org
+++ b/doc/manual/user_guide/chapters/chapter_01/system_bootstrapping_concepts.org
@@ -79,7 +79,7 @@ Provisioner.
 # system party and a two-level operational hierarchy. This can be
 # a PlantUML diagram rendered to PNG, or a hand-drawn/tool-drawn
 # illustration.
-[[../../../../assets/images/TODO_party_hierarchy_diagram.png]]
+[[../../../../../assets/images/TODO_party_hierarchy_diagram.png]]
 
 A user logs in to a specific party within a tenant. Their data
 visibility is determined by their position in the hierarchy: a user
@@ -116,7 +116,7 @@ completed, it cannot be launched again from the same backend.
 # Capture: connect to a freshly installed backend. The System
 # Provisioner should launch automatically. Screenshot the welcome
 # page before clicking Next.
-[[../../../../assets/images/TODO_system_provisioner_welcome.png]]
+[[../../../../../assets/images/TODO_system_provisioner_welcome.png]]
 
 The welcome page confirms that the backend is in bootstrap mode and
 explains that you are about to create the first platform administrator
@@ -131,7 +131,7 @@ Click *Next* to proceed.
 # Capture: on the administrator account step, fill in example
 # credentials (use a placeholder username, hide the password field
 # or use a dummy value). Show the full page with all fields visible.
-[[../../../../assets/images/TODO_system_provisioner_admin_account.png]]
+[[../../../../../assets/images/TODO_system_provisioner_admin_account.png]]
 
 Fill in the fields:
 
@@ -151,7 +151,7 @@ Click *Next*.
 #+caption: [SCREENSHOT NEEDED] The System Provisioner review page. Show the summary of choices made (username shown, password shown as asterisks), with Back and Finish buttons.
 # Capture: after filling in credentials, reach the review page.
 # Screenshot it with the username visible and password masked.
-[[../../../../assets/images/TODO_system_provisioner_review.png]]
+[[../../../../../assets/images/TODO_system_provisioner_review.png]]
 
 The review page shows a summary of what will be created. Verify the
 username. Click *Back* to correct any mistake, or *Finish* to
@@ -162,7 +162,7 @@ complete the bootstrap.
 #+caption: [SCREENSHOT NEEDED] The System Provisioner completion page (or success dialog). Show the confirmation message and the button to close the wizard and proceed to login.
 # Capture: after clicking Finish, the wizard completes and shows a
 # success message. Screenshot this final state before dismissing.
-[[../../../../assets/images/TODO_system_provisioner_complete.png]]
+[[../../../../../assets/images/TODO_system_provisioner_complete.png]]
 
 Once the wizard completes, the backend exits bootstrap mode. The
 System Provisioner closes and the Connection Manager or login dialog
@@ -179,14 +179,14 @@ shown.
 # Capture: while logged in as the platform administrator, open the
 # Administration menu. Show the menu with "Provision Tenant" visible
 # and highlighted (hover or focus it).
-[[../../../../assets/images/TODO_admin_menu_provision_tenant.png]]
+[[../../../../../assets/images/TODO_admin_menu_provision_tenant.png]]
 
 *** Welcome page
 
 #+caption: [SCREENSHOT NEEDED] The Tenant Provisioner welcome page. Show the full dialog with its title, a description of what provisioning will create, and the Next button.
 # Capture: open the Tenant Provisioner. Screenshot the welcome page
 # before interacting with any controls.
-[[../../../../assets/images/TODO_tenant_provisioner_welcome.png]]
+[[../../../../../assets/images/TODO_tenant_provisioner_welcome.png]]
 
 The welcome page explains that provisioning creates a new isolated
 tenant with its own system party and an initial administrator account
@@ -198,7 +198,7 @@ for that tenant.
 # Capture: on the tenant details step, fill in an example tenant name
 # (e.g. "Acme Group"), select a tenant type (e.g. "Production"), and
 # optionally add a description. Show the full page.
-[[../../../../assets/images/TODO_tenant_provisioner_details.png]]
+[[../../../../../assets/images/TODO_tenant_provisioner_details.png]]
 
 Fill in the fields:
 
@@ -220,7 +220,7 @@ Click *Next*.
 #+caption: [SCREENSHOT NEEDED] The Tenant Provisioner administrator account page. Show username, password, and confirm password fields with a partially filled-in example.
 # Capture: on the administrator account step, enter example
 # credentials for the new tenant's admin. Show all fields.
-[[../../../../assets/images/TODO_tenant_provisioner_admin.png]]
+[[../../../../../assets/images/TODO_tenant_provisioner_admin.png]]
 
 Create the initial administrator account for the new tenant:
 
@@ -241,7 +241,7 @@ Click *Next*.
 #+caption: [SCREENSHOT NEEDED] The Tenant Provisioner review page. Show tenant name, type, and administrator username summarised, with Back and Finish buttons.
 # Capture: reach the review page after filling in all details.
 # Show the summary with all provided information visible.
-[[../../../../assets/images/TODO_tenant_provisioner_review.png]]
+[[../../../../../assets/images/TODO_tenant_provisioner_review.png]]
 
 The review page summarises the tenant and administrator that will be
 created. Click *Back* to correct any detail, or *Finish* to provision.
@@ -251,7 +251,7 @@ created. Click *Back* to correct any detail, or *Finish* to provision.
 #+caption: [SCREENSHOT NEEDED] The Tenant Provisioner completion page confirming that the tenant and its administrator were created successfully.
 # Capture: after clicking Finish, screenshot the success confirmation
 # before dismissing the wizard.
-[[../../../../assets/images/TODO_tenant_provisioner_complete.png]]
+[[../../../../../assets/images/TODO_tenant_provisioner_complete.png]]
 
 Provisioning creates the tenant record, the system party, and the
 administrator account. It also copies the standard set of system-wide
@@ -276,7 +276,7 @@ Parties/, or from the tenant welcome screen on first login.
 #+caption: [SCREENSHOT NEEDED] The Party Provisioner welcome page. Show the full dialog with a description of what it will set up and the Next button.
 # Capture: log in as the tenant administrator and open the Party
 # Provisioner. Screenshot the welcome page.
-[[../../../../assets/images/TODO_party_provisioner_welcome.png]]
+[[../../../../../assets/images/TODO_party_provisioner_welcome.png]]
 
 The welcome page explains that you are about to define the
 organisational structure your tenant will use. Unlike the system and
@@ -290,7 +290,7 @@ tenant provisioners, the Party Provisioner can be run multiple times
 # Capture: on the root party step, fill in a realistic example (e.g.
 # name = "Acme Group Holdings", LEI = a 20-character alphanumeric
 # code, description optional). Show the full page.
-[[../../../../assets/images/TODO_party_provisioner_root.png]]
+[[../../../../../assets/images/TODO_party_provisioner_root.png]]
 
 The root party is the top of your operational hierarchy — typically
 your holding company, group entity, or the single legal entity if
@@ -311,7 +311,7 @@ Click *Next*.
 # Capture: on the child parties step, add one or two child parties
 # (e.g. "Acme London", "Acme New York") under the root. Show the
 # party tree with the children visible.
-[[../../../../assets/images/TODO_party_provisioner_children.png]]
+[[../../../../../assets/images/TODO_party_provisioner_children.png]]
 
 The child parties page lets you add operational parties beneath the
 root. This is optional — you can run the provisioner with just a root
@@ -342,7 +342,7 @@ Click *Next* when the hierarchy looks correct.
 # Capture: on the review page, show the full party hierarchy as it
 # will be created. The tree should show parent-child relationships
 # clearly.
-[[../../../../assets/images/TODO_party_provisioner_review.png]]
+[[../../../../../assets/images/TODO_party_provisioner_review.png]]
 
 The review page shows the full hierarchy as it will be created. Each
 party is shown with its name, level in the hierarchy, and LEI if
@@ -354,7 +354,7 @@ provision all parties in one operation.
 #+caption: [SCREENSHOT NEEDED] The Party Provisioner completion page confirming how many parties were created and providing a link or button to navigate to the Parties screen.
 # Capture: after clicking Finish, screenshot the completion message.
 # Show the count of parties created and any navigation options.
-[[../../../../assets/images/TODO_party_provisioner_complete.png]]
+[[../../../../../assets/images/TODO_party_provisioner_complete.png]]
 
 Provisioning creates all parties in the correct parent-child order.
 The system party remains at the top of the hierarchy as the

--- a/doc/manual/user_guide/user_manual.org
+++ b/doc/manual/user_guide/user_manual.org
@@ -45,3 +45,5 @@
 * Chapter 1
 
 #+include: "chapters/chapter_01/system_bootstrapping.org" :minlevel 2
+
+#+include: "chapters/chapter_01/system_bootstrapping_concepts.org" :minlevel 2


### PR DESCRIPTION
## Summary

- Adds `doc/manual/user_guide/chapters/chapter_01/system_bootstrapping_concepts.org` — conceptual overview of the multi-tenant/multi-party model followed by step-by-step walkthroughs of the System Provisioner, Tenant Provisioner, and Party Provisioner wizards, with `TODO_` screenshot placeholders throughout
- Wires the new chapter into `user_manual.org` via `#+include:`
- Adds `doc/llm/skills/manual-updater/SKILL.org` — a Claude Code skill instructing the LLM to update the user manual whenever UI features are added or changed; registered in the skills catalogue

## Test plan

- [ ] Verify `cmake --build --preset linux-clang-debug-ninja --target deploy_manual` produces a valid PDF including the new chapter
- [ ] Confirm `TODO_` placeholder links appear in the PDF as expected figure references
- [ ] Confirm the manual-updater skill appears in the skills catalogue under Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)