### PR TITLE
[ores.lisp] Fix DB dashboard operations to use .env database name

### DIFF
--- a/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/story.org
+++ b/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/story.org
@@ -26,12 +26,12 @@ offers an ORE Studio shell, and shows the ORE splash image.
 
 | Field         | Value                                      |
 |---------------+--------------------------------------------|
-| State         | DONE                                       |
-| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                                  |
-| Now           | Dashboard implemented and shipped; PR #831.|
-| Waiting on    | Nothing.                                   |
-| Next          | Nothing.                                   |
-| Last touched  | 2026-05-26                                 |
+| State         | STARTED                                                  |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                                                |
+| Now           | Bug fix task added: DB ops use discovery instead of .env.|
+| Waiting on    | Nothing.                                                 |
+| Next          | Implement and merge fix task.                            |
+| Last touched  | 2026-05-25                                               |
 
 * Acceptance
 
@@ -58,6 +58,7 @@ In execution order:
 - [[id:7E86CDB4-3FE6-46AD-BCC8-C0E9AD8857D6][Remove superseded ores.lisp modules]]
 - [[id:3C888F53-0522-4A56-A50A-A7AFEA101468][Write the ORE Studio dashboard user manual section]]
 - [[id:3C569365-B253-4BC6-9385-7CAF7B4FB54D][Make compass output paths clickable in dashboard output pane]]
+- [[id:FC26D072-3E4C-488B-BE3A-958F29041D02][Fix DB dashboard operations to use .env database name]]
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_fix_db_operations_use_env.org
+++ b/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_fix_db_operations_use_env.org
@@ -9,7 +9,7 @@
 #+filetags: :ores_studio_emacs_dashboard:sprint_18:v0:
 #+owner: marco
 #+branch: feature/dashboard-env-fix
-#+pr:
+#+pr: 849
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-25
@@ -32,9 +32,9 @@ prompting the user to choose one via =completing-read=.
 |--------------+----------------------------------------|
 | State        | STARTED                              |
 | Parent story | [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]] |
-| Now          | Implementing fix in ores-dashboard.el. |
-| Waiting on   | Nothing.                               |
-| Next         | Raise PR, CI green, merge.             |
+| Now          | PR #849 raised; review comments addressed.     |
+| Waiting on   | CI green, merge.                               |
+| Next         | Merge after CI passes.                         |
 | Last touched | 2026-05-25                               |
 
 * Acceptance
