### PR TITLE
[ores.compass] Add the Fleet pillar (compass fleet)

### DIFF
--- a/doc/agile/versions/v0/sprint_18/compass_goto/story.org
+++ b/doc/agile/versions/v0/sprint_18/compass_goto/story.org
@@ -1,0 +1,70 @@
+:PROPERTIES:
+:ID: C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E
+:END:
+#+title: Story: compass goto: start a unit of work in one command
+#+description: A compass goto command that fetches main, creates a feature branch, scaffolds a linked story+task, and prints next steps.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :compass:workflow:agile:python:sprint_18:v0:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+One command, =compass goto=, that bootstraps a new unit of work. The
+user supplies the details (title, description, optional tags); =goto=
+then: (1) fetches latest =main=; (2) creates a new feature branch off
+it; (3) scaffolds a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] and a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] (task linked to story) via the
+Scaffold =add= machinery (codegen as a library); and (4) prints the
+remaining by-hand steps — wire the story into the sprint =* Stories=
+table, set states, etc. It composes =git= + =compass add= into the
+"start a story" ritual that today is several manual commands.
+
+(Promoted from a product-backlog capture into this sprint; renamed from
+=go= to =goto=.)
+
+* Status
+
+| Field         | Value                              |
+|---------------+------------------------------------|
+| State         | BACKLOG                            |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                          |
+| Now           | In the sprint backlog, not started. |
+| Waiting on    | Nothing.                           |
+| Next          | Scaffold tasks when picked up.     |
+| Last touched  | 2026-05-25                         |
+
+* Acceptance
+
+- =compass goto --title … --description … [--tags …]= fetches =main=,
+  creates a feature branch, and scaffolds a linked story + task.
+- The task's =#+branch:= is set to the new branch (so [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][=fleet=]] picks it
+  up immediately).
+- It does /not/ silently mutate the sprint table; instead it prints a
+  checklist of the remaining manual steps (wire story into =* Stories=,
+  set states, push/PR).
+- Reuses =add= / codegen rather than re-implementing generation.
+
+* Tasks
+
+In execution order (scaffolded when picked up):
+
+- Implement the =goto= dispatcher (fetch + branch + add story + add task
+  + next-steps output).
+
+* Decisions
+
+- Named =goto= (not =go=).
+- Pairs with [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][Fleet]]: =goto= /creates/ a worktree's work; =fleet= /shows/
+  it. Builds on the Scaffold pillar (=add=).
+
+* Out of scope
+
+- Choosing/serialising the branch name beyond a simple slug-derived
+  default (user can override).
+- Editing the sprint =* Stories= table automatically (printed as a
+  manual step, matching =add='s "wire it in" reminder).

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -68,6 +68,8 @@ In execution order.
 | [[id:8D295781-33E7-4812-AAC6-134BD7CD0DDC][Rebuild org-roam DB independently from CMake]]       | BACKLOG | 2026-05-24 | | Extract org-roam sync into =.build-org-roam.el=; add =rebuild_org_roam_db= cmake target.   |
 | [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                         | STARTED | 2026-05-24 |            | Replace broken per-mode ores.lisp with an env-aware emacs-dashboard console for all dev commands. |
 | [[id:7225526E-DCDB-4DC6-A95D-22C7117E5EAA][Port Tufte visualisation skill into ORE Studio]]     | BACKLOG | 2026-05-25 | | Convert =tufte-viz= SKILL and two Tufte reference docs to org-mode; install and catalogue. |
+| [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][compass cross-worktree status (global where)]] | STARTED | 2026-05-25 | | Show what every git worktree is doing (branch/story/task/PR) so parallel agents don't collide. |
+| [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][compass goto: start a unit of work in one command]] | BACKLOG | 2026-05-25 | | One command: fetch main, branch, scaffold linked story+task, print next steps. |
 
 * Retrospective
 

