### PR TITLE
[ores.compass] goto: add existing-story mode (--story)

### DIFF
--- a/doc/agile/versions/v0/sprint_18/compass_goto/story.org
+++ b/doc/agile/versions/v0/sprint_18/compass_goto/story.org
@@ -15,14 +15,17 @@ This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id
 
 * Goal
 
-One command, =compass goto=, that bootstraps a new unit of work. The
-user supplies the details (title, description, optional tags); =goto=
-then: (1) fetches latest =main=; (2) creates a new feature branch off
-it; (3) scaffolds a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] and a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] (task linked to story) via the
-Scaffold =add= machinery (codegen as a library); and (4) prints the
-remaining by-hand steps — wire the story into the sprint =* Stories=
-table, set states, etc. It composes =git= + =compass add= into the
-"start a story" ritual that today is several manual commands.
+One command, =compass goto=, that bootstraps a unit of work. =goto=
+fetches latest =main=, creates a feature branch, scaffolds the task
+(and, for a new story, the story too) via the Scaffold =add= machinery
+(codegen as a library), sets the task =#+branch:=, and prints the
+remaining by-hand steps. It composes =git= + =compass add= into the
+"start a story" ritual that was several manual commands. Two modes:
+
+- /New story/: =--slug --title --description [--tags] [--task]= — branch
+  + new story (current sprint) + linked task.
+- /Existing story/: =--story <id-or-slug> --task-slug --task
+  [--description]= — branch + add a task to an existing story.
 
 (Promoted from a product-backlog capture into this sprint; renamed from
 =go= to =goto=.)
@@ -31,17 +34,19 @@ table, set states, etc. It composes =git= + =compass add= into the
 
 | Field         | Value                              |
 |---------------+------------------------------------|
-| State         | STARTED                            |
+| State         | DONE                               |
 | Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                          |
-| Now           | =compass goto= implemented on =feature/compass-goto=. |
+| Now           | Complete — both modes shipped (PRs #834, #838). |
 | Waiting on    | Nothing.                           |
-| Next          | Review.                            |
+| Next          | Done.                              |
 | Last touched  | 2026-05-25                         |
 
 * Acceptance
 
-- =compass goto --title … --description … [--tags …]= fetches =main=,
-  creates a feature branch, and scaffolds a linked story + task.
+- /New-story mode/: =goto --slug --title --description [--tags] [--task]=
+  fetches =main=, branches, and scaffolds a linked story + task.
+- /Existing-story mode/: =goto --story <id-or-slug> --task-slug --task=
+  branches and adds a task to the resolved existing story.
 - The task's =#+branch:= is set to the new branch (so [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][=fleet=]] picks it
   up immediately).
 - It does /not/ silently mutate the sprint table; instead it prints a
@@ -59,6 +64,8 @@ In execution order:
 * Decisions
 
 - Named =goto= (not =go=).
+- Two modes (new story / existing story), mutually exclusive; =--story=
+  resolves by =:ID:= or folder slug.
 - Pairs with [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][Fleet]]: =goto= /creates/ a worktree's work; =fleet= /shows/
   it. Builds on the Scaffold pillar (=add=).
 

--- a/doc/agile/versions/v0/sprint_18/compass_goto/story.org
+++ b/doc/agile/versions/v0/sprint_18/compass_goto/story.org
@@ -54,6 +54,7 @@ table, set states, etc. It composes =git= + =compass add= into the
 In execution order:
 
 - [[id:4A06DE45-1C09-4A24-88A7-E767CD293B24][Task: Implement the goto command]]
