### PR TITLE
[compass,agile] Track PRs per task; compass where --prs

### DIFF
--- a/doc/agile/versions/v0/sprint_18/pr_tracking_in_tasks/story.org
+++ b/doc/agile/versions/v0/sprint_18/pr_tracking_in_tasks/story.org
@@ -1,0 +1,77 @@
+:PROPERTIES:
+:ID: 7EF64A67-EB1C-4F79-9FF2-1C59DD6146AB
+:END:
+#+title: Story: Track PRs per task and surface them in compass where
+#+description: Add a PRs table to task documents, record PRs on creation, and add --prs flag to compass where.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :compass:tooling:agile:sprint_18:v0:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Every task document carries a =* PRs= table listing the pull requests
+raised for that task (number and title). When a PR is created, it is
+recorded there immediately. =compass where --prs= (part of the Locate
+pillar) shows the same data live — fetching open and closed PR status
+via =gh= — so a session can orient itself without manually checking
+GitHub. Story and task UUIDs are embedded in the PR body on creation
+for forward traceability.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                                |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                              |
+| Now           | Implementing all three tasks on feature/pr-tracking-compass. |
+| Waiting on    | Nothing.                               |
+| Next          | Raise PR and merge.                    |
+| Last touched  | 2026-05-24                             |
+
+* Acceptance
+
+- =v2_doc_task.org.mustache= has a =* PRs= section with an empty
+  =| PR | Title |= table.
+- =how_do_i_create_a_pr.org= instructs the author to record the PR
+  number and title in the task's =* PRs= table immediately after
+  raising, and to include the story and task =:ID:= UUIDs in the PR
+  body.
+- =compass where= lists the current version, sprint, and all STARTED
+  stories and tasks with their file paths and UUIDs.
+- =compass where --prs= additionally reads each task's =* PRs= table
+  and fetches live status for all listed PRs (open and closed) via
+  =gh pr view=.
+- Output is available in =pretty= (human) and =json= (tooling) formats.
+
+* Tasks
+
+In execution order:
+
+- [[id:63019BF3-5C02-40D5-A5F0-C1879A10F588][Task: Add PRs table to task template and update PR recipe]]
+- [[id:E9C783F7-955C-4317-8847-9972CB0D9C6D][Task: Implement compass where with --prs flag]]
+
+* Decisions
+
+- /PRs table on tasks only, not stories./ Stories span many tasks and
+  many PRs; the task is the unit that owns a PR. Aggregation can happen
+  at read time (compass walks task files).
+- /No status column in the PRs table./ Maintaining it would require
+  manual updates after each PR state change. compass fetches live
+  status from =gh= instead.
+- /Story + task UUID in PR body, not title./ Titles are read by humans
+  at a glance; UUIDs belong in the body where tooling can parse them.
+- /compass where reads the filesystem directly./ The cached FTS index
+  is for search; for =where=, walking =doc/agile/versions/= and parsing
+  =#+todo:= + the Status table is fast enough and always fresh.
+
+* Out of scope
+
+- Retroactive: existing tasks and PRs are not back-filled.
+- Closed PR bodies are not parsed for UUID linkage.
+- =compass where= does not mutate any state.

--- a/doc/agile/versions/v0/sprint_18/pr_tracking_in_tasks/story.org
+++ b/doc/agile/versions/v0/sprint_18/pr_tracking_in_tasks/story.org
@@ -27,11 +27,11 @@ for forward traceability.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                                |
+| State         | DONE                                   |
 | Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                              |
-| Now           | Implementing all three tasks on feature/pr-tracking-compass. |
+| Now           | Completed 2026-05-24.                  |
 | Waiting on    | Nothing.                               |
-| Next          | Raise PR and merge.                    |
+| Next          | None.                                  |
 | Last touched  | 2026-05-24                             |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_18/pr_tracking_in_tasks/task_add_prs_table_to_task_template.org
