### PR TITLE
[agile] Start story: Improve LLM runbook and skill tooling

### DIFF
--- a/doc/agile/product_backlog/inbox/knowledge_graph_improvements.org
+++ b/doc/agile/product_backlog/inbox/knowledge_graph_improvements.org
@@ -1,0 +1,32 @@
+:PROPERTIES:
+:ID:       F3CB848E-72C1-4F81-AAE4-1265F41D47C1
+:END:
+#+title: Knowledge graph improvements
+#+description: Issues with the current setup of the knowledge graph
+#+type: capture
+#+version: 2
+#+level: cross
+#+filetags: :inbox:capture:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+At present we have a number of problems with the Knowledge Graph:
+
+- missing configuration parameters on the left hand-side.
+- images are not displaying.
+
+* Why
+
+Motivation and context.
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/story.org
+++ b/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/story.org
@@ -1,0 +1,52 @@
+:PROPERTIES:
+:ID: E3C798C8-87E9-47E1-88F5-1BE6C8532BBE
+:END:
+#+title: Story: Improve LLM runbook and skill tooling
+#+description: Add skill support to compass add, update the skill-creation recipe to use it, and create a run-runbook skill that locates and executes the closest matching runbook from the catalogue.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :llm:skills:runbook:tooling:sprint_18:v0:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Tighten the runbook and skill workflow by closing three gaps discovered during sprint 18. First, =compass add= does not support =skill= as a document type, forcing manual invocation of =generate_v2_doc.sh=; this should be added. Second, the skill-creation recipe does not reference compass, so LLM sessions use the wrong scaffold path; the recipe should be updated. Third, there is no skill to locate and execute runbooks on demand; a =run-runbook= skill should be created so that "run the PR review runbook" resolves automatically from the catalogue.
+
+* Status
+
+| Field         | Value                                                                 |
+|---------------+-----------------------------------------------------------------------|
+| State         | STARTED                                                               |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                                                            |
+| Now           | Story scaffolded; tasks broken out.                                   |
+| Waiting on    | Nothing.                                                              |
+| Next          | Task 1 — add skill type to compass.                                   |
+| Last touched  | 2026-05-28                                                            |
+
+* Acceptance
+
+- =compass add skill= scaffolds a new skill under =doc/llm/skills/<slug>/SKILL.org=.
+- The skill-creation recipe (=how_do_i_create_a_new_skill.org= or equivalent) references =compass add skill= as the scaffold step.
+- A =run-runbook= skill exists at =doc/llm/skills/run-runbook/SKILL.org=, properly scaffolded via compass.
+- Invoking the skill reads =doc/llm/runbooks/runbooks.org=, matches the user's request to the closest runbook, and executes it step by step.
+- If no match is found the skill lists available runbooks and asks the user to choose.
+
+* Tasks
+
+In execution order:
+
+1. [[id:EC72C05A-BC4C-47EC-ADF9-324190D9A246][Task: Add skill type to compass add]] — extend compass so =compass add skill= works.
+2. [[id:487021A2-0324-43AE-8150-797B41CA77B9][Task: Update skill-creation recipe to use compass]] — update the recipe so the scaffold step uses =compass add skill=.
+3. [[id:8DC89ACF-3A1A-4417-B4EE-BA031FD3AE00][Task: Create run-runbook skill]] — scaffold and fill the skill that locates and runs runbooks.
+
+* Decisions
+
+* Out of scope
+
+- Modifying the content of existing runbooks.
+- Automated runbook testing or dry-run mode.

--- a/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_add_skill_type_to_compass.org
+++ b/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_add_skill_type_to_compass.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: EC72C05A-BC4C-47EC-ADF9-324190D9A246
+:END:
+#+title: Task: Add skill type to compass add
+#+description: Extend compass add to support the skill document type so that LLM sessions can scaffold new skills via compass add skill rather than calling generate_v2_doc.sh directly.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :improve_runbook_skill_tooling:sprint_18:v0:
+#+owner: marco
+#+branch: feature/improve-runbook-skill-tooling
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add =skill= to the list of types supported by =compass add=. Currently the command accepts =story task sprint version recipe knowledge component capture memory investigation product_identity= but not =skill=, forcing manual invocation of =generate_v2_doc.sh --type skill=. After this task, =compass add skill --slug <slug> --title "..." --description "..." --parent-dir doc/llm/skills= scaffolds the skill correctly.
+
+* Status
+
+| Field        | Value                                                                 |
+|--------------+-----------------------------------------------------------------------|
+| State        | BACKLOG                                                               |
+| Parent story | [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]]                                |
+| Now          | Not yet started.                                                      |
+| Waiting on   | Nothing.                                                              |
+| Next         | Locate where compass add types are defined and add skill.             |
+| Last touched | 2026-05-28                                                            |
+
+* Acceptance
+
+- =compass add skill --slug my_skill --title "My Skill" --description "..." --parent-dir doc/llm/skills= creates =doc/llm/skills/my_skill/SKILL.org= with correct frontmatter.
+- =compass add --help= lists =skill= among the supported types.
+- Existing types are unaffected.
+
+* Plan
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_create_run_runbook_skill.org
+++ b/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_create_run_runbook_skill.org
@@ -56,8 +56,8 @@ Draft skill was written manually during sprint 18 before compass skill support e
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                              | File          | Decision | Notes              |
+|---+--------------------------------------------------------------+---------------+----------+--------------------|
+| 1 | Folder names are snake_case not kebab-case                   | SKILL.org     | Accept   | Fixed in d851ef9df |
 
 * Result