+- [[id:ECEC4B5C-3731-4E53-8282-28FCD41FC5EE][Task: goto: add a task to an existing story]]
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_18/compass_goto/task_goto_existing_story.org
+++ b/doc/agile/versions/v0/sprint_18/compass_goto/task_goto_existing_story.org
@@ -1,0 +1,87 @@
+:PROPERTIES:
+:ID: ECEC4B5C-3731-4E53-8282-28FCD41FC5EE
+:END:
+#+title: Task: goto: add a task to an existing story
+#+description: Extend compass goto with an existing-story mode (--story) that branches and adds a task to an existing story instead of creating a new one.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :compass:workflow:python:compass_goto:sprint_18:v0:
+#+owner: marco
+#+branch: feature/compass-goto-existing-story
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][compass goto: start a unit of work in one command]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Extend =compass goto= so it can /also/ start work on an *existing*
+story: branch + add a task to that story, instead of only ever creating
+a new story. Today =goto= always scaffolds a new story and fails if the
+slug already exists.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                                |
+| Parent story | [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][compass goto: start a unit of work in one command]] |
+| Now          | Designing the interface; implementing. |
+| Waiting on   | Nothing.                               |
+| Next         | Implement and dogfood.                 |
+| Last touched | 2026-05-25                             |
+
+* Acceptance
+
+- /Existing-story mode/: =compass goto --story <id-or-slug> --task-slug
+  <slug> --task "<title>" [--description …]= fetches main, creates a
+  feature branch (=feature/<task-slug>=), adds a task to the resolved
+  story (via =add=), sets the task =#+branch:=, and prints next steps.
+- =--story= resolves by =:ID:= (UUID or unambiguous prefix) /or/ by the
+  story's folder slug, using =doc_index=.
+- =--story= is mutually exclusive with the new-story flags
+  (=--slug=/=--title=/=--description=); a clear error if both/neither
+  are given.
+- New-story mode is unchanged; =--dry-run= works for both.
+
+* Plan
+
+Interface decision ("have a think"): keep the current new-story mode and
+add an /existing-story/ mode keyed on =--story=:
+
+- =--story <id-or-slug>= → existing-story mode. Resolve via =doc_index=:
+  if the value is hex it matches a story =:ID:= (or prefix); otherwise
+  it matches the story folder name (slug). Accepting both keeps it
+  ergonomic (humans know slugs; tooling/links know UUIDs).
+- Required with =--story=: =--task-slug= and =--task= (title);
+  =--description= optional. Branch defaults to =feature/<task-slug>=.
+- Mutually exclusive with =--slug=/=--title=/=--description= (new-story).
+
+Steps:
+1. Add =--story= / =--task-slug= to =cmd_goto='s argparse; validate the
+   two modes are not mixed.
+2. =resolve_story(ident)= → (story_dir, story_title) via =doc_index=.
+3. In existing mode: branch from =task-slug=; skip story creation; one
+   =add task --parent-dir <story_dir>=; set =#+branch=; next steps.
+4. Dry-run + dogfood; update component overview + the goto recipe.
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/compass_goto/task_goto_existing_story.org
+++ b/doc/agile/versions/v0/sprint_18/compass_goto/task_goto_existing_story.org
@@ -29,11 +29,11 @@ slug already exists.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                                |
+| State        | DONE                                   |
 | Parent story | [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][compass goto: start a unit of work in one command]] |
-| Now          | Designing the interface; implementing. |
+| Now          | Implemented; both modes verified via --dry-run. |
 | Waiting on   | Nothing.                               |
-| Next         | Implement and dogfood.                 |
+| Next         | Review.                                |
 | Last touched | 2026-05-25                             |
 
 * Acceptance
@@ -71,6 +71,21 @@ Steps:
 4. Dry-run + dogfood; update component overview + the goto recipe.
 
 * Notes
+
+Verified via =--dry-run= for both modes (existing-story by folder slug
+and by =:ID:= prefix; new-story unchanged) and the three error paths
+(mixed modes, =--story= without task, unknown story). The execution path
+(=git switch= + =add task --parent-dir=) is the one already exercised by
+new-story =goto= and by =add=.
+
+* Result
+
+=cmd_goto= now has two modes. Existing-story mode: =goto --story
+<id-or-slug> --task-slug <slug> --task "<title>" [--description …]=
+resolves the story via =resolve_story= (by =:ID:= exact/prefix or folder
+slug), branches =feature/<task-slug>=, adds a task to the existing story
+(=add=), sets =#+branch=, and prints next steps. New-story mode is
+unchanged. The two modes are mutually exclusive with clear validation.
 
 * PRs
 

--- a/doc/agile/versions/v0/sprint_18/compass_goto/task_goto_existing_story.org
+++ b/doc/agile/versions/v0/sprint_18/compass_goto/task_goto_existing_story.org
@@ -78,15 +78,6 @@ and by =:ID:= prefix; new-story unchanged) and the three error paths
 (=git switch= + =add task --parent-dir=) is the one already exercised by
 new-story =goto= and by =add=.
 