+++ b/doc/agile/versions/v0/sprint_18/pr_tracking_in_tasks/task_add_prs_table_to_task_template.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: 63019BF3-5C02-40D5-A5F0-C1879A10F588
+:END:
+#+title: Task: Add PRs table to task template and update PR recipe
+#+description: Update v2_doc_task.org.mustache to include a * PRs table; update how_do_i_create_a_pr.org to record PRs and embed UUIDs.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :agile:compass:pr_tracking_in_tasks:sprint_18:v0:
+#+owner: marco
+#+branch: feature/pr-tracking-compass
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7EF64A67-EB1C-4F79-9FF2-1C59DD6146AB][Track PRs per task and surface them in compass where]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Every future task document starts with an empty =* PRs= table so PR
+numbers can be recorded at creation time. The PR creation recipe
+instructs authors to fill the table and to embed story/task UUIDs in
+the PR body for traceability.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                                   |
+| Parent story | [[id:7EF64A67-EB1C-4F79-9FF2-1C59DD6146AB][Track PRs per task and surface them in compass where]] |
+| Now          | Completed.                             |
+| Waiting on   | Nothing.                               |
+| Next         | None.                                  |
+| Last touched | 2026-05-24                             |
+
+* Acceptance
+
+- =v2_doc_task.org.mustache= has a =* PRs= section with a =| PR | Title |= table.
+- =how_do_i_create_a_pr.org= step 2 embeds story/task UUIDs in the PR body.
+- =how_do_i_create_a_pr.org= step 4 instructs recording the PR in the task's =* PRs= table.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+- =projects/ores.codegen/library/templates/v2_doc_task.org.mustache= — =* PRs= section
+  with empty =| PR | Title |= table added before =* Review=.
+- =doc/recipes/github/how_do_i_create_a_pr.org= — step 2 updated to embed
+  =Story: [[id:STORY-UUID]]= / =Task: [[id:TASK-UUID]]= in the PR body; new step 4
+  instructs recording the PR number and title in the task's =* PRs= table immediately
+  after the PR is raised.

--- a/doc/agile/versions/v0/sprint_18/pr_tracking_in_tasks/task_add_prs_table_to_task_template.org
+++ b/doc/agile/versions/v0/sprint_18/pr_tracking_in_tasks/task_add_prs_table_to_task_template.org
@@ -44,9 +44,9 @@ the PR body for traceability.
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR  | Title                                               |
+|-----+-----------------------------------------------------|
+| 816 | [compass,agile] Track PRs per task; compass where --prs |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/pr_tracking_in_tasks/task_implement_compass_where.org
+++ b/doc/agile/versions/v0/sprint_18/pr_tracking_in_tasks/task_implement_compass_where.org
@@ -46,9 +46,9 @@ view=, and prints them grouped by task.
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR  | Title                                               |
+|-----+-----------------------------------------------------|
+| 816 | [compass,agile] Track PRs per task; compass where --prs |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/pr_tracking_in_tasks/task_implement_compass_where.org
+++ b/doc/agile/versions/v0/sprint_18/pr_tracking_in_tasks/task_implement_compass_where.org
@@ -1,0 +1,72 @@
+:PROPERTIES:
+:ID: E9C783F7-955C-4317-8847-9972CB0D9C6D
+:END:
+#+title: Task: Implement compass where with --prs flag
+#+description: Add the where subcommand to compass.py: current version/sprint, STARTED items, and --prs flag fetching PR status via gh.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :compass:python:pr_tracking_in_tasks:sprint_18:v0:
+#+owner: marco
+#+branch: feature/pr-tracking-compass
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7EF64A67-EB1C-4F79-9FF2-1C59DD6146AB][Track PRs per task and surface them in compass where]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+=compass where= reports current version, sprint, and all STARTED
+stories/tasks. With =--prs= it additionally reads each task's =* PRs=
+table, fetches live status for every PR (open and closed) via =gh pr
+view=, and prints them grouped by task.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                                   |
+| Parent story | [[id:7EF64A67-EB1C-4F79-9FF2-1C59DD6146AB][Track PRs per task and surface them in compass where]] |
+| Now          | Completed.                             |
+| Waiting on   | Nothing.                               |
+| Next         | None.                                  |
+| Last touched | 2026-05-24                             |
+
+* Acceptance
+
+- =compass where= / =compass status= lists current version, sprint, and
+  STARTED stories/tasks.
+- =compass where --prs= additionally reads each task's =* PRs= table,
+  fetches live status via =gh pr view=, and displays open and closed PRs.
+- Both =--format pretty= and =--format json= are supported.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+The =where= subcommand was already implemented in the updated
+=projects/ores.compass/src/compass.py= (from the compass-tool PR). This
+task added:
+
+- =parse_prs_table(path)= — reads the =* PRs= org table from a task
+  file; returns =[(pr_number, title)]=.
+- =fetch_pr_statuses(pr_numbers)= — calls =gh pr view --json= for each
+  number; falls back gracefully if =gh= is unavailable.
+- =--prs= argument on the =where= / =status= subparser.
+- Updated =cmd_where= to walk all task files in the current sprint,
+  collect PR records, fetch live status, and render in both pretty and
+  JSON formats.

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -61,6 +61,7 @@ In execution order.
 | [[id:84C10B13-51E2-4D8D-B82A-F38F8DB10E86][Work through all types for ORE Example 1]] | BACKLOG | 2026-05-24 |          | Implement every ORE instrument and market-data type needed for Example 1.                    |
 | [[id:4941A490-0D66-4F09-9B1F-3BC928022A41][Fix instruments not visible in UI]]       | BACKLOG | 2026-05-24 |            | Instruments not showing in UI — investigate import/display path and fix.                     |
 | [[id:B3EBD70C-DAFA-4854-92F3-54E7D90D22C7][Qt: instrument creation in TradeDetailDialog]] | BACKLOG | 2026-05-24 |      | Create/associate instruments directly from TradeDetailDialog.                                |
