### PR TITLE
[ores.compass] Add the Goto pillar (compass goto)

### DIFF
--- a/doc/agile/versions/v0/sprint_18/compass_goto/story.org
+++ b/doc/agile/versions/v0/sprint_18/compass_goto/story.org
@@ -31,11 +31,11 @@ table, set states, etc. It composes =git= + =compass add= into the
 
 | Field         | Value                              |
 |---------------+------------------------------------|
-| State         | BACKLOG                            |
+| State         | STARTED                            |
 | Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                          |
-| Now           | In the sprint backlog, not started. |
+| Now           | =compass goto= implemented on =feature/compass-goto=. |
 | Waiting on    | Nothing.                           |
-| Next          | Scaffold tasks when picked up.     |
+| Next          | Review.                            |
 | Last touched  | 2026-05-25                         |
 
 * Acceptance
@@ -51,10 +51,9 @@ table, set states, etc. It composes =git= + =compass add= into the
 
 * Tasks
 
-In execution order (scaffolded when picked up):
+In execution order:
 
-- Implement the =goto= dispatcher (fetch + branch + add story + add task
-  + next-steps output).
+- [[id:4A06DE45-1C09-4A24-88A7-E767CD293B24][Task: Implement the goto command]]
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_18/compass_goto/task_implement_goto_command.org
+++ b/doc/agile/versions/v0/sprint_18/compass_goto/task_implement_goto_command.org
@@ -1,0 +1,77 @@
+:PROPERTIES:
+:ID: 4A06DE45-1C09-4A24-88A7-E767CD293B24
+:END:
+#+title: Task: Implement the goto command
+#+description: Add a compass goto command: fetch main, create a feature branch, scaffold a linked story+task, print next steps.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :compass:workflow:python:compass_goto:sprint_18:v0:
+#+owner: marco
+#+branch: feature/compass-goto
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][compass goto: start a unit of work in one command]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Implement =compass goto=: one command that fetches =main=, creates a
+feature branch, scaffolds a linked story + task (codegen as a library),
+sets the task's =#+branch:=, and prints the remaining manual steps.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | DONE                                   |
+| Parent story | [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][compass goto: start a unit of work in one command]] |
+| Now          | Implemented; dry-run + real run verified. |
+| Waiting on   | Nothing.                               |
+| Next         | Review.                                |
+| Last touched | 2026-05-25                             |
+
+* Acceptance
+
+- =compass goto --slug … --title … --description … [--tags …] [--task …]=
+  fetches =main=, =git switch -c feature/<slug>=, scaffolds the story
+  (current sprint) + a linked task, and sets the task =#+branch:=.
+- =--dry-run= prints the plan (branch / story / task / sprint) with no
+  side effects; =--base= overrides the branch base.
+- Generation goes through =v2_doc_generate= (shared =_import_generator=
+  with =add=) — no duplicated generator logic.
+- Prints next steps (wire into sprint table, set states, push/PR); does
+  not silently edit the sprint table.
+
+* Plan
+
+1. Share the lazy generator import between =add= and =goto=
+   (=_import_generator=).
+2. =cmd_goto=: argparse (slug/title/description/tags/task/base/dry-run);
+   resolve current sprint; =git fetch= + =git switch -c=; two
+   =v2_doc_generate.main= calls; =_set_frontmatter_branch=; next-steps.
+3. Short-circuit =goto= in =main()= (own argparse); register for =--help=.
+
+* Notes
+
+Dogfooded — though =goto= can't scaffold /its own/ story (that already
+exists), it was verified by =--dry-run= and a throwaway real run
+(branch + story + task created, =#+branch= set), then cleaned up.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -69,7 +69,7 @@ In execution order.
 | [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                         | STARTED | 2026-05-24 |            | Replace broken per-mode ores.lisp with an env-aware emacs-dashboard console for all dev commands. |
 | [[id:7225526E-DCDB-4DC6-A95D-22C7117E5EAA][Port Tufte visualisation skill into ORE Studio]]     | BACKLOG | 2026-05-25 | | Convert =tufte-viz= SKILL and two Tufte reference docs to org-mode; install and catalogue. |
 | [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][compass cross-worktree status (global where)]] | STARTED | 2026-05-25 | | Show what every git worktree is doing (branch/story/task/PR) so parallel agents don't collide. |
-| [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][compass goto: start a unit of work in one command]] | BACKLOG | 2026-05-25 | | One command: fetch main, branch, scaffold linked story+task, print next steps. |
+| [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][compass goto: start a unit of work in one command]] | STARTED | 2026-05-25 | | One command: fetch main, branch, scaffold linked story+task, print next steps. |
 
 * Retrospective
 

