### PR TITLE
Port domain concept notes to knowledge documents

### DIFF
--- a/doc/agile/versions/v0/sprint_18/port_domain_concept_notes/story.org
+++ b/doc/agile/versions/v0/sprint_18/port_domain_concept_notes/story.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: 4E375DD6-E300-4A0A-BD20-3D06AC8ED7A1
+:END:
+#+title: Story: Port domain concept notes to knowledge documents
+#+description: Tidy personal notes on finance/ORE domain concepts into v2 knowledge documents under doc/knowledge/domain, splitting by topic and aligning terminology with ORE Studio terms.
+#+type: story
+#+version: 2
+#+level: s2
+#+category: enabler
+#+filetags: :knowledge:domain:finance:ore:sprint_18:v0:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Convert nine personal domain notes from =/home/marco/Development/Notebooks/summaries/= into v2 knowledge documents under =doc/knowledge/domain/=. The notes cover FX volatility surfaces, compute infrastructure, P&L attribution, pricing configuration, rates and curves bootstrapping, reporting, risk reporting, time structures/tenors, and the trade blotter. They need to be split where appropriate, cross-linked, and updated to use ORE Studio terminology (e.g. "compute engine" rather than "grid", ORE Studio's report/batch concepts rather than generic "job" language).
+
+* Status
+
+| Field         | Value                                        |
+|---------------+----------------------------------------------|
+| State         | STARTED                                      |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                                    |
+| Now           | Survey and port in progress.                 |
+| Waiting on    | Nothing.                                     |
+| Next          | Complete first task; raise PR.               |
+| Last touched  | 2026-05-25                                   |
+
+* Acceptance
+
+- All nine source notes processed; none silently dropped.
+- =reporting.org= (already marked superseded) merged into the
+  =risk-reporting= and =pl-attribution= documents — not ported as a
+  standalone doc.
+- Each resulting knowledge document is a valid v2 =.org= file with
+  correct frontmatter (=#+type: knowledge=, UUID, =#+filetags:=, etc.).
+- Documents placed under =doc/knowledge/domain/= with one file per
+  coherent concept; a note that covers two distinct concepts is split
+  into two files with a cross-link between them.
+- Grid/job terminology updated to ORE Studio equivalents:
+  - "grid" → "compute engine"
+  - "Job Set Definition / Job Definition" → ORE Studio batch/run concepts
+    (or explicitly noted as an unresolved mapping if no equivalent exists yet)
+  - "trade blotter" section cross-linked to the ORE Studio Qt UI concepts
+    (=TradeDetailDialog=, instrument view) where applicable.
+- Every new knowledge doc linked from =doc/knowledge/domain/knowledge.org=
+  (or the relevant index) so it is reachable from the graph.
+
+* Tasks
+
+In execution order:
+
+- [[id:FBB4FEE3-5DB0-4404-893E-6FE298E22088][Task: Survey notes and create initial knowledge documents]]
+
+* Decisions
+
+* Out of scope
+
+- Implementing any functionality described in the notes (this story is
+  documentation only).
+- Resolving every terminology gap — notes can flag unresolved mappings for
+  a follow-up story.
+- Porting notes that are not in the =summaries/= directory.

--- a/doc/agile/versions/v0/sprint_18/port_domain_concept_notes/story.org
+++ b/doc/agile/versions/v0/sprint_18/port_domain_concept_notes/story.org
@@ -22,11 +22,11 @@ Convert nine personal domain notes from =/home/marco/Development/Notebooks/summa
 
 | Field         | Value                                        |
 |---------------+----------------------------------------------|
-| State         | STARTED                                      |
+| State         | DONE                                         |
 | Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                                    |
-| Now           | Survey and port in progress.                 |
+| Now           | All 8 knowledge documents committed; PR open.|
 | Waiting on    | Nothing.                                     |
-| Next          | Complete first task; raise PR.               |
+| Next          | Merge PR #844.                               |
 | Last touched  | 2026-05-25                                   |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_18/port_domain_concept_notes/task_implement_port_domain_concept_notes.org
+++ b/doc/agile/versions/v0/sprint_18/port_domain_concept_notes/task_implement_port_domain_concept_notes.org
@@ -9,7 +9,7 @@
 #+filetags: :port_domain_concept_notes:sprint_18:v0:
 #+owner: marco
 #+branch: feature/port-domain-concept-notes
-#+pr:
+#+pr: 844
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-25
@@ -66,9 +66,9 @@ Source files to process (=/home/marco/Development/Notebooks/summaries/=):
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR  | Title                                           |
+|-----+-------------------------------------------------|
+| 844 | Port domain concept notes to knowledge documents |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/port_domain_concept_notes/task_implement_port_domain_concept_notes.org
+++ b/doc/agile/versions/v0/sprint_18/port_domain_concept_notes/task_implement_port_domain_concept_notes.org
@@ -26,11 +26,11 @@ Read all nine source notes under =/home/marco/Development/Notebooks/summaries/=,
 
 | Field        | Value                                                      |
 |--------------+------------------------------------------------------------|
-| State        | STARTED                                                    |
+| State        | DONE                                                       |
 | Parent story | [[id:4E375DD6-E300-4A0A-BD20-3D06AC8ED7A1][Port domain concept notes to knowledge documents]]           |
-| Now          | Reading source notes; planning document split.             |
+| Now          | All 8 knowledge documents created and committed.           |
 | Waiting on   | Nothing.                                                   |
-| Next         | Create knowledge documents; raise PR.                      |
+| Next         | Raise PR.                                                  |
 | Last touched | 2026-05-25                                                 |
 
 * Acceptance
@@ -52,17 +52,17 @@ task closes. Plans do not outlive their task.)
 
 Source files to process (=/home/marco/Development/Notebooks/summaries/=):
 
-| File                           | Status  | Notes                                                      |
-|--------------------------------+---------+------------------------------------------------------------|
-| fx-vol-surface.org             | Pending |                                                            |
-| grid-infrastructure.org        | Pending | Rename: "compute engine". Map job/grid terms to ORE Studio |
-| pl-attribution.org             | Pending |                                                            |
-| pricing-configuration.org      | Pending |                                                            |
-| rates-curves-bootstrapping.org | Pending | May split: rates vs curves vs bootstrapping                |
-| reporting.org                  | Pending | Already superseded; merge into risk-reporting + pl-attribution |
-| risk-reporting.org             | Pending |                                                            |
-| time-structures-tenors.org     | Pending | May split: time structures vs tenor conventions            |
-| trade-blotter.org              | Pending | Cross-link to Qt UI concepts (TradeDetailDialog, etc.)     |
+| File                           | Status | Notes                                                         |
+|--------------------------------+--------+---------------------------------------------------------------|
+| fx-vol-surface.org             | Done   | → fx_volatility_surface.org (5B513D53)                       |
+| grid-infrastructure.org        | Done   | → compute_engine.org (98B9FE2A); grid/job terms → ORE Studio |
+| pl-attribution.org             | Done   | → pl_attribution.org (B50355E0); reporting.org merged here   |
+| pricing-configuration.org      | Done   | → pricing_configuration.org (EDAE3C87)                       |
+| rates-curves-bootstrapping.org | Done   | → interest_rate_curves.org (E808F432)                        |
+| reporting.org                  | Done   | Superseded; content merged into pl_attribution + risk_reporting |
+| risk-reporting.org             | Done   | → risk_reporting.org (04C68B55)                              |
+| time-structures-tenors.org     | Done   | → time_structures_and_tenors.org (1427C01C)                  |
+| trade-blotter.org              | Done   | → trade_blotter.org (3976695F)                               |
 
 * PRs
 
@@ -77,3 +77,12 @@ Source files to process (=/home/marco/Development/Notebooks/summaries/=):
 |   |                 |      |          |       |
 
 * Result
+
+8 v2 knowledge documents created under =doc/knowledge/domain/=:
+=fx_volatility_surface.org=, =interest_rate_curves.org=,
+=time_structures_and_tenors.org=, =compute_engine.org=,
+=pricing_configuration.org=, =pl_attribution.org=,
+=risk_reporting.org=, =trade_blotter.org=.
+=reporting.org= was superseded; its content merged into
+=pl_attribution.org= and =risk_reporting.org=.
+All documents committed on =feature/port-domain-concept-notes=.

--- a/doc/agile/versions/v0/sprint_18/port_domain_concept_notes/task_implement_port_domain_concept_notes.org
+++ b/doc/agile/versions/v0/sprint_18/port_domain_concept_notes/task_implement_port_domain_concept_notes.org
@@ -28,7 +28,7 @@ Read all nine source notes under =/home/marco/Development/Notebooks/summaries/=,
 |--------------+------------------------------------------------------------|
 | State        | DONE                                                       |
 | Parent story | [[id:4E375DD6-E300-4A0A-BD20-3D06AC8ED7A1][Port domain concept notes to knowledge documents]]           |
-| Now          | All 8 knowledge documents created and committed.           |
+| Now          | Complete.                                                  |
 | Waiting on   | Nothing.                                                   |
 | Next         | Raise PR.                                                  |
 | Last touched | 2026-05-25                                                 |
@@ -72,9 +72,10 @@ Source files to process (=/home/marco/Development/Notebooks/summaries/=):
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                              | File                                    | Decision | Notes                               |
+|---+--------------------------------------------------------------+-----------------------------------------+----------+-------------------------------------|
+| 1 | DONE task: Now field should be "Complete" not prose          | task_implement_port_domain_concept_notes.org | Fixed | Changed to "Complete."          |
+| 2 | Aggregation hierarchy uses "Trade Aggregate"; should be "Structure" | pl_attribution.org             | Fixed | Updated hierarchy line              |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_18/port_domain_concept_notes/task_implement_port_domain_concept_notes.org
+++ b/doc/agile/versions/v0/sprint_18/port_domain_concept_notes/task_implement_port_domain_concept_notes.org
@@ -9,7 +9,7 @@
 #+filetags: :port_domain_concept_notes:sprint_18:v0:
 #+owner: marco
 #+branch: feature/port-domain-concept-notes
-#+pr: 844
+#+pr: [[https://github.com/OreStudio/OreStudio/pull/844][844]]
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-25
@@ -66,9 +66,9 @@ Source files to process (=/home/marco/Development/Notebooks/summaries/=):
 
 * PRs
 
-| PR  | Title                                           |
-|-----+-------------------------------------------------|
-| 844 | Port domain concept notes to knowledge documents |
+| PR                                                                  | Title                                            |
+|---------------------------------------------------------------------+--------------------------------------------------|
+| [[https://github.com/OreStudio/OreStudio/pull/844][#844]]          | Port domain concept notes to knowledge documents |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/port_domain_concept_notes/task_implement_port_domain_concept_notes.org
+++ b/doc/agile/versions/v0/sprint_18/port_domain_concept_notes/task_implement_port_domain_concept_notes.org
@@ -9,7 +9,7 @@
 #+filetags: :port_domain_concept_notes:sprint_18:v0:
 #+owner: marco
 #+branch: feature/port-domain-concept-notes
-#+pr: [[https://github.com/OreStudio/OreStudio/pull/844][844]]
+#+pr: 844
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-25

--- a/doc/agile/versions/v0/sprint_18/port_domain_concept_notes/task_implement_port_domain_concept_notes.org
+++ b/doc/agile/versions/v0/sprint_18/port_domain_concept_notes/task_implement_port_domain_concept_notes.org
@@ -1,0 +1,79 @@
+:PROPERTIES:
+:ID: FBB4FEE3-5DB0-4404-893E-6FE298E22088
+:END:
+#+title: Task: Survey notes and create initial knowledge documents
+#+description: Read all nine source notes, decide on document split, create v2 knowledge documents under doc/knowledge/domain/, align terminology with ORE Studio.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :port_domain_concept_notes:sprint_18:v0:
+#+owner: marco
+#+branch: feature/port-domain-concept-notes
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:4E375DD6-E300-4A0A-BD20-3D06AC8ED7A1][Port domain concept notes to knowledge documents]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Read all nine source notes under =/home/marco/Development/Notebooks/summaries/=, produce a document split plan, then create the v2 knowledge documents under =doc/knowledge/domain/= with correct frontmatter, cross-links, and ORE Studio-aligned terminology.
+
+* Status
+
+| Field        | Value                                                      |
+|--------------+------------------------------------------------------------|
+| State        | STARTED                                                    |
+| Parent story | [[id:4E375DD6-E300-4A0A-BD20-3D06AC8ED7A1][Port domain concept notes to knowledge documents]]           |
+| Now          | Reading source notes; planning document split.             |
+| Waiting on   | Nothing.                                                   |
+| Next         | Create knowledge documents; raise PR.                      |
+| Last touched | 2026-05-25                                                 |
+
+* Acceptance
+
+- All nine source notes read and accounted for.
+- Document split plan recorded in =* Notes= below before writing begins.
+- All resulting files are valid v2 knowledge documents.
+- Terminology gaps (e.g. "grid", "jobs") either resolved or explicitly
+  flagged inline for follow-up.
+- New docs linked from the domain knowledge index.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+Source files to process (=/home/marco/Development/Notebooks/summaries/=):
+
+| File                           | Status  | Notes                                                      |
+|--------------------------------+---------+------------------------------------------------------------|
+| fx-vol-surface.org             | Pending |                                                            |
+| grid-infrastructure.org        | Pending | Rename: "compute engine". Map job/grid terms to ORE Studio |
+| pl-attribution.org             | Pending |                                                            |
+| pricing-configuration.org      | Pending |                                                            |
+| rates-curves-bootstrapping.org | Pending | May split: rates vs curves vs bootstrapping                |
+| reporting.org                  | Pending | Already superseded; merge into risk-reporting + pl-attribution |
+| risk-reporting.org             | Pending |                                                            |
+| time-structures-tenors.org     | Pending | May split: time structures vs tenor conventions            |
+| trade-blotter.org              | Pending | Cross-link to Qt UI concepts (TradeDetailDialog, etc.)     |
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -73,6 +73,7 @@ In execution order.
 | [[id:16851249-2FB0-443E-83E0-55D6B8051272][Sprint health review — System 2 analysis]]           | STARTED | 2026-05-25 | | =sprint-reviewer= skill writes a structured health-check section into =sprint.org=. |
 | [[id:C3B6F514-559F-4038-A1D7-947BC9F7F398][Add Downloads and Agile nav entries to the site]]    | BACKLOG | 2026-05-25 | | =doc/downloads.org= with release table; =Downloads= and =Agile= links in site nav.         |
 | [[id:6EBB206D-167F-4A0F-8F50-04D7EB4B7E33][Fix PDF site delivery and switch manual to book class]] | STARTED | 2026-05-25 | | Add =site:pdf= publish component; switch manual to =book= LaTeX class; regenerate PDF.     |
+| [[id:4E375DD6-E300-4A0A-BD20-3D06AC8ED7A1][Port domain concept notes to knowledge documents]]      | STARTED | 2026-05-25 | | Tidy personal finance/ORE domain notes into v2 knowledge docs; align with ORE Studio terms. |
 
 * Health Review
 

--- a/doc/knowledge/domain/compute_engine.org
+++ b/doc/knowledge/domain/compute_engine.org
@@ -1,0 +1,348 @@
+:PROPERTIES:
+:ID: 98B9FE2A-57FB-464F-A4E5-198461FE6987
+:END:
+#+title: Compute Engine
+#+description: Distributed computation architecture for valuation and reporting: run configurations, compute jobs, orchestration, chunking, environments, lifecycle, priorities, and auditability.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :knowledge:domain:finance:compute:ore:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+
+The *compute engine* is the execution backbone of the valuation and reporting
+system. All significant valuation work — risk reports, P&L explains, EOD MTM
+runs, credit exposure aggregations — is dispatched through it. This document
+describes the conceptual architecture of a production-grade distributed compute
+engine as it applies to FX/derivatives valuation, with notes on how these
+concepts map to [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][ORE]] and [[id:D04D3476-D7C5-3954-A33B-C641EBCB43F6][ORE Studio]]. For report definitions and
+Greek configuration see [[id:04C68B55-E0B5-41CD-B90E-D670C17530B6][Risk Reporting]]. For pricing configuration
+see [[id:EDAE3C87-7733-4D0C-881F-5AA65DD832AC][Pricing Configuration]].
+Return to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
+
+* Overview
+
+The compute engine separates /what to compute/ (run configurations, report
+definitions) from /how to compute it/ (the execution mechanics: workers,
+chunking, queuing). This separation allows the same report definition to be
+executed ad-hoc by a trader or as part of a scheduled overnight batch without
+changes to the definition itself.
+
+The infrastructure is responsible for scheduling, partitioning, dispatching,
+monitoring, and collecting the outputs of these computations.
+
+*ORE Studio mapping*: In ORE Studio, [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][ORE]] (Open Source Risk Engine) is the
+compute engine. ORE is currently single-process; it does not implement
+distributed orchestration itself. The concepts described below apply to
+production deployments that wrap ORE (or equivalent engines) in a distributed
+execution layer. ORE Studio will eventually add a multi-process execution layer
+on top of ORE; these concepts will apply directly when that work begins.
+
+* Core Entities
+
+** Run Configuration
+
+A *Run Configuration* (in generic grid systems called a /Job Set Definition/)
+is a template describing a logically related collection of work — for example,
+the full EOD P&L run for a branch. It groups one or more Computation
+Definitions and captures the dependencies between them. It is a
+/definition/, not an execution: it carries no runtime state.
+
+*ORE equivalent*: An ORE =ore.xml= analytics configuration file, which lists
+which analytics to run and in what order.
+
+** Computation Definition
+
+A *Computation Definition* (generic: /Job Definition/) is a template for a
+single unit of computation. It specifies:
+
+- *Inputs*: What data the computation needs. Inputs may be:
+  - Direct values (XML blobs, JSON payloads)
+  - /Tokens/: symbolic references resolved at runtime into concrete values
+    (e.g. a reference to "today's EOD market data cut" resolves to a specific
+    versioned snapshot when the computation is dispatched)
+- *Executor*: The service responsible for running the computation (e.g. the
+  ORE analytics service).
+- *Expected outputs*: The result schema.
+
+*ORE equivalent*: An individual analytics block in =ore.xml=, such as
+=<Analytic type="NPV">= or =<Analytic type="SENSITIVITY">=.
+
+** Computation Run
+
+A *Computation Run* (generic: /Job/) is a runtime instance of a Computation
+Definition. It is created by supplying concrete values for all inputs
+(including resolved tokens). A Computation Run is the atomic unit of
+scheduled and tracked work. Runs have:
+
+- A status (pending, running, succeeded, failed)
+- A priority
+- A reference to the Computation Definition it instantiates
+- Zero or more dependencies on other Runs
+
+** Batch
+
+A *Batch* (generic: /Job Set/) is a runtime instance of a Run Configuration
+— a collection of Computation Runs tracked and managed together. The Batch is
+the unit of /orchestrated work/ submitted by a user or a scheduler.
+
+** Run Dependency
+
+A *Run Dependency* links two Computation Runs within a Batch, specifying that
+one must complete successfully before another may begin. Dependencies form a
+directed acyclic graph (DAG) within a Batch.
+
+** Run Queue
+
+The *Run Queue* is the ordered list of ready-to-run Computation Runs — those
+whose dependencies have been satisfied and which are waiting for a free
+executor. The queue is ordered by priority. Persistent storage (e.g. an RDBMS)
+backs the queue to survive process restarts and node failures.
+
+* Execution Components
+
+** Orchestrator
+
+The *Orchestrator* (generic: /Director/) is the central coordinator of the
+compute engine. Its responsibilities:
+
+- Monitoring all active Executors and handling their failures
+- Dispatching Computation Runs from the queue to available Executors
+- Receiving status and progress reports from Executors
+- Managing Batch lifecycle (creation, completion, cancellation)
+- Applying retry logic for failed Runs
+
+The Orchestrator is the single authoritative source of engine state. It ensures
+that at most one Executor is running any given Computation Run at any time.
+
+** Executor
+
+An *Executor* (also called a /Worker/) is a service that runs on a Compute Node
+and is capable of executing Computation Runs of one or more types. Executors:
+
+- Register with the Orchestrator and report capacity
+- Accept dispatches from the Orchestrator
+- Invoke the appropriate Engine for the computation type
+- Report progress and completion back to the Orchestrator
+- Return results (or error details) on completion
+
+** Engine
+
+The *Engine* is the code running inside an Executor that performs the actual
+computation. It is the /domain-logic/ component:
+
+- *Quant Library*: Low-level numerical primitives (e.g. QuantLib, [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][ORE]]). Not
+  suitable for direct invocation; provides building blocks for the Risk Engine.
+- *Risk Engine*: Higher-level orchestration layer built on the Quant Library.
+  Handles trade population loading, market data assembly, pricer dispatch, and
+  result collection. Single-process. In ORE Studio this is ORE.
+
+The Risk Engine is versioned independently of the execution infrastructure.
+Users deploy a specific version of the Risk Engine to a cluster; Computation
+Runs reference the engine and version they require.
+
+** Chunker
+
+The *Chunker* is responsible for partitioning a large input set into
+sub-units — /chunks/ or /partitions/ — of roughly equal computational cost,
+distributed across available Executors. Chunking happens /up front/ before
+dispatch.
+
+Different chunking strategies are required depending on the nature of the input:
+
+- *By book*: partition the trade population by trading book
+- *By trade*: partition individual trades (for fine-grained parallelism)
+- *By scenario*: partition Monte Carlo scenarios
+- *By tenor*: partition curve bootstrapping by maturity segment
+
+The Chunker's goal is a /fair distribution/ of work: each Executor should
+finish at approximately the same time to avoid stragglers holding up the Batch.
+
+** Compute Node
+
+A *Compute Node* is a machine (physical or virtual) that hosts one or more
+Executors. It has the ability to run the Risk Engine. A Compute Node manages:
+
+- Receiving computation inputs from the Orchestrator / message bus
+- Invoking the Risk Engine
+- Retrieving and returning results
+
+** Cluster
+
+A *Cluster* is a named group of Compute Nodes. Each cluster has:
+
+- A defined set of authorised users
+- Specific technology interfaces and protocols (message queue, REST API, etc.)
+- An associated Environment label
+
+* Environments
+
+A cluster is always deployed within an *Environment*, which describes its
+purpose and production-readiness:
+
+| Environment    | Description                                                         |
+|----------------+---------------------------------------------------------------------|
+| Local          | Developer's own workstation; single-node, no HA                     |
+| Shared Dev     | Shared development environment; multiple developers                 |
+| Shared Testing | Shared environment for QA and integration testing                   |
+| Staging        | Near-production replica used for final pre-release validation       |
+| Pre-Live       | Limited release to end users before full rollout                    |
+| Live           | Full production environment                                         |
+
+*Blue/Green Deployment*: A staged rollout strategy that gradually shifts traffic
+from the previous version of the Risk Engine to a new one, enabling rollback
+without downtime.
+
+* In-Process Execution
+
+A Computation Run may be executed /in-process/ — without going through the
+distributed engine at all. This mode is used for:
+
+- Ad-hoc developer testing
+- Local-environment runs where distribution overhead is not justified
+- Fast single-trade valuations triggered from the trading UI
+
+In-process execution uses the same Risk Engine code path as distributed
+execution; only the transport and orchestration layers are bypassed.
+
+*ORE Studio today*: ORE Studio currently uses in-process execution exclusively.
+ORE is invoked directly from the application process. Distributing execution
+across multiple nodes is a future capability.
+
+* Computation Run Lifecycle
+
+#+begin_example
+  Definition
+      |
+      | (instantiate with inputs)
+      v
+   Pending ──► Chunking ──► Queued ──► Dispatched ──► Running ──► Succeeded
+                                                           |
+                                                           └──────────────► Failed ──► Retry / Abandoned
+#+end_example
+
+1. A Batch is created from a Run Configuration with concrete inputs (tokens
+   resolved).
+2. The Chunker partitions inputs and creates individual Computation Runs.
+3. Runs with no unsatisfied dependencies enter the queue.
+4. The Orchestrator dispatches queued Runs to available Executors in priority
+   order.
+5. The Executor runs the Engine and reports completion.
+6. Dependent Runs are released to the queue as their prerequisites complete.
+7. The Batch completes when all constituent Runs have succeeded (or the batch
+   is cancelled / failed).
+
+* Run Priorities
+
+Computation Runs carry a numeric priority. The Orchestrator dispatches
+higher-priority Runs first when multiple Runs are queued for the same Executor
+pool. Priority sources include:
+
+- Run type (intraday ad-hoc risk typically has higher priority than overnight
+  batch)
+- User or book (senior traders / risk managers may have elevated priority)
+- Deadline (runs with an approaching SLA deadline are escalated)
+
+* EOD Run Types
+
+The following run types execute as part of the standard end-of-day batch:
+
+| Run Type                | Description                                                          |
+|-------------------------+----------------------------------------------------------------------|
+| MTM Valuation           | Full valuation of all live trades against the EOD market data cut   |
+| P&L Explain (Day 0→1)   | Bump-and-Reset / Bump-and-Run P&L attribution for the day's move    |
+| IPV Explain             | P&L movement from internal bank rates to independently sourced rates|
+| Credit Aggregation      | Full counterparty portfolio aggregation (Monte Carlo + SCA)         |
+| Curve Bootstrapping     | Rebuild of all discount and projection curves from new market data  |
+| Vol Surface Build       | Reconstruction of all vol surfaces from updated pillars             |
+
+EOD runs may depend on each other (e.g. curve bootstrapping must complete
+before MTM valuation; MTM valuation must complete before the Explain). These
+dependencies are captured in the Run Configuration for the EOD batch.
+
+* Intraday and Scheduled Runs
+
+** Ad-Hoc Risk Requests
+
+Traders can submit ad-hoc reports at any time. These are instantiated as
+single-Run Batches with high priority and execute against a snapshot of current
+market data. Results are returned to the requesting UI session.
+
+** Scheduled Runs
+
+Runs can be scheduled to run at predefined times (e.g. AM Flash P&L at 08:00,
+PM Flash at 16:00, EOD batch at 18:30). The schedule is configured per Run
+Configuration and per environment.
+
+** Rules-Based Run Triggers
+
+Runs may be triggered automatically when a monitored condition is breached:
+
+- *Throughput Panic*: Triggered when the number of transactions in a currency
+  pair over a rolling window exceeds a configured threshold.
+- *Amount Breach*: Triggered when a notional amount exceeds a limit.
+- *Market Data Move*: Triggered when spot or vol moves by more than a
+  configured threshold.
+
+Triggered runs are recorded with a timestamp and the triggering event, creating
+an audit trail.
+
+* Credit Exposure Grid Points
+
+For credit exposure computation the engine has additional structure: future
+scenarios are simulated at a set of /grid points/ (future dates), and trade
+MtMs are computed at each grid point for each scenario.
+
+- *Grid Point*: A specific future date at which the portfolio value is
+  simulated under each Monte Carlo scenario.
+- *Scenario*: A realisation of all market variables (spots, rates, vols) at a
+  future grid point.
+
+Aggregation across scenarios at each grid point yields an MtM distribution; the
+95th percentile of that distribution is the *Credit Line Utilisation (CLU)*
+contribution from that grid point.
+
+Two aggregation modes:
+
+- *Full Aggregation*: Complete re-simulation and re-aggregation of the entire
+  counterparty portfolio.
+- *Gross Add-On*: An incremental mechanism to handle intraday trades without
+  re-running a full aggregation.
+
+$$\text{Uncollateralised CLU} = \text{MC 95th pct} + \text{SCA Max Shift} + \text{Trade Overwrites} + \text{Gross Add-On}$$
+
+* Tokenisation
+
+Inputs to Computation Definitions may be *tokens* — symbolic references to
+data that does not exist at definition time but will be resolved at run
+instantiation. Examples:
+
+- =TODAY_EOD_CUT= resolves to the specific versioned market data snapshot
+  signed off for today's EOD.
+- =ACTIVE_BOOKS(BRANCH_LONDON)= resolves to the current set of trading books
+  for the London branch.
+
+Tokenisation decouples the definition (written once, reused daily) from the
+runtime inputs (resolved fresh each time the run executes). The Tokenisation
+Table in the persistent store records the mapping from token to resolved value
+for each Run instance, ensuring reproducibility.
+
+* Reproducibility and Auditability
+
+A key requirement is that any Computation Run instance can be re-run and
+produce the same output. This requires:
+
+- All inputs (market data snapshots, trade population snapshots, model
+  configuration) to be version-stamped and immutable once captured.
+- Resolved token values to be persisted alongside the Run record.
+- The Risk Engine version used to be recorded on the Run.
+- Results to be stored and queryable independently of whether the original run
+  is still executing.
+
+Finance and Risk use this audit trail to reproduce EOD valuations, investigate
+P&L discrepancies, and respond to regulatory queries.
+
+*ORE Studio*: ORE's =ore.xml= together with the market data and trade
+population XML files constitute the full reproducible input set. ORE Studio
+must snapshot these at each analytics run and store them alongside the results
+for auditability.