-* Result
-
-=cmd_goto= now has two modes. Existing-story mode: =goto --story
-<id-or-slug> --task-slug <slug> --task "<title>" [--description …]=
-resolves the story via =resolve_story= (by =:ID:= exact/prefix or folder
-slug), branches =feature/<task-slug>=, adds a task to the existing story
-(=add=), sets =#+branch=, and prints next steps. New-story mode is
-unchanged. The two modes are mutually exclusive with clear validation.
-
 * PRs
 
 | PR | Title |
@@ -100,3 +91,10 @@ unchanged. The two modes are mutually exclusive with clear validation.
 |   |                 |      |          |       |
 
 * Result
+
+=cmd_goto= now has two modes. Existing-story mode: =goto --story
+<id-or-slug> --task-slug <slug> --task "<title>" [--description …]=
+resolves the story via =resolve_story= (by =:ID:= exact/prefix or folder
+slug), branches =feature/<task-slug>=, adds a task to the existing story
+(=add=), sets =#+branch=, and prints next steps. New-story mode is
+unchanged. The two modes are mutually exclusive with clear validation.

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -69,7 +69,7 @@ In execution order.
 | [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                         | DONE    | 2026-05-24 | 2026-05-26 | Replace broken per-mode ores.lisp with an env-aware emacs-dashboard console for all dev commands. |
 | [[id:7225526E-DCDB-4DC6-A95D-22C7117E5EAA][Port Tufte visualisation skill into ORE Studio]]     | DONE    | 2026-05-25 | 2026-05-25 | Convert =tufte-viz= SKILL and two Tufte reference docs to org-mode; install and catalogue. |
 | [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][compass cross-worktree status (global where)]] | DONE    | 2026-05-25 | 2026-05-25 | Show what every git worktree is doing (branch/story/task/PR) so parallel agents don't collide. |
-| [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][compass goto: start a unit of work in one command]] | STARTED | 2026-05-25 | | One command: fetch main, branch, scaffold linked story+task, print next steps. |
+| [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][compass goto: start a unit of work in one command]] | DONE | 2026-05-25 | 2026-05-25 | One command: fetch main, branch, scaffold linked story+task, print next steps. |
 | [[id:16851249-2FB0-443E-83E0-55D6B8051272][Sprint health review — System 2 analysis]]           | STARTED | 2026-05-25 | | =sprint-reviewer= skill writes a structured health-check section into =sprint.org=. |
 
 * Health Review

--- a/doc/recipes/compass/how_do_i_start_a_unit_of_work_with_compass.org
+++ b/doc/recipes/compass/how_do_i_start_a_unit_of_work_with_compass.org
@@ -15,12 +15,15 @@ Scaffold pillar ([[id:5B670808-D28B-4818-A2FA-EA5220D35E8D][=add=]]) into the "s
 
 * Question
 
-How do I start a new piece of work — fresh branch off =main= plus a
-linked story and task — without running the four manual commands?
+How do I start a piece of work — fresh branch off =main= plus a linked
+story/task — without running the manual commands? (Both for a brand-new
+story and for adding a task to an existing one.)
 
 * Answer
 
-Run =compass.sh goto= with the story details:
+=goto= has two modes.
+
+** New story
 
 #+begin_src sh :results verbatim
 ./projects/ores.compass/compass.sh goto \
@@ -28,21 +31,29 @@ Run =compass.sh goto= with the story details:
   --description "What it delivers." --tags "topic"
 #+end_src
 
