### PR TITLE
[skills] Update sprint-reviewer to write review into task, not sprint.org

### DIFF
--- a/doc/llm/runbooks/run_sprint_health_review/runbook.org
+++ b/doc/llm/runbooks/run_sprint_health_review/runbook.org
@@ -1,0 +1,121 @@
+:PROPERTIES:
+:ID: 30FE3C0F-ECCB-46AD-AC1F-75C6CE05F0E7
+:END:
+#+title: Run a sprint health review
+#+description: Scaffold a health review task, run the System 2 analysis, write findings into the task, add a summary row to sprint.org, and raise a PR.
+#+type: runbook
+#+version: 2
+#+level: cross
+#+filetags: :runbook:agile:sprint:review:health:
+#+created: 2026-05-26
+#+updated: 2026-05-26
+
+This page documents a [[id:B555D2A6-10CA-4A93-973E-F2AF4E1D7E55][runbook]] — a named, repeatable composition of [[id:0C57932D-D13A-480F-B426-49525AA8BA3D][recipes]] and [[id:6054CC20-5F41-482F-A587-759512577B1D][skills]] for a complete multi-step procedure. Each step references a recipe or skill by id-link.
+
+* Goal
+
+Produce a System 2 sprint health review: scaffold the review task,
+gather data, run the analysis, write the full findings into the task's
+=* Result=, add a one-row summary to =sprint.org=, and land it as a
+merged PR.
+
+* Preconditions
+
+- You are on, or can branch from, the latest =main=.
+- The current sprint's =sprint.org= exists and has a =* Health Review=
+  section (placeholder or existing summary table).
+- The sprint has a =sprint_health_review/= subdirectory containing
+  =story.org=.
+- =gh= is authenticated; =compass.sh= is available.
+
+* Steps
+
+In execution order:
+
+1. /Create a feature branch from latest main./
+
+   #+begin_src sh :results verbatim
+   git fetch origin && git checkout -b feature/sprint-<N>-health-review-<number> origin/main
+   #+end_src
+
+2. /Determine the review number./ Count existing
+   =task_health_review_*.org= files in the sprint's
+   =sprint_health_review/= directory and increment.
+
+   #+begin_src sh :results verbatim
+   ls doc/agile/versions/v0/sprint_<N>/sprint_health_review/task_health_review_*.org 2>/dev/null | wc -l
+   #+end_src
+
+3. /Scaffold the health review task via compass./
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.compass/compass.sh add task \
+     --parent-dir doc/agile/versions/v0/sprint_<N>/sprint_health_review \
+     --slug health_review_<number> \
+     --title "Health review <number> — sprint <N> <mid-sprint|close> analysis" \
+     --description "System 2 health review <number> of sprint <N>."
+   #+end_src
+
+   Set =#+branch:= to the feature branch. Wire the task into
+   =sprint_health_review/story.org= =* Tasks=.
+
+4. /Run the [[id:A7B3C241-D8E9-4F0A-B1C2-D3E4F5061728][sprint-reviewer]] skill./ Load the skill and follow its steps
+   (Steps 1–3 of the skill: activate System 2, gather data, analyse).
+   The skill's data-gathering commands:
+
+   #+begin_src sh :results verbatim
+   # Sprint start date from sprint.org #+created: field
+   git log --oneline --since=<sprint-start-date> | wc -l
+   gh pr list --state merged --search "merged:>=<sprint-start-date>" --limit 100 | wc -l
+   gh pr list --state open
+   find doc/agile/versions/v0/sprint_<N> -name "story.org" | sort
+   #+end_src
+
+5. /Write the full review into the task's =* Result=./ Follow skill
+   Step 4b: all six sub-sections (goal alignment, sprint load, PR
+   velocity, story and task balance, focus signal, overall verdict)
+   go under =* Result= in the task file, not in =sprint.org=.
+
+6. /Add a summary row to =sprint.org=./ Follow skill Step 4c: append
+   one row to the =* Health Review= table using the task's =:ID:=:
+
+   #+begin_example
+   | <number> | <date> | day <N> | <OVERALL> | [[id:<task-uuid>][Health review <number> — sprint <N> analysis]] |
+   #+end_example
+
+7. /Mark the task DONE./ Set =State: DONE= and =Now: Complete.= in
+   the task's =* Status= table.
+
+8. /Update the story if all tasks are DONE./ If every task in
+   =sprint_health_review/story.org= is DONE, set the story to DONE.
+
+9. /Commit./
+
+   #+begin_src sh :results verbatim
+   git add doc/agile/versions/v0/sprint_<N>/
+   git commit -m "[agile] Sprint <N> health review <number> — <overall-verdict>"
+   #+end_src
+
+10. /Push and raise a PR/ targeting =main=.
+
+    #+begin_src sh :results verbatim
+    git push -u origin feature/sprint-<N>-health-review-<number>
+    gh pr create --title "[agile] Sprint <N> health review <number>" --body "..."
+    #+end_src
+
+11. /Handle review comments/ per the [[id:5373A4E5-172B-44FD-BAE0-07E25BBD3292][Handle a PR review round]] runbook.
+
+* Postconditions
+
+- A new =task_health_review_<number>.org= exists under the sprint's
+  =sprint_health_review/= directory with the full analysis in =* Result=.
+- =sprint.org= =* Health Review= table has one new summary row.
+- The task is DONE; the story is DONE if all tasks complete.
+- A merged PR carries the review on =main=.
+
+* See also
+
+- [[id:A7B3C241-D8E9-4F0A-B1C2-D3E4F5061728][Sprint Reviewer]] — the skill that drives steps 4–6.
+- [[id:5373A4E5-172B-44FD-BAE0-07E25BBD3292][Handle a PR review round]] — step 11.
+- [[id:D1125E49-3C4E-48D4-B7F9-15CAA45B3ADD][Runbooks catalogue]] — all runbooks.
+- [[id:47032D2E-4922-4A43-B594-AD76F0213E10][Open a new sprint]] — the runbook that follows at sprint close.