--- a/doc/knowledge/domain/fx_volatility_surface.org
+++ b/doc/knowledge/domain/fx_volatility_surface.org
@@ -1,0 +1,247 @@
+:PROPERTIES:
+:ID: 5B513D53-5DF7-4540-99C0-60D909678873
+:END:
+#+title: FX Volatility Surface
+#+description: Structure, construction, and conventions of the FX implied volatility surface: pillar quoting (ATM/RR/STR), delta conventions, smile models (SABR, BS, spline), and cross-time interpolation.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :knowledge:domain:finance:fx:volatility:ore:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+
+The FX volatility surface is the primary market data input for pricing and
+risk-managing FX options in [[id:D04D3476-D7C5-3954-A33B-C641EBCB43F6][ORE Studio]]. It is a two-dimensional function of
+implied Black-Scholes volatility across strike (or delta) and expiry tenor.
+This document covers pillar structure, delta conventions, smile models, and
+surface construction. For how vol surfaces interact with pricing configuration
+see [[id:EDAE3C87-7733-4D0C-881F-5AA65DD832AC][Pricing Configuration]].
+Return to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
+
+* Overview
+
+An FX volatility surface is a two-dimensional function of implied Black-Scholes
+volatility across strike (or delta) and expiry tenor. Unlike equity vol surfaces
+— which are quoted strike-by-strike — FX vol surfaces are quoted using a set of
+/market pillars/ expressed in terms of option structure and delta: the ATM
+straddle, the Risk Reversal (RR), and the Strangle (STR). These three pillars,
+at each tenor, fully parameterise the surface under standard smile models such
+as SABR.
+
+The surface must be constructed consistently across both dimensions: across
+strikes at a fixed maturity (the /smile/) and across maturities at a fixed
+strike or delta (the /term structure/).
+
+* Core Pillar Structures
+
+** ATM Volatility
+
+The ATM (at-the-money) quote is the implied volatility of the option struck at
+the ATM level, quoted as a single number per tenor. The definition of "ATM"
+matters and is convention-dependent (see =* ATM Conventions= below).
+
+A *straddle* is a long call and long put at the same strike and expiry.
+At-the-money, the two delta components cancel and the position has (approximately)
+zero delta. The straddle price is driven almost entirely by volatility level.
+
+ATM vol captures the /height/ of the smile at a given tenor.
+
+** Risk Reversal (RR)
+
+A risk reversal is the difference in implied volatility between an
+out-of-the-money call and an OTM put at the same delta magnitude:
+
+$$\sigma_{RR}^{25\Delta} = \sigma_{call}^{25\Delta} - \sigma_{put}^{25\Delta}$$
+
+A positive RR means the call is more expensive than the put (market is paying
+for upside protection in the foreign currency). RR measures the /skew/ of the
+smile — the asymmetry between the two wings.
+
+At 25Δ the convention is to quote the 25-delta call vol minus the 25-delta put
+vol. At 10Δ the same structure gives a wider, more extreme read on the wings.
+
+** Strangle (STR) / Butterfly (BF)
+
+A strangle (or butterfly in some conventions) measures the average premium of
+the two OTM wings relative to ATM:
+
+$$\sigma_{STR}^{25\Delta} = \frac{\sigma_{call}^{25\Delta} + \sigma_{put}^{25\Delta}}{2} - \sigma_{ATM}$$
+
+The strangle captures the /curvature/ of the smile — how "fat" the wings are
+relative to the centre. A positive strangle means OTM options are more
+expensive than ATM, as is typical in FX.
+
+** The Three-Pillar Parameterisation
+
+ATM, RR, and STR together encode the first three degrees of freedom of the
+smile at each tenor: level (ATM), skew (RR), and curvature (STR). Under SABR
+and similar models, these three numbers uniquely determine the smile.
+
+Standard delta grids used in practice:
+
+| Delta | Structures quoted             |
+|-------+-------------------------------|
+| 25Δ   | ATM, 25Δ RR, 25Δ STR         |
+| 10Δ   | 10Δ RR, 10Δ STR (wings)      |
+
+The full five-pillar quote (10Δ put, 25Δ put, ATM, 25Δ call, 10Δ call) gives
+a richer representation of the wings and is needed for more exotic pricing.
+SABR does not natively support five-point smiles; five-point spline
+interpolation is used for those cases.
+
+* Delta Conventions
+
+The definition of delta used to locate option strikes is not universal in FX
+and must be agreed between counterparties and within systems.
+
+** Spot Delta vs. Forward Delta
+
+- *Spot Delta*: $\Delta_{spot} = e^{-r_f T} N(d_1)$ — measures sensitivity of
+  option value to the spot rate. Standard in the short end.
+- *Forward Delta*: $\Delta_{fwd} = N(d_1)$ — measures sensitivity to the
+  forward rate. Standard for longer maturities.
+
+The convention switch from spot to forward delta typically occurs around 1Y for
+most currency pairs, but varies. Quoting and risk systems must flag which
+convention is in use (often denoted S/F on screens).
+
+** Premium-Adjusted Delta
+
+When the option premium is paid in the foreign currency (as is common for
+currency pairs where the foreign currency is the numeraire), the delta must be
+adjusted for the premium received. Premium-adjusted delta differs from
+unadjusted delta by the option value divided by spot; the difference is small
+for OTM options but significant for ITM ones. This affects where OTM strikes
+sit and must be handled consistently across the surface.
+
+** Strike from Delta
+
+Given a delta convention and a vol, the corresponding strike is backed out from
+the Black-Scholes formula. The surface is therefore ultimately stored in strike
+space (or log-moneyness) internally, even though it is quoted in delta space in
+the market.
+
+* ATM Conventions
+
+The definition of "ATM" determines the anchor of the smile. Two conventions
+are in common use:
+
+- *Delta-Neutral Straddle (DNS / Zero-Delta Straddle)*: The strike at which a
+  straddle has zero delta. For a currency pair with significant interest rate
+  differential, this differs from the forward. This is the standard convention
+  for tenors up to =10Y=.
+
+- *ATM Forward (ATMF)*: The strike equal to the forward rate. Simpler to
+  compute; standard for tenors =12Y= and beyond (=12Y=--=30Y=).
+
+Systems must implement the DNS/ATMF switch cleanly, as the transition creates a
+discontinuity in delta space at the switch tenor if not handled carefully.
+
+* Smile Models
+
+** SABR
+
+SABR (Stochastic Alpha Beta Rho) is the standard smile model for FX. With
+$\beta = 1$ (log-normal backbone), SABR is a three-parameter model:
+
+- $\alpha$: initial volatility (maps to ATM)
+- $\nu$ (vol-of-vol): controls curvature (maps to STR)
+- $\rho$ (spot-vol correlation): controls skew (maps to RR)
+
+The calibration procedure maps the three market pillars (ATM, RR, STR) to the
+three SABR parameters at each tenor. SABR produces smooth, arbitrage-free smiles
+in the body but can exhibit instability in the far wings (very low or very high
+deltas), requiring wing stabilisation.
+
+Additional SABR term-structure parameters — per tenor — include correlation
+sensitivity (up/down), vol adjustments, RR infinite flag, vol swap adjustments,
+and standard deviation weighting. These are model parameters rather than market
+observables. In [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][ORE]] these appear as entries in the =EngineData= XML
+configuration.
+
+** Black-Scholes (Flat Vol)
+
+A flat Black-Scholes surface (one vol per tenor, no smile) is always maintained
+alongside the main smile model. It is used for re-parameterisation, as a
+fallback, and for ATM-only pricing. For EM currency pairs where smile data is
+sparse, a flat vol surface may be the primary representation.
+
+** Five-Point Spline
+
+For currency pairs that are well-quoted at 10Δ and 25Δ, a five-point spline
+gives a more detailed smile. SABR does not support five-point calibration;
+instead, spline interpolation is applied directly across the five strikes. The
+extra points give finer control over the wings but require more calibration
+data and introduce more model risk.
+
+* Surface Construction: Across Time
+
+The smile at each tenor is calibrated independently; the surface is then
+stitched together across maturities using one of two interpolation conventions:
+
+- *Market Interpolation*: Interpolate directly in market parameter space. For
+  example, if RR is 2% at =1Y= and 2.5% at =2Y=, then at =18M= it is
+  interpolated to ~2.25%. Simple and produces surfaces consistent with market
+  quotes at standard tenors.
+
+- *Physical Interpolation*: Convert market parameters to model (physical)
+  parameters first (e.g. RR → $\rho$, STR → $\nu$), interpolate in model
+  space, then convert back. Produces smoother model dynamics across time but
+  can deviate from quoted market levels at off-pillar tenors.
+
+The choice of interpolation convention (market vs. physical) is a system-level
+or currency-pair-level configuration. EM currency pairs often prefer linear vol
+or linear variance interpolation when ATM curve data is unreliable due to
+missing holidays or events.
+
+Standard vol tenors for consensus submission and surface construction:
+=1W=, =2W=, =1M=, =2M=, =3M=, =6M=, =9M=, =12M=, =18M=, =2Y=, =3Y=, =4Y=,
+=5Y=, =7Y=, =10Y=, =12Y=, =15Y=, =20Y=, =25Y=, =30Y=.
+
+** Curve Split Tenor
+
+A split tenor (typically =5Y=) separates the spline interpolation of the short
+end and long end of the surface. This prevents changes in long-dated vols from
+affecting short-dated smiles and vice versa. For curves that extend only to a
+short maturity, the last tenor is used as the split tenor.
+
+* Volatility Kinds
+
+Different volatility concepts are in use simultaneously; they must not be
+conflated:
+
+| Kind                            | Description                                                             |
+|---------------------------------+-------------------------------------------------------------------------|
+| Implied Vol                     | ATM implied vol of the spot-delta-neutral straddle at a given expiry   |
+| Forward-Forward Vol             | Implied vol for a forward-starting option between two future dates      |
+| Normalised Vol                  | Volatility with a standardised day count (e.g. 252 or 365)             |
+| Historic Vol                    | Realised volatility computed from historical spot moves                 |
+| Decreasing-Maturity Forward Vol | Historic vol computed over a window that ends at a fixed future date    |
+
+* Volatility Masters and Slaves
+
+In a multi-currency system, some currency pairs may not have independent vol
+surfaces. Instead, a /slave/ pair derives its ATM vol, RR, and STR from one or
+more /master/ pairs via a defined relationship:
+
+- *Correlation slaving*: The slave surface is implied from a triangular
+  relationship (e.g. EUR/GBP from EUR/USD and GBP/USD vols and their
+  correlation).
+- *Basis slaving*: The slave ATM vol is the master ATM plus a spread; RR and
+  STR may be independently set or also slaved.
+
+This mechanism reduces the number of independently managed surfaces while
+maintaining consistency across crosses.
+
+* ORE Studio Notes
+
+ORE uses the =FxVolatility= market datum type for FX vol surfaces. Relevant
+ORE configuration files:
+
+- =market.xml= — declares which vol surface type (=FxBlackVolatilitySurface=,
+  =FxBlackVolatilitySurfaceDelta=, etc.) is used per currency pair.
+- =pricingengines.xml= — maps product types to pricers; the pricer selects
+  which vol surface to consume.
+
+ORE Studio will need to model vol surface configurations as domain entities (see
+[[id:A3B7C9E1-4F2D-8A6B-5E1C-9D3F7A0B2E4C][ORE Model Configuration]] for the wider configuration landscape).