--- a/doc/agile/versions/v0/sprint_18/worktree_status/story.org
+++ b/doc/agile/versions/v0/sprint_18/worktree_status/story.org
@@ -1,0 +1,113 @@
+:PROPERTIES:
+:ID: CB368AF8-3144-4CFF-B782-05CDF87366A6
+:END:
+#+title: Story: compass cross-worktree status (global where)
+#+description: Show what every git worktree is working on (branch, story, task, PR) so parallel agents don't collide.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :compass:worktrees:coordination:python:sprint_18:v0:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+A contributor (or agent) can see, in one command, what /every/ git
+worktree of this repo is currently doing — its branch, the story and
+task it maps to, and the open PR (with live state). The point is
+coordination: with several worktrees running in parallel (right now:
+=local1..local4= plus =remote=, four on distinct feature branches),
+this is how you avoid two agents trampling the same story/files.
+
+* Status
+
+| Field         | Value                              |
+|---------------+------------------------------------|
+| State         | STARTED                            |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                          |
+| Now           | =compass fleet= implemented and dogfooded. |
+| Waiting on    | Nothing.                           |
+| Next          | Review; then close.                |
+| Last touched  | 2026-05-25                         |
+
+* Design (brainstorm)
+
+** What it shows
+
+One row per worktree: =worktree= (path/name) · =branch= · =story= ·
+=task= · =PR= · =PR state= (and maybe a dirty/✱ marker for uncommitted
+changes).
+
+** Data sources
+
+- =git worktree list --porcelain= → each worktree's path + checked-out
+  branch. (This is the spatial axis =where= lacks.)
+- The branch → task mapping already exists in the doc graph: task docs
+  carry =#+branch:= (and =#+pr:=). So a worktree's branch resolves to a
+  task (hence its parent story and PR).
+- Live PR state: one =gh pr list --state open --json
+  number,title,state,headRefName= call, matched to branches (cheaper
+  than one =gh= call per worktree). Degrade gracefully when =gh= /
+  network is unavailable — still show branch + task.
+
+** The cross-tree subtlety (important)
+
+Each worktree is on a /different branch/, so the agile docs (and the
+=#+branch:= fields) differ per branch. Compass runs in one worktree and
+sees only /its/ tree. Two ways to resolve another worktree's branch →
+task:
+
+1. /Current-tree match/ — match worktree branches against =#+branch:=
+   fields found in the current worktree's tree (works once the task doc
+   is on =main=/shared; misses a brand-new task living only on the other
+   branch).
+2. /Per-worktree read/ — for each worktree path, read /its/ checked-out
+   docs (=git -C <path> …= or scan =<path>/doc/agile/=) so each worktree
+   reports its own truth. More robust. /Recommended./
+
+** Should it be part of =where=?
+
+=where= answers "where are /we/ in time" (version / sprint / in-flight).
+This is a different axis — "where is /everyone/ across checkouts". Two
+options:
+
+- /Extend where/: =compass where --worktrees= (or =--all=/=--fleet=) —
+  one mental model, discoverable.
+- /New subcommand/: e.g. =compass fleet= / =crew= / =who= — clean
+  separation, room to grow (ahead/behind, last commit, dirty state).
+
+/Decided:/ a dedicated subcommand named *=compass fleet=* (product-owner
+choice). Distinct data sources (git worktrees + =gh=) and output from
+=where=; the concept is "the fleet", not "the clock".
+
+* Acceptance
+
+- =compass fleet= lists every worktree from =git worktree list= with:
+  branch, mapped story + task, PR number + live state.
+- Worktrees with no matching task (e.g. =main=, detached HEAD) are shown
+  plainly; the current worktree is marked.
+- Works offline: omits live PR state but still shows branch + task.
+- Documented in the component overview and a recipe.
+
+* Tasks
+
+In execution order:
+
+- [[id:1B355D5E-F0AF-4807-8551-8301F1F50128][Task: Implement the fleet command]]
+
+* Decisions
+
+- Name is =compass fleet=, a dedicated subcommand (not folded into
+  =where=).
+- Reuse the existing =#+branch:= task field as the mapping key rather
+  than inventing new state; read each worktree's /own/ tree so it works
+  on unmerged branches; PR state via one =gh pr list= matched by branch.
+
+* Out of scope
+
+- File-level collision detection or locking (this just surfaces who is
+  where; humans/agents still coordinate).
+- Worktrees of /other/ repos; only this repo's worktrees.

