### PR TITLE
[skills,doc] Port tufte-viz skill and reference docs into ORE Studio

### DIFF
--- a/doc/agile/versions/v0/sprint_18/tufte_skill_port/story.org
+++ b/doc/agile/versions/v0/sprint_18/tufte_skill_port/story.org
@@ -26,11 +26,11 @@ alongside the skill.
 
 | Field         | Value                              |
 |---------------+------------------------------------|
-| State         | BACKLOG                            |
+| State         | STARTED                            |
 | Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                          |
-| Now           | Not yet started.                   |
-| Waiting on    | Nothing.                           |
-| Next          | Reformat SKILL.md and reference files; add to skills tree. |
+| Now           | Implementation complete; PR raised. |
+| Waiting on    | PR review.                         |
+| Next          | Merge PR.                          |
 | Last touched  | 2026-05-25                         |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_18/tufte_skill_port/task_port_tufte_skill.org
+++ b/doc/agile/versions/v0/sprint_18/tufte_skill_port/task_port_tufte_skill.org
@@ -41,9 +41,9 @@ update the catalogue, and delete the originals from =tmp/=.
 |--------------+----------------------------------------|
 | State        | BACKLOG                                |
 | Parent story | [[id:7225526E-DCDB-4DC6-A95D-22C7117E5EAA][Port Tufte visualisation skill into ORE Studio]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Create skill directory; convert files. |
+| Now          | PR raised; awaiting review.            |
+| Waiting on   | PR merge.                              |
+| Next         | Mark DONE on merge.                    |
 | Last touched | 2026-05-25                             |
 
 * Acceptance

--- a/doc/llm/skills/claude_code_skills.org
+++ b/doc/llm/skills/claude_code_skills.org
@@ -85,6 +85,9 @@ See [[id:654D4A70-E63D-4C18-B5A5-886066E36314][CMake Runner]] for the deployment
   (Jony Ive-level precision with intentional personality).
 - [[id:2A167638-8B5A-4691-90CB-4A6B55785108][Icon Guidelines]] — pick the right Fluent UI icon and variant
   for a UI element from the visual-language catalogue.
+- [[id:E8629813-4F4A-4165-85AA-27BE7F38E32C][Tufte Viz]] — design and critique data visualisations using
+  Tufte's principles (data-ink ratio, chartjunk elimination,
+  small multiples, graphical integrity).
 
 * Code review
 