-It fetches =main=, creates =feature/my-feature= off it, scaffolds the
-story (in the current sprint) and a linked task (with the task's
-=#+branch:= set so [[id:0D378978-7CF1-45F5-896F-63E281CC02CB][=fleet=]] picks it up), and prints the remaining
-manual steps (wire the story into the sprint =* Stories= table, set
-states, push/PR).
+Fetches =main=, creates =feature/my-feature=, scaffolds the story (in
+the current sprint) + a linked task (with =#+branch:= set so [[id:0D378978-7CF1-45F5-896F-63E281CC02CB][=fleet=]]
+picks it up), and prints the remaining manual steps (wire the story into
+the sprint =* Stories= table, set states, push/PR).
 
-Preview without making any changes using =--dry-run=:
+** Add a task to an existing story
+
+Identify the story by its =:ID:= (or unique prefix) or its folder slug:
 
 #+begin_src sh :results verbatim
-./projects/ores.compass/compass.sh goto --slug my_feature \
-  --title "My feature" --description "…" --dry-run
+./projects/ores.compass/compass.sh goto \
+  --story compass_goto --task-slug fix_help_text \
+  --task "Fix the goto help text" --description "…"
 #+end_src
 
-=--task "<title>"= sets the initial task title (default: =Implement
-<title>=); =--base= overrides the branch base (default =origin/main=).
+Creates =feature/fix-help-text= and adds the task to that story (no new
+story). =--story= is mutually exclusive with =--slug/--title=.
+
+** Notes
+
+Preview either mode with =--dry-run= (no side effects). =--task= sets
+the task title (new mode default: =Implement <title>=); =--base=
+overrides the branch base (default =origin/main=).
 
 * Script
 

--- a/projects/ores.codegen/docs_exceptions.txt
+++ b/projects/ores.codegen/docs_exceptions.txt
@@ -17,3 +17,8 @@
 MISSING_OVERVIEW ores.workspace.api
 MISSING_OVERVIEW ores.workspace.core
 MISSING_OVERVIEW ores.workspace.service
+
+# ores.lisp is an Emacs-Lisp project, not a standard C++/Python component:
+# it has no PlantUML diagram and "Entry points" does not fit its module shape.
+MISSING_SECTION ores.lisp
+MISSING_PUML ores.lisp

--- a/projects/ores.compass/modeling/component_overview.org
+++ b/projects/ores.compass/modeling/component_overview.org
@@ -53,10 +53,12 @@ Pillars (the first three drawn from the Sprint 18 capture =* Tools=):
    /Implemented/ as =fleet= — see the [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][Fleet story]].
 
 5. /Goto — "start a unit of work."/ Fetch =main=, create a feature
-   branch, scaffold a linked story + task (Scaffold/codegen) with the
-   task's =#+branch:= set, and print the remaining manual steps — the
-   "start a story" ritual in one command. /Implemented/ as =goto= — see
-   the [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][Goto story]].
+   branch, scaffold the task (and, for a /new/ story, the story too) via
+   Scaffold/codegen with the task's =#+branch:= set, and print the
+   remaining manual steps — the "start a story" ritual in one command.
+   Two modes: new story (=--slug/--title/--description=) or add a task to
+   an existing story (=--story <id-or-slug> --task-slug --task=).
+   /Implemented/ as =goto= — see the [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][Goto story]].
 
 * Inputs
 
@@ -90,7 +92,8 @@ Pillars (the first three drawn from the Sprint 18 capture =* Tools=):
   =debug [-f FILE]= (Search); =where= / =status= [=-f pretty|json=]
   (Locate); =list [filters]= and =show <uuid>= (Navigate);
   =add <type> [flags]= (Scaffold); =fleet [-f pretty|json]= (Fleet); and
-  =goto --slug … --title … --description … [--dry-run]= (Goto).
+  =goto= (Goto) — new story (=--slug/--title/--description=) or existing
+  story (=--story <id-or-slug> --task-slug --task=); =--dry-run= for both.
 
 * Dependencies
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -888,36 +888,92 @@ def _set_frontmatter_branch(path, branch):
     if new != text:                      # avoid a redundant write
         Path(path).write_text(new, encoding="utf-8")
 
+def resolve_story(ident):
+    """Resolve a story identifier to (story_dir, title), or (None, None).
+
+    `ident` is matched against story docs by :ID: (exact, else unique prefix)
+    or by folder slug. Returns (None, None) if there is no unique match.
+    """
+    stories = [d for d in doc_index.load_all().values() if d.doctype == "story"]
+    il = ident.lower()
+    exact = [d for d in stories if d.id.lower() == il]
+    if exact:
+        cands = exact
+    else:
+        prefix = [d for d in stories if d.id.lower().startswith(il)]
+        slug = [d for d in stories if Path(d.rel_path).parent.name == ident]
+        cands = prefix or slug
+    if len(cands) == 1:
+        d = cands[0]
+        return _parent_dir(d.rel_path), _strip_type_prefix(d.title)
+    return None, None
+
 def cmd_goto(argv):
