### PR TITLE
[agile,doc] Add system-model-readability story and register DeepSeek as LLM co-author

### DIFF
--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -74,6 +74,7 @@ In execution order.
 | [[id:C3B6F514-559F-4038-A1D7-947BC9F7F398][Add Downloads and Agile nav entries to the site]]    | BACKLOG | 2026-05-25 | | =doc/downloads.org= with release table; =Downloads= and =Agile= links in site nav.         |
 | [[id:6EBB206D-167F-4A0F-8F50-04D7EB4B7E33][Fix PDF site delivery and switch manual to book class]] | STARTED | 2026-05-25 | | Add =site:pdf= publish component; switch manual to =book= LaTeX class; regenerate PDF.     |
 | [[id:4E375DD6-E300-4A0A-BD20-3D06AC8ED7A1][Port domain concept notes to knowledge documents]]      | STARTED | 2026-05-25 | | Tidy personal finance/ORE domain notes into v2 knowledge docs; align with ORE Studio terms. |
+| [[id:9AE5466D-E627-4587-BBEB-6D89E732ACE2][System model readability]]                         | STARTED | 2026-05-26 |            | Add layer blurbs and table-based component inventory to the system model. |
 
 * Health Review
 

--- a/doc/agile/versions/v0/sprint_18/system_model_readability/story.org
+++ b/doc/agile/versions/v0/sprint_18/system_model_readability/story.org
@@ -78,3 +78,14 @@ The improvement follows a top-down reading order:
 - Adding new components or removing existing ones from the inventory.
 - Rewriting individual [[id:B9D3D469-9E59-465F-8C18-34546B680D13][component_overview.org]] files — those are out of scope here.
 - Changes to the PlantUML system diagram (=ores.puml= / =ores.png=).
+
+* Review
+
+Review round 1 (gemini-code-assist, 2026-05-26).
+
+| # | Comment summary                        | File        | Decision | Notes                                    |
+|---+----------------------------------------+-------------+----------+------------------------------------------|
+| 1 | Use ID link for system_model.org       | story.org   | Applied  | Replaced with id:D773166D...             |
+| 2 | Remove empty Tasks bullet              | story.org   | Applied  | Removed trailing =-=                      |
+| 3 | Use ID link for component_overview.org | story.org   | Applied  | Replaced with id:B9D3D469... (×2)        |
+| 4 | Use ID link for component_overview.org | story.org   | Applied  | Second occurrence in Plan step 3         |

--- a/doc/agile/versions/v0/sprint_18/system_model_readability/story.org
+++ b/doc/agile/versions/v0/sprint_18/system_model_readability/story.org
@@ -43,6 +43,12 @@ In execution order:
 
 -
 
+* PRs
+
+| PR  | Title                                                                          |
+|-----+--------------------------------------------------------------------------------|
+| 859 | [agile,doc] Add system-model-readability story and register DeepSeek as LLM co-author |
+
 * Plan
 
 The current [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] at =projects/modeling/system_model.org= is a flat bullet list of components under four layer headings. It is accurate as a reference but does not /explain/ the architecture — there is no narrative and no layer rationale.

