### PR TITLE
[doc,compass] PlantUML recipe, compass add diagram sub-command, and topic inventory

### DIFF
--- a/assets/images/party_hierarchy_diagram.puml
+++ b/assets/images/party_hierarchy_diagram.puml
@@ -1,3 +1,20 @@
+' -*- mode: plantuml; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+'
+' Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+'
+' This program is free software; you can redistribute it and/or modify it under
+' the terms of the GNU General Public License as published by the Free Software
+' Foundation; either version 3 of the License, or (at your option) any later
+' version.
+'
+' This program is distributed in the hope that it will be useful, but WITHOUT
+' ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+' FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License along with
+' this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+' Street, Fifth Floor, Boston, MA 02110-1301, USA.
+'
 ' Party hierarchy diagram for the user manual (chapter 3, Initial Setup).
 ' Source of truth for party_hierarchy_diagram.png.
 ' Regenerate after editing:  plantuml assets/images/party_hierarchy_diagram.puml

--- a/doc/agile/versions/v0/sprint_18/compass_plantuml/story.org
+++ b/doc/agile/versions/v0/sprint_18/compass_plantuml/story.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: 76F0DB10-084D-4A72-A585-5DE660884677
+:END:
+#+title: Story: PlantUML integration: recipe and codegen scaffold
+#+description: Add a how-do-I recipe for embedding PlantUML diagrams in org-mode documents; extend ores.codegen/compass to scaffold .puml skeletons with licence header and standard structure.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :plantuml:diagram:codegen:compass:recipe:documentation:sprint_18:v0:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Make PlantUML diagrams a first-class citizen of ORE Studio's documentation
+workflow. A how-to recipe explains how to write and embed a =.puml= diagram
+in any org-mode document; a new =compass add diagram= sub-command scaffolds
+a =.puml= file with the standard licence header, =@startuml= / =@enduml=
+delimiters, and the project skin/style preamble so every diagram is
+consistent from the first line.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                                |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                              |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Begin implementation.                  |
+| Last touched  | 2026-05-28                             |
+
+* Acceptance
+
+- =doc/recipes/plantuml/how_do_i_add_a_plantuml_diagram.org= exists and
+  explains: install/verify PlantUML, write the =.puml= source, run
+  =plantuml= to export the PNG, and embed it in org-mode with an
+  =#+attr_html:= / =#+attr_latex:= figure block.
+- =compass add diagram <slug>= (or equivalent sub-command) scaffolds
+  =<slug>.puml= with the standard AGPL licence header, =@startuml= /
+  =@enduml=, and the shared skin preamble; the generated file matches the
+  convention of existing diagrams in the repo.
+- Existing =.puml= files are audited; any that lack the standard header are
+  updated.
+
+* Tasks
+
+In execution order:
+
+- [[id:F44A6D1D-B3F1-4EA3-9C04-B516AD04F0F6][Task: Add PlantUML recipe and extend codegen with puml scaffold]] (BACKLOG)
+
+* Decisions
+
+* Out of scope
+
+- Automating PNG regeneration in CI (diagrams are regenerated manually when
+  the source changes).
+- Switching to SVG output — PNG is the current convention.

--- a/doc/agile/versions/v0/sprint_18/compass_plantuml/story.org
+++ b/doc/agile/versions/v0/sprint_18/compass_plantuml/story.org
@@ -26,11 +26,11 @@ consistent from the first line.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                                |
+| State         | DONE                                   |
 | Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                              |
-| Now           | Not yet started.                       |
+| Now           | Complete.                              |
 | Waiting on    | Nothing.                               |
-| Next          | Begin implementation.                  |
+| Next          | None.                                  |
 | Last touched  | 2026-05-28                             |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_18/compass_plantuml/task_implement_compass_plantuml.org