--- a/doc/recipes/compass/compass.org
+++ b/doc/recipes/compass/compass.org
@@ -30,6 +30,8 @@ How to use =compass=, the [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][repository 
 
 - [[id:5B670808-D28B-4818-A2FA-EA5220D35E8D][How do I add a doc with compass?]] — create a v2 doc via codegen
   (=add=).
+- [[id:84C9177E-C737-428A-BDF9-E55FA6C9680C][How do I start a unit of work with compass?]] — fetch main, branch,
+  scaffold a linked story+task (=goto=).
 
 * Navigating the doc graph
 

--- a/doc/recipes/compass/how_do_i_start_a_unit_of_work_with_compass.org
+++ b/doc/recipes/compass/how_do_i_start_a_unit_of_work_with_compass.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: 84C9177E-C737-428A-BDF9-E55FA6C9680C
+:END:
+#+title: How do I start a unit of work with compass?
+#+description: Use compass goto to fetch main, create a feature branch, and scaffold a linked story and task in one step.
+#+type: recipe
+#+version: 2
+#+level: cross
+#+filetags: :compass:workflow:agile:recipe:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+
+The /Goto/ pillar of the [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][compass tool]] — it composes =git= and the
+Scaffold pillar ([[id:5B670808-D28B-4818-A2FA-EA5220D35E8D][=add=]]) into the "start a story" ritual.
+
+* Question
+
+How do I start a new piece of work — fresh branch off =main= plus a
+linked story and task — without running the four manual commands?
+
+* Answer
+
+Run =compass.sh goto= with the story details:
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh goto \
+  --slug my_feature --title "My feature" \
+  --description "What it delivers." --tags "topic"
+#+end_src
+
+It fetches =main=, creates =feature/my-feature= off it, scaffolds the
+story (in the current sprint) and a linked task (with the task's
+=#+branch:= set so [[id:0D378978-7CF1-45F5-896F-63E281CC02CB][=fleet=]] picks it up), and prints the remaining
+manual steps (wire the story into the sprint =* Stories= table, set
+states, push/PR).
+
+Preview without making any changes using =--dry-run=:
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh goto --slug my_feature \
+  --title "My feature" --description "…" --dry-run
+#+end_src
+
+=--task "<title>"= sets the initial task title (default: =Implement
+<title>=); =--base= overrides the branch base (default =origin/main=).
+
+* Script
+
+=projects/ores.compass/compass.sh goto= → =src/compass.py= (=cmd_goto=),
+which calls =git fetch= / =git switch -c= and =ores.codegen='s
+=v2_doc_generate= (via the shared =_import_generator=, same as =add=).
+
+* Tested by
+
+Manual: =--dry-run= plus a throwaway real run (branch + story + task
+created, =#+branch= set), then cleaned up.
+
+* See also
+
+- [[id:5B670808-D28B-4818-A2FA-EA5220D35E8D][How do I add a doc with compass?]] — the =add= primitive =goto= builds on.
+- [[id:0D378978-7CF1-45F5-896F-63E281CC02CB][How do I see what every worktree is doing?]] — =fleet=, the companion view.

--- a/projects/ores.compass/modeling/component_overview.org
+++ b/projects/ores.compass/modeling/component_overview.org
@@ -52,6 +52,12 @@ Pillars (the first three drawn from the Sprint 18 capture =* Tools=):
    open PR + live state, so parallel checkouts/agents don't collide.
    /Implemented/ as =fleet= — see the [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][Fleet story]].
 
+5. /Goto — "start a unit of work."/ Fetch =main=, create a feature
+   branch, scaffold a linked story + task (Scaffold/codegen) with the
+   task's =#+branch:= set, and print the remaining manual steps — the
+   "start a story" ritual in one command. /Implemented/ as =goto= — see
+   the [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][Goto story]].
+
 * Inputs
 
 - =.org-roam.db= (or =org-roam.db=) at the repository root — the