--- a/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_create_run_runbook_skill.org
+++ b/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_create_run_runbook_skill.org
@@ -1,0 +1,63 @@
+:PROPERTIES:
+:ID: 8DC89ACF-3A1A-4417-B4EE-BA031FD3AE00
+:END:
+#+title: Task: Create run-runbook skill
+#+description: Create a run-runbook skill that reads runbooks.org, matches the user request to the closest runbook, and executes it. If no match is found, lists available runbooks and asks the user to choose.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :improve_runbook_skill_tooling:sprint_18:v0:
+#+owner: marco
+#+branch: feature/improve-runbook-skill-tooling
+#+pr:
+#+blocked_on: EC72C05A-BC4C-47EC-ADF9-324190D9A246
+#+blocked_since:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Create a =run-runbook= skill at =doc/llm/skills/run-runbook/SKILL.org=, properly scaffolded via =compass add skill=. The skill reads =doc/llm/runbooks/runbooks.org=, matches the user's request to the closest runbook by title and description, and executes it end-to-end. If no match is found it lists the available runbooks and asks the user to choose. A draft was written manually during sprint 18; this task replaces it with a properly scaffolded version and deletes the draft.
+
+* Status
+
+| Field        | Value                                                                 |
+|--------------+-----------------------------------------------------------------------|
+| State        | BACKLOG                                                               |
+| Parent story | [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]]                                |
+| Now          | Draft skill exists at doc/llm/skills/run-runbook/SKILL.org.           |
+| Waiting on   | [[id:EC72C05A-BC4C-47EC-ADF9-324190D9A246][Task: Add skill type to compass add]]                                  |
+| Next         | Delete draft, scaffold via compass, fill in skill content.            |
+| Last touched | 2026-05-28                                                            |
+
+* Acceptance
+
+- =doc/llm/skills/run-runbook/SKILL.org= is scaffolded via =compass add skill=.
+- Skill reads =doc/llm/runbooks/runbooks.org= and matches on title + description.
+- On match: reads the runbook file and executes every step in order.
+- On no match: lists available runbook titles and asks the user to select one.
+- Skill is registered in the skills catalogue (=claude_code_skills.org=).
+- Draft manually-created version is replaced.
+
+* Plan
+
+* Notes
+
+Draft skill was written manually during sprint 18 before compass skill support existed. Content is correct but the scaffold is not compliant with the v2 contract. Replace rather than edit in place.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_update_skill_creation_recipe.org
+++ b/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_update_skill_creation_recipe.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: 487021A2-0324-43AE-8150-797B41CA77B9
+:END:
+#+title: Task: Update skill-creation recipe to use compass
+#+description: Update the how-do-I-create-a-new-skill recipe so that the scaffold step uses compass add skill rather than calling generate_v2_doc.sh directly.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :improve_runbook_skill_tooling:sprint_18:v0:
+#+owner: marco
+#+branch: feature/improve-runbook-skill-tooling
+#+pr:
+#+blocked_on: EC72C05A-BC4C-47EC-ADF9-324190D9A246
+#+blocked_since:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The skill-creation recipe (referenced by the skill-manager skill) currently directs LLM sessions to call =generate_v2_doc.sh --type skill= directly. Update it to use =compass add skill= once task [[id:EC72C05A-BC4C-47EC-ADF9-324190D9A246][Add skill type to compass add]] is complete. The skill-manager SKILL.org itself may need updating if it embeds the scaffold command.
+
+* Status
+
+| Field        | Value                                                                 |
+|--------------+-----------------------------------------------------------------------|
+| State        | BACKLOG                                                               |
+| Parent story | [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]]                                |
+| Now          | Not yet started.                                                      |
+| Waiting on   | [[id:EC72C05A-BC4C-47EC-ADF9-324190D9A246][Task: Add skill type to compass add]]                                  |
+| Next         | Locate the skill-creation recipe and skill-manager SKILL.org.         |
+| Last touched | 2026-05-28                                                            |
+
+* Acceptance
+
+- The skill-creation recipe scaffold step reads =compass add skill= (not =generate_v2_doc.sh=).
+- The skill-manager SKILL.org =* How to use this skill= section references =compass add skill=.
+- No other content is changed unnecessarily.
+
+* Plan
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -84,6 +84,7 @@ In execution order.
 | [[id:8BD3D28A-C5A1-4F8D-A685-1BC6EBF5C812][Sprint health charts]]                            | STARTED | 2026-05-26 |            | Generate daily charts of PRs, commits, story completions, and line churn using gnuplot. |
 | [[id:A388F0C8-0804-420F-A542-2C929CFCEC92][Document NATS: technology overview, system integration, and recipes]] | STARTED | 2026-05-26 | | NATS knowledge page, system model section, per-component subject tables, and NATS recipes. |
 | [[id:E6CC19FC-5469-45BD-AA87-9CDBB23A4A7F][Per-sprint capture workflow: individual files and compass integration]] | STARTED | 2026-05-27 | | captures/ folder per sprint; compass capture command; wontdo backlog bucket. |