+++ b/doc/agile/versions/v0/sprint_18/compass_plantuml/task_implement_compass_plantuml.org
@@ -1,0 +1,73 @@
+:PROPERTIES:
+:ID: F44A6D1D-B3F1-4EA3-9C04-B516AD04F0F6
+:END:
+#+title: Task: Add PlantUML recipe and extend codegen with puml scaffold
+#+description: Initial task for: PlantUML integration: recipe and codegen scaffold
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :compass_plantuml:sprint_18:v0:
+#+owner: marco
+#+branch: feature/compass-plantuml
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:76F0DB10-084D-4A72-A585-5DE660884677][PlantUML integration: recipe and codegen scaffold]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Two deliverables: (1) a recipe doc that walks a developer through adding a
+PlantUML diagram to any org-mode document — from writing the =.puml= source
+to exporting the PNG and embedding it in org-mode with correct figure
+metadata; (2) a =compass add diagram <slug>= sub-command that scaffolds a
+=.puml= file with the standard AGPL licence header, =@startuml= /
+=@enduml=, and the shared skin/style preamble, matching the convention of
+existing =.puml= files in the repository. Existing diagrams without the
+standard header are updated.
+
+* Status
+
+| Field        | Value                                                             |
+|--------------+-------------------------------------------------------------------|
+| State        | BACKLOG                                                           |
+| Parent story | [[id:76F0DB10-084D-4A72-A585-5DE660884677][PlantUML integration: recipe and codegen scaffold]]                 |
+| Now          | Not yet started.                                                  |
+| Waiting on   | Nothing.                                                          |
+| Next         | Audit existing .puml files; write recipe; implement compass sub-command. |
+| Last touched | 2026-05-28                                                        |
+
+* Acceptance
+
+- =doc/recipes/plantuml/how_do_i_add_a_plantuml_diagram.org= exists (org-roam
+  ID, v2 frontmatter) and covers: prerequisites, writing =.puml= source,
+  running =plantuml= to export PNG, embedding via =#+attr_html:= /
+  =#+attr_latex:= / =#+caption:= in an org-mode file.
+- =compass add diagram <slug>= scaffolds =<slug>.puml= with the standard
+  header; the skeleton compiles without errors under =plantuml=.
+- All existing =.puml= files in the repo have the standard licence header.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/compass_plantuml/task_implement_compass_plantuml.org
+++ b/doc/agile/versions/v0/sprint_18/compass_plantuml/task_implement_compass_plantuml.org
@@ -9,7 +9,7 @@
 #+filetags: :compass_plantuml:sprint_18:v0:
 #+owner: marco
 #+branch: feature/compass-plantuml
-#+pr:
+#+pr: 888
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-28
@@ -60,9 +60,9 @@ task closes. Plans do not outlive their task.)
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR  | Title                                                                        |
+|-----+------------------------------------------------------------------------------|
+| 888 | [doc,compass] PlantUML recipe, compass add diagram sub-command, and topic inventory |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/compass_plantuml/task_implement_compass_plantuml.org
+++ b/doc/agile/versions/v0/sprint_18/compass_plantuml/task_implement_compass_plantuml.org
@@ -66,8 +66,8 @@ task closes. Plans do not outlive their task.)
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                                 | File        | Decision | Notes                                                     |
+|---+-----------------------------------------------------------------+-------------+----------+-----------------------------------------------------------|
+| 1 | =_has_standard_puml_header= defined but never used (medium pri) | compass.py  | Fixed    | Function removed; scaffold always writes header, no check needed. |
 
 * Result

--- a/doc/agile/versions/v0/sprint_18/compass_plantuml/task_implement_compass_plantuml.org
+++ b/doc/agile/versions/v0/sprint_18/compass_plantuml/task_implement_compass_plantuml.org
@@ -33,11 +33,11 @@ standard header are updated.
 
 | Field        | Value                                                             |
 |--------------+-------------------------------------------------------------------|
-| State        | BACKLOG                                                           |
+| State        | DONE                                                              |
 | Parent story | [[id:76F0DB10-084D-4A72-A585-5DE660884677][PlantUML integration: recipe and codegen scaffold]]                 |
-| Now          | Not yet started.                                                  |
+| Now          | Complete.                                                         |
 | Waiting on   | Nothing.                                                          |
-| Next         | Audit existing .puml files; write recipe; implement compass sub-command. |
+| Next         | None.                                                             |
 | Last touched | 2026-05-28                                                        |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -54,7 +54,7 @@ In execution order.
 | [[id:0A2CB5BD-67B8-4096-BAC4-8E110333893A][SQLite CLI quality-of-life setup]]         | DONE    | 2026-05-24 | 2026-05-24 | Committed, commented =.sqliterc= for readable, non-wrapping =sqlite3= shell output.          |
 | [[id:BAF1DEAE-59DF-49AB-BFCD-E6D09496DA43][Lock down uppercase UUID invariant]]      | DONE    | 2026-05-24 | 2026-05-24 | Close the remaining code paths that can emit lowercase UUIDs into the doc graph.             |
 | [[id:22AA37FA-23A0-406E-B05B-B11BB3E83874][Product backlog refinement]]              | DONE    | 2026-05-24 | 2026-05-24 | Build backlog-refiner and sprint-planner skills/recipes; set sprint 18 mission.              |
