### PR TITLE
Add Downloads page and Downloads + Agile + Developer nav entries

### DIFF
--- a/.build-site.el
+++ b/.build-site.el
@@ -130,6 +130,8 @@
     <a href='/OreStudio/doc/recipes/recipes.html'>Recipes</a>
     <a href='/OreStudio/doc/llm/skills/claude_code_skills.html'>Skills</a>
     <a href='/OreStudio/doc/manual/manuals.html'>Manuals</a>
+    <a href='/OreStudio/doc/downloads.html'>Downloads</a>
+    <a href='/OreStudio/doc/agile/agile.html'>Agile</a>
     <a href='/OreStudio/doc/developer.html'>Developer</a>
     <a href='/OreStudio/doc/agile/versions/versions.html'>Roadmap</a>
     <a href='/OreStudio/graph/index.html'>Knowledge Graph</a>

--- a/doc/agile/versions/v0/sprint_18/site_nav_downloads_agile/story.org
+++ b/doc/agile/versions/v0/sprint_18/site_nav_downloads_agile/story.org
@@ -28,11 +28,11 @@ The site header gains two new nav entries:
 
 | Field         | Value                              |
 |---------------+------------------------------------|
-| State         | BACKLOG                            |
+| State         | DONE                               |
 | Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                          |
-| Now           | Not yet started.                   |
+| Now           | Complete. Pending PR merge.        |
 | Waiting on    | Nothing.                           |
-| Next          | Create downloads.org; patch nav.   |
+| Next          | —                                  |
 | Last touched  | 2026-05-25                         |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_18/site_nav_downloads_agile/task_add_downloads_agile_nav.org
+++ b/doc/agile/versions/v0/sprint_18/site_nav_downloads_agile/task_add_downloads_agile_nav.org
@@ -99,7 +99,7 @@ Manuals → *Downloads* → *Agile* → Roadmap → Knowledge Graph → GitHub
 
 | PR                                                              | Title                                                               |
 |-----------------------------------------------------------------+---------------------------------------------------------------------|
