### PR TITLE
Add compass product backlog listing and fix compass.sh CWD bug

### DIFF
--- a/doc/agile/versions/v0/sprint_18/compass_org_folder_index_links/task_add_index_links_to_compass_org.org
+++ b/doc/agile/versions/v0/sprint_18/compass_org_folder_index_links/task_add_index_links_to_compass_org.org
@@ -61,7 +61,7 @@ Folders already linked in compass.org before this task (no changes needed):
 
 | PR  | Title                                                                |
 |-----+----------------------------------------------------------------------|
-| 817 | [doc] Add org-roam index links to compass.org folder entries |
+| [[https://github.com/OreStudio/OreStudio/pull/817][#817]] | [doc] Add org-roam index links to compass.org folder entries |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/compass_product_backlog/story.org
+++ b/doc/agile/versions/v0/sprint_18/compass_product_backlog/story.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: 15CE567F-489C-4A80-9CEC-27FCF95E5C36
+:END:
+#+title: Story: ores.compass Product Backlog — near and far listing
+#+description: Add compass commands to list near and far product-backlog captures, mirroring the sprint-backlog listing in compass where.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :compass:tooling:python:backlog:near:far:sprint_18:v0:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+=compass backlog= lists the near and far product-backlog captures in the
+same style that =compass where= shows in-flight sprint work: a count
+summary followed by titled entries per bucket. An operator (human or
+LLM) can see at a glance what is queued for the next version and what
+is on the longer-term wishlist without opening any files.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                                |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Implement =cmd_backlog= in compass.py. |
+| Last touched  | 2026-05-24                             |
+
+* Acceptance
+
+- =compass.sh backlog= (or =compass.sh backlog --near= / =--far=) prints
+  near and far captures, one per line, with title and path.
+- Output includes a count summary line per bucket (e.g. =Near: 12  Far: 7=).
+- =--json= flag emits machine-readable output with the same structure as
+  the =where= command's in-flight list.
+- The command works correctly from any working directory (the CWD bug
+  that caused generated files to land in =projects/ores.compass/= is fixed
+  as part of this story).
+- The [[id:5B670808-D28B-4818-A2FA-EA5220D35E8D][How do I add a doc with compass?]] recipe is updated to include
+  the new command.
+
+* Tasks
+
+In execution order:
+
+- [[id:092931C3-633E-4885-8AA0-31B88E196A65][Task: Implement product backlog near/far listing in compass]]
+
+* Decisions
+
+- Implement as a new =backlog= subcommand rather than extending =where=,
+  so the two concerns remain separable and the output format can differ.
+
+* Out of scope
+
+- Filtering captures by tag or regex — that is already covered by =compass list=.
+- Editing or moving captures between buckets from the CLI.

--- a/doc/agile/versions/v0/sprint_18/compass_product_backlog/task_implement_product_backlog_listing.org
+++ b/doc/agile/versions/v0/sprint_18/compass_product_backlog/task_implement_product_backlog_listing.org
@@ -1,0 +1,75 @@
+:PROPERTIES:
+:ID: 092931C3-633E-4885-8AA0-31B88E196A65
+:END:
+#+title: Task: Implement product backlog near/far listing in compass
+#+description: Add compass backlog command to list near and far captures with counts and titles, mirroring the sprint in-flight display.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :compass:tooling:python:backlog:sprint_18:v0:compass_product_backlog:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:15CE567F-489C-4A80-9CEC-27FCF95E5C36][ores.compass Product Backlog — near and far listing]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add a =backlog= subcommand to =compass.py= that reads the near and far
+capture buckets from the doc index and prints them in a human-readable
+(and optionally JSON) format. Also fix the CWD bug in =compass.sh= that
+causes generated files to land inside =projects/ores.compass/= instead of
+the repo root.
+
+* Status
+
+| Field        | Value                                                              |
+|--------------+--------------------------------------------------------------------|
+| State        | BACKLOG                                                            |
+| Parent story | [[id:15CE567F-489C-4A80-9CEC-27FCF95E5C36][ores.compass Product Backlog — near and far listing]] |
+| Now          | Not yet started.                                                   |
+| Waiting on   | Nothing.                                                           |
+| Next         | Fix CWD bug in compass.sh; implement cmd_backlog in compass.py.    |
+| Last touched | 2026-05-24                                                         |
+
+* Acceptance
+
+- =compass.sh= changes to =cd "$REPO_ROOT"= (nearest ancestor with =.git=)
+  instead of =cd "$SCRIPT_DIR"=, so relative =--parent-dir= arguments
+  resolve against the repo root.
+- =compass.sh backlog= prints near captures then far captures, each group
+  headed by a count line (e.g. =Near (12):=).
+- Each capture prints as one line: title and relative path.
+- =compass.sh backlog --near= prints only the near bucket; =--far= only far.
+- =compass.sh backlog --json= emits ={"near": [...], "far": [...]}= with
+  the same fields as the =where --json= in-flight entries.
+- =compass.sh backlog --count= prints only the counts (=near=12 far=7=),
+  useful for scripting.
+- Existing =where=, =list=, =search=, and =add= commands are unaffected.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/compass_product_backlog/task_implement_product_backlog_listing.org
+++ b/doc/agile/versions/v0/sprint_18/compass_product_backlog/task_implement_product_backlog_listing.org
@@ -62,9 +62,9 @@ task closes. Plans do not outlive their task.)
 
 * PRs
 
-| PR  | Title                                                             |
-|-----+-------------------------------------------------------------------|
-| 824 | Add compass product backlog listing and fix compass.sh CWD bug    |
+| PR                                                               | Title                                                          |
+|------------------------------------------------------------------+----------------------------------------------------------------|
+| [[https://github.com/OreStudio/OreStudio/pull/824][#824]] | Add compass product backlog listing and fix compass.sh CWD bug |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/compass_product_backlog/task_implement_product_backlog_listing.org
+++ b/doc/agile/versions/v0/sprint_18/compass_product_backlog/task_implement_product_backlog_listing.org
@@ -62,14 +62,20 @@ task closes. Plans do not outlive their task.)
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR  | Title                                                             |
+|-----+-------------------------------------------------------------------|
+| 824 | Add compass product backlog listing and fix compass.sh CWD bug    |
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                        | File            | Decision | Notes                                                                 |
+|---+--------------------------------------------------------+-----------------+----------+-----------------------------------------------------------------------|
+| 1 | Manual dirname loop fragile — can infinite-loop or cd /  | compass.sh:44   | Accepted | Replaced with =git rev-parse --show-toplevel= + SCRIPT_DIR fallback (226e830e1) |
+| 2 | Use git rev-parse --show-toplevel for robustness       | compass.sh:45   | Accepted | Implemented; same fix as above                                        |
+| 3 | SCRIPT_DIR must be absolute before cd                  | compass.sh:44   | Accepted | SCRIPT_DIR already absolute (line 12); confirmed in reply             |
+| 4 | Missing cmd_backlog implementation in compass.py       | compass.sh:87   | Declined | This PR scaffolds docs; implementation ships in follow-up PR          |
+| 5 | Missing cmd_backlog implementation (task file)         | task…listing:37 | Declined | Same as above                                                         |
+| 6 | Missing recipe update from acceptance criteria         | story.org:46    | Declined | Future deliverable of story, not required for scaffolding PR          |
+| 7 | Story/task/sprint status should be DONE                | story.org:32    | Declined | Status correctly BACKLOG — work not yet done; will update on impl PR  |
 
 * Result

--- a/doc/agile/versions/v0/sprint_18/org_roam_db_rebuild/story.org
+++ b/doc/agile/versions/v0/sprint_18/org_roam_db_rebuild/story.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 8D295781-33E7-4812-AAC6-134BD7CD0DDC
+:END:
+#+title: Story: Rebuild org-roam DB independently from CMake
+#+description: Extract org-roam DB sync into .build-org-roam.el and add a standalone cmake target so the DB can be rebuilt without a full site build.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :build:cmake:org-roam:elisp:sprint_18:v0:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+The org-roam DB sync is currently embedded inside =.build-site.el= so
+the only way to get a fresh =.org-roam.db= is to run a full site
+build. This story extracts that logic into a standalone
+=.build-org-roam.el= and wires it to a =rebuild_org_roam_db= cmake
+target, giving contributors and the LLM a fast, lightweight way to
+keep the DB current without triggering the whole publish pipeline.
+
+* Status
+
+| Field         | Value                              |
+|---------------+------------------------------------|
+| State         | BACKLOG                            |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                          |
+| Now           | Not yet started.                   |
+| Waiting on    | Nothing.                           |
+| Next          | Implement .build-org-roam.el and cmake target. |
+| Last touched  | 2026-05-24                         |
+
+* Acceptance
+
+- =.build-org-roam.el= exists at the repo root and syncs the org-roam
+  DB in the same way as the current =.build-site.el= block.
+- =CMakeLists.txt= defines a =rebuild_org_roam_db= target that runs
+  =emacs -Q --script .build-org-roam.el=.
+- =deploy_site= no longer contains inline org-roam sync code; it calls
+  or depends on the new target instead.
+- Running =cmake --build . --target rebuild_org_roam_db= from the build
+  directory updates =.org-roam.db= without regenerating the site.
+
+* Tasks
+
+In execution order:
+
+- [[id:74DD59ED-7A1D-4C09-97EE-F9D59988E1AB][Task: Implement .build-org-roam.el and rebuild_org_roam_db cmake target]]
+
+* Decisions
+
+* Out of scope
+
+- Live file watching or inotify-based auto-sync.
+- Changing how =compass.sh index= updates the compass FTS5 cache; that
+  is a separate step after the org-roam DB is fresh.

--- a/doc/agile/versions/v0/sprint_18/org_roam_db_rebuild/task_implement_org_roam_db_rebuild.org
+++ b/doc/agile/versions/v0/sprint_18/org_roam_db_rebuild/task_implement_org_roam_db_rebuild.org
@@ -1,0 +1,91 @@
+:PROPERTIES:
+:ID: 74DD59ED-7A1D-4C09-97EE-F9D59988E1AB
+:END:
+#+title: Task: Implement .build-org-roam.el and rebuild_org_roam_db cmake target
+#+description: Extract org-roam DB sync from .build-site.el into a standalone .build-org-roam.el; add rebuild_org_roam_db cmake target; update deploy_site to depend on it.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :build:cmake:org-roam:elisp:org_roam_db_rebuild:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:8D295781-33E7-4812-AAC6-134BD7CD0DDC][Rebuild org-roam DB independently from CMake]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Create =.build-org-roam.el= at the repo root that syncs =.org-roam.db=
+using the same settings as the current inline block in =.build-site.el=
+(=org-roam-directory=, =org-roam-db-location=,
+=org-roam-file-exclude-regexp=). Add a =rebuild_org_roam_db= cmake
+target in =CMakeLists.txt=. Remove the duplicated inline block from
+=.build-site.el= and replace it with a call to the new script (or a
+cmake dependency).
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                                |
+| Parent story | [[id:8D295781-33E7-4812-AAC6-134BD7CD0DDC][Rebuild org-roam DB independently from CMake]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Implement .build-org-roam.el.          |
+| Last touched | 2026-05-24                             |
+
+* Acceptance
+
+- =.build-org-roam.el= exists at the repo root.
+- It sets =org-roam-directory=, =org-roam-db-location=, and
+  =org-roam-file-exclude-regexp= to the canonical repo-root-relative
+  values, installs =org-roam= if absent, and calls =org-roam-db-sync=.
+- =CMakeLists.txt= defines =rebuild_org_roam_db= target:
+  =emacs -Q --script .build-org-roam.el=.
+- =.build-site.el= no longer contains a duplicated org-roam sync block;
+  it calls =.build-org-roam.el= via =load-file= or the cmake target
+  handles ordering.
+- =cmake --build . --target rebuild_org_roam_db= completes successfully
+  and updates =.org-roam.db=.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+The existing org-roam block in =.build-site.el= (lines ~206–212) sets:
+
+#+begin_example
+(setq org-roam-directory (expand-file-name "./"))
+(setq org-roam-db-location (expand-file-name "./.org-roam.db"))
+(setq org-roam-file-exclude-regexp
+      "\\(^\\|/\\)\\(\\.packages\\|vcpkg\\|build\\|tmp\\)/\\|external/org-roam-ui")
+(require 'org-roam)
+(org-roam-db-sync)
+#+end_example
+
+The new =.build-org-roam.el= should mirror this exactly and wrap it in
+=condition-case= for consistent error handling (matching the pattern of
+=.build-site.el= and =.build-manual.el=).
+
+* PRs
+
+| PR  | Title                                              |
+|-----+----------------------------------------------------|
+|     |                                                    |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/pr_tracking_in_tasks/task_add_prs_table_to_task_template.org
+++ b/doc/agile/versions/v0/sprint_18/pr_tracking_in_tasks/task_add_prs_table_to_task_template.org
@@ -46,7 +46,7 @@ the PR body for traceability.
 
 | PR  | Title                                               |
 |-----+-----------------------------------------------------|
-| 816 | [compass,agile] Track PRs per task; compass where --prs |
+| [[https://github.com/OreStudio/OreStudio/pull/816][#816]] | [compass,agile] Track PRs per task; compass where --prs |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/pr_tracking_in_tasks/task_implement_compass_where.org
+++ b/doc/agile/versions/v0/sprint_18/pr_tracking_in_tasks/task_implement_compass_where.org
@@ -48,7 +48,7 @@ view=, and prints them grouped by task.
 
 | PR  | Title                                               |
 |-----+-----------------------------------------------------|
-| 816 | [compass,agile] Track PRs per task; compass where --prs |
+| [[https://github.com/OreStudio/OreStudio/pull/816][#816]] | [compass,agile] Track PRs per task; compass where --prs |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/rfl_complexity_resolution/task_implement_triple_isolation.org
+++ b/doc/agile/versions/v0/sprint_18/rfl_complexity_resolution/task_implement_triple_isolation.org
@@ -52,7 +52,7 @@ Apply the structural isolation strategy to permanently fix compilation failures 
 
 | PR  | Title                                                     |
 |-----+-----------------------------------------------------------|
-| 819 | [ores.qt.api] Implement triple isolation for RFL complexity |
+| [[https://github.com/OreStudio/OreStudio/pull/819][#819]] | [ores.qt.api] Implement triple isolation for RFL complexity |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -64,6 +64,7 @@ In execution order.
 | [[id:7EF64A67-EB1C-4F79-9FF2-1C59DD6146AB][Track PRs per task and surface in compass where]] | DONE    | 2026-05-24 | 2026-05-24 | PRs table in task docs; =compass where --prs= fetches live PR status via =gh=.          |
 | [[id:026AA423-68A1-43A1-8F2A-D9D3D6379E6C][Add org-roam index links to compass.org folder entries]] | DONE | 2026-05-24 | 2026-05-24 | Each folder in compass.org links to its index file; missing index files created. |
 | [[id:A2B3BFD0-F44C-48F3-BB01-6BAECB851356][Remove unused GitHub Actions workflows]] | DONE | 2026-05-24 | 2026-05-24 | Delete the four dormant Gemini workflows; PR review stays via the gemini-code-assist app. |
+| [[id:15CE567F-489C-4A80-9CEC-27FCF95E5C36][ores.compass Product Backlog — near and far listing]] | BACKLOG | 2026-05-24 | | =compass backlog= lists near/far captures with counts, mirroring =where= in-flight display. |
 
 * Retrospective
 

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -65,6 +65,7 @@ In execution order.
 | [[id:026AA423-68A1-43A1-8F2A-D9D3D6379E6C][Add org-roam index links to compass.org folder entries]] | DONE | 2026-05-24 | 2026-05-24 | Each folder in compass.org links to its index file; missing index files created. |
 | [[id:A2B3BFD0-F44C-48F3-BB01-6BAECB851356][Remove unused GitHub Actions workflows]] | DONE | 2026-05-24 | 2026-05-24 | Delete the four dormant Gemini workflows; PR review stays via the gemini-code-assist app. |
 | [[id:15CE567F-489C-4A80-9CEC-27FCF95E5C36][ores.compass Product Backlog — near and far listing]] | BACKLOG | 2026-05-24 | | =compass backlog= lists near/far captures with counts, mirroring =where= in-flight display. |
+| [[id:8D295781-33E7-4812-AAC6-134BD7CD0DDC][Rebuild org-roam DB independently from CMake]]       | BACKLOG | 2026-05-24 | | Extract org-roam sync into =.build-org-roam.el=; add =rebuild_org_roam_db= cmake target.   |
 
 * Retrospective
 

--- a/projects/ores.compass/compass.sh
+++ b/projects/ores.compass/compass.sh
@@ -35,8 +35,14 @@ fi
 
 source "$VENV_PATH/bin/activate"
 
-# Change to script directory so Python can find compass.py
-cd "$SCRIPT_DIR"
+# Change to the repository root so that relative paths (e.g. --parent-dir
+# doc/agile/...) resolve correctly. The repo root is the nearest ancestor of
+# this script that contains a .git entry.
+REPO_ROOT="$SCRIPT_DIR"
+while [ "$REPO_ROOT" != "/" ] && [ ! -e "$REPO_ROOT/.git" ]; do
+    REPO_ROOT="$(dirname "$REPO_ROOT")"
+done
+cd "$REPO_ROOT"
 
 # --- Parse command line arguments ---
 PYTHON_ARGS=()
@@ -78,4 +84,4 @@ if [ ${#PYTHON_ARGS[@]} -eq 0 ]; then
 fi
 
 # --- Execute the Python script ---
-python3 src/compass.py "${PYTHON_ARGS[@]}"
+python3 "$SCRIPT_DIR/src/compass.py" "${PYTHON_ARGS[@]}"

--- a/projects/ores.compass/compass.sh
+++ b/projects/ores.compass/compass.sh
@@ -36,12 +36,9 @@ fi
 source "$VENV_PATH/bin/activate"
 
 # Change to the repository root so that relative paths (e.g. --parent-dir
-# doc/agile/...) resolve correctly. The repo root is the nearest ancestor of
-# this script that contains a .git entry.
-REPO_ROOT="$SCRIPT_DIR"
-while [ "$REPO_ROOT" != "/" ] && [ ! -e "$REPO_ROOT/.git" ]; do
-    REPO_ROOT="$(dirname "$REPO_ROOT")"
-done
+# doc/agile/...) resolve correctly. Use git rev-parse for robustness;
+# fall back to SCRIPT_DIR if not inside a git repository.
+REPO_ROOT=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$SCRIPT_DIR")
 cd "$REPO_ROOT"
 
 # --- Parse command line arguments ---


### PR DESCRIPTION
## Summary

- **Bug fix**: `compass.sh` was `cd`-ing to `SCRIPT_DIR` (`projects/ores.compass/`) before invoking `compass.py`, causing relative `--parent-dir` paths to resolve inside the compass project rather than the repo root. Fixed by walking up to the nearest ancestor containing `.git` and `cd`-ing there instead.
- **Story**: `ores.compass Product Backlog — near and far listing` — new `compass backlog` subcommand that lists near and far product-backlog captures with counts, mirroring the sprint in-flight display in `compass where`.
- **Task**: Implement `cmd_backlog` in `compass.py` with `--near`/`--far` filters, `--json`, and `--count` flags.
- Story wired into Sprint 18 Stories table.

## Test plan

- [ ] Verify `compass.sh add story` now creates files under the repo root, not `projects/ores.compass/`
- [ ] Verify existing `compass.sh where`, `list`, `search` commands are unaffected
- [ ] Review story and task content for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)