### PR TITLE
[agile] Add runbook-support story to sprint 18

### DIFF
--- a/doc/agile/versions/v0/sprint_18/runbook_support/story.org
+++ b/doc/agile/versions/v0/sprint_18/runbook_support/story.org
@@ -1,0 +1,94 @@
+:PROPERTIES:
+:ID: 3D1935DC-562C-4AA3-A352-AC1BC037DFDD
+:END:
+#+title: Story: Runbook support
+#+description: Add runbook entity to the information architecture: a named composition of recipes and skills for repeatable multi-step operations.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :architecture:runbook:workflow:recipes:sprint_18:v0:
+#+created: 2026-05-26
+#+updated: 2026-05-26
+#+owner: CodeWhale
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Introduce a =runbook= as a new document type in the v2 information architecture. A runbook is a named, repeatable composition of recipes and skills — it captures the /sequence/ that currently exists only in the LLM's inference. Where a [[id:0C57932D-D13A-480F-B426-49525AA8BA3D][recipe]] is a single operation and a [[id:6054CC20-5F41-482F-A587-759512577B1D][skill]] is a unit-of-work playbook, a runbook chains them into a complete procedure with preconditions and postconditions. The user can say "begin work on X" and the LLM loads the corresponding runbook.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]] |
+| Now           | Designing runbook document type contract and scaffolding story. |
+| Waiting on    | Nothing.                               |
+| Next          | Define the runbook document type contract in [[id:8B29A8D8-E004-4E87-B81D-ABEAF68F2B98][document types]]. |
+| Last touched  | 2026-05-26                               |
+
+* Acceptance
+
+- A =runbook= is a recognised v2 document type with a defined frontmatter contract, required sections, and TODO state machine.
+- The [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] scaffolds runbooks (=--type runbook=) with pre-filled preconditions, steps, and postconditions skeleton.
+- The [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][compass tool]] supports =compass add runbook= and =compass list --type runbook=.
+- The [[id:47341FC6-B8FB-499E-AAE0-F4EE0ABFDA05][glossary]] defines the term =runbook=.
+- At least one concrete runbook exists: "Start work on a new story" — the sequence from story scaffold through to PR creation.
+- The runbook references all steps by [[id:0C57932D-D13A-480F-B426-49525AA8BA3D][recipe]] id-link, never inline.
+
+* Tasks
+
+In execution order:
+
+-
+
+* Plan
+
+The current information architecture has fine-grained [[id:0C57932D-D13A-480F-B426-49525AA8BA3D][recipes]] (single operations) and [[id:6054CC20-5F41-482F-A587-759512577B1D][skills]] (unit-of-work playbooks). But nothing captures the /sequence/ that chains them. An LLM must discover the order by inference — which is fragile, slow, and unrepeatable. The user should be able to say "begin work on X" and have the system load a composed procedure.
+
+A runbook fills this gap. It is to recipes what a meal is to individual cooking steps: a named DAG of steps, each referencing a recipe by id-link.
+
+** Runbook structure
+
+A runbook carries =#+type: runbook= and lives under =doc/runbooks/=. Required sections:
+
+- =* Goal= — what this runbook achieves, in one sentence.
+- =* Preconditions= — what must be true before starting (e.g. "you are on =main=", "current sprint exists").
+- =* Steps= — an ordered list. Each step references a recipe or skill by id-link, with a one-line description of what happens at that step.
+- =* Postconditions= — what is true after completing (e.g. "feature branch exists", "story is STARTED", "PR is open").
+- =* See also= — external links.
+
+A step may optionally name a skill to load before the recipe. Steps are ordered but may include branching ("if declined, go to step N").
+
+** Taxonomy placement
+
+Runbooks are owned by [[id:227958A5-0F78-4CC6-A116-B83988592B68][System 2 (Orchestrator)]] — they coordinate S1 operations (recipes) into higher-level procedures. They sit between functions (role-shaped priming) and recipes (single operations).
+
+** Deliverables
+
+1. /Document type contract./ Update [[id:8B29A8D8-E004-4E87-B81D-ABEAF68F2B98][document types]] with the runbook contract: frontmatter fields, required sections, TODO states, filename conventions.
+2. /Codegen support./ Add =--type runbook= to [[id:3153AA4B-23D4-4111-9710-5A4971102EDC][generate_v2_doc.sh]] with a mustache template that pre-fills Goal, Preconditions, Steps, Postconditions, and See also sections.
+3. /Compass support./ Add =compass add runbook= (scaffolds into =doc/runbooks/=) and =compass list --type runbook= (filters the doctype taxonomy).
+4. /Glossary entry./ Define =runbook= in [[id:47341FC6-B8FB-499E-AAE0-F4EE0ABFDA05][glossary]] with a stable id-link.
+5. /Concrete runbook./ Write =doc/runbooks/start_new_story.org= — the end-to-end procedure for "begin work on X" that chains: compass add story → feature branch → fill content → mark STARTED → wire into sprint → commit → push → PR.
+
+** Dependencies
+
+- [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] — add =runbook= to the type enum, template, and tag injection.
+- [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][compass]] — wire =runbook= into the Scaffold and Locate pillars.
+- [[id:8B29A8D8-E004-4E87-B81D-ABEAF68F2B98][Document types]] — the contract source.
+- [[id:47341FC6-B8FB-499E-AAE0-F4EE0ABFDA05][Glossary]] — the vocabulary source.
+
+* Decisions
+
+- Naming: =runbook= chosen over =workflow= (the latter already has a specific meaning in the ORE Studio codebase for saga orchestration).
+- Location: =doc/runbooks/=, not =doc/agile/runbooks/= — runbooks may span beyond agile operations (build, release, audit).
+- Steps reference recipes by id-link, never inline — the recipe is the single source of truth for how-to.
+
+* Out of scope
+
+- Automatic execution of runbooks (a =compass run= command). The runbook is a documented sequence for LLM consumption, not an execution engine.
+- Runbook versioning or branching — initial delivery is linear sequences only.
+- Migration of existing documentation into runbooks beyond the single concrete example.