--- a/doc/knowledge/domain/interest_rate_curves.org
+++ b/doc/knowledge/domain/interest_rate_curves.org
@@ -1,0 +1,250 @@
+:PROPERTIES:
+:ID: E808F432-2FDA-47E8-B003-1E8B908870FE
+:END:
+#+title: Interest Rate Curves
+#+description: Day-count conventions, discount factors, bootstrapping from deposits/FRAs/IRS/OIS, and interpolation methods for interest rate curves used in FX and rates pricing.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :knowledge:domain:finance:rates:curves:ore:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+
+Interest rate curves are a core market data input in [[id:D04D3476-D7C5-3954-A33B-C641EBCB43F6][ORE Studio]].
+[[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][ORE]] uses them as discount and projection curves throughout valuation. This
+document covers day-count conventions, the bootstrapping process, and
+interpolation. For tenor labels and settlement conventions see
+[[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]]. Return to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
+
+* Overview
+
+An interest rate curve (also called a /discount curve/ or /yield curve/) is a
+term structure of discount factors — one for each tenor — that expresses the
+time value of money. Given a discount factor function $DF(t)$, the present
+value of a future cash flow at time $t$ is obtained by multiplying by $DF(t)$.
+By convention $DF(0) = 1$ and $DF$ is monotonically decreasing for positive
+rates.
+
+The process of constructing a curve from observable market instruments is
+called *bootstrapping*. It proceeds tenor by tenor from the short end to the
+long end, selecting the discount factor at each pillar that reprices the
+corresponding instrument at its current market rate.
+
+Rates are stored internally as discount factors (typically to 15 decimal
+places). Interest rates — whether discrete or continuous — are derived from
+discount factors as required.
+
+* Day-Count Conventions
+
+A day-count convention specifies how to convert a date interval into a
+fraction of a year (the /day-count fraction/ or /year fraction/) for the
+purpose of computing interest. Different instruments and currencies use
+different conventions; mixing them silently is a common source of error.
+
+| Convention  | Description                                                          | Typical use                         |
+|-------------+----------------------------------------------------------------------+-------------------------------------|
+| =ACT/360=   | Actual calendar days divided by 360                                  | Money market (USD, EUR deposits)    |
+| =ACT/365=   | Actual calendar days divided by 365                                  | GBP money market, GBP IRS           |
+| =ACT/ACT=   | Actual days in period divided by actual days in year (ISDA or ICMA) | Government bonds, IRS in some ccys  |
+| =30/360=    | Each month treated as 30 days, year as 360                           | Fixed-rate bonds (USD, EUR)         |
+| =BUS/252=   | Business days divided by 252                                         | BRL and some LatAm money markets    |
+
+The day-count fraction $\Delta t$ appears directly in coupon and interest
+calculations:
+
+$$\text{Interest}(t_n, t_{n+k}) = \left[ \frac{DF(t_n)}{DF(t_{n+k})} - 1 \right]$$
+
+A single currency may use different conventions for its money market and its
+swap market. For example, a GBP IRS conventionally has a 6-month floating
+period on an =ACT/365= basis.
+
+** Day Basis vs. Spot Days
+
+The /day basis/ (day-count convention) for the money market of a currency can
+differ from the FX day basis used when computing forward points for that
+currency. These must not be conflated.
+
+* Discount Factors and Rates
+
+** Discount Factor to Rate Conversion
+
+Given a discount factor $DF$ over $D$ calendar days, the discrete (money
+market) rate is:
+
+$$r = \left[ \left( \frac{1}{DF} \right)^{365/D} - 1 \right] \times 100$$
+
+where 365 is replaced by the appropriate day basis for the currency.
+
+A continuous rate $r_c$ converts to a discrete rate as:
+
+$$r_d = \left( e^{r_c/100} - 1 \right) \times 100$$
+
+Internal implementations prefer continuous rates because they are additive in
+log space; market quotations are always discrete.
+
+** Spot Interest Rate
+
+A spot interest rate for maturity $M$ is an interest rate payable on a spot
+loan of maturity $M$ that accumulates interest to maturity. Discount factors
+therefore reflect discounting to the spot date, not to today — a convention
+that must be tracked when computing present values.
+
+** Zero Coupon Normalisation
+
+Because different instruments embed different coupon structures, bootstrapped
+curves are normalised to /zero coupon (ZC) curves/ — continuous rates where
+every tenor carries the same economic meaning (yield of a zero-coupon bond).
+This allows discount and projection curves built from different instruments to
+be compared and combined consistently.
+
+* Input Instruments
+
+The instruments used to build a curve are called /pillar instruments/. Each
+instrument fixes one point on the curve. The bootstrapped curve must reprice
+every pillar instrument at its observed market rate.
+
+** Deposits (Depos)
+
+A deposit is a single-period instrument: cash is placed (lent) at the near leg
+and returned with interest at the far leg. Deposits are the primary instrument
+for the very short end (=O/N= through to =6M=), quoting rates directly as
+LIBOR or equivalent fixings. The instrument defines:
+
+- Near leg: cash outflow on start date
+- Far leg: return of principal plus interest on maturity date
+- Rate: fixed on trade date; day basis is currency-specific
+
+** Forward Rate Agreements (FRA)
+
+An FRA is like a deposit that starts in the future. It locks in a fixed rate
+for a specified future period against the floating fixing at settlement. FRAs
+have zero value at initiation (fixed rate equals expected floating rate). They
+are used to bootstrap the curve in the =3M=--=12M= region where deposits
+become illiquid.
+
+** Interest Rate Swaps (IRS)
+
+An IRS exchanges two streams of interest payments — typically fixed vs.
+floating — on a notional principal over multiple periods. The fixed rate (the
+/swap rate/) is set at inception to make the trade NPV-zero:
+
+$$PV_{\text{fixed}} = \sum_{i=1}^{n} N \cdot r_{\text{fixed}} \cdot \Delta t_i \cdot DF(t_i)$$
+$$PV_{\text{float}} = \sum_{j=1}^{m} N \cdot r_{\text{fwd},j} \cdot \Delta t_j \cdot DF(t_j)$$
+
+IRS are the primary pillar instrument for tenors from =1Y= to =30Y=. Each
+currency has a standard IRS description specifying payment frequency and day
+count (e.g. GBP: 6M period, =ACT/365=).
+
+Key IRS types:
+
+- *Fixed/Floating, same currency*: the vanilla swap; floating leg typically
+  LIBOR or SOFR
+- *Fixed/Floating, cross-currency*: fixed rate on one currency notional vs.
+  floating on another; introduces FX risk
+- *Floating/Floating, same currency (Basis Swap)*: two different floating
+  indices (e.g. 3M LIBOR vs 6M LIBOR); used to capture tenor basis
+- *Floating/Floating, cross-currency*: two floating indices in different
+  currencies; carries both IR and FX risk
+
+** Short-Term Interest Rate (STIR) Futures
+
+Exchange-traded quarterly contracts (Eurodollar, Short Sterling) priced off
+3M rates at IMM dates. Used to fill the =6M=--=2Y= gap where liquid deposit
+and swap quotes are sparse. The bootstrapper takes the nearest IMM quarterly
+futures and discounts back to derive the curve.
+
+** OIS (Overnight Index Swap)
+
+An OIS exchanges a fixed rate for a compounded overnight rate (Fed Funds,
+EONIA, SONIA, SOFR, etc.) over a given period. Post-2008, OIS curves became
+the standard collateralised discount curve. The OIS rate represents near-risk-free
+funding; the spread over OIS is the basis adjustment for uncollateralised
+exposure (relevant for FVA and MVA calculations).
+
+* Bootstrapping: USD Curve Construction
+
+The USD discount curve is the foundation of most FX and rates market data
+systems. Many systems store only the USD curve plus forward points for all USD
+crosses, deriving other curves from these.
+
+Bootstrapping proceeds in segments by instrument type:
+
+| Tenor range             | Instrument                   | Notes                                        |
+|-------------------------+------------------------------+----------------------------------------------|
+| =O/N= -- =1M=           | Cash deposits / LIBOR        | May extend to =6M= for some currencies       |
+| =6M= -- =1Y=            | STIR Futures (quarterly IMM) | Nearest contracts discounted back            |
+| =1Y= -- =7Y=            | 1M Fixed IRS, time-valued    | Covers =1Y=, =2Y=, =3Y=, =4Y=, =5Y=, =6Y=, =7Y= |
+| =18M=                   | 3M Fixed IRS, time-valued    | Odd pillar between =1Y= and =2Y=             |
+| =2Y= -- =10Y=           | 3M Reset IRS, time-valued    | Overlaps with above for cross-check          |
+| =<15Y= odd              | Interpolated                 | No liquid instrument; interpolate            |
+| =15Y=, =20Y=, =25Y=, =30Y= | Plain IRS                 | Long end liquid vanilla swaps                |
+
+At each pillar, the bootstrapper solves for the discount factor that makes the
+instrument NPV zero, taking all shorter-maturity discount factors as given.
+Longer pillars require accounting for all intermediate coupon payments (e.g.
+an 18M IRS has two legs: a 12M leg reusing the already-bootstrapped =12M=
+point, plus a new =6M= leg from =12M= to =18M=).
+
+The USD curve is then used to derive forward rates for other currencies via
+forward point arithmetic.
+
+** Projection Curves
+
+A discount curve tells us the time value of money; a /projection curve/ tells
+us what future floating fixings are expected to be. A system maintains multiple
+projection curves per currency — one for each floating tenor (3M LIBOR, 6M
+LIBOR, etc.) — because basis spreads mean 3M and 6M projections diverge. All
+projected cashflows are discounted using the funding (discount) curve.
+
+* Interpolation Methods
+
+A bootstrapped curve is defined only at its pillar tenors. Interpolation is
+required for any date between pillars.
+
+** Local Methods
+
+Local methods use only the immediately bracketing pillars; changing one pillar
+does not affect distant tenors.
+
+- *Log-Linear (Linear in log-DF)*: Discount factor changes by a constant ratio
+  every day within an interval. Daily forward rates are constant within each
+  interval. Simple and stable; the industry default for the short end.
+
+- *Zero-Linear (Linear in zero rate)*: Linear in $-\ln(DF)/t$. Daily forward
+  rates change at a constant rate within each interval.
+
+Both perform well in low-curvature regimes.
+
+** Non-Local Methods
+
+Non-local methods take into account the full shape of the curve, producing
+smoother results but introducing the risk that changing one pillar affects
+distant tenors.
+
+- *Cubic Spline*: Piecewise cubic polynomial fitted globally. Produces smooth
+  forward curves but can generate oscillations and negative forward rates in
+  extreme cases.
+
+- *Monotone Spline*: A shape-preserving variant of the cubic spline that
+  prevents oscillations while maintaining smoothness.
+
+A single curve may use different interpolation methods at different tenor
+ranges (e.g. log-linear at the short end, cubic spline beyond =2Y=). A /curve
+split tenor/ (typically =5Y=) separates the short-end and long-end spline
+segments, preventing changes at one end from propagating to the other.
+
+It is critical that all systems consuming the same curve agree on the
+interpolation method; different methods will produce different forward rates at
+off-pillar dates.
+
+* ORE Studio Notes
+
+ORE models interest rate curves in =curveconfig.xml= (curve pillar
+definitions and instrument choices) and =market.xml= (which curves serve as
+discount vs. projection for each currency). Bootstrapping is performed
+automatically by ORE at the start of each analytics run before any pricing
+takes place. The interpolation method for each curve is set in =curveconfig.xml=.
+
+ORE Studio exposes these configurations through the reference data domain
+(=ores.refdata=) and will eventually surface them as editable entities in the
+UI.

