### PR TITLE
[doc] Add org-roam index links to compass.org folder entries

### DIFF
--- a/doc/agile/versions/v0/sprint_18/compass_org_folder_index_links/story.org
+++ b/doc/agile/versions/v0/sprint_18/compass_org_folder_index_links/story.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: 026AA423-68A1-43A1-8F2A-D9D3D6379E6C
+:END:
+#+title: Story: Add org-roam index links to compass.org folder entries
+#+description: Update doc/compass.org so every folder entry links to its index file; create missing index files where needed.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :docs:compass:navigation:sprint_18:v0:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Every folder entry in =doc/compass.org= links to its index file via an
+org-roam =[[id:UUID][Title]]= reference. Folders that lack an index file get one
+created. The result is that any LLM session reading =compass.org= can
+jump directly to the authoritative inventory of any folder without
+needing to know file names.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | DONE                                   |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                              |
+| Now           | Completed 2026-05-24.                  |
+| Waiting on    | Nothing.                               |
+| Next          | None.                                  |
+| Last touched  | 2026-05-24                             |
+
+* Acceptance
+
+- Every =**= and =***= folder section in =doc/compass.org= contains a
+  prominent org-roam link to the folder's index file.
+- Folders that were missing an index file have one: =meta/=, =analysis/=,
+  =investigations/=, =prompts/=, =samples/=.
+- =investigations/= is added to the folder layout tree in =compass.org=.
+- All new index files have an uppercase =:ID:=, correct frontmatter, and
+  list the folder contents.
+
+* Tasks
+
+In execution order:
+
+- [[id:E1D1F6BC-A69F-478A-8A66-9DDBF62C21FD][Task: Add index links to compass.org and create missing index files]]
+
+* Decisions
+
+- /One "See X for the full index." sentence at the top of each section./
+  Consistent with the pattern already used in =llm/=. Avoids duplicating
+  the index content inside compass.org.
+- /Only folders get index links; individual files (orientation.org) do not./
+  orientation.org is a navigation doc, not an index — it already sits at the
+  top level of the folder layout.
+- /investigations/ added to the compass.org folder tree./ It existed on disk
+  but was absent from compass.org's layout map — a gap that needed closing.
+
+* Out of scope
+
+- Retroactive: existing files without org-roam IDs in =analysis/= are not
+  back-filled. Only files that already have IDs are listed in the index.
+- The content of individual analysis or investigation files is not updated.

--- a/doc/agile/versions/v0/sprint_18/compass_org_folder_index_links/task_add_index_links_to_compass_org.org
+++ b/doc/agile/versions/v0/sprint_18/compass_org_folder_index_links/task_add_index_links_to_compass_org.org
@@ -9,7 +9,7 @@
 #+filetags: :docs:compass:navigation:compass_org_folder_index_links:sprint_18:v0:
 #+owner: marco
 #+branch: feature/compass-index-links