-    """Start a unit of work in one command: fetch main, branch, scaffold a
-    linked story + task (via codegen), and print the remaining manual steps."""
+    """Start a unit of work in one command. Two modes:
+
+      new story:      --slug --title --description [--tags] [--task]
+      existing story: --story <id-or-slug> --task-slug --task [--description]
+
+    Both fetch main, create a feature branch, scaffold the task (and the
+    story, in new-story mode) via codegen, set the task #+branch, and print
+    the remaining manual steps."""
     ap = argparse.ArgumentParser(prog="compass goto",
-                                 description="Fetch main, branch, scaffold a linked story+task, print next steps.")
-    ap.add_argument("--slug", required=True, help="snake_case slug; drives the branch and doc folder")
-    ap.add_argument("--title", required=True, help="story title")
-    ap.add_argument("--description", required=True, help="story description")
-    ap.add_argument("--tags", default="", help="comma-separated content tags")
-    ap.add_argument("--task", default="", help="initial task title (default: 'Implement <title>')")
+                                 description="Fetch main, branch, scaffold a story/task, print next steps.")
+    ap.add_argument("--story", default="", help="existing story (UUID/prefix or folder slug) — existing-story mode")
+    ap.add_argument("--slug", default="", help="new-story mode: snake_case slug (drives branch + folder)")
+    ap.add_argument("--title", default="", help="new-story mode: story title")
+    ap.add_argument("--description", default="", help="story description (new mode) or task description (existing mode)")
+    ap.add_argument("--tags", default="", help="new-story mode: comma-separated content tags")
+    ap.add_argument("--task", default="", help="task title (default in new mode: 'Implement <title>')")
+    ap.add_argument("--task-slug", default="", help="existing-story mode: task slug (drives the branch)")
     ap.add_argument("--base", default="origin/main", help="branch base (default: origin/main)")
     ap.add_argument("--dry-run", action="store_true", help="print the plan without executing")
     args = ap.parse_args(argv)
-
-    branch = "feature/" + args.slug.replace("_", "-")
-    task_title = args.task or f"Implement {args.title}"
-    task_slug = "implement_" + args.slug
 
     _, current_sprint = current_version_sprint(doc_index.load_all())
     if current_sprint is None:
         print("❌ No current sprint found under doc/agile/versions/.", file=sys.stderr)
         return 1
     sprint_dir = _parent_dir(current_sprint.rel_path)
-    story_dir = f"{sprint_dir}/{args.slug}"
+
+    if args.story:
+        # --- existing-story mode ---
+        if args.slug or args.title:
+            print("❌ --story cannot be combined with --slug/--title (new-story mode).", file=sys.stderr)
+            return 1
+        if not (args.task_slug and args.task):
+            print("❌ --story requires --task-slug and --task.", file=sys.stderr)
+            return 1
+        story_dir, story_title = resolve_story(args.story)
+        if story_dir is None:
+            print(f"❌ Could not resolve a unique story for '{args.story}'.", file=sys.stderr)
+            return 1
+        new_story = None
+        task_slug, task_title = args.task_slug, args.task
+        task_desc = args.description or f"Task for: {story_title}"
+        branch = "feature/" + task_slug.replace("_", "-")
+    else:
+        # --- new-story mode ---
+        if not (args.slug and args.title and args.description):
+            print("❌ new-story mode needs --slug, --title and --description "
+                  "(or use --story for an existing story).", file=sys.stderr)
+            return 1
+        story_dir = f"{sprint_dir}/{args.slug}"
+        story_title = args.title
+        new_story = (args.slug, args.title, args.description, args.tags)
+        task_slug = "implement_" + args.slug
+        task_title = args.task or f"Implement {args.title}"
+        task_desc = f"Initial task for: {args.title}"
+        branch = "feature/" + args.slug.replace("_", "-")
+
     task_path = Path(PROJECT_ROOT) / story_dir / f"task_{task_slug}.org"
 
     if args.dry_run:
         print("compass goto — plan (dry run):")
+        print(f"  mode:    {'new story' if new_story else 'existing story'}")
         print(f"  branch:  {branch}   (base {args.base})")
-        print(f"  story:   {story_dir}/story.org")
+        print(f"  story:   {story_dir}/story.org   "
+              f"({'new' if new_story else f'existing: {story_title}'})")
         print(f"  task:    {story_dir}/task_{task_slug}.org   (#+branch: {branch})")
         print(f"  sprint:  {current_sprint.title}")
         return 0
@@ -934,17 +990,17 @@ def cmd_goto(argv):
         return 1
     print(f"✅ created and switched to {branch} (off {args.base})")
 
