### PR TITLE
[doc,agile] Update agile.org to Sprint 18; add agile index step to new-sprint recipe

### DIFF
--- a/doc/agile/agile.org
+++ b/doc/agile/agile.org
@@ -8,7 +8,7 @@
 #+level: cross
 #+filetags: :agile:index:knowledge:
 #+created: 2024-06-15
-#+updated: 2026-05-21
+#+updated: 2026-05-24
 
 This is the entry point to the agile information architecture. Work flows as
 ideas in the [[id:D4219199-7B17-4A89-B4BC-6019738642DA][product backlog]], promoted into a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] when a [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprint]] pulls them in,
@@ -32,8 +32,8 @@ state transitions generically — it is not agile-specific. Agile is the loop
 | Field           | Value     |
 |-----------------+-----------|
 | Current Version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][v0]]        |
-| Current Sprint  | [[id:A2B8A670-3B02-11F1-BCE2-4B06F4BBA5D7][Sprint 17]] |
-| Next sprint     | Sprint 18 |
+| Current Sprint  | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]] |
+| Next sprint     | Sprint 19 |
 
 * See also
 

--- a/doc/llm/skills/new-sprint/SKILL.org
+++ b/doc/llm/skills/new-sprint/SKILL.org
@@ -8,7 +8,7 @@
 #+level: cross
 #+filetags: :skills:claude_code:agile:sprint:
 #+created: 2024-09-01
-#+updated: 2026-05-22
+#+updated: 2026-05-24
 
 #+begin_export markdown
 ---
@@ -41,16 +41,20 @@ do at the same time, before, or after.
 3. /Run/ [[id:1E666848-A785-437E-A463-3D5A0DA0765F][How do I open a new sprint?]] — codegen scaffold, set
    mission, wire into the version manifest.
 
-4. /If requested, bump the project version/ as a separate
+4. /Update the agile index/ — =doc/agile/agile.org= =* At a glance=
+   table: =Current Sprint= → id-link to the new sprint; =Next
+   sprint= → plain-text placeholder. Update =#+updated:=.
+
+5. /If requested, bump the project version/ as a separate
    commit/PR — [[id:E9F98DA1-CF33-4B53-BC4D-A034C652F3B0][How do I bump the project version?]]. Bumps and
    sprint openings are decoupled by design.
 
-5. /If requested, update the =vcpkg= submodule to latest/ as a
+6. /If requested, update the =vcpkg= submodule to latest/ as a
    separate commit on the same new-sprint PR —
    [[id:2A8F0D61-B3F9-4C20-9E76-1D92C8A47FB5][How do I update submodules to latest?]]. This ships the
    build-side housekeeping with the sprint open.
 
-6. /If the work moves to a new branch/, use [[id:6DAFFC2F-7F94-403B-87D0-2A56C4669B7F][Feature Branch
+7. /If the work moves to a new branch/, use [[id:6DAFFC2F-7F94-403B-87D0-2A56C4669B7F][Feature Branch
    Manager]]. Otherwise, raise the PR via [[id:545D6B43-17FC-0234-FF2B-AB6565695616][PR Manager]].
 
 * Recipes

--- a/doc/recipes/agile/how_do_i_open_a_new_sprint.org
+++ b/doc/recipes/agile/how_do_i_open_a_new_sprint.org
@@ -8,7 +8,7 @@
 #+level: cross
 #+filetags: :agile:sprint:codegen:recipe:
 #+created: 2026-05-21
-#+updated: 2026-05-22
+#+updated: 2026-05-24
 
 For the surrounding agile cycle (planning / execution / closure) and
 which cybernetic system owns the work, see [[id:46DFE47F-967B-4C24-95BF-3E21F97CFD20][Agile process]]. For the
@@ -62,15 +62,25 @@ folder, set its mission, and link it from the version manifest?
    - [[id:<sprint-uuid>][Sprint 17]] — TBD.
    #+end_src
 
-6. /Promote captures into stories/, if applicable. See [[id:2DF8ADAF-20C9-4757-9399-798EEC6DF828][Agile
+6. /Update the agile index/. Open =doc/agile/agile.org= and update
+   the =* At a glance= table — =Current Sprint= to an id-link for
+   the new sprint, =Next sprint= to plain text (the next sprint
+   doesn't exist yet). Update =#+updated:= to today:
+
+   #+begin_src org
+   | Current Sprint | [[id:<new-sprint-uuid>][Sprint N]] |
+   | Next sprint    | Sprint N+1                         |
+   #+end_src
+
+7. /Promote captures into stories/, if applicable. See [[id:2DF8ADAF-20C9-4757-9399-798EEC6DF828][Agile
    Product Owner]] for the promotion flow (capture → story, ID
    preserved).
 
-7. /Bump the project version/ as separate housekeeping — see
+8. /Bump the project version/ as separate housekeeping — see
    [[id:E9F98DA1-CF33-4B53-BC4D-A034C652F3B0][How do I bump the project version?]]. The version-number bump
    is decoupled from sprint opening; do not couple them in one PR.
 
-8. /Update the =vcpkg= submodule to latest/ — see [[id:2A8F0D61-B3F9-4C20-9E76-1D92C8A47FB5][How do I update
+9. /Update the =vcpkg= submodule to latest/ — see [[id:2A8F0D61-B3F9-4C20-9E76-1D92C8A47FB5][How do I update
    submodules to latest?]]. Land it as a separate commit on the
    same new-sprint PR so the build-side housekeeping ships with
    the sprint open.


### PR DESCRIPTION
## Summary

- `doc/agile/agile.org` — Current Sprint pointer updated to Sprint 18; Next sprint updated to Sprint 19
- `how_do_i_open_a_new_sprint.org` — new step 6: update `agile.org` At a glance table after wiring the version manifest (Current Sprint → id-link, Next sprint → plain-text placeholder)
- `new-sprint/SKILL.org` — matching step 4 added; `deploy_skills` CMake target run to regenerate `.claude/skills/new-sprint/SKILL.md`

## Test plan

- [ ] `doc/agile/agile.org` At a glance shows Sprint 18 with correct UUID link
- [ ] New-sprint skill step 4 mentions updating `agile.org`
- [ ] New-sprint recipe step 6 has the org example with correct field names

🤖 Generated with [Claude Code](https://claude.com/claude-code)