### PR TITLE
[agile][ci] Scaffold the 9 missing ore-samples tasks; gate site build…

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -19,6 +19,9 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches: ["main"]
 
+  pull_request:
+    branches: ["main"]
+
   workflow_dispatch:
 
 permissions:
@@ -26,15 +29,35 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
+  # Build the site on every push and pull request. The build fails when the
+  # org export cannot resolve a link — for example a story pointing at a task
+  # that was never created — so this job is the gate that catches such
+  # breakage on the PR, before it can reach main. It does not deploy.
   build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Emacs
+        uses: purcell/setup-emacs@v8.0
+        with:
+          version: 29.1
+      - name: Build site
+        run: |
+          emacs -Q --script .build-site.el
+
+  # Deploy to GitHub Pages only for pushes to main (and manual runs); never
+  # for pull requests. Runs after the build gate has passed.
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout

--- a/doc/agile/versions/v0/sprint_18/ore_samples_support/task_complete_workspace_phase_4_data_workshop_ui.org
+++ b/doc/agile/versions/v0/sprint_18/ore_samples_support/task_complete_workspace_phase_4_data_workshop_ui.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: ADF00C8F-0C17-498D-8F35-9BEB672E8672
+:END:
+#+title: Task: Complete workspace Phase 4: Data Workshop UI
+#+description: Finish workspace design Phase 4: report definition list and clone action in the Data Workshop UI.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :ore_samples_support:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Finish Phase 4 of the workspace design: the report-definition list and the
+clone action in the Data Workshop UI.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-05-25                               |
+
+* Acceptance
+
+- Report-definition list is shown in the Data Workshop.
+- Clone action duplicates a report definition.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+Detail in the source plan =doc/plans/2026-05-17-workspace-design.org=.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/ore_samples_support/task_data_import_db_schema_and_fsm.org
+++ b/doc/agile/versions/v0/sprint_18/ore_samples_support/task_data_import_db_schema_and_fsm.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: B3B64DD6-88A0-4866-9E47-665B210D4376
+:END:
+#+title: Task: Data import: DB schema and FSM
+#+description: Add the data import session database schema and the finite state machine governing the import lifecycle.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :ore_samples_support:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add the data-import-session database schema and the finite state machine that
+governs the import lifecycle, including partial success.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-05-25                               |
+
+* Acceptance
+
+- Import-session schema is in place and migrated.
+- FSM transitions cover success, partial success, and failure.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+Detail in the source plan =doc/plans/2026-05-16-trade-import-failed-state.org=.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/ore_samples_support/task_data_import_ore_import_handler.org
+++ b/doc/agile/versions/v0/sprint_18/ore_samples_support/task_data_import_ore_import_handler.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: 508554C1-214F-430C-9AB1-3C99C9F497D5
+:END:
+#+title: Task: Data import: ORE import handler
+#+description: Wire the ORE import handler end-to-end so sample input files are parsed and persisted.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :ore_samples_support:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Wire the ORE import handler end-to-end so ORE sample input files are parsed
+and persisted through the import session.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-05-25                               |
+
+* Acceptance
+
+- ORE sample files are parsed and imported via the handler.
+- Imported entities are persisted and linked to the session.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+Detail in the source plan =doc/plans/2026-02-27-ore-import-wizard-design.org=.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/ore_samples_support/task_data_import_session_window_and_workflow_ui.org
+++ b/doc/agile/versions/v0/sprint_18/ore_samples_support/task_data_import_session_window_and_workflow_ui.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: D10420E1-7447-4F80-B53E-42A20F8D353E
+:END:
+#+title: Task: Data import: session window and workflow UI
+#+description: Build the import session window and workflow UI surfacing progress, partial success, and results.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :ore_samples_support:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Build the import session window and workflow UI that surface import progress,
+partial success, and results to the user.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-05-25                               |
+
+* Acceptance
+
+- Session window shows live import progress and outcome.
+- Partial-success results are presented clearly.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+Detail in the source plan =doc/plans/2026-05-16-trade-import-failed-state.org=.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/ore_samples_support/task_data_import_trading_api_and_pending_book.org
+++ b/doc/agile/versions/v0/sprint_18/ore_samples_support/task_data_import_trading_api_and_pending_book.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: 37459E42-96A6-4A31-B4E8-96DFE36C77B0
+:END:
+#+title: Task: Data import: trading API and Pending Book
+#+description: Implement the trading API and Pending Book backing partial-success data import.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :ore_samples_support:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Implement the trading API and the Pending Book that back partial-success
+data import.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-05-25                               |
+
+* Acceptance
+
+- Trading API accepts imported trades into a Pending Book.
+- Pending Book is queryable and its entries are promotable.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+Detail in the source plan =doc/plans/2026-05-16-trade-import-failed-state.org=.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/ore_samples_support/task_fix_portfolios_and_books_not_visible_in_workspace_context.org
+++ b/doc/agile/versions/v0/sprint_18/ore_samples_support/task_fix_portfolios_and_books_not_visible_in_workspace_context.org
@@ -1,0 +1,63 @@
+:PROPERTIES:
+:ID: 1BFBA7F6-59BF-4814-BECE-C2AB75F78C41
+:END:
+#+title: Task: Fix: portfolios and books not visible in workspace context
+#+description: Fix the bug where portfolios and books are not visible when a workspace is active.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :ore_samples_support:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Fix the bug where portfolios and books are not visible when a workspace is
+active, so they appear in the workspace context as expected.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-05-25                               |
+
+* Acceptance
+
+- Portfolios and books are visible whenever a workspace is active.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+Detail in the source plan =doc/plans/2026-05-17-workspace-design.org=.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/ore_samples_support/task_workspace_full_entity_cpp_core.org
+++ b/doc/agile/versions/v0/sprint_18/ore_samples_support/task_workspace_full_entity_cpp_core.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: 71EB9DB0-1F5C-48D0-AA2E-E47A9F487B86
+:END:
+#+title: Task: Workspace full entity: C++ core
+#+description: Implement the C++ core for workspace as a full standard entity: repository, service, and history support generated from the model.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :ore_samples_support:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Implement the C++ core for workspace as a full standard entity: repository,
+service, and history operations generated from the model.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-05-25                               |
+
+* Acceptance
+
+- Workspace repository and service compile and pass tests.
+- History read/write operations work against the schema.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+Detail in the source plan =doc/plans/2026-05-21-workspace-full-entity.org=.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/ore_samples_support/task_workspace_full_entity_model_and_api.org
+++ b/doc/agile/versions/v0/sprint_18/ore_samples_support/task_workspace_full_entity_model_and_api.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: C10117BF-4054-4B31-AF2F-158EE8ABE88A
+:END:
+#+title: Task: Workspace full entity: model and API
+#+description: Promote workspace to a full standard entity at the model and API layer: history table, generated detail dialog metadata, and API surface.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :ore_samples_support:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Promote workspace from a lightweight record to a full standard entity at the
+model and API layer: add history (audit) support, the generated detail-dialog
+metadata, and the API surface the C++ and UI layers build on.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-05-25                               |
+
+* Acceptance
+
+- Workspace model carries history/audit support.
+- Generated detail-dialog metadata is produced for workspace.
+- API surface for workspace CRUD and history is defined.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+Detail in the source plan =doc/plans/2026-05-21-workspace-full-entity.org=.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/ore_samples_support/task_workspace_full_entity_qt_ui.org
+++ b/doc/agile/versions/v0/sprint_18/ore_samples_support/task_workspace_full_entity_qt_ui.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: FF7AAAB1-9C6D-4304-A74C-62FA45188D45
+:END:
+#+title: Task: Workspace full entity: Qt UI
+#+description: Wire the generated workspace detail dialog and history view into the Qt client.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :ore_samples_support:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-25
+#+updated: 2026-05-25
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Wire the generated workspace detail dialog and history view into the Qt
+client so workspaces can be viewed and edited like any other standard entity.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-05-25                               |
+
+* Acceptance
+
+- Workspace detail dialog opens from the workspace list.
+- History view shows past versions of a workspace.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+Detail in the source plan =doc/plans/2026-05-21-workspace-full-entity.org=.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result


### PR DESCRIPTION
… on PRs

PR #848 wired nine [[id:...]] task links into the ore_samples_support story but never created the task files, so the org export could not resolve them and the post-merge site build on main failed with "Unable to resolve link: C10117BF-...". The PR was not caught at review time because build-site.yml only ran on push to main, never on PRs.

- Scaffold the nine missing tasks via the v2 doc generator, reusing the IDs already referenced in the story so the links resolve, with goals and acceptance drawn from the story's acceptance criteria and a pointer to each source plan. State BACKLOG.
- Split build-site.yml into a build job that runs on push and pull_request (the gate that fails on unresolved links) and a deploy job that runs only off PRs and publishes to Pages. This catches the same class of breakage on the PR next time.