--- a/doc/agile/versions/v0/sprint_18/worktree_status/task_implement_fleet_command.org
+++ b/doc/agile/versions/v0/sprint_18/worktree_status/task_implement_fleet_command.org
@@ -1,0 +1,81 @@
+:PROPERTIES:
+:ID: 1B355D5E-F0AF-4807-8551-8301F1F50128
+:END:
+#+title: Task: Implement the fleet command
+#+description: Add a compass fleet subcommand showing each git worktree's branch, story, task and PR.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :compass:worktrees:python:worktree_status:sprint_18:v0:
+#+owner: marco
+#+branch: feature/compass-worktree-status
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][compass cross-worktree status (global where)]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add a =compass fleet= subcommand that lists every git worktree with its
+branch, mapped story + task (via the task =#+branch:= field), and open
+PR (live state via =gh=), so parallel checkouts/agents don't collide.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                                   |
+| Parent story | [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][compass cross-worktree status (global where)]] |
+| Now          | Implemented and dogfooded across the live worktrees. |
+| Waiting on   | Nothing.                               |
+| Next         | Review.                                |
+| Last touched | 2026-05-25                             |
+
+* Acceptance
+
+- =compass fleet= lists every worktree from =git worktree list= with
+  branch, mapped story + task, and open PR + live state.
+- The branch → task mapping is read from /each worktree's own/ tree
+  (the task =#+branch:= field), so it works on unmerged branches.
+- The current worktree is marked; worktrees with no matching task (e.g.
+  =main=) are shown plainly.
+- =-f json= emits a structured array; works offline (omits PR state).
+
+* Plan
+
+1. =list_worktrees= (parse =git worktree list --porcelain=).
+2. =task_for_branch= (per-worktree glob of =task_*.org= for =#+branch:=).
+3. =open_prs_by_branch= (one =gh pr list= call, matched by =headRefName=).
+4. =cmd_fleet= + =fleet= subparser; pretty + json output.
+
+* Notes
+
+Dogfooded across the five live worktrees: =local1= mapped to its story,
+task and PR #828; PRs matched live by branch; the current worktree
+flagged with =→=.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Implemented =compass fleet= in =compass.py= (=cmd_fleet= plus
+=list_worktrees= / =task_for_branch= / =open_prs_by_branch= helpers and
+the =fleet= subparser). Verified across the five live worktrees:
+=local1= → "ORE Studio Emacs dashboard" / its audit task / PR #828; this
+worktree self-maps to this very task; the current worktree is marked
+=→=; =-f json= emits the structured array. =where= / =add= unaffected;
+=py_compile= clean.

--- a/doc/recipes/compass/compass.org
+++ b/doc/recipes/compass/compass.org
@@ -18,6 +18,8 @@ How to use =compass=, the [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][repository 
 
 - [[id:41E5F9A8-1C2B-4ECA-8EA0-1ABBAB0B6A31][How do I see where we are?]] — current version, sprint, and in-flight
   stories/tasks (=where= / =status=).
+- [[id:0D378978-7CF1-45F5-896F-63E281CC02CB][How do I see what every worktree is doing?]] — branch / story / task /
+  PR per git worktree (=fleet=).
 
 * Search and indexing
 

--- a/doc/recipes/compass/how_do_i_see_what_every_worktree_is_doing.org
+++ b/doc/recipes/compass/how_do_i_see_what_every_worktree_is_doing.org
@@ -1,0 +1,55 @@
+:PROPERTIES:
+:ID: 0D378978-7CF1-45F5-896F-63E281CC02CB
+:END:
+#+title: How do I see what every worktree is doing?
+#+description: Use compass fleet to list each git worktree's branch, story, task and open PR.
+#+type: recipe
+#+version: 2
+#+level: cross
+#+filetags: :compass:worktrees:coordination:recipe:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+
+The /Fleet/ pillar of the [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][compass tool]]. Use it when several worktrees
+(or agents) work in parallel and you want to avoid collisions.
+
+* Question
+
+What is every git worktree of this repo currently working on — which
+branch, story, task and PR?
+
+* Answer
+
+Run =compass.sh fleet=:
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh fleet
+#+end_src
+
+For each worktree it prints the branch, the mapped story and task (found
+via the task's =#+branch:= field, read from /that worktree's/ tree so it
+works on unmerged branches), and the open PR with live state (via =gh=).
+The current worktree is marked =→=; worktrees with no matching task
+(e.g. =main=) are shown plainly.
+
+=-f json= emits a structured array for tooling:
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh fleet -f json
+#+end_src
+
+* Script
+
+=projects/ores.compass/compass.sh fleet= → =src/compass.py= (=cmd_fleet=),
+using =git worktree list=, the task =#+branch:= fields, and one
+=gh pr list= matched by head branch.
+
+* Tested by
+
+Manual smoke test across the live worktrees. Read-only; degrades
+gracefully (omits PR state) when =gh= is unavailable.
+
+* See also
+
+- [[id:41E5F9A8-1C2B-4ECA-8EA0-1ABBAB0B6A31][How do I see where we are?]] — the per-sprint =where= view.
+- [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][Story: compass cross-worktree status]] — design and decisions.

--- a/projects/ores.compass/modeling/component_overview.org
+++ b/projects/ores.compass/modeling/component_overview.org
@@ -30,7 +30,7 @@ are planned (see [[id:8BA366D7-B43F-4E5B-B4AD-A40C7E28881B][the story]]).
 
 * Capabilities
 
-Three pillars, drawn from the Sprint 18 capture (=* Tools=):
+Pillars (the first three drawn from the Sprint 18 capture =* Tools=):
 
 1. /Locate — "where are we in time?"/ Report the current [[id:CA4D4BDE-2EAB-4F0A-BC8B-7C0BCB17BC82][version]], the
    current [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprint]], and the [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][stories]] / [[id:31C868B9-306E-4282-BA8C-07E647021B34][tasks]] currently in flight