@@ -83,18 +89,19 @@ Pillars (the first three drawn from the Sprint 18 capture =* Tools=):
   =index [--rebuild]=, =search <query> [-l N] [-f FMT]=,
   =debug [-f FILE]= (Search); =where= / =status= [=-f pretty|json=]
   (Locate); =list [filters]= and =show <uuid>= (Navigate);
-  =add <type> [flags]= (Scaffold); and =fleet [-f pretty|json]= (Fleet).
+  =add <type> [flags]= (Scaffold); =fleet [-f pretty|json]= (Fleet); and
+  =goto --slug … --title … --description … [--dry-run]= (Goto).
 
 * Dependencies
 
 - Python 3 standard library for everything except Scaffold (=sqlite3=,
   =argparse=, =json=, =pathlib=, =re=, =dataclasses=, =subprocess=).
-- =pystache= — only for =add= (Scaffold), which imports codegen's
+- =pystache= — for =add= and =goto= (Scaffold), which import codegen's
   Mustache-based generator. Declared in =requirements.txt=; the other
   commands run without it.
-- =git= (for =fleet=, via =git worktree list=) and =gh= (for live PR
-  state in =fleet= and =where --prs=). =fleet= degrades gracefully when
-  =gh= is unavailable, still showing branch + task.
+- =git= (=fleet= uses =git worktree list=; =goto= uses =git fetch= +
+  =git switch -c=) and =gh= (live PR state in =fleet= and =where --prs=).
+  =fleet= degrades gracefully when =gh= is unavailable.
 - =org-roam= (in Emacs) to populate =.org-roam.db=, used only by the
   Search pillar. Compass never writes to it; it opens it read-only.
   Locate, Navigate and Fleet read the working tree directly and need
@@ -114,7 +121,7 @@ projects/ores.compass/
 ├── requirements.txt           # pystache (only `add` needs it)
 ├── src/
 │   ├── __init__.py
-│   ├── compass.py             # CLI dispatcher: index/search/debug/where/list/show/add/fleet
+│   ├── compass.py             # CLI dispatcher: index/search/debug/where/list/show/add/fleet/goto
 │   ├── doc_index.py           # canonical .org parser (walks the repo)
 │   ├── doc_list.py            # `list` — filter the doc graph
 │   └── doc_show.py            # `show` — one doc + inbound/outbound links

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -881,9 +881,12 @@ def _set_frontmatter_branch(path, branch):
         text = Path(path).read_text(encoding="utf-8")
     except OSError:
         return
-    new = re.sub(r"^#\+branch:.*$", f"#+branch: {branch}", text, count=1,
-                 flags=re.MULTILINE)
-    Path(path).write_text(new, encoding="utf-8")
+    new, count = re.subn(r"^#\+branch:.*$", f"#+branch: {branch}", text, count=1,
+                         flags=re.MULTILINE)
+    if count == 0:                       # field absent — append rather than no-op
+        new = text.rstrip() + f"\n#+branch: {branch}\n"
+    if new != text:                      # avoid a redundant write
+        Path(path).write_text(new, encoding="utf-8")
 
 def cmd_goto(argv):
     """Start a unit of work in one command: fetch main, branch, scaffold a
@@ -931,16 +934,23 @@ def cmd_goto(argv):
         return 1
     print(f"✅ created and switched to {branch} (off {args.base})")
 
-    # 2. scaffold story + task via codegen (as a library)
+    # 2. scaffold story + task via codegen (as a library). Check each call's
+    # result and stop on the first failure so we don't leave a half-made unit
+    # (gen.main returns 0 on success but may sys.exit on error).
     try:
-        gen.main(["--type", "story", "--slug", args.slug, "--parent-dir", sprint_dir,
-                  "--title", args.title, "--description", args.description, "--tags", args.tags])
-        gen.main(["--type", "task", "--slug", task_slug, "--parent-dir", story_dir,
-                  "--title", task_title,
-                  "--description", f"Initial task for: {args.title}"])
+        rc = gen.main(["--type", "story", "--slug", args.slug, "--parent-dir", sprint_dir,
+                       "--title", args.title, "--description", args.description, "--tags", args.tags])
+        if rc:
+            return rc
+        rc = gen.main(["--type", "task", "--slug", task_slug, "--parent-dir", story_dir,
+                       "--title", task_title,
+                       "--description", f"Initial task for: {args.title}"])
+        if rc:
+            return rc
     except SystemExit as exc:
-        print(f"❌ scaffolding failed: {exc.code}", file=sys.stderr)
-        return 1
+        if exc.code:
+            print(f"❌ scaffolding failed: {exc.code}", file=sys.stderr)
+        return exc.code or 0
 
     # 3. record the branch on the task so fleet/where can map this worktree
     _set_frontmatter_branch(task_path, branch)

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -12,6 +12,8 @@ Pillars:
     library — generation stays in codegen, not duplicated here.
   - Fleet: what every git worktree is doing — branch, story, task, PR
     (fleet), so parallel checkouts/agents don't collide.
+  - Goto: start a unit of work in one step — fetch main, branch, scaffold
+    a linked story+task, print next steps (goto).
 """
 
 import argparse
