### PR TITLE
Add skill type to compass add

### DIFF
--- a/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_add_skill_type_to_compass.org
+++ b/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_add_skill_type_to_compass.org
@@ -51,9 +51,9 @@ Add =skill= to the list of types supported by =compass add=. Currently the comma
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                    | File                              | Decision | Notes                      |
+|---+----------------------------------------------------+-----------------------------------+----------+----------------------------|
+| 1 | Now field in DONE task should be exactly Complete. | task_add_skill_type_to_compass.org | Accept  | Fixed in 3134d3c45         |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_add_skill_type_to_compass.org
+++ b/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_add_skill_type_to_compass.org
@@ -45,9 +45,9 @@ Add =skill= to the list of types supported by =compass add=. Currently the comma
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR  | Title                              |
+|-----+------------------------------------|
+| 881 | Add skill type to compass add      |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_add_skill_type_to_compass.org
+++ b/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_add_skill_type_to_compass.org
@@ -26,11 +26,11 @@ Add =skill= to the list of types supported by =compass add=. Currently the comma
 
 | Field        | Value                                                                 |
 |--------------+-----------------------------------------------------------------------|
-| State        | BACKLOG                                                               |
+| State        | DONE                                                                  |
 | Parent story | [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]]                                |
-| Now          | Not yet started.                                                      |
+| Now          | Complete. =compass add skill= works with default =doc/llm/skills=.   |
 | Waiting on   | Nothing.                                                              |
-| Next         | Locate where compass add types are defined and add skill.             |
+| Next         | Unblocks tasks 487021A2 and 8DC89ACF.                                 |
 | Last touched | 2026-05-28                                                            |
 
 * Acceptance
@@ -56,3 +56,5 @@ Add =skill= to the list of types supported by =compass add=. Currently the comma
 |   |                 |      |          |       |
 
 * Result
+
+Added =skill= to =compass add= help text and default parent-dir logic in =projects/ores.compass/src/compass.py=. When =--parent-dir= is omitted for =skill= type, compass injects =doc/llm/skills= automatically. The change delegates directly to =v2_doc_generate.py= which already handles the skill path convention (=<parent-dir>/<slug>/SKILL.org=). Verified with a test invocation.

--- a/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_add_skill_type_to_compass.org
+++ b/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_add_skill_type_to_compass.org
@@ -28,7 +28,7 @@ Add =skill= to the list of types supported by =compass add=. Currently the comma
 |--------------+-----------------------------------------------------------------------|
 | State        | DONE                                                                  |
 | Parent story | [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]]                                |
-| Now          | Complete. =compass add skill= works with default =doc/llm/skills=.   |
+| Now          | Complete.                                                             |
 | Waiting on   | Nothing.                                                              |
 | Next         | Unblocks tasks 487021A2 and 8DC89ACF.                                 |
 | Last touched | 2026-05-28                                                            |

--- a/doc/agile/versions/v0/sprint_18/system_model_readability/task_rework_system_model_document.org
+++ b/doc/agile/versions/v0/sprint_18/system_model_readability/task_rework_system_model_document.org
@@ -109,20 +109,20 @@ Each =**= component section follows this template:
 ** ores.iam
    <1–3 sentence description of purpose and boundaries.>
 
-   | Sub-component          | Role                          | Dependencies                         |
-   |------------------------+-------------------------------+--------------------------------------|
-   | [[id:...][ores.iam.api]]  | Shared types + NATS protocol | —                                    |
-   | [[id:...][ores.iam.core]] | Account lifecycle, RBAC, sessions | [[id:...][ores.database]], [[id:...][ores.security]] |
-   | [[id:...][ores.iam.service]] | Thin NATS entrypoint       | [[id:...][ores.iam.core]]                |
+   | Sub-component        | Role                               | Dependencies                  |
+   |----------------------+------------------------------------+-------------------------------|
+   | ores.iam.api         | Shared types + NATS protocol       | —                             |
+   | ores.iam.core        | Account lifecycle, RBAC, sessions  | ores.database, ores.security  |
+   | ores.iam.service     | Thin NATS entrypoint               | ores.iam.core                 |
 
-   - [[id:...][Multi-party model]] — how parties relate to tenants and accounts.
-   - [[id:...][Multi-tenancy]] — tenant isolation model and provisioning.
-   - [[id:...][Identity and Access Management]] — IAM concepts as applied in ores.iam.core.
-   - [[id:...][Role-Based Access Control]] — RBAC graph and permission assignment.
+   - Multi-party model — how parties relate to tenants and accounts.
+   - Multi-tenancy — tenant isolation model and provisioning.
+   - Identity and Access Management — IAM concepts as applied in ores.iam.core.
+   - Role-Based Access Control — RBAC graph and permission assignment.
 #+end_example
 
 Monolithic components (no =.api=/.core=/.service= split) have a