+| [[id:7EF64A67-EB1C-4F79-9FF2-1C59DD6146AB][Track PRs per task and surface in compass where]] | STARTED | 2026-05-24 |  | PRs table in task docs; =compass where --prs= fetches live PR status via =gh=.               |
 
 * Retrospective
 

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -61,7 +61,7 @@ In execution order.
 | [[id:84C10B13-51E2-4D8D-B82A-F38F8DB10E86][Work through all types for ORE Example 1]] | BACKLOG | 2026-05-24 |          | Implement every ORE instrument and market-data type needed for Example 1.                    |
 | [[id:4941A490-0D66-4F09-9B1F-3BC928022A41][Fix instruments not visible in UI]]       | BACKLOG | 2026-05-24 |            | Instruments not showing in UI — investigate import/display path and fix.                     |
 | [[id:B3EBD70C-DAFA-4854-92F3-54E7D90D22C7][Qt: instrument creation in TradeDetailDialog]] | BACKLOG | 2026-05-24 |      | Create/associate instruments directly from TradeDetailDialog.                                |
-| [[id:7EF64A67-EB1C-4F79-9FF2-1C59DD6146AB][Track PRs per task and surface in compass where]] | STARTED | 2026-05-24 |  | PRs table in task docs; =compass where --prs= fetches live PR status via =gh=.               |
+| [[id:7EF64A67-EB1C-4F79-9FF2-1C59DD6146AB][Track PRs per task and surface in compass where]] | DONE    | 2026-05-24 | 2026-05-24 | PRs table in task docs; =compass where --prs= fetches live PR status via =gh=.          |
 
 * Retrospective
 

--- a/doc/recipes/github/how_do_i_create_a_pr.org
+++ b/doc/recipes/github/how_do_i_create_a_pr.org
@@ -8,7 +8,7 @@
 #+level: cross
 #+filetags: :github:pr:gh:recipe:
 #+created: 2026-05-21
-#+updated: 2026-05-21
+#+updated: 2026-05-24
 
 The body content should be assembled via [[id:1882D6DF-4012-4C6E-BF62-0D943EF805B0][How do I generate a PR
 summary?]] before running the =gh= command here.
@@ -26,8 +26,9 @@ correctly-formatted title and a structured body?
    git push -u origin "$(git branch --show-current)"
    #+end_src
 
-2. /Create the PR/ with =gh pr create=. Use a HEREDOC for the body
-   so newlines are preserved:
+2. /Create the PR/ with =gh pr create=. Embed the story and task
+   =:ID:= UUIDs in the body so =compass where --prs= can surface them
+   later. Use a HEREDOC for the body so newlines are preserved:
 
    #+begin_src sh :results verbatim
    gh pr create --title "[component] One-line description" \
@@ -40,12 +41,25 @@ correctly-formatted title and a structured body?
 
    - First change
    - Second change