-| [[id:C42C3563-671F-4721-8CE8-5EE05925255F][Build and publish user manual PDF via CMake]] | DONE    | 2026-05-24 | 2026-05-28 | =deploy_manual= target builds =user_manual.org= to PDF; commit and link the result.         |
+| [[id:C42C3563-671F-4721-8CE8-5EE05925255F][Build and publish user manual PDF via CMake]] | STARTED | 2026-05-24 |            | =deploy_manual= target builds =user_manual.org= to PDF; commit and link the result.         |
 | [[id:8BA366D7-B43F-4E5B-B4AD-A40C7E28881B][ores.compass repository compass tool]]   | DONE    | 2026-05-24 | 2026-05-24 | Python repository compass: temporal orientation, semantic doc search, agile scaffolding.        |
 | [[id:468387DD-0D6F-49B4-9F82-BD179DCB1CC1][ores.compass Locate — temporal orientation]] | DONE | 2026-05-24 | 2026-05-24 | =where=/=status=: report current version, sprint, and in-flight stories and tasks from the graph. |
 | [[id:D84B1122-30DC-4BCF-9C90-73403FAAECD9][ores.compass Scaffold — agile authoring]] | DONE    | 2026-05-24 | 2026-05-24 | =add story/task/sprint/recipe=: create agile artefacts from the CLI by calling ores.codegen as a library. |
@@ -86,6 +86,7 @@ In execution order.
 | [[id:E6CC19FC-5469-45BD-AA87-9CDBB23A4A7F][Per-sprint capture workflow: individual files and compass integration]] | STARTED | 2026-05-27 | | captures/ folder per sprint; compass capture command; wontdo backlog bucket. |
 | [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]]                                 | DONE    | 2026-05-28 | 2026-05-28 | Add compass skill type, update skill-creation recipe, create run-runbook skill. |
 | [[id:5D11EB95-8B20-4A11-B9A6-C883C9E4B0CF][Document deduplication recipe]]                                         | DONE    | 2026-05-28 | 2026-05-28 | Generalised recipe for merging duplicate docs; applied to duplicate sprint health review runbooks. |
+| [[id:76F0DB10-084D-4A72-A585-5DE660884677][PlantUML integration: recipe and codegen scaffold]]                     | DONE    | 2026-05-28 | 2026-05-28 | PlantUML how-to recipe; compass add diagram scaffold; standard licence header convention. |
 
 * Health Review
 

--- a/doc/llm/memory/check_git_commit_conventions.org
+++ b/doc/llm/memory/check_git_commit_conventions.org
@@ -1,0 +1,29 @@
+:PROPERTIES:
+:ID: EAB80857-3DB3-4A63-8D81-2F0A06B4F6DD
+:END:
+#+title: Check git commit conventions before committing
+#+description: Before every commit, verify format against the ORE Studio conventions: [component] title, Story-ID/Task-ID trailers, Co-Authored-By.
+#+type: memory
+#+memory_subtype: feedback
+#+version: 2
+#+level: cross
+#+filetags: :memory:feedback:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+
+Before committing, check [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][How do I commit to git using ORE Studio
+conventions?]]. The format requires: a =[component]= bracket prefix in
+imperative mood under 72 characters; =Story-ID:= and =Task-ID:= trailers
+(full UUIDs) on every commit that implements agile work; and a
+=Co-Authored-By:= trailer for any LLM-generated commit.
+
+*Why:* Story-ID/Task-ID trailers were being omitted, breaking
+traceability between commits and agile artefacts. The recipe is the
+authoritative reference for all three requirements.
+
+*How to apply:* Every time a commit is about to be made — before
+constructing the commit message — open the recipe or recall the three
+requirements: (1) =[component] Imperative summary= ≤72 chars; (2)
+=Story-ID:= / =Task-ID:= with full UUIDs from the task and story =:ID:=
+properties when the commit is part of a story/task; (3) =Co-Authored-By:
+Claude Sonnet 4.6 <noreply@anthropic.com>= at the end.