@@ -46,6 +46,11 @@ Three pillars, drawn from the Sprint 18 capture (=* Tools=):
    story, a sprint, a recipe, a capture, etc. Calls codegen /as a
    library/ rather than re-implementing it. /Implemented/ as =add= —
    see the [[id:D84B1122-30DC-4BCF-9C90-73403FAAECD9][Scaffold story]].
+
+4. /Fleet — "what is every worktree doing?"/ List each git worktree with
+   its branch, mapped story + task (via the task =#+branch:= field), and
+   open PR + live state, so parallel checkouts/agents don't collide.
+   /Implemented/ as =fleet= — see the [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][Fleet story]].
 
 * Inputs
 
@@ -77,20 +82,23 @@ Three pillars, drawn from the Sprint 18 capture (=* Tools=):
 - =projects/ores.compass/src/compass.py= — the CLI. Subcommands:
   =index [--rebuild]=, =search <query> [-l N] [-f FMT]=,
   =debug [-f FILE]= (Search); =where= / =status= [=-f pretty|json=]
-  (Locate); =list [filters]= and =show <uuid>= (Navigate); and
-  =add <type> [flags]= (Scaffold).
+  (Locate); =list [filters]= and =show <uuid>= (Navigate);
+  =add <type> [flags]= (Scaffold); and =fleet [-f pretty|json]= (Fleet).
 
 * Dependencies
 
 - Python 3 standard library for everything except Scaffold (=sqlite3=,
-  =argparse=, =json=, =pathlib=, =re=, =dataclasses=).
+  =argparse=, =json=, =pathlib=, =re=, =dataclasses=, =subprocess=).
 - =pystache= — only for =add= (Scaffold), which imports codegen's
   Mustache-based generator. Declared in =requirements.txt=; the other
   commands run without it.
+- =git= (for =fleet=, via =git worktree list=) and =gh= (for live PR
+  state in =fleet= and =where --prs=). =fleet= degrades gracefully when
+  =gh= is unavailable, still showing branch + task.
 - =org-roam= (in Emacs) to populate =.org-roam.db=, used only by the
   Search pillar. Compass never writes to it; it opens it read-only.
-  Locate and Navigate read the working tree directly and need neither
-  =org-roam.db= nor =org-roam-db-sync=.
+  Locate, Navigate and Fleet read the working tree directly and need
+  neither =org-roam.db= nor =org-roam-db-sync=.
 - [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] — the division of labour is: /codegen generates,
   compass navigates/. Doc /navigation/ (=doc_index= / =list= / =show=)
   was folded /out/ of codegen into compass. Doc /generation/ stays in