-single-row table with =[[id:...][ores.X]]= in the Sub-component column.
+single-row table with the component name in the Sub-component column.
 
 ** Removals
 

--- a/doc/llm/runbooks/handle_pr_review_round/runbook.org
+++ b/doc/llm/runbooks/handle_pr_review_round/runbook.org
@@ -4,7 +4,7 @@
 #+title: Handle a PR review round
 #+description: Sync with main, read review comments, decide per comment, apply fixes, push, reply, resolve threads, and record.
 #+type: runbook
-#+version: 3
+#+version: 4
 #+level: cross
 #+filetags: :runbook:pr:review:github:
 #+created: 2026-05-26
@@ -28,27 +28,29 @@ In execution order:
 
 1. /Sync with main./ Fetch and rebase: =git fetch origin main && git rebase origin/main=. Never address review comments on a stale branch.
 
-2. /Read the comments./ Follow [[id:26C1DC06-82D2-46C4-94D6-DF9231BA171B][How do I address PR review comments?]] step 1: =gh pr view <N> --comments= and =gh api .../comments=.
-
-3. /Decide per comment./ For each comment, make an explicit accept/decline decision. Never silently ignore a comment.
-
-4. /Apply fixes./ One commit per logical fix. Never amend commits on a branch under review. Use [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][commit conventions]].
-
-5. /Push./ =git push=.
-
-6. /Verify CI passes./ Check that all required CI checks turn green after the push:
+2. /Check CI status./ Before reading comments, inspect the current CI state:
 
    #+begin_src sh :results verbatim
    gh pr checks <N>
    #+end_src
 
-   Wait for pending checks to complete (re-run until no =PENDING= rows). If any check fails, fix the root cause, commit, push again, and repeat this step before moving on. Do not reply to review comments while CI is red.
+   If any check is failing, identify and fix the root cause first — as a separate commit — before looking at review comments. A CI failure may explain or supersede some review comments. If CI is green or only pending, proceed; pending checks will be re-verified after the push.
 
-7. /Reply to every comment./ Accepted: "Fixed in commit <sha> — <description>." Declined: "Not changed. <reason>." Use =gh api ... --method POST -F ...= per the recipe.
+3. /Read the comments./ Follow [[id:26C1DC06-82D2-46C4-94D6-DF9231BA171B][How do I address PR review comments?]] step 1: =gh pr view <N> --comments= and =gh api .../comments=.
 
-8. /Resolve threads./ Use =gh api graphql= with =resolveReviewThread= mutation.
+4. /Decide per comment./ For each comment, make an explicit accept/decline decision. Never silently ignore a comment.
 
-9. /Record the round./ Add or update the =* Review= table in the task doc per step 7 of the review recipe.
+5. /Apply fixes./ One commit per logical fix. Never amend commits on a branch under review. Use [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][commit conventions]].
+
+6. /Push./ =git push=.
+
+7. /Verify CI is green./ Re-run =gh pr checks <N>= and wait until no checks are pending. If any check fails, fix, commit, push, and repeat this step. Do not reply to review comments while CI is red.
+
+8. /Reply to every comment./ Accepted: "Fixed in commit <sha> — <description>." Declined: "Not changed. <reason>." Use =gh api ... --method POST -F ...= per the recipe.
+
+9. /Resolve threads./ Use =gh api graphql= with =resolveReviewThread= mutation.
+
+10. /Record the round./ Add or update the =* Review= table in the task doc per step 7 of the review recipe.
 
 * Postconditions
 

--- a/doc/llm/runbooks/handle_pr_review_round/runbook.org
+++ b/doc/llm/runbooks/handle_pr_review_round/runbook.org
@@ -4,11 +4,11 @@
 #+title: Handle a PR review round
 #+description: Sync with main, read review comments, decide per comment, apply fixes, push, reply, resolve threads, and record.
 #+type: runbook
-#+version: 2
+#+version: 3
 #+level: cross
 #+filetags: :runbook:pr:review:github:
 #+created: 2026-05-26
-#+updated: 2026-05-26
+#+updated: 2026-05-28
 
 This page documents a [[id:B555D2A6-10CA-4A93-973E-F2AF4E1D7E55][runbook]] — a named, repeatable composition of [[id:0C57932D-D13A-480F-B426-49525AA8BA3D][recipes]] and [[id:6054CC20-5F41-482F-A587-759512577B1D][skills]] for a complete multi-step procedure. Each step references a recipe or skill by id-link.
 
@@ -36,14 +36,23 @@ In execution order:
 
 5. /Push./ =git push=.
 
