### PR TITLE
Use compass add in agile and codegen recipes

### DIFF
--- a/doc/recipes/agile/how_do_i_open_a_new_sprint.org
+++ b/doc/recipes/agile/how_do_i_open_a_new_sprint.org
@@ -43,7 +43,7 @@ folder, set its mission, and link it from the version manifest?
    ancestor tag chain:
 
    #+begin_src sh :results verbatim
-   ./projects/ores.compass/compass.sh add sprint \
+   projects/ores.compass/compass.sh add sprint \
      --slug sprint_17 \
      --title "Sprint 17" \
      --description "Sprint 17 — one-sentence mission." \
@@ -77,9 +77,9 @@ folder, set its mission, and link it from the version manifest?
 
 * Script
 
-=projects/ores.compass/compass.sh add= → =src/compass.py= (=cmd_add=),
-which calls =ores.codegen='s =v2_doc_generate= as a library. The
-sprint template is =v2_doc_sprint.org.mustache=.
+The entry point is =projects/ores.compass/compass.sh add=, mapping to
+=src/compass.py= (=cmd_add=), which calls =ores.codegen='s =v2_doc_generate=
+as a library. The sprint template is =v2_doc_sprint.org.mustache=.
 
 * Tested by
 

--- a/doc/recipes/agile/how_do_i_open_a_new_sprint.org
+++ b/doc/recipes/agile/how_do_i_open_a_new_sprint.org
@@ -37,14 +37,14 @@ folder, set its mission, and link it from the version manifest?
    Numbering is monotonic and cheap to reverse, but rolling
    backwards is awkward.
 
-3. /Scaffold the sprint/. The codegen mints a fresh =:ID:=, applies
-   the right frontmatter, builds the skeleton sections, and the
+3. /Scaffold the sprint/. Use =compass add= — it defaults =--parent-dir=
+   to the current version automatically and mints a fresh =:ID:=,
+   applies the right frontmatter, builds the skeleton sections, and the
    ancestor tag chain:
 
    #+begin_src sh :results verbatim
-   projects/ores.codegen/generate_v2_doc.sh \
-     --type sprint --slug sprint_17 \
-     --parent-dir doc/agile/versions/v0 \
+   ./projects/ores.compass/compass.sh add sprint \
+     --slug sprint_17 \
      --title "Sprint 17" \
      --description "Sprint 17 — one-sentence mission." \
      --tags "v0"
@@ -77,7 +77,8 @@ folder, set its mission, and link it from the version manifest?
 
 * Script
 
-The wrapper is =projects/ores.codegen/generate_v2_doc.sh=. The
+=projects/ores.compass/compass.sh add= → =src/compass.py= (=cmd_add=),
+which calls =ores.codegen='s =v2_doc_generate= as a library. The
 sprint template is =v2_doc_sprint.org.mustache=.
 
 * Tested by
@@ -89,5 +90,6 @@ file carries =#+version: 2=.
 
 - [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][Sprint]] (glossary).
 - [[id:F5426198-ACAF-41DA-A043-FF15785E4A1D][Planning phase]] of the agile process.
-- [[id:3153AA4B-23D4-4111-9710-5A4971102EDC][How do I create a new v2 doc?]] §"New sprint".
+- [[id:5B670808-D28B-4818-A2FA-EA5220D35E8D][How do I add a doc with compass?]] — preferred scaffold entry point.
+- [[id:3153AA4B-23D4-4111-9710-5A4971102EDC][How do I create a new v2 doc?]] §"New sprint" — full codegen reference.
 - [[id:C5EEF144-BB9D-2F44-453B-4B7338D8A457][New Sprint]] — the skill that drives this recipe.

--- a/doc/recipes/agile/how_do_i_plan_a_sprint.org
+++ b/doc/recipes/agile/how_do_i_plan_a_sprint.org
@@ -61,7 +61,7 @@ against it, and promote selected captures into stories?
       =--parent-dir= to the current sprint automatically:
 
       #+begin_src sh :results verbatim
-      ./projects/ores.compass/compass.sh add story \
+      projects/ores.compass/compass.sh add story \
         --slug <slug> \
         --id <capture-uuid> \
         --title "<title>" --description "<description>"

--- a/doc/recipes/agile/how_do_i_plan_a_sprint.org
+++ b/doc/recipes/agile/how_do_i_plan_a_sprint.org
@@ -57,15 +57,18 @@ against it, and promote selected captures into stories?
 6. /Promote each confirmed capture to a story/:
 
    a. Scaffold the story in the sprint folder, preserving the
-      capture's =:ID:= with =--id=:
+      capture's =:ID:= with =--id=. Use =compass add= — it defaults
+      =--parent-dir= to the current sprint automatically:
 
       #+begin_src sh :results verbatim
-      projects/ores.codegen/generate_v2_doc.sh \
-        --type story --slug <slug> \
+      ./projects/ores.compass/compass.sh add story \
+        --slug <slug> \
         --id <capture-uuid> \
-        --parent-dir doc/agile/versions/v0/sprint_NN \
         --title "<title>" --description "<description>"
       #+end_src
+
+      Pass =--parent-dir doc/agile/versions/v0/sprint_NN= explicitly
+      only if the story belongs to a sprint other than the current one.
 
    b. Remove the capture from the backlog:
 