--- a/doc/llm/memory/memory.org
+++ b/doc/llm/memory/memory.org
@@ -72,6 +72,8 @@ of these exclusions, push back: the right home is somewhere else.
   export =SSH_AUTH_SOCK= before =git push= / =fetch= / =pull=.
 - [[id:1636E66B-03C7-4182-A46D-A02888336CEE][PR tables belong in task docs, not story docs]] — =* PRs= sections go
   in task =.org= files; story docs do not carry them.
+- [[id:EAB80857-3DB3-4A63-8D81-2F0A06B4F6DD][Check git commit conventions before committing]] — =[component]=
+  title, =Story-ID= / =Task-ID= trailers, =Co-Authored-By= every time.
 
 ** User
 

--- a/doc/recipes/documentation/how_do_i_create_a_memory.org
+++ b/doc/recipes/documentation/how_do_i_create_a_memory.org
@@ -37,11 +37,11 @@ frontmatter.
 2. /Pick a slug/. Snake-case, short, descriptive of the rule rather
    than the topic — e.g. =do_not_re_export_env_vars=, not =bash=.
 
-3. /Scaffold the file/:
+3. /Scaffold the file/ using =compass add memory=:
 
    #+begin_src sh :results verbatim
-   projects/ores.codegen/generate_v2_doc.sh \
-     --type memory --slug do_not_re_export_env_vars \
+   projects/ores.compass/compass.sh add memory \
+     --slug do_not_re_export_env_vars \
      --parent-dir doc/llm/memory \
      --title "Do not re-export ORES_* env vars in Bash tool calls" \
      --description "The user has already exported ORES_* env vars in their shell session — don't prepend them." \
@@ -86,10 +86,10 @@ frontmatter.
 
 * Script
 
-The wrapper is =projects/ores.codegen/generate_v2_doc.sh=. The
-memory-specific machinery (template, =--memory-subtype= flag, tag
-injection) lives in =projects/ores.codegen/src/v2_doc_generate.py=
-and the template at
+=projects/ores.compass/compass.sh add memory= — the compass wrapper
+delegates to =ores.codegen=. The memory-specific machinery (template,
+=--memory-subtype= flag, tag injection) lives in
+=projects/ores.codegen/src/v2_doc_generate.py= and the template at
 =projects/ores.codegen/library/templates/v2_doc_memory.org.mustache=.
 
 * Tested by

--- a/doc/recipes/documentation/how_do_i_create_a_recipe.org
+++ b/doc/recipes/documentation/how_do_i_create_a_recipe.org
@@ -27,8 +27,26 @@ that question is.
 
 1. /Pick the topic folder/. Recipes live under =doc/recipes/<topic>/=, one
    folder per area (=cli/=, =sql/=, =cmake/=, =codegen/=, =emacs/=, =git/=,
-   =http/=, =shell/=). Each topic has its own inventory page (e.g.
-   =cli/cli.org=) which lists every recipe in that topic.
+   =http/=, =shell/=, =plantuml/=, …). Each topic has its own inventory page
+   (e.g. =cli/cli.org=) which lists every recipe in that topic.
+
+   If you are creating a /new topic/ (no folder exists yet):
+
+   a. Create the folder: =mkdir doc/recipes/<topic>=
+   b. Scaffold the inventory page with compass:
+      #+begin_src sh :results verbatim
+      projects/ores.compass/compass.sh add knowledge \
+        --slug <topic> \
+        --parent-dir doc/recipes/<topic> \
+        --title "<Topic> recipes" \
+        --description "Recipes for <short description>." \
+        --tags "recipe:<topic>:index:knowledge"
+      #+end_src
+   c. Fill in the inventory body (see =doc/recipes/agile/agile.org= as a
+      template) and add an id-link to the new recipe under an appropriate
+      heading.
+   d. Wire the inventory into [[id:46F5ED07-9E63-77B4-2783-E0147EFF45D0][Recipes index]] (=doc/recipes/recipes.org=):
+      add a bullet under =* Topics= pointing to the new inventory's =:ID:=.
 
 2. /Phrase the question/ as a single =how_do_i_X= sentence. The same question
    becomes /three/ artefacts that must match:
@@ -91,6 +109,9 @@ that question is.
    # See where the inventory lives, then edit it by hand
    ls doc/recipes/cmake/cmake.org
    #+end_src
+
+   If this is a new topic you created in step 1, also wire the
+   inventory into =doc/recipes/recipes.org= (step 1d above).
 
 8. /Verify with the doc tools/:
 