--- a/doc/agile/versions/v0/sprint_18/system_model_readability/story.org
+++ b/doc/agile/versions/v0/sprint_18/system_model_readability/story.org
@@ -1,0 +1,76 @@
+:PROPERTIES:
+:ID: 9AE5466D-E627-4587-BBEB-6D89E732ACE2
+:END:
+#+title: Story: System model readability
+#+description: Improve the system model document with layer blurbs and table-based component inventory — text only, no diagram changes.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :architecture:documentation:system_model:sprint_18:v0:
+#+created: 2026-05-26
+#+updated: 2026-05-26
+#+owner: CodeWhale
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Transform the [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] from a flat component inventory into a readable architecture document that a newcomer can understand top-to-bottom. Add a narrative introduction and layer blurbs explaining the role and rationale of each architectural layer, and convert component listings into scannable tables.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]] |
+| Now           | Writing layer blurbs and converting component lists to tables in system_model.org. |
+| Waiting on    | Nothing.                               |
+| Next          | Convert Foundation layer component list to table. |
+| Last touched  | 2026-05-26                               |
+
+* Acceptance
+
+- A newcomer reading the system model from top to bottom can explain what each layer does and why the system is organised this way.
+- Each layer heading is preceded by a 1–2 paragraph blurb describing the layer's role, the kind of components it contains, and its dependency rules.
+- Component inventories use tables (Component | Description | Dependencies) instead of bare bullet lists.
+- The Database Isolation section is preserved and remains accurate.
+- All id-links are valid; frontmatter =#+updated= is refreshed.
+
+* Tasks
+
+In execution order:
+
+-
+
+* Plan
+
+The current [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] at =projects/modeling/system_model.org= is a flat bullet list of components under four layer headings. It is accurate as a reference but does not /explain/ the architecture — there is no narrative and no layer rationale.
+
+The improvement follows a top-down reading order:
+
+1. *Narrative introduction.* A new opening paragraph under =* System Architecture= (before the diagram) explains the four-layer design: Foundation provides base infrastructure with no ORE dependencies, Infrastructure adds communication and testing, Domain encodes business logic, and Application delivers user-facing surfaces. The dependency rule (layers only depend downward) is stated explicitly.
+
+2. *Layer blurbs.* Each layer heading (=** Foundation Layer=, etc.) gains a short blurb:
+   - What the layer is responsible for.
+   - Why it exists as a separate layer.
+   - What kinds of components live here.
+   - What it depends on and what depends on it.
+   The blurbs are placed /before/ the component list so the reader has context before scanning the inventory.
+
+3. *Component tables.* Each layer's bullet list converts to a table:
+   - Column 1: Component (id-linked to its =component_overview.org=).
+   - Column 2: One-line description.
+   - Column 3: Depends on (other components or "none").
+   The =Depends on= column replaces the "Depends on:" suffixes currently appended to descriptions.
+
+4. *Preserve Database Isolation.* The =* Database Isolation= section is well-written and is kept as-is. No structural changes.
+
+* Decisions
+
+* Out of scope
+
+- Changing the component architecture itself (api/core/service split, dependency graph). This story is purely about documentation readability.
+- Adding new components or removing existing ones from the inventory.
+- Rewriting individual =component_overview.org= files — those are out of scope here.
+- Changes to the PlantUML system diagram (=ores.puml= / =ores.png=).

--- a/doc/agile/versions/v0/sprint_18/system_model_readability/story.org
+++ b/doc/agile/versions/v0/sprint_18/system_model_readability/story.org
@@ -24,7 +24,7 @@ Transform the [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] from a f
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]] |
-| Now           | Writing layer blurbs and converting component lists to tables in system_model.org. |
+| Now           | Writing layer blurbs and converting component lists to tables in the [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]]. |
 | Waiting on    | Nothing.                               |
 | Next          | Convert Foundation layer component list to table. |
 | Last touched  | 2026-05-26                               |
@@ -40,8 +40,6 @@ Transform the [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] from a f
 * Tasks
 
 In execution order:
-
--
 
 * PRs
 
@@ -65,7 +63,7 @@ The improvement follows a top-down reading order:
    The blurbs are placed /before/ the component list so the reader has context before scanning the inventory.
 
 3. *Component tables.* Each layer's bullet list converts to a table:
-   - Column 1: Component (id-linked to its =component_overview.org=).
+   - Column 1: Component (id-linked to its [[id:B9D3D469-9E59-465F-8C18-34546B680D13][component_overview.org]]).
    - Column 2: One-line description.
    - Column 3: Depends on (other components or "none").
    The =Depends on= column replaces the "Depends on:" suffixes currently appended to descriptions.
@@ -78,5 +76,5 @@ The improvement follows a top-down reading order:
 
 - Changing the component architecture itself (api/core/service split, dependency graph). This story is purely about documentation readability.
 - Adding new components or removing existing ones from the inventory.
-- Rewriting individual =component_overview.org= files — those are out of scope here.
+- Rewriting individual [[id:B9D3D469-9E59-465F-8C18-34546B680D13][component_overview.org]] files — those are out of scope here.
 - Changes to the PlantUML system diagram (=ores.puml= / =ores.png=).

--- a/doc/llm/memory/memory.org
+++ b/doc/llm/memory/memory.org
@@ -68,6 +68,8 @@ of these exclusions, push back: the right home is somewhere else.
   toolchain and vcpkg detection are blocked inside the sandbox.
 - [[id:5BDDD435-9F2A-4ABC-BA71-5BB3B980C785][run_sql.sh can run outside the sandbox]] — use =dangerouslyDisableSandbox: true=
   for =run_sql.sh= and =recreate_database.sh=; sandbox blocks =localhost:5432=.
+- [[id:F7E4C41F-AF34-43E5-ADC3-1D837126B3DE][Set SSH_AUTH_SOCK for git operations]] — the sandbox has no SSH agent;
+  export =SSH_AUTH_SOCK= before =git push= / =fetch= / =pull=.
 
 ** User
 

