### PR TITLE
[ores.qt.api] Implement triple isolation for RFL complexity

### DIFF
--- a/doc/agile/versions/v0/sprint_18/rfl_complexity_resolution/story.org
+++ b/doc/agile/versions/v0/sprint_18/rfl_complexity_resolution/story.org
@@ -22,12 +22,11 @@ Permanently resolve the compilation failures in =ores.qt.api= on Windows (MSVC C
 | Field         | Value                                  |
 |---------------+----------------------------------------|
 | State         | STARTED                                |
-| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]] |
-
-| Now           | Investigation complete; planning implementation. |
-| Waiting on    | Nothing.                               |
-| Next          | Implement triple isolation strategy.   |
-| Last touched  | 2026-05-23                           |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                              |
+| Now           | PR #819 raised; awaiting CI validation. |
+| Waiting on    | Windows CI build confirmation.          |
+| Next          | Merge PR 819; close story.              |
+| Last touched  | 2026-05-24                              |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_18/rfl_complexity_resolution/task_implement_triple_isolation.org
+++ b/doc/agile/versions/v0/sprint_18/rfl_complexity_resolution/task_implement_triple_isolation.org
@@ -8,7 +8,7 @@
 #+level: s1
 #+filetags: :refactor:build:reflect_cpp:rfl_complexity_resolution:sprint_18:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/rfl-complexity-isolation
 #+pr:
 #+blocked_on: none
 #+blocked_since:
@@ -26,12 +26,12 @@ Apply the structural isolation strategy to permanently fix compilation failures 
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                                |
+| State        | STARTED                                |
 | Parent story | [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D8][Resolve RFL complexity issues]] |
-| Now          | Not yet started.                       |
+| Now          | Implementation in progress.            |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation of TU split.      |
-| Last touched | 2026-05-23                               |
+| Next         | Step 1: increase Clang bracket depth.  |
+| Last touched | 2026-05-24                             |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_18/rfl_complexity_resolution/task_implement_triple_isolation.org
+++ b/doc/agile/versions/v0/sprint_18/rfl_complexity_resolution/task_implement_triple_isolation.org
@@ -9,7 +9,7 @@
 #+filetags: :refactor:build:reflect_cpp:rfl_complexity_resolution:sprint_18:v0:
 #+owner: marco
 #+branch: feature/rfl-complexity-isolation
-#+pr:
+#+pr: 819
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-23
@@ -47,6 +47,18 @@ Apply the structural isolation strategy to permanently fix compilation failures 
 3.  **Perform TU Split**: Move =getTradeDetail= from =ClientManagerTrades.cpp= to =ClientManagerTradeDetail.cpp=.
 4.  **Implement Two-Phase Parse**: Refactor the isolated =getTradeDetail= to perform two separate =rfl::json::read= calls.
 5.  **Validate**: Verify the build on all target platforms.
+
+* PRs
+
+| PR  | Title                                                     |
+|-----+-----------------------------------------------------------|
+| 819 | [ores.qt.api] Implement triple isolation for RFL complexity |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_18/rfl_complexity_resolution/task_implement_triple_isolation.org
+++ b/doc/agile/versions/v0/sprint_18/rfl_complexity_resolution/task_implement_triple_isolation.org
@@ -28,10 +28,10 @@ Apply the structural isolation strategy to permanently fix compilation failures 
 |--------------+----------------------------------------|
 | State        | STARTED                                |
 | Parent story | [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D8][Resolve RFL complexity issues]] |
-| Now          | Implementation in progress.            |
-| Waiting on   | Nothing.                               |
-| Next         | Step 1: increase Clang bracket depth.  |
-| Last touched | 2026-05-24                             |
+| Now          | PR #819 raised; awaiting CI validation. |
+| Waiting on   | Windows CI build confirmation.          |
+| Next         | Merge PR 819 after CI passes.           |
+| Last touched | 2026-05-24                              |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_18/rfl_complexity_resolution/task_implement_triple_isolation.org
+++ b/doc/agile/versions/v0/sprint_18/rfl_complexity_resolution/task_implement_triple_isolation.org
@@ -56,9 +56,9 @@ Apply the structural isolation strategy to permanently fix compilation failures 
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                          | File                          | Decision | Notes                                                         |
+|---+------------------------------------------+-------------------------------+----------+---------------------------------------------------------------|
+| 1 | Phase 2 silently ignores parse failure   | ClientManagerTradeDetail.cpp  | Applied  | Now returns std::nullopt + logs error; matches original behaviour. Fixed in dc0c653f5. |
 
 * Notes
 

