### PR TITLE
[agile] Add compass PR review management story

### DIFF
--- a/doc/agile/versions/v0/sprint_18/compass_pr_review/story.org
+++ b/doc/agile/versions/v0/sprint_18/compass_pr_review/story.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 166E8E44-1573-4DE2-825F-A6037A302AE9
+:END:
+#+title: Story: Compass PR review management
+#+description: Add compass subcommands to list, reply to, and resolve PR review comments — wrappers around the gh CLI.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :compass:github:pr:review:sprint_18:v0:
+#+created: 2026-05-26
+#+updated: 2026-05-26
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Add three new compass subcommands that wrap the GitHub API for PR review management — removing the need to remember the raw `gh api` invocations and the `-F` vs `-f` distinction for integer fields. The commands should be composable and work with both line-level and thread-level review comments.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-05-26                               |
+
+* Acceptance
+
+- =compass review list <PR> [--detail]= lists all review comments with their id, file, line, and a preview of the body. With =--detail=, shows the full body.
+- =compass review reply <PR> <comment-id> "message"= creates a reply to a specific review comment.
+- =compass review resolve <PR>= finds all unresolved threads and resolves them (with optional =--dry-run= to preview).
+- All three commands accept =--owner= and =--repo= with defaults from the git remote.
+- The =reply= command handles the =commit_id=, =path=, =line=, =side=, and =in_reply_to= fields correctly (using proper integer types for =line= and =in_reply_to=).
+- Commands are documented in =compass help=.
+
+* Tasks
+
+In execution order:
+
+-
+
+* Decisions
+
+- Commands live under =compass review <subcommand>=, not flat =compass review-list=, =compass review-reply= etc. The subcommand namespace stays open for future additions (e.g. =compass review approve=, =compass review request-changes=).
+- Implementation in =compass.py= following the existing =list= and =show= short-circuit pattern (passthrough to =doc_list.main()=, =doc_show.main()=). The review commands get their own module =compass_review.py=.
+- The Python =subprocess= module calls =gh api ...= to avoid reimplementing HTTP and auth.
+
+* Out of scope
+
+- Auto-merging or auto-approving PRs.
+- GitHub Actions / CI integration.
+- A full =gh= replacement — compass commands are convenience wrappers, not feature-complete API clients.

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -76,6 +76,7 @@ In execution order.
 | [[id:4E375DD6-E300-4A0A-BD20-3D06AC8ED7A1][Port domain concept notes to knowledge documents]]      | STARTED | 2026-05-25 | | Tidy personal finance/ORE domain notes into v2 knowledge docs; align with ORE Studio terms. |
 | [[id:9AE5466D-E627-4587-BBEB-6D89E732ACE2][System model readability]]                         | STARTED | 2026-05-26 |            | Add layer blurbs and table-based component inventory to the system model. |
 | [[id:3D1935DC-562C-4AA3-A352-AC1BC037DFDD][Runbook support]]                                  | STARTED | 2026-05-26 |            | Add runbook document type: named composition of recipes for repeatable multi-step operations. |
+| [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Compass PR review management]]                      | BACKLOG | 2026-05-26 |            | Add compass review list/reply/resolve subcommands wrapping gh API. |
 
 * Health Review
 


### PR DESCRIPTION
## Summary

Add compass PR review management story to sprint 18. The story covers three new compass subcommands: `review list`, `review reply`, and `review resolve` — wrappers around the gh CLI that handle the tricky `-F` vs `-f` distinction for integer fields like `line` and `in_reply_to`.

Story: [[id:166E8E44-1573-4DE2-825F-A6037A302AE9]]

Story page: https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/compass_pr_review/story.html