@@ -111,5 +114,5 @@ Manual. Run once per sprint, at the start of the planning phase.
 - [[id:DA003A23-1604-43E7-A98F-A305148FBCF4][How do I start work on a story?]] — next step after planning.
 - [[id:1E666848-A785-437E-A463-3D5A0DA0765F][How do I open a new sprint?]] — use this first if the sprint
   has not been scaffolded yet.
-- [[id:3153AA4B-23D4-4111-9710-5A4971102EDC][How do I create a new v2 doc?]] — codegen reference for story
-  scaffolding.
+- [[id:5B670808-D28B-4818-A2FA-EA5220D35E8D][How do I add a doc with compass?]] — preferred way to create stories and tasks.
+- [[id:3153AA4B-23D4-4111-9710-5A4971102EDC][How do I create a new v2 doc?]] — full codegen reference for all doc types.

--- a/doc/recipes/agile/how_do_i_refine_the_backlog.org
+++ b/doc/recipes/agile/how_do_i_refine_the_backlog.org
@@ -48,7 +48,7 @@ sharpening vague ones, and re-prioritising between =near/= and
 3. /File new captures/ that surface during the review:
 
    #+begin_src sh :results verbatim
-   ./projects/ores.compass/compass.sh add capture \
+   projects/ores.compass/compass.sh add capture \
      --parent-dir doc/agile/product_backlog/near \
      --slug <slug> \
      --title "<title>" --description "<one-liner>"

--- a/doc/recipes/agile/how_do_i_refine_the_backlog.org
+++ b/doc/recipes/agile/how_do_i_refine_the_backlog.org
@@ -48,11 +48,13 @@ sharpening vague ones, and re-prioritising between =near/= and
 3. /File new captures/ that surface during the review:
 
    #+begin_src sh :results verbatim
-   projects/ores.codegen/generate_v2_doc.sh \
-     --type capture --slug <slug> \
+   ./projects/ores.compass/compass.sh add capture \
      --parent-dir doc/agile/product_backlog/near \
+     --slug <slug> \
      --title "<title>" --description "<one-liner>"
    #+end_src
+
+   Use =--parent-dir doc/agile/product_backlog/far= for longer-horizon items.
 
 4. /Move items between buckets/:
 
@@ -88,6 +90,6 @@ the near bucket exceeds 20 items.
 
 - [[id:5358EC5A-F7FD-473A-A8AB-AF77E4D83A58][Backlog refiner]] — Claude Code skill for this procedure.
 - [[id:2C2E794B-7565-4FD8-BD26-E7949C874E43][How do I plan a sprint?]] — use after refinement to select stories.
-- [[id:3153AA4B-23D4-4111-9710-5A4971102EDC][How do I create a new v2 doc?]] — codegen invocations for new
-  captures.
+- [[id:5B670808-D28B-4818-A2FA-EA5220D35E8D][How do I add a doc with compass?]] — preferred scaffold entry point.
+- [[id:3153AA4B-23D4-4111-9710-5A4971102EDC][How do I create a new v2 doc?]] — full codegen reference.
 - [[id:D4219199-7B17-4A89-B4BC-6019738642DA][Product backlog]] — the near/far structure and its invariants.

--- a/doc/recipes/codegen/how_do_i_create_a_new_v2_doc.org
+++ b/doc/recipes/codegen/how_do_i_create_a_new_v2_doc.org
@@ -23,6 +23,12 @@ frontmatter?
 
 * Answer
 
+For *stories, tasks, and sprints* — the most common agile operations — use
+[[id:5B670808-D28B-4818-A2FA-EA5220D35E8D][compass add]] instead. It defaults =--parent-dir= from where you are (current
+sprint for stories, current version for sprints) so you rarely need to type
+a path. This recipe remains the authoritative reference for all other doc
+types and for edge cases (explicit =--id=, non-current parents, etc.).
+
 Call =projects/ores.codegen/generate_v2_doc.sh= with the type, slug, parent
 directory, and the document's title and description. The script fills in a fresh
 UUID, today's dates, the required frontmatter (including =#+version: 2= and the


### PR DESCRIPTION
## Summary

- `how_do_i_plan_a_sprint.org`: promote story scaffold step to use `compass.sh add story` (auto-defaults to current sprint); keep `--parent-dir` as an explicit override note
- `how_do_i_open_a_new_sprint.org`: scaffold sprint via `compass.sh add sprint` (auto-defaults to current version); update `* Script` section accordingly
- `how_do_i_refine_the_backlog.org`: file new captures via `compass.sh add capture`
- `how_do_i_create_a_new_v2_doc.org`: add a prominent note at the top of the Answer section directing story/task/sprint work to `compass add`; retain full codegen reference for all other doc types and edge cases

In all updated recipes the `* See also` section now links to [[How do I add a doc with compass?]] as the preferred entry point.

## Test plan

- [ ] Verify each updated recipe renders cleanly on the site
- [ ] Smoke-test `compass.sh add story`, `add sprint`, `add capture` to confirm they accept the flags shown in the recipes

🤖 Generated with [Claude Code](https://claude.com/claude-code)