### PR TITLE
Add Manuals index page and site nav link

### DIFF
--- a/.build-site.el
+++ b/.build-site.el
@@ -128,6 +128,7 @@
     <a href='/OreStudio/projects/modeling/system_model.html'>Architecture</a>
     <a href='/OreStudio/doc/recipes/recipes.html'>Recipes</a>
     <a href='/OreStudio/doc/llm/skills/claude_code_skills.html'>Skills</a>
+    <a href='/OreStudio/doc/manual/manuals.html'>Manuals</a>
     <a href='/OreStudio/doc/agile/versions/versions.html'>Roadmap</a>
     <a href='/OreStudio/graph/index.html'>Knowledge Graph</a>
     <a href='https://github.com/OreStudio/OreStudio' aria-label='GitHub' title='GitHub'><i class='fab fa-github'></i></a>

--- a/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/story.org
+++ b/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/story.org
@@ -26,9 +26,9 @@ build themselves.
 |---------------+----------------------------------------|
 | State         | STARTED                                |
 | Parent sprint | [[id:1737c00c-699a-475a-bc94-743c6cda1001][Sprint 18]] |
-| Now           | Chapter 1 (login/connection manager) merged in PR #811. System bootstrapping concepts + manual-updater skill pushed on feature/user-manual-system-bootstrapping (PR pending). |
-| Waiting on    | PR review for system bootstrapping concepts branch. Screenshots for all TODO_ placeholders. |
-| Next          | Raise PR for feature/user-manual-system-bootstrapping; capture screenshots. |
+| Now           | All core tasks done. PRs #807, #810, #811, #814 merged. Manuals index page + site nav link in PR #818 (open). |
+| Waiting on    | PR #818 review and merge. Screenshots for all TODO_ placeholders in chapters. |
+| Next          | Merge PR #818; capture screenshots per placeholder instructions. |
 | Last touched  | 2026-05-24                               |
 
 * Acceptance