-#+pr:
+#+pr: 817
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-24
@@ -59,9 +59,9 @@ Folders already linked in compass.org before this task (no changes needed):
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR  | Title                                                                |
+|-----+----------------------------------------------------------------------|
+| 817 | [doc] Add org-roam index links to compass.org folder entries |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/compass_org_folder_index_links/task_add_index_links_to_compass_org.org
+++ b/doc/agile/versions/v0/sprint_18/compass_org_folder_index_links/task_add_index_links_to_compass_org.org
@@ -1,0 +1,82 @@
+:PROPERTIES:
+:ID: E1D1F6BC-A69F-478A-8A66-9DDBF62C21FD
+:END:
+#+title: Task: Add index links to compass.org and create missing index files
+#+description: Wire each folder entry in doc/compass.org to its org-roam index file; scaffold any missing index docs.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :docs:compass:navigation:compass_org_folder_index_links:sprint_18:v0:
+#+owner: marco
+#+branch: feature/compass-index-links
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:026AA423-68A1-43A1-8F2A-D9D3D6379E6C][Add org-roam index links to compass.org folder entries]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+For every folder section in =doc/compass.org=, add a prominent org-roam
+link to the folder's index file. Create the five missing index files
+(=meta/=, =analysis/=, =investigations/=, =prompts/=, =samples/=) and add
+=investigations/= to the compass.org layout tree.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                                   |
+| Parent story | [[id:026AA423-68A1-43A1-8F2A-D9D3D6379E6C][Add org-roam index links to compass.org folder entries]] |
+| Now          | Completed.                             |
+| Waiting on   | Nothing.                               |
+| Next         | None.                                  |
+| Last touched | 2026-05-24                             |
+
+* Acceptance
+
+- =doc/compass.org= — every folder section has a "See [[id:UUID][Title]] for the full
+  index." sentence.
+- =doc/meta/meta.org= — new index listing the 5 contract docs.
+- =doc/analysis/analysis.org= — new index listing analysis files with IDs.
+- =doc/investigations/investigations.org= — new index listing investigation docs.
+- =doc/prompts/prompts.org= — new empty index placeholder.
+- =doc/samples/samples.org= — new index listing all image assets.
+- =investigations/= added to the folder layout tree in =compass.org=.
+
+* Notes
+
+Folders already linked in compass.org before this task (no changes needed):
+- =identity/= → [[id:2F71292F-CDB0-4E2E-B50F-4F02E10597C4][ORE Studio]] (product_identity.org is the index)
+- =functions/= → [[id:1A5E0079-5771-4213-B624-62FA9AC947B4][index page]] (functions.org)
+- =llm/= → [[id:94F9949A-1580-4D47-9331-AA0597543C99][LLM Configuration and Artefacts]]
+- =llm/skills/= → [[id:2003934B-ED05-D114-404B-08C0E0D844BB][Claude Code Skills]]
+- =llm/memory/= → [[id:DC0BBA22-9D4F-4FDD-B011-E30B02B4B82F][Project memory]]
+- =manual/user_guide/= → [[id:6A1A333C-A83A-8954-B9C3-C3AB1AEC3046][ORE Studio User Manual]]
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+- =doc/meta/meta.org= [[[id:82F08C3E-D00F-4888-8C11-CC4358AA9FB7][82F08C3E]]] — created; lists the 5 contract docs.
+- =doc/analysis/analysis.org= [[[id:E5DE23FF-8FE6-4B90-BD5A-F19F26D05737][E5DE23FF]]] — created; lists 5 files with IDs.
+- =doc/investigations/investigations.org= [[[id:249FEDB9-7010-4124-A593-A01160E4B56E][249FEDB9]]] — created; lists 1 file.
+- =doc/prompts/prompts.org= [[[id:9E971D53-0501-4B56-AD85-037057E295D8][9E971D53]]] — created; placeholder (empty folder).
+- =doc/samples/samples.org= [[[id:49FBC025-4B13-47E3-AC85-C86A81CA3056][49FBC025]]] — created; lists all image assets.
+- =doc/compass.org= — added "See [[id:UUID][Title]]" reference to: =meta/=, =agile/=,
+  =agile/versions/=, =agile/product_backlog/=, =recipes/=, =knowledge/=,
+  =plans/=, =prompts/=, =samples/=, =analysis/=, =investigations/=.
+  Added =investigations/= to the folder layout tree.

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -62,6 +62,7 @@ In execution order.
 | [[id:4941A490-0D66-4F09-9B1F-3BC928022A41][Fix instruments not visible in UI]]       | BACKLOG | 2026-05-24 |            | Instruments not showing in UI — investigate import/display path and fix.                     |
 | [[id:B3EBD70C-DAFA-4854-92F3-54E7D90D22C7][Qt: instrument creation in TradeDetailDialog]] | BACKLOG | 2026-05-24 |      | Create/associate instruments directly from TradeDetailDialog.                                |
 | [[id:7EF64A67-EB1C-4F79-9FF2-1C59DD6146AB][Track PRs per task and surface in compass where]] | DONE    | 2026-05-24 | 2026-05-24 | PRs table in task docs; =compass where --prs= fetches live PR status via =gh=.          |
+| [[id:026AA423-68A1-43A1-8F2A-D9D3D6379E6C][Add org-roam index links to compass.org folder entries]] | DONE | 2026-05-24 | 2026-05-24 | Each folder in compass.org links to its index file; missing index files created. |
 
 * Retrospective
 

