### PR TITLE
[codegen,agile] Replace story Tasks bullet list with status table

### DIFF
--- a/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/story.org
+++ b/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/story.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6
+:END:
+#+title: Story: Refactor story task lists to a status table
+#+description: Replace the bullet-list Tasks section in story docs with a table (Task | State | Start | End | Description), then back-fill all sprint 18 stories.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :agile:story:task:refactor:sprint_18:v0:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+The =* Tasks= section in story docs is currently a plain bullet list,
+giving no visibility into task state, start/end dates, or a brief
+description. This makes it hard to track progress at a glance.
+
+Replace the bullet list with a table that matches the structure of the
+sprint's =* Stories= table, adapted for tasks:
+
+| Task | State | Start | End | Description |
+
+Then update the codegen template so all future stories scaffold the
+table, and back-fill every in-flight sprint 18 story.
+
+* Status
+
+| Field         | Value                                                               |
+|---------------+---------------------------------------------------------------------|
+| State         | STARTED                                                             |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                                                           |
+| Now           | Scaffolded. Updating codegen template.                              |
+| Waiting on    | Nothing.                                                            |
+| Next          | Complete template update task; then back-fill sprint 18 stories.   |
+| Last touched  | 2026-05-28                                                          |
+
+* Acceptance
+
+- The =* Tasks= section in every new story doc scaffolded by compass or
+  codegen contains a table with columns =Task=, =State=, =Start=, =End=,
+  =Description=.
+- Every sprint 18 story doc has its =* Tasks= bullet list replaced with
+  the table format.
+- Task rows link to the task doc via =[[id:UUID][Title]]=.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:22C0724C-75A7-4060-8F1D-000E62BE8352][Update story codegen template to task table]] | STARTED | 2026-05-28 | | Update scaffold to generate task table |
+| [[id:3F5D9276-12DB-4A6B-A355-95E26AFA1CBD][Back-fill all sprint 18 story task lists]] | BACKLOG | | | Replace bullet lists with tables in all sprint 18 stories |
+
+* Decisions
+
+* Out of scope
+
+- Back-filling stories from sprints prior to sprint 18.

--- a/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/story.org
+++ b/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/story.org
@@ -33,9 +33,9 @@ table, and back-fill every in-flight sprint 18 story.
 |---------------+---------------------------------------------------------------------|
 | State         | STARTED                                                             |
 | Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                                                           |
-| Now           | Scaffolded. Updating codegen template.                              |
+| Now           | Template updated. Back-fill task ready to start.                    |
 | Waiting on    | Nothing.                                                            |
-| Next          | Complete template update task; then back-fill sprint 18 stories.   |
+| Next          | Run back-fill task across all sprint 18 stories.                    |
 | Last touched  | 2026-05-28                                                          |
 
 * Acceptance
@@ -51,7 +51,7 @@ table, and back-fill every in-flight sprint 18 story.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:22C0724C-75A7-4060-8F1D-000E62BE8352][Update story codegen template to task table]] | STARTED | 2026-05-28 | | Update scaffold to generate task table |
+| [[id:22C0724C-75A7-4060-8F1D-000E62BE8352][Update story codegen template to task table]] | DONE | 2026-05-28 | 2026-05-28 | Update scaffold to generate task table |
 | [[id:3F5D9276-12DB-4A6B-A355-95E26AFA1CBD][Back-fill all sprint 18 story task lists]] | BACKLOG | | | Replace bullet lists with tables in all sprint 18 stories |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_backfill_sprint18_story_task_tables.org