@@ -44,9 +44,10 @@ In execution order:
 
 - [[id:30AFB759-D3F2-4DD9-A5C7-209735F35B38][Task: User manual restructure]] (DONE — PR #807; prerequisite for PDF build)
 - [[id:001f63b6-c4e8-4dd2-b680-364393b15d51][Task: Add CMake target to build user manual PDF and commit it]] (DONE — PR #810)
-- [[id:63BF06CF-B61E-4163-A017-0E2D13586510][Task: Write Chapter 1: Login and Connection Manager]] (PR #811)
-- [[id:4834460E-0799-4379-ADD7-462A4BCF9FDF][Task: Write Chapter 1: System bootstrapping concepts and provisioning wizards]]
-- [[id:29379454-1B29-4BB5-905D-F129E0AC41FD][Task: Create documentation update skill]]
+- [[id:63BF06CF-B61E-4163-A017-0E2D13586510][Task: Write Chapter 1: Login and Connection Manager]] (DONE — PR #811)
+- [[id:4834460E-0799-4379-ADD7-462A4BCF9FDF][Task: Write Chapter 1: System bootstrapping concepts and provisioning wizards]] (DONE — PR #814)
+- [[id:29379454-1B29-4BB5-905D-F129E0AC41FD][Task: Create documentation update skill]] (DONE — PR #814)
+- Manuals index page and site nav link (PR #818)
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_chapter_01_system_bootstrapping_concepts.org
+++ b/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_chapter_01_system_bootstrapping_concepts.org
@@ -29,11 +29,11 @@ Party Provisioner), with screenshot placeholders throughout.
 
 | Field        | Value                                                       |
 |--------------+-------------------------------------------------------------|
-| State        | STARTED                                                     |
+| State        | DONE                                                        |
 | Parent story | [[id:C42C3563-671F-4721-8CE8-5EE05925255F][Build and publish user manual PDF via CMake]] |
-| Now          | Writing chapter content.                                    |
-| Waiting on   | Nothing.                                                    |
-| Next         | Author takes screenshots per placeholders; rebuild PDF.     |
+| Now          | Merged in PR #814.                                          |
+| Waiting on   | Screenshots from author per placeholder instructions.       |
+| Next         | —                                                           |
 | Last touched | 2026-05-24                                                  |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_create_documentation_update_skill.org
+++ b/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_create_documentation_update_skill.org
@@ -9,7 +9,7 @@
 #+filetags: :doc:manual:skill:llm:user_manual_pdf_build:sprint_18:v0:
 #+owner: marco
 #+branch: feature/user-manual-system-bootstrapping
-#+pr:
+#+pr: 814
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-24

--- a/doc/analysis/bootstrap-and-architecture-violations.org
+++ b/doc/analysis/bootstrap-and-architecture-violations.org
@@ -602,3 +602,8 @@ Track A from Part 4 has been implemented (mandatory role drops in
 | IAM bootstrap-mode service         | ~projects/ores.iam.core/src/service/bootstrap_mode_service.cpp~ |
 | RBAC design                        | ~doc/plans/2026-03-28-service-rbac-design.org~              |
 | WSL investigation (predecessor)    | ~doc/analysis/wsl-db-permission-investigation.org~          |
+
+* See also
+
+- [[id:A9F2C3E1-74B5-4D8A-9C6E-3B1F7D2E5A04][System Bootstrapping Concepts and Provisioning]] — user-facing
+  walkthrough of the bootstrap sequence and provisioning wizards.

--- a/doc/manual/manuals.org
+++ b/doc/manual/manuals.org
@@ -18,7 +18,7 @@ perspective: how to connect to a backend, manage connections, bootstrap
 the system, provision tenants and parties, enter trades, and run
 analytics.
 
-- [[file:user_guide/user_manual.org][Read online]] | [[file:user_guide/user_manual.pdf][Download PDF]]
+- [[id:6A1A333C-A83A-8954-B9C3-C3AB1AEC3046][Read online]] | [[file:user_guide/user_manual.pdf][Download PDF]]
 
 * Developer Guide
 

--- a/doc/manual/manuals.org
+++ b/doc/manual/manuals.org
@@ -1,0 +1,32 @@
+:PROPERTIES:
+:ID: 914738C6-7C77-41CD-A949-55DBBE0B6908
+:END:
+#+title: ORE Studio Manuals
+#+description: Index of all ORE Studio manuals and guides.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :knowledge:manual:index:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:nil
+
+* User Manual
+
+The [[id:6A1A333C-A83A-8954-B9C3-C3AB1AEC3046][ORE Studio User Manual]] documents the application from the end-user
+perspective: how to connect to a backend, manage connections, bootstrap
+the system, provision tenants and parties, enter trades, and run
+analytics.
+
+- [[file:user_guide/user_manual.org][Read online]] | [[file:user_guide/user_manual.pdf][Download PDF]]
+
+* Developer Guide
+
+Coming soon. Will cover the development environment setup, build
+system, coding conventions, testing strategy, and contribution
+workflow.
+
+* See also
+
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the full documentation graph.
+- [[id:1A5E0079-5771-4213-B624-62FA9AC947B4][Functions]] — component and service documentation.

--- a/doc/plans/2026-02-09-party-isolation-and-tenant-types-design.org
+++ b/doc/plans/2026-02-09-party-isolation-and-tenant-types-design.org
@@ -332,3 +332,11 @@ None at this time. The following items are deferred to separate stories:
 - Self-registration and approval workflow for production tenants.
 - Single-tenant mode implementation.
 - Party selection protocol changes (login flow extension).
+
+* See also
+
+- [[id:A9F2C3E1-74B5-4D8A-9C6E-3B1F7D2E5A04][System Bootstrapping Concepts and Provisioning]] — user-facing
+  explanation of tenants, tenant types, parties, party hierarchy, and
+  the provisioning wizards (System Provisioner, Tenant Provisioner,
+  Party Provisioner).
+- [[id:914738C6-7C77-41CD-A949-55DBBE0B6908][ORE Studio Manuals]] — index of all user and developer guides.


### PR DESCRIPTION
## Summary

- Adds `doc/manual/manuals.org` as the top-level index for all ORE Studio manuals (User Manual now; Developer Guide placeholder for the future), with online and PDF download links
- Adds a "Manuals" entry to the site navigation bar in `.build-site.el`
- Adds "See also" sections in `doc/plans/2026-02-09-party-isolation-and-tenant-types-design.org` and `doc/analysis/bootstrap-and-architecture-violations.org`, linking back to the user manual chapter that describes tenants, parties, and the provisioning wizards

## Test plan

- [ ] Verify site builds and "Manuals" link appears in the nav on all pages
- [ ] Confirm `manuals.org` renders with working links to the user manual HTML and PDF
- [ ] Confirm "See also" org-roam links resolve correctly in the knowledge graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)