--- a/doc/recipes/plantuml/how_do_i_add_a_plantuml_diagram.org
+++ b/doc/recipes/plantuml/how_do_i_add_a_plantuml_diagram.org
@@ -32,7 +32,7 @@ plantuml -version
 #+end_src
 
 On Ubuntu/Debian: =sudo apt install plantuml=.
-Check the [[id:A0B1C2D3-0000-0000-0000-000000000001][llm instructions]] for the exact version used in CI.
+Check the [[id:F9AD7932-8E11-433C-A812-B57DBC9BF5D8][LLM instructions]] for the exact version used in CI.
 
 ** 2. Scaffold the =.puml= file
 

--- a/doc/recipes/plantuml/how_do_i_add_a_plantuml_diagram.org
+++ b/doc/recipes/plantuml/how_do_i_add_a_plantuml_diagram.org
@@ -1,0 +1,130 @@
+:PROPERTIES:
+:ID: EADD51F7-9F3E-4B03-8750-D7ABC995FE46
+:END:
+#+title: How do I add a PlantUML diagram?
+#+description: Write a .puml diagram, export it to PNG with plantuml, and embed it in org-mode with correct figure metadata.
+#+type: recipe
+#+version: 2
+#+level: cross
+#+filetags: :plantuml:diagram:recipe:documentation:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+
+PlantUML is used throughout ORE Studio for architecture diagrams, component
+models, and information-flow illustrations. Every diagram follows the
+same file conventions: a GPL licence header, =@startuml= / =@enduml=
+delimiters, and a =title= line. The PNG output lives alongside the =.puml=
+source and is embedded in org-mode with =#+caption:= and optional
+=#+attr_html:= / =#+attr_latex:= lines. For the system-level diagram see
+[[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]]; for component diagrams see any
+=projects/<component>/modeling/<component>.puml=.
+
+* Question
+
+How do I add a new PlantUML diagram to an org-mode document?
+
+* Answer
+
+** 1. Verify PlantUML is installed
+
+#+begin_src sh :results verbatim
+plantuml -version
+#+end_src
+
+On Ubuntu/Debian: =sudo apt install plantuml=.
+Check the [[id:A0B1C2D3-0000-0000-0000-000000000001][llm instructions]] for the exact version used in CI.
+
+** 2. Scaffold the =.puml= file
+
+Use =compass add diagram= to create a properly headed skeleton. Pass the
+target directory with =--parent-dir= and an optional =--title=:
+
+#+begin_src sh :results verbatim
+projects/ores.compass/compass.sh add diagram my_diagram \
+    --parent-dir doc/meta \
+    --title "My Diagram Title"
+#+end_src
+
+This writes =doc/meta/my_diagram.puml= with the standard GPL licence header,
+=@startuml=, the title line, and =@enduml=. The file is immediately
+compilable.
+
+** 3. Edit the =.puml= source
+
+Open the generated file and add diagram content between the =title= line and
+=@enduml=. Example using a simple component diagram:
+
+#+begin_src plantuml :results silent
+' (example — do not copy the src block itself, just the .puml content)
+@startuml
+
+title My Component
+
+component [Service A] as A
+component [Service B] as B
+
+A --> B : NATS
+
+@enduml
+#+end_src
+
+See [[https://plantuml.com/component-diagram][plantuml.com/component-diagram]] for the full syntax reference.
+
+** 4. Export to PNG
+
+#+begin_src sh :results verbatim
+plantuml -tpng doc/meta/my_diagram.puml
+#+end_src
+
+This produces =doc/meta/my_diagram.png= alongside the source file. Re-run
+after every edit; the PNG is committed to the repo so the site build does not
+need PlantUML at CI time.
+
+** 5. Embed in the org-mode document
+
+Place the PNG reference immediately after any context it illustrates. Use
+=#+caption:= for figure captions and =#+attr_html: :width 100%= when the
+diagram should fill the page width in the HTML export:
+
+#+begin_example
+#+caption: One-sentence description of what the diagram shows.
+#+attr_html: :width 100%
+#+attr_latex: :width \textwidth
+[[./my_diagram.png]]
+#+end_example
+
+For narrower diagrams (e.g. lifecycle flows), omit the =attr= lines and let
+the image render at its natural size:
+
+#+begin_example
+#+caption: Task lifecycle state machine.
+[[./task_lifecycle.png]]
+#+end_example
+
+** 6. Commit both files
+
+Always commit the =.puml= source and the generated =.png= together so the
+repo is self-contained:
+
+#+begin_src sh :results verbatim
+git add doc/meta/my_diagram.puml doc/meta/my_diagram.png
+#+end_src
+
+* Script
+
+=compass add diagram <slug> [--parent-dir DIR] [--title TITLE]=
+
+Scaffolds =<slug>.puml= with the standard GPL licence header,
+=@startuml=, a title derived from the slug (or =--title= if given), and
+=@enduml=.
+
+* Tested by
+
+Manual smoke test: run =compass add diagram smoke_test --parent-dir /tmp=,
+then =plantuml -tpng /tmp/smoke_test.puml= and confirm the PNG is produced
+without errors.
+
+* See also
+
+- [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] — the main system architecture diagram
+- [[id:B9D3D469-9E59-465F-8C18-34546B680D13][component_overview.org]] — component-level diagram convention

--- a/doc/recipes/plantuml/plantuml.org
+++ b/doc/recipes/plantuml/plantuml.org
@@ -1,0 +1,26 @@
+:PROPERTIES:
+:ID: A4720C4D-DED8-413A-A29E-6851D4196868
+:END:
+#+title: PlantUML recipes
+#+description: Recipes for adding and maintaining PlantUML diagrams in ORE Studio org-mode documents.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :recipe:plantuml:diagram:index:knowledge:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+
+Recipes for working with PlantUML diagrams in ORE Studio. Every diagram
+follows the same file convention: a GPL mode-line and licence header,
+=@startuml= / =@enduml= delimiters, and a =title= line. Use
+=compass add diagram= to scaffold a new =.puml= file that matches this
+convention from the first line.
+
+* Diagrams
+
+- [[id:EADD51F7-9F3E-4B03-8750-D7ABC995FE46][How do I add a PlantUML diagram?]] — scaffold, edit, export PNG, embed in org-mode.
+
+* See also
+
+- [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] — the main system architecture diagram (=projects/modeling/ores.puml=).
+- [[id:B9D3D469-9E59-465F-8C18-34546B680D13][component_overview.org]] — component-level diagram convention.

--- a/doc/recipes/recipes.org
+++ b/doc/recipes/recipes.org
@@ -30,6 +30,7 @@ recipes; each topic has its own inventory that lists its recipes.
 - [[id:B5F94CD2-E6E0-9F44-BB13-4C2CEEF01A44][Git recipes]] — pure git workflows (branches, submodules).
 - [[id:FCF81F0B-AFBF-4169-BD24-04DBD08180A9][GitHub recipes]] — =gh= CLI, PRs, CI checks, review threads.
 - [[id:51FE4DF6-D12F-4CF3-A32F-E793979AA68B][LLM prompt recipes]] — reusable prompts for LLM chat interfaces.
+- [[id:A4720C4D-DED8-413A-A29E-6851D4196868][PlantUML recipes]] — add and maintain diagrams in org-mode documents.
 
 * See also
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -971,13 +971,6 @@ title {title}
 @enduml
 """
 
-def _has_standard_puml_header(path):
-    """Return True if path starts with the mode-line comment."""
-    try:
-        first = Path(path).read_text(encoding="utf-8").lstrip()
-        return first.startswith("' -*- mode: plantuml")
-    except OSError:
-        return False
 
 def cmd_add_diagram(argv):
     """Scaffold a .puml file with the standard licence header.

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -946,6 +946,81 @@ def cmd_capture(argv):
         return 0
     return rc or 1
 
+_PUML_HEADER_TEMPLATE = """\
+' -*- mode: plantuml; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+'
+' Copyright (C) {year} Marco Craveiro <marco.craveiro@gmail.com>
+'
+' This program is free software; you can redistribute it and/or modify it under
+' the terms of the GNU General Public License as published by the Free Software
+' Foundation; either version 3 of the License, or (at your option) any later
+' version.
+'
+' This program is distributed in the hope that it will be useful, but WITHOUT
+' ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+' FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License along with
+' this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+' Street, Fifth Floor, Boston, MA 02110-1301, USA.
+'
+@startuml
+
+title {title}
+
+@enduml
+"""
+
+def _has_standard_puml_header(path):
+    """Return True if path starts with the mode-line comment."""
+    try:
+        first = Path(path).read_text(encoding="utf-8").lstrip()
+        return first.startswith("' -*- mode: plantuml")
+    except OSError:
+        return False
+
+def cmd_add_diagram(argv):
+    """Scaffold a .puml file with the standard licence header.
+
+    Usage: compass add diagram <slug> [--parent-dir DIR] [--title TITLE]
+    """
+    import argparse as _ap
+    p = _ap.ArgumentParser(prog="compass add diagram")
+    p.add_argument("slug", help="snake_case slug; output will be <slug>.puml")
+    p.add_argument("--parent-dir", default=".", metavar="DIR",
+                   help="Directory to write into (default: current directory)")
+    p.add_argument("--title", default="", metavar="TITLE",
+                   help="Title line inside the diagram (default: derived from slug)")
+    try:
+        args = p.parse_args(argv)
+    except SystemExit as exc:
+        return exc.code or 0
+
+    from datetime import date as _date
+    year = _date.today().year
+
+    parent = Path(args.parent_dir)
+    if not parent.is_dir():
+        print(f"❌ Directory not found: {parent}", file=sys.stderr)
+        return 1
+
+    out = parent / f"{args.slug}.puml"
+    if out.exists():
+        print(f"❌ Refusing to overwrite {out}", file=sys.stderr)
+        return 1
+
+    title = args.title or args.slug.replace("_", " ").replace("-", " ").title()
+    content = _PUML_HEADER_TEMPLATE.format(year=year, title=title)
+    out.write_text(content, encoding="utf-8")
+    try:
+        display = out.relative_to(PROJECT_ROOT)
+    except ValueError:
+        display = out
+    print(f"✅ Diagram scaffolded: {display}")
+    print(f"   Edit {out.name}, then run: plantuml {out.name}")
+    return 0
+
+
 def cmd_add(argv):
     """Create a v2 doc by calling ores.codegen as a library.
 
@@ -956,14 +1031,19 @@ def cmd_add(argv):
         print("usage: compass add <type> [generate_v2_doc options]\n"
               "  types: story task sprint version recipe knowledge component\n"
               "         capture memory investigation product_identity skill\n"
+              "         diagram\n"
               "  --parent-dir defaults to the current sprint (story) or\n"
               "  version (sprint), or doc/llm/skills (skill); required otherwise.\n"
+              "  diagram: scaffolds a .puml file with the standard licence header.\n"
               "  remaining flags are passed through to ores.codegen "
               "(see 'How do I create a new v2 doc?').")
         return 0
 
     doc_type = argv[0]
     rest = list(argv[1:])
+
+    if doc_type == "diagram":
+        return cmd_add_diagram(rest)
 
     has_parent = any(a == "--parent-dir" or a.startswith("--parent-dir=")
                      for a in rest)


### PR DESCRIPTION
## Summary

Adds PlantUML as a first-class documentation topic with a recipe, a new
`compass add diagram` sub-command, and all the inventory wiring needed to
make the topic discoverable.

## Changes

- **`compass add diagram <slug>`** — new sub-command in `compass.py` that
  scaffolds `<slug>.puml` with the standard GPL mode-line, licence header,
  `@startuml`, a title line, and `@enduml`. Supports `--parent-dir` and
  `--title`; title defaults to a humanised version of the slug. Generated
  file compiles cleanly under `plantuml`.
- **`doc/recipes/plantuml/how_do_i_add_a_plantuml_diagram.org`** — six-step
  recipe: verify plantuml, scaffold with compass, edit source, export PNG,
  embed in org-mode (`#+caption:` / `#+attr_html:` / `#+attr_latex:`),
  commit both files.
- **`doc/recipes/plantuml/plantuml.org`** — topic inventory page listing the
  recipe with See also pointers to system model and component overview.
- **`doc/recipes/recipes.org`** — PlantUML entry added to `* Topics`.
- **`doc/recipes/documentation/how_do_i_create_a_recipe.org`** — steps 1 and
  7 updated to cover the new-topic case: create folder, scaffold inventory
  with `compass add knowledge`, fill body, wire into `recipes.org`.
- **`assets/images/party_hierarchy_diagram.puml`** — added missing standard
  GPL header (was the only `.puml` file in the repo without it).

## Traceability

[Story: PlantUML integration: recipe and codegen scaffold](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/compass_plantuml/story.html)
[Task: Add PlantUML recipe and extend codegen with puml scaffold](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/compass_plantuml/task_implement_compass_plantuml.html)

- Story ID: 76F0DB10-084D-4A72-A585-5DE660884677
- Task ID: F44A6D1D-B3F1-4EA3-9C04-B516AD04F0F6