### PR TITLE
[agile] Address #825 review: task Next field consistency

### DIFF
--- a/doc/agile/versions/v0/sprint_18/remove_unused_workflows/task_delete_gemini_workflows.org
+++ b/doc/agile/versions/v0/sprint_18/remove_unused_workflows/task_delete_gemini_workflows.org
@@ -30,7 +30,7 @@ Remove the four unused Gemini workflow files from =.github/workflows/=.
 | Parent story | [[id:A2B3BFD0-F44C-48F3-BB01-6BAECB851356][Remove unused GitHub Actions workflows]] |
 | Now          | Complete — four files deleted.         |
 | Waiting on   | Nothing.                               |
-| Next         | Review.                                |
+| Next         | Done.                                  |
 | Last touched | 2026-05-24                             |
 
 * Acceptance


### PR DESCRIPTION
## Summary

Follow-up to the (already-merged) PR #825. Addresses the one
gemini-code-assist review comment that landed after #825 merged.

## Changes

- `task_delete_gemini_workflows.org`: set the `Next` field to `Done.`
  (was `Review.`) so a DONE task matches the parent story and the
  sprint-table convention.

## Notes

Doc-only, one line. `validate_docs.sh` passes.