--- a/doc/agile/versions/v0/sprint_18/runbook_support/story.org
+++ b/doc/agile/versions/v0/sprint_18/runbook_support/story.org
@@ -91,6 +91,14 @@ Runbooks are owned by [[id:227958A5-0F78-4CC6-A116-B83988592B68][System 2 (Orche
 - Location: =doc/runbooks/=, not =doc/agile/runbooks/= — runbooks may span beyond agile operations (build, release, audit).
 - Steps reference recipes by id-link, never inline — the recipe is the single source of truth for how-to.
 
+* Review
+
+Review round 1 (gemini-code-assist, 2026-05-26).
+
+| # | Comment summary                | File        | Decision | Notes                                          |
+|---+--------------------------------+-------------+----------+------------------------------------------------|
+| 1 | Empty Tasks bullet (line 45)   | story.org   | Applied  | Already fixed in ea79db188: replaced by * PRs   |
+
 * Out of scope
 
 - Automatic execution of runbooks (a =compass run= command). The runbook is a documented sequence for LLM consumption, not an execution engine.

--- a/doc/agile/versions/v0/sprint_18/runbook_support/story.org
+++ b/doc/agile/versions/v0/sprint_18/runbook_support/story.org
@@ -42,7 +42,11 @@ Introduce a =runbook= as a new document type in the v2 information architecture.
 
 In execution order:
 
--
+* PRs
+
+| PR  | Title                                          |
+|-----+------------------------------------------------|
+| 860 | [agile] Add runbook-support story to sprint 18 |
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_18/runbook_support/story.org
+++ b/doc/agile/versions/v0/sprint_18/runbook_support/story.org
@@ -42,6 +42,8 @@ Introduce a =runbook= as a new document type in the v2 information architecture.
 
 In execution order:
 
+- [[id:4D2107C8-9253-4F5A-957D-CC909E440279][Implement runbook document type]]
+
 * PRs
 
 | PR  | Title                                          |

--- a/doc/agile/versions/v0/sprint_18/runbook_support/task_implement_runbook_doc_type.org
+++ b/doc/agile/versions/v0/sprint_18/runbook_support/task_implement_runbook_doc_type.org
@@ -1,0 +1,64 @@
+:PROPERTIES:
+:ID: 4D2107C8-9253-4F5A-957D-CC909E440279
+:END:
+#+title: Task: Implement runbook document type
+#+description: Add #+type: runbook to codegen, compass, glossary, and document types contract.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :runbook:codegen:compass:documentation:runbook_support:sprint_18:v0:
+#+owner: marco
+#+branch: feature/runbook-support
+#+pr: 860
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-26
+#+updated: 2026-05-26
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3D1935DC-562C-4AA3-A352-AC1BC037DFDD][Runbook support]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add =runbook= as a recognised v2 document type: update the [[id:8B29A8D8-E004-4E87-B81D-ABEAF68F2B98][document types]] contract, add =--type runbook= to [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]], add =compass add runbook= and =compass list --type runbook= to the [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][compass tool]], define =runbook= in the [[id:47341FC6-B8FB-499E-AAE0-F4EE0ABFDA05][glossary]], and write a concrete runbook (=start_new_story.org=) as validation.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:3D1935DC-562C-4AA3-A352-AC1BC037DFDD][Runbook support]] |
+| Now          | Scaffolding task and updating PR.       |
+| Waiting on   | Nothing.                               |
+| Next         | Update document types contract with runbook spec. |
+| Last touched | 2026-05-26                               |
+
+* Acceptance
+
+- [[id:8B29A8D8-E004-4E87-B81D-ABEAF68F2B98][Document types]] defines the runbook frontmatter contract, required sections, and TODO states.
+- [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] accepts =--type runbook= and produces a valid skeleton.
+- [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][Compass]] supports =compass add runbook= and =compass list --type runbook=.
+- [[id:47341FC6-B8FB-499E-AAE0-F4EE0ABFDA05][Glossary]] has a runbook entry with a stable id-link.
+- A concrete runbook at =doc/runbooks/start_new_story.org= chains: compass story scaffold → feature branch → fill content → mark STARTED → wire into sprint → commit → push → PR.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR  | Title                                          |
+|-----+------------------------------------------------|
+| 860 | [agile] Add runbook-support story to sprint 18 |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -75,6 +75,7 @@ In execution order.
 | [[id:6EBB206D-167F-4A0F-8F50-04D7EB4B7E33][Fix PDF site delivery and switch manual to book class]] | STARTED | 2026-05-25 | | Add =site:pdf= publish component; switch manual to =book= LaTeX class; regenerate PDF.     |
 | [[id:4E375DD6-E300-4A0A-BD20-3D06AC8ED7A1][Port domain concept notes to knowledge documents]]      | STARTED | 2026-05-25 | | Tidy personal finance/ORE domain notes into v2 knowledge docs; align with ORE Studio terms. |
 | [[id:9AE5466D-E627-4587-BBEB-6D89E732ACE2][System model readability]]                         | STARTED | 2026-05-26 |            | Add layer blurbs and table-based component inventory to the system model. |
