### PR TITLE
[doc,build] Add org-roam links to plans.org; fix site build; make builds incremental

### DIFF
--- a/.build-site.el
+++ b/.build-site.el
@@ -96,7 +96,6 @@
 ;; syntax highlighting, but we never want CI to execute src blocks.
 ;; Developers refresh #+RESULTS: manually via the org-babel-refresh recipe.
 (setq org-export-use-babel nil)
-(setq org-export-with-broken-links 'mark)
 
 ;; Customize the HTML output
 (setq org-html-validation-link nil            ;; Don't show validation link

--- a/.build-site.el
+++ b/.build-site.el
@@ -202,7 +202,7 @@
 
 (condition-case err
     (progn
-      (org-publish-all t)
+      (org-publish-all nil)
       (ores-deploy-org-roam-ui "./build/output/site/OreStudio")
       ;; Sync org-roam DB (mirrors .dir-locals.el project-local settings)
       (setq org-roam-directory (expand-file-name "./"))

--- a/.build-site.el
+++ b/.build-site.el
@@ -202,17 +202,20 @@
 
 (condition-case err
     (progn
-      (org-publish-all nil)
-      (ores-deploy-org-roam-ui "./build/output/site/OreStudio")
-      ;; Sync org-roam DB (mirrors .dir-locals.el project-local settings)
+      ;; Sync org-roam DB before publishing so id: links are resolvable
       (setq org-roam-directory (expand-file-name "./"))
       (setq org-roam-db-location (expand-file-name "./.org-roam.db"))
       (setq org-roam-file-exclude-regexp
             "\\(^\\|/\\)\\(\\.packages\\|vcpkg\\|build\\|tmp\\)/\\|external/org-roam-ui")
       (require 'org-roam)
       (condition-case roam-err
+          (org-roam-db-sync)
+        (error (message "Warning: org-roam DB sync failed: %s"
+                        (error-message-string roam-err))))
+      (org-publish-all nil)
+      (ores-deploy-org-roam-ui "./build/output/site/OreStudio")
+      (condition-case roam-err
           (progn
-            (org-roam-db-sync)
             (load-file (expand-file-name "./projects/ores.lisp/ores-org-roam-export.el"))
             (ores/org-roam-export-graph-json
              (expand-file-name "./.org-roam.db")

--- a/.build-site.el
+++ b/.build-site.el
@@ -96,6 +96,7 @@
 ;; syntax highlighting, but we never want CI to execute src blocks.
 ;; Developers refresh #+RESULTS: manually via the org-babel-refresh recipe.
 (setq org-export-use-babel nil)
+(setq org-export-with-broken-links 'mark)
 
 ;; Customize the HTML output
 (setq org-html-validation-link nil            ;; Don't show validation link
@@ -210,13 +211,17 @@
       (setq org-roam-file-exclude-regexp
             "\\(^\\|/\\)\\(\\.packages\\|vcpkg\\|build\\|tmp\\)/\\|external/org-roam-ui")
       (require 'org-roam)
-      (org-roam-db-sync)
-      (load-file (expand-file-name "./projects/ores.lisp/ores-org-roam-export.el"))
-      (ores/org-roam-export-graph-json
-       (expand-file-name "./.org-roam.db")
-       (expand-file-name "./build/output/site/OreStudio/graph/graphdata.json")
-       (expand-file-name "./")
-       "/OreStudio/")
+      (condition-case roam-err
+          (progn
+            (org-roam-db-sync)
+            (load-file (expand-file-name "./projects/ores.lisp/ores-org-roam-export.el"))
+            (ores/org-roam-export-graph-json
+             (expand-file-name "./.org-roam.db")
+             (expand-file-name "./build/output/site/OreStudio/graph/graphdata.json")
+             (expand-file-name "./")
+             "/OreStudio/"))
+        (error (message "Warning: org-roam graph export skipped: %s"
+                        (error-message-string roam-err))))
       (message "Build succeeded.")
       (kill-emacs 0))
   (error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,7 +321,6 @@ endif()
 set(ORES_SITE_DIRECTORY "build/output/site")
 add_custom_target(deploy_site
     COMMENT "Deploying ORE Studio Website to ${ORES_SITE_DIRECTORY}" VERBATIM
-    COMMAND echo "Removing site directory" && rm -rf ${ORES_SITE_DIRECTORY}
     COMMAND emacs -Q --script .build-site.el
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 

--- a/doc/agile/versions/v0/sprint_18/capture.org
+++ b/doc/agile/versions/v0/sprint_18/capture.org
@@ -1,7 +1,7 @@
 :PROPERTIES:
 :ID: 14606A1B-2742-DE34-F813-B4E3B736AEF1
 :END:
-#+title: Sprint 16 Capture
+#+title: Sprint 18 Capture
 #+description: Assorted notes taken during Sprint which have not yet been filled but we do not want to forget.
 #+type: capture
 #+version: 2
@@ -11,23 +11,15 @@
 #+updated: 2026-05-23
 #+todo: STARTED | DONE
 
-This page is the short-lived [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] document for [[id:A2B8A670-3B02-11F1-BCE2-4B06F4BBA5D7][Sprint 17]] of ORE Studio. At
+This page is the short-lived [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] document for [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]] of ORE Studio. At
 the end of the sprint, short-lived captures will migrate to their next
-destination (sprint backlog or [[id:D4219199-7B17-4A89-B4BC-6019738642DA][product backlog]]).
+destination ([[id:1737C00C-699A-475A-BC94-743C6CDA1001][sprint backlog]] or [[id:D4219199-7B17-4A89-B4BC-6019738642DA][product backlog]]).
 
 * Agile
 
 - add a template for sprint captures. Very often we are doing something and we
   just need to jot down a quick annotation, but if it goes into product backlog
   it will get lost. Ideally it should start in sprint and then get filled.
-- add linkage between previous sprint and next sprint to make navigation easier.
-- make release notes a property of the sprint table.
-- add to sprint table:
-  : | Previous | [[id:1C778CE6-25D6-429B-920E-D08A2CE9A0A6][Sprint 16]] |
-- UUIDs of sprints seem lower case, check codegen script.
-- we only updated sprint 16-18, rest needs updating with LLM.
-- add PR to tasks:
-  : | PR | [[https://github.com/OreStudio/OreStudio/pull/803][#803]] |
 - add a memory for the tmp directory.
 - add recipes to do doc commands (list etc). Link it to skills.
 - add a skill which drains capture buffer: for each entry decides to either file

--- a/doc/agile/versions/v0/sprint_18/compass_org_folder_index_links/task_add_index_links_to_compass_org.org
+++ b/doc/agile/versions/v0/sprint_18/compass_org_folder_index_links/task_add_index_links_to_compass_org.org
@@ -38,7 +38,7 @@ link to the folder's index file. Create the five missing index files
 
 * Acceptance
 
-- =doc/compass.org= — every folder section has a "See [[id:UUID][Title]] for the full
+- =doc/compass.org= — every folder section has a "See =[[id:UUID][Title]]= for the full
   index." sentence.
 - =doc/meta/meta.org= — new index listing the 5 contract docs.
 - =doc/analysis/analysis.org= — new index listing analysis files with IDs.
@@ -76,7 +76,7 @@ Folders already linked in compass.org before this task (no changes needed):
 - =doc/investigations/investigations.org= [[[id:249FEDB9-7010-4124-A593-A01160E4B56E][249FEDB9]]] — created; lists 1 file.
 - =doc/prompts/prompts.org= [[[id:9E971D53-0501-4B56-AD85-037057E295D8][9E971D53]]] — created; placeholder (empty folder).
 - =doc/samples/samples.org= [[[id:49FBC025-4B13-47E3-AC85-C86A81CA3056][49FBC025]]] — created; lists all image assets.
-- =doc/compass.org= — added "See [[id:UUID][Title]]" reference to: =meta/=, =agile/=,
+- =doc/compass.org= — added "See =[[id:UUID][Title]]=" reference to: =meta/=, =agile/=,
   =agile/versions/=, =agile/product_backlog/=, =recipes/=, =knowledge/=,
   =plans/=, =prompts/=, =samples/=, =analysis/=, =investigations/=.
   Added =investigations/= to the folder layout tree.

--- a/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/story.org
+++ b/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/story.org
@@ -1,5 +1,5 @@
 :PROPERTIES:
-:ID: c42c3563-671f-4721-8ce8-5ee05925255f
+:ID: C42C3563-671F-4721-8CE8-5EE05925255F
 :END:
 #+title: Story: Build and publish user manual PDF via CMake
 #+description: Add a CMake target that compiles user_manual.org to PDF, commits the PDF, and links to it from the documentation.

--- a/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/story.org
+++ b/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/story.org
@@ -11,7 +11,7 @@
 #+updated: 2026-05-24
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
-This page documents a [[id:699a8d45-b67e-4d3e-9206-24fa17c51ada][story]] in [[id:1737c00c-699a-475a-bc94-743c6cda1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
 
 * Goal
 
@@ -25,7 +25,7 @@ build themselves.
 | Field         | Value                                  |
 |---------------+----------------------------------------|
 | State         | STARTED                                |
-| Parent sprint | [[id:1737c00c-699a-475a-bc94-743c6cda1001][Sprint 18]] |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]] |
 | Now           | All core tasks done. PRs #807, #810, #811, #814 merged. Manuals index page + site nav link in PR #818 (open). |
 | Waiting on    | PR #818 review and merge. Screenshots for all TODO_ placeholders in chapters. |
 | Next          | Merge PR #818; capture screenshots per placeholder instructions. |
@@ -43,7 +43,7 @@ build themselves.
 In execution order:
 
 - [[id:30AFB759-D3F2-4DD9-A5C7-209735F35B38][Task: User manual restructure]] (DONE — PR #807; prerequisite for PDF build)
-- [[id:001f63b6-c4e8-4dd2-b680-364393b15d51][Task: Add CMake target to build user manual PDF and commit it]] (DONE — PR #810)
+- [[id:001F63B6-C4E8-4DD2-B680-364393B15D51][Task: Add CMake target to build user manual PDF and commit it]] (DONE — PR #810)
 - [[id:63BF06CF-B61E-4163-A017-0E2D13586510][Task: Write Chapter 1: Login and Connection Manager]] (DONE — PR #811)
 - [[id:4834460E-0799-4379-ADD7-462A4BCF9FDF][Task: Write Chapter 1: System bootstrapping concepts and provisioning wizards]] (DONE — PR #814)
 - [[id:29379454-1B29-4BB5-905D-F129E0AC41FD][Task: Create documentation update skill]] (DONE — PR #814)

--- a/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_add_cmake_pdf_target.org
+++ b/doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_add_cmake_pdf_target.org
@@ -1,5 +1,5 @@
 :PROPERTIES:
-:ID: 001f63b6-c4e8-4dd2-b680-364393b15d51
+:ID: 001F63B6-C4E8-4DD2-B680-364393B15D51
 :END:
 #+title: Task: Add CMake target to build user manual PDF and commit it
 #+description: Follow the existing deploy_site pattern to add a deploy_manual CMake target that runs Emacs/LaTeX to export user_manual.org as PDF. Commit the PDF and add a download link.
@@ -16,7 +16,7 @@
 #+updated: 2026-05-24
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
-This page documents a [[id:31c868b9-306e-4282-ba8c-07e647021b34][task]] in the [[id:c42c3563-671f-4721-8ce8-5ee05925255f][Build and publish user manual PDF via CMake]] story. It captures the goal, current status, acceptance, and any notes or results.
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:C42C3563-671F-4721-8CE8-5EE05925255F][Build and publish user manual PDF via CMake]] story. It captures the goal, current status, acceptance, and any notes or results.
 
 * Goal
 

--- a/doc/plans/2026-02-02-enum-table-tenancy-plan.org
+++ b/doc/plans/2026-02-02-enum-table-tenancy-plan.org
@@ -1,5 +1,8 @@
-#+TITLE: Enum Table Tenancy Consolidation Plan
-#+version: 1
+:PROPERTIES:
+:ID: 8917A5A9-D7CA-4B52-9B19-329BBE8315D6
+:END:
+#+title: Enum Table Tenancy Consolidation
+#+version: 2
 #+AUTHOR: Claude
 #+DATE: 2026-02-02
 

--- a/doc/plans/2026-02-07-party-sql-support-design.org
+++ b/doc/plans/2026-02-07-party-sql-support-design.org
@@ -2,7 +2,7 @@
 :ID: 9A726128-0E7E-4A82-A61B-C6B1C5CFC070
 :END:
 #+title: Party & Counterparty SQL Support Design
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-02-08-gleif-librarian-integration-design.org
+++ b/doc/plans/2026-02-08-gleif-librarian-integration-design.org
@@ -2,7 +2,7 @@
 :ID: 5C83C9D5-F4AE-4707-BA7A-85D82FB2292B
 :END:
 #+title: GLEIF Dataset Librarian Integration Design
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-02-09-party-isolation-and-tenant-types-design.org
+++ b/doc/plans/2026-02-09-party-isolation-and-tenant-types-design.org
@@ -2,7 +2,7 @@
 :ID: 046217E8-7259-492B-A713-A4043C867FE5
 :END:
 #+title: Party-Level Isolation and Tenant Types Design
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-02-11-librarian-party-counterparty-publication-design.org
+++ b/doc/plans/2026-02-11-librarian-party-counterparty-publication-design.org
@@ -2,7 +2,7 @@
 :ID: 7A3D1E52-B8F4-4C91-A9E7-6F2C3D841B05
 :END:
 #+title: Librarian Party & Counterparty Publication Design
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-02-14-generation-context-design.org
+++ b/doc/plans/2026-02-14-generation-context-design.org
@@ -2,7 +2,7 @@
 :ID: 9392F2F3-6ECF-4BD7-82D8-9B88175ABFBA
 :END:
 #+title: Generation Context Design
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-02-15-iam-generators-and-test-migration.org
+++ b/doc/plans/2026-02-15-iam-generators-and-test-migration.org
@@ -2,7 +2,7 @@
 :ID: A7F3E1C2-8D4A-4B91-9E6F-2C1D8F5A3B70
 :END:
 #+title: IAM Generators and Test Migration
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-02-16-trade-envelope-and-fsm-design.org
+++ b/doc/plans/2026-02-16-trade-envelope-and-fsm-design.org
@@ -1,1 +1,5 @@
-#+version: 1
+:PROPERTIES:
+:ID: EEC13CF9-9665-4BF0-B18D-8801275709CD
+:END:
+#+title: Trade Envelope and FSM Design
+#+version: 2

--- a/doc/plans/2026-02-22-cli-domain-submenus-design.org
+++ b/doc/plans/2026-02-22-cli-domain-submenus-design.org
@@ -2,7 +2,7 @@
 :ID: B7D4E2A1-3C9F-4E8B-A5D2-1F6B8C0E3A94
 :END:
 #+title: CLI Domain Sub-menus Design
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-02-22-currency-taxonomy-enhancement.org
+++ b/doc/plans/2026-02-22-currency-taxonomy-enhancement.org
@@ -2,7 +2,7 @@
 :ID: B3E7F2A1-9C5D-4E82-AF1B-7D8C3E6B0F24
 :END:
 #+title: Currency Taxonomy Enhancement: Asset Class and Market Tier
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-02-27-ore-import-wizard-design.org
+++ b/doc/plans/2026-02-27-ore-import-wizard-design.org
@@ -2,7 +2,7 @@
 :ID: 8F3A1C2E-4B7D-4E9F-A1C3-2D5E6F8A0B1C
 :END:
 #+title: ORE Import Wizard Design
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-03-01-reporting-component-design.org
+++ b/doc/plans/2026-03-01-reporting-component-design.org
@@ -2,7 +2,7 @@
 :ID: A3F7C812-5E2D-4B9A-8C1F-6D0E3A7B2F4C
 :END:
 #+title: Reporting Component Design
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-03-03-party-codename-queue-isolation.org
+++ b/doc/plans/2026-03-03-party-codename-queue-isolation.org
@@ -2,7 +2,7 @@
 :ID: B4E2F931-7A1C-4D8E-9B3F-5C0D6A8E1F2B
 :END:
 #+title: Party Codename and Queue Isolation Design
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-03-05-jwt-migration-rs256.org
+++ b/doc/plans/2026-03-05-jwt-migration-rs256.org
@@ -1,5 +1,8 @@
-#+TITLE: JWT Migration to ores.security + RS256
-#+version: 1
+:PROPERTIES:
+:ID: 3D041443-0717-49A9-B3A7-E0262CA3C608
+:END:
+#+title: JWT Migration to ores.security + RS256
+#+version: 2
 #+DATE: 2026-03-05
 #+AUTHOR: ORE Studio Team
 #+STATUS: COMPLETED

--- a/doc/plans/2026-03-13-nats-migration.org
+++ b/doc/plans/2026-03-13-nats-migration.org
@@ -1,5 +1,8 @@
-#+TITLE: NATS Migration Plan: Binary Protocol to NATS/JetStream
-#+version: 1
+:PROPERTIES:
+:ID: D7D33E74-F42C-4908-BC5C-BC2BF652D0B5
+:END:
+#+title: NATS Migration: Binary Protocol to NATS/JetStream
+#+version: 2
 #+DATE: 2026-03-13
 #+AUTHOR: ORE Studio Team
 #+STATUS: COMPLETED

--- a/doc/plans/2026-03-14-nats-idiomatic-architecture.org
+++ b/doc/plans/2026-03-14-nats-idiomatic-architecture.org
@@ -1,5 +1,8 @@
-#+TITLE: NATS Idiomatic Architecture: Drop Binary Protocol, Adopt MessagePack + JetStream
-#+version: 1
+:PROPERTIES:
+:ID: 10A1F61F-859E-4ACE-BE8C-361E404AE2A5
+:END:
+#+title: NATS Idiomatic Architecture: Drop Binary Protocol, Adopt MessagePack + JetStream
+#+version: 2
 #+DATE: 2026-03-14
 #+AUTHOR: ORE Studio Team
 #+STATUS: COMPLETED

--- a/doc/plans/2026-03-16-nats-monitor-design.org
+++ b/doc/plans/2026-03-16-nats-monitor-design.org
@@ -2,7 +2,7 @@
 :ID: A3F2E1D0-B4C5-6789-ABCD-EF0123456789
 :END:
 #+title: NATS Monitor Design
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-03-16-nats-multitenancy-design.org
+++ b/doc/plans/2026-03-16-nats-multitenancy-design.org
@@ -2,7 +2,7 @@
 :ID: 4E762126-2152-11F1-B1D1-40B0768014EB
 :END:
 #+title: NATS Multi-Tenancy and Multi-Party Design
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-03-20-compute-grid-design.org
+++ b/doc/plans/2026-03-20-compute-grid-design.org
@@ -1,6 +1,9 @@
+:PROPERTIES:
+:ID: 5DDB8AD7-DEC7-4706-A1CE-B547A6CE0951
+:END:
 # -*- mode: org; indent-tabs-mode: nil -*-
-#+TITLE: Compute Grid Design Plan
-#+version: 1
+#+title: Compute Grid Design
+#+version: 2
 #+DATE: 2026-03-20
 #+AUTHOR: Marco Craveiro
 #+STATUS: COMPLETED

--- a/doc/plans/2026-03-20-compute-wrapper-design.org
+++ b/doc/plans/2026-03-20-compute-wrapper-design.org
@@ -2,7 +2,7 @@
 :ID: F703B8AE-BD05-4B55-9E18-856F61920DDD
 :END:
 #+title: Compute Wrapper Design
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-03-20-jwt-token-refresh.org
+++ b/doc/plans/2026-03-20-jwt-token-refresh.org
@@ -1,5 +1,8 @@
-#+TITLE: JWT Token Refresh: Configurable Lifetimes, Proactive Renewal, Session Expiry
-#+version: 1
+:PROPERTIES:
+:ID: 03FA2F6D-9920-4BA1-A895-F8F796C94789
+:END:
+#+title: JWT Token Refresh: Configurable Lifetimes, Proactive Renewal
+#+version: 2
 #+DATE: 2026-03-20
 #+AUTHOR: ORE Studio Team
 #+STATUS: COMPLETED

--- a/doc/plans/2026-03-20-system-settings-unification.org
+++ b/doc/plans/2026-03-20-system-settings-unification.org
@@ -1,5 +1,8 @@
-#+TITLE: System Settings Unification: Replace Feature Flags with Typed System Settings
-#+version: 1
+:PROPERTIES:
+:ID: 8219C384-3CD8-449B-A0C1-40E7C36316C1
+:END:
+#+title: System Settings Unification: Replace Feature Flags with Typed System Settings
+#+version: 2
 #+DATE: 2026-03-20
 #+AUTHOR: ORE Studio Team
 #+STATUS: COMPLETED

--- a/doc/plans/2026-03-21-compute-e2e-improvements.org
+++ b/doc/plans/2026-03-21-compute-e2e-improvements.org
@@ -2,7 +2,7 @@
 :ID: 7A4E9C1B-3F2D-4E8A-B6D5-0C1E2F3A4B5C
 :END:
 #+title: Compute Grid End-to-End Improvements
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-03-21-compute-grid-telemetry-design.org
+++ b/doc/plans/2026-03-21-compute-grid-telemetry-design.org
@@ -2,7 +2,7 @@
 :ID: 7E3F9A2B-4C81-4D5E-8F2A-1B9C3D4E5F6A
 :END:
 #+title: Compute Grid Telemetry Design
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-03-22-messaging-architecture-migration.org
+++ b/doc/plans/2026-03-22-messaging-architecture-migration.org
@@ -2,7 +2,7 @@
 :ID: 7F3A8B21-4C9E-4E5B-B2D0-3F8A9C6D1E4F
 :END:
 #+title: Service Architecture Migration
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-03-22-secure-stamping.org
+++ b/doc/plans/2026-03-22-secure-stamping.org
@@ -2,7 +2,7 @@
 :ID: 7F3A1B2C-8D4E-4F5A-9B6C-1D2E3F4A5B6C
 :END:
 #+title: Secure Provenance Stamping
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-03-23-move-generators-to-api.org
+++ b/doc/plans/2026-03-23-move-generators-to-api.org
@@ -2,7 +2,7 @@
 :ID: B3F7D2A1-9C5E-4D82-8B1F-3E6A7C4F1D90
 :END:
 #+title: Move Synthetic Generators to API Layer
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-03-26-cdm-instrument-domain-model.org
+++ b/doc/plans/2026-03-26-cdm-instrument-domain-model.org
@@ -2,7 +2,7 @@
 :ID: A3F2C1D0-AB12-11F1-8E4A-40B0768014EB
 :END:
 #+title: CDM-Inspired Instrument Domain Model
-#+version: 1
+#+version: 2
 #+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 * Overview

--- a/doc/plans/2026-03-26-compute-console-design.org
+++ b/doc/plans/2026-03-26-compute-console-design.org
@@ -1,5 +1,8 @@
-#+TITLE: Compute Console UI Refactor
-#+version: 1
+:PROPERTIES:
+:ID: C57242F9-3D75-43DB-9D09-31EA5F147CC4
+:END:
+#+title: Compute Console UI Refactor
+#+version: 2
 #+DATE: 2026-03-26
 #+AUTHOR: Marco Craveiro
 

--- a/doc/plans/2026-03-27-compute-console-rework.org
+++ b/doc/plans/2026-03-27-compute-console-rework.org
@@ -1,5 +1,8 @@
-#+TITLE: Compute Console Rework
-#+version: 1
+:PROPERTIES:
+:ID: 8FBACF31-CFFC-4C98-9964-92B58952FC69
+:END:
+#+title: Compute Console Rework
+#+version: 2
 #+DATE: 2026-03-27
 #+AUTHOR: Marco Craveiro
 

--- a/doc/plans/2026-03-27-service-to-service-auth-design.org
+++ b/doc/plans/2026-03-27-service-to-service-auth-design.org
@@ -1,5 +1,8 @@
-#+TITLE: Service-to-Service Authentication Design
-#+version: 1
+:PROPERTIES:
+:ID: E11C4C56-5722-4A5B-9779-7BE2C658A3EF
+:END:
+#+title: Service-to-Service Authentication Design
+#+version: 2
 #+DATE: 2026-03-27
 #+AUTHOR: ORE Studio Team
 #+STATUS: DRAFT

--- a/doc/plans/2026-03-28-badge-system-design.org
+++ b/doc/plans/2026-03-28-badge-system-design.org
@@ -2,7 +2,7 @@
 :ID: 7E4B1C93-2F8A-4D56-B3E7-9A0C5F812D6E
 :END:
 #+title: Database-Driven Badge System Design
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-03-28-cdm-instrument-domain-model-phase2.org
+++ b/doc/plans/2026-03-28-cdm-instrument-domain-model-phase2.org
@@ -2,7 +2,7 @@
 :ID: B7E4D2A1-CD23-11F1-9F1E-40B0768014EB
 :END:
 #+title: CDM-Inspired Instrument Domain Model — Phase 2 (Equity, Commodity, Extensions)
-#+version: 1
+#+version: 2
 #+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 * Overview

--- a/doc/plans/2026-03-28-service-rbac-design.org
+++ b/doc/plans/2026-03-28-service-rbac-design.org
@@ -1,5 +1,8 @@
-#+TITLE: Service Account RBAC Design
-#+version: 1
+:PROPERTIES:
+:ID: DC79D8CE-FBEB-4FC9-9DB5-D39724F2DF86
+:END:
+#+title: Service Account RBAC Design
+#+version: 2
 #+DATE: 2026-03-28
 #+AUTHOR: ORE Studio Team
 #+STATUS: REVISED 2026-05-13

--- a/doc/plans/2026-03-29-ore-instrument-mappers-phase9.org
+++ b/doc/plans/2026-03-29-ore-instrument-mappers-phase9.org
@@ -2,7 +2,7 @@
 :ID: C9E3A2F4-DE45-11F1-B02C-40B0768014EB
 :END:
 #+title: ORE Instrument Mappers — Phase 9
-#+version: 1
+#+version: 2
 #+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 * Overview

--- a/doc/plans/2026-03-30-service-to-service-delegation.org
+++ b/doc/plans/2026-03-30-service-to-service-delegation.org
@@ -1,5 +1,8 @@
-#+TITLE: Service-to-Service JWT Delegation
-#+version: 1
+:PROPERTIES:
+:ID: 4B02695C-7C59-487A-8450-4240EC836685
+:END:
+#+title: Service-to-Service JWT Delegation
+#+version: 2
 #+DATE: 2026-03-30
 #+AUTHOR: ORE Studio Team
 #+STATUS: DRAFT

--- a/doc/plans/2026-03-31-instrument-trade-model-and-export.org
+++ b/doc/plans/2026-03-31-instrument-trade-model-and-export.org
@@ -1,5 +1,8 @@
-#+title: Instrument–Trade Model Refactor and ORE Portfolio Export
-#+version: 1
+:PROPERTIES:
+:ID: D4D975DB-A525-45E3-B383-581E51AEA8DB
+:END:
+#+title: Instrument-Trade Model Refactor and ORE Portfolio Export
+#+version: 2
 #+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 * Overview

--- a/doc/plans/2026-03-31-ore-market-data-file-types.org
+++ b/doc/plans/2026-03-31-ore-market-data-file-types.org
@@ -2,7 +2,7 @@
 :ID: F4A17B30-FE81-11F0-A3C4-40B0768014EB
 :END:
 #+title: ORE Market Data File Types — Phase 1 (ores.ore)
-#+version: 1
+#+version: 2
 #+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 * Overview

--- a/doc/plans/2026-03-31-ore-marketdata-domain-model.org
+++ b/doc/plans/2026-03-31-ore-marketdata-domain-model.org
@@ -2,7 +2,7 @@
 :ID: 9F3C2D87-5B14-4E8A-B6D1-0A7C3F921E45
 :END:
 #+title: ORE Market Data Domain Model
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-03-31-ore-trading-instrument-support.org
+++ b/doc/plans/2026-03-31-ore-trading-instrument-support.org
@@ -1,5 +1,8 @@
+:PROPERTIES:
+:ID: E3663D45-AE04-42AE-B588-06DCAE4DE119
+:END:
 #+title: ORE Trading Instrument Support — Complete Implementation
-#+version: 1
+#+version: 2
 #+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 * Overview

--- a/doc/plans/2026-04-01-asset-class-unification.org
+++ b/doc/plans/2026-04-01-asset-class-unification.org
@@ -2,7 +2,7 @@
 :ID: 4A7E9C12-3B85-4F2D-A8D6-1C5E0B734F92
 :END:
 #+title: Asset Class Unification
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-04-01-trade-instrument-unified-dialog.org
+++ b/doc/plans/2026-04-01-trade-instrument-unified-dialog.org
@@ -1,5 +1,8 @@
+:PROPERTIES:
+:ID: B0D35884-6703-4889-8B47-ED0E279F5E2F
+:END:
 #+title: Unified Trade + Instrument Detail Dialog
-#+version: 1
+#+version: 2
 #+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+STATUS: DONE
 

--- a/doc/plans/2026-04-03-server-side-ore-import.org
+++ b/doc/plans/2026-04-03-server-side-ore-import.org
@@ -1,6 +1,9 @@
+:PROPERTIES:
+:ID: 40F4FC83-3552-4788-8520-1570A74A8BCA
+:END:
 # -*- mode: org; indent-tabs-mode: nil -*-
-#+TITLE: Server-Side ORE Import
-#+version: 1
+#+title: Server-Side ORE Import
+#+version: 2
 #+DATE: 2026-04-03
 #+AUTHOR: Marco Craveiro
 #+STATUS: IN PROGRESS

--- a/doc/plans/2026-04-05-report-definition-to-instance.org
+++ b/doc/plans/2026-04-05-report-definition-to-instance.org
@@ -2,7 +2,7 @@
 :ID: A3F7C2D1-8E4B-4F9A-B6C3-2D1E8F5A7B9C
 :END:
 #+title: Report Definition to Instance Pipeline
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-04-05-report-execution.org
+++ b/doc/plans/2026-04-05-report-execution.org
@@ -2,7 +2,7 @@
 :ID: B4E8D3F2-9C5A-4B7E-C7D4-3E2F9A6C8D0E
 :END:
 #+title: Report Execution Pipeline
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-04-05-workflow-engine-generalisation.org
+++ b/doc/plans/2026-04-05-workflow-engine-generalisation.org
@@ -2,7 +2,7 @@
 :ID: C5F9E4A3-0D6B-5C8F-D8E5-4F3A0B7D9E1F
 :END:
 #+title: Workflow Engine Generalisation
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-04-06-report-execution-workflow-implementation.org
+++ b/doc/plans/2026-04-06-report-execution-workflow-implementation.org
@@ -2,7 +2,7 @@
 :ID: D7E2F1A3-4B8C-5D9E-A6F3-1C0D8E7B4A2F
 :END:
 #+title: Report Execution Workflow — Implementation Plan
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-04-07-trade-detail-dialog-data-driven-refactor.org
+++ b/doc/plans/2026-04-07-trade-detail-dialog-data-driven-refactor.org
@@ -1,5 +1,8 @@
+:PROPERTIES:
+:ID: AB46A15C-A46C-4317-8563-A3674BEE83AF
+:END:
 #+title: Data-Driven TradeDetailDialog Refactor
-#+version: 1
+#+version: 2
 #+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+STATUS: DONE
 

--- a/doc/plans/2026-04-08-qt-qpluginloader-architecture.org
+++ b/doc/plans/2026-04-08-qt-qpluginloader-architecture.org
@@ -2,7 +2,7 @@
 :ID: 720D74A0-DAD3-4F11-BC5F-AD78BF5A9DD2
 :END:
 #+title: Qt QPluginLoader Architecture Migration
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-04-08-unified-service-hosting.org
+++ b/doc/plans/2026-04-08-unified-service-hosting.org
@@ -1,5 +1,8 @@
-#+TITLE: Unified Service Hosting: Normalise All Services to ores.service Infrastructure
-#+version: 1
+:PROPERTIES:
+:ID: 1411D94A-24FA-4164-AD75-F3CE7415903B
+:END:
+#+title: Unified Service Hosting
+#+version: 2
 #+DATE: 2026-04-08
 #+AUTHOR: Marco Craveiro
 #+STATUS: IN PROGRESS

--- a/doc/plans/2026-04-08-utc-everywhere-enforcement.org
+++ b/doc/plans/2026-04-08-utc-everywhere-enforcement.org
@@ -2,7 +2,7 @@
 :ID: 3268BB6F-E87B-4EDD-B622-015888C1A6D3
 :END:
 #+title: UTC-Everywhere Timestamp Enforcement
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-04-09-instrument-tables-redesign.org
+++ b/doc/plans/2026-04-09-instrument-tables-redesign.org
@@ -1,5 +1,8 @@
+:PROPERTIES:
+:ID: 8F82C72D-CB65-45A8-AD91-3DBDFBD4BEDE
+:END:
 #+title: Instrument Tables Redesign — Standalone Asset-Class Tables
-#+version: 1
+#+version: 2
 #+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 * Overview

--- a/doc/plans/2026-04-10-scheduler-realtime-ui.org
+++ b/doc/plans/2026-04-10-scheduler-realtime-ui.org
@@ -2,7 +2,7 @@
 :ID: 8B8E0568-AF14-4820-B7AD-6FCA99C40626
 :END:
 #+title: Scheduler Real-Time UI — Job Lifecycle Events and Live Views
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-04-10-workflow-monitor-design.org
+++ b/doc/plans/2026-04-10-workflow-monitor-design.org
@@ -1,5 +1,8 @@
-#+TITLE: Workflow Monitor — Design & Implementation Plan
-#+version: 1
+:PROPERTIES:
+:ID: 3453C341-C060-4FE8-9F14-6B4A8570F308
+:END:
+#+title: Workflow Monitor — Design & Implementation Plan
+#+version: 2
 #+DATE: 2026-04-10
 #+AUTHOR: Marco Craveiro
 

--- a/doc/plans/2026-04-21-fx-forward-import-e2e.org
+++ b/doc/plans/2026-04-21-fx-forward-import-e2e.org
@@ -1,5 +1,8 @@
+:PROPERTIES:
+:ID: 982EC471-A825-45C1-982F-38681A2C14FD
+:END:
 #+title: FX Forward ORE Import End-to-End Wiring
-#+version: 1
+#+version: 2
 #+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 
 * Overview

--- a/doc/plans/2026-04-21-ore-import-conventions.org
+++ b/doc/plans/2026-04-21-ore-import-conventions.org
@@ -2,7 +2,7 @@
 :ID: 7D4E1A08-1F3E-11F2-B4B1-40B0768014EB
 :END:
 #+title: ORE Import: Conventions Persistence & Full Import Pipeline
-#+version: 1
+#+version: 2
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+startup: inlineimages

--- a/doc/plans/2026-04-22-equity-per-type-migration.org
+++ b/doc/plans/2026-04-22-equity-per-type-migration.org
@@ -1,5 +1,8 @@
+:PROPERTIES:
+:ID: 091B481F-914A-43D3-B86B-58E35ED0E463
+:END:
 #+title: Equity Per-Type Instrument Migration
-#+version: 1
+#+version: 2
 #+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+STATUS: DONE
 

--- a/doc/plans/2026-05-05-import-export-cleanup.org
+++ b/doc/plans/2026-05-05-import-export-cleanup.org
@@ -1,5 +1,8 @@
+:PROPERTIES:
+:ID: E2401716-C8B1-4FEA-8DB9-8EB4877328C8
+:END:
 #+title: ORE Import / Export Code Cleanup
-#+version: 1
+#+version: 2
 #+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+status: COMPLETE
 #+completed: 2026-05-06

--- a/doc/plans/2026-05-05-ore-domain-roundtrip.org
+++ b/doc/plans/2026-05-05-ore-domain-roundtrip.org
@@ -1,5 +1,8 @@
+:PROPERTIES:
+:ID: AF6A4F45-1AFB-46C6-8955-D88F67F9DA91
+:END:
 #+title: ORE Domain Roundtrip Check (Thing 3)
-#+version: 1
+#+version: 2
 #+STATUS: COMPLETE
 #+options: <:nil c:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
 #+note: Type bridge section updated 2026-05-06 — import/export cleanup (PR #728)

--- a/doc/plans/2026-05-12-strict-service-table-isolation.org
+++ b/doc/plans/2026-05-12-strict-service-table-isolation.org
@@ -1,5 +1,8 @@
-#+TITLE: Strict Service Table Isolation
-#+version: 1
+:PROPERTIES:
+:ID: 27A575D3-DB84-411D-B3C0-58122128E424
+:END:
+#+title: Strict Service Table Isolation
+#+version: 2
 #+SUBTITLE: Mandatory role drops + zero cross-component DB access
 #+DATE: 2026-05-12
 #+AUTHOR: ORE Studio Team

--- a/doc/plans/2026-05-13-cross-service-write-decoupling.org
+++ b/doc/plans/2026-05-13-cross-service-write-decoupling.org
@@ -1,5 +1,8 @@
-#+TITLE: Cross-Service Write Decoupling
-#+version: 1
+:PROPERTIES:
+:ID: 004B427A-2B3E-4556-8345-A72251238202
+:END:
+#+title: Cross-Service Write Decoupling
+#+version: 2
 #+SUBTITLE: IAM party cache + NATS write APIs for workflow/ORE
 #+DATE: 2026-05-13
 #+AUTHOR: ORE Studio Team

--- a/doc/plans/2026-05-13-identifier-length-cleanup.org
+++ b/doc/plans/2026-05-13-identifier-length-cleanup.org
@@ -1,5 +1,8 @@
-#+TITLE: PostgreSQL Identifier Length Cleanup
-#+version: 1
+:PROPERTIES:
+:ID: 7BBA5627-F13D-4BFC-9E03-C15B61A11AD5
+:END:
+#+title: PostgreSQL Identifier Length Cleanup
+#+version: 2
 #+SUBTITLE: Eliminate NAMEDATALEN truncation warnings for RLS policies and indexes
 #+DATE: 2026-05-13
 #+AUTHOR: ORE Studio Team

--- a/doc/plans/2026-05-13-symbol-visibility-migration.org
+++ b/doc/plans/2026-05-13-symbol-visibility-migration.org
@@ -2,7 +2,7 @@
 :ID: F2A4C6E8-B1D3-4E5F-A7B9-2C4D6E8F0A1B
 :END:
 #+title: Symbol Visibility Migration
-#+version: 1
+#+version: 2
 #+STATUS: COMPLETE
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil

--- a/doc/plans/2026-05-14-codegen-sql-debt.org
+++ b/doc/plans/2026-05-14-codegen-sql-debt.org
@@ -1,5 +1,8 @@
-#+TITLE: Codegen SQL Debt — Hand-Written Files with Existing Models
-#+version: 1
+:PROPERTIES:
+:ID: 05661A18-616C-4C39-8A88-BFBB4C68FD2E
+:END:
+#+title: Codegen SQL Debt — Hand-Written Files with Existing Models
+#+version: 2
 #+DATE: 2026-05-14
 #+AUTHOR: ORE Studio Team
 #+STATUS: COMPLETE (PR #752, investigation/codegen-drift-3)

--- a/doc/plans/2026-05-14-dq-publish-pattern.org
+++ b/doc/plans/2026-05-14-dq-publish-pattern.org
@@ -1,5 +1,8 @@
-#+TITLE: DQ Publish Pattern — Architecture and Decision
-#+version: 1
+:PROPERTIES:
+:ID: 98B3572E-A9F9-45F5-A4C5-3DC23F3CFF70
+:END:
+#+title: DQ Publish Pattern — Architecture and Decision
+#+version: 2
 #+SUBTITLE: Reconciling bulk artefact publishing with strict service table isolation
 #+DATE: 2026-05-14
 #+AUTHOR: ORE Studio Team

--- a/doc/plans/2026-05-14-workflow-engine-hardening.org
+++ b/doc/plans/2026-05-14-workflow-engine-hardening.org
@@ -1,5 +1,8 @@
-#+TITLE: Workflow Engine Hardening
-#+version: 1
+:PROPERTIES:
+:ID: D9143823-DFCD-4208-96BE-8AD647A78C8D
+:END:
+#+title: Workflow Engine Hardening
+#+version: 2
 #+SUBTITLE: Dynamic steps, ownership relocation, idempotency, and a reusable step widget
 #+DATE: 2026-05-14
 #+AUTHOR: ORE Studio Team

--- a/doc/plans/2026-05-15-login-environment-filter.org
+++ b/doc/plans/2026-05-15-login-environment-filter.org
@@ -1,5 +1,8 @@
+:PROPERTIES:
+:ID: D7F263C4-7A0C-4ABD-85E7-0BD90C0C4D98
+:END:
 #+title: Login Dialog Label Filter
-#+version: 1
+#+version: 2
 #+date: 2026-05-15
 #+author: Marco Craveiro
 

--- a/doc/plans/2026-05-15-ore-import-error-reporting.org
+++ b/doc/plans/2026-05-15-ore-import-error-reporting.org
@@ -1,5 +1,8 @@
+:PROPERTIES:
+:ID: E7976556-8EA4-4A54-A414-BE0D11762DEC
+:END:
 #+title: ORE Import Error Reporting and Step Warning State
-#+version: 1
+#+version: 2
 #+date: 2026-05-15
 #+author: Marco Craveiro
 #+STATUS: COMPLETE

--- a/doc/plans/2026-05-15-qt-plugin-isolation.org
+++ b/doc/plans/2026-05-15-qt-plugin-isolation.org
@@ -1,5 +1,8 @@
+:PROPERTIES:
+:ID: 3125F901-7AC2-421C-8AEF-8C508B0E315B
+:END:
 #+title: Qt Plugin Isolation: Cross-Plugin Symbol Dependencies
-#+version: 1
+#+version: 2
 #+STATUS: COMPLETE
 #+date: 2026-05-15
 #+author: Marco Craveiro

--- a/doc/plans/2026-05-16-controller-shutdown-latency.org
+++ b/doc/plans/2026-05-16-controller-shutdown-latency.org
@@ -1,5 +1,8 @@
-#+TITLE: Controller Startup and Shutdown Latency Fix
-#+version: 1
+:PROPERTIES:
+:ID: 45312FEA-BE7D-452E-8432-55E8AD04B3F1
+:END:
+#+title: Controller Startup and Shutdown Latency Fix
+#+version: 2
 #+SUBTITLE: Move blocking DB writes off the io_context thread in process_supervisor
 #+DATE: 2026-05-16
 #+AUTHOR: ORE Studio Team

--- a/doc/plans/2026-05-16-trade-import-failed-state.org
+++ b/doc/plans/2026-05-16-trade-import-failed-state.org
@@ -1,5 +1,8 @@
-#+TITLE: Data Import Session and Workflow Partial-Success
-#+version: 1
+:PROPERTIES:
+:ID: 5DAEC346-CB22-4CE1-8293-12A1986AFDB6
+:END:
+#+title: Data Import Session and Workflow Partial-Success
+#+version: 2
 #+SUBTITLE: Full ORE data import pipeline; pending trade staging; non-live marker for reference data; structured workflow failure reporting
 #+DATE: 2026-05-16
 #+AUTHOR: ORE Studio Team

--- a/doc/plans/2026-05-17-msvc-c1202-rfl-tu-split.org
+++ b/doc/plans/2026-05-17-msvc-c1202-rfl-tu-split.org
@@ -1,5 +1,8 @@
-#+TITLE: MSVC C1202 — Decompose trade into Sub-Structs
-#+version: 1
+:PROPERTIES:
+:ID: 5319618A-FEB6-46F4-9588-11495CA8E164
+:END:
+#+title: MSVC C1202 — Decompose trade into Sub-Structs
+#+version: 2
 #+DATE: 2026-05-17
 #+AUTHOR: ORE Studio Team
 #+STATUS: IN PROGRESS

--- a/doc/plans/2026-05-17-shared-audit-record.org
+++ b/doc/plans/2026-05-17-shared-audit-record.org
@@ -1,5 +1,8 @@
-#+TITLE: Shared audit_record and Codegen Composite-Type Support
-#+version: 1
+:PROPERTIES:
+:ID: 1EF768F1-5B86-402F-866A-5CB730F48319
+:END:
+#+title: Shared audit_record and Codegen Composite-Type Support
+#+version: 2
 #+DATE: 2026-05-17
 #+AUTHOR: ORE Studio Team
 #+STATUS: DRAFT

--- a/doc/plans/2026-05-17-tenant-system-reset.org
+++ b/doc/plans/2026-05-17-tenant-system-reset.org
@@ -1,5 +1,8 @@
-#+TITLE: Tenant and System Bootstrap Reset
-#+version: 1
+:PROPERTIES:
+:ID: B5EB3B4F-681A-48C9-BAF2-9256FE889A45
+:END:
+#+title: Tenant and System Bootstrap Reset
+#+version: 2
 #+SUBTITLE: Dev-cycle reset from shell scripts through to system-admin UI
 #+DATE: 2026-05-17
 #+AUTHOR: ORE Studio Team

--- a/doc/plans/2026-05-17-virtual-portfolio-design.org
+++ b/doc/plans/2026-05-17-virtual-portfolio-design.org
@@ -1,5 +1,8 @@
-#+TITLE: Virtual Portfolio Design
-#+version: 1
+:PROPERTIES:
+:ID: AD2D6529-4870-4BD0-9B68-6DF3CCAAFBCA
+:END:
+#+title: Virtual Portfolio Design
+#+version: 2
 #+SUBTITLE: User-owned reporting overlays that aggregate real portfolios and books across the book tree
 #+DATE: 2026-05-17
 #+AUTHOR: ORE Studio Team

--- a/doc/plans/2026-05-17-workspace-design.org
+++ b/doc/plans/2026-05-17-workspace-design.org
@@ -1,5 +1,8 @@
-#+TITLE: Workspace — Isolated Data Context Design
-#+version: 1
+:PROPERTIES:
+:ID: CEAD2E6A-8C12-489F-B64A-652EE2B81811
+:END:
+#+title: Workspace — Isolated Data Context Design
+#+version: 2
 #+SUBTITLE: Self-contained, layered data workspaces within OreStudio; prerequisite for ORE sample import and multi-track data import
 #+DATE: 2026-05-17
 #+AUTHOR: ORE Studio Team

--- a/doc/plans/2026-05-18-codegen-iam-permissions.org
+++ b/doc/plans/2026-05-18-codegen-iam-permissions.org
@@ -1,5 +1,8 @@
-#+TITLE: Codegen IAM Permissions and Roles Population
-#+version: 1
+:PROPERTIES:
+:ID: 847AECEA-D0E6-4D4F-870A-F0E720B49256
+:END:
+#+title: Codegen IAM Permissions and Roles Population
+#+version: 2
 #+DATE: 2026-05-18
 #+AUTHOR: ORE Studio Team
 #+STATUS: PROPOSED

--- a/doc/plans/2026-05-18-menu-structure-simplification.org
+++ b/doc/plans/2026-05-18-menu-structure-simplification.org
@@ -1,5 +1,8 @@
-#+TITLE: Menu Structure Analysis and Simplification
-#+version: 1
+:PROPERTIES:
+:ID: 8F08358F-3909-479A-872D-E1A362F9DF4F
+:END:
+#+title: Menu Structure Analysis and Simplification
+#+version: 2
 #+DATE: 2026-05-18
 #+AUTHOR: ORE Studio Team
 #+STATUS: IN PROGRESS

--- a/doc/plans/2026-05-19-qt-trading-codegen-drift.org
+++ b/doc/plans/2026-05-19-qt-trading-codegen-drift.org
@@ -1,5 +1,8 @@
-#+TITLE: Qt Trading Codegen Drift Remediation
-#+version: 1
+:PROPERTIES:
+:ID: 69FBCA3B-CDFE-43F5-8C4F-4C26B4D19ADD
+:END:
+#+title: Qt Trading Codegen Drift Remediation
+#+version: 2
 #+DATE: 2026-05-19
 #+AUTHOR: ORE Studio Team
 #+STATUS: IN PROGRESS

--- a/doc/plans/2026-05-19-uml-model-refresh.org
+++ b/doc/plans/2026-05-19-uml-model-refresh.org
@@ -1,5 +1,8 @@
-#+TITLE: UML Model Refresh
-#+version: 1
+:PROPERTIES:
+:ID: F806E77A-A8CC-4683-9563-06EE5DE3644F
+:END:
+#+title: UML Model Refresh
+#+version: 2
 #+SUBTITLE: Bring all component class diagrams up to date; introduce a generation script
 #+DATE: 2026-05-19
 #+AUTHOR: ORE Studio Team

--- a/doc/plans/2026-05-19-workspace-id-codegen-propagation.org
+++ b/doc/plans/2026-05-19-workspace-id-codegen-propagation.org
@@ -1,5 +1,8 @@
-#+TITLE: Workspace ID Codegen Propagation
-#+version: 1
+:PROPERTIES:
+:ID: 827CB04D-AE39-40BA-A291-CAAE5360CD92
+:END:
+#+title: Workspace ID Codegen Propagation
+#+version: 2
 #+DATE: 2026-05-19
 #+STATUS: Complete
 

--- a/doc/plans/2026-05-20-refdata-cpp-codegen-activation.org
+++ b/doc/plans/2026-05-20-refdata-cpp-codegen-activation.org
@@ -2,7 +2,7 @@
 :ID: 8B4C1D2E-93F7-4A68-C5B9-6D0E1F4A2B83
 :END:
 #+title: Refdata C++ Codegen: Activate Domain/Generator/Repository Generation
-#+version: 1
+#+version: 2
 #+STATUS: TODO
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil

--- a/doc/plans/2026-05-20-refdata-party-tenant-id-migration.org
+++ b/doc/plans/2026-05-20-refdata-party-tenant-id-migration.org
@@ -2,7 +2,7 @@
 :ID: 3A7F2B1C-84E6-4D59-B2A8-5C9E0F3D1A72
 :END:
 #+title: Refdata Party Domain: tenant_id Strong-Type Migration
-#+version: 1
+#+version: 2
 #+STATUS: DONE
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil

--- a/doc/plans/2026-05-21-doc-version-marker-and-v2-merge.org
+++ b/doc/plans/2026-05-21-doc-version-marker-and-v2-merge.org
@@ -1,5 +1,8 @@
-#+TITLE: Tagged v1/v2 Coexistence — Merge doc/v2/ and add #+version: markers
-#+version: 1
+:PROPERTIES:
+:ID: 7305A77A-3A41-42CA-BD1D-227E2FB18DF0
+:END:
+#+title: Tagged v1/v2 Coexistence — Merge doc/v2/ and Add Version Markers
+#+version: 2
 #+AUTHOR: Claude
 #+DATE: 2026-05-21
 

--- a/doc/plans/2026-05-21-entity-creator-skills-overhaul.org
+++ b/doc/plans/2026-05-21-entity-creator-skills-overhaul.org
@@ -2,7 +2,7 @@
 :ID: A4B5C6D7-E8F9-0A1B-2C3D-4E5F6A7B8C9D
 :END:
 #+title: Entity Creator Skills Overhaul: Orchestrator, Template References, Codegen Gaps
-#+version: 1
+#+version: 2
 #+STATUS: TODO
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil

--- a/doc/plans/2026-05-21-entity-creator-skills-v2-migration.org
+++ b/doc/plans/2026-05-21-entity-creator-skills-v2-migration.org
@@ -2,7 +2,7 @@
 :ID: 3F7A2C1D-84BE-4E9F-B261-5C0D9A3E7B48
 :END:
 #+title: Entity Creator Skills: v1 → v2 Migration
-#+version: 1
+#+version: 2
 #+STATUS: TODO
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil

--- a/doc/plans/2026-05-21-msvc-c1202-workaround-cleanup.org
+++ b/doc/plans/2026-05-21-msvc-c1202-workaround-cleanup.org
@@ -2,6 +2,7 @@
 :ID: 7E3A9C2F-B405-4D81-A63E-F18D205B47C9
 :END:
 #+title: MSVC C1202 Workaround Cleanup
+#+version: 2
 #+STATUS: COMPLETE
 #+author: Marco Craveiro
 #+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil

--- a/doc/plans/2026-05-21-workspace-full-entity.org
+++ b/doc/plans/2026-05-21-workspace-full-entity.org
@@ -1,3 +1,6 @@
+:PROPERTIES:
+:ID: B9A1498E-5903-4C82-8A19-3CE43A0BA5FA
+:END:
 #+TITLE: Promote Workspace to Full Standard Entity
 #+DATE: 2026-05-21
 #+STATUS: In Progress

--- a/doc/plans/plans.org
+++ b/doc/plans/plans.org
@@ -8,7 +8,7 @@
 #+level: cross
 #+filetags: :plans:index:knowledge:
 #+created: 2026-05-21
-#+updated: 2026-05-21
+#+updated: 2026-05-24
 
 These are pre-sprint design documents written during or before implementation.
 They are kept for historical context — to understand why a decision was made
@@ -19,89 +19,89 @@ Active work lives in the [[id:46DFE47F-967B-4C24-95BF-3E21F97CFD20][agile proces
 
 |       Date | Plan                                                                             | Status      |
 |------------+----------------------------------------------------------------------------------+-------------|
-| 2026-02-02 | Enum Table Tenancy Consolidation                                                 |             |
-| 2026-02-07 | Party & Counterparty SQL Support Design                                          | COMPLETED   |
-| 2026-02-08 | GLEIF Dataset Librarian Integration Design                                       |             |
-| 2026-02-09 | Party-Level Isolation and Tenant Types Design                                    | COMPLETED   |
-| 2026-02-11 | Librarian Party & Counterparty Publication Design                                |             |
-| 2026-02-14 | Generation Context Design                                                        | COMPLETED   |
-| 2026-02-15 | IAM Generators and Test Migration                                                | COMPLETED   |
-| 2026-02-16 | Trade Envelope and FSM Design                                                    |             |
-| 2026-02-22 | CLI Domain Sub-menus Design                                                      | COMPLETED   |
-| 2026-02-22 | Currency Taxonomy Enhancement: Asset Class and Market Tier                       | COMPLETED   |
-| 2026-02-27 | ORE Import Wizard Design                                                         | COMPLETED   |
-| 2026-03-01 | Reporting Component Design                                                       |             |
-| 2026-03-03 | Party Codename and Queue Isolation Design                                        |             |
-| 2026-03-05 | JWT Migration to ores.security + RS256                                           | COMPLETED   |
-| 2026-03-13 | NATS Migration: Binary Protocol to NATS/JetStream                                | COMPLETED   |
-| 2026-03-14 | NATS Idiomatic Architecture: Drop Binary Protocol, Adopt MessagePack + JetStream | COMPLETED   |
-| 2026-03-16 | NATS Monitor Design                                                              |             |
-| 2026-03-16 | NATS Multi-Tenancy and Multi-Party Design                                        | COMPLETED   |
-| 2026-03-20 | Compute Grid Design                                                              | COMPLETED   |
-| 2026-03-20 | Compute Wrapper Design                                                           | COMPLETED   |
-| 2026-03-20 | JWT Token Refresh: Configurable Lifetimes, Proactive Renewal                     | COMPLETED   |
-| 2026-03-20 | System Settings Unification: Replace Feature Flags with Typed System Settings    | COMPLETED   |
-| 2026-03-21 | Compute Grid End-to-End Improvements                                             | COMPLETED   |
-| 2026-03-21 | Compute Grid Telemetry Design                                                    | COMPLETED   |
-| 2026-03-22 | Service Architecture Migration                                                   | COMPLETED   |
-| 2026-03-22 | Secure Provenance Stamping                                                       | COMPLETED   |
-| 2026-03-23 | Move Synthetic Generators to API Layer                                           | COMPLETED   |
-| 2026-03-26 | CDM-Inspired Instrument Domain Model                                             |             |
-| 2026-03-26 | Compute Console UI Refactor                                                      |             |
-| 2026-03-27 | Compute Console Rework                                                           |             |
-| 2026-03-27 | Service-to-Service Authentication Design                                         | DRAFT       |
-| 2026-03-28 | Database-Driven Badge System Design                                              |             |
-| 2026-03-28 | CDM-Inspired Instrument Domain Model — Phase 2                                   |             |
-| 2026-03-28 | Service Account RBAC Design                                                      |             |
-| 2026-03-29 | ORE Instrument Mappers — Phase 9                                                 |             |
-| 2026-03-30 | Service-to-Service JWT Delegation                                                | DRAFT       |
-| 2026-03-31 | Instrument-Trade Model Refactor and ORE Portfolio Export                         |             |
-| 2026-03-31 | ORE Market Data Domain Model                                                     |             |
-| 2026-03-31 | ORE Market Data File Types — Phase 1                                             |             |
-| 2026-03-31 | ORE Trading Instrument Support — Complete Implementation                         |             |
-| 2026-04-01 | Asset Class Unification                                                          |             |
-| 2026-04-01 | Unified Trade + Instrument Detail Dialog                                         | DONE        |
-| 2026-04-03 | Server-Side ORE Import                                                           | IN PROGRESS |
-| 2026-04-05 | Report Definition to Instance Pipeline                                           | COMPLETED   |
-| 2026-04-05 | Report Execution Pipeline                                                        | DRAFT       |
-| 2026-04-05 | Workflow Engine Generalisation                                                   | IN PROGRESS |
-| 2026-04-06 | Report Execution Workflow — Implementation Plan                                  | IN PROGRESS |
-| 2026-04-07 | Data-Driven TradeDetailDialog Refactor                                           | DONE        |
-| 2026-04-08 | Qt QPluginLoader Architecture Migration                                          |             |
-| 2026-04-08 | Unified Service Hosting                                                          | IN PROGRESS |
-| 2026-04-08 | UTC-Everywhere Timestamp Enforcement                                             |             |
-| 2026-04-09 | Instrument Tables Redesign — Standalone Asset-Class Tables                       |             |
-| 2026-04-10 | Scheduler Real-Time UI                                                           | DONE        |
-| 2026-04-10 | Workflow Monitor — Design & Implementation Plan                                  |             |
-| 2026-04-21 | FX Forward ORE Import End-to-End Wiring                                          |             |
-| 2026-04-21 | ORE Import: Conventions Persistence & Full Import Pipeline                       | IN PROGRESS |
-| 2026-04-22 | Equity Per-Type Instrument Migration                                             | DONE        |
-| 2026-05-05 | ORE Import / Export Code Cleanup                                                 | COMPLETE    |
-| 2026-05-05 | ORE Domain Roundtrip Check                                                       | COMPLETE    |
-| 2026-05-12 | Strict Service Table Isolation                                                   | COMPLETE    |
-| 2026-05-13 | Cross-Service Write Decoupling                                                   | DONE        |
-| 2026-05-13 | PostgreSQL Identifier Length Cleanup                                             | COMPLETE    |
-| 2026-05-13 | Symbol Visibility Migration                                                      | COMPLETE    |
-| 2026-05-14 | Codegen SQL Debt — Hand-Written Files with Existing Models                       | COMPLETE    |
-| 2026-05-14 | DQ Publish Pattern — Architecture and Decision                                   | IN PROGRESS |
-| 2026-05-14 | Workflow Engine Hardening                                                        | COMPLETE    |
-| 2026-05-15 | Login Dialog Label Filter                                                        |             |
-| 2026-05-15 | ORE Import Error Reporting and Step Warning State                                | COMPLETE    |
-| 2026-05-15 | Qt Plugin Isolation: Cross-Plugin Symbol Dependencies                            | COMPLETE    |
-| 2026-05-16 | Controller Startup and Shutdown Latency Fix                                      | DONE        |
-| 2026-05-16 | Data Import Session and Workflow Partial-Success                                 | PROPOSED    |
-| 2026-05-17 | MSVC C1202 — Decompose trade into Sub-Structs                                    | IN PROGRESS |
-| 2026-05-17 | Shared audit_record and Codegen Composite-Type Support                           | DRAFT       |
-| 2026-05-17 | Tenant and System Bootstrap Reset                                                | DONE        |
-| 2026-05-17 | Virtual Portfolio Design                                                         | PROPOSED    |
-| 2026-05-17 | Workspace — Isolated Data Context Design                                         |             |
-| 2026-05-18 | Codegen IAM Permissions and Roles Population                                     | PROPOSED    |
-| 2026-05-18 | Menu Structure Analysis and Simplification                                       | IN PROGRESS |
-| 2026-05-19 | Qt Trading Codegen Drift Remediation                                             | IN PROGRESS |
-| 2026-05-19 | UML Model Refresh                                                                | IN PROGRESS |
-| 2026-05-19 | Workspace ID Codegen Propagation                                                 | COMPLETE    |
-| 2026-05-20 | Refdata C++ Codegen: Activate Domain/Generator/Repository                        | TODO        |
-| 2026-05-20 | Refdata Party Domain: tenant_id Strong-Type Migration                            | DONE        |
-| 2026-05-21 | Tagged v1/v2 Coexistence — Merge doc/v2/ and Add Version Markers                 |             |
-| 2026-05-21 | Entity Creator Skills Overhaul                                                   | TODO        |
-| 2026-05-21 | Entity Creator Skills: v1 → v2 Migration                                         | TODO        |
+| 2026-02-02 | [[id:8917A5A9-D7CA-4B52-9B19-329BBE8315D6][Enum Table Tenancy Consolidation]] |             |
+| 2026-02-07 | [[id:9A726128-0E7E-4A82-A61B-C6B1C5CFC070][Party & Counterparty SQL Support Design]] | DONE   |
+| 2026-02-08 | [[id:5C83C9D5-F4AE-4707-BA7A-85D82FB2292B][GLEIF Dataset Librarian Integration Design]] |             |
+| 2026-02-09 | [[id:046217E8-7259-492B-A713-A4043C867FE5][Party-Level Isolation and Tenant Types Design]] | DONE   |
+| 2026-02-11 | [[id:7A3D1E52-B8F4-4C91-A9E7-6F2C3D841B05][Librarian Party & Counterparty Publication Design]] |             |
+| 2026-02-14 | [[id:9392F2F3-6ECF-4BD7-82D8-9B88175ABFBA][Generation Context Design]] | DONE   |
+| 2026-02-15 | [[id:A7F3E1C2-8D4A-4B91-9E6F-2C1D8F5A3B70][IAM Generators and Test Migration]] | DONE   |
+| 2026-02-16 | [[id:EEC13CF9-9665-4BF0-B18D-8801275709CD][Trade Envelope and FSM Design]] |             |
+| 2026-02-22 | [[id:B7D4E2A1-3C9F-4E8B-A5D2-1F6B8C0E3A94][CLI Domain Sub-menus Design]] | DONE   |
+| 2026-02-22 | [[id:B3E7F2A1-9C5D-4E82-AF1B-7D8C3E6B0F24][Currency Taxonomy Enhancement: Asset Class and Market Tier]] | DONE   |
+| 2026-02-27 | [[id:8F3A1C2E-4B7D-4E9F-A1C3-2D5E6F8A0B1C][ORE Import Wizard Design]] | DONE   |
+| 2026-03-01 | [[id:A3F7C812-5E2D-4B9A-8C1F-6D0E3A7B2F4C][Reporting Component Design]] |             |
+| 2026-03-03 | [[id:B4E2F931-7A1C-4D8E-9B3F-5C0D6A8E1F2B][Party Codename and Queue Isolation Design]] |             |
+| 2026-03-05 | [[id:3D041443-0717-49A9-B3A7-E0262CA3C608][JWT Migration to ores.security + RS256]] | DONE   |
+| 2026-03-13 | [[id:D7D33E74-F42C-4908-BC5C-BC2BF652D0B5][NATS Migration: Binary Protocol to NATS/JetStream]] | DONE   |
+| 2026-03-14 | [[id:10A1F61F-859E-4ACE-BE8C-361E404AE2A5][NATS Idiomatic Architecture: Drop Binary Protocol, Adopt MessagePack + JetStream]] | DONE   |
+| 2026-03-16 | [[id:A3F2E1D0-B4C5-6789-ABCD-EF0123456789][NATS Monitor Design]] |             |
+| 2026-03-16 | [[id:4E762126-2152-11F1-B1D1-40B0768014EB][NATS Multi-Tenancy and Multi-Party Design]] | DONE   |
+| 2026-03-20 | [[id:5DDB8AD7-DEC7-4706-A1CE-B547A6CE0951][Compute Grid Design]] | DONE   |
+| 2026-03-20 | [[id:F703B8AE-BD05-4B55-9E18-856F61920DDD][Compute Wrapper Design]] | DONE   |
+| 2026-03-20 | [[id:03FA2F6D-9920-4BA1-A895-F8F796C94789][JWT Token Refresh: Configurable Lifetimes, Proactive Renewal]] | DONE   |
+| 2026-03-20 | [[id:8219C384-3CD8-449B-A0C1-40E7C36316C1][System Settings Unification: Replace Feature Flags with Typed System Settings]] | DONE   |
+| 2026-03-21 | [[id:7A4E9C1B-3F2D-4E8A-B6D5-0C1E2F3A4B5C][Compute Grid End-to-End Improvements]] | DONE   |
+| 2026-03-21 | [[id:7E3F9A2B-4C81-4D5E-8F2A-1B9C3D4E5F6A][Compute Grid Telemetry Design]] | DONE   |
+| 2026-03-22 | [[id:7F3A8B21-4C9E-4E5B-B2D0-3F8A9C6D1E4F][Service Architecture Migration]] | DONE   |
+| 2026-03-22 | [[id:7F3A1B2C-8D4E-4F5A-9B6C-1D2E3F4A5B6C][Secure Provenance Stamping]] | DONE   |
+| 2026-03-23 | [[id:B3F7D2A1-9C5E-4D82-8B1F-3E6A7C4F1D90][Move Synthetic Generators to API Layer]] | DONE   |
+| 2026-03-26 | [[id:A3F2C1D0-AB12-11F1-8E4A-40B0768014EB][CDM-Inspired Instrument Domain Model]] |             |
+| 2026-03-26 | [[id:C57242F9-3D75-43DB-9D09-31EA5F147CC4][Compute Console UI Refactor]] |             |
+| 2026-03-27 | [[id:8FBACF31-CFFC-4C98-9964-92B58952FC69][Compute Console Rework]] |             |
+| 2026-03-27 | [[id:E11C4C56-5722-4A5B-9779-7BE2C658A3EF][Service-to-Service Authentication Design]] | DRAFT       |
+| 2026-03-28 | [[id:7E4B1C93-2F8A-4D56-B3E7-9A0C5F812D6E][Database-Driven Badge System Design]] |             |
+| 2026-03-28 | [[id:B7E4D2A1-CD23-11F1-9F1E-40B0768014EB][CDM-Inspired Instrument Domain Model — Phase 2]] |             |
+| 2026-03-28 | [[id:DC79D8CE-FBEB-4FC9-9DB5-D39724F2DF86][Service Account RBAC Design]] |             |
+| 2026-03-29 | [[id:C9E3A2F4-DE45-11F1-B02C-40B0768014EB][ORE Instrument Mappers — Phase 9]] |             |
+| 2026-03-30 | [[id:4B02695C-7C59-487A-8450-4240EC836685][Service-to-Service JWT Delegation]] | DRAFT       |
+| 2026-03-31 | [[id:D4D975DB-A525-45E3-B383-581E51AEA8DB][Instrument-Trade Model Refactor and ORE Portfolio Export]] |             |
+| 2026-03-31 | [[id:9F3C2D87-5B14-4E8A-B6D1-0A7C3F921E45][ORE Market Data Domain Model]] |             |
+| 2026-03-31 | [[id:F4A17B30-FE81-11F0-A3C4-40B0768014EB][ORE Market Data File Types — Phase 1]] |             |
+| 2026-03-31 | [[id:E3663D45-AE04-42AE-B588-06DCAE4DE119][ORE Trading Instrument Support — Complete Implementation]] |             |
+| 2026-04-01 | [[id:4A7E9C12-3B85-4F2D-A8D6-1C5E0B734F92][Asset Class Unification]] |             |
+| 2026-04-01 | [[id:B0D35884-6703-4889-8B47-ED0E279F5E2F][Unified Trade + Instrument Detail Dialog]] | DONE        |
+| 2026-04-03 | [[id:40F4FC83-3552-4788-8520-1570A74A8BCA][Server-Side ORE Import]] | IN PROGRESS |
+| 2026-04-05 | [[id:A3F7C2D1-8E4B-4F9A-B6C3-2D1E8F5A7B9C][Report Definition to Instance Pipeline]] | DONE   |
+| 2026-04-05 | [[id:B4E8D3F2-9C5A-4B7E-C7D4-3E2F9A6C8D0E][Report Execution Pipeline]] | DRAFT       |
+| 2026-04-05 | [[id:C5F9E4A3-0D6B-5C8F-D8E5-4F3A0B7D9E1F][Workflow Engine Generalisation]] | IN PROGRESS |
+| 2026-04-06 | [[id:D7E2F1A3-4B8C-5D9E-A6F3-1C0D8E7B4A2F][Report Execution Workflow — Implementation Plan]] | IN PROGRESS |
+| 2026-04-07 | [[id:AB46A15C-A46C-4317-8563-A3674BEE83AF][Data-Driven TradeDetailDialog Refactor]] | DONE        |
+| 2026-04-08 | [[id:720D74A0-DAD3-4F11-BC5F-AD78BF5A9DD2][Qt QPluginLoader Architecture Migration]] |             |
+| 2026-04-08 | [[id:1411D94A-24FA-4164-AD75-F3CE7415903B][Unified Service Hosting]] | IN PROGRESS |
+| 2026-04-08 | [[id:3268BB6F-E87B-4EDD-B622-015888C1A6D3][UTC-Everywhere Timestamp Enforcement]] |             |
+| 2026-04-09 | [[id:8F82C72D-CB65-45A8-AD91-3DBDFBD4BEDE][Instrument Tables Redesign — Standalone Asset-Class Tables]] |             |
+| 2026-04-10 | [[id:8B8E0568-AF14-4820-B7AD-6FCA99C40626][Scheduler Real-Time UI]] | DONE        |
+| 2026-04-10 | [[id:3453C341-C060-4FE8-9F14-6B4A8570F308][Workflow Monitor — Design & Implementation Plan]] |             |
+| 2026-04-21 | [[id:982EC471-A825-45C1-982F-38681A2C14FD][FX Forward ORE Import End-to-End Wiring]] |             |
+| 2026-04-21 | [[id:7D4E1A08-1F3E-11F2-B4B1-40B0768014EB][ORE Import: Conventions Persistence & Full Import Pipeline]] | IN PROGRESS |
+| 2026-04-22 | [[id:091B481F-914A-43D3-B86B-58E35ED0E463][Equity Per-Type Instrument Migration]] | DONE        |
+| 2026-05-05 | [[id:E2401716-C8B1-4FEA-8DB9-8EB4877328C8][ORE Import / Export Code Cleanup]] | DONE    |
+| 2026-05-05 | [[id:AF6A4F45-1AFB-46C6-8955-D88F67F9DA91][ORE Domain Roundtrip Check]] | DONE    |
+| 2026-05-12 | [[id:27A575D3-DB84-411D-B3C0-58122128E424][Strict Service Table Isolation]] | DONE    |
+| 2026-05-13 | [[id:004B427A-2B3E-4556-8345-A72251238202][Cross-Service Write Decoupling]] | DONE        |
+| 2026-05-13 | [[id:7BBA5627-F13D-4BFC-9E03-C15B61A11AD5][PostgreSQL Identifier Length Cleanup]] | DONE    |
+| 2026-05-13 | [[id:F2A4C6E8-B1D3-4E5F-A7B9-2C4D6E8F0A1B][Symbol Visibility Migration]] | DONE    |
+| 2026-05-14 | [[id:05661A18-616C-4C39-8A88-BFBB4C68FD2E][Codegen SQL Debt — Hand-Written Files with Existing Models]] | DONE    |
+| 2026-05-14 | [[id:98B3572E-A9F9-45F5-A4C5-3DC23F3CFF70][DQ Publish Pattern — Architecture and Decision]] | IN PROGRESS |
+| 2026-05-14 | [[id:D9143823-DFCD-4208-96BE-8AD647A78C8D][Workflow Engine Hardening]] | DONE    |
+| 2026-05-15 | [[id:D7F263C4-7A0C-4ABD-85E7-0BD90C0C4D98][Login Dialog Label Filter]] |             |
+| 2026-05-15 | [[id:E7976556-8EA4-4A54-A414-BE0D11762DEC][ORE Import Error Reporting and Step Warning State]] | DONE    |
+| 2026-05-15 | [[id:3125F901-7AC2-421C-8AEF-8C508B0E315B][Qt Plugin Isolation: Cross-Plugin Symbol Dependencies]] | DONE    |
+| 2026-05-16 | [[id:45312FEA-BE7D-452E-8432-55E8AD04B3F1][Controller Startup and Shutdown Latency Fix]] | DONE        |
+| 2026-05-16 | [[id:5DAEC346-CB22-4CE1-8293-12A1986AFDB6][Data Import Session and Workflow Partial-Success]] | PROPOSED    |
+| 2026-05-17 | [[id:5319618A-FEB6-46F4-9588-11495CA8E164][MSVC C1202 — Decompose trade into Sub-Structs]] | IN PROGRESS |
+| 2026-05-17 | [[id:1EF768F1-5B86-402F-866A-5CB730F48319][Shared audit_record and Codegen Composite-Type Support]] | DRAFT       |
+| 2026-05-17 | [[id:B5EB3B4F-681A-48C9-BAF2-9256FE889A45][Tenant and System Bootstrap Reset]] | DONE        |
+| 2026-05-17 | [[id:AD2D6529-4870-4BD0-9B68-6DF3CCAAFBCA][Virtual Portfolio Design]] | PROPOSED    |
+| 2026-05-17 | [[id:CEAD2E6A-8C12-489F-B64A-652EE2B81811][Workspace — Isolated Data Context Design]] |             |
+| 2026-05-18 | [[id:847AECEA-D0E6-4D4F-870A-F0E720B49256][Codegen IAM Permissions and Roles Population]] | PROPOSED    |
+| 2026-05-18 | [[id:8F08358F-3909-479A-872D-E1A362F9DF4F][Menu Structure Analysis and Simplification]] | IN PROGRESS |
+| 2026-05-19 | [[id:69FBCA3B-CDFE-43F5-8C4F-4C26B4D19ADD][Qt Trading Codegen Drift Remediation]] | IN PROGRESS |
+| 2026-05-19 | [[id:F806E77A-A8CC-4683-9563-06EE5DE3644F][UML Model Refresh]] | IN PROGRESS |
+| 2026-05-19 | [[id:827CB04D-AE39-40BA-A291-CAAE5360CD92][Workspace ID Codegen Propagation]] | DONE    |
+| 2026-05-20 | [[id:8B4C1D2E-93F7-4A68-C5B9-6D0E1F4A2B83][Refdata C++ Codegen: Activate Domain/Generator/Repository]] | TODO        |
+| 2026-05-20 | [[id:3A7F2B1C-84E6-4D59-B2A8-5C9E0F3D1A72][Refdata Party Domain: tenant_id Strong-Type Migration]] | DONE        |
+| 2026-05-21 | [[id:7305A77A-3A41-42CA-BD1D-227E2FB18DF0][Tagged v1/v2 Coexistence — Merge doc/v2/ and Add Version Markers]] |             |
+| 2026-05-21 | [[id:A4B5C6D7-E8F9-0A1B-2C3D-4E5F6A7B8C9D][Entity Creator Skills Overhaul]] | TODO        |
+| 2026-05-21 | [[id:3F7A2C1D-84BE-4E9F-B261-5C0D9A3E7B48][Entity Creator Skills: v1 → v2 Migration]] | TODO        |

--- a/doc/plans/plans.org
+++ b/doc/plans/plans.org
@@ -19,89 +19,89 @@ Active work lives in the [[id:46DFE47F-967B-4C24-95BF-3E21F97CFD20][agile proces
 
 |       Date | Plan                                                                             | Status      |
 |------------+----------------------------------------------------------------------------------+-------------|
-| 2026-02-02 | [[id:8917A5A9-D7CA-4B52-9B19-329BBE8315D6][Enum Table Tenancy Consolidation]] |             |
-| 2026-02-07 | [[id:9A726128-0E7E-4A82-A61B-C6B1C5CFC070][Party & Counterparty SQL Support Design]] | DONE   |
-| 2026-02-08 | [[id:5C83C9D5-F4AE-4707-BA7A-85D82FB2292B][GLEIF Dataset Librarian Integration Design]] |             |
-| 2026-02-09 | [[id:046217E8-7259-492B-A713-A4043C867FE5][Party-Level Isolation and Tenant Types Design]] | DONE   |
-| 2026-02-11 | [[id:7A3D1E52-B8F4-4C91-A9E7-6F2C3D841B05][Librarian Party & Counterparty Publication Design]] |             |
-| 2026-02-14 | [[id:9392F2F3-6ECF-4BD7-82D8-9B88175ABFBA][Generation Context Design]] | DONE   |
-| 2026-02-15 | [[id:A7F3E1C2-8D4A-4B91-9E6F-2C1D8F5A3B70][IAM Generators and Test Migration]] | DONE   |
-| 2026-02-16 | [[id:EEC13CF9-9665-4BF0-B18D-8801275709CD][Trade Envelope and FSM Design]] |             |
-| 2026-02-22 | [[id:B7D4E2A1-3C9F-4E8B-A5D2-1F6B8C0E3A94][CLI Domain Sub-menus Design]] | DONE   |
-| 2026-02-22 | [[id:B3E7F2A1-9C5D-4E82-AF1B-7D8C3E6B0F24][Currency Taxonomy Enhancement: Asset Class and Market Tier]] | DONE   |
-| 2026-02-27 | [[id:8F3A1C2E-4B7D-4E9F-A1C3-2D5E6F8A0B1C][ORE Import Wizard Design]] | DONE   |
-| 2026-03-01 | [[id:A3F7C812-5E2D-4B9A-8C1F-6D0E3A7B2F4C][Reporting Component Design]] |             |
-| 2026-03-03 | [[id:B4E2F931-7A1C-4D8E-9B3F-5C0D6A8E1F2B][Party Codename and Queue Isolation Design]] |             |
-| 2026-03-05 | [[id:3D041443-0717-49A9-B3A7-E0262CA3C608][JWT Migration to ores.security + RS256]] | DONE   |
-| 2026-03-13 | [[id:D7D33E74-F42C-4908-BC5C-BC2BF652D0B5][NATS Migration: Binary Protocol to NATS/JetStream]] | DONE   |
-| 2026-03-14 | [[id:10A1F61F-859E-4ACE-BE8C-361E404AE2A5][NATS Idiomatic Architecture: Drop Binary Protocol, Adopt MessagePack + JetStream]] | DONE   |
-| 2026-03-16 | [[id:A3F2E1D0-B4C5-6789-ABCD-EF0123456789][NATS Monitor Design]] |             |
-| 2026-03-16 | [[id:4E762126-2152-11F1-B1D1-40B0768014EB][NATS Multi-Tenancy and Multi-Party Design]] | DONE   |
-| 2026-03-20 | [[id:5DDB8AD7-DEC7-4706-A1CE-B547A6CE0951][Compute Grid Design]] | DONE   |
-| 2026-03-20 | [[id:F703B8AE-BD05-4B55-9E18-856F61920DDD][Compute Wrapper Design]] | DONE   |
-| 2026-03-20 | [[id:03FA2F6D-9920-4BA1-A895-F8F796C94789][JWT Token Refresh: Configurable Lifetimes, Proactive Renewal]] | DONE   |
-| 2026-03-20 | [[id:8219C384-3CD8-449B-A0C1-40E7C36316C1][System Settings Unification: Replace Feature Flags with Typed System Settings]] | DONE   |
-| 2026-03-21 | [[id:7A4E9C1B-3F2D-4E8A-B6D5-0C1E2F3A4B5C][Compute Grid End-to-End Improvements]] | DONE   |
-| 2026-03-21 | [[id:7E3F9A2B-4C81-4D5E-8F2A-1B9C3D4E5F6A][Compute Grid Telemetry Design]] | DONE   |
-| 2026-03-22 | [[id:7F3A8B21-4C9E-4E5B-B2D0-3F8A9C6D1E4F][Service Architecture Migration]] | DONE   |
-| 2026-03-22 | [[id:7F3A1B2C-8D4E-4F5A-9B6C-1D2E3F4A5B6C][Secure Provenance Stamping]] | DONE   |
-| 2026-03-23 | [[id:B3F7D2A1-9C5E-4D82-8B1F-3E6A7C4F1D90][Move Synthetic Generators to API Layer]] | DONE   |
-| 2026-03-26 | [[id:A3F2C1D0-AB12-11F1-8E4A-40B0768014EB][CDM-Inspired Instrument Domain Model]] |             |
-| 2026-03-26 | [[id:C57242F9-3D75-43DB-9D09-31EA5F147CC4][Compute Console UI Refactor]] |             |
-| 2026-03-27 | [[id:8FBACF31-CFFC-4C98-9964-92B58952FC69][Compute Console Rework]] |             |
-| 2026-03-27 | [[id:E11C4C56-5722-4A5B-9779-7BE2C658A3EF][Service-to-Service Authentication Design]] | DRAFT       |
-| 2026-03-28 | [[id:7E4B1C93-2F8A-4D56-B3E7-9A0C5F812D6E][Database-Driven Badge System Design]] |             |
-| 2026-03-28 | [[id:B7E4D2A1-CD23-11F1-9F1E-40B0768014EB][CDM-Inspired Instrument Domain Model — Phase 2]] |             |
-| 2026-03-28 | [[id:DC79D8CE-FBEB-4FC9-9DB5-D39724F2DF86][Service Account RBAC Design]] |             |
-| 2026-03-29 | [[id:C9E3A2F4-DE45-11F1-B02C-40B0768014EB][ORE Instrument Mappers — Phase 9]] |             |
-| 2026-03-30 | [[id:4B02695C-7C59-487A-8450-4240EC836685][Service-to-Service JWT Delegation]] | DRAFT       |
-| 2026-03-31 | [[id:D4D975DB-A525-45E3-B383-581E51AEA8DB][Instrument-Trade Model Refactor and ORE Portfolio Export]] |             |
-| 2026-03-31 | [[id:9F3C2D87-5B14-4E8A-B6D1-0A7C3F921E45][ORE Market Data Domain Model]] |             |
-| 2026-03-31 | [[id:F4A17B30-FE81-11F0-A3C4-40B0768014EB][ORE Market Data File Types — Phase 1]] |             |
-| 2026-03-31 | [[id:E3663D45-AE04-42AE-B588-06DCAE4DE119][ORE Trading Instrument Support — Complete Implementation]] |             |
-| 2026-04-01 | [[id:4A7E9C12-3B85-4F2D-A8D6-1C5E0B734F92][Asset Class Unification]] |             |
-| 2026-04-01 | [[id:B0D35884-6703-4889-8B47-ED0E279F5E2F][Unified Trade + Instrument Detail Dialog]] | DONE        |
-| 2026-04-03 | [[id:40F4FC83-3552-4788-8520-1570A74A8BCA][Server-Side ORE Import]] | IN PROGRESS |
-| 2026-04-05 | [[id:A3F7C2D1-8E4B-4F9A-B6C3-2D1E8F5A7B9C][Report Definition to Instance Pipeline]] | DONE   |
-| 2026-04-05 | [[id:B4E8D3F2-9C5A-4B7E-C7D4-3E2F9A6C8D0E][Report Execution Pipeline]] | DRAFT       |
-| 2026-04-05 | [[id:C5F9E4A3-0D6B-5C8F-D8E5-4F3A0B7D9E1F][Workflow Engine Generalisation]] | IN PROGRESS |
-| 2026-04-06 | [[id:D7E2F1A3-4B8C-5D9E-A6F3-1C0D8E7B4A2F][Report Execution Workflow — Implementation Plan]] | IN PROGRESS |
-| 2026-04-07 | [[id:AB46A15C-A46C-4317-8563-A3674BEE83AF][Data-Driven TradeDetailDialog Refactor]] | DONE        |
-| 2026-04-08 | [[id:720D74A0-DAD3-4F11-BC5F-AD78BF5A9DD2][Qt QPluginLoader Architecture Migration]] |             |
-| 2026-04-08 | [[id:1411D94A-24FA-4164-AD75-F3CE7415903B][Unified Service Hosting]] | IN PROGRESS |
-| 2026-04-08 | [[id:3268BB6F-E87B-4EDD-B622-015888C1A6D3][UTC-Everywhere Timestamp Enforcement]] |             |
-| 2026-04-09 | [[id:8F82C72D-CB65-45A8-AD91-3DBDFBD4BEDE][Instrument Tables Redesign — Standalone Asset-Class Tables]] |             |
-| 2026-04-10 | [[id:8B8E0568-AF14-4820-B7AD-6FCA99C40626][Scheduler Real-Time UI]] | DONE        |
-| 2026-04-10 | [[id:3453C341-C060-4FE8-9F14-6B4A8570F308][Workflow Monitor — Design & Implementation Plan]] |             |
-| 2026-04-21 | [[id:982EC471-A825-45C1-982F-38681A2C14FD][FX Forward ORE Import End-to-End Wiring]] |             |
-| 2026-04-21 | [[id:7D4E1A08-1F3E-11F2-B4B1-40B0768014EB][ORE Import: Conventions Persistence & Full Import Pipeline]] | IN PROGRESS |
-| 2026-04-22 | [[id:091B481F-914A-43D3-B86B-58E35ED0E463][Equity Per-Type Instrument Migration]] | DONE        |
-| 2026-05-05 | [[id:E2401716-C8B1-4FEA-8DB9-8EB4877328C8][ORE Import / Export Code Cleanup]] | DONE    |
-| 2026-05-05 | [[id:AF6A4F45-1AFB-46C6-8955-D88F67F9DA91][ORE Domain Roundtrip Check]] | DONE    |
-| 2026-05-12 | [[id:27A575D3-DB84-411D-B3C0-58122128E424][Strict Service Table Isolation]] | DONE    |
-| 2026-05-13 | [[id:004B427A-2B3E-4556-8345-A72251238202][Cross-Service Write Decoupling]] | DONE        |
-| 2026-05-13 | [[id:7BBA5627-F13D-4BFC-9E03-C15B61A11AD5][PostgreSQL Identifier Length Cleanup]] | DONE    |
-| 2026-05-13 | [[id:F2A4C6E8-B1D3-4E5F-A7B9-2C4D6E8F0A1B][Symbol Visibility Migration]] | DONE    |
-| 2026-05-14 | [[id:05661A18-616C-4C39-8A88-BFBB4C68FD2E][Codegen SQL Debt — Hand-Written Files with Existing Models]] | DONE    |
-| 2026-05-14 | [[id:98B3572E-A9F9-45F5-A4C5-3DC23F3CFF70][DQ Publish Pattern — Architecture and Decision]] | IN PROGRESS |
-| 2026-05-14 | [[id:D9143823-DFCD-4208-96BE-8AD647A78C8D][Workflow Engine Hardening]] | DONE    |
-| 2026-05-15 | [[id:D7F263C4-7A0C-4ABD-85E7-0BD90C0C4D98][Login Dialog Label Filter]] |             |
-| 2026-05-15 | [[id:E7976556-8EA4-4A54-A414-BE0D11762DEC][ORE Import Error Reporting and Step Warning State]] | DONE    |
-| 2026-05-15 | [[id:3125F901-7AC2-421C-8AEF-8C508B0E315B][Qt Plugin Isolation: Cross-Plugin Symbol Dependencies]] | DONE    |
-| 2026-05-16 | [[id:45312FEA-BE7D-452E-8432-55E8AD04B3F1][Controller Startup and Shutdown Latency Fix]] | DONE        |
-| 2026-05-16 | [[id:5DAEC346-CB22-4CE1-8293-12A1986AFDB6][Data Import Session and Workflow Partial-Success]] | PROPOSED    |
-| 2026-05-17 | [[id:5319618A-FEB6-46F4-9588-11495CA8E164][MSVC C1202 — Decompose trade into Sub-Structs]] | IN PROGRESS |
-| 2026-05-17 | [[id:1EF768F1-5B86-402F-866A-5CB730F48319][Shared audit_record and Codegen Composite-Type Support]] | DRAFT       |
-| 2026-05-17 | [[id:B5EB3B4F-681A-48C9-BAF2-9256FE889A45][Tenant and System Bootstrap Reset]] | DONE        |
-| 2026-05-17 | [[id:AD2D6529-4870-4BD0-9B68-6DF3CCAAFBCA][Virtual Portfolio Design]] | PROPOSED    |
-| 2026-05-17 | [[id:CEAD2E6A-8C12-489F-B64A-652EE2B81811][Workspace — Isolated Data Context Design]] |             |
-| 2026-05-18 | [[id:847AECEA-D0E6-4D4F-870A-F0E720B49256][Codegen IAM Permissions and Roles Population]] | PROPOSED    |
-| 2026-05-18 | [[id:8F08358F-3909-479A-872D-E1A362F9DF4F][Menu Structure Analysis and Simplification]] | IN PROGRESS |
-| 2026-05-19 | [[id:69FBCA3B-CDFE-43F5-8C4F-4C26B4D19ADD][Qt Trading Codegen Drift Remediation]] | IN PROGRESS |
-| 2026-05-19 | [[id:F806E77A-A8CC-4683-9563-06EE5DE3644F][UML Model Refresh]] | IN PROGRESS |
-| 2026-05-19 | [[id:827CB04D-AE39-40BA-A291-CAAE5360CD92][Workspace ID Codegen Propagation]] | DONE    |
-| 2026-05-20 | [[id:8B4C1D2E-93F7-4A68-C5B9-6D0E1F4A2B83][Refdata C++ Codegen: Activate Domain/Generator/Repository]] | TODO        |
-| 2026-05-20 | [[id:3A7F2B1C-84E6-4D59-B2A8-5C9E0F3D1A72][Refdata Party Domain: tenant_id Strong-Type Migration]] | DONE        |
-| 2026-05-21 | [[id:7305A77A-3A41-42CA-BD1D-227E2FB18DF0][Tagged v1/v2 Coexistence — Merge doc/v2/ and Add Version Markers]] |             |
-| 2026-05-21 | [[id:A4B5C6D7-E8F9-0A1B-2C3D-4E5F6A7B8C9D][Entity Creator Skills Overhaul]] | TODO        |
-| 2026-05-21 | [[id:3F7A2C1D-84BE-4E9F-B261-5C0D9A3E7B48][Entity Creator Skills: v1 → v2 Migration]] | TODO        |
+| 2026-02-02 | [[id:8917A5A9-D7CA-4B52-9B19-329BBE8315D6][Enum Table Tenancy Consolidation]]                                                 |             |
+| 2026-02-07 | [[id:9A726128-0E7E-4A82-A61B-C6B1C5CFC070][Party & Counterparty SQL Support Design]]                                          | DONE        |
+| 2026-02-08 | [[id:5C83C9D5-F4AE-4707-BA7A-85D82FB2292B][GLEIF Dataset Librarian Integration Design]]                                       |             |
+| 2026-02-09 | [[id:046217E8-7259-492B-A713-A4043C867FE5][Party-Level Isolation and Tenant Types Design]]                                    | DONE        |
+| 2026-02-11 | [[id:7A3D1E52-B8F4-4C91-A9E7-6F2C3D841B05][Librarian Party & Counterparty Publication Design]]                                |             |
+| 2026-02-14 | [[id:9392F2F3-6ECF-4BD7-82D8-9B88175ABFBA][Generation Context Design]]                                                        | DONE        |
+| 2026-02-15 | [[id:A7F3E1C2-8D4A-4B91-9E6F-2C1D8F5A3B70][IAM Generators and Test Migration]]                                                | DONE        |
+| 2026-02-16 | [[id:EEC13CF9-9665-4BF0-B18D-8801275709CD][Trade Envelope and FSM Design]]                                                    |             |
+| 2026-02-22 | [[id:B7D4E2A1-3C9F-4E8B-A5D2-1F6B8C0E3A94][CLI Domain Sub-menus Design]]                                                      | DONE        |
+| 2026-02-22 | [[id:B3E7F2A1-9C5D-4E82-AF1B-7D8C3E6B0F24][Currency Taxonomy Enhancement: Asset Class and Market Tier]]                       | DONE        |
+| 2026-02-27 | [[id:8F3A1C2E-4B7D-4E9F-A1C3-2D5E6F8A0B1C][ORE Import Wizard Design]]                                                         | DONE        |
+| 2026-03-01 | [[id:A3F7C812-5E2D-4B9A-8C1F-6D0E3A7B2F4C][Reporting Component Design]]                                                       |             |
+| 2026-03-03 | [[id:B4E2F931-7A1C-4D8E-9B3F-5C0D6A8E1F2B][Party Codename and Queue Isolation Design]]                                        |             |
+| 2026-03-05 | [[id:3D041443-0717-49A9-B3A7-E0262CA3C608][JWT Migration to ores.security + RS256]]                                           | DONE        |
+| 2026-03-13 | [[id:D7D33E74-F42C-4908-BC5C-BC2BF652D0B5][NATS Migration: Binary Protocol to NATS/JetStream]]                                | DONE        |
+| 2026-03-14 | [[id:10A1F61F-859E-4ACE-BE8C-361E404AE2A5][NATS Idiomatic Architecture: Drop Binary Protocol, Adopt MessagePack + JetStream]] | DONE        |
+| 2026-03-16 | [[id:A3F2E1D0-B4C5-6789-ABCD-EF0123456789][NATS Monitor Design]]                                                              |             |
+| 2026-03-16 | [[id:4E762126-2152-11F1-B1D1-40B0768014EB][NATS Multi-Tenancy and Multi-Party Design]]                                        | DONE        |
+| 2026-03-20 | [[id:5DDB8AD7-DEC7-4706-A1CE-B547A6CE0951][Compute Grid Design]]                                                              | DONE        |
+| 2026-03-20 | [[id:F703B8AE-BD05-4B55-9E18-856F61920DDD][Compute Wrapper Design]]                                                           | DONE        |
+| 2026-03-20 | [[id:03FA2F6D-9920-4BA1-A895-F8F796C94789][JWT Token Refresh: Configurable Lifetimes, Proactive Renewal]]                     | DONE        |
+| 2026-03-20 | [[id:8219C384-3CD8-449B-A0C1-40E7C36316C1][System Settings Unification: Replace Feature Flags with Typed System Settings]]    | DONE        |
+| 2026-03-21 | [[id:7A4E9C1B-3F2D-4E8A-B6D5-0C1E2F3A4B5C][Compute Grid End-to-End Improvements]]                                             | DONE        |
+| 2026-03-21 | [[id:7E3F9A2B-4C81-4D5E-8F2A-1B9C3D4E5F6A][Compute Grid Telemetry Design]]                                                    | DONE        |
+| 2026-03-22 | [[id:7F3A8B21-4C9E-4E5B-B2D0-3F8A9C6D1E4F][Service Architecture Migration]]                                                   | DONE        |
+| 2026-03-22 | [[id:7F3A1B2C-8D4E-4F5A-9B6C-1D2E3F4A5B6C][Secure Provenance Stamping]]                                                       | DONE        |
+| 2026-03-23 | [[id:B3F7D2A1-9C5E-4D82-8B1F-3E6A7C4F1D90][Move Synthetic Generators to API Layer]]                                           | DONE        |
+| 2026-03-26 | [[id:A3F2C1D0-AB12-11F1-8E4A-40B0768014EB][CDM-Inspired Instrument Domain Model]]                                             |             |
+| 2026-03-26 | [[id:C57242F9-3D75-43DB-9D09-31EA5F147CC4][Compute Console UI Refactor]]                                                      |             |
+| 2026-03-27 | [[id:8FBACF31-CFFC-4C98-9964-92B58952FC69][Compute Console Rework]]                                                           |             |
+| 2026-03-27 | [[id:E11C4C56-5722-4A5B-9779-7BE2C658A3EF][Service-to-Service Authentication Design]]                                         | DRAFT       |
+| 2026-03-28 | [[id:7E4B1C93-2F8A-4D56-B3E7-9A0C5F812D6E][Database-Driven Badge System Design]]                                              |             |
+| 2026-03-28 | [[id:B7E4D2A1-CD23-11F1-9F1E-40B0768014EB][CDM-Inspired Instrument Domain Model — Phase 2]]                                   |             |
+| 2026-03-28 | [[id:DC79D8CE-FBEB-4FC9-9DB5-D39724F2DF86][Service Account RBAC Design]]                                                      |             |
+| 2026-03-29 | [[id:C9E3A2F4-DE45-11F1-B02C-40B0768014EB][ORE Instrument Mappers — Phase 9]]                                                 |             |
+| 2026-03-30 | [[id:4B02695C-7C59-487A-8450-4240EC836685][Service-to-Service JWT Delegation]]                                                | DRAFT       |
+| 2026-03-31 | [[id:D4D975DB-A525-45E3-B383-581E51AEA8DB][Instrument-Trade Model Refactor and ORE Portfolio Export]]                         |             |
+| 2026-03-31 | [[id:9F3C2D87-5B14-4E8A-B6D1-0A7C3F921E45][ORE Market Data Domain Model]]                                                     |             |
+| 2026-03-31 | [[id:F4A17B30-FE81-11F0-A3C4-40B0768014EB][ORE Market Data File Types — Phase 1]]                                             |             |
+| 2026-03-31 | [[id:E3663D45-AE04-42AE-B588-06DCAE4DE119][ORE Trading Instrument Support — Complete Implementation]]                         |             |
+| 2026-04-01 | [[id:4A7E9C12-3B85-4F2D-A8D6-1C5E0B734F92][Asset Class Unification]]                                                          |             |
+| 2026-04-01 | [[id:B0D35884-6703-4889-8B47-ED0E279F5E2F][Unified Trade + Instrument Detail Dialog]]                                         | DONE        |
+| 2026-04-03 | [[id:40F4FC83-3552-4788-8520-1570A74A8BCA][Server-Side ORE Import]]                                                           | IN PROGRESS |
+| 2026-04-05 | [[id:A3F7C2D1-8E4B-4F9A-B6C3-2D1E8F5A7B9C][Report Definition to Instance Pipeline]]                                           | DONE        |
+| 2026-04-05 | [[id:B4E8D3F2-9C5A-4B7E-C7D4-3E2F9A6C8D0E][Report Execution Pipeline]]                                                        | DRAFT       |
+| 2026-04-05 | [[id:C5F9E4A3-0D6B-5C8F-D8E5-4F3A0B7D9E1F][Workflow Engine Generalisation]]                                                   | IN PROGRESS |
+| 2026-04-06 | [[id:D7E2F1A3-4B8C-5D9E-A6F3-1C0D8E7B4A2F][Report Execution Workflow — Implementation Plan]]                                  | IN PROGRESS |
+| 2026-04-07 | [[id:AB46A15C-A46C-4317-8563-A3674BEE83AF][Data-Driven TradeDetailDialog Refactor]]                                           | DONE        |
+| 2026-04-08 | [[id:720D74A0-DAD3-4F11-BC5F-AD78BF5A9DD2][Qt QPluginLoader Architecture Migration]]                                          |             |
+| 2026-04-08 | [[id:1411D94A-24FA-4164-AD75-F3CE7415903B][Unified Service Hosting]]                                                          | IN PROGRESS |
+| 2026-04-08 | [[id:3268BB6F-E87B-4EDD-B622-015888C1A6D3][UTC-Everywhere Timestamp Enforcement]]                                             |             |
+| 2026-04-09 | [[id:8F82C72D-CB65-45A8-AD91-3DBDFBD4BEDE][Instrument Tables Redesign — Standalone Asset-Class Tables]]                       |             |
+| 2026-04-10 | [[id:8B8E0568-AF14-4820-B7AD-6FCA99C40626][Scheduler Real-Time UI]]                                                           | DONE        |
+| 2026-04-10 | [[id:3453C341-C060-4FE8-9F14-6B4A8570F308][Workflow Monitor — Design & Implementation Plan]]                                  |             |
+| 2026-04-21 | [[id:982EC471-A825-45C1-982F-38681A2C14FD][FX Forward ORE Import End-to-End Wiring]]                                          |             |
+| 2026-04-21 | [[id:7D4E1A08-1F3E-11F2-B4B1-40B0768014EB][ORE Import: Conventions Persistence & Full Import Pipeline]]                       | IN PROGRESS |
+| 2026-04-22 | [[id:091B481F-914A-43D3-B86B-58E35ED0E463][Equity Per-Type Instrument Migration]]                                             | DONE        |
+| 2026-05-05 | [[id:E2401716-C8B1-4FEA-8DB9-8EB4877328C8][ORE Import / Export Code Cleanup]]                                                 | DONE        |
+| 2026-05-05 | [[id:AF6A4F45-1AFB-46C6-8955-D88F67F9DA91][ORE Domain Roundtrip Check]]                                                       | DONE        |
+| 2026-05-12 | [[id:27A575D3-DB84-411D-B3C0-58122128E424][Strict Service Table Isolation]]                                                   | DONE        |
+| 2026-05-13 | [[id:004B427A-2B3E-4556-8345-A72251238202][Cross-Service Write Decoupling]]                                                   | DONE        |
+| 2026-05-13 | [[id:7BBA5627-F13D-4BFC-9E03-C15B61A11AD5][PostgreSQL Identifier Length Cleanup]]                                             | DONE        |
+| 2026-05-13 | [[id:F2A4C6E8-B1D3-4E5F-A7B9-2C4D6E8F0A1B][Symbol Visibility Migration]]                                                      | DONE        |
+| 2026-05-14 | [[id:05661A18-616C-4C39-8A88-BFBB4C68FD2E][Codegen SQL Debt — Hand-Written Files with Existing Models]]                       | DONE        |
+| 2026-05-14 | [[id:98B3572E-A9F9-45F5-A4C5-3DC23F3CFF70][DQ Publish Pattern — Architecture and Decision]]                                   | IN PROGRESS |
+| 2026-05-14 | [[id:D9143823-DFCD-4208-96BE-8AD647A78C8D][Workflow Engine Hardening]]                                                        | DONE        |
+| 2026-05-15 | [[id:D7F263C4-7A0C-4ABD-85E7-0BD90C0C4D98][Login Dialog Label Filter]]                                                        |             |
+| 2026-05-15 | [[id:E7976556-8EA4-4A54-A414-BE0D11762DEC][ORE Import Error Reporting and Step Warning State]]                                | DONE        |
+| 2026-05-15 | [[id:3125F901-7AC2-421C-8AEF-8C508B0E315B][Qt Plugin Isolation: Cross-Plugin Symbol Dependencies]]                            | DONE        |
+| 2026-05-16 | [[id:45312FEA-BE7D-452E-8432-55E8AD04B3F1][Controller Startup and Shutdown Latency Fix]]                                      | DONE        |
+| 2026-05-16 | [[id:5DAEC346-CB22-4CE1-8293-12A1986AFDB6][Data Import Session and Workflow Partial-Success]]                                 | PROPOSED    |
+| 2026-05-17 | [[id:5319618A-FEB6-46F4-9588-11495CA8E164][MSVC C1202 — Decompose trade into Sub-Structs]]                                    | IN PROGRESS |
+| 2026-05-17 | [[id:1EF768F1-5B86-402F-866A-5CB730F48319][Shared audit_record and Codegen Composite-Type Support]]                           | DRAFT       |
+| 2026-05-17 | [[id:B5EB3B4F-681A-48C9-BAF2-9256FE889A45][Tenant and System Bootstrap Reset]]                                                | DONE        |
+| 2026-05-17 | [[id:AD2D6529-4870-4BD0-9B68-6DF3CCAAFBCA][Virtual Portfolio Design]]                                                         | PROPOSED    |
+| 2026-05-17 | [[id:CEAD2E6A-8C12-489F-B64A-652EE2B81811][Workspace — Isolated Data Context Design]]                                         |             |
+| 2026-05-18 | [[id:847AECEA-D0E6-4D4F-870A-F0E720B49256][Codegen IAM Permissions and Roles Population]]                                     | PROPOSED    |
+| 2026-05-18 | [[id:8F08358F-3909-479A-872D-E1A362F9DF4F][Menu Structure Analysis and Simplification]]                                       | IN PROGRESS |
+| 2026-05-19 | [[id:69FBCA3B-CDFE-43F5-8C4F-4C26B4D19ADD][Qt Trading Codegen Drift Remediation]]                                             | IN PROGRESS |
+| 2026-05-19 | [[id:F806E77A-A8CC-4683-9563-06EE5DE3644F][UML Model Refresh]]                                                                | IN PROGRESS |
+| 2026-05-19 | [[id:827CB04D-AE39-40BA-A291-CAAE5360CD92][Workspace ID Codegen Propagation]]                                                 | DONE        |
+| 2026-05-20 | [[id:8B4C1D2E-93F7-4A68-C5B9-6D0E1F4A2B83][Refdata C++ Codegen: Activate Domain/Generator/Repository]]                        | TODO        |
+| 2026-05-20 | [[id:3A7F2B1C-84E6-4D59-B2A8-5C9E0F3D1A72][Refdata Party Domain: tenant_id Strong-Type Migration]]                            | DONE        |
+| 2026-05-21 | [[id:7305A77A-3A41-42CA-BD1D-227E2FB18DF0][Tagged v1/v2 Coexistence — Merge doc/v2/ and Add Version Markers]]                 |             |
+| 2026-05-21 | [[id:A4B5C6D7-E8F9-0A1B-2C3D-4E5F6A7B8C9D][Entity Creator Skills Overhaul]]                                                   | TODO        |
+| 2026-05-21 | [[id:3F7A2C1D-84BE-4E9F-B261-5C0D9A3E7B48][Entity Creator Skills: v1 → v2 Migration]]                                         | TODO        |


### PR DESCRIPTION
## Summary

- **plans.org**: All 86 table entries now link to their plan files via org-roam `[[id:UUID][Title]]` links; all `COMPLETE`/`COMPLETED` status values normalised to `DONE`
- **Plan files**: All 87 plan files converted to v2 front matter (`:PROPERTIES:` block with uppercase `:ID:`, lowercase `#+title:`, `#+version: 2`)
- **Site build fixes**: Uppercase all lowercase `:ID:` properties and `[[id:...]]` links in `sprint_18/user_manual_pdf_build/` files; fix `[[id:UUID][Title]]` placeholder in task file that was aborting the export; revert `org-export-with-broken-links 'mark` so broken links still abort the build
- **Incremental builds**: Remove `rm -rf` from `deploy_site` CMake target and switch `org-publish-all` to non-force mode — only files newer than their cached output are republished

## Details

The site build was aborting on:
1. A bare `[[id:UUID][Title]]` placeholder text in a task file (not wrapped in verbatim), causing org to try resolving "UUID" as an org-roam ID → wrapped in `=verbatim=`
2. Lowercase `:ID:` values in `user_manual_pdf_build/` files (likely created via `uuidgen` without uppercasing) → uppercased all IDs and links

The incremental build change means `deploy_site` no longer wipes the output directory each run. To force a full rebuild, delete `build/output/site` manually before running the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)