### PR TITLE
[agile,doc] Sprint 18 health review 1 + story category taxonomy

### DIFF
--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -66,7 +66,7 @@ In execution order.
 | [[id:A2B3BFD0-F44C-48F3-BB01-6BAECB851356][Remove unused GitHub Actions workflows]] | DONE | 2026-05-24 | 2026-05-24 | Delete the four dormant Gemini workflows; PR review stays via the gemini-code-assist app. |
 | [[id:15CE567F-489C-4A80-9CEC-27FCF95E5C36][ores.compass Product Backlog — near and far listing]] | BACKLOG | 2026-05-24 | | =compass backlog= lists near/far captures with counts, mirroring =where= in-flight display. |
 | [[id:8D295781-33E7-4812-AAC6-134BD7CD0DDC][Rebuild org-roam DB independently from CMake]]       | BACKLOG | 2026-05-24 | | Extract org-roam sync into =.build-org-roam.el=; add =rebuild_org_roam_db= cmake target.   |
-| [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                         | DONE    | 2026-05-24 | 2026-05-26 | Replace broken per-mode ores.lisp with an env-aware emacs-dashboard console for all dev commands. |
+| [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                         | DONE    | 2026-05-24 | 2026-05-25 | Replace broken per-mode ores.lisp with an env-aware emacs-dashboard console for all dev commands. |
 | [[id:7225526E-DCDB-4DC6-A95D-22C7117E5EAA][Port Tufte visualisation skill into ORE Studio]]     | DONE    | 2026-05-25 | 2026-05-25 | Convert =tufte-viz= SKILL and two Tufte reference docs to org-mode; install and catalogue. |
 | [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][compass cross-worktree status (global where)]] | DONE    | 2026-05-25 | 2026-05-25 | Show what every git worktree is doing (branch/story/task/PR) so parallel agents don't collide. |
 | [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][compass goto: start a unit of work in one command]] | STARTED | 2026-05-25 | | One command: fetch main, branch, scaffold linked story+task, print next steps. |
@@ -81,7 +81,7 @@ In execution order.
 #+ATTR_HTML: :class hug-leading
 | Goal                              | Coverage | Stories (DONE / STARTED / BACKLOG) | Verdict |
 |-----------------------------------+----------+------------------------------------+---------|
-| ORE imports into workspaces       | WEAK     | 0 / 0 / 4                          | RED     |
+| ORE imports into workspaces       | WEAK     | 0 / 0 / 5                          | RED     |
 | More ORE types                    | WEAK     | 0 / 1 / 1                          | AMBER   |
 | Compass tool                      | STRONG   | 8 / 1 / 2                          | GREEN   |
 | Backlog refinement tooling        | STRONG   | 1 / 1 / 0                          | GREEN   |
@@ -96,7 +96,7 @@ ORE Example 1= is BACKLOG; =Resolve RFL complexity issues= is STARTED but
 is a prerequisite/unblocking task, not the ORE types work itself. Minimal
 progress expected at close.
 
-*Scope creep signal*: 10 of 25 stories have no direct mapping to the four
+*Scope creep signal*: 10 of 24 stories have no direct mapping to the four
 stated goals. These include =Inline org-roam export=, =SQLite CLI
 quality-of-life=, =ORE Studio Emacs dashboard=, =Tufte viz skill=, =Add
 investigation support=, and =Remove unused workflows=. These are legitimate
@@ -119,9 +119,9 @@ ORE sample data and the imports pipeline.
 | Projected at close   | ~325   | ≤ 300     | AMBER  |
 
 At 46.5 commits/day the sprint is tracking to ~325 commits at close —