--- a/doc/knowledge/domain/pl_attribution.org
+++ b/doc/knowledge/domain/pl_attribution.org
@@ -1,0 +1,306 @@
+:PROPERTIES:
+:ID: B50355E0-F016-4CA1-9932-404DAF83EA7A
+:END:
+#+title: P&L Attribution
+#+description: P&L attribution (Explain) methodology: the attribution identity, Bump and Reset, Bump and Run, trade activity categories, market data bucketing, time component, deal population rules, EOD sign-off, and aggregation.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :knowledge:domain:finance:pnl:reporting:ore:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+
+P&L Attribution (also called /Explain/) decomposes the change in a book's
+P&L between two time periods into a set of identified, labelled causes. The
+purpose is to ensure that every unit of P&L movement has an explanation;
+unexplained P&L is not permitted. This document describes the attribution
+methodology, decomposition categories, bucketing hierarchy, and EOD sign-off
+process. The reports that consume this methodology are described in
+[[id:04C68B55-E0B5-41CD-B90E-D670C17530B6][Risk Reporting]]. For the pricing configuration that drives each valuation step
+see [[id:EDAE3C87-7733-4D0C-881F-5AA65DD832AC][Pricing Configuration]].
+Return to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
+
+* P&L Types
+
+Before describing attribution it is necessary to define the P&L types that
+appear as reference values and outputs.
+
+| Type           | Definition                                                                          |
+|----------------+-------------------------------------------------------------------------------------|
+| LTD P&L        | Life-to-Date P&L. The current MTM without any manual adjustments. The raw NPV.     |
+| Daily P&L      | NPV change since the previous business day close.                                   |
+| MTD P&L        | Current NPV minus the NPV at the previous month-end.                               |
+| YTD P&L        | Current NPV minus the NPV at the previous year-end.                                |
+| Flash P&L      | Preliminary P&L computed against a draft market data cut before formal sign-off.   |
+| Actual P&L     | Final P&L after sign-off, including all journals and adjustments.                  |
+| Variance       | Difference between Flash and Actual P&L.                                           |
+| Hypo P&L       | Hypothetical P&L — a what-if estimate computed from Risk Predict without re-valuation. |
+| Clean P&L      | P&L excluding a defined set of adjustments (e.g. brokerage, CVA).                 |
+| Post Month-End | Adjustments applied after month-end close.                                         |
+
+MTD and YTD P&L are computed as:
+
+$$\text{MTD P\&L} = PV_\text{now} - \text{Monthly Adjustments} - \text{Brokerage Adjustments}$$
+$$\text{YTD P\&L} = PV_\text{now} - \text{YTD Adjustments} - \text{Brokerage Adjustments}$$
+
+* The Attribution Identity
+
+The fundamental decomposition of daily P&L is:
+
+$$\underbrace{D_1 M_1 T_1 - D_0 M_0 T_0}_{\text{Total P\&L}} =
+  \underbrace{(D_1 M_1 T_1 - D_0 M_1 T_1)}_{\text{Trade Activity}} +
+  \underbrace{(D_0 M_1 T_0 - D_0 M_0 T_0)}_{\text{Market Data}} +
+  \underbrace{(D_0 M_1 T_1 - D_0 M_1 T_0)}_{\text{Time}}$$
+
+Where:
+- $D_0$, $D_1$: Trade population at Day 0 and Day 1
+- $M_0$, $M_1$: Market data (spots, vols, rates) at Day 0 and Day 1
+- $T_0$, $T_1$: Valuation dates at Day 0 and Day 1
+
+The three components are mutually exclusive and exhaustive:
+
+#+begin_example
+                                    ┌─ NEW
+               ┌─ TRADE ACTIVITY ──┤─ AMEND / RESTRUCTURE
+               │                   │─ CANCEL
+               │                   │─ EXPIRED
+               │                   │─ EXERCISED
+               │                   │─ FIXINGS
+               │                   │─ FUNDING ROLLS
+  TOTAL P&L ───┤                   │─ CONTRA REVENUE (Brokerage)
+               │                   └─ CVA / RESERVES
+               │
+               ├─ MARKET DATA ─────┬─ FX SPOT
+               │                   ├─ ATM VOL
+               │                   ├─ RISK REVERSAL
+               │                   ├─ STRANGLE
+               │                   ├─ IR PROJECTION
+               │                   ├─ IR DISCOUNT
+               │                   └─ CROSS EFFECTS
+               │
+               └─ TIME (THETA)
+#+end_example
+
+A fourth category, *Unexplained P&L*, captures any residual. A well-implemented
+attribution should drive this to zero. Its presence indicates missing or
+misclassified attribution components.
+
+The full formula including cross effects:
+
+$$\text{Market Movements} = (\text{ATM} + \text{RR} + \text{STR} + \text{FX Spot} + \text{IR Discount} + \text{IR Projection}) + \text{Cross Effects}$$
+$$\text{Cross Effects} = \text{Bump All} - (\text{ATM} + \text{RR} + \text{STR} + \text{FX Spot} + \text{IR Discount} + \text{IR Projection})$$
+
+* Bump and Reset: The Attribution Methodology
+
+Bump and Reset is the standard methodology for market data attribution. Each
+component is computed by bumping only that component from Day 0 to Day 1 while
+holding all others at Day 0 levels. The baseline is always Day 0.
+
+| Component     | Formula                                                           |
+|---------------+-------------------------------------------------------------------|
+| FX Spot       | $D_0 \{S_1, V_0, IR_0\} T_0 - D_0 M_0 T_0$                     |
+| ATM Vol       | $D_0 \{S_0, ATM_1, RR_0, STR_0, IR_0\} T_0 - D_0 M_0 T_0$     |
+| Risk Reversal | $D_0 \{S_0, ATM_0, RR_1, STR_0, IR_0\} T_0 - D_0 M_0 T_0$     |
+| Strangle      | $D_0 \{S_0, ATM_0, RR_0, STR_1, IR_0\} T_0 - D_0 M_0 T_0$     |
+| IR (combined) | $D_0 \{S_0, V_0, IR_1\} T_0 - D_0 M_0 T_0$                     |
+| Time          | $D_0 M_0 T_1 - D_0 M_0 T_0$                                     |
+| Models        | Change in valuation due to model setting changes Day 0 → Day 1  |
+
+Bump and Reset ensures all components add to total market movements (up to
+cross effects). It does not capture interaction terms between components; those
+appear in the Cross Effects bucket.
+
+* Bump and Run: Cumulative Attribution
+
+In Bump and Run, bumps are applied /cumulatively/ in a defined order. The
+$\Delta P\&L$ at each step is measured against the previous step, not against
+Day 0.
+
+| Step | Components active                           | $\Delta P\&L$ interpretation            |
+|------+---------------------------------------------+------------------------------------------|
+|    1 | FX Spot                                     | Spot-only P&L move                       |
+|    2 | FX Spot + ATM                               | Incremental ATM contribution             |
+|    3 | FX Spot + ATM + RR                          | Incremental RR contribution              |
+|    4 | FX Spot + ATM + RR + STR                    | Incremental STR contribution             |
+|    5 | FX Vol + IR Projection + IR Discount        | Incremental rates contribution           |
+|    6 | All above + Model Parameters                | Incremental model change contribution    |
+|    7 | All market data                             | Residual market data effects             |
+|    8 | All market data + Time                      | Time/theta contribution                  |
+
+Bump and Run is complementary to Bump and Reset. It is better for detecting
+cross-effects (a large step 2 increment implies a strong ATM×Spot interaction).
+Bump and Reset is better for attributing absolute magnitudes to individual
+components.
+
+** Theta: First vs. Last
+
+- *Theta Last* (standard for Bump and Run): Update market data to Day 1 first,
+  then roll the date: $\Theta = NPV(D_0, M_1, T_1) - NPV(D_0, M_1, T_0)$
+- *Theta First* (standard for Bump and Reset): Roll the date first, then apply
+  market data: $\Theta = NPV(D_0, M_0, T_1) - NPV(D_0, M_0, T_0)$
+
+The Bump and Run time bucket is not a pure theta: it absorbs any residual P&L
+not otherwise attributed, so it may differ from a clean Theta First calculation.
+The guiding rule: Fix/Fix/Fix — fix the order, fix the convention, fix the
+methodology.
+
+* Trade Activity Component
+
+Trade Activity explains the P&L contribution from changes to the trade
+population between Day 0 and Day 1. It uses Day 1 market data for all
+sub-components so that trade changes and market data changes do not interact.
+
+$$\text{Trade Activity} = D_1 M_1 T_1 - D_0 M_1 T_1$$
+
+Sub-buckets (additive):
+
+$$\text{Trade Activity} = \text{New} + \text{Amended} + \text{Cancelled} + \text{Expired} + \text{Exercised} + \text{Fixings} + \text{Funding Rolls} + \text{Contra Revenue} + \text{CVA} + \text{Reserves}$$
+
+** Trade Activity Categories
+
+- *NEW*: A new legal contract. $\text{NEW} = NPV(D_{\text{new}}, M_1, T_1)$
+- *CLOSE-OUT*: Customer or bank wishes to close an existing position. The
+  close-out deal is equal and opposite to the original.
+- *EARLY TERMINATION*: Close-out by mutual agreement before scheduled maturity.
+  Includes tear-ups and compression exercises.
+- *RESTRUCTURE / ROLL*: Terms of an existing trade renegotiated (e.g. extending
+  maturity or changing the strike).
+- *PARTIAL CLOSE-OUT*: Notional of an existing trade reduced.
+- *UPSIZE*: Notional of an existing trade increased.
+- *NOVATION*: Counterparty of an existing trade changes.
+- *AMENDED*: An amendment that does not require new confirmation.
+  $\text{AMENDED} = NPV(D_{\text{amended}}, M_1, T_1) - NPV(D_{\text{original}}, M_1, T_1)$
+- *CANCELLED*: Trades deleted on Day 1.
+  $\text{CANCELLED} = -NPV(D_{\text{cancelled}}, M_1, T_1)$
+- *EXPIRED*: Day 0 trades whose scheduled expiry fell on Day 1.
+  $\text{EXPIRED} = -NPV(D_{\text{expired}}, M_1, T_1)$
+- *EXERCISED*: Exercise of options. Also captures rebates booked at exercise.
+- *FIXINGS*: Trades that fixed on Day 1; attribution captures the P&L impact
+  of the rate being fixed vs. the expected rate.
+- *RATE RESET / FLOATING RESET*: Coupon or floating rate reset to a new level.
+- *NOTIONAL RESET / STRIKE RESET*: Notional or strike adjusted in structured
+  products with resetting features.
+- *TRIGGERED*: Barrier events (knock-in or knock-out).
+- *REBALANCE / AMORTISATION*: Scheduled notional reductions or rebalancings.
+- *PHYSICAL DELIVERY / CASH SETTLEMENT*: Trade maturing into physical delivery
+  or cash settlement.
+- *MATURITY*: A forward or deposit that has reached its maturity date and is
+  delivered. Matured trades are converted into cash positions (Nostro entries);
+  omitting them generates spurious unexplained P&L.
+- *FUNDING ROLLS*: New funding tickets from rolling existing funding positions.
+
+** Contra Revenue
+
+Items that are not primary trading P&L but are attributed to specific trades:
+
+- *Brokerage*: Fees paid to brokers. Calculated per trade using brokerage
+  templates.
+- *Agency Commissions*: Similar to brokerage for agency-model trades.
+- *Sales Credits*: Internal revenue-sharing credits.
+- *Transfer Pricing*: Inter-entity charges.
+- *Bullion Fees*: For precious metals products.
+
+** CVA (Credit Valuation Adjustment)
+
+CVA is the market value of counterparty credit risk:
+
+$$CVA = -LGD \int_0^T EE(t) \cdot dPD(t)$$
+
+Where $LGD$ is Loss Given Default, $EE(t)$ is Expected Exposure at time $t$,
+and $PD(t)$ is the probability of default by time $t$.
+
+CVA is tracked separately because its P&L can be large and volatile, it is
+managed by a separate CVA desk, and Finance require a clear view of its
+contribution.
+
+** Reserves and Valuation Adjustments
+
+| Reserve Type                   | Description                                                    |
+|--------------------------------+----------------------------------------------------------------|
+| Bid/Offer                      | Liquidity reserve for the cost of unwinding a position         |
+| Model Limitation — Barrier Shifts | Reserve for model uncertainty on barrier products           |
+| Unobservable Parameters        | Reserve for parameters not observable in the market            |
+| OIS Discounting                | Reserve for the switch from LIBOR to OIS discounting           |
+| Model Limitation — Stochastic IR | Reserve for not modelling stochastic interest rates          |
+| Prudential Valuation           | Regulatory-driven conservative valuation adjustment            |
+
+* Market Data Component
+
+The market data component captures the P&L from changes in market rates and
+prices between Day 0 and Day 1, holding the trade population and date constant.
+
+$$\text{Market Data} = D_0 M_1 T_0 - D_0 M_0 T_0$$
+
+Sub-buckets (Bump and Reset methodology):
+
+| Bucket        | What is bumped     | Scope                          |
+|---------------+--------------------+--------------------------------|
+| FX Spot       | Spot rate          | Per currency pair              |
+| ATM Vol       | ATM volatility     | Per currency pair, per tenor   |
+| Risk Reversal | RR                 | Per currency pair, per tenor   |
+| Strangle      | STR                | Per currency pair, per tenor   |
+| IR Projection | Projection curves  | Per currency, per tenor        |
+| IR Discount   | Discount curves    | Per currency, per tenor        |
+| Cross Effects | All combined − sum | Residual interaction terms     |
+
+** Bucketing Granularity
+
+Attribution can be presented at multiple levels:
+
+- *Finest level*: Per underlier and per type.
+- *Mid level*: By type: all projection curves together, all discount curves
+  together, all IR, all vol.
+- *Top level*: FX Spot, FX Vol, IR, Cross Effects.
+
+$$\text{Cross Effects at level } L = \text{Bump All at level } L - \sum_i \text{Bucket}_i$$
+
+* Time Component (Theta)
+
+The time component captures the P&L resulting purely from the passage of one
+business day, holding market data and trade population constant.
+
+Under Bump and Reset (Theta First):
+$$\Theta = NPV(D_0, M_0, T_1) - NPV(D_0, M_0, T_0)$$
+
+Under Bump and Run (Theta Last):
+$$\Theta = NPV(D_0, M_1, T_1) - NPV(D_0, M_1, T_0)$$
+
+* Deal Population for Attribution
+
+Determining the correct deal population for an explain requires care:
+
+- From a *Market Data* perspective, only Day 0 trades matter.
+- From a *Trade Activity* perspective, all trade changes must be captured:
+  trades that only exist on Day 0 (matured, cancelled, expired), trades that
+  only exist on Day 1 (new), and trades that exist on both days.
+- *Settled positions* must be included. A forward that matured on Day 1 appears
+  as a cash Nostro position in the ledger on Day 1; if the cash position is
+  omitted from trade activity, a spurious unexplained P&L appears.
+
+* EOD Sign-Off Process
+
+1. *Trade cut*: Snapshot of the trade population.
+2. *Market data cut*: Snapshot of market data (spots, forwards, vols, rates).
+3. *AM Flash / PM Flash*: Preliminary P&L. Finance generates an exception
+   report comparing traders' expected P&L against the Finance P&L. Traders
+   sign off exceptions.
+4. *Rate sign-off*: Finance formally approves the market data cut.
+5. *Full P&L execution*: The official Flash is produced with all exceptions and
+   trader comments attached and published.
+6. *Diff analysis*: Comparison of AM Flash vs EOD Flash; exceptions reviewed.
+   Final sign-off can only be completed once the total P&L difference is below
+   a configured threshold.
+7. *EOD start*: Full Actual P&L begins.
+
+* Aggregation and Currency Conversion
+
+P&L is held in its /natural currency/ (the denomination of each cash flow).
+At EOD, all amounts are consolidated into the branch /functional currency/
+(the domestic currency of the branch, e.g. GBP for a London branch).
+
+Any P&L from spot conversion of non-domestic P&L is recorded as a *P&L
+Adjustment* (FX Adjustment). Traders are expected to hedge this FX exposure.
+
+The aggregation hierarchy:
+
+: Trade → Trade Aggregate → Book → Sub-Portfolio → Portfolio → Branch → Firm

--- a/doc/knowledge/domain/pl_attribution.org
+++ b/doc/knowledge/domain/pl_attribution.org
@@ -303,4 +303,4 @@ Adjustment* (FX Adjustment). Traders are expected to hedge this FX exposure.
 
 The aggregation hierarchy:
 
-: Trade → Trade Aggregate → Book → Sub-Portfolio → Portfolio → Branch → Firm
+: Trade → Structure → Book → Sub-Portfolio → Portfolio → Branch → Firm

--- a/doc/knowledge/domain/pricing_configuration.org
+++ b/doc/knowledge/domain/pricing_configuration.org
@@ -1,0 +1,316 @@
+:PROPERTIES:
+:ID: EDAE3C87-7733-4D0C-881F-5AA65DD832AC
+:END:
+#+title: Pricing Configuration
+#+description: Named, versioned bundle of valuation settings: valuation model mapping, smile surface configuration, Greek configuration, general valuation settings, model parameters, layered overrides, and MRU views.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :knowledge:domain:finance:pricing:ore:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+
+A *Pricing Configuration* is a named, versioned bundle of valuation settings
+that fully determines how the pricing engine values a set of trades. It bridges
+a report definition (which says /what/ to compute) and the engine (which needs
+to know /how/ to compute it). In [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][ORE]] the equivalent is =EngineData=
+(=pricingengines.xml=). This document covers the five configuration layers,
+the override hierarchy, snapshotting for reproducibility, and MRU views. For
+the reports that consume pricing configurations see [[id:04C68B55-E0B5-41CD-B90E-D670C17530B6][Risk Reporting]]. For the vol
+surface configuration layer see [[id:5B513D53-5DF7-4540-99C0-60D909678873][FX Volatility Surface]].
+Return to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
+
+* Overview
+
+Pricing configurations exist because:
+
+1. Different reports need different valuation configurations. A trader's
+   intraday risk report may use SABR with physical interpolation, while the
+   official EOD may use 5-point spline with market interpolation.
+2. Different users (FO, Finance, Quant) may use different models and model
+   parameters for the same trade population. These differences must be
+   explained, not hidden.
+3. Valuations must be reproducible. All model configuration used for a
+   valuation must be snapshotted alongside the market data cut and the deal
+   population.
+
+The pricing configuration is what makes it possible to re-run a historical
+valuation and obtain the same result: it captures not just which model was used,
+but every parameter, interpolation setting, and override that shaped the output.
+
+* Anatomy of a Pricing Configuration
+
+A pricing configuration is composed of five distinct layers. Each layer
+addresses a different aspect of how the engine values a trade.
+
+#+begin_example
+┌──────────────────────────────────────────────────────────────┐
+│                   PRICING CONFIGURATION                      │
+│                    (named, versioned)                        │
+├──────────────────────────────────────────────────────────────┤
+│  1. Valuation Model Configuration                            │
+│     (product type → pricing model mapping)                   │
+│                                                              │
+│  2. Smile Surface Configuration                              │
+│     (currency pair → smile model + interpolation)            │
+│                                                              │
+│  3. Greek Configuration                                      │
+│     (which Greeks, numeric/analytic, bump parameters)        │
+│                                                              │
+│  4. General Valuation Settings                               │
+│     (cross-model settings: interpolation, roll, coupons)     │
+│                                                              │
+│  5. Model Parameters                                         │
+│     (scalar + term-structure parameters for each model)      │
+└──────────────────────────────────────────────────────────────┘
+#+end_example
+
+** Valuation Model Configuration
+
+The *Valuation Model Configuration* maps each product type to the pricing model
+(or models) used to value it. This is the first-order decision: for a given
+vanilla option, which model prices it?
+
+The mapping can be conditional:
+
+- *By product property*: "If expiry > 3M use Model X, else use Model Y."
+- *By time property*: "For maturity < 2Y use Model X, for maturity ≥ 2Y use
+  Model Y."
+- *By currency pair*: "For EUR/USD use Model X; for all EM pairs use Model Y."
+- *Composite*: "The value of a Greek is a weighted composite of values produced
+  by multiple models." Used for models that produce skew adjustments (e.g.
+  replication models).
+- *Fallback*: "If Model X fails to calibrate, fall back to Model Y."
+
+Not all product types are supported by every model. For simple products
+(forwards, deposits) there may be only one model. For exotic products, the set
+of available models is narrower and the choice may have a material impact on
+valuation.
+
+*ORE equivalent*: =pricingengines.xml= — maps trade type identifiers to ORE
+engine and model names.
+
+** Smile Surface Configuration
+
+The *Smile Surface Configuration* determines which vol surface model is used
+for each currency pair, and how the surface is built and interpolated.
+
+Three values define the smile surface:
+
+| Setting              | Description                                                                                                                                      |
+|----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------|
+| Smile model          | The surface construction model: SABR, 5-point spline, Black-Scholes (flat)                                                                       |
+| Smile parameter form | Which form of smile parameters to use as input (ATM + RR + STR, or raw vols, etc.)                                                              |
+| Interpolation method | How the surface is stitched across maturities: linear in variance, linear in vol, physical (model parameter space), market (market quote space) |
+
+Constraints between these settings:
+
+- The smile model and parameter form are coupled: not all permutations are
+  valid. For Black-Scholes, only ATM DNS or ATM Forward is valid.
+- Market interpolation should not be used with Black-Scholes because the
+  DNS/Forward switch creates a discontinuity in the term structure.
+- SABR does not support 5-point calibration; 5-point requires spline
+  interpolation.
+
+*** Main and Backup Surfaces
+
+Every pricing configuration maintains two vol surfaces:
+
+- *Main surface*: The primary surface used for pricing (SABR, 5-point, or BS).
+- *Black-Scholes surface*: Always BS. Used as a backup, for reparameterisation,
+  and for producing BS-equivalent Greeks.
+
+*** Per-Currency-Pair Assignment
+
+The smile surface configuration can be set per currency pair, following a
+layered model:
+
+1. *System default*: A global default smile model and interpolation.
+2. *Currency pair override*: An explicit configuration for a specific pair.
+3. *Force override*: Forces all currency pairs to use a given smile model
+   and/or interpolation, regardless of per-pair settings. Used for scenario
+   analysis (e.g. "revalue everything under flat vol").
+
+** Greek Configuration
+
+The *Greek Configuration* determines which sensitivities are computed and how.
+It consists of:
+
+- A selection from the canonical list of Greeks (PV, Delta, Gamma, Vega, Rega,
+  Sega, Theta, Rho, etc.).
+- For each selected Greek, the computation mode:
+  - *Unbumped*: base PV (no perturbation).
+  - *Bumped*: numeric finite-difference.
+  - *Analytic*: closed-form where the model supports it.
+  - *Weighted*: scaled by a weighting factor.
+  - *Model*: produced by a specific model variant (e.g. BS Delta vs Smile Delta).
+
+A Greek only has meaning in the context of a Valuation Model Configuration.
+Greek configurations are typically packaged into reusable /Greek Sets/
+(templates) that users select by name (e.g. "MTD P&L", "Daily Risk",
+"Exotic Full Greeks"). A Greek set implies its pricing configuration.
+
+*ORE equivalent*: The =<Analytics>= block in =ore.xml= specifies which analytics
+(NPV, SENSITIVITY, CASHFLOWS, etc.) ORE computes. Sensitivity configuration
+lives in =sensitivity.xml=.
+
+** General Valuation Settings
+
+*General Valuation Settings* are cross-model parameters that apply uniformly
+to all valuations within the pricing configuration.
+
+| Setting                 | Description                                                                               |
+|-------------------------+-------------------------------------------------------------------------------------------|
+| Rates interpolation     | Interpolation method for discount and projection curves                                   |
+| Vols interpolation      | Interpolation method for the vol surface time dimension                                   |
+| Use of ATM curve        | Whether ATM curve interpolation is used vs. direct vol interpolation                      |
+| Roll types              | How curves and surfaces roll when the valuation date advances                             |
+| PV offset in days       | Number of spot days for discounting (normally 2)                                          |
+| Value past coupons      | Whether to include cash flows before the valuation date                                   |
+| Include brokerage       | Whether brokerage trades enter the valuation                                              |
+| Multi-threading         | Whether the engine parallelises valuation across trades                                   |
+| Hull-White vol bump size | Size of the vol bump used in Hull-White stochastic rates models                          |
+| Rate bump size          | Default size for interest rate bumps                                                      |
+
+** Model Parameters
+
+Model parameters are the numeric inputs to each pricing model.
+
+*** Scalar Parameters
+
+Single-valued inputs with no tenor dimension:
+
+| Category                | Override per report? | Examples                                                                                    |
+|-------------------------+----------------------+---------------------------------------------------------------------------------------------|
+| Default scalars         | No                   | Bid/offer strike shift, Hull-White mean reversion (mid), number of replication dates        |
+| Report-specific scalars | Yes                  | Number of Monte Carlo simulations, number of spatial points, time steps, use of Sobol       |
+
+*** Term Structure Parameters
+
+Parameters that have a value at each tenor, structurally identical to a market
+data curve but used as model inputs. Examples for SABR:
+
+- Correlation sensitivity (up/down)
+- Vol adjustments
+- RR infinite flag
+- Vol swap adjustments
+- Standard deviation weighting
+
+See [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]] for the scalar vs. term-structure distinction.
+
+* Configuration Layering and Overrides
+
+Pricing configuration follows a layered override hierarchy:
+
+#+begin_example
+┌──────────────────────────────────────────────────┐
+│  Layer 4: Deal-Level Overrides                   │  ← highest priority
+├──────────────────────────────────────────────────┤
+│  Layer 3: Report Instance Overrides              │
+├──────────────────────────────────────────────────┤
+│  Layer 2: Report Definition Defaults             │
+├──────────────────────────────────────────────────┤
+│  Layer 1: System Defaults                        │
+└──────────────────────────────────────────────────┘  ← lowest priority
+#+end_example
+
+- *System defaults* (Layer 1): The baseline. Every setting has a system-wide
+  default; if no override exists at any higher layer, this value is used.
+- *Report definition defaults* (Layer 2): When a user saves a named report
+  configuration (e.g. ".1 Triple — G10"), they are saving a Layer 2 override
+  set.
+- *Report instance overrides* (Layer 3): Ad-hoc overrides applied at the time
+  a report is run. Persisted with the report instance for reproducibility but
+  do not affect the saved report definition.
+- *Deal-level overrides* (Layer 4): Non-standard valuation settings for
+  specific deals or deal types. Finance must be able to track all changes at
+  this level.
+
+** Front Office vs. Back Office Settings
+
+FO and Finance may use different pricing configurations for the same trade
+population. Common differences include more aggressive models or model
+parameters in FO vs. more conservative settings in Finance. The differences
+must be explained: the P&L attribution framework (see [[id:B50355E0-F016-4CA1-9932-404DAF83EA7A][P&L Attribution]])
+includes a "Models" bucket that captures the P&L impact of changing model
+settings between Day 0 and Day 1:
+
+$$\text{Models P\&L} = NPV(D_0, M_0, T_0)_{\text{Day}_1\text{ model}} - NPV(D_0, M_0, T_0)_{\text{Day}_0\text{ model}}$$
+
+* Snapshotting and Reproducibility
+
+A reproducible valuation requires the conjunction of:
+
+1. *Trade population snapshot*: Versioned at the trade cut.
+2. *Market data snapshot*: Versioned at the market data cut.
+3. *Pricing configuration snapshot*: Versioned at the same time as the market
+   data cut. Includes all general valuation settings, scalar parameters, term
+   structure parameters, valuation model configuration, and smile surface
+   configuration.
+4. *Report definition*: The saved configuration (Layer 2) at run time.
+5. *Report instance overrides*: Any Layer 3 or Layer 4 overrides applied at
+   run time.
+
+Given these five inputs, the engine must produce the same output. This is the
+core reproducibility contract.
+
+*ORE Studio*: The equivalent inputs are the ORE XML files (=ore.xml=,
+=pricingengines.xml=, =market.xml=, =portfolio.xml=) plus the market data
+fixtures. ORE Studio must snapshot and version these at each analytics run.
+
+* MRU and Alternative Valuations
+
+The Model Risk Unit (MRU) and quantitative analysts need to produce alternative
+valuations against historical snapshots to assess model risk.
+
+** Views
+
+A *View* is a set of overrides applied on top of a baseline pricing
+configuration snapshot. Views:
+
+- Can be applied to any historical snapshot (not just the current one).
+- Are versioned and maintained independently of the snapshot.
+- Can be composed: multiple views maintained and applied selectively.
+- Must be recorded alongside the snapshot for audit purposes.
+
+** Standard MRU Scenarios
+
+| Scenario                  | What changes in the view                                                  |
+|---------------------------+---------------------------------------------------------------------------|
+| Baseline EOD              | No overrides (the control)                                                |
+| Different Skews           | Alternative RR/STR parameters or skew model                               |
+| Black-Scholes Valuation   | Force all products to BS flat vol (no smile)                              |
+| Stochastic Interest Rates | Switch to a stochastic IR model (e.g. Hull-White)                         |
+| High Model Parameters     | Push all model parameters to their upper bounds                           |
+| Low Model Parameters      | Push all model parameters to their lower bounds                           |
+| Alternative Models        | Substitute the primary model with a challenger (e.g. replication vs. SABR) |
+
+The result of MRU analysis is a set of P&L reserves and model uncertainty
+bounds that feed into the reserve calculations described in
+[[id:B50355E0-F016-4CA1-9932-404DAF83EA7A][P&L Attribution]].
+
+* Relationship to Reports
+
+#+begin_example
+  Report Definition
+       │
+       ├── Report Type (methodology: bump-and-reset, sensitivity, etc.)
+       ├── Greek Set ──────────►  Greek Configuration
+       │                              │
+       │                              ▼
+       │                         Valuation Model Configuration
+       │                              │
+       │                              ▼
+       │                         Smile Surface Configuration
+       ├── General Valuation Settings
+       ├── Scalar Parameters (report-specific)
+       └── Bump Parameters (spot/vol/rate bump sizes, types, counts)
+
+  ─────────── snapshotted at run time ───────────
+
+  Report Instance = Report Definition
+                  + Trade Population Snapshot
+                  + Market Data Snapshot
+                  + Pricing Configuration Snapshot
+                  + Instance Overrides
+#+end_example

