### PR TITLE
[ores.lisp] Dashboard: fix start-client and add SQLite connections DB entry

### DIFF
--- a/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/story.org
+++ b/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/story.org
@@ -59,6 +59,7 @@ In execution order:
 - [[id:3C888F53-0522-4A56-A50A-A7AFEA101468][Write the ORE Studio dashboard user manual section]]
 - [[id:3C569365-B253-4BC6-9385-7CAF7B4FB54D][Make compass output paths clickable in dashboard output pane]]
 - [[id:FC26D072-3E4C-488B-BE3A-958F29041D02][Fix DB dashboard operations to use .env database name]]
+- [[id:A1347F1E-C771-4762-9159-88EB624C0CCB][Add SQLite connections DB entry to dashboard DB card]]
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_add_sqlite_db_dashboard_entry.org
+++ b/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_add_sqlite_db_dashboard_entry.org
@@ -9,7 +9,7 @@
 #+filetags: :ores_studio_emacs_dashboard:sprint_18:v0:
 #+owner: marco
 #+branch: feature/fix-dashboard-start-client
-#+pr:
+#+pr: 851
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-25
@@ -57,14 +57,15 @@ task closes. Plans do not outlive their task.)
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR                                                              | Title                                                                              |
+|-----------------------------------------------------------------+------------------------------------------------------------------------------------|
+| [[https://github.com/OreStudio/OreStudio/pull/851][#851]] | Dashboard: fix start-client and add SQLite connections DB entry |
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                                        | File                | Decision | Notes                                                              |
+|---+------------------------------------------------------------------------+---------------------+----------+--------------------------------------------------------------------|
+| 1 | Missing (require 'sql): sql-* vars not declared special under lex-bind | ores-dashboard.el   | Fixed    | Added (require 'sql) to requires block                             |
+| 2 | ores/dashboard--start-client-do crashes if context nil (direct M-x)   | ores-dashboard.el   | Fixed    | Added user-error guard before let* binding                         |
 
 * Result

--- a/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_add_sqlite_db_dashboard_entry.org
+++ b/doc/agile/versions/v0/sprint_18/ores_studio_emacs_dashboard/task_add_sqlite_db_dashboard_entry.org
@@ -1,0 +1,70 @@
+:PROPERTIES:
+:ID: A1347F1E-C771-4762-9159-88EB624C0CCB
+:END:
+#+title: Task: Add SQLite connections DB entry to dashboard DB card
+#+description: Add an item to the dashboard DB card that opens ~/.local/share/ores.qt/connections.db in sql-sqlite, loading the project sqliterc for ergonomic display.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :ores_studio_emacs_dashboard:sprint_18:v0:
+#+owner: marco
+#+branch: feature/fix-dashboard-start-client
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add an "Open connections DB (SQLite)" entry to the dashboard Database
+card. When activated it opens =~/.local/share/ores.qt/connections.db=
+in an =sql-sqlite= buffer, pre-loading
+=projects/ores.sql/utility/sqliterc.sql= via =-init= so column
+headers, box formatting, NULL display, and prompt branding are active
+immediately. The DB path is environment-independent (one shared file).
+
+* Status
+
+| Field        | Value                                      |
+|--------------+--------------------------------------------|
+| State        | DONE                                       |
+| Parent story | [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                 |
+| Now          | Complete.                                  |
+| Waiting on   | Nothing.                                   |
+| Next         | —                                          |
+| Last touched | 2026-05-25                                 |
+
+* Acceptance
+
+- The Database card has an "Open connections DB (SQLite)" item.
+- Activating it opens =~/.local/share/ores.qt/connections.db= in a
+  dedicated =*ores-connections-db*= buffer using =sql-sqlite=.
+- The sqliterc at =projects/ores.sql/utility/sqliterc.sql= is loaded
+  via =-init=, giving box output, headers, NULL marker, and =ore>= prompt.
+- The item is environment-agnostic (same DB path for all presets).
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/projects/ores.lisp/src/ores-dashboard.el
+++ b/projects/ores.lisp/src/ores-dashboard.el
@@ -33,6 +33,7 @@
 (require 'ores-env)
 (require 'ores-shell)
 (require 'ores-db)
+(require 'transient)
 
 ;; ---------------------------------------------------------------------------
 ;; Faces
@@ -437,6 +438,42 @@ Falls back to two spaces when icons are unavailable, preserving alignment."
     (ores/dashboard--display comp-buf dash-buf)))
 
 ;; ---------------------------------------------------------------------------
+;; Start-client transient
+;;
+;; "Start client" uses setsid so ores.qt survives the compilation shell's
+;; exit.  Without it, Emacs's process-group cleanup kills the child before
+;; the Qt window appears — the log stays empty because the process dies
+;; before it can write anything.
+;; ---------------------------------------------------------------------------
+
+(defvar ores/dashboard--client-context nil
+  "List (root label dash-buf) passed into the start-client transient.")
+
+(defun ores/dashboard--start-client-do ()
+  "Launch ores.qt using the options chosen in the transient."
+  (interactive)
+  (let* ((ctx     ores/dashboard--client-context)
+         (root    (nth 0 ctx))
+         (label   (nth 1 ctx))
+         (dashbuf (nth 2 ctx))
+         (args    (transient-args 'ores/dashboard--start-client-transient))
+         (script  (expand-file-name "build/scripts/start-client.sh" root))
+         (cmd     (concat "setsid " script
+                          (if args
+                              (concat " " (mapconcat #'shell-quote-argument args " "))
+                            ""))))
+    (ores/dashboard--compile label cmd "start-client" root dashbuf)))
+
+(transient-define-prefix ores/dashboard--start-client-transient ()
+  "Start the ORE Studio Qt client."
+  ["Instance"
+   ("-c" "Colour"    "--colour="    :choices ("red" "green" "blue"))
+   ("-n" "Name"      "--name=")
+   ("-l" "Log level" "--log-level=" :choices ("trace" "debug" "info" "warn" "error"))]
+  ["Actions"
+   ("s" "Start" ores/dashboard--start-client-do)])
+
+;; ---------------------------------------------------------------------------
 ;; Group builders — each returns (title icon-fn icon-arg items title-face)
 ;; All use nerd-icons-faicon (Font Awesome 4) for reliable icon availability.
 ;; Colors are Nord palette hues via named deffaces above.
@@ -584,21 +621,31 @@ Falls back to two spaces when icons are unavailable, preserving alignment."
 (defun ores/dashboard--services-group (env root dash-buf)
   (let ((label (or (cdr (assoc "ORES_CHECKOUT_LABEL" env)) "local")))
     (list "Services" 'nerd-icons-faicon "nf-fa-server"
-          (mapcar
-           (lambda (spec)
-             (ores/dashboard--mkitem
-              (nth 0 spec) 'nerd-icons-faicon (nth 3 spec)
-              (let ((lbl label)
-                    (s   (expand-file-name (nth 1 spec)
-                                           (expand-file-name "build/scripts" root)))
-                    (sfx (nth 2 spec))
-                    (r   root)
-                    (db  dash-buf))
-                (lambda (_) (ores/dashboard--compile lbl s sfx r db)))))
-           '(("Start services" "start-services.sh"  "start-services"  "nf-fa-play")
-             ("Start client"   "start-client.sh"    "start-client"    "nf-fa-play_circle")
-             ("Service status" "status-services.sh" "service-status"  "nf-fa-info_circle")
-             ("Stop services"  "stop-services.sh"   "stop-services"   "nf-fa-stop")))
+          (list
+           (ores/dashboard--mkitem
+            "Start services" 'nerd-icons-faicon "nf-fa-play"
+            (let ((lbl label)
+                  (s   (expand-file-name "build/scripts/start-services.sh" root))
+                  (r   root) (db dash-buf))
+              (lambda (_) (ores/dashboard--compile lbl s "start-services" r db))))
+           (ores/dashboard--mkitem
+            "Start client" 'nerd-icons-faicon "nf-fa-play_circle"
+            (let ((lbl label) (r root) (db dash-buf))
+              (lambda (_)
+                (setq ores/dashboard--client-context (list r lbl db))
+                (ores/dashboard--start-client-transient))))
+           (ores/dashboard--mkitem
+            "Service status" 'nerd-icons-faicon "nf-fa-info_circle"
+            (let ((lbl label)
+                  (s   (expand-file-name "build/scripts/status-services.sh" root))
+                  (r   root) (db dash-buf))
+              (lambda (_) (ores/dashboard--compile lbl s "service-status" r db))))
+           (ores/dashboard--mkitem
+            "Stop services" 'nerd-icons-faicon "nf-fa-stop"
+            (let ((lbl label)
+                  (s   (expand-file-name "build/scripts/stop-services.sh" root))
+                  (r   root) (db dash-buf))
+              (lambda (_) (ores/dashboard--compile lbl s "stop-services" r db)))))
           'ores/dashboard-group-services-face)))
 
 (defun ores/dashboard--compass-group (env root dash-buf)

--- a/projects/ores.lisp/src/ores-dashboard.el
+++ b/projects/ores.lisp/src/ores-dashboard.el
@@ -34,6 +34,7 @@
 (require 'ores-shell)
 (require 'ores-db)
 (require 'transient)
+(require 'sql)
 
 ;; ---------------------------------------------------------------------------
 ;; Faces
@@ -452,6 +453,8 @@ Falls back to two spaces when icons are unavailable, preserving alignment."
 (defun ores/dashboard--start-client-do ()
   "Launch ores.qt using the options chosen in the transient."
   (interactive)
+  (unless ores/dashboard--client-context
+    (user-error "No client context — invoke Start client from the dashboard"))
   (let* ((ctx     ores/dashboard--client-context)
          (root    (nth 0 ctx))
          (label   (nth 1 ctx))

--- a/projects/ores.lisp/src/ores-dashboard.el
+++ b/projects/ores.lisp/src/ores-dashboard.el
@@ -615,7 +615,19 @@ Falls back to two spaces when icons are unavailable, preserving alignment."
               (lambda (_)
                 (unless (yes-or-no-p (format "DROP and recreate ores_dev_%s? " lbl))
                   (user-error "Aborted"))
-                (ores-db/--run-recreate-env lbl r)))))
+                (ores-db/--run-recreate-env lbl r))))
+           (ores/dashboard--mkitem
+            "Open connections DB (SQLite)" 'nerd-icons-faicon "nf-fa-table"
+            (let ((sqlite-db (expand-file-name "~/.local/share/ores.qt/connections.db"))
+                  (sqliterc  (expand-file-name "projects/ores.sql/utility/sqliterc.sql" root))
+                  (dash      dash-buf))
+              (lambda (_)
+                (let* ((buf-name "*ores-connections-db*")
+                       (sql-sqlite-options `("-init" ,sqliterc))
+                       (sql-database       sqlite-db))
+                  (save-window-excursion (sql-sqlite buf-name))
+                  (when-let ((buf (get-buffer buf-name)))
+                    (ores/dashboard--display buf dash)))))))
           'ores/dashboard-group-db-face)))
 
 (defun ores/dashboard--services-group (env root dash-buf)


### PR DESCRIPTION
## Summary

- Fix start-client action: handle process death gracefully and add transient menu for client control.
- Add "Open connections DB (SQLite)" item to the Database card — opens \`~/.local/share/ores.qt/connections.db\` in \`sql-sqlite\` with the project sqliterc loaded via \`-init\` (box output, headers, \`∅\` for NULL, \`ore>\` prompt). DB path is environment-agnostic.

## Test plan

- [ ] Dashboard start-client no longer crashes on process exit.
- [ ] "Open connections DB (SQLite)" item appears in the Database card.
- [ ] Activating it opens \`*ores-connections-db*\` in \`sql-sqlite\` mode.
- [ ] sqliterc settings are active: box output, \`ore>\` prompt, NULL shown as \`∅\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)