--- a/doc/analysis/analysis.org
+++ b/doc/analysis/analysis.org
@@ -1,0 +1,20 @@
+:PROPERTIES:
+:ID: E5DE23FF-8FE6-4B90-BD5A-F19F26D05737
+:END:
+#+title: Analysis
+#+description: Index of one-off historical analyses — architecture, entity design, Qt patterns, and early explorations.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :analysis:index:knowledge:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+
+One-off analyses from earlier development phases. Not actively maintained but
+retained as background context. For ongoing design decisions see [[id:6E09902A-5D78-4697-9934-F818073FA5D9][Plans]].
+
+- [[id:6F1A8C2E-9A4D-4F71-B6E0-2D5C8B9E7A41][Bootstrap, Role Lifecycle and Architecture Violations]] — early architecture audit.
+- [[id:A3F8C2D1-7E4B-4F9A-B2C5-8D1E6A3F0B7C][Entity Coverage Matrix]] — entity type tracking across the stack.
+- [[id:A3F9B2C1-4E72-4D8A-B1C5-F2A73E9D0456][ORE Studio Qt Plugin Architecture Analysis]] — plugin model evaluation.
+- [[id:B7E4D1F3-9A2C-4B8E-C3D6-E5F8A1B2C4D7][ORE Studio Qt Plugin Refactor — Implementation Plan]] — refactor plan for the plugin layer.
+- [[id:9A2F3B14-2E4C-11F0-C7D2-50A1879125FC][WSL DB Permission Errors: Cross-Service Grant Investigation]] — WSL-specific database permission issues.

--- a/doc/compass.org
+++ b/doc/compass.org
@@ -8,7 +8,7 @@
 #+level: cross
 #+filetags: :meta:overview:entry_point:
 #+created: 2026-05-18
-#+updated: 2026-05-21
+#+updated: 2026-05-24
 
 This is the entry point for the [[id:2F71292F-CDB0-4E2E-B50F-4F02E10597C4][ORE Studio]] cybernetic information architecture
 and the top-level orientation for the =doc/= tree. Read it first on a new
@@ -38,13 +38,14 @@ doc/
 ├── manual/               ← user-facing PDF/LaTeX manual
 ├── prompts/              ← reusable LLM prompts
 ├── samples/              ← screenshots and product imagery
-└── analysis/             ← older one-off analyses (v1, mostly historical)
+├── analysis/             ← older one-off analyses (v1, mostly historical)
+└── investigations/       ← targeted deep-dive investigations
 #+end_example
 
 ** =meta/= — how documents are shaped
 
-The five contract documents. Read in order on first contact; refer
-back to individual ones as needed.
+See [[id:82F08C3E-D00F-4888-8C11-CC4358AA9FB7][Meta]] for the full index. The five contract documents, read in order on
+first contact; refer back to individual ones as needed.
 
 1. [[id:47341FC6-B8FB-499E-AAE0-F4EE0ABFDA05][Glossary]] — what we mean by [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]], [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]], [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprint]], [[id:CA4D4BDE-2EAB-4F0A-BC8B-7C0BCB17BC82][version]], [[id:66F2A9E8-0385-4D56-B4B1-0957208990DC][function]], [[id:58D491A6-E4BD-4B0D-86BD-BB8465DFD4C7][plan]],
    [[id:117A95F9-B03D-490B-BB74-DA9FE74537E2][recipe]] and many other such terms. This is not a ORE Studio glossary --- for
@@ -60,11 +61,15 @@ back to individual ones as needed.
 
 ** =agile/=: the operational tree
 
+See [[id:E5635EAC-CCE9-C0A4-A00B-C1780FF4A88E][Agile]] for the full index.
+
 Everything related to the rolling agile process: versions of the product, their
 sprints, the stories and tasks that compose them, and the product backlog of
 pre-sprint ideas.
 
 *** =agile/versions/=: the composition tree
+
+See [[id:37C10313-E6E9-4D42-B82D-B6758D0A3AD9][Versions]] for the full index.
 
 Where the operational documents live. Path shape:
 
@@ -80,6 +85,8 @@ Stories and sprints are folders (they contain children); tasks are flat files
 
 *** =agile/product_backlog/=: the pre-sprint queue
 
+See [[id:D4219199-7B17-4A89-B4BC-6019738642DA][Product backlog]] for the full index.
+
 Holds [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][captures]] — ideas not yet pulled into a sprint as stories. Split into two
 buckets:
 
@@ -92,12 +99,17 @@ preserved so links keep working.
 
 ** =recipes/=: how do I do X?
 