--- a/doc/llm/runbooks/runbooks.org
+++ b/doc/llm/runbooks/runbooks.org
@@ -35,6 +35,7 @@ all runbooks with =compass list --type runbook=.
 | [[id:1EE6EF7C-53E1-41D1-B6AF-6E21D7ACFB25][Create a new recipe]]                                        | Scaffold → fill Question/Answer → test commands → wire inventory → PR       |
 | [[id:F91B7D13-8A16-4466-B444-36D7B8AC3EBE][Add a new knowledge document]]                               | Scaffold → fill Summary/Detail → tag → wire knowledge index → PR            |
 | [[id:7BAF8188-A760-4F62-9B49-F9DA6E84FC17][Port a v1 document to v2]]                                    | Audit → scaffold v2 → port content → tag → validate → delete v1 → PR       |
+| [[id:30FE3C0F-ECCB-46AD-AC1F-75C6CE05F0E7][Run a sprint health review]]                                  | Scaffold task → System 2 analysis → write findings → update sprint.org → PR |
 
 * See also
 

--- a/doc/llm/skills/sprint-reviewer/SKILL.org
+++ b/doc/llm/skills/sprint-reviewer/SKILL.org
@@ -174,70 +174,107 @@ critical dimension is RED; AMBER if two or more are AMBER). Name
 the most important concern and the one thing that, if fixed, would
 most improve sprint health.
 
-** Step 4 — Write the review into sprint.org
+** Step 4 — Create a health review task and write the full review into it
 
-Find the =* Health Review= section in =sprint.org=. If it contains
-only the placeholder line, replace the entire section content. If a
-previous review exists (from a prior run of this skill), replace it
-— the section is idempotent.
+The full review content lives in a dedicated task, not in =sprint.org=
+directly. =sprint.org= holds only a compact summary table — one row
+per review run.
 
-The section must appear before =* Retrospective=.
+*** 4a — Scaffold the task
 
-Format:
+Determine the review number (count existing =task_health_review_*.org=
+files in the sprint directory and increment). Then run:
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh add task \
+  --parent-dir doc/agile/versions/v0/sprint_<N>/sprint_health_review \
+  --slug health_review_<number> \
+  --title "Health review <number> — sprint <N> <mid-sprint|close> analysis" \
+  --description "System 2 health review <number> of sprint <N>."
+#+end_src
+
+Set =#+branch:= to the current working branch and wire the new task
+into the story's =* Tasks= list.
+
+*** 4b — Write the full review into the task's =* Result=
+
+Write the complete analysis under =* Result= in the new task file,
+using this structure:
 
 #+begin_example