--- a/doc/knowledge/domain/risk_reporting.org
+++ b/doc/knowledge/domain/risk_reporting.org
@@ -1,0 +1,580 @@
+:PROPERTIES:
+:ID: 04C68B55-E0B5-41CD-B90E-D670C17530B6
+:END:
+#+title: Risk Reporting
+#+description: Market risk and trading desk reporting: report definitions, instances, measures, Greek sets, classification taxonomy (cycle/frequency/audience/scope/methodology), full report catalogue, EOD batch set, and report configuration reference.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :knowledge:domain:finance:reporting:ore:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+
+This document covers market risk and trading desk reporting in
+[[id:D04D3476-D7C5-3954-A33B-C641EBCB43F6][ORE Studio]]: the reports used by traders, risk managers, and quantitative
+analysts to monitor and attribute risk and P&L. It does not cover finance,
+regulatory capital, or accounting reports. P&L attribution methodology is
+documented separately in [[id:B50355E0-F016-4CA1-9932-404DAF83EA7A][P&L Attribution]]. For the pricing configuration that
+drives each report see [[id:EDAE3C87-7733-4D0C-881F-5AA65DD832AC][Pricing Configuration]].
+Return to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
+
+* Core Concepts
+
+** Report Definition
+
+A *Report Definition* is a named, reusable template specifying what to compute.
+It contains no trade or market data. It captures:
+
+- The report /type/ (which valuation and bumping methodology to use)
+- The /Greek set/ (which measures to compute and in what form)
+- All /configuration parameters/ (bump sizes, smile model, roll method,
+  display currency, aggregation level, etc.)
+
+Report Definitions can have multiple saved configurations. For example, a
+trader may maintain a ".1 Triple — Asia EM" configuration and a ".1 Triple —
+G10" configuration from the same report type.
+
+*ORE equivalent*: An analytics block in =ore.xml= plus the associated
+=sensitivity.xml= / =stresstest.xml= configuration.
+
+** Report Instance
+
+A *Report Instance* is a specific execution of a Report Definition against
+concrete inputs: a trade population snapshot, a market data snapshot, and a
+valuation date. Instances are versioned and reproducible; all inputs are
+captured at run time.
+
+** Measure
+
+A *Measure* is a single computable quantity for a trade or portfolio. Measures
+are either /base valuations/ (PV, NPV) or /sensitivities/ (Greeks). The set of
+measures to compute is defined by a Greek set attached to the report.
+
+** Greek Set (Greek Template)
+
+A *Greek Set* is a named, reusable collection of measures. Users define sets
+appropriate to their role (e.g. a vol desk set: PV, Vega, Rega, Sega, Gamma;
+a rates desk set: PV, Delta, DV01, Rho). A report may reference one or more
+Greek sets.
+
+** Aggregation Level
+
+Results may be produced and viewed at multiple levels of the organisational
+hierarchy:
+
+: Trade → Structure → Book → Sub-Portfolio → Portfolio → Branch → Firm
+
+Each book belongs to one branch and carries one aggregation currency. Risk
+figures at book level and above are converted to the aggregation currency.
+
+* Classification Taxonomy
+
+Every report is tagged across five orthogonal axes.
+
+** Axis: Cycle
+
+| Value     | Meaning                                                                                       |
+|-----------+-----------------------------------------------------------------------------------------------|
+| =intraday= | Runs against live/current market data during the trading day. Results are indicative.        |
+| =eod=     | Runs against the officially signed-off EOD market data cut. Results are authoritative.       |
+
+All =eod= reports are =scheduled= by definition.
+
+** Axis: Frequency
+
+| Value          | Meaning                                                                                 |
+|----------------+-----------------------------------------------------------------------------------------|
+| =on-demand=    | Launched explicitly by a user at any time.                                              |
+| =scheduled=    | Launched automatically at a pre-configured time or as part of an ordered batch.         |
+| =event-driven= | Launched automatically in response to a system event (new trade, vol surface rebuild). |
+
+** Axis: Audience
+
+| Value          | Who                                                                              |
+|----------------+----------------------------------------------------------------------------------|
+| =trading-desk= | Front-office traders and sales. Day-to-day position monitoring, intraday P&L.  |
+| =market-risk=  | Risk managers. Official EOD Greeks, stress scenarios, regulatory risk monitoring.|
+| =finance=      | P&L controllers. IPV, official valuations, sign-off reports.                    |
+| =middle-office= | MO/Operations staff. Trade lifecycle events, STP, confirmations, settlement.   |
+| =quant=        | Quantitative analysts. Model validation, vol surface quality checks.            |
+
+** Axis: Scope
+
+| Value      | Meaning                                                     |
+|------------+-------------------------------------------------------------|
+| =trade=    | One result row per trade or deal leg                        |
+| =book=     | One result row per trading book                             |
+| =portfolio= | One result row per portfolio or sub-portfolio              |
+| =firm=     | Firm-wide aggregation                                       |
+
+** Axis: Methodology
+
+| Value           | Meaning                                                                           |
+|-----------------+-----------------------------------------------------------------------------------|
+| =numeric-bump=  | Finite-difference sensitivity: re-value with bumped input, subtract base PV       |
+| =analytic=      | Closed-form derivative expression                                                 |
+| =risk-predict=  | Approximate P&L from stored Greeks via Taylor expansion; no re-valuation          |
+| =audit-derived= | Derived from trade or market data state; no valuation engine involvement          |
+
+* Methodologies
+
+** Numeric (Bumped) Greeks
+
+The standard method for computing sensitivities. The valuation engine is called
+twice: once with the base market data and once with a single input perturbed by
+a small /bump/. The Greek is the finite difference:
+
+$$\text{Greek} = \frac{PV(\text{bumped}) - PV(\text{base})}{\text{bump size}}$$
+
+Bump parameters:
+
+- *Bump size*: Magnitude of the perturbation (e.g. 0.1 vol point, 1 bp, 1% spot).
+- *Bump type*: Absolute (add the size) or relative/multiplicative.
+- *Bump count*: Number of symmetric bumps for grid reports (e.g. ±1%, ±2%, ±5%).
+- *Which underlyings to bump*: Specific currency pairs, specific tenors, or all.
+
+** Analytic (Closed-Form) Greeks
+
+For certain product/model combinations the sensitivity has a closed-form
+expression (e.g. Black-Scholes Delta: $\Delta = e^{-r_f T} N(d_1)$). Where
+supported, analytic Greeks are faster and more precise than bumped Greeks.
+
+** Bump and Reset
+
+A P&L attribution methodology. Each market data component is perturbed
+independently while all others remain at their Day 0 levels. Individual
+components are additive up to cross effects. Full description in
+[[id:B50355E0-F016-4CA1-9932-404DAF83EA7A][P&L Attribution]].
+
+** Bump and Run
+
+A cumulative P&L attribution methodology. Bumps are applied in a defined
+sequence; each step adds one more component on top of all previously applied
+bumps. Full description in [[id:B50355E0-F016-4CA1-9932-404DAF83EA7A][P&L Attribution]].
+
+** Risk Predict
+
+An approximation of P&L resulting from a hypothetical market data move,
+computed from stored Greeks rather than by re-running the valuation engine:
+
+$$\Delta P\&L \approx \sum_i \text{Greek}_i \times \text{Shift}_i + \tfrac{1}{2} \sum_i \Gamma_i \times \text{Shift}_i^2$$
+
+For spot deltas the market movement is computed as a relative change:
+$MM = (D_1 - D_0) / D_0$, not an absolute shift. Greeks must be re-centred
+against the spot rates matrix before the predict is computed. Risk Predict is
+used by Finance to scale IPV Greeks by the difference between internal and
+independent rates, producing the /IPV risk number/.
+
+Note: Risk Predict is an approximation. Cross effects and higher-order terms
+beyond second order are not captured.
+
+* Measures Catalogue
+
+** Base Measures
+
+| Measure | Description                                          |
+|---------+------------------------------------------------------|
+| PV      | Present value: discounted future cash flows          |
+| NPV     | Net present value: PV net of past settled amounts    |
+| MTM     | Mark-to-Market: NPV against the official EOD cut     |
+
+** Greeks
+
+| Greek | Symbol   | Input bumped        | Notes                                        |
+|-------+----------+---------------------+----------------------------------------------|
+| Delta | $\Delta$ | FX Spot rate        | Primary directional risk                     |
+| Gamma | $\Gamma$ | FX Spot (2nd order) | Curvature; approximated via Taylor expansion |
+| Vega  | $\nu$    | ATM volatility      | Tenor-by-tenor                               |
+| Rega  | —        | Risk Reversal       | Skew sensitivity                             |
+| Sega  | —        | Strangle            | Curvature/wing sensitivity                   |
+| Theta | $\Theta$ | Time (date roll)    | Time decay                                   |
+| Rho   | $\rho$   | Interest rate       | Discount and projection separately           |
+
+** Greek Variants
+
+| Variant  | Description                                                           |
+|----------+-----------------------------------------------------------------------|
+| Unbumped | PV with no perturbation (the base valuation)                          |
+| Bumped   | Numeric finite-difference computation                                 |
+| Analytic | Closed-form computation where model supports it                       |
+| Weighted | Greek scaled by a notional or price weighting                         |
+| Model    | Greek produced by a specific model variant (e.g. BS Delta vs Smile Delta) |
+
+** P&L Measures
+
+| Measure     | Description                                                     |
+|-------------+-----------------------------------------------------------------|
+| Daily P&L   | NPV change since previous business day                          |
+| MTD P&L     | NPV minus previous month-end NPV                               |
+| YTD P&L     | NPV minus previous year-end NPV                                |
+| LTD P&L     | Current MTM without adjustments; the raw NPV                   |
+| P&L Impact  | Estimated P&L change from a hypothetical shift (Risk Predict)  |
+| BS Daily P&L | Black-Scholes equivalent of Daily P&L                         |
+| BS MTD P&L  | Black-Scholes equivalent of MTD P&L                            |
+
+** Vol Sensitivity Measures
+
+| Measure   | Description                                           |
+|-----------+-------------------------------------------------------|
+| .1 ATM    | PV change from 0.1 bump to ATM vol                   |
+| .1 RR     | PV change from 0.1 bump to Risk Reversal              |
+| .1 STR    | PV change from 0.1 bump to Strangle                  |
+| .1 Triple | PV change from 0.1 bump applied to ATM + RR + STR    |
+| .1 Quad   | As Triple plus a fourth surface component             |
+
+* Report Catalogue
+
+** Headline Position
+
+| Cycle       | intraday · eod              |
+| Frequency   | on-demand · scheduled       |
+| Audience    | trading-desk · market-risk  |
+| Scope       | book · portfolio            |
+| Methodology | risk-predict · numeric-bump |
+
+*Purpose*: Displays the most important Greeks across the entire trade set for a
+book or portfolio. The primary real-time risk overview report for traders and
+risk managers. Provides high-level sign-off visibility on the current state of
+risk.
+
+*Measures*: Configurable; typically PV, Daily P&L, MTD P&L, YTD P&L, Delta
+P&L.
+
+*Aggregation*: Book, Portfolio, Currency Pair, Greek, Unit Hedge.
+
+** Spot Ladder
+
+| Cycle       | intraday      |
+| Frequency   | on-demand     |
+| Audience    | trading-desk  |
+| Scope       | book          |
+| Methodology | audit-derived |
+
+*Purpose*: For a given currency pair, shows the full forward curve (all tenor
+outright rates) in a ladder format. Primary tool for quoting and hedging at
+specific tenors.
+
+*Measures*: Forward outright rates at each tenor; optionally swap/forward
+points. Aggregation can be "Out of Today", "Out of Tomorrow", or "Out of Spot"
+(see [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]]).
+
+** Spot Greeks Report
+
+| Cycle       | intraday · eod             |
+| Frequency   | on-demand · scheduled      |
+| Audience    | trading-desk · market-risk |
+| Scope       | book                       |
+| Methodology | numeric-bump · risk-predict |
+
+*Purpose*: Displays P&L and Delta at a grid of spot shift levels. Answers
+"what happens to my P&L if spot moves by X%?" Provides a scenario view of
+directional risk; used by market risk for stress testing.
+
+*Measures*: Per shift level: Daily P&L, MTD P&L, YTD P&L, P&L Impact, BS
+equivalents, PV, Delta, BS Delta.
+
+** Triple Vol Spot Ladder
+
+| Cycle       | intraday · eod             |
+| Frequency   | on-demand · scheduled      |
+| Audience    | trading-desk · market-risk |
+| Scope       | book                       |
+| Methodology | numeric-bump               |
+
+*Purpose*: Headline sensitivity report combining vol sensitivity (Vega) and
+skew sensitivities (Rega, Sega) across all curve tenors at multiple spot shift
+levels. The primary vol risk overview report. Splits exotic and vanilla
+populations separately.
+
+*Measures*: Per tenor × per spot shift: Vega, Rega, Sega. Standard shift
+series: 30, 20, 10, 5, 2, 1, 0.5, 0.
+
+** .1 ATM Report
+
+| Cycle       | intraday · eod             |
+| Frequency   | on-demand · scheduled      |
+| Audience    | trading-desk · market-risk |
+| Scope       | trade · book               |
+| Methodology | numeric-bump               |
+
+*Purpose*: Measures sensitivity to a parallel 0.1-unit shift in ATM
+volatility, broken out by currency pair and tenor.
+
+** .1 Triple Report
+
+| Cycle       | intraday · eod             |
+| Frequency   | on-demand · scheduled      |
+| Audience    | trading-desk · market-risk |
+| Scope       | trade · book               |
+| Methodology | numeric-bump               |
+
+*Purpose*: Measures the combined effect of bumping ATM + RR + STR
+simultaneously by 0.1. Captures total vol sensitivity including smile
+structure. Equivalent to shifting the entire vol surface by 0.1 while
+preserving its shape.
+
+** .1 Quad Report
+
+| Cycle       | intraday · eod             |
+| Frequency   | on-demand · scheduled      |
+| Audience    | trading-desk · market-risk |
+| Scope       | trade · book               |
+| Methodology | numeric-bump               |
+
+*Purpose*: Extension of the Triple adding a fourth vol surface component.
+Used for surface models with a fourth degree of freedom beyond ATM/RR/STR.
+
+** .1 Rate (Rho) Report
+
+| Cycle       | intraday · eod         |
+| Frequency   | on-demand · scheduled  |
+| Audience    | market-risk            |
+| Scope       | book                   |
+| Methodology | numeric-bump           |
+
+*Purpose*: Measures the effect of a 0.1% change in interest rates at each
+point in the rate term structure. Discount and projection effects shown
+separately.
+
+** .1 RR/STR Report
+
+| Cycle       | intraday · eod             |
+| Frequency   | on-demand · scheduled      |
+| Audience    | trading-desk · market-risk |
+| Scope       | trade · book               |
+| Methodology | numeric-bump               |
+
+*Purpose*: Measures sensitivity to Risk Reversal and Strangle independently
+(not combined as in Triple). Separates the skew contribution (Rega) from the
+wing/curvature contribution (Sega).
+
+** Rho/Vol Matrix Report
+
+| Cycle       | eod          |
+| Frequency   | scheduled    |
+| Audience    | market-risk  |
+| Scope       | book         |
+| Methodology | numeric-bump |
+
+*Purpose*: Shows the P&L effect of simultaneously bumping ATM vols and
+interest rates across a grid of joint shift levels. Captures the cross-sensitivity
+between rates and vols.
+
+*Example axes*: Rho: −25 bps to +25 bps in 5 bp increments; Vol: −2% to +10%.
+
+** Spot/Vol Matrix Report
+
+| Cycle       | eod          |
+| Frequency   | scheduled    |
+| Audience    | market-risk  |
+| Scope       | book         |
+| Methodology | numeric-bump |
+
+*Purpose*: Sensitivity to simultaneous spot and vol shifts across a grid.
+
+** Spot/Rho Matrix Report
+
+| Cycle       | eod          |
+| Frequency   | scheduled    |
+| Audience    | market-risk  |
+| Scope       | book         |
+| Methodology | numeric-bump |
+
+*Purpose*: Combined spot and interest rate sensitivity matrix.
+
+** Spot Ladder — All Crosses (Market Risk EOD)
+
+| Cycle       | eod          |
+| Frequency   | scheduled    |
+| Audience    | market-risk  |
+| Scope       | book         |
+| Methodology | numeric-bump |
+
+*Purpose*: Spot sensitivity across all currency crosses at standard shift
+levels. EOD market risk version is a systematic run across all books and all
+currency pairs, distinct from the trader's real-time Spot Ladder.
+
+** Spot Vol Ladder — Base and Quote Currency
+
+| Cycle       | eod          |
+| Frequency   | scheduled    |
+| Audience    | market-risk  |
+| Scope       | trade · book |
+| Methodology | numeric-bump |
+
+*Purpose*: Trade-level spot and vol sensitivity report, produced separately
+for the base currency and the quote currency.
+
+** Trade Level Ladder — Premium Currency Bumped
+
+| Cycle       | eod          |
+| Frequency   | scheduled    |
+| Audience    | market-risk  |
+| Scope       | trade        |
+| Methodology | numeric-bump |
+
+*Purpose*: Spot ladder at trade level where the premium currency is the
+bumped spot underlier. Used for structures where the option premium currency
+differs from the base currency.
+
+** Vol Manipulation Report
+
+| Cycle       | eod                  |
+| Frequency   | event-driven         |
+| Audience    | quant · market-risk  |
+| Scope       | book                 |
+| Methodology | audit-derived        |
+
+*Purpose*: Audit report. For any vol surface adjustments (e.g. wing
+stabilisation, smile corrections), reports the adjustment made by tenor and
+adjustment type. Provides transparency between raw market quotes and the vols
+actually used in pricing.
+
+** Spike Map
+
+| Cycle       | intraday                   |
+| Frequency   | on-demand · event-driven   |
+| Audience    | trading-desk · market-risk |
+| Scope       | book                       |
+| Methodology | audit-derived              |
+
+*Purpose*: Per currency pair, a visual map of option notional concentration
+(or theoretical value) against expiry date and spot level. Helps traders
+identify large concentrations of barrier and digital risk across time and spot
+space.
+
+*Modes*: American Notional, American TV, European Notional, European TV.
+
+** Strike Map
+
+| Cycle       | intraday      |
+| Frequency   | on-demand     |
+| Audience    | trading-desk  |
+| Scope       | book          |
+| Methodology | audit-derived |
+
+*Purpose*: Similar to the Spike Map but bucketed by option strike rather than
+expiry date. Shows notional concentration across strike space at each tenor.
+
+** Option Map
+
+| Cycle       | intraday      |
+| Frequency   | on-demand     |
+| Audience    | trading-desk  |
+| Scope       | book          |
+| Methodology | audit-derived |
+
+*Purpose*: Combines the traditional option map (bucketed by delta) with a
+strike view. Unified view of notional distribution across both delta and strike.
+
+** Intraday Change Report (Daily Activity Report)
+
+| Cycle       | intraday                 |
+| Frequency   | scheduled · event-driven |
+| Audience    | trading-desk             |
+| Scope       | book · portfolio         |
+| Methodology | risk-predict             |
+
+*Purpose*: Shows how market data and risk have changed since a configurable
+reference time. Provides a continuous intraday P&L attribution without
+requiring a full EOD explain run.
+
+** IPV Explain Report
+
+| Cycle       | eod                        |
+| Frequency   | scheduled                  |
+| Audience    | finance · market-risk      |
+| Scope       | book · portfolio           |
+| Methodology | risk-predict · numeric-bump |
+
+*Purpose*: Quantifies the P&L difference between internal bank rates and
+independently sourced rates (the IPV cut). Used by Finance to identify
+mis-marks. Greeks are always computed even for points with no IPV data, so
+uncovered risk is visible.
+
+*Measures*: PV at EOD rates, PV at IPV rates, difference (IPV adjustment),
+scaled risk (IPV risk number = Greek × IPV market data move).
+
+** Trades Since Last In Report
+
+| Cycle       | intraday                      |
+| Frequency   | on-demand                     |
+| Audience    | trading-desk · middle-office  |
+| Scope       | book · portfolio              |
+| Methodology | audit-derived                 |
+
+*Purpose*: Shows all trades booked since a specified date-time. Used for
+morning review and monitoring activity on shared books.
+
+* Market Risk EOD Report Set
+
+The following reports constitute the standard end-of-day market risk batch.
+All are =eod= cycle, =scheduled= frequency. They run after the market data cut
+is signed off and the curve bootstrap and vol surface build are complete.
+
+|  # | Report                              | Scope         | Methodology     | Audience                |
+|----+-------------------------------------+---------------+-----------------+-------------------------|
+|  1 | .1 Rho                              | Book          | Numeric bump    | market-risk             |
+|  2 | Rho/Vol Matrix                      | Book, per ccy | Numeric bump    | market-risk             |
+|  3 | Spot/Vol Matrix                     | Book          | Numeric bump    | market-risk             |
+|  4 | Spot/Rho Matrix                     | Book          | Numeric bump    | market-risk             |
+|  5 | Spot Vol Ladder (Base Currency)     | Trade & Book  | Numeric bump    | market-risk             |
+|  6 | Spot Vol Ladder (Quote Currency)    | Trade & Book  | Numeric bump    | market-risk             |
+|  7 | Spot Ladder (all crosses)           | Book          | Numeric bump    | market-risk             |
+|  8 | Trade Level Ladder (Premium Ccy)    | Trade         | Numeric bump    | market-risk             |
+|  9 | Trade and Book Level .1 Triple Vol  | Trade & Book  | Numeric bump    | trading-desk · mkt-risk |
+| 10 | Vol Manipulation Report             | Book          | Audit-derived   | quant · market-risk     |
+
+Estimated batch start: 18:30–19:00 London time (branch-dependent). The full
+batch must complete before the start of the next trading session.
+
+* Report Configuration Reference
+
+** Valuation Model
+
+- *Smile model*: SABR, 5-point spline, Black-Scholes (flat). Per-currency-pair
+  overrides; a default is applied when no override exists.
+- *ATM curve interpolation*: Interpolation type for the ATM vol term structure.
+- *Rates interpolation*: Interpolation for discount and projection curves.
+- *Vol interpolation*: Market or Physical (see [[id:EDAE3C87-7733-4D0C-881F-5AA65DD832AC][Pricing Configuration]]).
+- *Value past coupons*: Whether to include cash flows before the valuation date.
+- *PV offset in days*: Number of spot days used for discounting.
+
+** Bump Parameters
+
+- Bump size, bump type (absolute / relative), bump count.
+- Which underlyings to bump (specific pairs, all pairs, specific tenors).
+- Whether to bump model term-structure parameters (e.g. SABR correlation).
+
+** Monte Carlo
+
+- Number of simulations, use of Sobol, Brownian bridge, number of time steps,
+  number of spatial points.
+
+** Rolling
+
+- *Spot roll method*: Fixed roll or other; how spot is treated when advancing
+  the valuation date.
+- *Vol roll method*: How vol tenors roll with time.
+- *Date steps*: Weekday only vs. calendar day.
+- *Days forward*: Number of days to roll for theta/multi-day risk.
+
+** Display and Aggregation
+
+- Display currency, aggregation currency, aggregation mode.
+- Summary levels: Book, Sub-Portfolio, Portfolio, Branch.
+- Threshold filters (min/max Greek value) for Headline-style reports.
+
+* ORE Studio Notes
+
+ORE produces many of the above reports as analytics outputs:
+
+- =NPV=, =CASHFLOWS=: Base valuation measures.
+- =SENSITIVITY=: Numeric bumped Greeks (configured in =sensitivity.xml=).
+- =STRESS=: Scenario / stress testing (configured in =stresstest.xml=).
+- =VAR=: Value-at-Risk (configured in =var.xml=).
+
+ORE Studio will need to expose report configuration as domain entities, allow
+users to define Greek sets and report definitions, and display results in the
+Qt UI. The report catalogue above defines the target set of reports for the
+ORE Studio trading desk UI.