+| [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]]                                 | STARTED | 2026-05-28 | | Add compass skill type, update skill-creation recipe, create run-runbook skill. |
 
 * Health Review
 

--- a/doc/llm/runbooks/start_new_story/runbook.org
+++ b/doc/llm/runbooks/start_new_story/runbook.org
@@ -27,7 +27,15 @@ Take a story from idea to open PR — scaffold, fill in, branch, mark STARTED, w
 
 In execution order:
 
-1. /Scaffold the story./ Use [[id:84C9177E-C737-428A-BDF9-E55FA6C9680C][How do I start a unit of work with compass?]] — specifically =compass goto= — to create the feature branch, scaffold the story, and link a task in one step:
+1. /Ensure main is up to date./ If you are not already on =main=, fetch without switching branches so the new branch starts from the latest remote state:
+
+   #+begin_src sh :results verbatim
+   git fetch origin main
+   #+end_src
+
+   =compass goto= also fetches =main= internally, but doing it explicitly first makes divergence visible before any files are created.
+
+2. /Scaffold the story./ Use [[id:84C9177E-C737-428A-BDF9-E55FA6C9680C][How do I start a unit of work with compass?]] — specifically =compass goto= — to create the feature branch, scaffold the story, and link a task in one step:
 
    #+begin_src sh :results verbatim
    ./projects/ores.compass/compass.sh goto \
@@ -37,15 +45,15 @@ In execution order:
 
    This fetches =main=, creates =feature/my-feature=, and writes =story.org= + a linked task into the current sprint. To add a task to an /existing/ story instead, see [[id:84C9177E-C737-428A-BDF9-E55FA6C9680C][the recipe]] for the =--story= form.
 
-2. /Fill in the story content./ Open =story.org= and complete the =* Goal=, =* Acceptance=, =* Tasks=, and =* Out of scope= sections. Use [[id:F9AD7932-8E11-433C-A812-B57DBC9BF5D8][LLM instructions]] as the entry-point skill. Every internal-doc reference uses an =[[id:UUID]]= link, never a relative path.
+3. /Fill in the story content./ Open =story.org= and complete the =* Goal=, =* Acceptance=, =* Tasks=, and =* Out of scope= sections. Use [[id:F9AD7932-8E11-433C-A812-B57DBC9BF5D8][LLM instructions]] as the entry-point skill. Every internal-doc reference uses an =[[id:UUID]]= link, never a relative path.
 
-3. /Mark the story STARTED./ Update the =* Status= table: state → =STARTED=, fill =Now= and =Next=, set =#+owner:=, refresh =#+updated:=. Follow [[id:DA003A23-1604-43E7-A98F-A305148FBCF4][How do I start work on a story?]] step 3.
+4. /Mark the story STARTED./ Update the =* Status= table: state → =STARTED=, fill =Now= and =Next=, set =#+owner:=, refresh =#+updated:=. Follow [[id:DA003A23-1604-43E7-A98F-A305148FBCF4][How do I start work on a story?]] step 3.
 
-4. /Wire into the sprint./ Add a row to the parent sprint's =* Stories= table. Each row: =| [[id:UUID][Title]] | STARTED | date | | Theme |=.
+5. /Wire into the sprint./ Add a row to the parent sprint's =* Stories= table. Each row: =| [[id:UUID][Title]] | STARTED | date | | Theme |=.
 
-5. /Commit the status change./ Use [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][ORE Studio commit conventions]]: =[agile] Mark <story> STARTED= with a =Co-Authored-By:= trailer.
+6. /Commit the status change./ Use [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][ORE Studio commit conventions]]: =[agile] Mark <story> STARTED= with a =Co-Authored-By:= trailer.
 