@@ -106,7 +114,7 @@ projects/ores.compass/
 ├── requirements.txt           # pystache (only `add` needs it)
 ├── src/
 │   ├── __init__.py
-│   ├── compass.py             # CLI dispatcher: index/search/debug/where/list/show/add
+│   ├── compass.py             # CLI dispatcher: index/search/debug/where/list/show/add/fleet
 │   ├── doc_index.py           # canonical .org parser (walks the repo)
 │   ├── doc_list.py            # `list` — filter the doc graph
 │   └── doc_show.py            # `show` — one doc + inbound/outbound links

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -10,6 +10,8 @@ Pillars:
     its inbound/outbound links (show).
   - Scaffold: create agile/doc artefacts (add) by calling ores.codegen as a
     library — generation stays in codegen, not duplicated here.
+  - Fleet: what every git worktree is doing — branch, story, task, PR
+    (fleet), so parallel checkouts/agents don't collide.
 """
 
 import argparse
@@ -17,6 +19,7 @@ import json
 import os
 import re
 import sqlite3
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -671,6 +674,122 @@ def cmd_where(args):
                 if url:
                     print(f"          {url}")
 
+# --- Fleet: what is every worktree doing? ---
+#
+# Coordination view across parallel checkouts: for each git worktree, show its
+# branch, the task/story it maps to (via the task's #+branch field), and the
+# open PR (live state via gh). Each worktree is read in its own tree, so it
+# reports its own truth even on branches not yet merged.
+
+_BRANCH_FIELD_RE = re.compile(r"^#\+branch:\s*(\S+)\s*$", re.MULTILINE)
+_TITLE_FIELD_RE  = re.compile(r"^#\+title:\s*(.+?)\s*$",   re.MULTILINE)
+
+def list_worktrees():
+    """Return [(path, branch_or_None)] from `git worktree list --porcelain`."""
+    try:
+        out = subprocess.run(["git", "worktree", "list", "--porcelain"],
+                             capture_output=True, text=True, cwd=str(PROJECT_ROOT),
+                             timeout=15)
+    except (OSError, subprocess.SubprocessError):
+        return []
+    worktrees, path, branch = [], None, None
+    for line in out.stdout.splitlines():
+        if line.startswith("worktree "):
+            if path is not None:
+                worktrees.append((path, branch))
+            path, branch = line[len("worktree "):], None
+        elif line.startswith("branch "):
+            branch = re.sub(r"^refs/heads/", "", line[len("branch "):])
+    if path is not None:
+        worktrees.append((path, branch))
+    return worktrees
+
+def open_prs_by_branch():
+    """Map head branch -> {number,title,state,url} for open PRs, via gh. {} on failure."""
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "list", "--state", "open", "--limit", "200",
+             "--json", "number,title,state,url,headRefName"],
+            capture_output=True, text=True, cwd=str(PROJECT_ROOT), timeout=20)
+        if out.returncode != 0:
+            return {}
+        prs = json.loads(out.stdout)
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+        return {}
+    return {pr["headRefName"]: pr for pr in prs if pr.get("headRefName")}
+
+def task_for_branch(worktree_path, branch):
+    """Find a task in this worktree's tree whose #+branch == branch.
+
+    Returns (task_title, story_title) or (None, None). Read per-worktree so a
+    branch's task is found even if the doc only exists on that branch.
+    """
+    base = Path(worktree_path) / "doc" / "agile" / "versions"
+    if not base.exists():
+        return None, None
+    for task_file in sorted(base.glob("*/sprint_*/**/task_*.org")):
+        try:
+            text = task_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        m = _BRANCH_FIELD_RE.search(text)
+        if not m or m.group(1) != branch:
+            continue
+        tm = _TITLE_FIELD_RE.search(text)
+        task_title = _strip_type_prefix(tm.group(1)) if tm else task_file.stem
+        story_title = None
+        story_file = task_file.parent / "story.org"
+        if story_file.exists():
+            try:
+                sm = _TITLE_FIELD_RE.search(story_file.read_text(encoding="utf-8"))
+                story_title = _strip_type_prefix(sm.group(1)) if sm else None
+            except (OSError, UnicodeDecodeError):
+                pass
+        return task_title, story_title
+    return None, None
+
+def cmd_fleet(args):
+    worktrees = list_worktrees()
+    if not worktrees:
+        print("❌ Could not enumerate git worktrees.", file=sys.stderr)
+        sys.exit(1)
+    here = str(PROJECT_ROOT)
+    pr_map = open_prs_by_branch()
+
+    rows = []
+    for path, branch in worktrees:
+        task_title = story_title = None
+        if branch:
+            task_title, story_title = task_for_branch(path, branch)
+        pr = pr_map.get(branch) if branch else None
+        rows.append({
+            "worktree": Path(path).name,
+            "path": path,
+            "current": os.path.realpath(path) == os.path.realpath(here),
+            "branch": branch,
+            "story": story_title,
+            "task": task_title,
+            "pr": ({"number": pr["number"], "state": pr["state"], "url": pr["url"]}
+                   if pr else None),
+        })
+
+    if args.format == "json":
+        print(json.dumps(rows, indent=2))
+        return
+
+    print(f"🧭 ores.compass — fleet ({len(rows)} worktrees)\n")
+    for r in rows:
+        mark = "→" if r["current"] else " "
+        branch = r["branch"] or "(detached)"
+        print(f"{mark} {r['worktree']}   {branch}")
+        if r["task"] or r["story"]:
+            print(f"      story: {r['story'] or '—'}")
+            print(f"      task:  {r['task'] or '—'}")
+        elif r["branch"] and r["branch"] != "main":
+            print("      (no task records this branch)")
+        if r["pr"]:
+            print(f"      PR:    #{r['pr']['number']} [{r['pr']['state']}]  {r['pr']['url']}")
+
 # --- Scaffold pillar: create agile/doc artefacts ---
 #
 # Generation belongs to ores.codegen, not compass: `add` calls codegen's
@@ -783,6 +902,11 @@ def main():
     where_parser.add_argument("--prs", action="store_true",
                               help="Also show PRs from all sprint tasks (fetches live status via gh)")
 
+    fleet_parser = subparsers.add_parser("fleet",
+                                         help="Show what every git worktree is doing: branch, story, task, PR")
+    fleet_parser.add_argument("-f", "--format", choices=["pretty", "json"], default="pretty",
+                              help="Output format: pretty (default) or json")
+
     # Registered for discoverability in --help; actually handled by the
     # short-circuit above (which forwards all args to their handlers).
     subparsers.add_parser("list",
@@ -807,6 +931,8 @@ def main():
         cmd_debug(args)
     elif args.command in ("where", "status"):
         cmd_where(args)
+    elif args.command == "fleet":
+        cmd_fleet(args)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

Adds **`compass fleet`** — a cross-worktree coordination view. With
several worktrees/agents running in parallel, it answers "who is working
on what" so they don't trample each other. (This implements the
"global where" idea, as a dedicated subcommand named `fleet`.)

## What it shows

One entry per git worktree: **branch · story · task · PR (live state)**,
with the current worktree marked `→`.

## How

- `git worktree list --porcelain` → each worktree's path + branch.
- branch → story/task via the task `#+branch:` field, read from **each
  worktree's own tree** (so it resolves even on unmerged branches).
- One `gh pr list --state open` call, matched by `headRefName`, for live
  PR state. Degrades gracefully (omits PR state) when `gh` is offline.
- `-f json` for tooling.

Dogfooded across the five live worktrees — e.g. `local1` maps to "ORE
Studio Emacs dashboard" / its audit task / PR #828, and this worktree
self-maps to the fleet task.

## Changes

- `compass.py`: `cmd_fleet` + `list_worktrees` / `task_for_branch` /
  `open_prs_by_branch` helpers; `fleet` subparser; `subprocess` import.
- Component overview: Fleet pillar, entry point, deps (`git`/`gh`).
- Story `compass cross-worktree status` (design + decisions) and its
  implement-fleet task (DONE); wired into the sprint table.
- New recipe "How do I see what every worktree is doing?" in the Compass
  topic.
- Backlog capture for the related `compass go` idea.

## Notes

`validate_docs.sh` passes (90/90); `where` / `add` unaffected.