--- a/doc/knowledge/domain/time_structures_and_tenors.org
+++ b/doc/knowledge/domain/time_structures_and_tenors.org
@@ -1,0 +1,293 @@
+:PROPERTIES:
+:ID: 1427C01C-17C0-4D7E-AE55-BF16C414FD58
+:END:
+#+title: Time Structures and Tenors
+#+description: Scalar, tenor, and term-structure concepts; settlement conventions; standard tenor labels; curve-type tenor conventions (spot/swap/CDS); date rolling; IMM dates; broken dates and turn points.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :knowledge:domain:finance:tenors:curves:ore:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+
+Market data in [[id:D04D3476-D7C5-3954-A33B-C641EBCB43F6][ORE Studio]] is fundamentally time-dependent. This document
+covers the three foundational concepts — scalars, tenors, and term structures —
+together with settlement conventions, date rolling, and the special handling
+required at the short end of FX curves. For how these tenors appear in
+bootstrapped curves see [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]]. For vol surface tenors see
+[[id:5B513D53-5DF7-4540-99C0-60D909678873][FX Volatility Surface]]. Return to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
+
+* Overview
+
+A /term structure/ (also called a /time structure/ or /curve/) represents the
+evolution of a quantity — a rate, a price, a volatility — across a series of
+future dates. Each point in that series is identified by a /tenor/. A /scalar/
+is a single market data value that carries no tenor dimension.
+
+Three concepts anchor this domain:
+
+- *Scalar*: A single, dimensionless market data value. Examples include spot FX
+  rates, scalar model parameters (e.g. Hull-White mean reversion, bid/offer
+  strike shift), or general valuation settings (e.g. number of Monte Carlo
+  simulations). Scalars may evolve over time but have a single value at any
+  given valuation date.
+
+- *Tenor*: A label identifying a point in time relative to a reference date
+  (the /horizon/ or /curve date/). Tenors are not absolute dates; they are
+  symbolic identifiers (=O/N=, =1M=, =5Y=) whose meaning depends on the
+  curve type, the horizon date, and market convention.
+
+- *Term Structure / Time Structure*: An ordered series of tenor points
+  representing the time profile of a quantity. A term structure also carries
+  metadata: holiday calendars, non-deliverable currency flags, and
+  interpolation method.
+
+The horizon date is the base date from which all tenored dates are derived.
+It is not necessarily today; valuation may be performed as of any business date.
+
+* Key Definitions
+
+** Business Day and Settlement Day
+
+A *business day* is any day that is not a weekend and is not a holiday for any
+of a specified set of currencies. USD is a special case: USD holidays are
+conventionally treated as valid business days and are excluded from business
+day calculations.
+
+A *settlement day* is any day that is both a valid business day for the relevant
+currencies /and/ is not a USD holiday. Settlement day conventions govern when
+cash actually moves.
+
+** Spot Days (Spot Lag)
+
+The *spot days* (also called /settlement days/) for a single currency is the
+number of business days required for delivery of cash. For a currency pair the
+spot days are the *maximum* of the two individual currencies' spot days. Most
+major pairs (e.g. EUR/USD) settle T+2, giving a spot date of today + 2
+business days.
+
+** Spot Date
+
+The *spot date* is the settlement date for an FX trade entered today. It is
+today plus the spot days of the currency pair, adjusted for holidays in both
+currencies and in the settlement currency (typically USD).
+
+** Horizon Date (Curve Date)
+
+The *horizon date* is the reference date from which tenored dates are
+computed. All tenor calculations start here. It is sometimes called the /reval
+date/ when used in a valuation context.
+
+** Reval Date vs. Spot Date
+
+- *Reval Date*: The date at which valuation is performed. Not necessarily today.
+- *Spot Date*: The settlement date derived from the reval date and spot days.
+- *Valuation Spot Date*: A normalised spot date used to ensure consistent
+  treatment across currencies when valuing settled cash, also called the
+  adjusted or normalised spot date.
+
+* Standard Tenor Labels
+
+The short end of the curve uses named tenors; the long end uses period
+notation.
+
+| Tenor  | Common Name   | Description                                                             |
+|--------+---------------+-------------------------------------------------------------------------|
+| =O/N=  | Overnight     | From today to the next business day. The earliest possible tenor.       |
+| =T/N=  | Tom/Next      | From tomorrow to the day after (i.e. from next business day to spot).  |
+| =S/N=  | Spot/Next     | From spot to the next business day after spot.                          |
+| =S/W=  | Spot/Week     | From spot to one week after spot (by convention, for rate curves).      |
+| =1W=   | One Week      | One week. For rate curves this is spot + 1W; for vol surfaces today + 1W. |
+| =1M=   | One Month     | One calendar month off spot (rates) or today (vols).                   |
+| =3M=   | Three Months  | Three calendar months off spot.                                         |
+| =6M=   | Six Months    | Six calendar months off spot.                                           |
+| =1Y=   | One Year      | Twelve calendar months off spot.                                        |
+
+Longer tenors follow the pattern =nM= (months) or =nY= (years). Odd tenors
+between liquid points are /broken dates/.
+
+** Rates vs. Vols Convention
+
+A critical cross-asset convention: for *rate curves*, tenors beyond =S/N= are
+measured from /spot/. For *volatility surfaces*, tenors are measured from
+/today/. This distinction means that =1W= on a rate curve and =1W= on a vol
+surface refer to different calendar dates. Failure to align these conventions
+leads to significant pricing errors.
+
+** Unambiguous Date Labels
+
+To avoid ambiguity at the short end, the following canonical names are useful:
+
+| Label              | Meaning                                     |
+|--------------------+---------------------------------------------|
+| =TODAY=            | Current date in a given timezone            |
+| =TOMORROW=         | Next business day after today               |
+| =SPOT=             | Today + spot days (currency-pair specific)  |
+| =nBD=              | Today + n business days                     |
+| =nCD=              | Today + n calendar days                     |
+| =nW= / =nM= / =nY= | Forward by n weeks / months / years        |
+| =BSOM= / =BEOM=    | Business Start/End of Month                 |
+| =BSOQ= / =BEOQ=    | Business Start/End of Quarter               |
+
+* Tenor Conventions by Curve Type
+
+The /meaning/ of a tenor label depends on the curve type. Three major
+conventions exist.
+
+** Spot / Forward Curves (FX, Interest Rate)
+
+The standard convention used by most FX and interest rate curves:
+
+- =O/N=: horizon date to next business day (tomorrow)
+- =T/N=: next business day to spot
+- =Spot=: horizon date + spot days
+- =S/N=: spot to spot + 1 business day
+- All subsequent tenors (=1W=, =1M=, =1Y=, ...): measured from spot
+
+** Swap Curves
+
+Used for short-dated FX swap quotation. Tenors are quoted in terms of the
+/near leg/:
+
+- =O/N=: today (not tomorrow)
+- =T/N=: tomorrow
+
+This convention differs from the forward curve convention and models the
+near leg of a one-day FX swap. The tenor set typically runs up to =S/N=.
+
+** Credit / CDS Curves
+
+CDS instruments use a restricted tenor set tied to the four /CDS roll dates/
+per year: 20 March, 20 June, 20 September, 20 December. Tenors resolve to
+the first business day following the appropriate roll date, which can make
+nominal tenors such as =1Y= resolve to materially different dates than on a
+rates curve. A common disambiguation convention appends the roll quarter:
+e.g. =1Y 1RQ= (one year, one roll quarter).
+
+* Date Rolling and Calendar Conventions
+
+When a tenor date falls on a non-business day it must be /rolled/. The rolling
+process applies rules to find the nearest valid business day. Standard
+rolling conventions (Modified Following, Following, Preceding, End of Month)
+apply at this stage.
+
+*Date rolling* is the process of moving a calculated date forward or backward
+by a specified period while enforcing business day validity. The rolled date
+depends on the holiday calendars of all relevant currencies.
+
+Key market timing concepts:
+
+- *New York Close*: Conventional end-of-day for the global FX market. Used as
+  the anchor for date boundaries across time zones.
+- *Market Cut*: The cut-off time for a specific market (date + time). Determines
+  which business date a trade belongs to.
+- *DST (Daylight Saving Time)*: Seasonal time shifts that affect cut-off times
+  and timestamp arithmetic; must be handled explicitly.
+
+* Term Structure Parameters vs. Scalar Parameters
+
+Market data in a system separates into two categories:
+
+** Scalar Parameters
+
+Single-valued inputs with no tenor dimension. These may be global or
+report-specific:
+
+- *Global scalars*: bid/offer strike shift, Hull-White mean reversion (mid),
+  number of replication dates. These are unlikely to vary report-by-report but
+  can evolve over time.
+- *Report-specific scalars*: number of Monte Carlo simulations, number of
+  spatial/time steps, use of Sobol sequences. These are set per analytics run.
+
+** Term Structure Parameters
+
+Model parameters that carry a value at each tenor, structurally identical to a
+market data curve but used as model inputs rather than market observables.
+Examples from SABR: correlation sensitivity (up/down), vol adjustments, risk
+reversal infinite flag, vol swap adjustments, standard deviation weighting.
+Like global scalars, these do not typically require per-report overrides.
+
+* Advanced: FX Short-End Conventions and the Start Tenor
+
+** Spot Days and the Pre-Spot Region
+
+For currencies with a T+2 spot lag, there is a two-day region before spot:
+today → tomorrow (=O/N=) and tomorrow → spot (=T/N=). For currencies with a
+T+1 spot lag (e.g. USD/CAD, USD/TRY) this region collapses to a single day.
+
+To value an FX position as of /today/ rather than /spot/, the spot rate must be
+adjusted by the short-end rates:
+
+- *T+1 spot currencies*:
+  - Outright today  = Spot rate − O/N points × scaling factor
+  - Outright tomorrow = Spot rate
+
+- *T+2 spot currencies*:
+  - Outright today  = Spot rate − T/N points × scaling factor − O/N points × scaling factor
+  - Outright tomorrow = Spot rate − T/N points × scaling factor
+
+** The "Out Of" Convention on Forward Ladders
+
+A forward rate ladder can be expressed starting from different reference points:
+
+- *Out of Spot* (standard): rates beyond =S/N= are computed off spot.
+- *Out of Tomorrow*: rates beyond =T/N= are computed off tomorrow.
+- *Out of Today*: all rates are computed off today. Tenors in this mode are
+  non-standard and should be visually distinguished to alert users.
+
+** Tom/Next and Funding
+
+Tom/Next serves a dual role:
+
+1. *A time reference*: the standard settlement convention for rolling an open
+   spot position to the next business day.
+2. *A funding mechanism*: interest accrues on accumulated cash up to the
+   Tom/Next date.
+
+* Advanced: Broken Dates and Turn Points
+
+** Broken Dates (Odd Dates)
+
+A broken date (also called an odd date) is a maturity that does not correspond
+to a standard tenor label — for example, a 47-day or 63-day forward. Broken
+dates arise in bespoke trade structures and require interpolation between the
+surrounding standard tenor points.
+
+** Turn Points
+
+Turn points mark discontinuities in the short-end rate curve caused by calendar
+effects — most commonly year-end, where funding costs spike. They appear in
+pairs:
+
+- *Turn Start*: the date the turn effect begins (e.g. 31 Dec)
+- *Turn End*: the date it ends (e.g. 2 Jan)
+
+Unlike standard tenors, turn points are /fixed in calendar time/; they do not
+roll forward as the horizon date advances. They require special handling in
+interpolation so that the spike does not bleed into adjacent tenors.
+
+* Advanced: IMM Dates
+
+IMM (International Monetary Market) dates are the quarterly expiry / delivery
+dates used by exchange-traded interest rate futures and CDS roll conventions:
+the first business day following 20 March, 20 June, 20 September, and 20
+December each year.
+
+Notation =nIMM= refers to rolling forward by n IMM quarters (e.g. =IMM3= is
+three IMM dates forward). IMM dates are used:
+
+- As an alternative bucketing scheme for position reporting.
+- As the underlying schedule for Eurodollar / Short Sterling futures used in
+  USD curve bootstrapping (see [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]]).
+- In CDS curves, where all standard tenors resolve relative to the nearest
+  following CDS roll date.
+
+* ORE Studio Notes
+
+ORE models calendar and tenor conventions through the reference data domain.
+Holiday calendars and settlement conventions are defined in =calendars.xml= and
+=conventions.xml= under the ORE reference data. ORE Studio exposes these
+through =ores.refdata=. When implementing date arithmetic in the UI (e.g.
+computing settlement dates for new trades), all calculations must route through
+the reference data service to pick up the correct holiday calendar for each
+currency pair.