+
+   Story: [[id:STORY-UUID]]
+   Task:  [[id:TASK-UUID]]
    EOF
    )"
    #+end_src
 
 3. /Confirm the PR URL/ that =gh= prints; verify the title format
    matches =[COMPONENT] Description=.
+
+4. /Record the PR in the task./ Open the task's =* PRs= table and add
+   a row with the PR number and title. The table carries the canonical
+   record — =compass where --prs= reads it to fetch live status:
+
+   #+begin_example
+   | PR  | Title                         |
+   |-----+-------------------------------|
+   | 123 | [component] One-line description |
+   #+end_example
 
 * Conventions
 
@@ -54,6 +68,8 @@ correctly-formatted title and a structured body?
   use =[a,b,c]=.
 - Body sections may be expanded (Notes, Decisions, Follow-ups), but
   Summary and Changes are the load-bearing pair.
+- /Story/Task UUIDs in the body/ are forward-only: they make PRs
+  discoverable from the task but are not back-filled on old PRs.
 
 * Script
 

--- a/projects/ores.codegen/library/templates/v2_doc_task.org.mustache
+++ b/projects/ores.codegen/library/templates/v2_doc_task.org.mustache
@@ -45,6 +45,12 @@ task closes. Plans do not outlive their task.)
 
 * Notes
 
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
 * Review
 
 | # | Comment summary | File | Decision | Notes |

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -481,6 +481,12 @@ def cmd_debug(args):
 STATE_RE = re.compile(r"^\|\s*State\s*\|\s*([A-Z]+)\s*\|", re.MULTILINE)
 IN_FLIGHT_STATE = "STARTED"
 
+# Matches the body rows of a "* PRs" table. The header row (PR | Title) and
+# separator row are consumed by the leading anchors; each data row must have a
+# numeric PR number in the first cell and a non-empty title in the second.
+_PRS_SECTION_RE = re.compile(r"^\* PRs\s*\n", re.MULTILINE)
+_PRS_ROW_RE = re.compile(r"^\|\s*(\d+)\s*\|\s*([^|\n]+?)\s*\|", re.MULTILINE)
+
 def read_state(path):
     """Return the State value from a doc's Status table, or None if absent."""
     try:
@@ -489,6 +495,53 @@ def read_state(path):
         return None
     match = STATE_RE.search(text)
     return match.group(1) if match else None
+
+def parse_prs_table(path):
+    """Return list of (pr_number: int, title: str) from the task's * PRs table."""
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    section_match = _PRS_SECTION_RE.search(text)
+    if not section_match:
+        return []
+    # Slice from the section heading to the next heading (or EOF)
+    section_start = section_match.end()
+    next_heading = re.search(r"^\*+ ", text[section_start:], re.MULTILINE)
+    section_text = text[section_start: section_start + next_heading.start()] if next_heading else text[section_start:]
+    prs = []
+    for m in _PRS_ROW_RE.finditer(section_text):
+        try:
+            num = int(m.group(1))
+        except ValueError:
+            continue
+        title = m.group(2).strip()
+        if num and title:
+            prs.append((num, title))
+    return prs
+
+def fetch_pr_statuses(pr_numbers):
+    """
+    Fetch live PR state from GitHub for each PR number.
+    Returns {pr_number: {"title": str, "state": str, "url": str}}.
+    Falls back gracefully if gh is unavailable.
+    """
+    import subprocess
+    result = {}
+    for num in sorted(set(pr_numbers)):
+        try:
+            proc = subprocess.run(
+                ["gh", "pr", "view", str(num), "--json", "number,title,state,url"],
+                capture_output=True, text=True, timeout=15,
+            )
+            if proc.returncode == 0:
+                data = json.loads(proc.stdout)
+                result[num] = {"title": data.get("title", ""), "state": data.get("state", ""), "url": data.get("url", "")}
+            else:
+                result[num] = {"title": "", "state": "UNKNOWN", "url": ""}
+        except Exception:
+            result[num] = {"title": "", "state": "UNKNOWN", "url": ""}
+    return result
 
 def _parent_dir(rel_path):
     """Directory holding a doc, as a forward-slash relative string."""