+See [[id:46F5ED07-9E63-77B4-2783-E0147EFF45D0][Recipes]] for the full index.
+
 Short, tested, executable how-tos grouped by topic
 (=recipes/<topic>/how_do_i_xxx.org=). Each recipe answers one NLP question.
 Shell commands inside =#+begin_src sh :results verbatim= blocks so they run in place via
 =C-c C-c=.
 
 ** =knowledge/=: durable reference
+
+See [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] for the full index; external reference docs are under
+[[id:CF2C4F3A-9C5C-4E7A-9E16-2A3A8C1D4C11][External knowledge]].
 
 Cross-cutting knowledge that outlives any sprint. Lives under
 =knowledge/<topic>/=. Component-specific knowledge (e.g. an architecture
@@ -130,19 +142,21 @@ See [[id:94F9949A-1580-4D47-9331-AA0597543C99][LLM Configuration and Artefacts]]
 
 ** Secondary folders
 
-- =plans/= — historical design plans, one =YYYY-MM-DD-name.org= per plan. Plans
-  inside a sprint live as the =* Plan= section of the task/story; this folder is
-  for one-off cross-cutting designs retained for the record.
+- =plans/= ([[id:6E09902A-5D78-4697-9934-F818073FA5D9][Plans]]) — historical design plans, one =YYYY-MM-DD-name.org= per plan.
+  Plans inside a sprint live as the =* Plan= section of the task/story; this
+  folder is for one-off cross-cutting designs retained for the record.
 - =manual/= — user-facing manual. The root file is
   [[id:6A1A333C-A83A-8954-B9C3-C3AB1AEC3046][ORE Studio User Manual]] at
   =manual/user_guide/user_manual.org=; chapters live under
   =manual/user_guide/chapters/=. Surfaced to end users, not part of the
   developer-doc tree.
-- =prompts/= — reusable LLM prompts that don't fit cleanly as a [[id:4F6384FE-CDE9-40F6-B13D-8A84B6CD77F7][skill]].
-- =samples/= — screenshots and product imagery referenced from [[id:2F71292F-CDB0-4E2E-B50F-4F02E10597C4][product identity]]
-  and visual mockups.
-- =analysis/= — older one-off analyses from before v2. Some still useful as
-  background context; not actively maintained.
+- =prompts/= ([[id:9E971D53-0501-4B56-AD85-037057E295D8][Prompts]]) — reusable LLM prompts that don't fit cleanly as a [[id:4F6384FE-CDE9-40F6-B13D-8A84B6CD77F7][skill]].
+- =samples/= ([[id:49FBC025-4B13-47E3-AC85-C86A81CA3056][Samples]]) — screenshots and product imagery referenced from
+  [[id:2F71292F-CDB0-4E2E-B50F-4F02E10597C4][product identity]] and visual mockups.
+- =analysis/= ([[id:E5DE23FF-8FE6-4B90-BD5A-F19F26D05737][Analysis]]) — older one-off analyses from before v2. Some still
+  useful as background context; not actively maintained.
+- =investigations/= ([[id:249FEDB9-7010-4124-A593-A01160E4B56E][Investigations]]) — targeted deep-dive investigations into
+  specific technical problems.
 
 ** Reserved folders
 

--- a/doc/investigations/investigations.org
+++ b/doc/investigations/investigations.org
@@ -1,0 +1,18 @@
+:PROPERTIES:
+:ID: 249FEDB9-7010-4124-A593-A01160E4B56E
+:END:
+#+title: Investigations
+#+description: Index of targeted deep-dive investigations into specific technical problems.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :investigations:index:knowledge:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+
+Targeted investigations into specific technical problems encountered during
+development. Each is a focused deep-dive capturing the problem, findings,
+and resolution.
+
+- [[id:D75F4921-B431-4E78-99AB-62A47F761D1D][Investigation: MSVC C1202 and rfl complexity]] — MSVC C1202 and Clang
+  expression nesting limits caused by =rfl= reflection depth.

--- a/doc/meta/meta.org
+++ b/doc/meta/meta.org
@@ -1,0 +1,23 @@
+:PROPERTIES:
+:ID: 82F08C3E-D00F-4888-8C11-CC4358AA9FB7
+:END:
+#+title: Meta
+#+description: Index of the document-contract docs — the rules every document in the graph follows.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :meta:index:knowledge:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+
+The document contract for the entire [[id:B69989F6-19E1-430D-AC6D-B2416E4C433F][ORE Studio]] information graph. Every
+document in =doc/= follows the rules defined here. Read in order on first
+contact; refer back to individual entries as needed.
+
+1. [[id:47341FC6-B8FB-499E-AAE0-F4EE0ABFDA05][Glossary]] — what we mean by [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]], [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]], [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprint]], [[id:CA4D4BDE-2EAB-4F0A-BC8B-7C0BCB17BC82][version]], [[id:66F2A9E8-0385-4D56-B4B1-0957208990DC][function]],
+   [[id:58D491A6-E4BD-4B0D-86BD-BB8465DFD4C7][plan]], [[id:117A95F9-B03D-490B-BB74-DA9FE74537E2][recipe]], and many other architectural terms.
+2. [[id:926B916E-A57E-498E-99AB-720B583C0362][Cybernetic levels]] — the five levels of concern and what each is responsible for.
+3. [[id:8B29A8D8-E004-4E87-B81D-ABEAF68F2B98][Document types]] — every document type, its frontmatter contract, filename
+   convention, and required sections.
+4. [[id:8810E0F9-C5B9-4CFA-A710-774AD6C771DD][Lifecycle]] — =TODO= state transitions and where each state lives.
+5. [[id:F58CA9E7-C65F-4D17-A9A7-95FDE25B9EBD][Execution model]] — how LLMs and agents operate inside this system.