-| [[https://github.com/OreStudio/OreStudio/pull/841][#841]] | Fix PDF delivery, manual book class, and introduction restructuring |
+| [[https://github.com/OreStudio/OreStudio/pull/843][#843]] | Add Downloads page and Downloads + Agile + Developer nav entries |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/site_nav_downloads_agile/task_add_downloads_agile_nav.org
+++ b/doc/agile/versions/v0/sprint_18/site_nav_downloads_agile/task_add_downloads_agile_nav.org
@@ -29,11 +29,11 @@ add =Downloads= and =Agile= nav entries.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                                |
+| State        | DONE                                   |
 | Parent story | [[id:C3B6F514-559F-4038-A1D7-947BC9F7F398][Add Downloads and Agile nav entries to the site]] |
-| Now          | Not yet started.                       |
+| Now          | Complete. Pending PR merge.            |
 | Waiting on   | Nothing.                               |
-| Next         | Write downloads.org; patch nav.        |
+| Next         | —                                      |
 | Last touched | 2026-05-25                             |
 
 * Acceptance
@@ -97,9 +97,9 @@ Manuals → *Downloads* → *Agile* → Roadmap → Knowledge Graph → GitHub
 
 * PRs
 
-| PR  | Title                                              |
-|-----+----------------------------------------------------|
-|     |                                                    |
+| PR                                                              | Title                                                               |
+|-----------------------------------------------------------------+---------------------------------------------------------------------|
+| [[https://github.com/OreStudio/OreStudio/pull/841][#841]] | Fix PDF delivery, manual book class, and introduction restructuring |
 
 * Review
 

--- a/doc/downloads.org
+++ b/doc/downloads.org
@@ -1,0 +1,42 @@
+:PROPERTIES:
+:ID: E3C547E9-8F47-4853-BF73-8094CD312295
+:END:
+#+title: Downloads
+#+description: Release download index listing every ORE Studio release with binary assets, by platform.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :downloads:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+
+* Summary
+
+ORE Studio is in early active development (version 0.x). Releases are
+published on [[https://github.com/OreStudio/OreStudio/releases][GitHub]] and are provided for evaluation and learning
+purposes only. Many problems are expected — do not use these builds for
+production, real trading, or any financial decision-making. See the
+[[id:6A1A333C-A83A-8954-B9C3-C3AB1AEC3046][User Manual]] for guidance on getting started.
+
+* Releases
+
+#+ATTR_HTML: :class hug-leading
+| Version                                                          | Code Name             | Linux                                                                                                              | macOS                                                                                                              | Windows                                                                                                                | Comments                          |
+|------------------------------------------------------------------+-----------------------+--------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+-----------------------------------|
+| [[https://github.com/OreStudio/OreStudio/releases/tag/v0.0.17][v0.0.17]] | Mutumieque            | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.17/linux-gcc-release-ninja-v0.0.17.zip][Download]] | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.17/macos-clang-release-ninja-v0.0.17.zip][Download]] | —                                                                                                                      | No Windows build in this release. |
+| [[https://github.com/OreStudio/OreStudio/releases/tag/v0.0.14][v0.0.14]] | Curoca Norte          | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.14/linux-gcc-release-ninja-v0.0.14.zip][Download]] | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.14/macos-clang-release-ninja-v0.0.14.zip][Download]] | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.14/windows-msvc-release-ninja-v0.0.14.zip][Download]] |                                   |
+| [[https://github.com/OreStudio/OreStudio/releases/tag/v0.0.12][v0.0.12]] | Gruta do Leão         | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.12/linux-gcc-release-v0.0.12.zip][Download]] | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.12/macos-clang-release-v0.0.12.zip][Download]] | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.12/windows-msvc-release-v0.0.12.zip][Download]] |                                   |
+| [[https://github.com/OreStudio/OreStudio/releases/tag/v0.0.11][v0.0.11]] | Cambêno               | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.11/linux-gcc-release-v0.0.11.zip][Download]] | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.11/macos-clang-release-v0.0.11.zip][Download]] | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.11/windows-msvc-release-v0.0.11.zip][Download]] |                                   |
+| [[https://github.com/OreStudio/OreStudio/releases/tag/v0.0.10][v0.0.10]] | Morros do Tchitundulo | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.10/linux-gcc-release-v0.0.10.zip][Download]] | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.10/macos-clang-release-v0.0.10.zip][Download]] | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.10/windows-msvc-release-v0.0.10.zip][Download]] |                                   |
+| [[https://github.com/OreStudio/OreStudio/releases/tag/v0.0.8][v0.0.8]]   | Espinheira            | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.8/linux-gcc-release-v0.0.8.zip][Download]]   | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.8/macos-clang-release-v0.0.8.zip][Download]]   | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.8/windows-msvc-release-v0.0.8.zip][Download]]   |                                   |
+| [[https://github.com/OreStudio/OreStudio/releases/tag/v0.0.7][v0.0.7]]   | Pediba                | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.7/linux-gcc-release-v0.0.7.zip][Download]]   | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.7/macos-clang-release-v0.0.7.zip][Download]]   | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.7/windows-msvc-release-v0.0.7.zip][Download]]   |                                   |
+| [[https://github.com/OreStudio/OreStudio/releases/tag/v0.0.5][v0.0.5]]   | Tambor                | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.5/linux-gcc-release-v0.0.5.zip][Download]]   | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.5/macos-clang-release-v0.0.5.zip][Download]]   | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.5/windows-msvc-release-v0.0.5.zip][Download]]   |                                   |
+| [[https://github.com/OreStudio/OreStudio/releases/tag/v0.0.4][v0.0.4]]   | Fazenda Camilunga     | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.4/linux-gcc-release-v0.0.4.zip][Download]]   | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.4/macos-clang-release-v0.0.4.zip][Download]]   | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.4/windows-msvc-release-v0.0.4.zip][Download]]   |                                   |
+| [[https://github.com/OreStudio/OreStudio/releases/tag/v0.0.3][v0.0.3]]   | Venâncio Guimarães    | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.3/linux-gcc-release-v0.0.3.zip][Download]]   | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.3/macos-clang-release-v0.0.3.zip][Download]]   | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.3/windows-msvc-release-v0.0.3.zip][Download]]   |                                   |
+
+Releases v0.0.9, v0.0.13, v0.0.15, v0.0.16 had no binary assets and are omitted.
+
+* See also
+
+- [[id:6A1A333C-A83A-8954-B9C3-C3AB1AEC3046][ORE Studio User Manual]] — getting started guide.
+- [[id:B69989F6-19E1-430D-AC6D-B2416E4C433F][Compass]] — orientation for the doc tree.


### PR DESCRIPTION
## Summary

- `doc/downloads.org`: new release index page with binary download table covering all 10 releases that ship assets (Linux/macOS/Windows columns, alpha-software warning, link to User Manual). Scaffolded via compass.
- `.build-site.el`: adds Downloads, Agile, and Developer nav entries. Final nav order: Home → Orientation → Product → Architecture → Recipes → Skills → Manuals → **Downloads** → **Agile** → **Developer** → Roadmap → Knowledge Graph → GitHub.
- `doc/developer.org`: quick-reference tables for GitHub, Doxygen, Discord, CDash, CI pipelines, releases, and DeepWiki.
- `doc/compass.org`: Developer Links section pointing to developer.org.
- `build/doxygen/Doxyfile`: output directory moved inside the site artifact tree so doxygen is included in GitHub Pages deploy.
- `readme.org`: sprint badge URL updated to current path.

## Test plan

- [ ] Site build succeeds: `emacs -Q --script .build-site.el`.
- [ ] `build/output/site/OreStudio/doc/downloads.html` renders with the release table and alpha warning.
- [ ] `build/output/site/OreStudio/doc/developer.html` renders with the resource tables.
- [ ] Nav bar shows Downloads, Agile, Developer links on all pages.
- [ ] Agile nav link resolves to `doc/agile/agile.html`.
- [ ] Downloads link resolves to `doc/downloads.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)