### PR TITLE
[agile] Add story+task: Port Tufte visualisation skill into ORE Studio

### DIFF
--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -67,6 +67,7 @@ In execution order.
 | [[id:15CE567F-489C-4A80-9CEC-27FCF95E5C36][ores.compass Product Backlog — near and far listing]] | BACKLOG | 2026-05-24 | | =compass backlog= lists near/far captures with counts, mirroring =where= in-flight display. |
 | [[id:8D295781-33E7-4812-AAC6-134BD7CD0DDC][Rebuild org-roam DB independently from CMake]]       | BACKLOG | 2026-05-24 | | Extract org-roam sync into =.build-org-roam.el=; add =rebuild_org_roam_db= cmake target.   |
 | [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                         | STARTED | 2026-05-24 |            | Replace broken per-mode ores.lisp with an env-aware emacs-dashboard console for all dev commands. |
+| [[id:7225526E-DCDB-4DC6-A95D-22C7117E5EAA][Port Tufte visualisation skill into ORE Studio]]     | BACKLOG | 2026-05-25 | | Convert =tufte-viz= SKILL and two Tufte reference docs to org-mode; install and catalogue. |
 
 * Retrospective
 

--- a/doc/agile/versions/v0/sprint_18/tufte_skill_port/story.org
+++ b/doc/agile/versions/v0/sprint_18/tufte_skill_port/story.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: 7225526E-DCDB-4DC6-A95D-22C7117E5EAA
+:END:
+#+title: Story: Port Tufte visualisation skill into ORE Studio
+#+description: Reformat the tufte-viz SKILL and its two reference documents into org-mode, add them to doc/llm/skills/tufte-viz/, and catalogue the skill in claude_code_skills.org.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :skills:design:visualisation:tufte:sprint_18:v0:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+A =tufte-viz= skill exists in =doc/llm/skills/= and is listed in the
+skills catalogue. It teaches the LLM to design and critique data
+visualisations using Tufte's principles. Two companion reference
+documents — adapted from the work of [[https://x.com/draparente][Dr. Angelica Parente]] — are
+converted from Markdown to org-mode knowledge files and stored
+alongside the skill.
+
+* Status
+
+| Field         | Value                              |
+|---------------+------------------------------------|
+| State         | BACKLOG                            |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                          |
+| Now           | Not yet started.                   |
+| Waiting on    | Nothing.                           |
+| Next          | Reformat SKILL.md and reference files; add to skills tree. |
+| Last touched  | 2026-05-25                         |
+
+* Acceptance
+
+- =doc/llm/skills/tufte-viz/SKILL.org= exists and follows the
+  standard skill layout (=#+begin_export markdown= frontmatter block,
+  =* When to use=, =* How to use=, references to the knowledge docs).
+- =doc/llm/skills/tufte-viz/references/tufte-principles.org= exists
+  as an org-mode knowledge file, with correct attribution to
+  [[https://x.com/draparente][Dr. Angelica Parente]] in its header.
+- =doc/llm/skills/tufte-viz/references/analytical-design.org= exists
+  as an org-mode knowledge file with the same attribution.
+- =doc/llm/skills/claude_code_skills.org= lists =tufte-viz= under
+  =* Design= with a one-line description.
+- The source files in =tmp/= (=SKILL.md=,
+  =references__tufte-principles.md=,
+  =references__analytical-design.md=) are removed once their content
+  is in place.
+
+* Tasks
+
+In execution order:
+
+- [[id:9F6635A3-A770-44F2-BC85-B5324A0E65EA][Task: Reformat and install the tufte-viz skill and reference docs]]
+
+* Decisions
+
+* Out of scope
+
+- Implementing any actual visualisation code or Qt/Wt UI changes.
+- Extending the skill content beyond what is already in the source files.

--- a/doc/agile/versions/v0/sprint_18/tufte_skill_port/task_port_tufte_skill.org
+++ b/doc/agile/versions/v0/sprint_18/tufte_skill_port/task_port_tufte_skill.org
@@ -79,12 +79,14 @@ task closes. Plans do not outlive their task.)
 The two reference files cross-reference each other: the quick
 reference at the end of =analytical-design.org= calls the 7-question
 test in =tufte-principles.org= "the standard test" and adds 7 more
-questions. Maintain that cross-reference in the org versions using
-=[[file:tufte-principles.org][...]]= links.
+questions. Assign org-roam UUIDs to both reference files at creation
+time and use =[[id:UUID][...]]= links for all cross-references — not
+=[[file:...]]= links, which break on rename.
 
 The skill's =* How to use= section currently points to
 =references/tufte-principles.md= and =references/analytical-design.md=
-— update those paths to the new =.org= files.
+— update those paths to =[[id:UUID][...]]= links once the org files
+exist and have IDs.
 
 Attribution line to use in both reference files (after the title,
 before the first section):
@@ -101,8 +103,8 @@ Adapted from the work of [[https://x.com/draparente][Dr. Angelica Parente]].
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                              | File                    | Decision | Notes                                                                  |
+|---+--------------------------------------------------------------+-------------------------+----------+------------------------------------------------------------------------|
+| 1 | Use org-roam ID links, not file links, for cross-references  | task_port_tufte_skill   | Accepted | Notes updated: assign UUIDs at creation; use =[[id:...]]= throughout.  |
 
 * Result

--- a/doc/agile/versions/v0/sprint_18/tufte_skill_port/task_port_tufte_skill.org
+++ b/doc/agile/versions/v0/sprint_18/tufte_skill_port/task_port_tufte_skill.org
@@ -1,0 +1,108 @@
+:PROPERTIES:
+:ID: 9F6635A3-A770-44F2-BC85-B5324A0E65EA
+:END:
+#+title: Task: Reformat and install the tufte-viz skill and reference docs
+#+description: Convert SKILL.md and the two Tufte reference Markdown files to org-mode; place them under doc/llm/skills/tufte-viz/; catalogue the skill in claude_code_skills.org.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :skills:design:visualisation:tufte:tufte_skill_port:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7225526E-DCDB-4DC6-A95D-22C7117E5EAA][Port Tufte visualisation skill into ORE Studio]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The three files currently sitting in =tmp/= are:
+
+- =tmp/SKILL.md= — the =tufte-viz= skill playbook.
+- =tmp/references__tufte-principles.md= — Tufte's core principles
+  (lie factor, data-ink ratio, chartjunk, small multiples, etc.),
+  adapted from the work of [[https://x.com/draparente][Dr. Angelica Parente]].
+- =tmp/references__analytical-design.md= — extensions from
+  /Envisioning Information/, /Visual Explanations/, and /Beautiful
+  Evidence/ (six principles of analytical design, sparklines,
+  layering, micro/macro, range-frames, causality), adapted from the
+  same source.
+
+Convert all three to org-mode, install them into the skills tree,
+update the catalogue, and delete the originals from =tmp/=.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                                |
+| Parent story | [[id:7225526E-DCDB-4DC6-A95D-22C7117E5EAA][Port Tufte visualisation skill into ORE Studio]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Create skill directory; convert files. |
+| Last touched | 2026-05-25                             |
+
+* Acceptance
+
+- =doc/llm/skills/tufte-viz/SKILL.org= — standard skill layout:
+  org-mode frontmatter, =#+begin_export markdown= block with =name:
+  tufte-viz= and description, =* When to use this skill=, =* How to
+  use this skill= with the two-workflow structure (new visualisations
+  / critiquing existing ones), key-principles reference list pointing
+  to the companion org files, and a quick checklist.
+- =doc/llm/skills/tufte-viz/references/tufte-principles.org= —
+  org-mode conversion of =references__tufte-principles.md=; header
+  includes attribution: "Adapted from the work of
+  [[https://x.com/draparente][Dr. Angelica Parente]]."
+- =doc/llm/skills/tufte-viz/references/analytical-design.org= —
+  org-mode conversion of =references__analytical-design.md=; same
+  attribution line.
+- =doc/llm/skills/claude_code_skills.org= =* Design= section gains:
+  =- [[id:…][Tufte Viz]] — design and critique data visualisations
+  using Tufte's principles (data-ink ratio, chartjunk, small
+  multiples, graphical integrity).=
+- =tmp/SKILL.md=, =tmp/references__tufte-principles.md=, and
+  =tmp/references__analytical-design.md= are deleted.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+The two reference files cross-reference each other: the quick
+reference at the end of =analytical-design.org= calls the 7-question
+test in =tufte-principles.org= "the standard test" and adds 7 more
+questions. Maintain that cross-reference in the org versions using
+=[[file:tufte-principles.org][...]]= links.
+
+The skill's =* How to use= section currently points to
+=references/tufte-principles.md= and =references/analytical-design.md=
+— update those paths to the new =.org= files.
+
+Attribution line to use in both reference files (after the title,
+before the first section):
+
+#+begin_example
+Adapted from the work of [[https://x.com/draparente][Dr. Angelica Parente]].
+#+end_example
+
+* PRs
+
+| PR  | Title                                              |
+|-----+----------------------------------------------------|
+|     |                                                    |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result


### PR DESCRIPTION
## Summary

- Adds `doc/agile/versions/v0/sprint_18/tufte_skill_port/story.org` (ID `7225526E`) — story to port the `tufte-viz` skill into ORE Studio.
- Adds `doc/agile/versions/v0/sprint_18/tufte_skill_port/task_port_tufte_skill.org` (ID `9F6635A3`) — task describing conversion of the three files in `tmp/` to org-mode, installation under `doc/llm/skills/tufte-viz/`, and catalogue entry in `claude_code_skills.org`.
- Updates `sprint.org` to list the new BACKLOG story.

The skill and its two reference documents (Tufte principles; analytical design, sparklines, and layering) are adapted from the work of [Dr. Angelica Parente](https://x.com/draparente). The task records the attribution requirement and the cross-reference structure between the two org files.

## Test plan

- [ ] Story and task files parse correctly as org-mode (IDs are valid uppercase UUIDs, frontmatter fields complete).
- [ ] Sprint 18 story table in `sprint.org` includes the new BACKLOG row with the correct ID link.
- [ ] No implementation changes — this PR is planning docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)