@@ -108,14 +108,16 @@ All groups were inspected in =ores-dashboard.el=.
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR  | Title                                                               |
+|-----+---------------------------------------------------------------------|
+| [[https://github.com/OreStudio/OreStudio/pull/849][#849]] | [ores.lisp] Fix DB dashboard operations to use .env database name |
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                  | File                  | Decision | Notes                                                                                                         |
+|---+--------------------------------------------------+-----------------------+----------+---------------------------------------------------------------------------------------------------------------|
+| 1 | Kill connections hardcodes =--host localhost=    | ores-dashboard.el:546 | Applied  | Added =pg-host= binding reading =PGHOST= from =.env= alist (fallback =localhost=). Fixed in 2832519e0.        |
+| 2 | Teardown DB hardcodes =--host localhost=         | ores-dashboard.el:562 | Applied  | Same fix as #1. Fixed in 2832519e0.                                                                           |
+| 3 | Recreate environment shows =dbn= but ignores it | ores-dashboard.el:580 | Applied  | Reverted confirmation to =ores_dev_<label>=; =ores-db/--run-recreate-env= uses label naming, not =ORES_DATABASE_NAME=. Fixed in 2832519e0. |
 
 * Result

--- a/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_fix_db_operations_use_env.org
+++ b/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_fix_db_operations_use_env.org
@@ -1,0 +1,121 @@
+:PROPERTIES:
+:ID: FC26D072-3E4C-488B-BE3A-958F29041D02
+:END:
+#+title: Task: Fix DB dashboard operations to use .env database name
+#+description: Kill connections, Teardown DB and Recreate DB all prompt for a database via completing-read instead of reading ORES_DATABASE_NAME from .env.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :ores_studio_emacs_dashboard:sprint_18:v0:
+#+owner: marco
+#+branch: feature/dashboard-env-fix
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Fix the three DB-group dashboard operations — "Kill connections",
+"Teardown DB", and "Recreate DB" — so they act on the database
+obtained from =.env= (=ORES_DATABASE_NAME=, or =ores_dev_<label>= when
+absent) instead of discovering all ORES databases on localhost and
+prompting the user to choose one via =completing-read=.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]] |
+| Now          | Implementing fix in ores-dashboard.el. |
+| Waiting on   | Nothing.                               |
+| Next         | Raise PR, CI green, merge.             |
+| Last touched | 2026-05-25                               |
+
+* Acceptance
+
+- "Kill connections" runs against the database from =.env= with no
+  =completing-read= prompt.
+- "Teardown DB" runs against the database from =.env= with no
+  =completing-read= prompt.
+- "Recreate DB" runs against the database from =.env= with no
+  =completing-read= prompt.
+- "Recreate environment" uses =ORES_DATABASE_NAME= (or =ores_dev_<label>=)
+  — no hardcoded pattern divergence.
+- No other dashboard option prompts for an environment or database name.
+- All confirmation dialogs (=yes-or-no-p=) remain in place.
+- Dashboard still functions correctly when =ORES_DATABASE_NAME= is absent
+  (falls back to =ores_dev_<label>=).
+
+* Plan
+
+1. In =ores/dashboard--db-group= (=ores-dashboard.el=), =db-name= is
+   already bound from =ORES_DATABASE_NAME= / =ores_dev_<label>=.
+
+2. *Kill connections* — remove the =ores-db/database-list-discovery=
+   call and =completing-read=; obtain the host from =db-name=
+   (localhost), pass =db-name= directly to the kill script.
+
+3. *Teardown DB* — same: remove discovery + prompt; pass =db-name=
+   directly to the teardown script.
+
+4. *Recreate DB* — same: remove discovery + prompt; pass =db-name=
+   directly to =ores-db/--run-recreate-db=.
+
+5. *Recreate environment* — already uses =lbl= from env; verify it
+   also honours =ORES_DATABASE_NAME= if set (adjust if needed).
+
+6. Audit all other groups for any =completing-read= or =read-string=
+   calls that ask for an environment or database — none found (see
+   Analysis below).
+
+* Analysis — all dashboard options audited
+
+All groups were inspected in =ores-dashboard.el=.
+
+| Group       | Option                  | Env source                  | Prompts? | Status |
+|-------------+-------------------------+-----------------------------+----------+--------|
+| Environment | Init environment        | =ORES_PRESET= / =label=     | No       | OK     |
+| Environment | Edit environment        | =root= from =.env=          | No       | OK     |
+| Environment | Reload environment      | re-reads =.env=             | No       | OK     |
+| Environment | Diff .env vs .env.old   | =root= from =.env=          | No       | OK     |
+| Database    | Open database connection| =label=, service names      | Yes*     | OK*    |
+| Database    | Kill connections        | hardcoded discovery         | Yes      | *BUG*  |
+| Database    | Teardown DB             | hardcoded discovery         | Yes      | *BUG*  |
+| Database    | Recreate DB             | hardcoded discovery         | Yes      | *BUG*  |
+| Database    | Recreate environment    | =label= (hardcoded pattern) | No       | Minor  |
+| Services    | Start/Stop/Status/Client| =label=                     | No       | OK     |
+| Compass     | where/list/status/fleet | =label=                     | No       | OK     |
+| Build       | Configure/Build/Test    | =label=, =ORES_PRESET=      | No       | OK     |
+| Site        | Rebuild/Start/Stop site | =label=, =ORES_PRESET=      | No       | OK     |
+| Skills      | Open folder / Deploy    | =label=, =ORES_PRESET=      | No       | OK     |
+| Bookmarks   | Log dir / Bin dir       | =ORES_PRESET=               | No       | OK     |
+| Links       | Manual / Recipes / Agile| hardcoded relative path     | No       | OK     |
+| Shell       | Open ORE Studio shell   | =label=, =ORES_PRESET=      | No       | OK     |
+| NATS        | Init NATS / +provision  | =label=                     | No       | OK     |
+
+*=Open database connection= prompts only to choose between multiple
+ service connections for the /same/ environment (e.g. =ores-local1-refdata=
+ vs =ores-local1-trading=); it does not ask which environment to use.
+ This is intentional and correct.
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/projects/ores.lisp/src/ores-dashboard.el
+++ b/projects/ores.lisp/src/ores-dashboard.el
@@ -476,8 +476,9 @@ Falls back to two spaces when icons are unavailable, preserving alignment."
           'ores/dashboard-group-env-face)))
 
 (defun ores/dashboard--db-group (env root dash-buf)
-  (let* ((label  (or (cdr (assoc "ORES_CHECKOUT_LABEL" env)) "local"))
-         (pgpw   (cdr (assoc "PGPASSWORD" env)))
+  (let* ((label   (or (cdr (assoc "ORES_CHECKOUT_LABEL" env)) "local"))
+         (pgpw    (cdr (assoc "PGPASSWORD" env)))
+         (pg-host (or (cdr (assoc "PGHOST" env)) "localhost"))
          (db-name (or (cdr (assoc "ORES_DATABASE_NAME" env))
                       (format "ores_dev_%s" label))))
     (list "Database" 'nerd-icons-faicon "nf-fa-database"
@@ -531,7 +532,7 @@ Falls back to two spaces when icons are unavailable, preserving alignment."
                                      (error-message-string err))))))))))
            (ores/dashboard--mkitem
             "Kill connections" 'nerd-icons-faicon "nf-fa-times_circle"
-            (let ((r root) (pw pgpw) (dbn db-name) (db dash-buf))
+            (let ((r root) (pw pgpw) (h pg-host) (dbn db-name) (db dash-buf))
               (lambda (_)
                 (unless (yes-or-no-p (format "Kill all connections to %s? " dbn))
                   (user-error "Aborted"))
@@ -542,12 +543,12 @@ Falls back to two spaces when icons are unavailable, preserving alignment."
                           process-environment))
                        (buf-name (format "*ores-db-kill-%s*" dbn))
                        (comp-buf (compilation-start
-                                  (format "%s --host localhost %s" script dbn)
+                                  (format "%s --host %s %s" script h dbn)
                                   nil (lambda (_) buf-name))))
                   (ores/dashboard--display comp-buf db)))))
            (ores/dashboard--mkitem
             "Teardown DB" 'nerd-icons-faicon "nf-fa-bomb"
-            (let ((r root) (pw pgpw) (dbn db-name) (db dash-buf))
+            (let ((r root) (pw pgpw) (h pg-host) (dbn db-name) (db dash-buf))
               (lambda (_)
                 (unless (yes-or-no-p (format "Teardown %s (kill + drop)? " dbn))
                   (user-error "Aborted"))
@@ -558,7 +559,7 @@ Falls back to two spaces when icons are unavailable, preserving alignment."
                           process-environment))
                        (buf-name "*ores-db-teardown*")
                        (comp-buf (compilation-start
-                                  (format "%s -y --host localhost %s" script dbn)
+                                  (format "%s -y --host %s %s" script h dbn)
                                   nil (lambda (_) buf-name))))
                   (ores/dashboard--display comp-buf db)))))
            (ores/dashboard--mkitem
@@ -573,9 +574,9 @@ Falls back to two spaces when icons are unavailable, preserving alignment."
                     (ores/dashboard--display comp-buf db))))))
            (ores/dashboard--mkitem
             "Recreate environment" 'nerd-icons-faicon "nf-fa-trash"
-            (let ((lbl label) (dbn db-name) (r root))
+            (let ((lbl label) (r root))
               (lambda (_)
-                (unless (yes-or-no-p (format "DROP and recreate %s? " dbn))
+                (unless (yes-or-no-p (format "DROP and recreate ores_dev_%s? " lbl))
                   (user-error "Aborted"))
                 (ores-db/--run-recreate-env lbl r)))))
           'ores/dashboard-group-db-face)))

--- a/projects/ores.lisp/src/ores-dashboard.el
+++ b/projects/ores.lisp/src/ores-dashboard.el
@@ -531,70 +531,51 @@ Falls back to two spaces when icons are unavailable, preserving alignment."
                                      (error-message-string err))))))))))
            (ores/dashboard--mkitem
             "Kill connections" 'nerd-icons-faicon "nf-fa-times_circle"
-            (let ((r root) (pw pgpw) (db dash-buf))
+            (let ((r root) (pw pgpw) (dbn db-name) (db dash-buf))
               (lambda (_)
-                (let* ((dbs   (let ((default-directory r)) (ores-db/database-list-discovery)))
-                       (names (mapcar #'car dbs)))
-                  (if (null names)
-                      (user-error "No ORES databases found on localhost")
-                    (let* ((choice (completing-read "Kill connections to DB: " names nil t))
-                           (entry  (cl-find choice dbs :key #'car :test #'string=))
-                           (host   (nth 1 entry))
-                           (script (expand-file-name
-                                    "projects/ores.sql/utility/kill_db_connections.sh" r))
-                           (process-environment
-                            (if pw (cons (format "PGPASSWORD=%s" pw) process-environment)
-                              process-environment))
-                           (buf-name (format "*ores-db-kill-%s*" choice)))
-                      (unless (yes-or-no-p (format "Kill all connections to %s? " choice))
-                        (user-error "Aborted"))
-                      (let ((comp-buf (compilation-start
-                                       (format "%s --host %s %s" script host choice)
-                                       nil (lambda (_) buf-name))))
-                        (ores/dashboard--display comp-buf db))))))))
+                (unless (yes-or-no-p (format "Kill all connections to %s? " dbn))
+                  (user-error "Aborted"))
+                (let* ((script (expand-file-name
+                                "projects/ores.sql/utility/kill_db_connections.sh" r))
+                       (process-environment
+                        (if pw (cons (format "PGPASSWORD=%s" pw) process-environment)
+                          process-environment))
+                       (buf-name (format "*ores-db-kill-%s*" dbn))
+                       (comp-buf (compilation-start
+                                  (format "%s --host localhost %s" script dbn)
+                                  nil (lambda (_) buf-name))))
+                  (ores/dashboard--display comp-buf db)))))
            (ores/dashboard--mkitem
             "Teardown DB" 'nerd-icons-faicon "nf-fa-bomb"
-            (let ((r root) (pw pgpw) (db dash-buf))
+            (let ((r root) (pw pgpw) (dbn db-name) (db dash-buf))
               (lambda (_)
-                (let* ((dbs   (let ((default-directory r)) (ores-db/database-list-discovery)))
-                       (names (mapcar #'car dbs)))
-                  (if (null names)
-                      (user-error "No ORES databases found on localhost")
-                    (let* ((choice (completing-read "Teardown database: " names nil t))
-                           (entry  (cl-find choice dbs :key #'car :test #'string=))
-                           (host   (nth 1 entry))
-                           (script (expand-file-name
-                                    "projects/ores.sql/teardown_database.sh" r))
-                           (process-environment
-                            (if pw (cons (format "PGPASSWORD=%s" pw) process-environment)
-                              process-environment))
-                           (buf-name "*ores-db-teardown*"))
-                      (unless (yes-or-no-p (format "Teardown %s (kill + drop)? " choice))
-                        (user-error "Aborted"))
-                      (let ((comp-buf (compilation-start
-                                       (format "%s -y --host %s %s" script host choice)
-                                       nil (lambda (_) buf-name))))
-                        (ores/dashboard--display comp-buf db))))))))
+                (unless (yes-or-no-p (format "Teardown %s (kill + drop)? " dbn))
+                  (user-error "Aborted"))
+                (let* ((script (expand-file-name
+                                "projects/ores.sql/teardown_database.sh" r))
+                       (process-environment
+                        (if pw (cons (format "PGPASSWORD=%s" pw) process-environment)
+                          process-environment))
+                       (buf-name "*ores-db-teardown*")
+                       (comp-buf (compilation-start
+                                  (format "%s -y --host localhost %s" script dbn)
+                                  nil (lambda (_) buf-name))))
+                  (ores/dashboard--display comp-buf db)))))
            (ores/dashboard--mkitem
             "Recreate DB" 'nerd-icons-faicon "nf-fa-recycle"
-            (let ((r root) (db dash-buf))
+            (let ((r root) (dbn db-name) (db dash-buf))
               (lambda (_)
-                (let* ((dbs   (let ((default-directory r)) (ores-db/database-list-discovery)))
-                       (names (mapcar #'car dbs)))
-                  (if (null names)
-                      (user-error "No ORES databases found on localhost")
-                    (let* ((choice (completing-read "Recreate database: " names nil t)))
-                      (unless (yes-or-no-p (format "DROP and recreate %s? " choice))
-                        (user-error "Aborted"))
-                      (let ((comp-buf (let ((default-directory r))
-                                        (ores-db/--run-recreate-db choice))))
-                        (when comp-buf
-                          (ores/dashboard--display comp-buf db)))))))))
+                (unless (yes-or-no-p (format "DROP and recreate %s? " dbn))
+                  (user-error "Aborted"))
+                (let ((comp-buf (let ((default-directory r))
+                                  (ores-db/--run-recreate-db dbn))))
+                  (when comp-buf
+                    (ores/dashboard--display comp-buf db))))))
            (ores/dashboard--mkitem
             "Recreate environment" 'nerd-icons-faicon "nf-fa-trash"
-            (let ((lbl label) (r root))
+            (let ((lbl label) (dbn db-name) (r root))
               (lambda (_)
-                (unless (yes-or-no-p (format "DROP and recreate ores_dev_%s? " lbl))
+                (unless (yes-or-no-p (format "DROP and recreate %s? " dbn))
                   (user-error "Aborted"))
                 (ores-db/--run-recreate-env lbl r)))))
           'ores/dashboard-group-db-face)))


### PR DESCRIPTION
## Summary

- `Kill connections`, `Teardown DB`, and `Recreate DB` in the dashboard's DB card previously called `ores-db/database-list-discovery` to enumerate all ORES databases on localhost, then prompted the user to choose one via `completing-read` — completely ignoring the environment loaded from `.env`.
- All three now read `db-name` (already bound in the closure from `ORES_DATABASE_NAME` or `ores_dev_<label>`) directly, with no discovery and no prompt.
- `Recreate environment` likewise now shows the actual database name from env in its confirmation dialog instead of the hardcoded `ores_dev_%s` pattern.
- Confirmation `yes-or-no-p` guards are preserved on all operations.
- Task doc added: `doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_fix_db_operations_use_env.org`.
- Story re-opened to STARTED; wired new task into story's Tasks list.

## Test plan

- [ ] Open dashboard (`M-x ores/dashboard`) in a checkout with `.env` containing `ORES_DATABASE_NAME=my_db`.
- [ ] Trigger "Kill connections" — confirm dialog shows `my_db`, no `completing-read` prompt appears.
- [ ] Trigger "Teardown DB" — same: shows `my_db` directly.
- [ ] Trigger "Recreate DB" — same.
- [ ] Trigger "Recreate environment" — confirmation shows `my_db` (not `ores_dev_<label>`).
- [ ] Repeat without `ORES_DATABASE_NAME` in `.env` — all dialogs show `ores_dev_<label>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)