--- a/projects/ores.qt.api/src/ClientManagerTradeDetail.cpp
+++ b/projects/ores.qt.api/src/ClientManagerTradeDetail.cpp
@@ -1,0 +1,79 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2025 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include "ores.qt/ClientManager.hpp"
+
+namespace ores::qt {
+
+using namespace ores::logging;
+
+// Two-phase parse: phase 1 reflects only trade (a flat struct); phase 2
+// reflects only trade_instrument (the variant) with AddTagsToVariants.
+// Keeping them in separate TUs prevents the compiler from having to
+// instantiate both reflection passes simultaneously — the combination that
+// triggers MSVC C1202 and Clang bracket-depth limits.
+std::optional<trading::messaging::trade_export_item>
+ClientManager::getTradeDetail(const std::string& trade_id) {
+    try {
+        trading::messaging::get_trade_detail_request request;
+        request.trade_id = trade_id;
+        const auto raw = send_authenticated_request(
+            trading::messaging::get_trade_detail_request::nats_subject,
+            rfl::json::write(request),
+            std::chrono::seconds(30));
+
+        // Phase 1: parse success/message/trade — no variant, no AddTagsToVariants.
+        auto base = rfl::json::read<
+            trading::messaging::get_trade_detail_response_base>(raw);
+        if (!base) {
+            BOOST_LOG_SEV(lg(), error)
+                << "getTradeDetail deserialize error: " << base.error().what();
+            return std::nullopt;
+        }
+        if (!base->success) {
+            BOOST_LOG_SEV(lg(), error)
+                << "getTradeDetail server error: " << base->message;
+            return std::nullopt;
+        }
+
+        // Phase 2: parse instrument variant — isolated from trade reflection.
+        trading::domain::trade_instrument instrument;
+        auto wrapper = rfl::json::read<
+            trading::messaging::get_trade_detail_instrument_wrapper,
+            rfl::AddTagsToVariants>(raw);
+        if (wrapper)
+            instrument = std::move(wrapper->instrument);
+
+        return trading::messaging::trade_export_item{
+            .trade = std::move(base->trade),
+            .instrument = std::move(instrument)
+        };
+    } catch (const ores::nats::service::nats_connect_error&) {
+        throw;
+    } catch (const ores::nats::service::session_expired_error& e) {
+        BOOST_LOG_SEV(lg(), warn) << "Session expired: " << e.what();
+        QMetaObject::invokeMethod(this, [this] { emit sessionExpired(); }, Qt::QueuedConnection);
+        return std::nullopt;
+    } catch (const std::exception& e) {
+        BOOST_LOG_SEV(lg(), error) << "getTradeDetail failed: " << e.what();
+        return std::nullopt;
+    }
+}
+
+}

--- a/projects/ores.qt.api/src/ClientManagerTradeDetail.cpp
+++ b/projects/ores.qt.api/src/ClientManagerTradeDetail.cpp
@@ -53,16 +53,19 @@ ClientManager::getTradeDetail(const std::string& trade_id) {
         }
 
         // Phase 2: parse instrument variant — isolated from trade reflection.
-        trading::domain::trade_instrument instrument;
         auto wrapper = rfl::json::read<
             trading::messaging::get_trade_detail_instrument_wrapper,
             rfl::AddTagsToVariants>(raw);
-        if (wrapper)
-            instrument = std::move(wrapper->instrument);
+        if (!wrapper) {
+            BOOST_LOG_SEV(lg(), error)
+                << "getTradeDetail instrument deserialize error: "
+                << wrapper.error().what();
+            return std::nullopt;
+        }
 
         return trading::messaging::trade_export_item{
             .trade = std::move(base->trade),
-            .instrument = std::move(instrument)
+            .instrument = std::move(wrapper->instrument)
         };
     } catch (const ores::nats::service::nats_connect_error&) {
         throw;

--- a/projects/ores.qt.api/src/ClientManagerTrades.cpp
+++ b/projects/ores.qt.api/src/ClientManagerTrades.cpp
@@ -62,44 +62,4 @@ std::optional<TradeListResult> ClientManager::listTrades(
     }
 }
 
