### PR TITLE
[doc] Add NATS external knowledge page

### DIFF
--- a/doc/agile/versions/v0/sprint_18/nats_documentation/task_create_nats_knowledge_page.org
+++ b/doc/agile/versions/v0/sprint_18/nats_documentation/task_create_nats_knowledge_page.org
@@ -1,0 +1,74 @@
+:PROPERTIES:
+:ID: 6FE6B89C-78C4-4FB7-803C-022C3E8FF237
+:END:
+#+title: Task: Create NATS external knowledge page
+#+description: Scaffold doc/knowledge/external/nats.org describing NATS as a technology: subjects, queue groups, JetStream, security model, and upstream links.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :nats_documentation:sprint_18:v0:
+#+owner: marco
+#+branch: feature/create-nats-knowledge-page
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-26
+#+updated: 2026-05-26
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:A388F0C8-0804-420F-A542-2C929CFCEC92][Document NATS: technology overview, system integration, and recipes]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Create =doc/knowledge/external/nats.org= — an external knowledge page
+describing [[https://nats.io][NATS]] as a technology in its own right, independent of ORE
+Studio. Covers core concepts (subjects, wildcards, queue groups,
+JetStream), security (TLS, NKey/JWT auth), deployment modes, and
+upstream links. This mirrors the pattern of [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][Open Source Risk Engine
+(ORE)]] and [[id:0412444A-0A4C-4611-887C-09353A3CB253][QuantLib]] pages. Wire the new page into [[id:CF2C4F3A-9C5C-4E7A-9E16-2A3A8C1D4C11][External knowledge]]
+under a new "Messaging infrastructure" section.
+
+* Status
+
+| Field        | Value                                               |
+|--------------+-----------------------------------------------------|
+| State        | STARTED                                             |
+| Parent story | [[id:A388F0C8-0804-420F-A542-2C929CFCEC92][Document NATS: technology overview, system integration, and recipes]] |
+| Now          | Implementing nats.org and wiring into external.org. |
+| Waiting on   | Nothing.                                            |
+| Next         | Scaffold via codegen, fill content, update index.   |
+| Last touched | 2026-05-26                                          |
+
+* Acceptance
+
+- [ ] =doc/knowledge/external/nats.org= exists with =#+version: 2=,
+  =#+type: knowledge=, scaffolded via =generate_v2_doc.sh=.
+- [ ] Covers: what NATS is, subjects and wildcards, queue groups,
+  request/reply, JetStream, security (TLS + NKey/JWT), deployment
+  modes (server, leaf node, cluster).
+- [ ] Links to [[https://nats.io][nats.io]], [[https://github.com/nats-io][github.com/nats-io]], and [[https://docs.nats.io][docs.nats.io]].
+- [ ] Links back to [[id:C9C24C99-F16C-45BE-A262-1C0F4502765E][ores.nats]] for how ORE Studio uses the transport.
+- [ ] =doc/knowledge/external/external.org= has a new "Messaging
+  infrastructure" section with an id-link to =nats.org=.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/nats_documentation/task_create_nats_knowledge_page.org
+++ b/doc/agile/versions/v0/sprint_18/nats_documentation/task_create_nats_knowledge_page.org
@@ -106,8 +106,11 @@ NATS sections task.
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                              | File          | Decision | Notes                          |
+|---+----------------------------------------------+---------------+----------+--------------------------------|
+| 1 | Mark task DONE, Now → Complete.              | task doc      | Accept   | Fixed in =1d675a477=           |
+| 1 | Tick all acceptance criteria [X]             | task doc      | Accept   | Fixed in =1d675a477=           |
+| 1 | RAFT → Raft (name, not acronym)              | nats.org      | Accept   | Fixed in =1d675a477=           |
+| 1 | Super-cluster → Supercluster (official term) | nats.org      | Accept   | Fixed in =1d675a477=           |
 
 * Result

--- a/doc/agile/versions/v0/sprint_18/nats_documentation/task_create_nats_knowledge_page.org
+++ b/doc/agile/versions/v0/sprint_18/nats_documentation/task_create_nats_knowledge_page.org
@@ -32,30 +32,30 @@ under a new "Messaging infrastructure" section.
 
 | Field        | Value                                               |
 |--------------+-----------------------------------------------------|
-| State        | STARTED                                             |
+| State        | DONE                                                |
 | Parent story | [[id:A388F0C8-0804-420F-A542-2C929CFCEC92][Document NATS: technology overview, system integration, and recipes]] |
-| Now          | Implementing nats.org and wiring into external.org. |
+| Now          | Complete.                                           |
 | Waiting on   | Nothing.                                            |
-| Next         | Scaffold via codegen, fill content, update index.   |
+| Next         | None.                                               |
 | Last touched | 2026-05-26                                          |
 
 * Acceptance
 
-- [ ] =doc/knowledge/external/nats.org= exists with =#+version: 2=,
+- [X] =doc/knowledge/external/nats.org= exists with =#+version: 2=,
   =#+type: knowledge=, scaffolded via =generate_v2_doc.sh=.
-- [ ] Covers: what NATS is, subjects and wildcards, queue groups,
+- [X] Covers: what NATS is, subjects and wildcards, queue groups,
   request/reply, JetStream, security (TLS + NKey/JWT), deployment
   modes (server, leaf node, cluster).
-- [ ] Links to [[https://nats.io][nats.io]], [[https://github.com/nats-io][github.com/nats-io]], and [[https://docs.nats.io][docs.nats.io]].
-- [ ] Links back to [[id:C9C24C99-F16C-45BE-A262-1C0F4502765E][ores.nats]] for how ORE Studio uses the transport.
-- [ ] =doc/knowledge/external/external.org= has a new "Messaging
+- [X] Links to [[https://nats.io][nats.io]], [[https://github.com/nats-io][github.com/nats-io]], and [[https://docs.nats.io][docs.nats.io]].
+- [X] Links back to [[id:C9C24C99-F16C-45BE-A262-1C0F4502765E][ores.nats]] for how ORE Studio uses the transport.
+- [X] =doc/knowledge/external/external.org= has a new "Messaging
   infrastructure" section with an id-link to =nats.org=.
-- [ ] =projects/modeling/protocol.org= renamed to =messaging.org=,
+- [X] =projects/modeling/protocol.org= renamed to =messaging.org=,
   ported to v2, title "ORE Studio Messaging Reference", =:ID:= preserved.
-- [ ] =messaging.org= links to =nats.org=.
-- [ ] =ores.nats= component overview =* See also= links to =nats.org=
+- [X] =messaging.org= links to =nats.org=.
+- [X] =ores.nats= component overview =* See also= links to =nats.org=
   and =messaging.org=.
-- [ ] =system_model.org= "Useful Pages" display text reads "Messaging
+- [X] =system_model.org= "Useful Pages" display text reads "Messaging
   Reference" (not "Protocol Reference").
 
 * Plan

--- a/doc/agile/versions/v0/sprint_18/nats_documentation/task_create_nats_knowledge_page.org
+++ b/doc/agile/versions/v0/sprint_18/nats_documentation/task_create_nats_knowledge_page.org
@@ -50,12 +50,51 @@ under a new "Messaging infrastructure" section.
 - [ ] Links back to [[id:C9C24C99-F16C-45BE-A262-1C0F4502765E][ores.nats]] for how ORE Studio uses the transport.
 - [ ] =doc/knowledge/external/external.org= has a new "Messaging
   infrastructure" section with an id-link to =nats.org=.
+- [ ] =projects/modeling/protocol.org= renamed to =messaging.org=,
+  ported to v2, title "ORE Studio Messaging Reference", =:ID:= preserved.
+- [ ] =messaging.org= links to =nats.org=.
+- [ ] =ores.nats= component overview =* See also= links to =nats.org=
+  and =messaging.org=.
+- [ ] =system_model.org= "Useful Pages" display text reads "Messaging
+  Reference" (not "Protocol Reference").
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+Four documents form the messaging documentation landscape; their
+responsibilities must be non-overlapping and their cross-links
+complete.
+
+| Document | Responsibility |
+|----------+----------------|
+| =nats.org= (external knowledge) | What NATS is as a technology — concepts, security, upstream links. |
+| =ores.nats= component overview | How ORE Studio uses NATS — C++ transport library, patterns, entry points. |
+| =messaging.org= (renamed from =protocol.org=) | Which service owns which subject namespace — the cross-service index. |
+| =ores.*.protocol.org= (11 files) | Complete subject inventory for one service. |
+
+Navigation chain a developer follows: =nats.org= → =ores.nats= →
+=messaging.org= → =ores.iam.protocol.org=.
+
+*Step 1* — Rename =projects/modeling/protocol.org= to =messaging.org=.
+The name "protocol" was accurate when =ores.comms= (binary protocol)
+existed alongside NATS. =ores.comms= is gone; calling this a
+"protocol reference" now implies a wire-format spec. The per-service
+files are already titled "ores.iam Messaging Reference" — the
+top-level should match. Keep the =:ID:= unchanged so all existing
+id-links survive. Port to v2 format. Add link to =nats.org=.
+
+*Step 2* — Fix =ores.nats= component overview =* See also=, currently
+empty. Add links to =nats.org= (technology) and =messaging.org=
+(namespace index).
+
+*Step 3* — Update =system_model.org= "Useful Pages" entry, which
+refers to "Protocol Reference" by name. The id-link already resolves
+correctly (UUID preserved), but the display text should say "Messaging
+Reference".
+
+*Step 4* (deferred to per-component NATS task) — Port all 11
+=ores.*.protocol.org= files to v2 and add =nats.org= to their See
+also. Touch-it-to-port-it applies; they are covered by the component
+NATS sections task.
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_18/nats_documentation/task_create_nats_knowledge_page.org
+++ b/doc/agile/versions/v0/sprint_18/nats_documentation/task_create_nats_knowledge_page.org
@@ -61,9 +61,9 @@ task closes. Plans do not outlive their task.)
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR                                                          | Title                              | State | Round |
+|-------------------------------------------------------------+------------------------------------+-------+-------|
+| [[https://github.com/OreStudio/OreStudio/pull/872][#872]] | [doc] Add NATS external knowledge page | OPEN  |     1 |
 
 * Review
 

--- a/doc/knowledge/external/external.org
+++ b/doc/knowledge/external/external.org
@@ -8,7 +8,7 @@
 #+level: cross
 #+filetags: :knowledge:external:index:
 #+created: 2026-05-21
-#+updated: 2026-05-21
+#+updated: 2026-05-26
 
 Reference material about systems and concepts ORE Studio /uses but
 does not own/. The rule of thumb: if the doc would exist (in roughly
@@ -35,6 +35,12 @@ though it references [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][ORE]].
 
 - [[id:0929B047-1A31-3514-9EDB-EF7B4F012C5D][Standing settlement instructions]] — what SSIs are and how they
   flow through the trading lifecycle.
+
+* Messaging infrastructure
+
+- [[id:D9B0988E-D783-43D6-BCCD-CE2F70022B9C][NATS]] — the open-source messaging system ORE Studio uses for all
+  inter-service communication (subjects, queue groups, JetStream,
+  NKey/JWT security).
 
 * Platform features
 

--- a/doc/knowledge/external/nats.org
+++ b/doc/knowledge/external/nats.org
@@ -94,8 +94,8 @@ NATS supports three security layers that can be combined:
 | Mode        | Description                                                                 |
 |-------------+-----------------------------------------------------------------------------|
 | Single server | One =nats-server= process. Simplest; no redundancy.                       |
-| Cluster     | 3+ servers using RAFT consensus for message and JetStream replication.      |
-| Super-cluster | Multiple clusters linked by gateway connections for geo-distribution.    |
+| Cluster     | 3+ servers using Raft consensus for message and JetStream replication.      |
+| Supercluster | Multiple clusters linked by gateway connections for geo-distribution.    |
 | Leaf node   | A lightweight =nats-server= that extends a hub cluster with local subjects. |
 
 ORE Studio development runs a single server; production targets a

--- a/doc/knowledge/external/nats.org
+++ b/doc/knowledge/external/nats.org
@@ -1,0 +1,118 @@
+:PROPERTIES:
+:ID: D9B0988E-D783-43D6-BCCD-CE2F70022B9C
+:END:
+#+title: NATS
+#+description: The open-source messaging system ORE Studio uses for all inter-service communication.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :nats:messaging:external:knowledge:
+#+created: 2026-05-26
+#+updated: 2026-05-26
+
+[[https://nats.io][NATS]] is an open-source, cloud-native messaging system written in Go
+and maintained by [[https://synadia.com][Synadia]]. It provides publish/subscribe,
+request/reply, and durable streaming (JetStream) over a lightweight
+binary protocol. ORE Studio uses NATS as the /sole/ inter-service
+message bus — every domain service publishes and subscribes over NATS.
+The ORE Studio transport library is [[id:C9C24C99-F16C-45BE-A262-1C0F4502765E][ores.nats]]. Return to
+[[id:CF2C4F3A-9C5C-4E7A-9E16-2A3A8C1D4C11][External knowledge]] / [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
+
+* Detail
+
+** Subjects and wildcards
+
+A NATS /subject/ is a dot-separated UTF-8 string, e.g.
+=iam.v1.account.find=. Wildcards allow pattern subscriptions:
+
+- =*= matches exactly one subject token (e.g. =iam.v1.*.find= matches
+  =iam.v1.account.find= but not =iam.v1.role.find.all=).
+- =>= matches one or more trailing tokens and must appear last
+  (e.g. =iam.v1.>= matches everything under =iam.v1=).
+
+** Core messaging patterns
+
+*** Publish/subscribe
+
+A publisher sends a message to a subject; all current subscribers
+receive it. Fire-and-forget with no delivery guarantee unless
+JetStream is used.
+
+*** Request/reply
+
+The client sends to a subject with a private reply-to inbox
+(=_INBOX.<nonce>=); the server or service replies to that inbox. NATS
+manages the inbox lifecycle. This is the primary pattern for
+synchronous RPC across ORE Studio services.
+
+*** Queue groups
+
+Multiple subscribers sharing the same queue-group name receive
+messages in a round-robin fashion — exactly one subscriber per
+message. This provides load balancing and horizontal scale-out without
+coordination. ORE Studio uses queue groups on every domain-service
+handler so multiple service instances share load transparently.
+
+** JetStream
+
+JetStream is NATS's built-in persistence layer, available when the
+server starts with =-js=. Key concepts:
+
+- /Stream/ — an append-only, subject-filtered log, retained by age,
+  size, or message count.
+- /Consumer/ — a named cursor into a stream; can be push-based
+  (server delivers) or pull-based (client polls). Supports
+  acknowledgements, redelivery on timeout, and durable state across
+  reconnects.
+- /Key-Value store/ — a JetStream abstraction for versioned key-value
+  data with watch semantics.
+- /Object store/ — chunked, large-object storage layered on JetStream.
+
+ORE Studio uses JetStream for domain events that must survive service
+restarts (e.g. workspace-state changes, audit trails).
+
+** Security
+
+NATS supports three security layers that can be combined:
+
+- /TLS/ — mutual TLS for transport encryption and peer
+  authentication. ORE Studio runs all connections over TLS with
+  server-side and client certificates (see =build/scripts/generate_nats_certs.sh=).
+- /NKeys/ — Ed25519 keypairs used to sign and verify identity tokens.
+  The public key is a human-readable encoded string beginning with a
+  letter that encodes the key type (=O= operator, =A= account, =U=
+  user).
+- /JWT-based operator/account/user model/ — a decentralised
+  multi-tenancy hierarchy. An /operator/ signs /account/ JWTs; each
+  account is an isolated messaging namespace. An account signs /user/
+  JWTs that carry permissions (publish/subscribe allow-lists and
+  limits). ORE Studio uses this model for per-tenant isolation: each
+  registered ORE Studio account receives its own NATS user JWT.
+
+** Deployment modes
+
+| Mode        | Description                                                                 |
+|-------------+-----------------------------------------------------------------------------|
+| Single server | One =nats-server= process. Simplest; no redundancy.                       |
+| Cluster     | 3+ servers using RAFT consensus for message and JetStream replication.      |
+| Super-cluster | Multiple clusters linked by gateway connections for geo-distribution.    |
+| Leaf node   | A lightweight =nats-server= that extends a hub cluster with local subjects. |
+
+ORE Studio development runs a single server; production targets a
+three-node cluster.
+
+** Client libraries
+
+The canonical client is [[https://github.com/nats-io/nats.c][nats.c]] (C), which ORE Studio wraps in
+[[id:C9C24C99-F16C-45BE-A262-1C0F4502765E][ores.nats]]. Other official clients exist for Go, Rust, Python, Java,
+and JavaScript — see [[https://github.com/nats-io][github.com/nats-io]].
+
+* See also
+
+- [[id:C9C24C99-F16C-45BE-A262-1C0F4502765E][ores.nats]] — the ORE Studio C++ transport library wrapping =nats.c=.
+- [[id:A7B3C9D2-E5F1-4A8B-9C6D-3E2F1A0B8C7D][ORE Studio Messaging Protocol Reference]] — the subject namespace and
+  message types for every domain service.
+- [[id:D773166D-0C91-8CB4-3323-42166BC07687][System model]] — how NATS fits into ORE Studio's four-layer architecture.
+- [[https://nats.io][nats.io]] — project home page.
+- [[https://docs.nats.io][docs.nats.io]] — official documentation.
+- [[https://github.com/nats-io][github.com/nats-io]] — all NATS client and server repositories.

--- a/projects/modeling/messaging.org
+++ b/projects/modeling/messaging.org
@@ -1,23 +1,27 @@
 :PROPERTIES:
 :ID: A7B3C9D2-E5F1-4A8B-9C6D-3E2F1A0B8C7D
 :END:
-#+title: ORE Studio Messaging Protocol Reference
-#+version: 1
-#+author: Marco Craveiro
-#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t html-postamble:nil
-#+startup: overview
+#+title: ORE Studio Messaging Reference
+#+description: Index of NATS subject namespaces owned by each domain service, with links to per-service messaging references.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :nats:messaging:index:knowledge:
+#+created: 2026-05-26
+#+updated: 2026-05-26
 
 All inter-service and client-server communication in [[id:D773166D-0C91-8CB4-3323-42166BC07687][ORE Studio]] uses
-[[https://nats.io][NATS]] with JSON payloads. See [[id:C9C24C99-F16C-45BE-A262-1C0F4502765E][ores.nats]] for transport details (request/reply
-pattern, subject naming convention, queue groups, JetStream).
+[[id:D9B0988E-D783-43D6-BCCD-CE2F70022B9C][NATS]] with JSON payloads. The transport library is [[id:C9C24C99-F16C-45BE-A262-1C0F4502765E][ores.nats]]
+(request/reply pattern, subject naming convention, queue groups,
+JetStream). This page is the cross-service namespace index; each row
+links to the full subject inventory for that service.
 
 * Services
 
-Each domain service owns a subject namespace. Click a protocol reference
-for the full list of subjects and message types.
+Each domain service owns a subject namespace.
 
-| Service | Subject Namespace | Protocol Reference |
-|---------+-------------------+--------------------|
+| Service | Subject Namespace | Messaging Reference |
+|---------+-------------------+---------------------|
 | [[id:D00BEA0D-E501-C534-A013-E6F40C1A6097][ores.iam]] | =iam.v1.>= | [[id:D3C4E5F6-A7B8-9012-CDEF-123456789012][ores.iam Messaging Reference]] |
 | [[id:204DB292-C32B-03E4-9DDB-BFE634F7CE91][ores.refdata]] | =refdata.v1.>= | [[id:C2B3D4E5-F6A7-8901-BCDE-F12345678901][ores.refdata Messaging Reference]] |
 | [[id:1EE1B07C-3EC4-9BC4-1C4B-5BD458A8B2E5][ores.variability]] | =variability.v1.>= | [[id:E4D5F6A7-B8C9-0123-DEFA-234567890123][ores.variability Messaging Reference]] |
@@ -29,7 +33,9 @@ for the full list of subjects and message types.
 | [[id:DC252F72-1BB0-4CC8-B558-C191FFA5E826][ores.synthetic]] | =synthetic.v1.>= | [[id:7AF2DCAB-BC62-43A9-885A-E557FCD4254F][ores.synthetic Messaging Reference]] |
 | [[id:D65B6932-7A33-471C-98C6-6AC345D4684C][ores.reporting]] | =reporting.v1.>= | [[id:B1A5C952-B709-444B-8A63-5FD834D87D52][ores.reporting Messaging Reference]] |
 
-* Useful Pages
+* See also
 
-- [[id:C9C24C99-F16C-45BE-A262-1C0F4502765E][ores.nats]] — transport layer: request/reply, subject naming, configuration
-- [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] — overall system architecture
+- [[id:C9C24C99-F16C-45BE-A262-1C0F4502765E][ores.nats]] — transport library: request/reply, subject naming, queue
+  groups, JetStream.
+- [[id:D9B0988E-D783-43D6-BCCD-CE2F70022B9C][NATS]] — the upstream messaging technology this is built on.
+- [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] — overall system architecture.

--- a/projects/modeling/system_model.org
+++ b/projects/modeling/system_model.org
@@ -201,7 +201,7 @@ path from service SQL functions; ordinary DML handlers must not query
 
 * Useful Pages
 
-- To understand the NATS messaging protocol, see the [[id:A7B3C9D2-E5F1-4A8B-9C6D-3E2F1A0B8C7D][Protocol Reference]] and [[id:C9C24C99-F16C-45BE-A262-1C0F4502765E][ores.nats]].
+- To understand the NATS messaging layer, see [[id:D9B0988E-D783-43D6-BCCD-CE2F70022B9C][NATS]] (the technology), [[id:C9C24C99-F16C-45BE-A262-1C0F4502765E][ores.nats]] (the transport library), and the [[id:A7B3C9D2-E5F1-4A8B-9C6D-3E2F1A0B8C7D][Messaging Reference]] (subject namespace index).
 - To understand how we generate PlantUML diagrams see the [[id:D6D86317-4961-6754-A6DB-9C12B5FAC997][PlantUML Modeler]]
   skill.
 - To understand how to add new domain types, see the [[id:B1450696-8C51-4CC5-8910-84912A411AB6][Domain Type Creator]] skill.

--- a/projects/ores.nats/modeling/component_overview.org
+++ b/projects/ores.nats/modeling/component_overview.org
@@ -54,4 +54,7 @@ stack (=ores.comms=) and is a direct dependency of every domain service.
 
 * See also
 
--
+- [[id:D9B0988E-D783-43D6-BCCD-CE2F70022B9C][NATS]] — the upstream messaging technology: subjects, wildcards, queue
+  groups, JetStream, NKey/JWT security.
+- [[id:A7B3C9D2-E5F1-4A8B-9C6D-3E2F1A0B8C7D][ORE Studio Messaging Reference]] — index of every service's subject
+  namespace and links to per-service messaging references.


### PR DESCRIPTION
## Summary

- Add `doc/knowledge/external/nats.org` — a technology knowledge page describing NATS (subjects, wildcards, queue groups, request/reply, JetStream, security model, deployment modes, client libraries).
- Wire the new page into `external.org` under a new "Messaging infrastructure" section.
- Scaffold task doc for this unit of work.

## Story

- Story UUID: `A388F0C8-0804-420F-A542-2C929CFCEC92`
- Story page: `doc/agile/versions/v0/sprint_18/nats_documentation/story.org`

## Task

- Task UUID: `6FE6B89C-78C4-4FB7-803C-022C3E8FF237`
- Task page: `doc/agile/versions/v0/sprint_18/nats_documentation/task_create_nats_knowledge_page.org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)