### PR TITLE
[build] Skip RFL PCH on coverage builds to fix sccache crash

### DIFF
--- a/doc/agile/versions/v0/sprint_18/rfl_complexity_resolution/task_disable_pch_with_coverage.org
+++ b/doc/agile/versions/v0/sprint_18/rfl_complexity_resolution/task_disable_pch_with_coverage.org
@@ -1,0 +1,72 @@
+:PROPERTIES:
+:ID: 8F36631E-2CCE-4E2C-8E54-9B93F0DEE454
+:END:
+#+title: Task: Disable RFL precompiled headers when building with coverage
+#+description: Guard target_precompile_headers with NOT WITH_PROFILING to fix sccache failure on coverage builds.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :build:pch:coverage:sccache:rfl_complexity_resolution:sprint_18:v0:
+#+owner: marco
+#+branch: feature/pch-sccache-coverage
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D8][Resolve RFL complexity issues]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The RFL precompiled headers added in PR #835 break sccache on coverage
+builds. When =WITH_PROFILING=On=, =-fprofile-arcs -ftest-coverage= are
+added globally; sccache then expects a =.gcno= file alongside every
+compiled output, including the PCH. The PCH step does not produce a
+=.gcno= in the expected location, so sccache aborts with:
+
+#+begin_example
+sccache: error: failed to zip up compiler outputs
+sccache: caused by: failed to open file `cmake_pch.hxx.gcno`: No such file or directory
+#+end_example
+
+The fix is to skip =target_precompile_headers= when =WITH_PROFILING= is
+set — coverage builds are slow by design and do not benefit from PCH
+caching.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                                |
+| Parent story | [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D8][Resolve RFL complexity issues]] |
+| Now          | Implementing fix.                      |
+| Waiting on   | CI green.                              |
+| Next         | Merge after CI passes.                 |
+| Last touched | 2026-05-25                             |
+
+* Acceptance
+
+- CI coverage build (=linux-clang-debug-ninja= with =code_coverage=1=) passes without sccache errors.
+- Non-coverage builds still use PCH (i.e. the guard is tight).
+- No regression on macOS or Windows builds.
+
+* Plan
+
+Wrap =target_precompile_headers= in all 17 affected =CMakeLists.txt=
+files with =if(NOT WITH_PROFILING)=.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -47,6 +47,19 @@ set(ORES_CATCH2_ARGS --allow-running-no-tests --durations yes --filenames-as-tag
 # Projects
 #
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ores.utility)
+
+# Interface library for RFL precompiled headers. Link PRIVATE to any target
+# that includes <rfl.hpp> or <rfl/json.hpp>. PCH is omitted when
+# WITH_PROFILING is set: sccache expects a .gcno alongside every compiled
+# output, but the PCH step does not produce one.
+add_library(ores.rfl.pch INTERFACE)
+if(NOT WITH_PROFILING)
+    target_precompile_headers(ores.rfl.pch INTERFACE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
+
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ores.platform)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ores.logging)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ores.database)