-6. /Reply to every comment./ Accepted: "Fixed in commit <sha> — <description>." Declined: "Not changed. <reason>." Use =gh api ... --method POST -F ...= per the recipe.
+6. /Verify CI passes./ Check that all required CI checks turn green after the push:
 
-7. /Resolve threads./ Use =gh api graphql= with =resolveReviewThread= mutation.
+   #+begin_src sh :results verbatim
+   gh pr checks <N>
+   #+end_src
 
-8. /Record the round./ Add or update the =* Review= table in the task doc per step 7 of the review recipe.
+   Wait for pending checks to complete (re-run until no =PENDING= rows). If any check fails, fix the root cause, commit, push again, and repeat this step before moving on. Do not reply to review comments while CI is red.
+
+7. /Reply to every comment./ Accepted: "Fixed in commit <sha> — <description>." Declined: "Not changed. <reason>." Use =gh api ... --method POST -F ...= per the recipe.
+
+8. /Resolve threads./ Use =gh api graphql= with =resolveReviewThread= mutation.
+
+9. /Record the round./ Add or update the =* Review= table in the task doc per step 7 of the review recipe.
 
 * Postconditions
 
+- All CI checks on the PR are green.
 - All review comments have replies.
 - All threads are resolved.
 - Review round is recorded in the task's =* Review= table.

--- a/doc/llm/runbooks/handle_pr_review_round/runbook.org
+++ b/doc/llm/runbooks/handle_pr_review_round/runbook.org
@@ -4,7 +4,7 @@
 #+title: Handle a PR review round
 #+description: Sync with main, read review comments, decide per comment, apply fixes, push, reply, resolve threads, and record.
 #+type: runbook
-#+version: 4
+#+version: 2
 #+level: cross
 #+filetags: :runbook:pr:review:github:
 #+created: 2026-05-26

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -955,9 +955,9 @@ def cmd_add(argv):
     if not argv or argv[0] in ("-h", "--help"):
         print("usage: compass add <type> [generate_v2_doc options]\n"
               "  types: story task sprint version recipe knowledge component\n"
-              "         capture memory investigation product_identity\n"
-              "  --parent-dir defaults to the current sprint (story) or "
-              "version (sprint); required otherwise.\n"
+              "         capture memory investigation product_identity skill\n"
+              "  --parent-dir defaults to the current sprint (story) or\n"
+              "  version (sprint), or doc/llm/skills (skill); required otherwise.\n"
               "  remaining flags are passed through to ores.codegen "
               "(see 'How do I create a new v2 doc?').")
         return 0
@@ -968,11 +968,17 @@ def cmd_add(argv):
     has_parent = any(a == "--parent-dir" or a.startswith("--parent-dir=")
                      for a in rest)
     if not has_parent:
-        default_parent = _default_parent_dir(doc_type)
-        if default_parent:
+        if doc_type == "skill":
+            default_parent = "doc/llm/skills"
             rest += ["--parent-dir", default_parent]
-            print(f"ℹ️  --parent-dir not given; using current "
-                  f"{_DEFAULTABLE_PARENT[doc_type]}: {default_parent}", file=sys.stderr)
+            print(f"ℹ️  --parent-dir not given; using default: {default_parent}",
+                  file=sys.stderr)
+        else:
+            default_parent = _default_parent_dir(doc_type)
+            if default_parent:
+                rest += ["--parent-dir", default_parent]
+                print(f"ℹ️  --parent-dir not given; using current "
+                      f"{_DEFAULTABLE_PARENT[doc_type]}: {default_parent}", file=sys.stderr)
 
     # Lazy, optional import: the generator lives in ores.codegen and needs
     # pystache. Only `add` / `goto` require it; the other commands stay


### PR DESCRIPTION
## Summary

- `compass add skill` now scaffolds `doc/llm/skills/<slug>/SKILL.org` via `ores.codegen`, matching the skill folder convention
- Default `--parent-dir` set to `doc/llm/skills` when omitted, consistent with how story/sprint get their sprint/version defaults
- Help text updated to list `skill` among supported types

## Changes

- `projects/ores.compass/src/compass.py`: added `skill` branch in `cmd_add` default-parent logic; updated help string

## Traceability

- Story: Improve LLM runbook and skill tooling — https://github.com/OreStudio/OreStudio/blob/feature/improve-runbook-skill-tooling/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/story.org
  - Story-ID: E3C798C8-87E9-47E1-88F5-1BE6C8532BBE
- Task: Add skill type to compass add — https://github.com/OreStudio/OreStudio/blob/feature/improve-runbook-skill-tooling/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_add_skill_type_to_compass.org
  - Task-ID: EC72C05A-BC4C-47EC-ADF9-324190D9A246

🤖 Generated with [Claude Code](https://claude.com/claude-code)