### PR TITLE
[doc] Manual: where connections are stored + how to back up

### DIFF
--- a/doc/manual/user_guide/chapters/chapter_01/system_bootstrapping.org
+++ b/doc/manual/user_guide/chapters/chapter_01/system_bootstrapping.org
@@ -179,6 +179,42 @@ Enter (or comma) to add it; click the × on an existing tag chip to
 remove it. Tags are created on first use — there is no separate tag
 management screen.
 
+*** Where your connections are stored
+
+ORE Studio keeps your connections — together with their environments,
+folders, and tags — in a single local SQLite database file named
+=connections.db=. Your UI settings (preferences and window layout) are
+stored separately, in the operating system's standard settings store.
+Neither leaves your machine.
+
+#+attr_html: :class hug-leading
+| Operating system | Connection database (=connections.db=)                 | Settings / preferences                              |
+|------------------+--------------------------------------------------------+-----------------------------------------------------|
+| Linux            | =~/.local/share/ores.qt/connections.db=                | =~/.config/OreStudio/OreStudio.conf= (INI file)     |
+| macOS            | =~/Library/Application Support/ores.qt/connections.db= | =~/Library/Preferences/= (a =.plist= named for the org/app) |
+| Windows          | =%APPDATA%\ores.qt\connections.db=                     | Registry: =HKCU\Software\OreStudio\OreStudio=       |
+
+If =connections.db= is missing when ORE Studio starts, it creates a new
+empty one — so the Connection Manager simply opens with no entries.
+
+*** Backing up and restoring your connections
+
+Because everything you configure here lives in that one =connections.db=
+file, backing it up is a file copy:
+
+1. Quit ORE Studio, so the database is fully written and not locked.
+2. Copy =connections.db= from the location above to a safe place — on
+   Linux, for example:
+
+   #+begin_src sh
+   cp ~/.local/share/ores.qt/connections.db ~/connections-backup.db
+   #+end_src
+
+To restore, quit ORE Studio and copy the backup back over
+=connections.db=. To move your connections to another machine, copy the
+file to the same location there. The file is self-contained, so a single
+copy preserves all your connections, environments, folders, and tags.
+
 ** Connecting and logging in
 
 Once you have at least one connection configured, you can log in.
@@ -325,11 +361,13 @@ The =--color= spelling (without the 'u') is accepted as an alias.
 
 *** Configuration directory
 
-By default ORE Studio stores its settings — saved connections,
-preferences, window layout — in the platform's standard user
-configuration directory (=~/.config/OreStudio/= on Linux,
+By default ORE Studio stores its UI settings — preferences and window
+layout — in the platform's standard user configuration directory
+(=~/.config/OreStudio/= on Linux,
 =~/Library/Application Support/OreStudio/= on macOS,
-=%APPDATA%\OreStudio\= on Windows). To use a different directory:
+=%APPDATA%\OreStudio\= on Windows). Your saved connections live
+separately, in =connections.db= (see [[*Where your connections are stored][Where your connections are
+stored]]). To use a different directory:
 
 #+begin_src sh
 ores --config-dir /path/to/config


### PR DESCRIPTION
## Summary

Documents where the Connection Manager keeps its data and how to back it
up, in chapter 1 (System bootstrapping → The Connection Manager). Also
fixes an inaccuracy in the existing "Configuration directory" subsection.

## Changes

- **New: "Where your connections are stored"** — connections (plus
  environments, folders, tags) live in a single SQLite file
  `connections.db`; UI settings are stored separately. Includes a
  per-OS table of the **database** and **settings** locations:

  | OS | connections.db | Settings |
  |----|----------------|----------|
  | Linux | `~/.local/share/ores.qt/connections.db` | `~/.config/OreStudio/OreStudio.conf` |
  | macOS | `~/Library/Application Support/ores.qt/connections.db` | `~/Library/Preferences/` (plist) |
  | Windows | `%APPDATA%\ores.qt\connections.db` | Registry `HKCU\Software\OreStudio\OreStudio` |

  (Paths verified against the code: app name `ores.qt` →
  `QStandardPaths::AppDataLocation` for the DB; `QSettings("OreStudio",
  "OreStudio")` for settings.)

- **New: "Backing up and restoring your connections"** — quit, copy the
  file, copy it back; copy to another machine to migrate.

- **Fix:** the "Configuration directory" subsection wrongly listed
  *saved connections* among `~/.config/OreStudio/` contents. Connections
  are in the data dir (`connections.db`), not the config dir — corrected
  and cross-referenced.

## Notes

`validate_docs.sh` passes (90/90). Doc-only.