--- a/projects/ores.analytics.api/src/CMakeLists.txt
+++ b/projects/ores.analytics.api/src/CMakeLists.txt
@@ -50,9 +50,13 @@ target_link_libraries(${lib_target_name}
 # Note: reflectcpp comes transitively through ores.utility.lib -> ores.platform.lib (PUBLIC)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.analytics.api/src/CMakeLists.txt
+++ b/projects/ores.analytics.api/src/CMakeLists.txt
@@ -50,13 +50,6 @@ target_link_libraries(${lib_target_name}
 # Note: reflectcpp comes transitively through ores.utility.lib -> ores.platform.lib (PUBLIC)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.assets.api/src/CMakeLists.txt
+++ b/projects/ores.assets.api/src/CMakeLists.txt
@@ -48,13 +48,6 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.assets.api/src/CMakeLists.txt
+++ b/projects/ores.assets.api/src/CMakeLists.txt
@@ -48,9 +48,13 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.compute.api/src/CMakeLists.txt
+++ b/projects/ores.compute.api/src/CMakeLists.txt
@@ -41,13 +41,6 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.compute.api/src/CMakeLists.txt
+++ b/projects/ores.compute.api/src/CMakeLists.txt
@@ -41,9 +41,13 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.connections/src/CMakeLists.txt
+++ b/projects/ores.connections/src/CMakeLists.txt
@@ -50,13 +50,6 @@ target_link_libraries(${lib_target_name}
         Boost::boost)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.connections/src/CMakeLists.txt
+++ b/projects/ores.connections/src/CMakeLists.txt
@@ -50,9 +50,13 @@ target_link_libraries(${lib_target_name}
         Boost::boost)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.controller.api/src/CMakeLists.txt
+++ b/projects/ores.controller.api/src/CMakeLists.txt
@@ -46,13 +46,6 @@ target_link_libraries(${lib_target_name}
         Boost::boost)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.controller.api/src/CMakeLists.txt
+++ b/projects/ores.controller.api/src/CMakeLists.txt
@@ -46,9 +46,13 @@ target_link_libraries(${lib_target_name}
         Boost::boost)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.database/src/CMakeLists.txt
+++ b/projects/ores.database/src/CMakeLists.txt
@@ -48,13 +48,6 @@ target_link_libraries(${lib_target_name}
         ores.utility.lib)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.database/src/CMakeLists.txt
+++ b/projects/ores.database/src/CMakeLists.txt
@@ -48,9 +48,13 @@ target_link_libraries(${lib_target_name}
         ores.utility.lib)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.dq.api/src/CMakeLists.txt
+++ b/projects/ores.dq.api/src/CMakeLists.txt
@@ -54,13 +54,6 @@ target_link_libraries(${lib_target_name}
         Boost::boost)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.dq.api/src/CMakeLists.txt
+++ b/projects/ores.dq.api/src/CMakeLists.txt
@@ -54,9 +54,13 @@ target_link_libraries(${lib_target_name}
         Boost::boost)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.eventing/src/CMakeLists.txt
+++ b/projects/ores.eventing/src/CMakeLists.txt
@@ -50,9 +50,13 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.eventing/src/CMakeLists.txt
+++ b/projects/ores.eventing/src/CMakeLists.txt
@@ -50,13 +50,6 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.iam.api/src/CMakeLists.txt
+++ b/projects/ores.iam.api/src/CMakeLists.txt
@@ -41,13 +41,6 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.iam.api/src/CMakeLists.txt
+++ b/projects/ores.iam.api/src/CMakeLists.txt
@@ -41,9 +41,13 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.marketdata.api/src/CMakeLists.txt
+++ b/projects/ores.marketdata.api/src/CMakeLists.txt
@@ -48,13 +48,6 @@ target_link_libraries(${lib_target_name}
 # Note: reflectcpp comes transitively through ores.platform.lib (PUBLIC)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.marketdata.api/src/CMakeLists.txt
+++ b/projects/ores.marketdata.api/src/CMakeLists.txt
@@ -48,9 +48,13 @@ target_link_libraries(${lib_target_name}
 # Note: reflectcpp comes transitively through ores.platform.lib (PUBLIC)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.refdata.api/src/CMakeLists.txt
+++ b/projects/ores.refdata.api/src/CMakeLists.txt
@@ -51,13 +51,6 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.refdata.api/src/CMakeLists.txt
+++ b/projects/ores.refdata.api/src/CMakeLists.txt
@@ -51,9 +51,13 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.reporting.api/src/CMakeLists.txt
+++ b/projects/ores.reporting.api/src/CMakeLists.txt
@@ -50,9 +50,13 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.reporting.api/src/CMakeLists.txt
+++ b/projects/ores.reporting.api/src/CMakeLists.txt
@@ -50,13 +50,6 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.scheduler.api/src/CMakeLists.txt
+++ b/projects/ores.scheduler.api/src/CMakeLists.txt
@@ -48,13 +48,6 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.scheduler.api/src/CMakeLists.txt
+++ b/projects/ores.scheduler.api/src/CMakeLists.txt
@@ -48,9 +48,13 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.trading.api/src/CMakeLists.txt
+++ b/projects/ores.trading.api/src/CMakeLists.txt
@@ -58,13 +58,6 @@ target_compile_options(${lib_target_name} PUBLIC
     $<$<AND:$<CXX_COMPILER_ID:Clang>,$<COMPILE_LANGUAGE:CXX>>:-fbracket-depth=1024>)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.trading.api/src/CMakeLists.txt
+++ b/projects/ores.trading.api/src/CMakeLists.txt
@@ -58,9 +58,13 @@ target_compile_options(${lib_target_name} PUBLIC
     $<$<AND:$<CXX_COMPILER_ID:Clang>,$<COMPILE_LANGUAGE:CXX>>:-fbracket-depth=1024>)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.variability.api/src/CMakeLists.txt
+++ b/projects/ores.variability.api/src/CMakeLists.txt
@@ -48,13 +48,6 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.variability.api/src/CMakeLists.txt
+++ b/projects/ores.variability.api/src/CMakeLists.txt
@@ -48,9 +48,13 @@ target_link_libraries(${lib_target_name}
         libfort::fort)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.workflow.core/src/CMakeLists.txt
+++ b/projects/ores.workflow.core/src/CMakeLists.txt
@@ -58,13 +58,6 @@ target_link_libraries(${lib_target_name}
 # Note: reflectcpp comes transitively through ores.utility.lib -> ores.platform.lib (PUBLIC)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.workflow.core/src/CMakeLists.txt
+++ b/projects/ores.workflow.core/src/CMakeLists.txt
@@ -58,9 +58,13 @@ target_link_libraries(${lib_target_name}
 # Note: reflectcpp comes transitively through ores.utility.lib -> ores.platform.lib (PUBLIC)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.workspace.api/src/CMakeLists.txt
+++ b/projects/ores.workspace.api/src/CMakeLists.txt
@@ -48,13 +48,6 @@ target_link_libraries(${lib_target_name}
         faker-cxx::faker-cxx)
 
 
-# PCH is skipped when building with coverage: sccache expects a .gcno file
-# alongside every output but the PCH step does not produce one.
-if(NOT WITH_PROFILING)
-    target_precompile_headers(${lib_target_name} PRIVATE
-        <rfl.hpp>
-        <rfl/json.hpp>
-        <ores.utility/rfl/reflectors.hpp>)
-endif()
+target_link_libraries(${lib_target_name} PRIVATE ores.rfl.pch)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.workspace.api/src/CMakeLists.txt
+++ b/projects/ores.workspace.api/src/CMakeLists.txt
@@ -48,9 +48,13 @@ target_link_libraries(${lib_target_name}
         faker-cxx::faker-cxx)
 
 
-target_precompile_headers(${lib_target_name} PRIVATE
-    <rfl.hpp>
-    <rfl/json.hpp>
-    <ores.utility/rfl/reflectors.hpp>)
+# PCH is skipped when building with coverage: sccache expects a .gcno file
+# alongside every output but the PCH step does not produce one.
+if(NOT WITH_PROFILING)
+    target_precompile_headers(${lib_target_name} PRIVATE
+        <rfl.hpp>
+        <rfl/json.hpp>
+        <ores.utility/rfl/reflectors.hpp>)
+endif()
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)


### PR DESCRIPTION
## Summary

Follow-on to PR #835 (RFL precompiled headers).

- Coverage builds (`WITH_PROFILING=On`, triggered by `code_coverage=1` in CI) add `-fprofile-arcs -ftest-coverage` to all compile flags
- sccache expects a `.gcno` file alongside every compiled output — including PCH
- The PCH step does not produce `.gcno` in the expected location, causing sccache to abort:
  ```
  sccache: error: failed to zip up compiler outputs
  sccache: caused by: failed to open file `cmake_pch.hxx.gcno`: No such file or directory
  ```
- Fix: guard `target_precompile_headers` with `if(NOT WITH_PROFILING)` in all 17 affected libraries
- Coverage builds are slow by design and gain nothing from PCH caching, so skipping PCH there is the right trade-off

## Test plan

- [ ] `linux-gcc-debug-ninja` CI (coverage) passes without sccache errors
- [ ] `linux-clang-debug-ninja` CI (coverage) passes without sccache errors
- [ ] Non-coverage macOS/Windows builds still use PCH (OOM fix intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)