### PR TITLE
Update skill-creation recipe and skill-manager to use compass

### DIFF
--- a/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_update_skill_creation_recipe.org
+++ b/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_update_skill_creation_recipe.org
@@ -51,9 +51,9 @@ The skill-creation recipe (referenced by the skill-manager skill) currently dire
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                         | File                              | Decision | Notes                |
+|---+---------------------------------------------------------+-----------------------------------+----------+----------------------|
+| 1 | Orphaned em-dash before "use" should be a comma         | how_do_i_create_a_new_v2_doc.org  | Accept   | Fixed in 67b9e0131   |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_update_skill_creation_recipe.org
+++ b/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_update_skill_creation_recipe.org
@@ -26,11 +26,11 @@ The skill-creation recipe (referenced by the skill-manager skill) currently dire
 
 | Field        | Value                                                                 |
 |--------------+-----------------------------------------------------------------------|
-| State        | BACKLOG                                                               |
+| State        | DONE                                                                  |
 | Parent story | [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]]                                |
-| Now          | Not yet started.                                                      |
-| Waiting on   | [[id:EC72C05A-BC4C-47EC-ADF9-324190D9A246][Task: Add skill type to compass add]]                                  |
-| Next         | Locate the skill-creation recipe and skill-manager SKILL.org.         |
+| Now          | Complete.                                                             |
+| Waiting on   | Nothing.                                                              |
+| Next         | None.                                                                 |
 | Last touched | 2026-05-28                                                            |
 
 * Acceptance
@@ -56,3 +56,5 @@ The skill-creation recipe (referenced by the skill-manager skill) currently dire
 |   |                 |      |          |       |
 
 * Result
+
+Updated =doc/recipes/codegen/how_do_i_create_a_new_v2_doc.org=: the "New Claude Code skill" section now shows =compass add skill= with a snake_case slug, and the compass-preferred types note at the top now includes =skill=. Updated =doc/llm/skills/skill-manager/SKILL.org= step 3 to reference =compass add skill= and snake_case slugs.

--- a/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_update_skill_creation_recipe.org
+++ b/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_update_skill_creation_recipe.org
@@ -10,7 +10,7 @@
 #+owner: marco
 #+branch: feature/improve-runbook-skill-tooling
 #+pr:
-#+blocked_on: EC72C05A-BC4C-47EC-ADF9-324190D9A246
+#+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-28
 #+updated: 2026-05-28

--- a/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_update_skill_creation_recipe.org
+++ b/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_update_skill_creation_recipe.org
@@ -45,9 +45,9 @@ The skill-creation recipe (referenced by the skill-manager skill) currently dire
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR  | Title                                                               |
+|-----+---------------------------------------------------------------------|
+| 883 | Update skill-creation recipe and skill-manager to use compass       |
 
 * Review
 

--- a/doc/llm/skills/skill-manager/SKILL.org
+++ b/doc/llm/skills/skill-manager/SKILL.org
@@ -37,9 +37,9 @@ shipped bundle so the skill changes propagate to Claude Code.
    needed recipe doesn't exist yet, create it first via
    [[id:D4E65EF1-54F4-47E1-9388-58BE9E36FBE3][How do I create a recipe?]].
 
-3. /Scaffold the skill/ via the codegen. Use kebab-case for the
-   slug; it doubles as the Claude Code =name:= field and the
-   folder name (=doc/llm/skills/<slug>/SKILL.org=). See
+3. /Scaffold the skill/ via =compass add skill=. Use snake_case for
+   the slug; it becomes the folder name and the Claude Code =name:=
+   field (=doc/llm/skills/<slug>/SKILL.org=). See
    [[id:3153AA4B-23D4-4111-9710-5A4971102EDC][How do I create a new v2 doc?]] §"New Claude Code skill" for
    the exact invocation.
 

--- a/doc/recipes/codegen/how_do_i_create_a_new_v2_doc.org
+++ b/doc/recipes/codegen/how_do_i_create_a_new_v2_doc.org
@@ -23,11 +23,12 @@ frontmatter?
 
 * Answer
 