-,* Health Review
+,* Result
 
-/Reviewed: <date> — <sprint elapsed days> days in./
+,** Review on <date> (day <N> of 7)
 
-,** Goal alignment
+,*** Goal alignment
 
-[narrative + table: Goal | Coverage | Stories | Notes]
+[narrative + table: Goal | Coverage | Stories (DONE/STARTED/BACKLOG) | Verdict]
 
-,** Sprint load
+,*** Sprint load
 
 [narrative + table: Metric | Value | Target | Status]
 
-,** PR velocity
+,*** PR velocity
 
 [narrative + table: Metric | Value | Notes]
 
-,** Story and task balance
+,*** Story and task balance
 
-[narrative + table: Story | State | Tasks | Days open | Notes]
+[narrative + table: Story | State | Tasks | Age | Notes]
 
-,** Focus signal
+,*** Focus signal
 
-[narrative: count, themes, verdict]
+[narrative + table: Metric | Value | Verdict]
 
-,** Overall verdict
+,*** Velocity
+
+[narrative + table: Metric | Value | Notes]
+
+,*** Overall verdict
 
 [RAG table: Dimension | Verdict]
 
 [one paragraph summary]
 #+end_example
 
-After writing, confirm the section replaced (not appended) and
-report the file path.
+Mark the task =State: DONE= and =Now: Complete.= once written.
 
-** Step 5 — Update agile paperwork
+*** 4c — Add a summary row to =sprint.org=
 
-If the sprint has a sprint-health-review story and task in its
-directory, update their =State= and =Now= fields to reflect the
-review having been run. This step is optional and context-dependent —
-skip it if the review is being run informally or the story does not
-exist.
-
-* Sprint template note
-
-New sprints scaffolded with =compass add sprint= include an empty
-=* Health Review= placeholder:
+Find the =* Health Review= section in =sprint.org=. It contains a
+summary table. Add one row for this review:
 
 #+begin_example
 ,* Health Review
 
-(Run =sprint-reviewer= to generate this section.)
+| # | Date       | Day   | Overall | Task                          |
+|---+------------+-------+---------+-------------------------------|
+| 1 | 2026-05-25 | day 4 | AMBER   | [[id:UUID][Health review 1 — sprint N analysis]] |
+| 2 | <date>     | day N | <RAG>   | [[id:UUID][Health review 2 — sprint N analysis]] |
 #+end_example
 
-This placeholder is present from day one so the section header
-always exists in the document even before the first review.
+Use the task's =:ID:= property for the org-roam link. Do not replace
+the existing rows — append only.
+
+** Step 5 — Update agile paperwork
+
+Update the sprint-health-review story's =State= and =Now= fields if
+all tasks are now DONE. Wire the new task into the story's =* Tasks=
+list if not already done in Step 4a.
+
+* Sprint template note
+
+New sprints scaffolded with =compass add sprint= include an empty
+=* Health Review= placeholder with the summary table header:
+
+#+begin_example
+,* Health Review
+
+| # | Date | Day | Overall | Task |
+|---+------+-----+---------+------|
+
+(Run =sprint-reviewer= to populate this table.)
+#+end_example
+
+This placeholder is present from day one. Each run of this skill
+adds one row; the full analysis lives in the task linked from that row.


### PR DESCRIPTION
## Summary

The `sprint-reviewer` SKILL.org previously instructed writing the full review content directly into `sprint.org`. This contradicted the convention established in PR #852, where `sprint.org`'s `* Health Review` section is a compact summary table and the full analysis lives in a dedicated task's `* Result` section.

- **Step 4** rewritten into three sub-steps:
  - **4a** — scaffold a new health review task via compass (numbered sequentially)
  - **4b** — write the full analysis (goal alignment, load, PR velocity, story/task balance, focus, velocity, overall verdict) into the task's `* Result`
  - **4c** — append one summary row to `sprint.org`'s `* Health Review` table
- **Step 5** updated to wire the new task into the story's Tasks list
- **Sprint template note** updated to show the summary-table placeholder format instead of the old prose placeholder

## Test plan

- [ ] Verify SKILL.org step 4 no longer says to write full content into `sprint.org`.
- [ ] Verify step 4a gives the correct compass command with numbered slug.
- [ ] Verify step 4c shows the summary table append format with org-roam link.
- [ ] Verify sprint template note shows the table-header placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)