+++ b/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_backfill_sprint18_story_task_tables.org
@@ -1,0 +1,71 @@
+:PROPERTIES:
+:ID: 3F5D9276-12DB-4A6B-A355-95E26AFA1CBD
+:END:
+#+title: Task: Back-fill sprint 18 story task lists to tables
+#+description: Replace the bullet-list Tasks section in every sprint 18 story doc with the new task status table format.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :refactor_task_list_to_table:sprint_18:v0:
+#+owner: marco
+#+branch: feature/backfill-sprint18-story-task-tables
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6][Refactor story task lists to a status table]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+For every story doc in sprint 18, replace the =* Tasks= bullet list
+with the new task status table:
+
+| Task | State | Start | End | Description |
+
+Each row should link to the task doc via =[[id:UUID][Title]]=. State,
+Start, and End should be filled from the task doc's own =* Status=
+table where available.
+
+* Status
+
+| Field        | Value                                                                               |
+|--------------+-------------------------------------------------------------------------------------|
+| State        | BACKLOG                                                                             |
+| Parent story | [[id:FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6][Refactor story task lists to a status table]]                                         |
+| Now          | Waiting on template update task to complete first.                                  |
+| Waiting on   | [[id:22C0724C-75A7-4060-8F1D-000E62BE8352][Update story codegen template to task table]]                                         |
+| Next         | List all sprint 18 stories; update each Tasks section to table format.              |
+| Last touched | 2026-05-28                                                                          |
+
+* Acceptance
+
+- Every story doc under =doc/agile/versions/v0/sprint_18/= has its
+  =* Tasks= section replaced with the status table format.
+- Each task row links to the task doc via =[[id:UUID][Title]]=.
+- State, Start, and End columns are populated where the task doc
+  provides that information.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_backfill_sprint18_story_task_tables.org
+++ b/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_backfill_sprint18_story_task_tables.org
@@ -35,8 +35,8 @@ table where available.
 |--------------+-------------------------------------------------------------------------------------|
 | State        | BACKLOG                                                                             |
 | Parent story | [[id:FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6][Refactor story task lists to a status table]]                                         |
-| Now          | Waiting on template update task to complete first.                                  |
-| Waiting on   | [[id:22C0724C-75A7-4060-8F1D-000E62BE8352][Update story codegen template to task table]]                                         |
+| Now          | Ready to begin back-filling sprint 18 stories.                                      |
+| Waiting on   | Nothing.                                                                             |
 | Next         | List all sprint 18 stories; update each Tasks section to table format.              |
 | Last touched | 2026-05-28                                                                          |
 

--- a/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_implement_refactor_task_list_to_table.org
+++ b/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_implement_refactor_task_list_to_table.org
@@ -58,9 +58,9 @@ task closes. Plans do not outlive their task.)
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR  | Title                                                              |
+|-----+--------------------------------------------------------------------|
+| 893 | [codegen,agile] Replace story Tasks bullet list with status table |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_implement_refactor_task_list_to_table.org
+++ b/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_implement_refactor_task_list_to_table.org
@@ -64,9 +64,9 @@ task closes. Plans do not outlive their task.)
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                              | File                                    | Decision | Notes              |
+|---+--------------------------------------------------------------+-----------------------------------------+----------+--------------------|
+| 1 | Back-fill task Waiting on is stale; template task is DONE    | task_backfill_sprint18_story_task_tables | Accept   | Fixed in 9fb190431 |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_implement_refactor_task_list_to_table.org
+++ b/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_implement_refactor_task_list_to_table.org
@@ -1,0 +1,71 @@
+:PROPERTIES:
+:ID: 22C0724C-75A7-4060-8F1D-000E62BE8352
+:END:
+#+title: Task: Update story codegen template to task table
+#+description: Change the story doc scaffold to generate a task status table (Task | State | Start | End | Description) instead of a bullet list.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :refactor_task_list_to_table:sprint_18:v0:
+#+owner: marco
+#+branch: feature/refactor-task-list-to-table
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6][Refactor story task lists to a status table]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Update the story doc scaffold so that the =* Tasks= section generates a
+status table instead of a bullet list. The table columns are:
+
+| Task | State | Start | End | Description |
+
+Changes required:
+- The Jinja/codegen template for =story= type in =ores.codegen=.
+- The =compass add story= scaffolding path if it has its own template.
+
+* Status
+
+| Field        | Value                                                                        |
+|--------------+------------------------------------------------------------------------------|
+| State        | STARTED                                                                      |
+| Parent story | [[id:FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6][Refactor story task lists to a status table]]                                  |
+| Now          | Locating the story template in ores.codegen.                                 |
+| Waiting on   | Nothing.                                                                     |
+| Next         | Update template; verify scaffold output; commit.                             |
+| Last touched | 2026-05-28                                                                   |
+
+* Acceptance
+
+- Running =compass add story= or =generate_v2_doc.sh --type story= produces
+  a =* Tasks= section containing the table skeleton, not a bullet list.
+- The table header row is =| Task | State | Start | End | Description |=.
+- Existing story docs are not modified by this task (back-fill is a
+  separate task).
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_implement_refactor_task_list_to_table.org
+++ b/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_implement_refactor_task_list_to_table.org
@@ -33,11 +33,11 @@ Changes required:
 
 | Field        | Value                                                                        |
 |--------------+------------------------------------------------------------------------------|