-For *stories, tasks, and sprints* — the most common agile operations — use
+For *stories, tasks, sprints, and skills* — use
 [[id:5B670808-D28B-4818-A2FA-EA5220D35E8D][compass add]] instead. It defaults =--parent-dir= from where you are (current
-sprint for stories, current version for sprints) so you rarely need to type
-a path. This recipe remains the authoritative reference for all other doc
-types and for edge cases (explicit =--id=, non-current parents, etc.).
+sprint for stories/tasks, current version for sprints, =doc/llm/skills= for
+skills) so you rarely need to type a path. This recipe remains the
+authoritative reference for all other doc types and for edge cases (explicit
+=--id=, non-current parents, etc.).
 
 Call =projects/ores.codegen/generate_v2_doc.sh= with the type, slug, parent
 directory, and the document's title and description. The script fills in a fresh
@@ -189,20 +190,18 @@ projects/ores.codegen/generate_v2_doc.sh \
 :ID: 6054CC20-5F41-482F-A587-759512577B1D
 :END:
 
-Use kebab-case for the slug (matches existing =cmake-runner=,
-=v2-doc-author=). The slug becomes both the folder name and the
-=name:= field in the skill's markdown frontmatter:
+Use =compass add skill=. The slug must be snake_case; it becomes the
+folder name and the =name:= field in the skill's markdown frontmatter.
+=--parent-dir= defaults to =doc/llm/skills= and can be omitted:
 
 #+begin_src sh :results verbatim
-projects/ores.codegen/generate_v2_doc.sh \
-  --type skill --slug my-new-skill \
-  --parent-dir doc/llm/skills \
+./projects/ores.compass/compass.sh add skill \
+  --slug my_new_skill \
   --title "My New Skill" \
-  --description "When and how to use the new skill." \
-  --tags "skill"
+  --description "When and how to use the new skill."
 #+end_src
 
-Output: =doc/llm/skills/my-new-skill/SKILL.org=.
+Output: =doc/llm/skills/my_new_skill/SKILL.org=.
 
 ** New product identity
 :PROPERTIES:

--- a/doc/recipes/codegen/how_do_i_create_a_new_v2_doc.org
+++ b/doc/recipes/codegen/how_do_i_create_a_new_v2_doc.org
@@ -23,7 +23,7 @@ frontmatter?
 
 * Answer
 
-For *stories, tasks, sprints, and skills* — use
+For *stories, tasks, sprints, and skills*, use
 [[id:5B670808-D28B-4818-A2FA-EA5220D35E8D][compass add]] instead. It defaults =--parent-dir= from where you are (current
 sprint for stories/tasks, current version for sprints, =doc/llm/skills= for
 skills) so you rarely need to type a path. This recipe remains the


### PR DESCRIPTION
## Summary

- `how_do_i_create_a_new_v2_doc.org`: "New Claude Code skill" section now shows `compass add skill` (snake_case slug, `--parent-dir` omitted); compass-preferred types note updated to include `skill`
- `skill-manager/SKILL.org` step 3: references `compass add skill` and snake_case slugs instead of `generate_v2_doc.sh`

## Changes

- `doc/recipes/codegen/how_do_i_create_a_new_v2_doc.org`: updated skill scaffold invocation and intro note
- `doc/llm/skills/skill-manager/SKILL.org`: updated step 3 wording
- `doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_update_skill_creation_recipe.org`: marked DONE

## Traceability

- Story: Improve LLM runbook and skill tooling — https://github.com/OreStudio/OreStudio/blob/feature/improve-runbook-skill-tooling/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/story.org
  - Story-ID: E3C798C8-87E9-47E1-88F5-1BE6C8532BBE
- Task: Update skill-creation recipe to use compass — https://github.com/OreStudio/OreStudio/blob/feature/improve-runbook-skill-tooling/doc/agile/versions/v0/sprint_18/improve_runbook_skill_tooling/task_update_skill_creation_recipe.org
  - Task-ID: 487021A2-0324-43AE-8150-797B41CA77B9

🤖 Generated with [Claude Code](https://claude.com/claude-code)