--- a/doc/llm/skills/tufte-viz/SKILL.org
+++ b/doc/llm/skills/tufte-viz/SKILL.org
@@ -1,0 +1,73 @@
+:PROPERTIES:
+:ID: E8629813-4F4A-4165-85AA-27BE7F38E32C
+:END:
+#+title: Tufte Viz Skill
+#+description: Design and critique data visualisations using Edward Tufte's principles — data-ink ratio, chartjunk elimination, graphical integrity, small multiples, and analytical design.
+#+type: skill
+#+version: 2
+#+level: cross
+#+filetags: :skills:claude_code:design:visualisation:tufte:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+
+#+begin_export markdown
+---
+name: tufte-viz
+description: |
+  Ideate and critique data visualisations using Edward Tufte's principles. Use this skill when:
+  (1) Designing new data visualisations or charts
+  (2) Critiquing or improving existing visualisations
+  (3) Reviewing dashboards or reports for graphical integrity
+  (4) Deciding between visualisation approaches
+  (5) Reducing chartjunk or improving data-ink ratio
+  (6) Planning small multiples or high-density displays
+  Applies principles: data-ink ratio, chartjunk elimination, graphical integrity, lie factor, small multiples, data density, layering, and analytical design.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+When designing or evaluating any data display — charts, dashboards,
+tables, reports, inline graphics. Use it before writing visualisation
+code and when reviewing existing displays for clarity or integrity.
+
+* How to use this skill
+
+** For new visualisations
+
+1. *Clarify the data story* — what comparisons matter? What is the key insight? Who is the audience?
+2. *Select approach* using Tufte principles:
+   - High comparison need → small multiples.
+   - Dense data → data tables, sparklines.
+   - Time-series → line charts with minimal grid.
+   - Part-to-whole → avoid pie charts; prefer bar/table.
+3. *Design with data-ink in mind* — start minimal, add only what is necessary. Every element must earn its ink. Default to greyscale; use colour purposefully.
+4. *Apply the Tufte Test* — see [[id:F322DD08-D114-4B9E-8B89-E392ED5C591E][Tufte's Principles for Data Visualisation]].
+
+** For critiquing visualisations
+
+1. *Check graphical integrity* — calculate lie factor if proportions seem off; verify baselines and scales; look for 3D distortion.
+2. *Identify chartjunk* — decorative elements, heavy grids, unnecessary 3D effects, moiré patterns.
+3. *Evaluate data-ink ratio* — what can be erased? What is redundant?
+4. *Apply the six analytical design principles* — see [[id:613C09B0-D516-417F-9627-2349D46A3645][Analytical Design, Sparklines, and Layering]].
+5. *Suggest improvements* with specific before/after recommendations.
+
+* Key principles reference
+
+- [[id:F322DD08-D114-4B9E-8B89-E392ED5C591E][Tufte's Principles for Data Visualisation]] — core principles from /The Visual Display of Quantitative Information/: lie factor, data-ink ratio, chartjunk, small multiples, graphical integrity, and the 7-question Tufte Test.
+- [[id:613C09B0-D516-417F-9627-2349D46A3645][Analytical Design, Sparklines, and Layering]] — extensions from /Envisioning Information/, /Visual Explanations/, and /Beautiful Evidence/: the six principles of analytical design, sparklines, layering and separation, micro/macro, range-frames, causality, confections. Load when designing dashboards, dense displays, sparklines, or explanatory graphics.
+
+* Quick checklist
+
+- [ ] Lie Factor ≈ 1.0 (no visual distortion).
+- [ ] Maximum data-ink ratio.
+- [ ] Zero chartjunk.
+- [ ] Clear labelling.
+- [ ] Answers "compared to what?"
+- [ ] Shows causality or mechanism where relevant.
+- [ ] Multivariate (not over-reduced).
+- [ ] Words, numbers, images integrated — not segregated.
+- [ ] Reveals multiple levels of detail (micro + macro).
+- [ ] Layering: primary data dominates, secondary recedes.
+- [ ] Appropriate data density.

--- a/doc/llm/skills/tufte-viz/references/analytical-design.org
+++ b/doc/llm/skills/tufte-viz/references/analytical-design.org
@@ -1,0 +1,154 @@
+:PROPERTIES:
+:ID: 613C09B0-D516-417F-9627-2349D46A3645
+:END:
+#+title: Analytical Design, Sparklines, and Layering
+#+description: Extensions from Envisioning Information, Visual Explanations, and Beautiful Evidence: six principles of analytical design, sparklines, layering and separation, micro/macro, range-frames, causality, and confections.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :skills:design:visualisation:tufte:knowledge:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+
+Adapted from the work of [[https://x.com/draparente][Dr. Angelica Parente]].
+
+Extends [[id:F322DD08-D114-4B9E-8B89-E392ED5C591E][Tufte's Principles for Data Visualisation]] with material from /Envisioning Information/ (1990), /Visual Explanations/ (1997), and /Beautiful Evidence/ (2006).
+
+* 1. The Six Principles of Analytical Design
+
+From /Beautiful Evidence/. The most actionable framework Tufte produced — applies to any analytical presentation, not just charts.
+
+1. *Show comparisons, contrasts, differences* — the fundamental analytical act. Every display should answer "compared to what?"
+2. *Show causality, mechanism, structure, explanation* — move beyond description. What is the /why/ behind the pattern?
+3. *Show multivariate data — more than 1 or 2 variables* — real problems are multivariate. Reducing to a single variable hides interactions.
+4. *Completely integrate words, numbers, images, diagrams* — don't segregate by mode. Labels next to the data they describe; equations next to the curves they generate.
+5. *Thoroughly describe the evidence* — provenance, authorship, scales, sources, measurements. Documentation enables trust.
+6. *Analytical presentations ultimately stand or fall depending on the quality, relevance, and integrity of their content* — no amount of design fixes weak evidence. Content is paramount.
+
+*Use in critique:* walk through all six. The lowest-scoring principle is usually the biggest improvement opportunity.
+
+* 2. Sparklines
+
+Word-sized, data-intense graphics. Tufte's signature /Beautiful Evidence/ invention.
+
+** Defining properties
+
+- Typographic resolution — sized like text, embedded inline with prose or tables.
+- No axes, no labels, no decoration.
+- Endpoints often marked (start/end values, or min/max).
+- Reveals shape, trend, variability at a glance.
+
+** Design rules
+
+- Height ≈ x-height of surrounding text (~14–20 px).
+- Length ≈ a word or short phrase.
+- Use a single red/coloured dot to flag a key point (current value, anomaly).
+- Pair with the most recent numeric value: =120 ▁▂▃▅▇▇▆▅ 132=.
+- Stack in tables so eyes can scan vertically.
+
+** When to use
+
+- Dashboards with many metrics (one row per metric: name | sparkline | current | delta).
+- Inline prose: "revenue trended up ▁▂▄▆▇ over the quarter."
+- Anywhere a full chart would dominate but trend matters.
+
+** When not to use
+
+- When precise readings matter — sparklines show shape, not value.
+- For categorical or part-to-whole data.
+
+* 3. Layering and Separation
+
+From /Envisioning Information/. The most useful concept for dense displays.
+
+*The principle:* visually distinct elements can coexist in the same space if they are /layered/ — separated by value, weight, hue, or transparency rather than spatial isolation.
+
+** Techniques
+
+- *1+1=3 effect* — two heavy lines next to each other create a phantom third line. Lighten one to suppress this.
+- *Hierarchy by weight* — primary data in dark/saturated; secondary in light grey; annotations even lighter.
+- *Colour for separation, not decoration* — distinct hues let overlapping data remain readable.
+- *Whisper, don't shout* — grids, axes, reference lines should fade into the background: present but unobtrusive.
+
+*Test:* squint at the graphic. The most important data should remain visible; chartjunk should disappear first.
+
+* 4. Micro/Macro Design
+
+Distinct from raw data density. A micro/macro graphic reveals *different stories at different viewing distances*.
+
+- *Macro view* (zoomed out, peripheral) — overall pattern, shape, trend.
+- *Micro view* (close inspection) — individual data points, labels, exceptions.
+
+** Canonical examples
+
+- Vietnam Memorial: macro = sweep of names; micro = a single name.
+- Galaxy maps: macro = structure; micro = individual stars.
+- Financial tables with sparklines: macro = which rows trended up; micro = the actual values.
+
+*Design implication:* don't choose between overview and detail — show both simultaneously by layering.
+
+* 5. Escaping Flatland
+
+The 2D page/screen is inherently flat; good information design adds dimensions /without/ 3D gimmicks.
+
+** Dimensions you can add on flat media
+
+- Colour (categorical or sequential).
+- Size (continuous).
+- Shape (categorical).
+- Position (2–3 axes via projection).
+- Time (small multiples, animation, or sparkline-style inline series).
+- Layering (foreground/background via value).
+
+*Anti-pattern:* 3D bar charts, pie charts with depth, isometric projections that distort proportions. These add visual dimension without adding information dimension — pure chartjunk.
+
+* 6. Range-Frame and Dot-Dash Plot
+
+Tufte's signature reinventions of standard chart elements. Direct applications of data-ink maximisation.
+
+** Range-frame
+
+- Replace the full axis with a line that spans only the /range of actual data/.
+- Axis ends at min/max values, not arbitrary round numbers.
+- Tells the viewer the data extent without explicit annotation.
+
+** Dot-dash plot
+
+- Scatter plot where the axes are replaced by marginal rug plots.
+- Each axis becomes a 1D distribution of the data on that variable.
+- Same ink, more information — the axes now show marginal density.
+
+*Pattern:* every standard chart element (axis, tick, gridline) can be redesigned to carry data.
+
+* 7. Confections, Parallelism, Narrative
+
+From /Visual Explanations/.
+
+- *Confections* — assemblages of disparate visual elements (images, maps, text, diagrams) into a single explanatory composition. They work when each element serves the argument. Examples: Minard's Napoleon march, Snow's cholera map, exploded technical illustrations.
+- *Parallelism* — repetition of visual structure to enable comparison. Small multiples are one form, but parallelism extends to side-by-side maps, before/after states, repeated annotation styles.
+- *Narrative graphics of space and time* — combine spatial and temporal dimensions in one frame. Minard's Napoleon graphic encodes troop size, geography, direction, temperature, and time simultaneously.
+
+* 8. Cause and Effect
+
+From /Visual Explanations/. Causality is hard to visualise because it requires showing both the variables and the mechanism linking them.
+
+** Techniques
+
+- Show the intervention and the response in the same frame.
+- Annotate the causal mechanism directly on the data.
+- Use sequence (small multiples through time) to imply mechanism.
+- Pair the data display with a process diagram showing the proposed cause.
+
+*Worked example:* Challenger O-ring decision. The available data, plotted against temperature, showed catastrophic risk — but the engineers presented it in a way that hid the causal relationship. Tufte's redesign makes the causality unavoidable.
+
+* Quick Reference: Extended Tufte Test
+
+After applying the standard 7-question test in [[id:F322DD08-D114-4B9E-8B89-E392ED5C591E][Tufte's Principles for Data Visualisation]], add:
+
+8. *Comparison* — does the graphic answer "compared to what?"
+9. *Causality* — is the mechanism or explanation visible, not just the pattern?
+10. *Multivariate* — are interactions among variables shown, or has the problem been over-reduced?
+11. *Integration* — are words, numbers, and images interleaved — or segregated?
+12. *Documentation* — can a stranger evaluate the evidence (sources, scales, authorship)?
+13. *Layering* — do important elements dominate; do secondary elements recede?
+14. *Micro/macro* — does the display reward both a glance and a close read?

--- a/doc/llm/skills/tufte-viz/references/tufte-principles.org
+++ b/doc/llm/skills/tufte-viz/references/tufte-principles.org
@@ -1,0 +1,221 @@
+:PROPERTIES:
+:ID: F322DD08-D114-4B9E-8B89-E392ED5C591E
+:END:
+#+title: Tufte's Principles for Data Visualisation
+#+description: Core principles from The Visual Display of Quantitative Information: graphical excellence, integrity, data-ink ratio, chartjunk, small multiples, and data density.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :skills:design:visualisation:tufte:knowledge:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+
+Adapted from the work of [[https://x.com/draparente][Dr. Angelica Parente]].
+
+See also [[id:613C09B0-D516-417F-9627-2349D46A3645][Analytical Design, Sparklines, and Layering]] for extensions from /Envisioning Information/, /Visual Explanations/, and /Beautiful Evidence/.
+
+* 1. Graphical Excellence
+
+Excellence in statistical graphics consists of complex ideas communicated with clarity, precision, and efficiency.
+
+** Core qualities
+
+- Show the data.
+- Induce the viewer to think about substance, not methodology or design.
+- Avoid distorting what the data have to say.
+- Present many numbers in a small space.
+- Make large datasets coherent.
+- Encourage eye comparison of different pieces of data.
+- Reveal data at several levels of detail (broad overview to fine structure).
+- Serve a reasonably clear purpose.
+- Integrate closely with statistical and verbal descriptions.
+
+** Questions to ask
+
+- Does the graphic show the data clearly?
+- Does it encourage thinking about content over decoration?
+- Can the viewer compare data elements easily?
+
+* 2. Graphical Integrity
+
+Graphics must tell the truth about the data.
+
+** The Lie Factor
+
+#+begin_example
+Lie Factor = Size of effect shown in graphic / Size of effect in data
+#+end_example
+
+- Lie Factor = 1.0 → truthful.
+- Lie Factor > 1.05 or < 0.95 → distortion.
+
+** Six principles of graphical integrity
+
+1. Representation of numbers should be directly proportional to quantities represented.
+2. Clear, detailed, thorough labeling defeats distortion.
+3. Show data variation, not design variation.
+4. In time-series displays, standardise money (deflate) and use consistent baselines.
+5. Dimensions of graphics should not exceed dimensions of data.
+6. Graphics must not quote data out of context.
+
+** Common violations
+
+- 3D effects on 2D data (adds fake dimension).
+- Truncated axes that exaggerate change.
+- Inconsistent intervals.
+- Area/volume encoding of linear data.
+- Missing context or baselines.
+
+* 3. Data-Ink Ratio
+
+The data-ink ratio is the proportion of a graphic's ink devoted to the non-redundant display of data-information.
+
+#+begin_example
+Data-Ink Ratio = Data-ink / Total ink used in graphic
+#+end_example
+
+Maximise the data-ink ratio within reason:
+
+1. Erase non-data-ink (decoration, heavy grids, boxes).
+2. Erase redundant data-ink (3D when 2D suffices).
+3. Revise and edit.
+
+** Non-data-ink to eliminate
+
+- Heavy gridlines.
+- Unnecessary borders and boxes.
+- Redundant labels.
+- Decorative elements.
+- Excessive tick marks.
+- 3D effects that add no information.
+
+The *eraser test*: if you can erase something without losing data information, erase it.
+
+* 4. Chartjunk
+
+Chartjunk is the interior decoration of graphics that does not convey information.
+
+** Three categories
+
+*** A. Unintentional optical art (moiré vibration)
+
+- Busy patterns that create visual noise.
+- Cross-hatching that vibrates.
+- Competing visual frequencies.
+
+*** B. The Grid
+
+- Heavy grids compete with data.
+- Grids should be muted or eliminated.
+- If needed, use light grey or dotted lines.
+
+*** C. The Duck (self-promoting graphics)
+
+- Graphics that draw attention to their own design.
+- Decoration masquerading as information.
+- Style over substance.
+
+** Chartjunk indicators
+
+- Viewer notices the design before the data.
+- Colours/patterns used for decoration, not encoding.
+- 3D effects, shadows, gradients without purpose.
+- Clip art, icons, or illustrations that don't carry data.
+
+* 5. Small Multiples
+
+Small multiples are series of graphics showing the same combination of variables, indexed by changes in another variable.
+
+** Characteristics
+
+- Same design structure repeated.
+- Changes in data, not design.
+- Enables direct visual comparison.
+- High information density.
+- Eye moves across variations effortlessly.
+
+** When to use
+
+- Comparing across categories, time periods, or conditions.
+- Showing change or variation.
+- Revealing patterns across groups.
+- When animation would work but static display is needed.
+
+** Design guidelines
+
+- Identical scales across all panels.
+- Consistent visual encoding.
+- Minimal between-panel decoration.
+- Clear labelling of what varies.
+- Tight spacing (data should dominate).
+
+* 6. Data Density & Information Resolution
+
+*Data density = numbers plotted per unit area.*
+
+High data density is a sign of graphical quality. Maps and time-series can achieve thousands of numbers per square inch.
+
+** Shrink principle
+
+Graphics can often be reduced significantly while maintaining readability and gaining impact. Consider:
+
+- Sparklines (word-sized graphics).
+- Condensed time-series.
+- Small multiple arrays.
+
+** Resolution thinking
+
+- What is the minimum size that remains readable?
+- Can we show more data in the same space?
+- Are we wasting white space?
+
+* 7. Multifunctioning Graphical Elements
+
+Every graphical element should serve multiple purposes when possible.
+
+Data measures that can serve as: data point, label, scale marker, grid reference.
+
+** Examples
+
+- Data points that also serve as labels (scatter plots with text).
+- Axis that is also a data series.
+- Range frames (axis shows data range, not arbitrary extent).
+
+* 8. Aesthetics and Technique
+
+** Balance complexity and simplicity
+
+- Simple design, complex data.
+- Complexity should come from data, not decoration.
+
+** Visual hierarchy
+
+Data > Labels > Annotations > Grids > Borders. Prominent elements should carry the most information.
+
+** Colour use
+
+- Use sparingly and purposefully.
+- Ensure accessibility (colorblind-safe palettes).
+- Grey as default; colour for emphasis or encoding.
+- Avoid "rainbow" colour maps for sequential data.
+
+** Typography
+
+- Clear, readable fonts.
+- Appropriate sizing hierarchy.
+- Horizontal text when possible.
+- Labels close to the data they describe.
+
+* Quick Reference: The Tufte Test
+
+For any visualisation, ask:
+
+1. *Data-Ink* — can I erase any element without losing data? (Erase it.)
+2. *Integrity* — does the visual effect match the data effect? (Lie Factor ≈ 1.)
+3. *Chartjunk* — does any element exist for decoration only? (Remove it.)
+4. *Excellence* — does it reveal the data at multiple levels? (Broad + detailed.)
+5. *Comparison* — can the viewer easily compare data elements? (Enable it.)
+6. *Density* — could this show more data in the same space? (Condense.)
+7. *Context* — is all necessary context provided? (Labels, sources, scales.)
+
+For the extended 14-question test see [[id:613C09B0-D516-417F-9627-2349D46A3645][Analytical Design, Sparklines, and Layering]].


### PR DESCRIPTION
## Summary

- Adds `doc/llm/skills/tufte-viz/SKILL.org` — the `tufte-viz` skill, following the standard skill layout (`#+begin_export markdown` frontmatter, `* When to use`, `* How to use` with new/critique workflows, cross-linked reference list, quick checklist).
- Adds `doc/llm/skills/tufte-viz/references/tufte-principles.org` — Tufte's core principles (graphical excellence, integrity, data-ink ratio, chartjunk, small multiples, data density, the 7-question Tufte Test).
- Adds `doc/llm/skills/tufte-viz/references/analytical-design.org` — extensions from *Envisioning Information*, *Visual Explanations*, and *Beautiful Evidence* (six analytical design principles, sparklines, layering & separation, micro/macro, range-frames, causality, confections, extended 14-question test).
- Both reference docs are attributed to [Dr. Angelica Parente](https://x.com/draparente) and cross-linked via org-roam ID links.
- Updates `doc/llm/skills/claude_code_skills.org` `* Design` section with the new entry.
- Updates sprint 18 story/task status to STARTED.
- Removes the three source files from `tmp/` (untracked; deleted from disk).

Story: [[id:7225526E-DCDB-4DC6-A95D-22C7117E5EAA]]
Task: [[id:9F6635A3-A770-44F2-BC85-B5324A0E65EA]]

## Test plan

- [ ] `doc/llm/skills/tufte-viz/SKILL.org` loads and exports correctly (org-roam ID, frontmatter, markdown export block).
- [ ] Both reference org files have valid uppercase UUIDs and attribution line.
- [ ] Cross-references between the two reference files use `[[id:...]]` links.
- [ ] `claude_code_skills.org` `* Design` section lists `tufte-viz` with ID link.
- [ ] `tmp/SKILL.md`, `tmp/references__tufte-principles.md`, `tmp/references__analytical-design.md` are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)