--- a/doc/prompts/prompts.org
+++ b/doc/prompts/prompts.org
@@ -1,0 +1,15 @@
+:PROPERTIES:
+:ID: 9E971D53-0501-4B56-AD85-037057E295D8
+:END:
+#+title: Prompts
+#+description: Index of reusable LLM prompts — standalone prompts that don't fit cleanly as a skill.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :prompts:index:knowledge:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+
+Reusable LLM prompts that are too short or situational to warrant a full
+[[id:4F6384FE-CDE9-40F6-B13D-8A84B6CD77F7][skill]] but are worth capturing for repeated use. Currently empty; prompts
+are added here as they are identified.

--- a/doc/samples/samples.org
+++ b/doc/samples/samples.org
@@ -1,0 +1,24 @@
+:PROPERTIES:
+:ID: 49FBC025-4B13-47E3-AC85-C86A81CA3056
+:END:
+#+title: Samples
+#+description: Index of screenshots and product imagery referenced from product identity and visual mockups.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :samples:index:knowledge:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+
+Screenshots and product imagery referenced from [[id:2F71292F-CDB0-4E2E-B50F-4F02E10597C4][product identity]] and visual
+mockups. These are static image assets; this index documents what they depict.
+
+- =BitMex-Screen.png= — BitMex trading interface reference.
+- =channel_analytics_dashboard.png=, =client_dashboard.png= — dashboard reference designs.
+- =gnucash_new_hierarchy_setup_*.png= — GnuCash account hierarchy workflow screenshots.
+- =crypto_*.png/jpeg=, =spread_dashboard*.png= — market trading interface references.
+- =QDirStat-main-win.png= — file system visualisation reference.
+- =quadra_*.png= — Quadra trading platform reference screens.
+- =sample_pnl_screen.png= — P&L display reference.
+- =world_map_statistics.png=, =nanex_order_depth_3d.jpg= — data visualisation references.
+- =thesium_desk.png= — desk/workspace reference image.


### PR DESCRIPTION
## Summary

- Every folder section in `doc/compass.org` now has a "See [[id:UUID][Title]]" org-roam link to its index file
- Created five missing index files: `doc/meta/meta.org`, `doc/analysis/analysis.org`, `doc/investigations/investigations.org`, `doc/prompts/prompts.org`, `doc/samples/samples.org`
- Added `investigations/` to the folder layout tree in `compass.org` (it existed on disk but was absent from the map)
- Added story and task docs for this work under `sprint_18/compass_org_folder_index_links/`

Story: [[id:026AA423-68A1-43A1-8F2A-D9D3D6379E6C]]
Task: [[id:E1D1F6BC-A69F-478A-8A66-9DDBF62C21FD]]

## Test plan

- [ ] Check that `doc/compass.org` renders correctly in Org — each folder section has a visible index link
- [ ] Verify all new index files have uppercase `:ID:` values and correct `#+type: knowledge` frontmatter
- [ ] Confirm `investigations/` appears in both the layout tree and the Secondary folders section

🤖 Generated with [Claude Code](https://claude.com/claude-code)