-    # 2. scaffold story + task via codegen (as a library). Check each call's
-    # result and stop on the first failure so we don't leave a half-made unit
-    # (gen.main returns 0 on success but may sys.exit on error).
+    # 2. scaffold the story (new mode only) + the task via codegen, stopping on
+    # the first failure (gen.main returns 0 on success but may sys.exit on error).
     try:
-        rc = gen.main(["--type", "story", "--slug", args.slug, "--parent-dir", sprint_dir,
-                       "--title", args.title, "--description", args.description, "--tags", args.tags])
-        if rc:
-            return rc
+        if new_story:
+            slug, title, desc, tags = new_story
+            rc = gen.main(["--type", "story", "--slug", slug, "--parent-dir", sprint_dir,
+                           "--title", title, "--description", desc, "--tags", tags])
+            if rc:
+                return rc
         rc = gen.main(["--type", "task", "--slug", task_slug, "--parent-dir", story_dir,
-                       "--title", task_title,
-                       "--description", f"Initial task for: {args.title}"])
+                       "--title", task_title, "--description", task_desc])
         if rc:
             return rc
     except SystemExit as exc:
@@ -957,8 +1013,9 @@ def cmd_goto(argv):
 
     # 4. next steps (deliberately manual — needs judgement)
     print("\nNext steps:")
-    print(f"  - wire the story into {sprint_dir}/sprint.org (* Stories table)")
-    print(f"  - flip the story/task State to STARTED when you begin")
+    if new_story:
+        print(f"  - wire the story into {sprint_dir}/sprint.org (* Stories table)")
+    print(f"  - flip the task State to STARTED when you begin")
     print(f"  - git push -u origin {branch}   &&   open a PR")
     return 0
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -900,9 +900,12 @@ def resolve_story(ident):
     if exact:
         cands = exact
     else:
+        # Combine id-prefix and (case-insensitive) folder-slug matches and
+        # require a single unique match — so an id-prefix and a different
+        # story's slug don't silently resolve to the id one.
         prefix = [d for d in stories if d.id.lower().startswith(il)]
-        slug = [d for d in stories if Path(d.rel_path).parent.name == ident]
-        cands = prefix or slug
+        slug = [d for d in stories if Path(d.rel_path).parent.name.lower() == il]
+        cands = list({d.id: d for d in prefix + slug}.values())
     if len(cands) == 1:
         d = cands[0]
         return _parent_dir(d.rel_path), _strip_type_prefix(d.title)
@@ -1015,7 +1018,7 @@ def cmd_goto(argv):
     print("\nNext steps:")
     if new_story:
         print(f"  - wire the story into {sprint_dir}/sprint.org (* Stories table)")
-    print(f"  - flip the task State to STARTED when you begin")
+    print(f"  - flip the {'story and task' if new_story else 'task'} State to STARTED when you begin")
     print(f"  - git push -u origin {branch}   &&   open a PR")
     return 0
 


### PR DESCRIPTION
## Summary

Answers "can `goto` add a task to an *existing* story?" — now yes. Adds
a second mode to `compass goto` so it can branch + add a task to an
existing story, not only create a new one.

## Modes

**New story** (unchanged):
```
compass goto --slug my_feature --title "My feature" --description "…" [--tags …] [--task …]
```

**Existing story** (new):
```
compass goto --story <id-or-slug> --task-slug fix_x --task "Fix X" [--description …]
```
→ fetch main, `git switch -c feature/fix-x`, add a task to the resolved
story (codegen), set the task `#+branch:`, print next steps.

## Design

- `--story` resolves via `doc_index` by `:ID:` (exact or unique prefix)
  **or** folder slug — ergonomic for both humans (slugs) and links
  (UUIDs).
- The two modes are mutually exclusive, with clear validation (mixed
  modes / missing task / unknown story all error cleanly).
- Reuses the same execution path as new-story `goto` and `add` (no new
  generation logic).

## Verification

`--dry-run` for both modes (existing-story by slug and by UUID prefix;
new-story unchanged) and all three error paths. `validate_docs.sh`
passes (90/90); `where`/`fleet`/`add` unaffected.

## Changes

- `compass.py`: two-mode `cmd_goto` + `resolve_story` helper.
- Component overview (Goto pillar + entry point) and the goto recipe.
- New task on the goto story (DONE).