+| [[id:3D1935DC-562C-4AA3-A352-AC1BC037DFDD][Runbook support]]                                  | STARTED | 2026-05-26 |            | Add runbook document type: named composition of recipes for repeatable multi-step operations. |
 
 * Health Review
 

--- a/doc/recipes/compass/how_do_i_add_a_doc_with_compass.org
+++ b/doc/recipes/compass/how_do_i_add_a_doc_with_compass.org
@@ -14,6 +14,15 @@ The /Scaffold/ pillar of the [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][compass 
 over [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]]'s generator (called as a library) — for the full set
 of flags per document type, see [[id:3153AA4B-23D4-4111-9710-5A4971102EDC][How do I create a new v2 doc?]].
 
+#+begin_note
+*Prefer =goto= for starting work.* [[id:84C9177E-C737-428A-BDF9-E55CA6C9680C][=compass goto=]] creates both a story
+and a linked task, fetches =main=, and creates a feature branch in one
+step — the full "start work on a story" ritual. Use =add= when you need
+the primitive: scaffolding a single document (a standalone task inside
+an existing story, a sprint, a recipe, etc.) without the branch/task
+side-effects.
+#+end_note
+
 * Question
 
 How do I create a new v2 document (story, task, sprint, recipe, …) from

--- a/doc/recipes/github/how_do_i_address_pr_review_comments.org
+++ b/doc/recipes/github/how_do_i_address_pr_review_comments.org
@@ -89,12 +89,31 @@ requested fixes, and close the review threads?
 
    Use =-F= (not =-f=) for all fields — =-f= sends everything as
    strings and GitHub rejects integer fields like =line= and
-   =in_reply_to= with a 422 error. Get the =original_line=,
-   =commit_id=, and =path= for each comment from:
+   =in_reply_to= with a 422 error. The =commit_id= /must/ be the
+   full 40-character SHA (not the abbreviated 7–8 char form); use
+   =git log --format=%H -1= to obtain it.
+
+   Get the =original_line=, =commit_id=, and =path= for each
+   comment from:
 
    #+begin_src sh :results verbatim
    gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