--- a/doc/knowledge/domain/trade_blotter.org
+++ b/doc/knowledge/domain/trade_blotter.org
@@ -1,0 +1,717 @@
+:PROPERTIES:
+:ID: 3976695F-F526-4C2A-80ED-89B54854CF6D
+:END:
+#+title: Trade Blotter
+#+description: Primary front-office screen: multi-panel architecture, deal grid columns and colour coding, deal actions (new/amend/cancel/link/allocate), deal entry form and field interdependence, structure view, STP panel, dynamic books, Expiry Manager, Fixing Manager, Barrier Management, Delta Jump Screen, Spike Map, and cross-screen navigation.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :knowledge:domain:finance:trading:blotter:ore:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+
+The *Trade Blotter* is the primary front-office screen: the central hub
+from which traders, sales staff, and middle office (MO) staff view, manage,
+and act on the live book of trades. It is not a passive read-only view — the
+blotter is the entry point for booking new deals, amending existing ones, and
+routing trades through their lifecycle: expiry, fixing, delivery, exercise, and
+settlement. Lifecycle management screens (Expiry Manager, Fixing Manager,
+Barrier Management) are separate but linked from the blotter; a user should be
+able to navigate to any of these from a deal row with a single action.
+For the reports consumed alongside the blotter see [[id:04C68B55-E0B5-41CD-B90E-D670C17530B6][Risk Reporting]].
+For the P&L attribution that records trade activity categories see [[id:B50355E0-F016-4CA1-9932-404DAF83EA7A][P&L Attribution]].
+Return to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
+
+* Users
+
+| Role                 | Primary need                                                                          |
+|----------------------+---------------------------------------------------------------------------------------|
+| Trader               | Monitor live positions; amend and book trades; navigate to risk reports               |
+| Sales                | Book client trades; check premium and settlement details; manage allocations          |
+| Middle Office        | Validate trades awaiting confirmation; process STP messages; manage lifecycle events  |
+| Risk Manager         | Inspect deal population for a book or portfolio; cross-navigate to Greeks and P&L    |
+| Quantitative Analyst | Investigate pricing errors; inspect deal properties for model validation              |
+
+* Panel Layout
+
+The blotter is structured as a multi-panel application. All panels are
+resizable; the layout is user-configurable and saved per user session.
+
+#+begin_example
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  TOOLBAR: [ Search ] │ Valuation Date/Time │ NPV │ Actions                 │
+├──────────────┬──────────────────────────────────────────────────────────────┤
+│              │                                                              │
+│  BOOK TREE   │                  DEAL GRID                                   │
+│              │  (Deals matching book selection + search/filter)             │
+│  [▾] Portfolio│                                                             │
+│   ├─ [▾] A   │                                                              │
+│   └─ [▾] B   │                                                              │
+│              │                                                              │
+├──────────────┴──────────────────────────────────────────────────────────────┤
+│  DETAIL PANEL  — Deal Properties  /  Structure Mini-Blotter                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│  GREEKS PANEL  — Greeks for Selection  |  Total Greeks for Book             │
+└─────────────────────────────────────────────────────────────────────────────┘
+#+end_example
+
+** Toolbar
+
+- *Search box*: Free-text filter across all visible columns and key deal
+  properties. Supports expressions (=T-7=, =T+5=) and field prefixes (=cpty:HSBC=).
+- *Valuation date/time*: Current valuation context; displayed in red if stale or
+  historical.
+- *NPV of selection*: Live aggregated NPV of the current grid selection.
+- *Action buttons*: New, Clone, Amend, Cancel, Reload, Link with keyboard shortcuts.
+
+** Book Tree
+
+A hierarchical tree of books and portfolios (Portfolio → Sub-Portfolio → Book).
+Selecting any node filters the deal grid to deals in that node and its
+descendants. Multi-select is supported. The book tree also displays /Dynamic
+Books/ — user-defined virtual groupings based on filter criteria (see
+[[*Dynamic Books and Filtering]]).
+
+** Deal Grid
+
+The central deal list, showing all trades matching the current book tree
+selection and applied search/filter:
+
+- Sortable by any column; multi-column sort supported.
+- Columns configurable per user: show, hide, reorder.
+- Multi-row selection for bulk actions (cancel, aggregate).
+- Structures collapse to a single header row with a disclosure triangle; expanding
+  shows component legs inline.
+- New deals and amendments appear immediately on booking without a manual refresh.
+
+** Detail Panel
+
+A context-sensitive panel below the grid:
+
+- *Deal view*: Full deal fields for a single selected trade.
+- *Structure view*: When a structure header row is selected, shows a mini-blotter
+  with all component legs tabbed by product type.
+
+** Greeks Panel
+
+Shows Greeks and P&L measures for the current selection and separately for the
+full book tree selection. Refreshes on demand or on a user-configurable interval.
+
+* Deal Grid Columns
+
+** Identity and Booking
+
+| Column          | Description                                                            |
+|-----------------+------------------------------------------------------------------------|
+| Deal ID         | Unique deal identifier across the system                               |
+| Structure ID    | Parent structure identifier; blank for standalone trades               |
+| Version         | Amendment counter; 0 = original booking                               |
+| Trade Date      | Date the deal was booked                                               |
+| Book            | Trading book that owns the deal                                        |
+| Entity / Branch | Legal entity and branch                                                |
+| Trader          | Name of the trader who booked                                          |
+| Sales Person    | Associated sales person (if any)                                       |
+| Counterparty    | Full legal name of the counterparty                                    |
+| Broker          | Broker (populated for brokered trades only)                            |
+| Status          | Live, Expired, Exercised, Cancelled, Matured, Triggered, Fixing Pending |
+| Origin          | How the trade arrived: Manual, STP, ECN, Allocation                   |
+
+** Economics
+
+| Column           | Description                                                           |
+|------------------+-----------------------------------------------------------------------|
+| Product Type     | Vanilla Option, Barrier, Digital, Forward, Depo, IRS, NDF, NDO, etc. |
+| Ccy Pair         | Currency pair in market convention (e.g. EUR/USD)                    |
+| Buy / Sell       | Direction from the bank's perspective                                 |
+| Notional (Base)  | Notional in the base currency                                         |
+| Notional (Quote) | Notional in the quote currency                                        |
+| Spot Rate        | Spot rate at time of booking                                          |
+| Strike           | Strike for options/forwards                                           |
+| Strategy         | Named structure: RR, Butterfly, Strangle, Spread, DNT, etc.          |
+| Premium          | Premium amount                                                        |
+| Premium Ccy      | Currency in which the premium is denominated                          |
+| Premium Date     | Settlement date for the premium                                       |
+
+** Dates
+
+| Column        | Description                                                       |
+|---------------+-------------------------------------------------------------------|
+| Value Date    | Spot settlement date                                              |
+| Expiry Date   | Option expiry date (date and cut code determine exact expiry time)|
+| Delivery Date | Physical or cash delivery date                                    |
+| Cut Code      | Expiry cut: NY 10:00, Tokyo 15:00, ECB, etc.                     |
+| Fixing Date   | NDF or floating rate fixing date                                  |
+
+** Risk and Status Indicators
+
+| Column          | Description                                              |
+|-----------------+----------------------------------------------------------|
+| NPV             | Current NPV in display currency                          |
+| Delta           | Delta in display currency                                |
+| Vega            | ATM vega                                                 |
+| % Away          | For barrier trades: distance of current spot from barrier|
+| Smile Error     | Non-empty if vol surface construction failed             |
+| Valuation Error | Non-empty if the pricer returned an error                |
+
+** Colour Coding
+
+| Condition                            | Visual                            |
+|--------------------------------------+-----------------------------------|
+| Expired today                        | Grey row                          |
+| Matures or delivers today            | Orange row                        |
+| Cancelled today                      | Strikethrough text, dark red      |
+| Booked today                         | Green highlight                   |
+| Pre-spot forward (value date < spot) | Yellow                            |
+| Back-dated trade                     | Blue                              |
+| Barrier within strike tolerance      | Light blue (row or % Away cell)   |
+| Triggered barrier                    | Red                               |
+| STP trade awaiting booking           | Amber                             |
+| Stale market data reference          | Red timestamp in toolbar          |
+
+* Deal Actions
+
+All actions are available from the toolbar, right-click context menu, and
+keyboard shortcuts. Bulk actions operate on multi-row selections.
+
+** New
+
+Opens a blank deal entry form for the user's choice of product type. On save,
+the deal appears in the grid immediately and an STP confirmation (where
+applicable) is dispatched.
+
+** Clone
+
+Creates a copy of the selected deal, pre-populating the entry form with all
+fields from the source. The fastest way to book a series of similar trades.
+
+** Amend
+
+Opens the selected deal in edit mode. On save, the deal version is incremented
+and the prior version is archived and auditable. Amendment types include:
+
+- Financial amendment (rate, notional, strike, dates, premium)
+- Client information update (counterparty, sales person, broker)
+- Spot roll (advance value date; recalculate forward points)
+- Forward roll back (move value date earlier)
+- Convert spot to forward or forward to spot, or either to swap
+
+Credit checks are triggered automatically for changes to counterparty, deal
+amount, or value date.
+
+** Cancel
+
+Marks the selected deal(s) as cancelled. A cancellation reason is mandatory.
+The system generates a P&L attribution entry (Category: CANCELLED — see
+[[id:B50355E0-F016-4CA1-9932-404DAF83EA7A][P&L Attribution]]) and produces any required settlement reversals. Cancelled
+trades remain visible in a greyed/struck-through state unless explicitly
+filtered out.
+
+** Reload
+
+Discards unsaved local changes and reloads from the database. Used when an
+external amendment has arrived via STP.
+
+** Link / Unlink
+
+Associates two or more trades into a linked group. Use cases:
+
+- Linking an ECN block trade to its client allocations.
+- Linking a hedge forward to the option it hedges.
+- Linking legs of a multi-deal structure booked separately.
+
+| Operation  | Description                                                        |
+|------------+--------------------------------------------------------------------|
+| Link Amend | Amend the linked counterpart trade to match changes in the primary |
+| Link Net   | Net multiple trades of the same currency pair and value date       |
+| Link Split | Break an existing link                                             |
+
+When starting a link from a block trade, eligible counterpart targets are
+restricted by type (Spot links to Spot/Outright/Swap; Outright to Outright/Spot;
+Swap to Swap only).
+
+** Allocate (Split)
+
+Splits a block trade into multiple child trades across different clients,
+notionals, or value dates. The user can enter each child manually, apply a
+saved allocation template, use auto-split, or submit allocations to an ECN
+via FIX.
+
+** Roll Forward
+
+Extends the value date of a trade, adjusting forward points to the new date.
+
+** Aggregate / Net
+
+Combines multiple selected trades of the same currency pair and value date into
+a single net position. Validates eligibility for netting before proceeding.
+
+* Deal Entry Form
+
+Presented as a modal dialog or docked panel when booking or amending. The form
+is product-aware: the fields shown depend on the product type.
+
+#+begin_example
+┌──────────────────────────────────────────────────────────────────┐
+│  [ Clone ] [ Amend ] [ Reload ] [ Close ]                        │
+├──────────────────────────────────────────────────────────────────┤
+│  Counterparty: [             ]  Book:   [     ]  Entity: [     ] │
+│  Branch:       [             ]  Broker: [     ]  Trader: [     ] │
+│  AV/CTU:       [             ]  Sales:  [     ]                  │
+├──────────────────────────────────────────────────────────────────┤
+│  [ Overview ] [ F/O Details ] [ Confos/Settlements ] [ Deal ]   │
+├──────────────────────────────────────────────────────────────────┤
+│  Sub-tabs: [ Forward ] [ Option ]    ← one tab per product leg   │
+│                                                                  │
+│  Trade Date: [          ]  Delivery:  [         ]                │
+│  Ccy Pair:   [          ]  Spot Rate: [         ]                │
+│  Notional:   [          ]  Strike:    [         ]                │
+│  Expiry:     [          ]  Cut Code:  [         ]                │
+│  Buy / Sell: [          ]  Strategy:  [         ]                │
+│  Premium:    [          ]  Prem Ccy:  [         ]                │
+└──────────────────────────────────────────────────────────────────┘
+#+end_example
+
+** Tabs
+
+- *Overview*: All primary economic fields. Default view on open.
+- *F/O Details*: Front-office metadata — broker, STP origin system, OS deal ID,
+  OS counterparty, OS trader account, message ID, Cit code, deal notes.
+- *Confos / Settlements*: Confirmation and settlement status (sent, received,
+  matched), SWIFT details, netting group assignment.
+- *Deal*: Full audit trail — version history with diffs, lifecycle event log,
+  user and timestamp for every change.
+
+** Field Groups and Interdependence
+
+Many fields recalculate each other when any one member changes:
+
+- The explicitly keyed field is shown with a distinct highlight (e.g. blue border).
+- Derived fields are shown in a secondary colour (e.g. light grey background).
+- If input is inconsistent or overdetermined, conflicting fields are highlighted
+  in red and the user is prompted.
+
+Key field groups for options:
+
+| Group              | Members                                                      |
+|--------------------+--------------------------------------------------------------|
+| Option term        | Named tenor, expiry date, delivery date, days to expiry      |
+| Strike / Delta     | Strike, delta (spot or forward), call/put direction          |
+| Premium / Vol      | Premium amount, implied volatility                           |
+| Notional (base/quote) | Notional base ccy, notional quote ccy, spot rate          |
+
+** Strike and Delta Entry
+
+- Typing in Strike: delta recalculates. Typing in Delta: strike recalculates.
+- Suffix =S= or =F= sets spot or forward delta convention (=25F= = 25 forward delta).
+- Typing just =S= or =F= toggles the convention; the strike recalculates.
+- Double-clicking the delta field opens a combo selector.
+- Special strike shortcuts: =A= (ATM DNS), =F= (ATM Forward), =S= (ATM Spot).
+- Press =R= to display the reciprocal of the current strike.
+- Call/Put defaults to the OTM option for the given strike; press =C= or =P= to
+  override.
+
+** Option-Specific Fields
+
+| Field         | Behaviour                                                              |
+|---------------+------------------------------------------------------------------------|
+| Currency Pair | Auto-flipped to market convention if entered inverted                  |
+| Expiry Date   | Entered as tenor (=1M=) or specific date; holidays and ambiguous dates warned |
+| Delivery Date | Auto-set to expiry spot date; can be overridden for late-delivery options |
+| Cut Code      | Defines the time portion of expiry; system-wide default per currency pair |
+| Premium Ccy   | Defaults to pair convention; third-currency premiums highlighted        |
+| Strategy      | Opens a multi-leg entry template for composite products                 |
+
+** IRS Multi-Leg Form
+
+For Interest Rate Swaps, the form expands to a two-column leg comparison layout
+with fields for currency, pay/receive, fixed/float, fixing source, fix time,
+start date, maturity, delivery, coupon/rate, notional, pay period, yield basis,
+and payment convention.
+
+* Structure View
+
+When a multi-leg structure (e.g. a Risk Reversal consisting of a call leg, a
+put leg, a premium leg, and a brokerage leg) is selected in the deal grid, the
+Detail Panel switches to Structure View.
+
+#+begin_example
+┌──────────────────────────────────────────────────────────────────┐
+│  Structure ID: 127        Sales Person: ADC                      │
+├──────────────────────────────────────────────────────────────────┤
+│  [ Option ]  [ Forward ]  [ Depo ]  [ … ]   ← tab per leg type  │
+├──────────────────────────────────────────────────────────────────┤
+│  Mini Blotter — all legs for this structure                      │
+│  ┌──────────┬──────────┬──────────┬──────────┬────────────────┐  │
+│  │ Deal ID  │ Type     │ Ccy Pair │ Notional │ Strike / Rate  │  │
+│  ├──────────┼──────────┼──────────┼──────────┼────────────────┤  │
+│  │ 10042    │ Option   │ EUR/USD  │ 5,000,000│ 1.0900 Call    │  │
+│  │ 10043    │ Option   │ EUR/USD  │ 5,000,000│ 1.0700 Put     │  │
+│  │ 10044    │ Premium  │ EUR/USD  │          │ 45,000 USD     │  │
+│  │ 10045    │ Brokerage│ EUR/USD  │          │ 500 USD        │  │
+│  └──────────┴──────────┴──────────┴──────────┴────────────────┘  │
+│                                                                  │
+│  ← Selecting a leg row populates the deal view below →          │
+└──────────────────────────────────────────────────────────────────┘
+#+end_example
+
+Every leg — including legs with no standalone economic meaning such as premium
+and brokerage legs — has its own row and can be inspected or amended
+individually. In the main deal grid, structures are displayed as a single
+collapsed row with a disclosure triangle.
+
+* STP Panel
+
+Straight-Through Processing (STP) trades arrive from external systems —
+brokers, ECNs, voice-capture systems — and queue for booking. The STP panel
+(docked sub-view or separate tab within the blotter) shows pending messages.
+
+#+begin_example
+┌──────────────────────────────────────────────────────────────────────┐
+│  STP QUEUE                              [ Refresh ]  [ Book ]       │
+├────────┬───────────┬────────────┬─────────┬──────────┬──────────────┤
+│ Msg ID │ Broker    │ Received   │ Waiting │ Status   │ Ccy Pair     │
+├────────┼───────────┼────────────┼─────────┼──────────┼──────────────┤
+│ 00421  │ GFI       │ 09:14:22   │ 00:03   │ Received │ EUR/USD      │
+│ 00422  │ Tullett   │ 09:17:01   │ 00:01   │ Received │ USD/JPY      │
+│ 00418  │ e-Speed   │ 09:10:44   │ 00:10   │ Failed   │ GBP/USD      │ ← red
+│ 00419  │ Vol Broker│ 09:11:55   │ 00:09   │ Pending  │ EUR/GBP      │ ← amber
+└────────┴───────────┴────────────┴─────────┴──────────┴──────────────┘
+#+end_example
+
+Key behaviours:
+
+- Order of entry is preserved; if a message is subsequently amended by the
+  originating system it does not move from its original queue position.
+- Waiting time colour-escalates: neutral → amber (>5 min) → red (>15 min).
+- Status lifecycle: Received → Pending → Booked. Failed indicates a parse or
+  validation error; the raw message can be inspected for manual re-keying.
+
+The F/O Details tab of the deal entry form shows STP-specific metadata:
+originating system name, broker ID, version in the OS, OS deal ID, OS
+counterparty, OS trader account, Cit code, message ID, STP status.
+
+* Dynamic Books and Filtering
+
+Beyond the standard book tree, users can define *Dynamic Books* — named virtual
+groupings aggregating deals based on filter criteria rather than organisational
+hierarchy (e.g. "All EUR/USD options expiring this week", "All NDF fixings
+tomorrow").
+
+** Filter Configuration
+
+#+begin_example
+┌────────────────────────────────────────────────────────────────┐
+│  Filter Name: [  All HSBC NDF Fixings Tomorrow  ]             │
+├────────────────────┬───────────────────┬───────────────────────┤
+│  Property          │ Operator          │ Value                 │
+├────────────────────┼───────────────────┼───────────────────────┤
+│  Counterparty      │ =                 │ HSBC                  │
+│  Product Type      │ =                 │ NDF                   │
+│  Fixing Date       │ =                 │ T+1                   │
+│  Status            │ =                 │ Live                  │
+└────────────────────┴───────────────────┴───────────────────────┘
+#+end_example
+
+- Properties: any deal column.
+- Operators: =, ≠, <, >, ≤, ≥, in, not in, contains.
+- Values: literals, date expressions (=T=, =T±n=, named tenors), multi-select.
+
+Saved Dynamic Books appear in the book tree and behave like real books.
+Free-text toolbar search and Dynamic Books are composable (both apply
+simultaneously).
+
+* Expiry Manager
+
+The Expiry Manager handles the expiry of options at each cut. It is the primary
+MO tool at each cut time (typically once or twice per day per cut).
+
+** Purpose
+
+At each option cut time (NY 10:00, Tokyo 15:00, ECB), a set of options reaches
+expiry. For each, one of four actions must be taken: *Exercise* (in the money),
+*Expire* (out of the money), *Fix* (NDF options: the underlying NDF requires
+fixing), or *Leave* (defer).
+
+** Settings and Filters
+
+#+begin_example
+┌─────────────────────────────────────────────────────────────────┐
+│  CUT DETAILS                                                    │
+│  Expiry Date: [ 2026-03-31  ]   Cut: [ NY 10:00 ▾ ]           │
+│  Ccy Pair:    [ EUR/USD ▾ ]  (All pairs / specific pair)       │
+│                                                                 │
+│  STRIKE TOLERANCE  (highlight deals within this distance of spot)│
+│  ( ) Percentage    (•) Pips    [ 5 ]                           │
+│                                                                 │
+│  SPOTS  (load on demand — do not auto-refresh)                 │
+│  ┌──────────┬────────────┐                                     │
+│  │ EUR/USD  │  1.0823    │  ← red border when stale           │
+│  └──────────┴────────────┘                                     │
+└─────────────────────────────────────────────────────────────────┘
+#+end_example
+
+Spots are loaded at session start or on user demand and are deliberately *not*
+auto-refreshed so that deals do not change status while the operator is
+mid-process. A last-chance staleness check is performed before final submission.
+
+** Cut Timeline
+
+A visual timeline shows which cuts have been processed and which are outstanding:
+
+#+begin_example
+  ●──────────────●──────────────○──────────────○
+  NY 10:00 ✓     Tokyo 15:00 ✓  ECB ✗          NY Close ✗
+#+end_example
+
+** Flat View
+
+#+begin_example
+┌──────────┬──────┬───────────┬─────────┬────────────┬────────┬────────────────┬─────────┐
+│ Ccy Pair │ Book │ Cpty      │ Product │ Buy/Sell   │ Strike │ Expiry Status  │ Action  │
+├──────────┼──────┼───────────┼─────────┼────────────┼────────┼────────────────┼─────────┤
+│ EUR/USD  │ FX1  │ Barclays  │ VanCall │ Buy 5M EUR │ 1.0900 │ Leave          │ [▾]     │
+│ EUR/USD  │ FX1  │ HSBC      │ VanPut  │ Sell 2M EUR│ 1.0750 │                │ Expire  │
+└──────────┴──────┴───────────┴─────────┴────────────┴────────┴────────────────┴─────────┘
+     ↑ blue rows are within strike tolerance
+#+end_example
+
+The Action column is a per-row dropdown: Exercise / Expire / Fix / Leave. Deals
+can be multi-selected for bulk action assignment. Interbank counterparties are
+visually distinguished.
+
+** Grouped View
+
+An alternative to the flat view where deals are grouped into four panes: Leave |
+Exercise | Expire | Fix. The user drags deals between panes or uses the action
+dropdown. Preferred when many deals are near spot; flat view is better for large
+deal counts.
+
+** NDF / NDO Two-Step Flow
+
+Non-Deliverable Options require:
+
+1. Exercise the NDO → system generates an NDF.
+2. User reloads the deal list (the new NDF now appears).
+3. Fix the NDF.
+
+The NDF fixing date is shown alongside the NDO; it is normally today but can
+differ due to holiday calendars (see [[id:1427C01C-17C0-4D7E-AE55-BF16C414FD58][Time Structures and Tenors]]).
+
+** Undo
+
+Every action taken in the session is recorded in an in-session action log.
+Users can view the log and undo any action or all actions (unexpiry, unfixing,
+exercise reversal).
+
+#+begin_example
+│ [ List Actions ]   [ Undo Selected ]   [ Undo All ]          │
+#+end_example
+
+* Fixing Manager
+
+The Fixing Manager handles authorisation of floating rate fixings: NDF fixings,
+LIBOR/SOFR/EURIBOR fixings for coupon resets, and other published reference
+rates. Used primarily by Operations (MO/BO).
+
+** Authorisation Workflow
+
+Six operations are supported (all require the published fixing time to have passed):
+
+1. *Authorise a published fixing*: Reuters rate has arrived; operator confirms and authorises.
+2. *Authorise an Ops-keyed fixing*: Operator has manually entered a rate and authorises it.
+3. *Authorise an FO-keyed fixing*: FO has keyed a rate; Ops verifies and authorises.
+4. *Overkey an FO fixing and authorise*: Ops disagrees, enters a different value, and authorises that.
+5. *Overkey a published fixing and authorise*: Ops substitutes a manual value for the Reuters rate.
+6. *Unauthorise and re-authorise*: Reverts an authorised fixing for correction.
+
+** Grid
+
+#+begin_example
+┌────────────────┬────────────────┬──────────────────┬────────┬─────┬─────────────┐
+│ Fixing Source  │ NY Fix Date    │ Local Fix Date   │ Asset  │ Src │ Fix Value   │
+├────────────────┼────────────────┼──────────────────┼────────┼─────┼─────────────┤
+│ ECB EUR fix    │ 2026-03-31     │ 2026-03-31 13:00 │ EUR    │ Pub │ 1.0823      │
+│ USD LIBOR 3M   │ 2026-03-31     │ 2026-03-31 11:00 │ USD    │ Key │ 4.8200      │
+└────────────────┴────────────────┴──────────────────┴────────┴─────┴─────────────┘
+│ Reuters Rate │ Fix T-1 │ Spot/Proj Rate │ Status    │ Origin    │ Published │
+│ 1.0823       │ 1.0801  │ 1.0819         │ Official  │ Published │ ✓         │
+│ —            │ 4.7950  │ 4.8150         │ Unofficial│ FO Keyed  │           │
+└──────────────┴─────────┴────────────────┴───────────┴───────────┴───────────┘
+#+end_example
+
+| Column           | Description                                                      |
+|------------------+------------------------------------------------------------------|
+| Fixing Source    | Name of the fixing (ECB EUR, EURIBOR 3M, USD/JPY NDF, etc.)    |
+| NY / Local Fix Date | NY date and local market date/time side by side               |
+| Asset            | Currency (IR fixings) or currency pair (FX fixings)             |
+| Fix Value        | Rate to be authorised; up to 6 decimal places                   |
+| Reuters Rate     | Officially published rate; always recorded even if overridden    |
+| Fixing T-1       | Yesterday's value; quick sanity check                           |
+| Spot/Proj Rate   | Current spot, forward, or projection rate for comparison         |
+| Status           | Official (authorised) or Unofficial (keyed but not authorised)  |
+| Origin           | Published / FO Keyed / Ops Keyed / Default Valuation / etc.    |
+
+** Control Reports
+
+- *Fixings Audit Report*: Every fixing entered, authorised, overkeyed, or
+  unauthorised — by whom, what value, and when.
+- *Missing Fixings Report*: Fixings required by the deal book but not yet
+  authorised by a configurable cutoff time; used as a morning checklist.
+
+* Barrier Management
+
+The Barrier Management screen monitors live American/continuous barriers and
+triggers those breached by spot during the trading day.
+
+** Purpose
+
+American-style barriers (knock-ins, knock-outs) trigger the moment spot touches
+or crosses the barrier level, at any time during market hours. A large book can
+have hundreds of active barriers; the screen must surface the critical ones —
+those close to current spot — without burying them in noise.
+
+** Layout
+
+The screen uses a two-pane master-detail design:
+
+- *Top pane (master)*: One row per distinct barrier level — level, cut, distance
+  from current spot, and count of deals at that level.
+- *Bottom pane (detail)*: When a top-pane row is selected, individual deals at
+  that level; each deal can be ticked or unticked for the trigger action.
+
+#+begin_example
+┌──────────────────┬──────────┬─────────────────────────┬────────┬─────────┐
+│ Barrier Level    │ CUT      │ % Away from Spot        │ Deals  │ Select  │
+├──────────────────┼──────────┼─────────────────────────┼────────┼─────────┤
+│ 1.0750  DnOut    │ NY       │ ████░░░░░░  1.0%        │ 3      │ [x]     │
+│ 1.0900  UpOut    │ NY       │ ░░░░████░░  1.5%        │ 1      │ [ ]     │
+│ 1.0500  DnIn     │ Tokyo    │ ░░░░░░░░██  2.8%        │ 2      │ [ ]     │
+└──────────────────┴──────────┴─────────────────────────┴────────┴─────────┘
+#+end_example
+
+When individual deals are deselected in the bottom pane, the top-pane tick box
+for that level is greyed out, preventing accidental bulk triggers of an
+incomplete set.
+
+** Colour Coding
+
+| State                              | Colour            |
+|------------------------------------+-------------------|
+| Triggered                          | Red row           |
+| Partially triggered (some legs done) | Amber           |
+| Selected to trigger                | Green highlight   |
+| Within strike tolerance            | Blue              |
+| Interbank trade                    | Bold or flag icon |
+| Stale market data                  | Red spot indicator|
+
+** Operational Considerations
+
+- Multiple operators may run the barrier screen simultaneously; the system must
+  implement locking at the trigger level to prevent double-triggering.
+- Interbank trades are flagged because triggering them requires a Reuters
+  confirmation call to the counterparty.
+- *Late trigger*: If a barrier was breached while the screen was unmonitored
+  (e.g. overnight), the operator can trigger it after the fact with a timestamp
+  reflecting the actual breach time.
+
+* Delta Jump Screen
+
+A read-only analytical report showing the expected change in delta if any live
+barrier is hit. It answers: "if spot touches this barrier right now, how much
+delta will I suddenly have?"
+
+#+begin_example
+ Currency Pair: [ EUR/USD ▾ ]
+
+┌──────────────────┬────────────────────┬────────────────────────────┐
+│ Barrier Level    │ Net Delta Jump Ccy1│ Net Delta Jump / Deal Val  │
+├──────────────────┼────────────────────┼────────────────────────────┤
+│ 1.0750 DnOut     │                    │                            │
+│ 1.0900 UpOut     │                    │                            │
+└──────────────────┴────────────────────┴────────────────────────────┘
+#+end_example
+
+Days to Maturity is an important additional column: the delta jump magnitude is
+maturity-dependent for both continuous and discrete barriers.
+
+* Spike Map
+
+The Spike Map visualises notional (or theoretical value) concentration across
+the option book, bucketed by expiry date and spot level. It is the primary tool
+for understanding where concentrations of barrier and digital risk lie in time
+and space.
+
+** Settings
+
+#+begin_example
+┌─────────────────────────────────────────────────────────────────┐
+│  SPOT BUCKETS    Number: [ 10 ▾ ]   Size: [ 0.0131 ]           │
+│  DATE BUCKETS    Days: [ 14 ]  Weeks: [ 5 ]  Months: [ 10 ]  Years: [ 4 ]│
+│  Ccy Pair:       [ EUR/USD ▾ ]    Display Ccy: [ EUR ▾ ]       │
+│  Include Reserves: [x]                                          │
+│  Display Mode:   ( ) Notional   (•) Theoretical Value          │
+│  Population:     ( ) American   ( ) European   (•) Both        │
+└─────────────────────────────────────────────────────────────────┘
+#+end_example
+
+American and European spikes are displayed separately: American barriers trigger
+at any time; European barriers trigger only at expiry.
+
+** Output Grid
+
+#+begin_example
+┌────────┬────────┬─────────────┬──────────────────┬───┬────────────────┬──────────┐
+│ Books  │ Date   │ ≤ 1.0550    │ 1.0550 – 1.0600  │ … │  Spot (1.0823) │ ≥ 1.1200 │
+├────────┼────────┼─────────────┼──────────────────┼───┼────────────────┼──────────┤
+│ [▾] A  │ Apr-26 │             │  12.5M           │   │                │          │
+│ [▾] A  │ May-26 │  8.0M       │                  │   │                │  4.0M    │
+└────────┴────────┴─────────────┴──────────────────┴───┴────────────────┴──────────┘
+     ↑ yellow/red for warnings (e.g. forward-starting barrier in wrong date bucket)
+#+end_example
+
+- The column centred on current spot is highlighted.
+- Clicking a cell drills down to the contributing deals.
+- Each cell shows spike TV (theoretical value) and TV% (TV as percentage of notional).
+- Cells turn yellow (warning) or red (error) for anomalies.
+
+* Cross-Screen Navigation
+
+The blotter is the hub from which all lifecycle screens are reachable via
+right-click context menu on any deal row. Navigation is context-preserving:
+arriving at the Expiry Manager from a deal row pre-filters to that deal's cut,
+date, and currency pair.
+
+| From                        | Destination                                                     |
+|-----------------------------+-----------------------------------------------------------------|
+| Any deal row                | Deal entry form (Amend or Clone)                                |
+| Option row                  | Expiry Manager (pre-filtered to deal's cut and date)            |
+| Barrier deal row            | Barrier Management (pre-filtered to currency pair and level)    |
+| NDF / floating deal row     | Fixing Manager (pre-filtered to deal's fixing source)           |
+| Any deal row                | Single-deal risk report                                         |
+| Book tree selection         | Headline Position                                               |
+| Headline Position tile      | Full Greek report for that book                                 |
+| Spike Map cell              | Deal blotter filtered to cell's deals                           |
+| Barrier level (top pane)    | Deal list for that level (bottom pane)                          |
+| Fixing Manager → View Deals | Deal blotter filtered to affected deals                         |
+
+* ORE Studio Notes
+
+ORE Studio is implementing blotter functionality as part of the front-office
+interface layer. Key implementation considerations:
+
+- The deal entry form corresponds to the =TradeDetailDialog= component in the
+  ORE Studio Qt UI. The form's product-aware field display maps directly to ORE's
+  trade XML schema differences across product types (see [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][ORE]]).
+- The deal grid's NPV, Delta, and Vega columns are produced by ORE's NPV and
+  SENSITIVITY analytics. In ORE Studio, these are computed via in-process
+  execution (see [[id:98B9FE2A-57FB-464F-A4E5-198461FE6987][Compute Engine]]) and displayed per-deal.
+- Colour coding for Valuation Error and Smile Error maps to the error flags
+  returned by ORE analytics runs.
+- Expiry Manager cut times align with the cut codes defined in ORE's
+  =conventions.xml= reference data.
+- The Fixing Manager authorisation workflow corresponds to the fixing management
+  APIs and relates directly to the fixing inputs that ORE requires for NDF and
+  floating-coupon pricing.
+- The Spike Map spot and date bucketing is configurable; its underlying data is
+  produced by running the ORE NPV analytic across the full trade population
+  partitioned by expiry and barrier level.

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -84,6 +84,14 @@ Authentication, authorisation, and tenancy.
 - [[id:3CAA394F-E84C-3434-331B-6E664F7E84D2][Role-Based Access Control]] — the RBAC model that backs IAM:
   roles compose permissions, the assignment graph.
 
+* Manuals
+
+Published user-facing documentation for ORE Studio.
+
+- [[id:914738C6-7C77-41CD-A949-55DBBE0B6908][ORE Studio Manuals]] — index of all manuals and guides.
+- [[id:6A1A333C-A83A-8954-B9C3-C3AB1AEC3046][ORE Studio User Manual]] — full user manual; covers all screens and
+  workflows.
+
 * External reference
 
 Concepts and systems we don't own — captured here so other docs can

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -18,7 +18,8 @@ in two places, that concept belongs here.
 
 Knowledge is grouped by topic; jump to the section that fits what you
 are looking for. The [[id:CF2C4F3A-9C5C-4E7A-9E16-2A3A8C1D4C11][external/]] subfolder contains pure reference docs
-about systems and concepts ORE Studio does not own.
+about systems and concepts ORE Studio does not own. For user-facing
+documentation see [[id:914738C6-7C77-41CD-A949-55DBBE0B6908][ORE Studio Manuals]].
 
 * Domain
 
@@ -83,14 +84,6 @@ Authentication, authorisation, and tenancy.
   [[id:D00BEA0D-E501-C534-A013-E6F40C1A6097][ores.iam.core]]: tenants, accounts, roles, permissions.
 - [[id:3CAA394F-E84C-3434-331B-6E664F7E84D2][Role-Based Access Control]] — the RBAC model that backs IAM:
   roles compose permissions, the assignment graph.
-
-* Manuals
-
-Published user-facing documentation for ORE Studio.
-
-- [[id:914738C6-7C77-41CD-A949-55DBBE0B6908][ORE Studio Manuals]] — index of all manuals and guides.
-- [[id:6A1A333C-A83A-8954-B9C3-C3AB1AEC3046][ORE Studio User Manual]] — full user manual; covers all screens and
-  workflows.
 
 * External reference
 

--- a/doc/manual/user_guide/user_manual.org
+++ b/doc/manual/user_guide/user_manual.org
@@ -31,6 +31,7 @@
 #+latex: \thispagestyle{empty}
 #+latex: \newpage
 
+#+html: <script>document.title = "ORE Studio User Manual";</script>
 #+HTML: <p><a href="user_manual.pdf">Download PDF</a></p>
 
 * Introduction


### PR DESCRIPTION
## Summary

- Convert 9 personal notes from `~/Development/Notebooks/summaries/` to v2 knowledge documents under `doc/knowledge/domain/`
- One commit per source document; `reporting.org` (superseded) merged into `pl_attribution.org` and `risk_reporting.org`
- All terminology aligned to ORE Studio concepts (grid→compute engine, job→computation run, etc.)
- Cross-linked documents reference each other and the knowledge index via org-roam IDs

Documents created:
- `fx_volatility_surface.org` — pillar quoting, delta conventions, smile models, interpolation
- `interest_rate_curves.org` — day-count conventions, bootstrapping instruments, USD curve construction
- `time_structures_and_tenors.org` — scalars/tenors/term structures, settlement conventions, IMM dates
- `compute_engine.org` — run configurations, computation runs, orchestration, environments, lifecycle
- `pricing_configuration.org` — 5-layer anatomy, override hierarchy, snapshotting, MRU views
- `pl_attribution.org` — attribution identity, Bump and Reset/Run, trade activity categories, EOD sign-off
- `risk_reporting.org` — 5-axis taxonomy, methodologies, full measures catalogue, 17 named reports
- `trade_blotter.org` — panel layout, deal grid, deal actions, entry form, lifecycle screens

## Test plan

- [ ] All 8 new files parse as valid org-mode documents with correct v2 frontmatter
- [ ] All org-roam IDs are unique and cross-links resolve correctly
- [ ] Terminology in `compute_engine.org` uses ORE Studio terms throughout (no bare "job" or "grid" language)
- [ ] `reporting.org` source is not ported as a standalone file (content merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)