### PR TITLE
[recipe] Bulk capture from freeform text; update PR/commit conventions

### DIFF
--- a/doc/agile/versions/v0/sprint_18/per_sprint_capture_files/task_bulk_capture_recipe.org
+++ b/doc/agile/versions/v0/sprint_18/per_sprint_capture_files/task_bulk_capture_recipe.org
@@ -8,7 +8,7 @@
 #+level: s1
 #+filetags: :per_sprint_capture_files:sprint_18:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/bulk-capture-recipe
 #+pr:
 #+blocked_on: none
 #+blocked_since:
@@ -20,28 +20,29 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Write a recipe that lets a user paste a paragraph of freeform notes into Claude Code and have the LLM decompose them into one or more well-structured captures filed directly in =inbox/=, with no manual file editing required.
 
 * Status
 
-| Field        | Value                                  |
-|--------------+----------------------------------------|
-| State        | BACKLOG                              |
-| Parent story | [[id:E6CC19FC-5469-45BD-AA87-9CDBB23A4A7F][Per-sprint capture workflow: individual files and compass integration]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-05-27                               |
+| Field        | Value                                                                    |
+|--------------+--------------------------------------------------------------------------|
+| State        | STARTED                                                                  |
+| Parent story | [[id:E6CC19FC-5469-45BD-AA87-9CDBB23A4A7F][Per-sprint capture workflow: individual files and compass integration]]    |
+| Now          | Implementing recipe and updating PR/commit convention docs.              |
+| Waiting on   | Nothing.                                                                 |
+| Next         | PR.                                                                      |
+| Last touched | 2026-05-27                                                               |
 
 * Acceptance
 
--
+- Recipe =how_do_i_bulk_capture_from_freeform_text.org= exists in =doc/recipes/compass/=.
+- Recipe explains the workflow: paste freeform text, LLM decomposes into titles/descriptions, runs =compass capture --note= per idea.
+- Recipe includes a concrete example showing input text and the resulting slugs.
+- Recipe explains what to do after captures land in =inbox/= (file, defer, discard).
+- =how_do_i_create_a_pr.org= updated: Story/Task section uses markdown hyperlinks to the HTML page and =- Story ID:= / =- Task ID:= bullet lines.
+- =how_do_i_commit_to_git_using_ore_studio_conventions.org= updated: commit message template adds =Story-ID:= and =Task-ID:= trailers before =Co-Authored-By:=.
 
 * Plan
-
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_18/per_sprint_capture_files/task_bulk_capture_recipe.org
+++ b/doc/agile/versions/v0/sprint_18/per_sprint_capture_files/task_bulk_capture_recipe.org
@@ -48,9 +48,9 @@ Write a recipe that lets a user paste a paragraph of freeform notes into Claude 
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR   | Title                                                                              |
+|------+------------------------------------------------------------------------------------|
+| [[https://github.com/OreStudio/OreStudio/pull/876][#876]] | Bulk capture from freeform text; update PR/commit conventions |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/per_sprint_capture_files/task_bulk_capture_recipe.org
+++ b/doc/agile/versions/v0/sprint_18/per_sprint_capture_files/task_bulk_capture_recipe.org
@@ -54,8 +54,8 @@ Write a recipe that lets a user paste a paragraph of freeform notes into Claude 
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                        | File                        | Decision | Notes          |
+|---+--------------------------------------------------------+-----------------------------+----------+----------------|
+| 1 | EOF delimiter indented — shell syntax error on copy-paste | how_do_i_create_a_pr.org:53 | Accept   | Fixed in 2d2158c |
 
 * Result

--- a/doc/recipes/compass/compass.org
+++ b/doc/recipes/compass/compass.org
@@ -33,6 +33,12 @@ How to use =compass=, the [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][repository 
 - [[id:84C9177E-C737-428A-BDF9-E55FA6C9680C][How do I start a unit of work with compass?]] — fetch main, branch,
   scaffold a linked story+task (=goto=).
 
+* Captures
+
+- [[id:7072D39C-9607-48F9-8EE6-50E8647DB8ED][How do I capture ideas from freeform text?]] — paste unstructured
+  notes; LLM decomposes into well-structured captures in =inbox/=
+  (=compass capture --note=).
+
 * Navigating the doc graph
 
 These commands moved into compass from =ores.codegen= (the tool now owns

--- a/doc/recipes/compass/how_do_i_bulk_capture_from_freeform_text.org
+++ b/doc/recipes/compass/how_do_i_bulk_capture_from_freeform_text.org
@@ -1,0 +1,92 @@
+:PROPERTIES:
+:ID: 7072D39C-9607-48F9-8EE6-50E8647DB8ED
+:END:
+#+title: How do I capture ideas from freeform text?
+#+description: Write a paragraph of unstructured notes and ask the LLM to decompose it into well-structured captures filed in inbox/.
+#+type: recipe
+#+version: 2
+#+level: cross
+#+filetags: :compass:capture:llm:recipe:
+#+created: 2026-05-27
+#+updated: 2026-05-27
+
+For the capture type contract and bucket lifecycle, see [[id:8B29A8D8-E004-4E87-B81D-ABEAF68F2B98][document types]].
+For moving captures between buckets after they land in =inbox/=, see
+[[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][Product backlog]].
+
+* Question
+
+I have a block of unstructured notes — meeting notes, a brain-dump, a
+rough idea paragraph — and I want to turn it into one or more
+well-structured captures in =inbox/= without manually editing each
+file. How?
+
+* Answer
+
+Paste or type the freeform text directly into a message to the LLM
+(Claude Code) with the instruction:
+
+#+begin_example
+Capture the following notes: <paste text here>
+#+end_example
+
+The LLM will:
+
+1. Parse the text for distinct ideas and themes.
+2. For each idea, distil a concise title (5–10 words, imperative or
+   noun phrase) and a one-sentence description.
+3. Call =compass capture --note "..."= for each idea, landing the
+   file in =doc/agile/product_backlog/inbox/=.
+4. Report the slug(s) created so you can find them immediately.
+
+You do not need to structure the text first.  The LLM handles
+splitting, de-duplication, and canonicalisation.
+
+** Example
+
+#+begin_example
+Capture the following notes:
+
+We should look at adding dark-mode support to the Qt UI — there have
+been a few user requests.  Also the CSV export in the reporting view
+is slow when there are more than 10k rows; worth investigating whether
+streaming the write helps.  And someone mentioned wanting an audit log
+for configuration changes so we can see who changed what and when.
+#+end_example
+
+The LLM would call =compass capture= three times — one per distinct idea —
+and report back three slugs such as:
+
+#+begin_example
+Created: doc/agile/product_backlog/inbox/dark_mode_support_qt_ui.org
+Created: doc/agile/product_backlog/inbox/csv_export_performance_reporting.org
+Created: doc/agile/product_backlog/inbox/audit_log_configuration_changes.org
+#+end_example
+
+** After capturing
+
+Each file lands in =inbox/= (untriaged).  At your next triage session:
+
+- Promote to =next/= if it is an imminent candidate:
+  =compass capture file <slug> next=
+- Park in =deferred/= for long-horizon ideas:
+  =compass capture file <slug> deferred=
+- Discard if not aligned:
+  =compass capture file <slug> discarded=
+
+* Script
+
+=projects/ores.compass/compass.sh capture --note "..."= — creates one
+capture file in =inbox/= per call.  The LLM drives it; no manual
+invocation is required for the bulk workflow.
+
+* Tested by
+
+Manual: paste a paragraph of notes into Claude Code and verify the
+created files in =inbox/=.
+
+* See also
+
+- [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][Product backlog]] — bucket structure and triage lifecycle.
+- [[id:8B29A8D8-E004-4E87-B81D-ABEAF68F2B98][Document types]] — capture frontmatter contract.
+- [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][How do I create a PR?]] — after captures are promoted to stories/tasks.

--- a/doc/recipes/git/how_do_i_commit_to_git_using_ore_studio_conventions.org
+++ b/doc/recipes/git/how_do_i_commit_to_git_using_ore_studio_conventions.org
@@ -64,7 +64,21 @@ The body is separated from the title by a blank line. It should explain the
 - Wrap text at 72 characters.
 - Use bullet points for multiple distinct changes within a single commit.
 
-** 3. Co-Author Attribution
+** 3. Story and Task Trailers
+
+Every commit that implements agile work (story or task) must include
+=Story-ID:= and =Task-ID:= trailers with the *full* UUID from the
+=:ID:= property of the respective =.org= files:
+
+#+begin_example
+Story-ID: E6CC19FC-5469-45BD-AA87-9CDBB23A4A7F
+Task-ID: 477F1A3A-7090-4519-937B-2A79176CBAF6
+#+end_example
+
+These trailers make commits discoverable by story/task without parsing
+file paths. Place them after the body, before =Co-Authored-By:=.
+
+** 4. Co-Author Attribution
 
 When a commit is produced by an LLM (directly or via an agent), it must include
 a =Co-Authored-By:= trailer at the end of the commit message.
@@ -88,6 +102,8 @@ Example commit message:
 - ws-shim: intercept node/{id} and return HTML content.
 - .build-site.el: reset body flex/padding.
 
+Story-ID: E6CC19FC-5469-45BD-AA87-9CDBB23A4A7F
+Task-ID: 477F1A3A-7090-4519-937B-2A79176CBAF6
 Co-Authored-By: Gemini 2.0 Flash <noreply@google.com>
 #+end_src
 
@@ -95,7 +111,11 @@ Co-Authored-By: Gemini 2.0 Flash <noreply@google.com>
 
 #+begin_src sh :results verbatim
 # Typical commit command
-git commit -m "[comp] Title" -m "Detail body." -m "Co-Authored-By: Your Identity <your@email.com>"
+git commit -m "[comp] Title" \
+  -m "Detail body." \
+  -m "Story-ID: STORY-FULL-UUID
+Task-ID: TASK-FULL-UUID
+Co-Authored-By: Your Identity <your@email.com>"
 #+end_src
 
 * Tested by

--- a/doc/recipes/github/how_do_i_create_a_pr.org
+++ b/doc/recipes/github/how_do_i_create_a_pr.org
@@ -69,6 +69,9 @@ EOF
 
 * Conventions
 
+- /PR body is Markdown, not org-mode./ GitHub renders the body as
+  Markdown; use =**bold**=, =`code`=, =[text](url)= etc. — never
+  =[[id:...]]= links, =#+begin_src= blocks, or other org syntax.
 - /No "Test plan" section/ in the body.
 - /Title format/ is =[COMPONENT] Description=. Multi-component PRs
   use =[a,b,c]=.

--- a/doc/recipes/github/how_do_i_create_a_pr.org
+++ b/doc/recipes/github/how_do_i_create_a_pr.org
@@ -26,11 +26,10 @@ correctly-formatted title and a structured body?
    git push -u origin "$(git branch --show-current)"
    #+end_src
 
-2. /Create the PR/ with =gh pr create=. Embed the story and task
-   =:ID:= UUIDs in the body so =compass where --prs= can surface them
-   later, and a clickable HTML link to the published story page so
-   reviewers can open it directly. Use a HEREDOC for the body so
-   newlines are preserved:
+2. /Create the PR/ with =gh pr create=. Include a =## Traceability=
+   section at the end of the body with markdown hyperlinks to the
+   published HTML pages and the full UUIDs. Use a HEREDOC for the body
+   so newlines are preserved:
 
    #+begin_src sh :results verbatim
    gh pr create --title "[component] One-line description" \
@@ -44,11 +43,13 @@ correctly-formatted title and a structured body?
    - First change
    - Second change
 
-   Story: [[id:STORY-UUID]]
-   Task:  [[id:TASK-UUID]]
+   ## Traceability
 
-   Story page: https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_NN/STORY_SLUG/story.html
-   Task page:  https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_NN/STORY_SLUG/task_TASK_SLUG.html
+   [Story: Story title here](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_NN/STORY_SLUG/story.html)
+   [Task: Task title here](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_NN/STORY_SLUG/task_TASK_SLUG.html)
+
+   - Story ID: STORY-FULL-UUID
+   - Task ID: TASK-FULL-UUID
    EOF
    )"
    #+end_src
@@ -73,12 +74,21 @@ correctly-formatted title and a structured body?
   use =[a,b,c]=.
 - Body sections may be expanded (Notes, Decisions, Follow-ups), but
   Summary and Changes are the load-bearing pair.
-- /Story/Task UUIDs in the body/ are forward-only: they make PRs
-  discoverable from the task but are not back-filled on old PRs.
-- /Story and task page links/ follow the patterns:
-  - Story: =https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_<NN>/<STORY_SLUG>/story.html=
-  - Task:  =https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_<NN>/<STORY_SLUG>/task_<TASK_SLUG>.html=
-  Construct them from the sprint number, story slug, and task slug.
+- /Traceability section/ goes at the end of the body, always. It
+  contains:
+  1. A markdown link per artefact with the link text
+     =Story: <title>= or =Task: <title>= and the URL pointing to the
+     published HTML page.
+  2. =- Story ID:= and =- Task ID:= bullet lines with the *full*
+     UUID as read from the =:ID:= property of the =.org= file.
+     Never abbreviate the UUID to just the first segment.
+- /Story and task page URLs/ follow the pattern:
+  =https://orestudio.github.io/OreStudio/<path-without-extension>.html=
+  where =<path>= is the file path relative to the repo root:
+  - Story: =doc/agile/versions/v0/sprint_<NN>/<STORY_SLUG>/story=
+  - Task:  =doc/agile/versions/v0/sprint_<NN>/<STORY_SLUG>/task_<TASK_SLUG>=
+- /Traceability is forward-only/: add it to new PRs; do not back-fill
+  old ones.
 
 * Script
 

--- a/doc/recipes/github/how_do_i_create_a_pr.org
+++ b/doc/recipes/github/how_do_i_create_a_pr.org
@@ -50,7 +50,7 @@ correctly-formatted title and a structured body?
 
    - Story ID: STORY-FULL-UUID
    - Task ID: TASK-FULL-UUID
-   EOF
+EOF
    )"
    #+end_src
 


### PR DESCRIPTION
## Summary

Adds a recipe for the bulk-capture workflow and updates two convention docs to match the new Story/Task traceability format.

## Changes

- New recipe =how_do_i_bulk_capture_from_freeform_text.org= in =doc/recipes/compass/=: explains how to paste unstructured notes into Claude Code and have the LLM decompose them into well-structured captures in =inbox/=, with a worked example.
- =how_do_i_create_a_pr.org=: replaces the ad-hoc =Story: [[id:...]]= lines with a =## Traceability= section using markdown hyperlinks to the published HTML pages and =- Story ID:= / =- Task ID:= bullets with full UUIDs.
- =how_do_i_commit_to_git_using_ore_studio_conventions.org=: adds a new section 3 documenting =Story-ID:= / =Task-ID:= trailers before =Co-Authored-By:=; renumbers Co-Author section to 4; updates the Script example.

## Traceability

[Story: Per-sprint capture workflow: individual files and compass integration](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/per_sprint_capture_files/story.html)
[Task: Write recipe: bulk capture from freeform text](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/per_sprint_capture_files/task_bulk_capture_recipe.html)

- Story ID: E6CC19FC-5469-45BD-AA87-9CDBB23A4A7F
- Task ID: 477F1A3A-7090-4519-937B-2A79176CBAF6

🤖 Generated with [Claude Code](https://claude.com/claude-code)