-| State        | STARTED                                                                      |
+| State        | DONE                                                                         |
 | Parent story | [[id:FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6][Refactor story task lists to a status table]]                                  |
-| Now          | Locating the story template in ores.codegen.                                 |
+| Now          | Complete.                                                                    |
 | Waiting on   | Nothing.                                                                     |
-| Next         | Update template; verify scaffold output; commit.                             |
+| Next         | Back-fill sprint 18 stories (separate task).                                 |
 | Last touched | 2026-05-28                                                                   |
 
 * Acceptance
@@ -69,3 +69,11 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+Updated =projects/ores.codegen/library/templates/v2_doc_story.org.mustache=.
+Replaced =* Tasks= bullet list with the table skeleton:
+
+=| Task | State | Start | End | Description |=
+
+Verified via =generate_v2_doc.sh --type story= — output contains the
+correct table header.

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -86,6 +86,7 @@ In execution order.
 | [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]]                                 | DONE    | 2026-05-28 | 2026-05-28 | Add compass skill type, update skill-creation recipe, create run-runbook skill. |
 | [[id:5D11EB95-8B20-4A11-B9A6-C883C9E4B0CF][Document deduplication recipe]]                                         | DONE    | 2026-05-28 | 2026-05-28 | Generalised recipe for merging duplicate docs; applied to duplicate sprint health review runbooks. |
 | [[id:76F0DB10-084D-4A72-A585-5DE660884677][PlantUML integration: recipe and codegen scaffold]]                     | DONE    | 2026-05-28 | 2026-05-28 | PlantUML how-to recipe; compass add diagram scaffold; standard licence header convention. |
+| [[id:FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6][Refactor story task lists to a status table]]                           | STARTED | 2026-05-28 |            | Replace bullet-list Tasks section in story docs with a Task/State/Start/End/Description table. |
 
 * Health Review
 

--- a/projects/ores.codegen/library/templates/v2_doc_story.org.mustache
+++ b/projects/ores.codegen/library/templates/v2_doc_story.org.mustache
@@ -41,9 +41,9 @@ Continued from: [[id:{{predecessor_id}}][{{predecessor_title}}]].
 
 * Tasks
 
-In execution order:
-
--
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+|      |       |       |     |             |
 
 * Decisions
 


### PR DESCRIPTION
## Summary

Replaces the plain bullet-list \`* Tasks\` section in story docs with a status table, matching the structure of the sprint Stories table. The table columns are \`Task | State | Start | End | Description\`. Updates the codegen template so all future stories scaffold the table automatically.

## Changes

- **codegen**: \`v2_doc_story.org.mustache\` — \`* Tasks\` section now scaffolds a \`| Task | State | Start | End | Description |\` table instead of a bullet list
- **agile**: scaffold \`refactor_task_list_to_table\` story with two tasks: (1) update template — DONE; (2) back-fill all sprint 18 stories — BACKLOG
- **agile**: wire story into sprint 18 Stories table

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Refactor story task lists to a status table](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/story.html) | FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6 |
| Task | [Update story codegen template to task table](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_implement_refactor_task_list_to_table.html) | 22C0724C-75A7-4060-8F1D-000E62BE8352 |