### PR TITLE
[agile] Scaffold ORE Studio Emacs dashboard story for sprint 18

### DIFF
--- a/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/story.org
+++ b/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/story.org
@@ -28,9 +28,9 @@ offers an ORE Studio shell, and shows the ORE splash image.
 |---------------+--------------------------------------------|
 | State         | STARTED                                    |
 | Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                                  |
-| Now           | Tasks scaffolded; audit/design task first. |
+| Now           | Tasks scaffolded; [[id:962FDC09-8DED-4C60-8725-FDE288E55C00][audit/design task]] first.  |
 | Waiting on    | Nothing.                                   |
-| Next          | Begin task_audit_and_design.               |
+| Next          | Begin [[id:962FDC09-8DED-4C60-8725-FDE288E55C00][task_audit_and_design]].              |
 | Last touched  | 2026-05-24                                 |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/story.org
+++ b/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/story.org
@@ -1,0 +1,74 @@
+:PROPERTIES:
+:ID: 8E5543CD-AD7C-41B5-A7EA-F2DC534F5248
+:END:
+#+title: Story: ORE Studio Emacs dashboard
+#+description: Replace per-mode ores.lisp approach with an env-aware Emacs dashboard — one-stop console for all dev commands, grouped by function, bound to the active checkout.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :emacs:lisp:dashboard:sprint_18:v0:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Replace the broken per-mode =ores.lisp= approach — where scripts from
+one checkout bleed into another — with an env-aware [[https://github.com/emacs-dashboard/emacs-dashboard][emacs-dashboard]]
+console. The dashboard binds to the active checkout via =.env=,
+groups all dev commands (DB, services, compass, build), provides
+bookmarks to key directories, links to recipes and the user manual,
+offers an ORE Studio shell, and shows the ORE splash image.
+
+* Status
+
+| Field         | Value                                      |
+|---------------+--------------------------------------------|
+| State         | STARTED                                    |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                                  |
+| Now           | Tasks scaffolded; audit/design task first. |
+| Waiting on    | Nothing.                                   |
+| Next          | Begin task_audit_and_design.               |
+| Last touched  | 2026-05-24                                 |
+
+* Acceptance
+
+- =ores-dashboard.el= loads without error via =(require 'ores-dashboard)=.
+- Dashboard binds dynamically to the current checkout's =.env= — two
+  Emacs instances on =local1= and =local2= run independent commands.
+- Command groups cover: DB (init, migrate, reset), Services (start/stop
+  server, NATS), Compass (list, where, add), Build (configure, build,
+  test, deploy site, deploy skills).
+- Bookmarks section resolves log dir and bin dir from =.env=.
+- Links section opens key recipes and the user manual inside Emacs.
+- "Open ORE Studio shell" launches a comint shell bound to the active env.
+- ORE splash image displayed in dashboard header.
+- Superseded per-mode modules (=ores-db.el= etc.) are removed or gutted.
+- A dashboard chapter exists in the user guide.
+- Reusable helpers (=ores-env.el=, =ores-shell.el=, =ores-shell-mode.el=) are retained and wired in.
+
+* Tasks
+
+In execution order:
+
+- [[id:962FDC09-8DED-4C60-8725-FDE288E55C00][Audit existing ores.lisp modules and design dashboard architecture]]
+- [[id:696612A2-A9D5-47FE-BC5A-2F90FDCA4E15][Implement ores-dashboard.el]]
+- [[id:7E86CDB4-3FE6-46AD-BCC8-C0E9AD8857D6][Remove superseded ores.lisp modules]]
+- [[id:3C888F53-0522-4A56-A50A-A7AFEA101468][Write the ORE Studio dashboard user manual section]]
+
+* Decisions
+
+- Use =emacs-dashboard= as the host framework rather than a custom
+  buffer, so ORE commands land in an established, maintainable widget
+  system.
+- Dashboard is dev-only; no production-environment integration.
+- Each Emacs instance reads =.env= at load time — no global singleton
+  that could leak state between checkouts.
+
+* Out of scope
+
+- Integration with production or staging environments.
+- A new Emacs minor-mode API surface (the dashboard replaces the old
+  per-mode approach entirely; no shim layer).

--- a/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_audit_and_design.org
+++ b/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_audit_and_design.org
@@ -42,7 +42,7 @@ group layout, and which helpers it will reuse.
 - Every =.el= file classified with a rationale.
 - Dashboard architecture written up: sections, env-binding approach,
   command groups, helper dependencies.
-- Design signed off by user before =task_implement_dashboard= starts.
+- Design signed off by user before [[id:696612A2-A9D5-47FE-BC5A-2F90FDCA4E15][task_implement_dashboard]] starts.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_audit_and_design.org
+++ b/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_audit_and_design.org
@@ -1,0 +1,67 @@
+:PROPERTIES:
+:ID: 962FDC09-8DED-4C60-8725-FDE288E55C00
+:END:
+#+title: Task: Audit existing ores.lisp modules and design dashboard architecture
+#+description: Survey all .el files under projects/ores.lisp, identify what is reusable vs superseded, and produce the design for ores-dashboard.el.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :emacs:lisp:dashboard:ores_studio_emacs_dashboard:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Produce a written design (in =* Notes= below) that classifies every
+=.el= file under =projects/ores.lisp/= as REUSABLE, PARTIALLY
+REUSABLE, or SUPERSEDED, and specifies the architecture of
+=ores-dashboard.el=: required sections, data flow from =.env=, command
+group layout, and which helpers it will reuse.
+
+* Status
+
+| Field        | Value                                                  |
+|--------------+--------------------------------------------------------|
+| State        | BACKLOG                                                |
+| Parent story | [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                             |
+| Now          | Not yet started.                                       |
+| Waiting on   | Nothing.                                               |
+| Next         | Read all .el files; write classification + design.     |
+| Last touched | 2026-05-24                                             |
+
+* Acceptance
+
+- Every =.el= file classified with a rationale.
+- Dashboard architecture written up: sections, env-binding approach,
+  command groups, helper dependencies.
+- Design signed off by user before =task_implement_dashboard= starts.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_implement_dashboard.org
+++ b/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_implement_dashboard.org
@@ -30,7 +30,7 @@ command groups, bookmarks, recipe links, ORE shell, and splash image.
 |--------------+--------------------------------------------------|
 | State        | BACKLOG                                          |
 | Parent story | [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                       |
-| Now          | Blocked on audit/design task.                    |
+| Now          | Blocked on [[id:962FDC09-8DED-4C60-8725-FDE288E55C00][audit/design task]].                   |
 | Waiting on   | [[id:962FDC09-8DED-4C60-8725-FDE288E55C00][task_audit_and_design]] sign-off.                  |
 | Next         | Implement once design is approved.               |
 | Last touched | 2026-05-24                                       |

--- a/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_implement_dashboard.org
+++ b/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_implement_dashboard.org
@@ -1,0 +1,69 @@
+:PROPERTIES:
+:ID: 696612A2-A9D5-47FE-BC5A-2F90FDCA4E15
+:END:
+#+title: Task: Implement ores-dashboard.el
+#+description: Create the ores-dashboard.el core: env binding, .env reading, command groups (db, services, compass, build), bookmarks, ORE shell, splash image.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :emacs:lisp:dashboard:ores_studio_emacs_dashboard:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Create =projects/ores.lisp/ores-dashboard.el= — a fully functional
+ORE Studio console built on =emacs-dashboard=, with env binding,
+command groups, bookmarks, recipe links, ORE shell, and splash image.
+
+* Status
+
+| Field        | Value                                            |
+|--------------+--------------------------------------------------|
+| State        | BACKLOG                                          |
+| Parent story | [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                       |
+| Now          | Blocked on audit/design task.                    |
+| Waiting on   | [[id:962FDC09-8DED-4C60-8725-FDE288E55C00][task_audit_and_design]] sign-off.                  |
+| Next         | Implement once design is approved.               |
+| Last touched | 2026-05-24                                       |
+
+* Acceptance
+
+- =ores-dashboard.el= loads cleanly via =(require 'ores-dashboard)=.
+- Dashboard header shows ORE splash image.
+- Command groups present and functional: DB, Services, Compass, Build.
+- All commands read their env from the checkout's =.env= via =ores-env.el=.
+- Bookmarks section: log dir and bin dir resolved from =.env=.
+- Links section: key recipes and user manual open in Emacs.
+- "Open ORE Studio shell" launches a =comint= shell bound to active env.
+- Tested on both =local1= and =local2= checkouts with no cross-env bleed.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_remove_superseded_modules.org
+++ b/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_remove_superseded_modules.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: 7E86CDB4-3FE6-46AD-BCC8-C0E9AD8857D6
+:END:
+#+title: Task: Remove superseded ores.lisp modules
+#+description: Delete or gut ores-db.el and other per-mode modules that are superseded by the dashboard; keep reusable helpers (ores-env.el, ores-shell.el).
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :emacs:lisp:dashboard:ores_studio_emacs_dashboard:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Remove or gut the per-mode =ores.lisp= modules that the dashboard
+supersedes, keeping only the reusable helpers; update the package load
+list accordingly.
+
+* Status
+
+| Field        | Value                                               |
+|--------------+-----------------------------------------------------|
+| State        | BACKLOG                                             |
+| Parent story | [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                          |
+| Now          | Blocked on implement task.                          |
+| Waiting on   | [[id:696612A2-A9D5-47FE-BC5A-2F90FDCA4E15][task_implement_dashboard]] merged.                    |
+| Next         | Delete superseded files once dashboard is in place. |
+| Last touched | 2026-05-24                                          |
+
+* Acceptance
+
+- =ores-db.el= and all other SUPERSEDED modules (per audit) deleted.
+- =ores-env.el=, =ores-shell.el=, =ores-shell-mode.el=, =ores-babel.el=,
+  =ores-org-roam-export.el= retained unchanged.
+- Package declaration and =:require= lists updated; no broken references.
+- Emacs starts cleanly with only the remaining modules loaded.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_remove_superseded_modules.org
+++ b/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_remove_superseded_modules.org
@@ -30,7 +30,7 @@ list accordingly.
 |--------------+-----------------------------------------------------|
 | State        | BACKLOG                                             |
 | Parent story | [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                          |
-| Now          | Blocked on implement task.                          |
+| Now          | Blocked on [[id:696612A2-A9D5-47FE-BC5A-2F90FDCA4E15][implement task]].                         |
 | Waiting on   | [[id:696612A2-A9D5-47FE-BC5A-2F90FDCA4E15][task_implement_dashboard]] merged.                    |
 | Next         | Delete superseded files once dashboard is in place. |
 | Last touched | 2026-05-24                                          |

--- a/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_write_dashboard_manual.org
+++ b/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_write_dashboard_manual.org
@@ -29,7 +29,7 @@ dashboard, each command group, bookmarks, and the ORE Studio shell.
 |--------------+----------------------------------------------------------|
 | State        | BACKLOG                                                  |
 | Parent story | [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                               |
-| Now          | Blocked on implement task.                               |
+| Now          | Blocked on [[id:696612A2-A9D5-47FE-BC5A-2F90FDCA4E15][implement task]].                              |
 | Waiting on   | [[id:696612A2-A9D5-47FE-BC5A-2F90FDCA4E15][task_implement_dashboard]] merged.                         |
 | Next         | Write manual chapter once implementation is stable.      |
 | Last touched | 2026-05-24                                               |

--- a/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_write_dashboard_manual.org
+++ b/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_write_dashboard_manual.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: 3C888F53-0522-4A56-A50A-A7AFEA101468
+:END:
+#+title: Task: Write the ORE Studio dashboard user manual section
+#+description: Add a dashboard chapter to the user guide covering: launching the dashboard, each command group, bookmarks, and the ORE Studio shell.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :emacs:lisp:dashboard:ores_studio_emacs_dashboard:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-24
+#+updated: 2026-05-24
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add a dashboard chapter to the user guide covering: how to launch the
+dashboard, each command group, bookmarks, and the ORE Studio shell.
+
+* Status
+
+| Field        | Value                                                    |
+|--------------+----------------------------------------------------------|
+| State        | BACKLOG                                                  |
+| Parent story | [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                               |
+| Now          | Blocked on implement task.                               |
+| Waiting on   | [[id:696612A2-A9D5-47FE-BC5A-2F90FDCA4E15][task_implement_dashboard]] merged.                         |
+| Next         | Write manual chapter once implementation is stable.      |
+| Last touched | 2026-05-24                                               |
+
+* Acceptance
+
+- Dashboard chapter present under =doc/manual/user_guide/=.
+- Covers: launching, all command groups, bookmarks, shell, limitations.
+- Includes a note that the dashboard is dev-only (not for production).
+- Renders correctly via the =deploy_manual= CMake target.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -66,6 +66,7 @@ In execution order.
 | [[id:A2B3BFD0-F44C-48F3-BB01-6BAECB851356][Remove unused GitHub Actions workflows]] | DONE | 2026-05-24 | 2026-05-24 | Delete the four dormant Gemini workflows; PR review stays via the gemini-code-assist app. |
 | [[id:15CE567F-489C-4A80-9CEC-27FCF95E5C36][ores.compass Product Backlog — near and far listing]] | BACKLOG | 2026-05-24 | | =compass backlog= lists near/far captures with counts, mirroring =where= in-flight display. |
 | [[id:8D295781-33E7-4812-AAC6-134BD7CD0DDC][Rebuild org-roam DB independently from CMake]]       | BACKLOG | 2026-05-24 | | Extract org-roam sync into =.build-org-roam.el=; add =rebuild_org_roam_db= cmake target.   |
+| [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                         | STARTED | 2026-05-24 |            | Replace broken per-mode ores.lisp with an env-aware emacs-dashboard console for all dev commands. |
 
 * Retrospective
 


### PR DESCRIPTION
## Summary

- New story `8E5543CD`: replace broken per-mode `ores.lisp` with an env-aware `emacs-dashboard` console.
- Four tasks scaffolded: audit/design, implement `ores-dashboard.el`, remove superseded modules, write user manual section.
- Sprint 18 stories table updated with new STARTED row.

## Test plan

- [ ] All new `.org` files have `#+version: 2` and valid `:ID:` UUIDs.
- [ ] Story links to all four task IDs; tasks back-link to story ID.
- [ ] Sprint 18 table row renders correctly in Org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)