-     --jq '.[] | {id, original_line, path}'
+     --jq '.[] | {id, original_line, path, commit_id}'
+   #+end_src
+
+   *Worked example.* Replying to comment #3303523758 on PR #859 in
+   the =OreStudio/OreStudio= repo, with commit
+   =feffaceb1416b5998e042c83123e0100ee3201d5=:
+
+   #+begin_src sh :results verbatim
+   gh api repos/OreStudio/OreStudio/pulls/859/comments \
+     --method POST \
+     -F "body=Fixed in 7fbf2f523: replaced relative path with ID link." \
+     -F "commit_id=feffaceb1416b5998e042c83123e0100ee3201d5" \
+     -F "path=doc/agile/versions/v0/sprint_18/story.org" \
+     -F "line=27" \
+     -F "side=RIGHT" \
+     -F "in_reply_to=3303523758"
    #+end_src
 
 6. /Resolve each review thread/ via GraphQL. First get the thread

--- a/doc/recipes/github/how_do_i_create_a_pr.org
+++ b/doc/recipes/github/how_do_i_create_a_pr.org
@@ -28,7 +28,9 @@ correctly-formatted title and a structured body?
 
 2. /Create the PR/ with =gh pr create=. Embed the story and task
    =:ID:= UUIDs in the body so =compass where --prs= can surface them
-   later. Use a HEREDOC for the body so newlines are preserved:
+   later, and a clickable HTML link to the published story page so
+   reviewers can open it directly. Use a HEREDOC for the body so
+   newlines are preserved:
 
    #+begin_src sh :results verbatim
    gh pr create --title "[component] One-line description" \
@@ -44,6 +46,8 @@ correctly-formatted title and a structured body?
 
    Story: [[id:STORY-UUID]]
    Task:  [[id:TASK-UUID]]
+
+   Story page: https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_NN/SLUG/story.html
    EOF
    )"
    #+end_src
@@ -70,6 +74,9 @@ correctly-formatted title and a structured body?
   Summary and Changes are the load-bearing pair.
 - /Story/Task UUIDs in the body/ are forward-only: they make PRs
   discoverable from the task but are not back-filled on old PRs.
+- /Story page link/ follows the pattern
+  =https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_<NN>/<slug>/story.html=.
+  Construct it from the story's parent sprint folder and slug.
 
 * Script
 

--- a/doc/recipes/github/how_do_i_create_a_pr.org
+++ b/doc/recipes/github/how_do_i_create_a_pr.org
@@ -47,7 +47,8 @@ correctly-formatted title and a structured body?
    Story: [[id:STORY-UUID]]
    Task:  [[id:TASK-UUID]]
 
-   Story page: https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_NN/SLUG/story.html
+   Story page: https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_NN/STORY_SLUG/story.html
+   Task page:  https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_NN/STORY_SLUG/task_TASK_SLUG.html
    EOF
    )"
    #+end_src
@@ -74,9 +75,10 @@ correctly-formatted title and a structured body?
   Summary and Changes are the load-bearing pair.
 - /Story/Task UUIDs in the body/ are forward-only: they make PRs
   discoverable from the task but are not back-filled on old PRs.
-- /Story page link/ follows the pattern
-  =https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_<NN>/<slug>/story.html=.
-  Construct it from the story's parent sprint folder and slug.
+- /Story and task page links/ follow the patterns:
+  - Story: =https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_<NN>/<STORY_SLUG>/story.html=
+  - Task:  =https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_<NN>/<STORY_SLUG>/task_<TASK_SLUG>.html=
+  Construct them from the sprint number, story slug, and task slug.
 
 * Script
 


### PR DESCRIPTION
## Summary

Introduce the runbook as a new v2 document type — a named, repeatable composition of recipes and skills. Fills the gap between single-operation recipes and role-shaped functions: an LLM can load a runbook and execute a complete multi-step procedure from scaffold to PR.

## Changes

- Create story scaffold for runbook-support in sprint 18 with goal, acceptance criteria, plan, and out-of-scope sections
- Wire the story into the sprint 18 Stories table

## Plan summary

The runbook is a `#+type: runbook` living under `doc/runbooks/`. Each runbook has Goal, Preconditions, ordered Steps (referencing recipes by id-link), Postconditions, and See also. Deliverables: document type contract update, codegen support (`--type runbook`), compass support, glossary entry, and one concrete runbook ("Start work on a new story").

Story: [[id:3D1935DC-562C-4AA3-A352-AC1BC037DFDD]]
Task:  [[id:4D2107C8-9253-4F5A-957D-CC909E440279]]

Story page: https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/runbook_support/story.html
Task page:  https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/runbook_support/task_implement_runbook_doc_type.html