--- a/doc/llm/memory/set_ssh_auth_sock_for_git_operations.org
+++ b/doc/llm/memory/set_ssh_auth_sock_for_git_operations.org
@@ -1,0 +1,33 @@
+:PROPERTIES:
+:ID: F7E4C41F-AF34-43E5-ADC3-1D837126B3DE
+:END:
+#+title: Set SSH_AUTH_SOCK for git operations
+#+description: The sandboxed shell does not inherit the user SSH agent. Export SSH_AUTH_SOCK before git push/fetch/pull.
+#+type: memory
+#+memory_subtype: feedback
+#+version: 2
+#+level: cross
+#+filetags: :memory:feedback:
+#+created: 2026-05-26
+#+updated: 2026-05-26
+
+The sandboxed shell environment does not inherit the user's SSH agent
+socket. Any =git push=, =git fetch=, or =git pull= will hang waiting
+for credentials unless =SSH_AUTH_SOCK= is explicitly exported first.
+
+*Why:* The user's terminal has an SSH agent running with the key
+unlocked, but the sandbox starts with an empty =SSH_AUTH_SOCK=. The
+git remote uses SSH (=git@github.com:=), and without the agent the
+connection hangs on a passphrase prompt that the sandbox can't
+display.
+
+*How to apply:* Before any =git push=, =git fetch=, or =git pull=,
+prefix the command with:
+
+#+begin_src sh
+export SSH_AUTH_SOCK=/home/marco/.ssh/agent/s.qEp3u81YnU.agent.P4RgmsqyMr
+#+end_src
+
+If the =SSH_AUTH_SOCK= value changes (the agent restarts), ask the
+user to run =echo $SSH_AUTH_SOCK= in their terminal and use the
+fresh value.

--- a/doc/recipes/git/how_do_i_commit_to_git_using_ore_studio_conventions.org
+++ b/doc/recipes/git/how_do_i_commit_to_git_using_ore_studio_conventions.org
@@ -63,6 +63,7 @@ Examples:
 - **Gemini**: =Co-Authored-By: Gemini 2.0 Flash <noreply@google.com>=
 - **Claude**: =Co-Authored-By: Claude 3.7 Sonnet <noreply@anthropic.com>=
 - **GPT**: =Co-Authored-By: GPT-4o <noreply@openai.com>=
+- **DeepSeek**: =Co-Authored-By: DeepSeek V4 Pro <noreply@deepseek.com>=
 
 Example commit message:
 

--- a/doc/recipes/github/how_do_i_address_pr_review_comments.org
+++ b/doc/recipes/github/how_do_i_address_pr_review_comments.org
@@ -76,10 +76,25 @@ requested fixes, and close the review threads?
      reasoning.
 
    #+begin_src sh :results verbatim
-   gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
-     -X POST -f body="Fixed in commit <sha> — <brief description>."
+   gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --method POST \
+     -F "body=Fixed in commit <sha> — <brief description>." \
+     -F "commit_id=<sha>" \
+     -F "path=<file-path>" \
+     -F "line=<original_line>" \
+     -F "side=RIGHT" \
+     -F "in_reply_to=<comment_id>"
    # or, for a declined comment:
-   # -f body="Not changed. <reason>."
+   # -F "body=Not changed. <reason>."
+   #+end_src
+
+   Use =-F= (not =-f=) for all fields — =-f= sends everything as
+   strings and GitHub rejects integer fields like =line= and
+   =in_reply_to= with a 422 error. Get the =original_line=,
+   =commit_id=, and =path= for each comment from:
+
+   #+begin_src sh :results verbatim
+   gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
+     --jq '.[] | {id, original_line, path}'
    #+end_src
 
 6. /Resolve each review thread/ via GraphQL. First get the thread
@@ -112,7 +127,7 @@ requested fixes, and close the review threads?
    }"
    #+end_src
 
-7. /Record the review round in the task doc/. Add or update the
+7. /Record the review round in the story or task doc/. Add or update the
    =* Review= section of the task's =.org= file with a summary table:
 
    #+begin_example
@@ -123,8 +138,10 @@ requested fixes, and close the review threads?
    | 3 | Relative PDF link       | user_manual.org   | Applied  | Changed to user_manual.pdf     |
    #+end_example
 
-   Commit the updated task doc in the same push (or as a follow-up
-   commit on the feature branch).
+   For stories without tasks, record in =story.org=. The PR URL is
+   tracked in the =* PRs= table there (see [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][How do I create a PR?]]
+   step 4). Commit the updated doc in the same push or as a
+   follow-up commit on the feature branch.
 
 * Conventions
 


### PR DESCRIPTION
## Summary

Scaffold the system-model-readability story in sprint 18 and add DeepSeek V4 Pro to the recognised LLM co-author identity list.

## Changes

- Create story scaffold for system-model-readability in sprint 18 with goal, acceptance criteria, plan, and out-of-scope sections
- Wire the story into the sprint 18 Stories table
- Add DeepSeek V4 Pro to the commit conventions recipe LLM identity list

Story: [[id:9AE5466D-E627-4587-BBEB-6D89E732ACE2]]