@@ -841,16 +843,9 @@ def cmd_add(argv):
                   f"{_DEFAULTABLE_PARENT[doc_type]}: {default_parent}", file=sys.stderr)
 
     # Lazy, optional import: the generator lives in ores.codegen and needs
-    # pystache. Only `add` requires it, so importing here keeps the other
-    # commands dependency-free.
-    sys.path.insert(0, str(PROJECT_ROOT / "projects" / "ores.codegen" / "src"))
-    try:
-        import v2_doc_generate
-    except ImportError as exc:
-        print(f"❌ `add` needs ores.codegen's generator ({exc}). Install its "
-              f"dependency into the compass venv: pip install pystache",
-              file=sys.stderr)
-        return 1
+    # pystache. Only `add` / `goto` require it; the other commands stay
+    # dependency-free.
+    v2_doc_generate = _import_generator()
 
     # v2_doc_generate.main returns 0 on success but may sys.exit on error;
     # catch SystemExit so the reminder prints only on success and the
@@ -868,6 +863,95 @@ def cmd_add(argv):
         return 1
     return rc
 
+def _import_generator():
+    """Import ores.codegen's v2_doc_generate (needs pystache). Exit on failure."""
+    sys.path.insert(0, str(PROJECT_ROOT / "projects" / "ores.codegen" / "src"))
+    try:
+        import v2_doc_generate
+        return v2_doc_generate
+    except ImportError as exc:
+        print(f"❌ This needs ores.codegen's generator ({exc}). Install its "
+              f"dependency into the compass venv: pip install pystache",
+              file=sys.stderr)
+        sys.exit(1)
+
+def _set_frontmatter_branch(path, branch):
+    """Set the #+branch field of a task doc (so fleet/where pick it up)."""
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError:
+        return
+    new = re.sub(r"^#\+branch:.*$", f"#+branch: {branch}", text, count=1,
+                 flags=re.MULTILINE)
+    Path(path).write_text(new, encoding="utf-8")
+
+def cmd_goto(argv):
+    """Start a unit of work in one command: fetch main, branch, scaffold a
+    linked story + task (via codegen), and print the remaining manual steps."""
+    ap = argparse.ArgumentParser(prog="compass goto",
+                                 description="Fetch main, branch, scaffold a linked story+task, print next steps.")
+    ap.add_argument("--slug", required=True, help="snake_case slug; drives the branch and doc folder")
+    ap.add_argument("--title", required=True, help="story title")
+    ap.add_argument("--description", required=True, help="story description")
+    ap.add_argument("--tags", default="", help="comma-separated content tags")
+    ap.add_argument("--task", default="", help="initial task title (default: 'Implement <title>')")
+    ap.add_argument("--base", default="origin/main", help="branch base (default: origin/main)")
+    ap.add_argument("--dry-run", action="store_true", help="print the plan without executing")
+    args = ap.parse_args(argv)
+
+    branch = "feature/" + args.slug.replace("_", "-")
+    task_title = args.task or f"Implement {args.title}"
+    task_slug = "implement_" + args.slug
+
+    _, current_sprint = current_version_sprint(doc_index.load_all())
+    if current_sprint is None:
+        print("❌ No current sprint found under doc/agile/versions/.", file=sys.stderr)
+        return 1
+    sprint_dir = _parent_dir(current_sprint.rel_path)
+    story_dir = f"{sprint_dir}/{args.slug}"
+    task_path = Path(PROJECT_ROOT) / story_dir / f"task_{task_slug}.org"
+
+    if args.dry_run:
+        print("compass goto — plan (dry run):")
+        print(f"  branch:  {branch}   (base {args.base})")
+        print(f"  story:   {story_dir}/story.org")
+        print(f"  task:    {story_dir}/task_{task_slug}.org   (#+branch: {branch})")
+        print(f"  sprint:  {current_sprint.title}")
+        return 0
+
+    gen = _import_generator()
+
+    # 1. fetch + new branch off base
+    subprocess.run(["git", "fetch", "origin"], cwd=str(PROJECT_ROOT), check=False)
+    sw = subprocess.run(["git", "switch", "-c", branch, args.base],
+                        cwd=str(PROJECT_ROOT), capture_output=True, text=True)
+    if sw.returncode != 0:
+        print(f"❌ git switch -c {branch} {args.base} failed:\n{sw.stderr.strip()}",
+              file=sys.stderr)
+        return 1
+    print(f"✅ created and switched to {branch} (off {args.base})")
+
+    # 2. scaffold story + task via codegen (as a library)
+    try:
+        gen.main(["--type", "story", "--slug", args.slug, "--parent-dir", sprint_dir,
+                  "--title", args.title, "--description", args.description, "--tags", args.tags])
+        gen.main(["--type", "task", "--slug", task_slug, "--parent-dir", story_dir,
+                  "--title", task_title,
+                  "--description", f"Initial task for: {args.title}"])
+    except SystemExit as exc:
+        print(f"❌ scaffolding failed: {exc.code}", file=sys.stderr)
+        return 1
+
+    # 3. record the branch on the task so fleet/where can map this worktree
+    _set_frontmatter_branch(task_path, branch)
+
+    # 4. next steps (deliberately manual — needs judgement)
+    print("\nNext steps:")
+    print(f"  - wire the story into {sprint_dir}/sprint.org (* Stories table)")
+    print(f"  - flip the story/task State to STARTED when you begin")
+    print(f"  - git push -u origin {branch}   &&   open a PR")
+    return 0
+
 def main():
     # `list` and `show` pass every remaining argument straight through to the
     # bundled doc tools (full flag compatibility, including their own --help).