-slightly over the 300 target. Day 2 (2026-05-24) was a burst day (27 PRs
+slightly over the 300 target. Day 3 (2026-05-24) was a burst day (27 PRs
 merged) driven by the compass and dashboard work. If the remaining days
-maintain the day-5 rate (which is likely lower as focused code work
+maintain the day-4 rate (which is likely lower as focused code work
 produces fewer small commits), the sprint may land within target.
 
 *Recommendation*: No action required yet. If day 5–6 continue at 30+
@@ -160,7 +160,7 @@ avoid review fatigue.
 | Fix instruments not visible in UI        | BACKLOG |     0 | —    | Not decomposed — expected      |
 | Qt: instrument creation in TradeDialog   | BACKLOG |     0 | —    | Not decomposed — expected      |
 
-DONE/total ratio: 14/25 = 56%. Throughput is healthy.
+DONE/total ratio: 13/24 = 54%. Throughput is healthy.
 
 The 5 undecomposed BACKLOG stories are all in the ORE imports/types track —
 they have not been decomposed because they have not been picked up. This is
@@ -202,10 +202,10 @@ AMBER/RED boundary.
 
 | Metric                        | Value  | Notes                                        |
 |-------------------------------+--------+----------------------------------------------|
-| Stories completed this sprint | 14     | Over 4 days                                  |
-| Story throughput               | 3.5/day | Unusually high; many were small stories     |
+| Stories completed this sprint | 13     | Over 4 days                                  |
+| Story throughput               | 3.25/day | Unusually high; many were small stories    |
 | Median cycle time (DONE)      | 0 days  | Most stories opened and closed same day     |
-| Max cycle time (DONE)         | 2 days  | ORE Studio Emacs dashboard (2026-05-24–26)  |
+| Max cycle time (DONE)         | 1 day   | ORE Studio Emacs dashboard (2026-05-24–25)  |
 | STARTED stories age           | 3d max  | User manual; RFL                             |
 
 Story throughput is high (3.5/day) but requires context: the majority of

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -74,7 +74,181 @@ In execution order.
 
 * Health Review
 
-(Run =sprint-reviewer= to generate this section.)
+** Review on 2026-05-25 (day 4 of 7)
+
+*** Goal alignment
+
+#+ATTR_HTML: :class hug-leading
+| Goal                              | Coverage | Stories (DONE / STARTED / BACKLOG) | Verdict |
+|-----------------------------------+----------+------------------------------------+---------|
+| ORE imports into workspaces       | WEAK     | 0 / 0 / 4                          | RED     |
+| More ORE types                    | WEAK     | 0 / 1 / 1                          | AMBER   |
+| Compass tool                      | STRONG   | 8 / 1 / 2                          | GREEN   |
+| Backlog refinement tooling        | STRONG   | 1 / 1 / 0                          | GREEN   |
+
+Goal 1 (ORE imports) has zero started stories at day 4 of 7. The five
+stories that serve it — ORE sample data, running samples, ORE Example 1
+types, instrument visibility, instrument creation in TradeDialog — are all
+BACKLOG. With three days left this goal will not be achieved in this sprint.
+
+Goal 2 (more ORE types) has partial coverage: =Work through all types for
+ORE Example 1= is BACKLOG; =Resolve RFL complexity issues= is STARTED but
+is a prerequisite/unblocking task, not the ORE types work itself. Minimal
+progress expected at close.
+
+*Scope creep signal*: 10 of 25 stories have no direct mapping to the four
+stated goals. These include =Inline org-roam export=, =SQLite CLI
+quality-of-life=, =ORE Studio Emacs dashboard=, =Tufte viz skill=, =Add
+investigation support=, and =Remove unused workflows=. These are legitimate
+housekeeping and enabler work, but they absorbed most of the sprint's
+energy in days 1–2.
+
+*Recommendation*: The sprint goals are now unreachable for the ORE imports
+and types tracks. Consider either: (a) accepting this sprint as a compass +
+tooling sprint and updating the goals retroactively to match reality, or (b)
+hard-stopping new housekeeping work and funnelling the remaining 3 days into
+ORE sample data and the imports pipeline.
+
+*** Sprint load
+
+| Metric               | Value  | Target    | Status |
+|----------------------+--------+-----------+--------|
+| Commits so far       | 186    | —         | —      |
+| Elapsed days         | 4 of 7 | ≤ 7 days  | GREEN  |
+| Commits/day          | 46.5   | —         | —      |
+| Projected at close   | ~325   | ≤ 300     | AMBER  |
+
+At 46.5 commits/day the sprint is tracking to ~325 commits at close —
+slightly over the 300 target. Day 2 (2026-05-24) was a burst day (27 PRs
+merged) driven by the compass and dashboard work. If the remaining days
+maintain the day-5 rate (which is likely lower as focused code work
+produces fewer small commits), the sprint may land within target.
+
+*Recommendation*: No action required yet. If day 5–6 continue at 30+
+commits/day, pause and question whether more PRs are needed or whether
+consolidation commits can be batched.
+
+*** PR velocity
+
+| Metric                  | Value       | Notes                                   |
+|-------------------------+-------------+-----------------------------------------|
+| PRs merged              | 47          | Over 4 days                             |
+| PRs/day                 | 11.8        | Exceptionally high; day 2 burst = 27 PRs |
+| Open PRs                | 1           | PR #838 (compass-goto-existing-story)   |
+| PR #838 age             | <1 day      | Raised today; not yet WIP accumulation  |
+| WIP accumulation        | None        | Clean                                   |
+
+PR velocity is exceptional. 47 PRs in 4 days reflects the exploratory
+nature of the sprint — many small, focused PRs rather than large branches.
+PR #838 is the only open PR and was raised today; no WIP concern.
+
+*Recommendation*: Maintain the small-PR discipline. If ORE imports/types
+work starts, expect larger PRs (C++ code changes) — batch them sensibly to
+avoid review fatigue.
+
+*** Story and task balance
+
+| Story                                     | State   | Tasks | Age  | Notes                          |
+|-------------------------------------------+---------+-------+------+--------------------------------|
+| Build and publish user manual PDF         | STARTED |     5 | 3d+  | Long open; active              |
+| Resolve RFL complexity issues             | STARTED |     3 | 3d+  | PCH/coverage work active (local4) |
+| Sprint health review — System 2 analysis | STARTED |     2 | 0d   | This review                    |
+| compass goto                              | STARTED |     1 | 0d   | Core merged; extension active  |
+| ORE sample data                           | BACKLOG |     0 | —    | Not decomposed — expected      |
+| Add support for running ORE samples       | BACKLOG |     0 | —    | Not decomposed — expected      |
+| Work through all types for ORE Example 1 | BACKLOG |     0 | —    | Not decomposed — expected      |
+| Fix instruments not visible in UI        | BACKLOG |     0 | —    | Not decomposed — expected      |
+| Qt: instrument creation in TradeDialog   | BACKLOG |     0 | —    | Not decomposed — expected      |
+
+DONE/total ratio: 14/25 = 56%. Throughput is healthy.
+
+The 5 undecomposed BACKLOG stories are all in the ORE imports/types track —
+they have not been decomposed because they have not been picked up. This is
+normal, but it means there is zero implementation visibility into how
+complex these stories are. If the decision is made to start them in the last
+3 days, task decomposition will be the first step.
+
+=Build and publish user manual PDF= has been STARTED for 3+ days with 5
+tasks. This is the longest-running open story; verify it is genuinely in
+progress and not stalled waiting on prerequisites.
+
+*Recommendation*: The 5 undecomposed ORE stories are not a problem if they
+remain BACKLOG. If any are to be started this sprint, decompose before
+starting so progress is trackable.
+
+*** Focus signal
+
+| Metric                   | Value | Verdict |
+|--------------------------+-------+---------|
+| Simultaneously STARTED   | 4     | GREEN   |
+| Distinct active worktrees | 4    | —       |
+| Theme coherence          | Mixed | AMBER   |
+
+Four STARTED stories across four worktrees: user manual, RFL/build,
+sprint health review, and compass goto. The themes span documentation,
+C++ build, agile tooling, and compass — not tightly coherent but each is in
+a distinct worktree with a dedicated agent. No single contributor is
+context-switching between them.
+
+The compass goto work on =local3= is extending a just-merged feature
+(PR #834); this is normal post-merge polish. =local4= is doing focused
+RFL/PCH build work. Focus is adequate for a parallel-agent workflow.
+
+*Recommendation*: If a fifth worktree picks up an ORE imports story,
+re-check focus. Five simultaneous themes for a 7-day sprint would be at the
+AMBER/RED boundary.
+
+*** Velocity
+
+| Metric                        | Value  | Notes                                        |
+|-------------------------------+--------+----------------------------------------------|
+| Stories completed this sprint | 14     | Over 4 days                                  |
+| Story throughput               | 3.5/day | Unusually high; many were small stories     |
+| Median cycle time (DONE)      | 0 days  | Most stories opened and closed same day     |
+| Max cycle time (DONE)         | 2 days  | ORE Studio Emacs dashboard (2026-05-24–26)  |
+| STARTED stories age           | 3d max  | User manual; RFL                             |
+
+Story throughput is high (3.5/day) but requires context: the majority of
+DONE stories were small-scope (1-task) housekeeping, tooling, or agile
+scaffolding items opened and closed on the same day. This inflates the
+throughput number.
+
+Zero-day cycle time stories (opened and closed 2026-05-24): =SQLite CLI
+setup=, =Lock down UUID invariant=, =Compass locate=, =Compass scaffold=,
+=Track PRs per task=, =Org-roam index links=, =Remove unused workflows=,
+=Product backlog refinement=. These are real delivered value but not
+comparable to multi-day feature stories.
+
+The ORE imports track has produced no velocity whatsoever — all five
+stories are still in their initial BACKLOG state.
+
+*Recommendation*: Track throughput separately for /feature stories/ vs
+/housekeeping stories/ in future reviews. Housekeeping velocity is real but
+masks feature velocity. Consider adding a =#+category:= tag (feature /
+housekeeping / enabler) to stories to support this.
+
+*** Overall verdict
+
+| Dimension           | Verdict |
+|---------------------+---------|
+| Goal alignment      | RED     |
+| Sprint load         | AMBER   |
+| PR velocity         | GREEN   |
+| Story/task balance  | GREEN   |
+| Focus signal        | GREEN   |
+| Velocity            | AMBER   |
+| *Overall*           | *AMBER* |
+
+Sprint 18 is delivering well on compass tooling, developer experience, and
+agile infrastructure — but it is failing on its two primary goals: ORE
+imports into workspaces and more ORE types. At day 4 of 7, those tracks
+have zero velocity; three days remain. The sprint has not failed yet, but
+without an explicit decision to pivot resources to the ORE track, it will
+close with Goals 1 and 2 unachieved. The most important single action is
+to decide now whether to pursue those goals in the remaining time or to
+accept this sprint as a tooling sprint and reset goal expectations.
+Velocity looks high in aggregate but is dominated by same-day housekeeping
+stories; feature-level throughput is lower than the headline number suggests.
 
 * Retrospective
 

--- a/doc/agile/versions/v0/sprint_18/sprint_health_review/story.org
+++ b/doc/agile/versions/v0/sprint_18/sprint_health_review/story.org
@@ -28,9 +28,9 @@ the team is focused — rather than merely summarising status.
 |---------------+----------------------------------------|
 | State         | STARTED                                |
 | Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                              |
-| Now           | SKILL.org implemented; sprint template and catalogue updated. |
+| Now           | Skill shipped (PR #839); first review in progress. |
 | Waiting on    | Nothing.                               |
-| Next          | Review and merge.                      |
+| Next          | Complete review 1; raise PR.           |
 | Last touched  | 2026-05-25                             |
 
 * Acceptance
@@ -71,6 +71,7 @@ the team is focused — rather than merely summarising status.
 In execution order:
 
 - [[id:4B327802-3E59-438F-8726-6984B2BC2BB0][Task: Implement sprint-reviewer skill]]
+- [[id:FA5A76DC-913B-481C-8D65-13F58032D950][Task: Health review 1 — sprint 18 mid-sprint analysis]]
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_18/sprint_health_review/task_health_review_1.org
+++ b/doc/agile/versions/v0/sprint_18/sprint_health_review/task_health_review_1.org
@@ -59,8 +59,12 @@ task closes. Plans do not outlive their task.)
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                     | File                | Decision | Notes                                          |
+|---+-----------------------------------------------------+---------------------+----------+------------------------------------------------|
+| 1 | Day/date mismatch; future dashboard end date (−26) | sprint.org          | Fixed    | Day 2→Day 3; date 2026-05-24–26→25; day-5→day-4 |
+| 2 | ORE imports table shows 4 stories, narrative says 5 | sprint.org          | Fixed    | 0/0/4→0/0/5                                   |
+| 3 | "day-5 rate" typo for a day-4 review                | sprint.org          | Fixed    | Combined with comment 1                        |
+| 4 | DONE/total counts inconsistent (14/25 vs table 23)  | sprint.org          | Fixed    | 13/24=54%; throughput 3.5→3.25/day; max cycle 2→1 day |
+| 5 | #+category: template has unsupported ; inline comments | document_types.org | Fixed    | Moved field docs to prose below src block      |
 
 * Result

--- a/doc/agile/versions/v0/sprint_18/sprint_health_review/task_health_review_1.org
+++ b/doc/agile/versions/v0/sprint_18/sprint_health_review/task_health_review_1.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: FA5A76DC-913B-481C-8D65-13F58032D950
+:END:
+#+title: Task: Health review 1 — sprint 18 mid-sprint analysis
+#+description: First System 2 health review of sprint 18: goal alignment, load, PR velocity, story/task balance, focus signal, velocity, and overall verdict.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :sprint_health_review:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:16851249-2FB0-443E-83E0-55D6B8051272][Sprint health review — System 2 analysis]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Run the first System 2 health review of sprint 18 using the
+=sprint-reviewer= skill; write the findings into =sprint.org= under
+=* Health Review=; include velocity metrics and recommendations.
+
+* Status
+
+| Field        | Value                                    |
+|--------------+------------------------------------------|
+| State        | STARTED                                  |
+| Parent story | [[id:16851249-2FB0-443E-83E0-55D6B8051272][Sprint health review — System 2 analysis]] |
+| Now          | Analysis in progress.                    |
+| Waiting on   | Nothing.                                 |
+| Next         | Complete analysis; write review section. |
+| Last touched | 2026-05-25                               |
+
+* Acceptance
+
+- =* Health Review= section written into sprint 18 =sprint.org=.
+- All seven dimensions covered: goal alignment, sprint load, PR
+  velocity, story/task balance, focus signal, velocity (throughput +
+  cycle time), overall verdict.
+- Concrete recommendations included for each AMBER or RED dimension.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/sprint_health_review/task_implement_sprint_reviewer.org
+++ b/doc/agile/versions/v0/sprint_18/sprint_health_review/task_implement_sprint_reviewer.org
@@ -28,11 +28,11 @@ template so every new sprint has an empty =* Health Review= placeholder.
 
 | Field        | Value                                        |
 |--------------+----------------------------------------------|
-| State        | STARTED                                      |
+| State        | DONE                                         |
 | Parent story | [[id:16851249-2FB0-443E-83E0-55D6B8051272][Sprint health review — System 2 analysis]]     |
-| Now          | =doc/llm/skills/sprint-reviewer/SKILL.org= written; sprint template and catalogue updated. |
+| Now          | Merged on PR #839.                           |
 | Waiting on   | Nothing.                                     |
-| Next         | Review and merge.                            |
+| Next         | Nothing.                                     |
 | Last touched | 2026-05-25                                   |
 
 * Acceptance
@@ -60,9 +60,9 @@ task closes. Plans do not outlive their task.)
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR                                                                                 | Title                                                             |
+|------------------------------------------------------------------------------------+-------------------------------------------------------------------|
+| [[https://github.com/OreStudio/OreStudio/pull/839][#839]] | [skills,agile] Implement sprint-reviewer skill (System 2 health review) |
 
 * Review
 

--- a/doc/meta/document_types.org
+++ b/doc/meta/document_types.org
@@ -450,10 +450,15 @@ matching =#+successor= pointing back.
 *** Story frontmatter (additions on top of the standard set)
 
 #+begin_src org
-,#+category: <feature|housekeeping|enabler>  ; required; drives velocity tracking
-,#+predecessor: <id-of-prior-story>           ; optional; on continuations
-,#+successor:   <id-of-next-story>            ; optional; on closed stories that continue
+,#+category: <feature|housekeeping|enabler>
+,#+predecessor: <id-of-prior-story>
+,#+successor:   <id-of-next-story>
 #+end_src
+
+- =#+category:= — required; one of =feature=, =housekeeping=, or =enabler=.
+  Drives velocity tracking (see =** Story categories= in =* Tags= above).
+- =#+predecessor:= / =#+successor:= — optional; used on stories that span
+  sprints (see =*** Cross-sprint stories= above for full conventions).
 
 The =#+category:= field classifies the story's intent so velocity
 metrics can be sliced by type (see =** Story categories= in =* Tags=

--- a/doc/meta/document_types.org
+++ b/doc/meta/document_types.org
@@ -248,6 +248,30 @@ the ancestor slugs from the =--parent-dir= path (following the
 =versions/<version>/<sprint>/<story>/= layout) and adds them all to
 =#+filetags= automatically, on top of any =--tags= the user supplies.
 
+** Story categories
+
+Stories carry a =#+category:= frontmatter field (not a tag) that
+classifies their intent. Categories are used to slice velocity metrics:
+feature throughput, housekeeping load, and enabler investment are
+tracked separately so the team can see whether sprint time is going to
+the right places.
+
+| Category      | Meaning                                                               |
+|---------------+-----------------------------------------------------------------------|
+| =feature=     | Adds or changes user-visible behaviour. Counted in feature velocity.  |
+| =housekeeping= | Cleanup, refactoring, dependency upgrades, docs, tooling fixes. Does not advance features but is necessary work. |
+| =enabler=     | Infrastructure, scaffolding, CI, build, or platform work that unblocks future features but delivers nothing user-visible on its own. |
+
+Rules:
+
+- Every story must carry exactly one category.
+- When a story spans multiple categories, assign the /dominant/ intent.
+  A story that mostly refactors but incidentally adds an endpoint is
+  still =housekeeping=.
+- Sprints should aim for ≥ 50% =feature= stories by count. A sprint
+  skewed toward =housekeeping= or =enabler= should be noted in the
+  health review focus signal.
+
 ** Governance
 
 - The audit job (System 3*) lists every tag in use and flags singletons
@@ -422,6 +446,18 @@ The successor's slug is the original slug suffixed with =_continued=,
 
 Audit verifies bidirectional links: every =#+predecessor= has a
 matching =#+successor= pointing back.
+
+*** Story frontmatter (additions on top of the standard set)
+
+#+begin_src org
+,#+category: <feature|housekeeping|enabler>  ; required; drives velocity tracking
+,#+predecessor: <id-of-prior-story>           ; optional; on continuations
+,#+successor:   <id-of-next-story>            ; optional; on closed stories that continue
+#+end_src
+
+The =#+category:= field classifies the story's intent so velocity
+metrics can be sliced by type (see =** Story categories= in =* Tags=
+above). It is required on every story created from sprint 18 onward.
 
 ** sprint
 


### PR DESCRIPTION
## Summary

- First System 2 health review of sprint 18 written into `sprint.org` under `** Review on 2026-05-25 (day 4 of 7)` with all seven dimensions covered (goal alignment, sprint load, PR velocity, story/task balance, focus signal, velocity, overall verdict).
- Overall verdict: AMBER — the critical finding is that sprint 18's primary goals (ORE imports, ORE types) are completely uncovered at day 4 of 7, with all five related stories still BACKLOG.
- Added `#+category:` field (feature/housekeeping/enabler) to the story frontmatter contract in `doc/meta/document_types.org` with a canonical table and sprint health guidance.
- Scaffolded `task_health_review_1.org`; updated story and prior task states/PR URLs.

## Test plan

- [ ] `sprint.org` contains a `** Review on 2026-05-25 (day 4 of 7)` section with all seven sub-sections
- [ ] `document_types.org` `** Story categories` section present with the three-row table
- [ ] `task_health_review_1.org` exists and is STARTED
- [ ] `task_implement_sprint_reviewer.org` is DONE with PR #839 linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)