-6. /Push and open a PR./ Push with =git push -u origin <branch>=, then [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][create a PR]] with a structured body (Summary, Changes, Story/Task UUIDs, Story/Task page links). Record the PR number in the task's =* PRs= table.
+7. /Push and open a PR./ Push with =git push -u origin <branch>=, then [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][create a PR]] with a structured body (Summary, Changes, Story/Task UUIDs, Story/Task page links). Record the PR number in the task's =* PRs= table.
 
 * Postconditions
 

--- a/doc/llm/skills/run-runbook/SKILL.org
+++ b/doc/llm/skills/run-runbook/SKILL.org
@@ -38,7 +38,7 @@ the current session.
 
 3. /Locate the runbook file./ Runbooks live at
    =doc/llm/runbooks/<slug>/runbook.org= where =<slug>= is the
-   kebab-case folder name derived from the runbook title.  Confirm the
+   snake_case folder name derived from the runbook title.  Confirm the
    file exists before proceeding.
 
 4. /Read the runbook./ Load =runbook.org= and identify the =* Steps=

--- a/doc/llm/skills/run-runbook/SKILL.org
+++ b/doc/llm/skills/run-runbook/SKILL.org
@@ -1,0 +1,84 @@
+:PROPERTIES:
+:ID: 9A87A66D-13AB-4CF5-96A3-BF42E85CD743
+:END:
+#+title: Run Runbook Skill
+#+description: Find the runbook closest to the user's request and execute it end-to-end.
+#+type: skill
+#+version: 2
+#+level: cross
+#+filetags: :skills:claude_code:runbook:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+
+#+begin_export markdown
+---
+name: run-runbook
+description: Find the runbook closest to the user's request and execute it end-to-end.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+When the user asks to "run a runbook" or "run the <X> runbook" without
+specifying a path.  Resolves the request to the closest matching
+runbook in the catalogue, then executes every step of that runbook in
+the current session.
+
+* How to use this skill
+
+1. /Read the catalogue./ Open =doc/llm/runbooks/runbooks.org= (relative
+   to the project root).  Parse the =* Catalogue= table — each row has
+   a title, an org-id link, and a description.
+
+2. /Match the request./ Compare the user's request against every row
+   title and description.  Pick the single best match.  If nothing is
+   close, stop and tell the user: "No runbook found matching '<request>'.
+   Available runbooks: <list titles>."
+
+3. /Locate the runbook file./ Runbooks live at
+   =doc/llm/runbooks/<slug>/runbook.org= where =<slug>= is the
+   kebab-case folder name derived from the runbook title.  Confirm the
+   file exists before proceeding.
+
+4. /Read the runbook./ Load =runbook.org= and identify the =* Steps=
+   section.  Read the preconditions in =* Preconditions= — verify they
+   hold or flag any that are unmet before starting.
+
+5. /Execute the runbook./ Work through every numbered step in =* Steps=
+   in order.  Each step references a recipe or action; follow it fully
+   before moving to the next.  Do not skip or reorder steps.
+
+6. /Confirm postconditions./ After the final step, check the
+   =* Postconditions= section and verify each one is satisfied.  Report
+   any that are not met.
+
+* Recipes
+
+- [[id:D1125E49-3C4E-48D4-B7F9-15CAA45B3ADD][Runbooks catalogue]] — the index this skill reads to resolve requests.
+
+* Reference
+
+- [[id:D1125E49-3C4E-48D4-B7F9-15CAA45B3ADD][Runbooks catalogue]] — full list of available runbooks with descriptions.
+- [[id:B555D2A6-10CA-4A93-973E-F2AF4E1D7E55][Runbook glossary entry]] — definition and contract for runbooks.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENCE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC


### PR DESCRIPTION
## Summary

- Scaffolds story E3C798C8 with three ordered tasks: add `skill` type to `compass add`, update the skill-creation recipe to use it, and create the `run-runbook` skill
- Wires the story into sprint 18's Stories table
- Adds a draft `run-runbook` skill at `doc/llm/skills/run-runbook/SKILL.org` (will be replaced by a compass-scaffolded version in task 3)
- Updates the `start_new_story` runbook to include an explicit `git fetch origin main` step before `compass goto`

## Test plan

- [ ] Story, three task docs, and sprint table row are all present and correctly cross-linked
- [ ] `start_new_story` runbook step numbering is consistent and fetch step is in the right place

## Traceability

- [Story: Improve LLM runbook and skill tooling](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/story.html)
- [Task: Add skill type to compass add](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_add_skill_type_to_compass.html)

- Story ID: E3C798C8-87E9-47E1-88F5-1BE6C8532BBE
- Task ID: EC72C05A-BC4C-47EC-ADF9-324190D9A246

🤖 Generated with [Claude Code](https://claude.com/claude-code)