### PR TITLE
[build] Add rfl precompiled headers to fix OOM on macOS

### DIFF
--- a/projects/ores.analytics.api/src/CMakeLists.txt
+++ b/projects/ores.analytics.api/src/CMakeLists.txt
@@ -49,4 +49,10 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 # Note: reflectcpp comes transitively through ores.utility.lib -> ores.platform.lib (PUBLIC)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.analytics.api/src/CMakeLists.txt
+++ b/projects/ores.analytics.api/src/CMakeLists.txt
@@ -53,6 +53,6 @@ target_link_libraries(${lib_target_name}
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.assets.api/src/CMakeLists.txt
+++ b/projects/ores.assets.api/src/CMakeLists.txt
@@ -47,4 +47,10 @@ target_link_libraries(${lib_target_name}
         ores.utility.lib
         libfort::fort)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.assets.api/src/CMakeLists.txt
+++ b/projects/ores.assets.api/src/CMakeLists.txt
@@ -51,6 +51,6 @@ target_link_libraries(${lib_target_name}
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.compute.api/src/CMakeLists.txt
+++ b/projects/ores.compute.api/src/CMakeLists.txt
@@ -44,6 +44,6 @@ target_link_libraries(${lib_target_name}
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.compute.api/src/CMakeLists.txt
+++ b/projects/ores.compute.api/src/CMakeLists.txt
@@ -40,4 +40,10 @@ target_link_libraries(${lib_target_name}
         faker-cxx::faker-cxx
         libfort::fort)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.connections/src/CMakeLists.txt
+++ b/projects/ores.connections/src/CMakeLists.txt
@@ -53,6 +53,6 @@ target_link_libraries(${lib_target_name}
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.connections/src/CMakeLists.txt
+++ b/projects/ores.connections/src/CMakeLists.txt
@@ -49,4 +49,10 @@ target_link_libraries(${lib_target_name}
         libfort::fort
         Boost::boost)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.controller.api/src/CMakeLists.txt
+++ b/projects/ores.controller.api/src/CMakeLists.txt
@@ -49,6 +49,6 @@ target_link_libraries(${lib_target_name}
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.controller.api/src/CMakeLists.txt
+++ b/projects/ores.controller.api/src/CMakeLists.txt
@@ -45,4 +45,10 @@ target_link_libraries(${lib_target_name}
         ores.utility.lib
         Boost::boost)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.database/src/CMakeLists.txt
+++ b/projects/ores.database/src/CMakeLists.txt
@@ -47,4 +47,10 @@ target_link_libraries(${lib_target_name}
     PRIVATE
         ores.utility.lib)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.database/src/CMakeLists.txt
+++ b/projects/ores.database/src/CMakeLists.txt
@@ -51,6 +51,6 @@ target_link_libraries(${lib_target_name}
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.dq.api/src/CMakeLists.txt
+++ b/projects/ores.dq.api/src/CMakeLists.txt
@@ -53,4 +53,10 @@ target_link_libraries(${lib_target_name}
         libfort::fort
         Boost::boost)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.dq.api/src/CMakeLists.txt
+++ b/projects/ores.dq.api/src/CMakeLists.txt
@@ -57,6 +57,6 @@ target_link_libraries(${lib_target_name}
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.eventing/src/CMakeLists.txt
+++ b/projects/ores.eventing/src/CMakeLists.txt
@@ -53,6 +53,6 @@ target_link_libraries(${lib_target_name}
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.eventing/src/CMakeLists.txt
+++ b/projects/ores.eventing/src/CMakeLists.txt
@@ -49,4 +49,10 @@ target_link_libraries(${lib_target_name}
         faker-cxx::faker-cxx
         libfort::fort)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.iam.api/src/CMakeLists.txt
+++ b/projects/ores.iam.api/src/CMakeLists.txt
@@ -44,6 +44,6 @@ target_link_libraries(${lib_target_name}
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.iam.api/src/CMakeLists.txt
+++ b/projects/ores.iam.api/src/CMakeLists.txt
@@ -40,4 +40,10 @@ target_link_libraries(${lib_target_name}
         faker-cxx::faker-cxx
         libfort::fort)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.marketdata.api/src/CMakeLists.txt
+++ b/projects/ores.marketdata.api/src/CMakeLists.txt
@@ -47,4 +47,10 @@ target_link_libraries(${lib_target_name}
         faker-cxx::faker-cxx)
 # Note: reflectcpp comes transitively through ores.platform.lib (PUBLIC)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.marketdata.api/src/CMakeLists.txt
+++ b/projects/ores.marketdata.api/src/CMakeLists.txt
@@ -51,6 +51,6 @@ target_link_libraries(${lib_target_name}
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.refdata.api/src/CMakeLists.txt
+++ b/projects/ores.refdata.api/src/CMakeLists.txt
@@ -54,6 +54,6 @@ target_link_libraries(${lib_target_name}
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.refdata.api/src/CMakeLists.txt
+++ b/projects/ores.refdata.api/src/CMakeLists.txt
@@ -50,4 +50,10 @@ target_link_libraries(${lib_target_name}
         faker-cxx::faker-cxx
         libfort::fort)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.reporting.api/src/CMakeLists.txt
+++ b/projects/ores.reporting.api/src/CMakeLists.txt
@@ -53,6 +53,6 @@ target_link_libraries(${lib_target_name}
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.reporting.api/src/CMakeLists.txt
+++ b/projects/ores.reporting.api/src/CMakeLists.txt
@@ -49,4 +49,10 @@ target_link_libraries(${lib_target_name}
         faker-cxx::faker-cxx
         libfort::fort)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.scheduler.api/src/CMakeLists.txt
+++ b/projects/ores.scheduler.api/src/CMakeLists.txt
@@ -47,4 +47,10 @@ target_link_libraries(${lib_target_name}
         faker-cxx::faker-cxx
         libfort::fort)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.scheduler.api/src/CMakeLists.txt
+++ b/projects/ores.scheduler.api/src/CMakeLists.txt
@@ -51,6 +51,6 @@ target_link_libraries(${lib_target_name}
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.trading.api/src/CMakeLists.txt
+++ b/projects/ores.trading.api/src/CMakeLists.txt
@@ -61,6 +61,6 @@ target_compile_options(${lib_target_name} PUBLIC
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.trading.api/src/CMakeLists.txt
+++ b/projects/ores.trading.api/src/CMakeLists.txt
@@ -57,4 +57,10 @@ target_compile_options(${lib_target_name} PUBLIC
     $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<COMPILE_LANGUAGE:CXX>>:/constexpr:steps10000000>
     $<$<AND:$<CXX_COMPILER_ID:Clang>,$<COMPILE_LANGUAGE:CXX>>:-fbracket-depth=1024>)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.variability.api/src/CMakeLists.txt
+++ b/projects/ores.variability.api/src/CMakeLists.txt
@@ -47,4 +47,10 @@ target_link_libraries(${lib_target_name}
         ores.utility.lib
         libfort::fort)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.variability.api/src/CMakeLists.txt
+++ b/projects/ores.variability.api/src/CMakeLists.txt
@@ -51,6 +51,6 @@ target_link_libraries(${lib_target_name}
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.workflow.core/src/CMakeLists.txt
+++ b/projects/ores.workflow.core/src/CMakeLists.txt
@@ -57,4 +57,10 @@ target_link_libraries(${lib_target_name}
         Boost::boost)
 # Note: reflectcpp comes transitively through ores.utility.lib -> ores.platform.lib (PUBLIC)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.workflow.core/src/CMakeLists.txt
+++ b/projects/ores.workflow.core/src/CMakeLists.txt
@@ -61,6 +61,6 @@ target_link_libraries(${lib_target_name}
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.workspace.api/src/CMakeLists.txt
+++ b/projects/ores.workspace.api/src/CMakeLists.txt
@@ -47,4 +47,10 @@ target_link_libraries(${lib_target_name}
         libfort::fort
         faker-cxx::faker-cxx)
 
+
+target_precompile_headers(${lib_target_name} PRIVATE
+    <rfl.hpp>
+    <rfl/json.hpp>
+    "ores.utility/rfl/reflectors.hpp")
+
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.workspace.api/src/CMakeLists.txt
+++ b/projects/ores.workspace.api/src/CMakeLists.txt
@@ -51,6 +51,6 @@ target_link_libraries(${lib_target_name}
 target_precompile_headers(${lib_target_name} PRIVATE
     <rfl.hpp>
     <rfl/json.hpp>
-    "ores.utility/rfl/reflectors.hpp")
+    <ores.utility/rfl/reflectors.hpp>)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)


### PR DESCRIPTION
## Summary

- macOS CI was dying with `clang frontend command failed due to signal (use -v to see invocation)` / `Killed: 9` (SIGKILL = OOM) when compiling `ores.refdata.api`
- Root cause: 148 `json_io.cpp` files across 17 libraries each independently include `<rfl.hpp>`, `<rfl/json.hpp>`, and `ores.utility/rfl/reflectors.hpp` — these are very heavy template headers (~2–3 GB of compiler memory per TU). Ninja spawns all of them in parallel, collectively exhausting RAM.
- Fix: Add `target_precompile_headers(${lib_target_name} PRIVATE <rfl.hpp> <rfl/json.hpp> "ores.utility/rfl/reflectors.hpp")` to each of the 17 affected libraries. The three headers are compiled once per library target and the `.gch`/`.pch` is reused by every TU in that target.

## Affected libraries (17)

`ores.analytics.api`, `ores.assets.api`, `ores.compute.api`, `ores.connections`, `ores.controller.api`, `ores.database`, `ores.dq.api`, `ores.eventing`, `ores.iam.api`, `ores.marketdata.api`, `ores.refdata.api`, `ores.reporting.api`, `ores.scheduler.api`, `ores.trading.api`, `ores.variability.api`, `ores.workflow.core`, `ores.workspace.api`

## Test plan

- [ ] macOS CI build passes without SIGKILL on `ores.refdata.api` or any other affected library
- [ ] Linux CI build passes
- [ ] Windows CI build passes (PCH is supported by MSVC; REUSE_FROM not needed since each library builds its own)

🤖 Generated with [Claude Code](https://claude.com/claude-code)