@@ -879,6 +963,8 @@ def main():
         sys.exit(doc_show.main(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] == "add":
         sys.exit(cmd_add(sys.argv[2:]))
+    if len(sys.argv) >= 2 and sys.argv[1] == "goto":
+        sys.exit(cmd_goto(sys.argv[2:]))
 
     parser = argparse.ArgumentParser(description="Compass: orientation tool for ORE Studio")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -915,6 +1001,8 @@ def main():
                           help="Show one doc by UUID/prefix: metadata, blurb, in/out links")
     subparsers.add_parser("add",
                           help="Create a v2 doc via ores.codegen (story/task/sprint/...); 'add --help' for usage")
+    subparsers.add_parser("goto",
+                          help="Start work: fetch main, branch, scaffold story+task, print next steps ('goto --help')")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary

Implements **`compass goto`** — start a unit of work in one command. It
composes `git` + the Scaffold pillar (`add`) into the "start a story"
ritual that was several manual steps.

## What it does

`compass goto --slug <slug> --title <t> --description <d> [--tags …] [--task …]`:

1. `git fetch origin`
2. `git switch -c feature/<slug>` off `origin/main` (`--base` to override)
3. scaffolds a story (current sprint) + a linked task via `ores.codegen`
   (as a library — shared `_import_generator` with `add`, no duplicated
   generator logic)
4. sets the task's `#+branch:` so `fleet`/`where` map it immediately
5. prints the remaining manual steps (wire into sprint table, set
   states, push/PR) — it does **not** silently edit the sprint table

`--dry-run` previews the plan with no side effects.

## Verification

- `--dry-run` shows the right branch/story/task/sprint.
- Real end-to-end run (throwaway `feature/goto-smoke-test`): branch
  created, story + task scaffolded, `#+branch` set, next steps printed —
  then cleaned up.
- `where` / `fleet` / `add` unaffected; `validate_docs.sh` passes (90/90).

## Changes

- `compass.py`: `cmd_goto` + `_import_generator` (shared with `add`) +
  `_set_frontmatter_branch`; `goto` short-circuit + `--help` entry.
- Component overview: Goto pillar, entry point, deps.
- The goto story (STARTED) + its implement task (DONE); a "How do I
  start a unit of work with compass?" recipe; sprint table row STARTED.