@@ -527,6 +580,20 @@ def cmd_where(args):
                 in_flight.append((d, state))
     in_flight.sort(key=lambda pair: (pair[0].doctype, pair[0].rel_path))
 
+    # --prs: collect PRs from all task files in the current sprint (any state).
+    sprint_prs = []   # list of (pr_number, title, task_doc)
+    pr_statuses = {}  # pr_number -> {title, state, url}
+    if getattr(args, "prs", False):
+        all_tasks = [d for d in docs.values()
+                     if d.doctype == "task" and d.rel_path.startswith(sprint_dir + "/")]
+        all_tasks.sort(key=lambda d: d.rel_path)
+        for d in all_tasks:
+            for pr_num, pr_title in parse_prs_table(d.path):
+                sprint_prs.append((pr_num, pr_title, d))
+        if sprint_prs:
+            all_nums = [pr_num for pr_num, _, _ in sprint_prs]
+            pr_statuses = fetch_pr_statuses(all_nums)
+
     if args.format == "json":
         def entry(d):
             return {"id": d.id.upper(), "title": d.title, "path": d.rel_path}
@@ -539,6 +606,18 @@ def cmd_where(args):
                 for d, state in in_flight
             ],
         }
+        if getattr(args, "prs", False):
+            out["prs"] = [
+                {
+                    "pr": pr_num,
+                    "task_id": td.id.upper(),
+                    "task_title": _strip_type_prefix(td.title),
+                    "title": pr_statuses.get(pr_num, {}).get("title") or pr_title,
+                    "state": pr_statuses.get(pr_num, {}).get("state", "UNKNOWN"),
+                    "url": pr_statuses.get(pr_num, {}).get("url", ""),
+                }
+                for pr_num, pr_title, td in sprint_prs
+            ]
         print(json.dumps(out, indent=2))
         return
 
@@ -554,6 +633,22 @@ def cmd_where(args):
         for d, state in in_flight:
             print(f"  {d.doctype:<5} {_strip_type_prefix(d.title)}")
             print(f"        [{d.id.upper()}]  {d.rel_path}")
+
+    if getattr(args, "prs", False):
+        print(f"\nPRs (sprint {current_sprint.title}):")
+        if not sprint_prs:
+            print("  (no PRs recorded in task * PRs tables)")
+        else:
+            for pr_num, pr_title, td in sprint_prs:
+                info = pr_statuses.get(pr_num, {})
+                live_title = info.get("title") or pr_title
+                state_label = info.get("state", "UNKNOWN")
+                url = info.get("url", "")
+                task_label = _strip_type_prefix(td.title)
+                print(f"  #{pr_num:<5} [{state_label:<6}] {live_title}")
+                print(f"          task: {task_label}")
+                if url:
+                    print(f"          {url}")
 
 def main():
     # `list` and `show` pass every remaining argument straight through to the
@@ -584,6 +679,8 @@ def main():
                                          help="Show where we are: current version, sprint, in-flight work")
     where_parser.add_argument("-f", "--format", choices=["pretty", "json"], default="pretty",
                               help="Output format: pretty (default) or json")
+    where_parser.add_argument("--prs", action="store_true",
+                              help="Also show PRs from all sprint tasks (fetches live status via gh)")
 
     # Registered for discoverability in --help; actually handled by the
     # short-circuit above (which forwards all args to the bundled doc tools).


### PR DESCRIPTION
## Summary

Adds first-class PR tracking to the agile workflow and surfaces it through compass.

## Changes

- `v2_doc_task.org.mustache` — new `* PRs` section with `| PR | Title |` table; every new task document will carry it from generation time.
- `doc/recipes/github/how_do_i_create_a_pr.org` — updated to embed `Story: [[id:UUID]]` / `Task: [[id:UUID]]` in the PR body (step 2) and record the PR number and title in the task's `* PRs` table immediately after raising (new step 4).
- `projects/ores.compass/src/compass.py` — `parse_prs_table()` reads a task's `* PRs` org table; `fetch_pr_statuses()` calls `gh pr view --json` for each PR number; `--prs` flag on `where`/`status` walks all task files in the current sprint, collects PR numbers, and fetches live state (open and closed) via `gh`.

Story: [[id:7EF64A67-EB1C-4F79-9FF2-1C59DD6146AB]]