-std::optional<trading::messaging::trade_export_item>
-ClientManager::getTradeDetail(const std::string& trade_id) {
-    try {
-        trading::messaging::get_trade_detail_request request;
-        request.trade_id = trade_id;
-        const auto raw = send_authenticated_request(
-            trading::messaging::get_trade_detail_request::nats_subject,
-            rfl::json::write(request),
-            std::chrono::seconds(30));
-
-        auto resp = rfl::json::read<
-            trading::messaging::get_trade_detail_response,
-            rfl::AddTagsToVariants>(raw);
-        if (!resp) {
-            BOOST_LOG_SEV(lg(), error)
-                << "getTradeDetail deserialize error: " << resp.error().what();
-            return std::nullopt;
-        }
-        if (!resp->success) {
-            BOOST_LOG_SEV(lg(), error)
-                << "getTradeDetail server error: " << resp->message;
-            return std::nullopt;
-        }
-
-        return trading::messaging::trade_export_item{
-            .trade = std::move(resp->trade),
-            .instrument = std::move(resp->instrument)
-        };
-    } catch (const ores::nats::service::nats_connect_error&) {
-        throw;
-    } catch (const ores::nats::service::session_expired_error& e) {
-        BOOST_LOG_SEV(lg(), warn) << "Session expired: " << e.what();
-        QMetaObject::invokeMethod(this, [this] { emit sessionExpired(); }, Qt::QueuedConnection);
-        return std::nullopt;
-    } catch (const std::exception& e) {
-        BOOST_LOG_SEV(lg(), error) << "getTradeDetail failed: " << e.what();
-        return std::nullopt;
-    }
-}
-
 }

--- a/projects/ores.trading.api/include/ores.trading.api/messaging/trade_protocol.hpp
+++ b/projects/ores.trading.api/include/ores.trading.api/messaging/trade_protocol.hpp
@@ -88,6 +88,19 @@ struct get_trade_detail_response {
     ores::trading::domain::trade_instrument instrument;
 };
 
+// Two-phase parse helpers: split the single rfl::AddTagsToVariants pass into
+// two smaller ones so no TU has to reflect both trade (25 fields) and the
+// trade_instrument variant (9 alternatives) simultaneously.
+struct get_trade_detail_response_base {
+    bool success = false;
+    std::string message;
+    ores::trading::domain::trade trade;
+};
+
+struct get_trade_detail_instrument_wrapper {
+    ores::trading::domain::trade_instrument instrument;
+};
+
 struct save_trade_request {
     using response_type = struct save_trade_response;
     static constexpr std::string_view nats_subject = "trading.v1.trades.save";

--- a/projects/ores.trading.api/src/CMakeLists.txt
+++ b/projects/ores.trading.api/src/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(${lib_target_name}
 # consumers automatically so they don't need to set this independently.
 target_compile_options(${lib_target_name} PUBLIC
     $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<COMPILE_LANGUAGE:CXX>>:/constexpr:depth100000>
-    $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<COMPILE_LANGUAGE:CXX>>:/constexpr:steps10000000>)
+    $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<COMPILE_LANGUAGE:CXX>>:/constexpr:steps10000000>
+    $<$<AND:$<CXX_COMPILER_ID:Clang>,$<COMPILE_LANGUAGE:CXX>>:-fbracket-depth=1024>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)


### PR DESCRIPTION
## Summary

Permanently resolves MSVC C1202 and Clang bracket-depth failures by applying the three-part triple isolation strategy from [Investigation: MSVC C1202 and rfl complexity](doc/investigations/msvc_c1202_rfl_complexity.org):

- **Clang `-fbracket-depth=1024`** — added to `ores.trading.api/src/CMakeLists.txt` as a `PUBLIC` compile option so all consumers (including `ores.qt.api`) inherit it without extra configuration
- **TU split** — `getTradeDetail` moved from `ClientManagerTrades.cpp` to new `ClientManagerTradeDetail.cpp` so the variant-heavy reflection is isolated from the struct-heavy `listTrades` pass
- **Two-phase parse** — `getTradeDetail` now performs two separate `rfl::json::read` calls: phase 1 reads `get_trade_detail_response_base` (trade only, no variant); phase 2 reads `get_trade_detail_instrument_wrapper` with `rfl::AddTagsToVariants` (instrument only). Helper types added to `trade_protocol.hpp`.

Story: [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D8]]
Task: [[id:D2E4921B-B431-4E78-99AB-62A47F761D1D]]

## Test plan

- [ ] Build succeeds on Linux (Clang) — no bracket-depth errors
- [ ] Build succeeds on Windows (MSVC) — no C1202 errors
- [ ] Trade detail fetch returns correct trade and instrument data
- [ ] Trade list (`listTrades`) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)