### PR TITLE
[agile] Introduce sprint theme grouping and Achievements across all sprints

### DIFF
--- a/doc/agile/agile.org
+++ b/doc/agile/agile.org
@@ -17,6 +17,8 @@ sprints that compose a [[id:CA4D4BDE-2EAB-4F0A-BC8B-7C0BCB17BC82][version]]. The
 
 - [[id:46DFE47F-967B-4C24-95BF-3E21F97CFD20][Agile process]] — how the loop runs: backlog refinement, opening and closing
   sprints, sizing tasks, cross-sprint continuations.
+- [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Sprint themes]] — definitions of the six themes and the epic convention used
+  to group stories in sprint backlogs.
 - [[id:37C10313-E6E9-4D42-B82D-B6758D0A3AD9][Versions]] — every version of the product, the sprints inside each, and the
   stories and tasks that compose those sprints.
 - [[id:D4219199-7B17-4A89-B4BC-6019738642DA][Product backlog]] — pre-sprint ideas split into [[id:9A17E8DF-7E94-4F55-8A14-BCB7D9A16D6B][next]] (next-version candidates)

--- a/doc/agile/process.org
+++ b/doc/agile/process.org
@@ -235,6 +235,7 @@ A document is /done/ when:
 - [[id:8810E0F9-C5B9-4CFA-A710-774AD6C771DD][Lifecycle]] — the generic TODO state machine on each document.
 - [[id:8B29A8D8-E004-4E87-B81D-ABEAF68F2B98][Document types]] — per-type frontmatter and section contract.
 - [[id:D4219199-7B17-4A89-B4BC-6019738642DA][Product backlog]] — what the backlog is and how next/deferred buckets work.
+- [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Sprint themes]] — the six themes and epic convention for sprint story tables.
 - [[id:47341FC6-B8FB-499E-AAE0-F4EE0ABFDA05][Glossary]] — definitions of every term used here.
 - [[id:3153AA4B-23D4-4111-9710-5A4971102EDC][How do I create a new v2 doc?]] — the recipe used at every promotion
   step above.

--- a/doc/agile/process.org
+++ b/doc/agile/process.org
@@ -149,17 +149,23 @@ Closure is more than transitioning to =DONE=. The sequence is:
 1. *Resolve every story.* Every story in the sprint is =DONE=,
    =ABANDONED=, or has been explicitly carried to a successor (see
    /Cross-sprint continuations/).
-2. *Generate the release notes* if a release is being cut. The notes
+2. *Write the Achievements.* Add a =** Achievements= sub-heading
+   inside =* Status=, after the Status table. Write 4–6 bullet points
+   capturing what the sprint actually delivered — specific outcomes,
+   not story titles. Clear the =Now= field to =Nothing.= at the same
+   time. Achievements are only written at sprint close; the heading
+   does not appear in in-flight sprints.
+3. *Generate the release notes* if a release is being cut. The notes
    are produced from the closed tasks' =* Result= sections and the
    PRs that landed.
-3. *Cut the release* (tag, build, publish artefacts) when the version
+4. *Cut the release* (tag, build, publish artefacts) when the version
    warrants it. Not every sprint produces a release; many sprints
    land mid-version. See [[id:B69989F6-19E1-430D-AC6D-B2416E4C433F][Compass]] for what the release tag means in
    terms of CMake major/minor.
-4. *Run the post-mortem.* Fill the sprint's =* Retrospective= section
+5. *Run the post-mortem.* Fill the sprint's =* Retrospective= section
    — what went well, what hurt, what changed. Past sprints under
    =doc/agile/versions/v0/sprint_*/= are the template.
-5. *Transition the sprint* itself to =DONE= and update =Last touched=
+6. *Transition the sprint* itself to =DONE= and update =Last touched=
    on the Status row.
 
 Sprint closure ends when all five steps are complete; the next

--- a/doc/agile/process.org
+++ b/doc/agile/process.org
@@ -150,7 +150,7 @@ Closure is more than transitioning to =DONE=. The sequence is:
    =ABANDONED=, or has been explicitly carried to a successor (see
    /Cross-sprint continuations/).
 2. *Write the Achievements.* Add a =** Achievements= sub-heading
-   inside =* Status=, after the Status table. Write 4–6 bullet points
+   inside =* Status=, after the Status table. Write 3–7 bullet points
    capturing what the sprint actually delivered — specific outcomes,
    not story titles. Clear the =Now= field to =Nothing.= at the same
    time. Achievements are only written at sprint close; the heading

--- a/doc/agile/product_backlog/inbox/add_support_to_compass_to_search_stories_by_folder_name.org
+++ b/doc/agile/product_backlog/inbox/add_support_to_compass_to_search_stories_by_folder_name.org
@@ -1,0 +1,123 @@
+:PROPERTIES:
+:ID:       809D32DC-22D2-4E9E-ACAA-1771A84EA1E2
+:END:
+#+title: Add support to compass to search stories by folder name
+#+description: Improve compass search to support a common use case which is to search by exact folder name, with underscores.
+#+type: capture
+#+version: 2
+#+level: cross
+#+filetags: :inbox:capture:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+At present compass does not find a story if we search by the exact story name.
+We need to replace underscores with spaces for it to work. It should work
+without having to do this.
+
+* Why
+
+LLM just did the following:
+
+#+begin_src shell
+Now scaffold Task 1 with compass. Let me check the compass goto usage for adding a task to an existing story:
+
+● Bash(python3 tools/compass/compass.py --help 2>&1 | head -30)
+  ⎿  python3: can't open file '/mnt/development/Development/OreStudio/OreStudio.local2/tools/compass/compass.py': [Errno 2] No su
+     ch file or directory
+
+  Searched for 1 pattern (ctrl+o to expand)
+
+● Bash(projects/ores.compass/compass.sh goto --help 2>&1)
+  ⎿  usage: compass goto [-h] [--story STORY] [--slug SLUG] [--title TITLE]
+                         [--description DESCRIPTION] [--tags TAGS] [--task TASK]
+                         [--task-slug TASK_SLUG] [--base BASE] [--dry-run]
+     … +19 lines (ctrl+o to expand)
+
+● Bash(projects/ores.compass/compass.sh index --rebuild 2>&1 | tail -5)
+  ⎿  ✅ Done.
+        Files updated: 1852
+        Files skipped (up to date): 0
+        Total content chunks: 1899
+
+● Bash(projects/ores.compass/compass.sh where --story user_manual_pdf_build 2>&1)
+  ⎿  Error: Exit code 2
+     usage: compass.py [-h]
+                       {index,search,debug,where,status,fleet,list,show,add,goto} ...
+     compass.py: error: unrecognized arguments: --story user_manual_pdf_build
+
+❯ also make all references to NATS a org-roam link. the new story could follow the existing compass stories naming compass_plantum...
+● Bash(projects/ores.compass/compass.sh search "user manual pdf build" 2>&1 | head -20)
+  ⎿  Found 10 results for 'user manual pdf build':
+     --------------------------------------------------
+     📄 "Task: Add CMake target to build user manual PDF and commit it"  🏷️   "doc" "manual" "cmake" "pdf" "latex" "user_manual_pd
+     … +18 lines (ctrl+o to expand)
+
+● Good — story UUID is C42C3563-671F-4721-8CE8-5EE05925255F. Now scaffold both tasks. Task 1 goes into user_manual_pdf_build, and for
+  the new story I'll use compass_plantuml as the slug per user's note. Let me run them sequentially:
+
+● Bash(projects/ores.compass/compass.sh goto \
+        --story C42C3563-671F-4721-8CE8-5EE05925255F \…)
+  ⎿  ✅ created and switched to feature/task-split-system-model-layers (off origin/main)
+     doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_split_system_model_layers.org
+     … +3 lines (ctrl+o to expand)
+#+end_src
+
+Even if we did:
+
+#+begin_src shell
+marco@neumann:~/Development/OreStudio/OreStudio.local2$ ./projects/ores.compass/compass.sh search user_manual_pdf_build
+
+Found 9 results for 'user_manual_pdf_build':
+--------------------------------------------------
+📄 "Task: Add CMake target to build user manual PDF and commit it"  🏷️  "doc" "manual" "cmake" "pdf" "latex" "user_manual_pdf_build" "sprint_18" "v0"
+   doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_add_cmake_pdf_target.org
+   ......s1 #+filetags: :doc:manual:cmake:pdf:latex:user_manual_pdf_build:sprint_18:v0: #+owner: marco #+branch: feature/user-manual......
+--------------------------------------------------
+📄 "Task: Write Chapter 1: Login and Connection Manager"  🏷️  "doc" "manual" "chapter_01" "user_manual_pdf_build" "sprint_18" "v0"
+   doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_chapter_01_login_connection_manager.org
+   ......s1 #+filetags: :doc:manual:chapter_01:user_manual_pdf_build:sprint_18:v0: #+owner: marco #+branch: feature/user-manual-chapter......
+--------------------------------------------------
+📄 "Task: Create documentation update skill"  🏷️  "doc" "manual" "skill" "llm" "user_manual_pdf_build" "sprint_18" "v0"
+   doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_create_documentation_update_skill.org
+   ......s1 #+filetags: :doc:manual:skill:llm:user_manual_pdf_build:sprint_18:v0: #+owner: marco #+branch: feature/user-manual-system......
+--------------------------------------------------
+📄 "Task: Write Chapter 1: System bootstrapping concepts and provisioning wizards"  🏷️  "doc" "manual" "chapter_01" "bootstrapping" "user_manual_pdf_build" "sprint_18" "v0"
+   doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_chapter_01_system_bootstrapping_concepts.org
+   ......s1 #+filetags: :doc:manual:chapter_01:bootstrapping:user_manual_pdf_build:sprint_18:v0: #+owner: marco #+branch: feature/user-manual......
+--------------------------------------------------
+📄 "Task: Add user_manual_site.org and update manuals.org"  🏷️  "user_manual_pdf_build" "sprint_18" "v0"
+   doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_add_manual_site_page.org
+   ......s1 #+filetags: :user_manual_pdf_build:sprint_18:v0: #+owner: marco #+branch: feature/add-manual-site-page #+pr: 882 #+blocked......
+--------------------------------------------------
+📄 "Task: User manual restructure"  🏷️  "doc" "manual" "retrospective" "user_manual_pdf_build" "sprint_18" "v0"
+   doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_user_manual_restructure.org
+   ......s1 #+filetags: :doc:manual:retrospective:user_manual_pdf_build:sprint_18:v0: #+owner: marco #+branch: feature/user-manual-restructure #+pr......
+--------------------------------------------------
+📄 "Deploy the documentation site"  🏷️  "runbook" "site" "deploy" "documentation"
+   doc/llm/runbooks/deploy_documentation_site/runbook.org
+   ......4. /Build the manual PDF./ Run =cmake --build ... --target deploy_manual= per the =user_manual_pdf_build= story.  5. /Verify......
+--------------------------------------------------
+📄 "Task: Health review 2 — sprint 18 backlog audit and shape check"  🏷️  "sprint_health_review" "sprint_18" "v0"
+   doc/agile/versions/v0/sprint_18/sprint_health_review/task_health_review_2.org
+   ......Real in-flight count is 3: =ore_samples_support=, =user_manual_pdf_build=, =sprint_health_review=. That is GREEN.  *** Overall......
+--------------------------------------------------
+📄 "Task: Generate all missing screenshots for the manual"  🏷️  "manual" "screenshots" "documentation" "user_manual_pdf_build" "sprint_18" "v0"
+   doc/agile/versions/v0/sprint_18/user_manual_pdf_build/task_generate_missing_screenshots.org
+   ......s1 #+filetags: :manual:screenshots:documentation:user_manual_pdf_build:sprint_18:v0: #+owner: marco #+branch: feature/finish-missing-screenshots #+pr......
+--------------------------------------------------
+#+end_src
+
+This should have matched the story first, then all tasks for the story. We
+should somehow detect the underscores and then give priority to catalogues.
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/sprint_themes.org
+++ b/doc/agile/sprint_themes.org
@@ -1,0 +1,67 @@
+:PROPERTIES:
+:ID: A064D838-F127-4DD6-BB42-9A7902039AEE
+:END:
+#+title: Sprint themes
+#+description: Definitions of the six sprint themes (Product, Tooling, Agile, LLMs, Documentation, Infrastructure) and the epic convention used to group stories in sprint backlogs.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :agile:sprint:themes:knowledge:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+
+* Summary
+
+Each [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprint]]'s =* Stories= section is split into six theme subheadings so
+that the reader can scan the backlog by domain at a glance. Themes are
+permanent labels — every story in every sprint belongs to exactly one.
+Within a theme, an /epic/ is an optional sub-grouping for a cluster of
+stories that form a coherent multi-story arc toward a single named
+capability.
+
+* Detail
+
+** Themes
+
+| Theme          | What belongs here                                                        |
+|----------------+--------------------------------------------------------------------------|
+| Product        | End-user features: ORE types and imports, trading domain, Qt UI, workspace, data quality, user-facing CLI. |
+| Tooling        | Developer and LLM tooling: =ores.compass=, codegen, sqlgen, build scripts, developer CLI. |
+| Agile          | Sprint management: health reviews, charts, captures, backlog refinement, sprint planning. |
+| LLMs           | LLM-facing infrastructure: Claude Code skills, runbooks, recipes, AI code review. |
+| Documentation  | Knowledge graph, system model, diagrams, site content, user manual.      |
+| Infrastructure | Build system, CI/CD, test infrastructure, database infrastructure, comms substrate, security primitives, compiler/platform work. |
+
+** Epics
+
+An epic is an optional =***= sub-subheading inside a theme for a cluster
+of two or more stories that all contribute to a single named capability.
+It carries a one-paragraph description of what the arc is working toward.
+Stories that belong to no epic sit directly in the theme's table without
+a sub-heading.
+
+Example structure:
+
+#+begin_src org
+,** Product
+
+,*** Epic: ORE Imports End-to-End
+
+Enable loading ORE input files into workspaces end-to-end — sample data
+sourcing, execution support, and full instrument-type coverage.
+
+| [[id:...][ORE sample data]]                    | BACKLOG | ... |
+| [[id:...][Add support for running ORE samples]] | BACKLOG | ... |
+| [[id:...][Work through all types for Example 1]] | BACKLOG | ... |
+
+| [[id:...][Standalone product story]]            | DONE    | ... |
+#+end_src
+
+Epics are structural headings only — they have no =:ID:=, no document
+file, and no state machine. They are introduced where the grouping adds
+clarity; they are not forced on every theme.
+
+* See also
+
+- [[id:46DFE47F-967B-4C24-95BF-3E21F97CFD20][Agile process]] — the loop: backlog refinement, sprint phases, closure.
+- [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][Sprint]] — the document type that hosts theme subheadings.

--- a/doc/agile/versions/v0/sprint_01/sprint.org
+++ b/doc/agile/versions/v0/sprint_01/sprint.org
@@ -35,7 +35,10 @@ the stack.
 
 ** Achievements
 
-- All stories merged.
+- Project bootstrapped: build, packaging, and CI in place.
+- Qt UI scaffold established as the desktop surface.
+- Currencies working end-to-end as the first live domain feature.
+- Documentation infrastructure laid down.
 
 * Stories
 

--- a/doc/agile/versions/v0/sprint_01/sprint.org
+++ b/doc/agile/versions/v0/sprint_01/sprint.org
@@ -20,50 +20,56 @@ the stack.
 
 * Status
 
-| Field          | Value                                                  |
-|----------------+--------------------------------------------------------|
-| State          | DONE                                                   |
-| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]] |
-| Previous       | —                                                      |
-| Start          | 2024-06-15                                             |
-| End (expected) | 2025-02-02                                             |
-| Now            | Sprint closed 2024-07-28. All stories merged.          |
-| Waiting on     | Nothing.                                               |
-| Next           | [[id:8CBC2B51-E3D0-4320-8582-3CFD2F96537A][Sprint 02]] |
-| Release Notes  | [[id:9FEBF736-19F2-4007-BF3A-ACCA6DB5C537][Release notes]]                                                      |
-| Last touched   | 2024-07-28                                             |
+| Field          | Value         |
+|----------------+---------------|
+| State          | DONE          |
+| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]]     |
+| Previous       | —             |
+| Start          | 2024-06-15    |
+| End (expected) | 2025-02-02    |
+| Now            | Nothing.      |
+| Waiting on     | Nothing.      |
+| Next           | [[id:8CBC2B51-E3D0-4320-8582-3CFD2F96537A][Sprint 02]]     |
+| Release Notes  | [[id:9FEBF736-19F2-4007-BF3A-ACCA6DB5C537][Release notes]] |
+| Last touched   | 2024-07-28    |
+
+** Achievements
+
+- All stories merged.
 
 * Stories
+
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
 
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                     | State | Start      | End        | Theme                                                                                               |
-|---------------------------------------------------------------------------+-------+------------+------------+-----------------------------------------------------------------------------------------------------|
-| [[id:64E55E42-12EB-46CF-8269-6B30DA277A1B][Project bootstrap]]            | DONE  |            | 2024-07-01 | diffuse story covering repo, build, CI, and packaging. The plumbing every later story stands on.    |
-| [[id:1D334356-F123-43B5-A98E-317EBAD2848A][Build quality]]                | DONE  |            | 2024-07-28 | nightly memcheck, Valgrind stabilisation, C++ standard bump, vcpkg warning hygiene.                 |
+| Story             | State | Start |        End | Theme                                                                                            |
+|-------------------+-------+-------+------------+--------------------------------------------------------------------------------------------------|
+| [[id:64E55E42-12EB-46CF-8269-6B30DA277A1B][Project bootstrap]] | DONE  |       | 2024-07-01 | diffuse story covering repo, build, CI, and packaging. The plumbing every later story stands on. |
+| [[id:1D334356-F123-43B5-A98E-317EBAD2848A][Build quality]]     | DONE  |       | 2024-07-28 | nightly memcheck, Valgrind stabilisation, C++ standard bump, vcpkg warning hygiene.              |
 
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                     | State | Start      | End        | Theme                                                                                                        |
-|---------------------------------------------------------------------------+-------+------------+------------+--------------------------------------------------------------------------------------------------------------|
-| [[id:36A36BCB-6D25-4CEA-A2DE-53741EDAD563][Qt UI scaffold]]               | DONE  |            | 2024-07-28 | initial Qt application: hello world, splash, refactor toward a usable layout, icon set.                      |
-| [[id:AF70CDF6-071F-43A9-91BB-7EB9A59A550F][Currencies end-to-end]]        | DONE  |            | 2024-07-28 | tight story: bring currency data through XML, JSON, the database, and the Qt UI as the pathfinder data type. |
+| Story                 | State | Start |        End | Theme                                                                                                        |
+|-----------------------+-------+-------+------------+--------------------------------------------------------------------------------------------------------------|
+| [[id:36A36BCB-6D25-4CEA-A2DE-53741EDAD563][Qt UI scaffold]]        | DONE  |       | 2024-07-28 | initial Qt application: hello world, splash, refactor toward a usable layout, icon set.                      |
+| [[id:AF70CDF6-071F-43A9-91BB-7EB9A59A550F][Currencies end-to-end]] | DONE  |       | 2024-07-28 | tight story: bring currency data through XML, JSON, the database, and the Qt UI as the pathfinder data type. |
 
 ** Documentation
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                     | State | Start      | End        | Theme                                             |
-|---------------------------------------------------------------------------+-------+------------+------------+---------------------------------------------------|
-| [[id:C85F2DCA-F7D6-40AE-B796-8B4CF84A7093][Documentation infrastructure]] | DONE  |            | 2024-07-28 | project site, Doxygen, README, seed domain notes. |
+| Story                        | State | Start |        End | Theme                                             |
+|------------------------------+-------+-------+------------+---------------------------------------------------|
+| [[id:C85F2DCA-F7D6-40AE-B796-8B4CF84A7093][Documentation infrastructure]] | DONE  |       | 2024-07-28 | project site, Doxygen, README, seed domain notes. |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                     | State | Start      | End        | Theme                                                                                                      |
-|---------------------------------------------------------------------------+-------+------------+------------+------------------------------------------------------------------------------------------------------------|
-| [[id:BCA419E2-DFF2-474B-969E-CFBD19E7C832][Sprint 01 housekeeping]]       | DONE  |            | 2024-07-28 | sprint-level work that doesn't fit a product story: sprint instrumentation, dev setup, community channels. |
+| Story                  | State | Start |        End | Theme                                                                                                      |
+|------------------------+-------+-------+------------+------------------------------------------------------------------------------------------------------------|
+| [[id:BCA419E2-DFF2-474B-969E-CFBD19E7C832][Sprint 01 housekeeping]] | DONE  |       | 2024-07-28 | sprint-level work that doesn't fit a product story: sprint instrumentation, dev setup, community channels. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_01/sprint.org
+++ b/doc/agile/versions/v0/sprint_01/sprint.org
@@ -47,7 +47,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story             | State | Start |        End | Theme                                                                                            |
+| Story             | State | Start |        End | Description |
 |-------------------+-------+-------+------------+--------------------------------------------------------------------------------------------------|
 | [[id:64E55E42-12EB-46CF-8269-6B30DA277A1B][Project bootstrap]] | DONE  |       | 2024-07-01 | diffuse story covering repo, build, CI, and packaging. The plumbing every later story stands on. |
 | [[id:1D334356-F123-43B5-A98E-317EBAD2848A][Build quality]]     | DONE  |       | 2024-07-28 | nightly memcheck, Valgrind stabilisation, C++ standard bump, vcpkg warning hygiene.              |
@@ -55,7 +55,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                 | State | Start |        End | Theme                                                                                                        |
+| Story                 | State | Start |        End | Description |
 |-----------------------+-------+-------+------------+--------------------------------------------------------------------------------------------------------------|
 | [[id:36A36BCB-6D25-4CEA-A2DE-53741EDAD563][Qt UI scaffold]]        | DONE  |       | 2024-07-28 | initial Qt application: hello world, splash, refactor toward a usable layout, icon set.                      |
 | [[id:AF70CDF6-071F-43A9-91BB-7EB9A59A550F][Currencies end-to-end]] | DONE  |       | 2024-07-28 | tight story: bring currency data through XML, JSON, the database, and the Qt UI as the pathfinder data type. |
@@ -63,14 +63,14 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Documentation
 
 #+ATTR_HTML: :class hug-leading
-| Story                        | State | Start |        End | Theme                                             |
+| Story                        | State | Start |        End | Description |
 |------------------------------+-------+-------+------------+---------------------------------------------------|
 | [[id:C85F2DCA-F7D6-40AE-B796-8B4CF84A7093][Documentation infrastructure]] | DONE  |       | 2024-07-28 | project site, Doxygen, README, seed domain notes. |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                  | State | Start |        End | Theme                                                                                                      |
+| Story                  | State | Start |        End | Description |
 |------------------------+-------+-------+------------+------------------------------------------------------------------------------------------------------------|
 | [[id:BCA419E2-DFF2-474B-969E-CFBD19E7C832][Sprint 01 housekeeping]] | DONE  |       | 2024-07-28 | sprint-level work that doesn't fit a product story: sprint instrumentation, dev setup, community channels. |
 

--- a/doc/agile/versions/v0/sprint_01/sprint.org
+++ b/doc/agile/versions/v0/sprint_01/sprint.org
@@ -35,15 +35,35 @@ the stack.
 
 * Stories
 
+** Infrastructure
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                     | State | Start      | End        | Theme                                                                                               |
+|---------------------------------------------------------------------------+-------+------------+------------+-----------------------------------------------------------------------------------------------------|
+| [[id:64E55E42-12EB-46CF-8269-6B30DA277A1B][Project bootstrap]]            | DONE  |            | 2024-07-01 | diffuse story covering repo, build, CI, and packaging. The plumbing every later story stands on.    |
+| [[id:1D334356-F123-43B5-A98E-317EBAD2848A][Build quality]]                | DONE  |            | 2024-07-28 | nightly memcheck, Valgrind stabilisation, C++ standard bump, vcpkg warning hygiene.                 |
+
+** Product
+
 #+ATTR_HTML: :class hug-leading
 | Story                                                                     | State | Start      | End        | Theme                                                                                                        |
 |---------------------------------------------------------------------------+-------+------------+------------+--------------------------------------------------------------------------------------------------------------|
-| [[id:64E55E42-12EB-46CF-8269-6B30DA277A1B][Project bootstrap]]            | DONE  |            | 2024-07-01 | diffuse story covering repo, build, CI, and packaging. The plumbing every later story stands on.             |
 | [[id:36A36BCB-6D25-4CEA-A2DE-53741EDAD563][Qt UI scaffold]]               | DONE  |            | 2024-07-28 | initial Qt application: hello world, splash, refactor toward a usable layout, icon set.                      |
-| [[id:C85F2DCA-F7D6-40AE-B796-8B4CF84A7093][Documentation infrastructure]] | DONE  |            | 2024-07-28 | project site, Doxygen, README, seed domain notes.                                                            |
-| [[id:1D334356-F123-43B5-A98E-317EBAD2848A][Build quality]]                | DONE  |            | 2024-07-28 | nightly memcheck, Valgrind stabilisation, C++ standard bump, vcpkg warning hygiene.                          |
 | [[id:AF70CDF6-071F-43A9-91BB-7EB9A59A550F][Currencies end-to-end]]        | DONE  |            | 2024-07-28 | tight story: bring currency data through XML, JSON, the database, and the Qt UI as the pathfinder data type. |
-| [[id:BCA419E2-DFF2-474B-969E-CFBD19E7C832][Sprint 01 housekeeping]]       | DONE  |            | 2024-07-28 | sprint-level work that doesn't fit a product story: sprint instrumentation, dev setup, community channels.   |
+
+** Documentation
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                     | State | Start      | End        | Theme                                             |
+|---------------------------------------------------------------------------+-------+------------+------------+---------------------------------------------------|
+| [[id:C85F2DCA-F7D6-40AE-B796-8B4CF84A7093][Documentation infrastructure]] | DONE  |            | 2024-07-28 | project site, Doxygen, README, seed domain notes. |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                     | State | Start      | End        | Theme                                                                                                      |
+|---------------------------------------------------------------------------+-------+------------+------------+------------------------------------------------------------------------------------------------------------|
+| [[id:BCA419E2-DFF2-474B-969E-CFBD19E7C832][Sprint 01 housekeeping]]       | DONE  |            | 2024-07-28 | sprint-level work that doesn't fit a product story: sprint instrumentation, dev setup, community channels. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_02/sprint.org
+++ b/doc/agile/versions/v0/sprint_02/sprint.org
@@ -40,16 +40,36 @@ explicitly.)
 
 * Stories
 
+** Infrastructure
+
 #+ATTR_HTML: :class hug-leading
 | Story                                                                            | State | Start      | End        | Theme                                                                                                                                        |
 |----------------------------------------------------------------------------------+-------+------------+------------+----------------------------------------------------------------------------------------------------------------------------------------------|
-| [[id:0FE2033D-180F-4195-A314-998917D570BE][Sprint 02 housekeeping]]              | DONE  |            | 2025-10-23 | sprint refinement, whiteboarding for the new architecture, dev-environment fixes, Gemini action.                                             |
 | [[id:AC14558D-A526-4BE2-ADB6-81BCFE0E7292][Build stabilisation]]                 | DONE  |            | 2025-10-23 | Windows/macOS builds, vcpkg caching, Valgrind suppressions, broken-build firefighting.                                                       |
 | [[id:145ADEDE-C3DD-4B51-AD3B-D6B5506C6C37][Client/server foundations]]           | DONE  |            | 2025-10-15 | cobalt-based server and client, =comms= library, messaging for risk. Records the GRPC and 0MQ experiments that were abandoned along the way. |
 | [[id:1F9F213C-6BEA-45FB-B0E0-AA5A7A9B7A23][Modernise serialisation and storage]] | DONE  |            | 2025-10-10 | adopt reflect-cpp for JSON, replace XML parsing with reflect-cpp, use sqlgen for Postgres.                                                   |
-| [[id:ED5BC735-FB54-4CE0-9A08-6DAB88C242D0][Currencies temporal and export]]      | DONE  |            | 2025-09-30 | temporal support for currencies, CLI dump command, a containing structure for ORE example data.                                              |
-| [[id:6C63D2B2-7065-4AFC-AE54-86220C427B20][Risk module extraction]]              | DONE  |            | 2025-10-05 | rename =core= to =risk= and refactor the contents accordingly.                                                                               |
-| [[id:CF13FFB1-4D84-4965-AD65-C38B1D4849AB][CLI refactor and test]]               | DONE  |            | 2025-10-10 | restructure the CLI to follow the new project layout and add tests to the CLI parser.                                                        |
+
+** Product
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                            | State | Start      | End        | Theme                                                                                           |
+|----------------------------------------------------------------------------------+-------+------------+------------+-------------------------------------------------------------------------------------------------|
+| [[id:ED5BC735-FB54-4CE0-9A08-6DAB88C242D0][Currencies temporal and export]]      | DONE  |            | 2025-09-30 | temporal support for currencies, CLI dump command, a containing structure for ORE example data. |
+| [[id:6C63D2B2-7065-4AFC-AE54-86220C427B20][Risk module extraction]]              | DONE  |            | 2025-10-05 | rename =core= to =risk= and refactor the contents accordingly.                                  |
+
+** Tooling
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                            | State | Start      | End        | Theme                                                                                 |
+|----------------------------------------------------------------------------------+-------+------------+------------+---------------------------------------------------------------------------------------|
+| [[id:CF13FFB1-4D84-4965-AD65-C38B1D4849AB][CLI refactor and test]]               | DONE  |            | 2025-10-10 | restructure the CLI to follow the new project layout and add tests to the CLI parser. |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                            | State | Start      | End        | Theme                                                                                            |
+|----------------------------------------------------------------------------------+-------+------------+------------+--------------------------------------------------------------------------------------------------|
+| [[id:0FE2033D-180F-4195-A314-998917D570BE][Sprint 02 housekeeping]]              | DONE  |            | 2025-10-23 | sprint refinement, whiteboarding for the new architecture, dev-environment fixes, Gemini action. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_02/sprint.org
+++ b/doc/agile/versions/v0/sprint_02/sprint.org
@@ -40,9 +40,9 @@ explicitly.)
 
 ** Achievements
 
-- Client/server foundations in place;
-- serialisation and storage modernised;
-- risk module extracted.
+- Client/server foundations established.
+- Serialisation and storage modernised.
+- Risk module extracted.
 
 * Stories
 
@@ -51,7 +51,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                               | State | Start |        End | Theme                                                                                                                                        |
+| Story                               | State | Start |        End | Description |
 |-------------------------------------+-------+-------+------------+----------------------------------------------------------------------------------------------------------------------------------------------|
 | [[id:AC14558D-A526-4BE2-ADB6-81BCFE0E7292][Build stabilisation]]                 | DONE  |       | 2025-10-23 | Windows/macOS builds, vcpkg caching, Valgrind suppressions, broken-build firefighting.                                                       |
 | [[id:145ADEDE-C3DD-4B51-AD3B-D6B5506C6C37][Client/server foundations]]           | DONE  |       | 2025-10-15 | cobalt-based server and client, =comms= library, messaging for risk. Records the GRPC and 0MQ experiments that were abandoned along the way. |
@@ -60,7 +60,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                          | State | Start |        End | Theme                                                                                           |
+| Story                          | State | Start |        End | Description |
 |--------------------------------+-------+-------+------------+-------------------------------------------------------------------------------------------------|
 | [[id:ED5BC735-FB54-4CE0-9A08-6DAB88C242D0][Currencies temporal and export]] | DONE  |       | 2025-09-30 | temporal support for currencies, CLI dump command, a containing structure for ORE example data. |
 | [[id:6C63D2B2-7065-4AFC-AE54-86220C427B20][Risk module extraction]]         | DONE  |       | 2025-10-05 | rename =core= to =risk= and refactor the contents accordingly.                                  |
@@ -68,14 +68,14 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Tooling
 
 #+ATTR_HTML: :class hug-leading
-| Story                 | State | Start |        End | Theme                                                                                 |
+| Story                 | State | Start |        End | Description |
 |-----------------------+-------+-------+------------+---------------------------------------------------------------------------------------|
 | [[id:CF13FFB1-4D84-4965-AD65-C38B1D4849AB][CLI refactor and test]] | DONE  |       | 2025-10-10 | restructure the CLI to follow the new project layout and add tests to the CLI parser. |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                  | State | Start |        End | Theme                                                                                            |
+| Story                  | State | Start |        End | Description |
 |------------------------+-------+-------+------------+--------------------------------------------------------------------------------------------------|
 | [[id:0FE2033D-180F-4195-A314-998917D570BE][Sprint 02 housekeeping]] | DONE  |       | 2025-10-23 | sprint refinement, whiteboarding for the new architecture, dev-environment fixes, Gemini action. |
 

--- a/doc/agile/versions/v0/sprint_02/sprint.org
+++ b/doc/agile/versions/v0/sprint_02/sprint.org
@@ -25,51 +25,59 @@ explicitly.)
 
 * Status
 
-| Field          | Value                                                                                                                      |
-|----------------+----------------------------------------------------------------------------------------------------------------------------|
-| State          | DONE                                                                                                                       |
-| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]]                                                                     |
-| Previous       | [[id:2CF90D10-890D-4CB0-A71B-5E8C3261BC54][Sprint 01]]                                                                     |
-| Start          | 2025-02-02                                                                                                                 |
-| End (expected) | 2025-10-23                                                                                                                 |
-| Now            | Sprint closed 2025-10-23. Client/server foundations in place; serialisation and storage modernised; risk module extracted. |
-| Waiting on     | Nothing.                                                                                                                   |
-| Next           | [[id:3BC3B9ED-60C8-4A86-A6F1-925E58C74B6E][Sprint 03]]                                                                     |
-| Release Notes  | [[id:4E977745-BE0B-4441-B85C-6BE6035A4A3D][Release notes]]                                                                                                                          |
-| Last touched   | 2025-10-23                                                                                                                 |
+| Field          | Value         |
+|----------------+---------------|
+| State          | DONE          |
+| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]]     |
+| Previous       | [[id:2CF90D10-890D-4CB0-A71B-5E8C3261BC54][Sprint 01]]     |
+| Start          | 2025-02-02    |
+| End (expected) | 2025-10-23    |
+| Now            | Nothing.      |
+| Waiting on     | Nothing.      |
+| Next           | [[id:3BC3B9ED-60C8-4A86-A6F1-925E58C74B6E][Sprint 03]]     |
+| Release Notes  | [[id:4E977745-BE0B-4441-B85C-6BE6035A4A3D][Release notes]] |
+| Last touched   | 2025-10-23    |
+
+** Achievements
+
+- Client/server foundations in place;
+- serialisation and storage modernised;
+- risk module extracted.
 
 * Stories
+
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
 
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                            | State | Start      | End        | Theme                                                                                                                                        |
-|----------------------------------------------------------------------------------+-------+------------+------------+----------------------------------------------------------------------------------------------------------------------------------------------|
-| [[id:AC14558D-A526-4BE2-ADB6-81BCFE0E7292][Build stabilisation]]                 | DONE  |            | 2025-10-23 | Windows/macOS builds, vcpkg caching, Valgrind suppressions, broken-build firefighting.                                                       |
-| [[id:145ADEDE-C3DD-4B51-AD3B-D6B5506C6C37][Client/server foundations]]           | DONE  |            | 2025-10-15 | cobalt-based server and client, =comms= library, messaging for risk. Records the GRPC and 0MQ experiments that were abandoned along the way. |
-| [[id:1F9F213C-6BEA-45FB-B0E0-AA5A7A9B7A23][Modernise serialisation and storage]] | DONE  |            | 2025-10-10 | adopt reflect-cpp for JSON, replace XML parsing with reflect-cpp, use sqlgen for Postgres.                                                   |
+| Story                               | State | Start |        End | Theme                                                                                                                                        |
+|-------------------------------------+-------+-------+------------+----------------------------------------------------------------------------------------------------------------------------------------------|
+| [[id:AC14558D-A526-4BE2-ADB6-81BCFE0E7292][Build stabilisation]]                 | DONE  |       | 2025-10-23 | Windows/macOS builds, vcpkg caching, Valgrind suppressions, broken-build firefighting.                                                       |
+| [[id:145ADEDE-C3DD-4B51-AD3B-D6B5506C6C37][Client/server foundations]]           | DONE  |       | 2025-10-15 | cobalt-based server and client, =comms= library, messaging for risk. Records the GRPC and 0MQ experiments that were abandoned along the way. |
+| [[id:1F9F213C-6BEA-45FB-B0E0-AA5A7A9B7A23][Modernise serialisation and storage]] | DONE  |       | 2025-10-10 | adopt reflect-cpp for JSON, replace XML parsing with reflect-cpp, use sqlgen for Postgres.                                                   |
 
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                            | State | Start      | End        | Theme                                                                                           |
-|----------------------------------------------------------------------------------+-------+------------+------------+-------------------------------------------------------------------------------------------------|
-| [[id:ED5BC735-FB54-4CE0-9A08-6DAB88C242D0][Currencies temporal and export]]      | DONE  |            | 2025-09-30 | temporal support for currencies, CLI dump command, a containing structure for ORE example data. |
-| [[id:6C63D2B2-7065-4AFC-AE54-86220C427B20][Risk module extraction]]              | DONE  |            | 2025-10-05 | rename =core= to =risk= and refactor the contents accordingly.                                  |
+| Story                          | State | Start |        End | Theme                                                                                           |
+|--------------------------------+-------+-------+------------+-------------------------------------------------------------------------------------------------|
+| [[id:ED5BC735-FB54-4CE0-9A08-6DAB88C242D0][Currencies temporal and export]] | DONE  |       | 2025-09-30 | temporal support for currencies, CLI dump command, a containing structure for ORE example data. |
+| [[id:6C63D2B2-7065-4AFC-AE54-86220C427B20][Risk module extraction]]         | DONE  |       | 2025-10-05 | rename =core= to =risk= and refactor the contents accordingly.                                  |
 
 ** Tooling
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                            | State | Start      | End        | Theme                                                                                 |
-|----------------------------------------------------------------------------------+-------+------------+------------+---------------------------------------------------------------------------------------|
-| [[id:CF13FFB1-4D84-4965-AD65-C38B1D4849AB][CLI refactor and test]]               | DONE  |            | 2025-10-10 | restructure the CLI to follow the new project layout and add tests to the CLI parser. |
+| Story                 | State | Start |        End | Theme                                                                                 |
+|-----------------------+-------+-------+------------+---------------------------------------------------------------------------------------|
+| [[id:CF13FFB1-4D84-4965-AD65-C38B1D4849AB][CLI refactor and test]] | DONE  |       | 2025-10-10 | restructure the CLI to follow the new project layout and add tests to the CLI parser. |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                            | State | Start      | End        | Theme                                                                                            |
-|----------------------------------------------------------------------------------+-------+------------+------------+--------------------------------------------------------------------------------------------------|
-| [[id:0FE2033D-180F-4195-A314-998917D570BE][Sprint 02 housekeeping]]              | DONE  |            | 2025-10-23 | sprint refinement, whiteboarding for the new architecture, dev-environment fixes, Gemini action. |
+| Story                  | State | Start |        End | Theme                                                                                            |
+|------------------------+-------+-------+------------+--------------------------------------------------------------------------------------------------|
+| [[id:0FE2033D-180F-4195-A314-998917D570BE][Sprint 02 housekeeping]] | DONE  |       | 2025-10-23 | sprint refinement, whiteboarding for the new architecture, dev-environment fixes, Gemini action. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_03/sprint.org
+++ b/doc/agile/versions/v0/sprint_03/sprint.org
@@ -42,16 +42,30 @@ code/ + /finish login related functionality/.)
 
 * Stories
 
+** Infrastructure
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                             | State | Start      | End        | Theme                                                                             |
+|-----------------------------------------------------------------------------------+-------+------------+------------+-----------------------------------------------------------------------------------|
+| [[id:D246FFBE-11EE-4FF9-9309-2A693E2476EF][Build stabilisation 3]]                | DONE  |            | 2025-11-15 | Windows clang-cl, dynamic libraries, vcpkg patches on Windows, Postgres on CI.    |
+| [[id:22EFE1E8-427F-488A-94A3-8CA78F180966][Test infrastructure]]                  | DONE  |            | 2025-12-01 | separate test DB, split test code, ctest suite-level tests, test data generators. |
+| [[id:3F819EE3-0834-4522-8B01-DF4A7D09E77F][Postgres-backed currency persistence]] | DONE  |            | 2025-11-25 | currency repository write path, service command-line DB args.                     |
+| [[id:1A411B50-2C3A-4248-9AE7-59A835EF6774][Logging and observability]]            | DONE  |            | 2025-12-30 | proper Boost.Log usage, Valgrind/leak investigations, code-coverage uplift.       |
+
+** Product
+
 #+ATTR_HTML: :class hug-leading
 | Story                                                                             | State | Start      | End        | Theme                                                                                    |
 |-----------------------------------------------------------------------------------+-------+------------+------------+------------------------------------------------------------------------------------------|
-| [[id:BCEF2C68-65FE-4848-95BA-6DDB01B2AB9F][Sprint 03 housekeeping]]               | DONE  |            | 2025-12-31 | sprint sundries, backlog refinement, postponed work tracking.                            |
-| [[id:D246FFBE-11EE-4FF9-9309-2A693E2476EF][Build stabilisation 3]]                | DONE  |            | 2025-11-15 | Windows clang-cl, dynamic libraries, vcpkg patches on Windows, Postgres on CI.           |
-| [[id:22EFE1E8-427F-488A-94A3-8CA78F180966][Test infrastructure]]                  | DONE  |            | 2025-12-01 | separate test DB, split test code, ctest suite-level tests, test data generators.        |
 | [[id:EDA3D069-F3C1-43B5-93FB-E5705A8F9ADC][Client console and Qt integration]]    | DONE  |            | 2025-12-15 | merge client into console, enable Qt GUI on the new socket layer, locking, Prodigy tags. |
 | [[id:B09E0D06-0314-4424-AD57-2DA31A335D99][Login and sessions]]                   | DONE  |            | 2025-12-20 | account and session domain types end-to-end.                                             |
-| [[id:3F819EE3-0834-4522-8B01-DF4A7D09E77F][Postgres-backed currency persistence]] | DONE  |            | 2025-11-25 | currency repository write path, service command-line DB args.                            |
-| [[id:1A411B50-2C3A-4248-9AE7-59A835EF6774][Logging and observability]]            | DONE  |            | 2025-12-30 | proper Boost.Log usage, Valgrind/leak investigations, code-coverage uplift.              |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                             | State | Start      | End        | Theme                                                         |
+|-----------------------------------------------------------------------------------+-------+------------+------------+---------------------------------------------------------------|
+| [[id:BCEF2C68-65FE-4848-95BA-6DDB01B2AB9F][Sprint 03 housekeeping]]               | DONE  |            | 2025-12-31 | sprint sundries, backlog refinement, postponed work tracking. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_03/sprint.org
+++ b/doc/agile/versions/v0/sprint_03/sprint.org
@@ -27,45 +27,52 @@ code/ + /finish login related functionality/.)
 
 * Status
 
-| Field          | Value                                                                                                            |
-|----------------+------------------------------------------------------------------------------------------------------------------|
-| State          | DONE                                                                                                             |
-| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]]                                                           |
-| Previous       | [[id:8CBC2B51-E3D0-4320-8582-3CFD2F96537A][Sprint 02]]                                                           |
-| Start          | 2025-10-23                                                                                                       |
-| End (expected) | 2025-11-07                                                                                                       |
-| Now            | Sprint closed 2025-12-31. UI now uses the new socket layer end-to-end; accounts and sessions ship as part of v0. |
-| Waiting on     | Nothing.                                                                                                         |
-| Next           | [[id:38DAA167-E791-48FB-AFEB-1813615037DE][Sprint 04]]                                                           |
-| Release Notes  | [[id:2B050F4F-006C-44F6-8F51-0FB44DCD292D][Release notes]]                                                                                                                |
-| Last touched   | 2025-12-31                                                                                                       |
+| Field          | Value         |
+|----------------+---------------|
+| State          | DONE          |
+| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]]     |
+| Previous       | [[id:8CBC2B51-E3D0-4320-8582-3CFD2F96537A][Sprint 02]]     |
+| Start          | 2025-10-23    |
+| End (expected) | 2025-11-07    |
+| Now            | Nothing.      |
+| Waiting on     | Nothing.      |
+| Next           | [[id:38DAA167-E791-48FB-AFEB-1813615037DE][Sprint 04]]     |
+| Release Notes  | [[id:2B050F4F-006C-44F6-8F51-0FB44DCD292D][Release notes]] |
+| Last touched   | 2025-12-31    |
+
+** Achievements
+
+- UI now uses the new socket layer end-to-end;
+- accounts and sessions ship as part of v0.
 
 * Stories
+
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
 
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                             | State | Start      | End        | Theme                                                                             |
-|-----------------------------------------------------------------------------------+-------+------------+------------+-----------------------------------------------------------------------------------|
-| [[id:D246FFBE-11EE-4FF9-9309-2A693E2476EF][Build stabilisation 3]]                | DONE  |            | 2025-11-15 | Windows clang-cl, dynamic libraries, vcpkg patches on Windows, Postgres on CI.    |
-| [[id:22EFE1E8-427F-488A-94A3-8CA78F180966][Test infrastructure]]                  | DONE  |            | 2025-12-01 | separate test DB, split test code, ctest suite-level tests, test data generators. |
-| [[id:3F819EE3-0834-4522-8B01-DF4A7D09E77F][Postgres-backed currency persistence]] | DONE  |            | 2025-11-25 | currency repository write path, service command-line DB args.                     |
-| [[id:1A411B50-2C3A-4248-9AE7-59A835EF6774][Logging and observability]]            | DONE  |            | 2025-12-30 | proper Boost.Log usage, Valgrind/leak investigations, code-coverage uplift.       |
+| Story                                | State | Start |        End | Theme                                                                             |
+|--------------------------------------+-------+-------+------------+-----------------------------------------------------------------------------------|
+| [[id:D246FFBE-11EE-4FF9-9309-2A693E2476EF][Build stabilisation 3]]                | DONE  |       | 2025-11-15 | Windows clang-cl, dynamic libraries, vcpkg patches on Windows, Postgres on CI.    |
+| [[id:22EFE1E8-427F-488A-94A3-8CA78F180966][Test infrastructure]]                  | DONE  |       | 2025-12-01 | separate test DB, split test code, ctest suite-level tests, test data generators. |
+| [[id:3F819EE3-0834-4522-8B01-DF4A7D09E77F][Postgres-backed currency persistence]] | DONE  |       | 2025-11-25 | currency repository write path, service command-line DB args.                     |
+| [[id:1A411B50-2C3A-4248-9AE7-59A835EF6774][Logging and observability]]            | DONE  |       | 2025-12-30 | proper Boost.Log usage, Valgrind/leak investigations, code-coverage uplift.       |
 
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                             | State | Start      | End        | Theme                                                                                    |
-|-----------------------------------------------------------------------------------+-------+------------+------------+------------------------------------------------------------------------------------------|
-| [[id:EDA3D069-F3C1-43B5-93FB-E5705A8F9ADC][Client console and Qt integration]]    | DONE  |            | 2025-12-15 | merge client into console, enable Qt GUI on the new socket layer, locking, Prodigy tags. |
-| [[id:B09E0D06-0314-4424-AD57-2DA31A335D99][Login and sessions]]                   | DONE  |            | 2025-12-20 | account and session domain types end-to-end.                                             |
+| Story                             | State | Start |        End | Theme                                                                                    |
+|-----------------------------------+-------+-------+------------+------------------------------------------------------------------------------------------|
+| [[id:EDA3D069-F3C1-43B5-93FB-E5705A8F9ADC][Client console and Qt integration]] | DONE  |       | 2025-12-15 | merge client into console, enable Qt GUI on the new socket layer, locking, Prodigy tags. |
+| [[id:B09E0D06-0314-4424-AD57-2DA31A335D99][Login and sessions]]                | DONE  |       | 2025-12-20 | account and session domain types end-to-end.                                             |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                             | State | Start      | End        | Theme                                                         |
-|-----------------------------------------------------------------------------------+-------+------------+------------+---------------------------------------------------------------|
-| [[id:BCEF2C68-65FE-4848-95BA-6DDB01B2AB9F][Sprint 03 housekeeping]]               | DONE  |            | 2025-12-31 | sprint sundries, backlog refinement, postponed work tracking. |
+| Story                  | State | Start |        End | Theme                                                         |
+|------------------------+-------+-------+------------+---------------------------------------------------------------|
+| [[id:BCEF2C68-65FE-4848-95BA-6DDB01B2AB9F][Sprint 03 housekeeping]] | DONE  |       | 2025-12-31 | sprint sundries, backlog refinement, postponed work tracking. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_03/sprint.org
+++ b/doc/agile/versions/v0/sprint_03/sprint.org
@@ -42,8 +42,8 @@ code/ + /finish login related functionality/.)
 
 ** Achievements
 
-- UI now uses the new socket layer end-to-end;
-- accounts and sessions ship as part of v0.
+- UI uses the new socket layer end-to-end.
+- Accounts and sessions ship as part of v0.
 
 * Stories
 
@@ -52,7 +52,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                | State | Start |        End | Theme                                                                             |
+| Story                                | State | Start |        End | Description |
 |--------------------------------------+-------+-------+------------+-----------------------------------------------------------------------------------|
 | [[id:D246FFBE-11EE-4FF9-9309-2A693E2476EF][Build stabilisation 3]]                | DONE  |       | 2025-11-15 | Windows clang-cl, dynamic libraries, vcpkg patches on Windows, Postgres on CI.    |
 | [[id:22EFE1E8-427F-488A-94A3-8CA78F180966][Test infrastructure]]                  | DONE  |       | 2025-12-01 | separate test DB, split test code, ctest suite-level tests, test data generators. |
@@ -62,7 +62,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                             | State | Start |        End | Theme                                                                                    |
+| Story                             | State | Start |        End | Description |
 |-----------------------------------+-------+-------+------------+------------------------------------------------------------------------------------------|
 | [[id:EDA3D069-F3C1-43B5-93FB-E5705A8F9ADC][Client console and Qt integration]] | DONE  |       | 2025-12-15 | merge client into console, enable Qt GUI on the new socket layer, locking, Prodigy tags. |
 | [[id:B09E0D06-0314-4424-AD57-2DA31A335D99][Login and sessions]]                | DONE  |       | 2025-12-20 | account and session domain types end-to-end.                                             |
@@ -70,7 +70,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                  | State | Start |        End | Theme                                                         |
+| Story                  | State | Start |        End | Description |
 |------------------------+-------+-------+------------+---------------------------------------------------------------|
 | [[id:BCEF2C68-65FE-4848-95BA-6DDB01B2AB9F][Sprint 03 housekeeping]] | DONE  |       | 2025-12-31 | sprint sundries, backlog refinement, postponed work tracking. |
 

--- a/doc/agile/versions/v0/sprint_04/sprint.org
+++ b/doc/agile/versions/v0/sprint_04/sprint.org
@@ -38,17 +38,43 @@ UI; introduce the Claude Code skills layer.
 
 * Stories
 
+** Infrastructure
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                        | State | Start      | End        | Theme                                                                           |
+|------------------------------------------------------------------------------+-------+------------+------------+---------------------------------------------------------------------------------|
+| [[id:A9055A54-AE06-4CC4-8B51-2CB9627E0D5A][Test infrastructure follow-up]]   | DONE  |            | 2025-11-20 | successor of sprint 03's BLOCKED CTest item.                                    |
+| [[id:C2E401C5-3F2B-4910-A91A-82DCF1B826E1][Build and packaging]]             | DONE  |            | 2025-11-20 | Windows install end-to-end, =localtime= fix, shutdown crash, sqlgen leak fixes. |
+
+** Product
+
 #+ATTR_HTML: :class hug-leading
 | Story                                                                        | State | Start      | End        | Theme                                                                                  |
 |------------------------------------------------------------------------------+-------+------------+------------+----------------------------------------------------------------------------------------|
-| [[id:D0A1C624-DC57-424E-A958-279F68956976][Sprint 04 housekeeping]]          | DONE  |            | 2025-11-30 | backlog refinement plus a new pie-chart resourcing report.                             |
-| [[id:A9055A54-AE06-4CC4-8B51-2CB9627E0D5A][Test infrastructure follow-up]]   | DONE  |            | 2025-11-20 | successor of sprint 03's BLOCKED CTest item.                                           |
-| [[id:50B83CE1-6E12-44E7-AFEB-F6BAC09DDC14][Claude Code skills introduction]] | DONE  |            | 2025-11-15 | first skill, CMake deploy targets, weaving analysis.                                   |
-| [[id:C2E401C5-3F2B-4910-A91A-82DCF1B826E1][Build and packaging]]             | DONE  |            | 2025-11-20 | Windows install end-to-end, =localtime= fix, shutdown crash, sqlgen leak fixes.        |
 | [[id:2A9269E4-049A-49C3-9354-F26C95390E1F][UI polish and branding]]          | DONE  |            | 2025-11-22 | splash, Fluent icons, application icon, window-management defaults.                    |
 | [[id:1E99EEE4-DCA5-4384-942E-0CE28B0A467C][Currencies UI]]                   | DONE  |            | 2025-11-25 | export, edit, add, history, multi-select. Pattern-setter for later reference-data UIs. |
-| [[id:F8D6459D-71D3-4BAE-8ECE-43201CD2B8BA][LLM code review and refactor]]    | DONE  |            | 2025-11-28 | review pass + Dogen-layout restructure + per-component PlantUML.                       |
-| [[id:13E4F41F-82E1-400A-9C84-E60A587E2647][Documentation polish]]            | DONE  |            | 2025-11-30 | website restructure following the weaving analysis, Doxygen main-page refresh.         |
+
+** LLMs
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                        | State | Start      | End        | Theme                                                            |
+|------------------------------------------------------------------------------+-------+------------+------------+------------------------------------------------------------------|
+| [[id:50B83CE1-6E12-44E7-AFEB-F6BAC09DDC14][Claude Code skills introduction]] | DONE  |            | 2025-11-15 | first skill, CMake deploy targets, weaving analysis.             |
+| [[id:F8D6459D-71D3-4BAE-8ECE-43201CD2B8BA][LLM code review and refactor]]    | DONE  |            | 2025-11-28 | review pass + Dogen-layout restructure + per-component PlantUML. |
+
+** Documentation
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                        | State | Start      | End        | Theme                                                                          |
+|------------------------------------------------------------------------------+-------+------------+------------+--------------------------------------------------------------------------------|
+| [[id:13E4F41F-82E1-400A-9C84-E60A587E2647][Documentation polish]]            | DONE  |            | 2025-11-30 | website restructure following the weaving analysis, Doxygen main-page refresh. |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                        | State | Start      | End        | Theme                                                      |
+|------------------------------------------------------------------------------+-------+------------+------------+------------------------------------------------------------|
+| [[id:D0A1C624-DC57-424E-A958-279F68956976][Sprint 04 housekeeping]]          | DONE  |            | 2025-11-30 | backlog refinement plus a new pie-chart resourcing report. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_04/sprint.org
+++ b/doc/agile/versions/v0/sprint_04/sprint.org
@@ -38,9 +38,9 @@ UI; introduce the Claude Code skills layer.
 
 ** Achievements
 
-- LLM-driven review pass complete across the first three components;
-- currencies UI feature-complete;
-- the Claude Code skills layer is in the build.
+- LLM-driven review pass complete across the first three components.
+- Currencies UI feature-complete.
+- Claude Code skills layer established in the build.
 
 * Stories
 
@@ -49,7 +49,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                         | State | Start |        End | Theme                                                                           |
+| Story                         | State | Start |        End | Description |
 |-------------------------------+-------+-------+------------+---------------------------------------------------------------------------------|
 | [[id:A9055A54-AE06-4CC4-8B51-2CB9627E0D5A][Test infrastructure follow-up]] | DONE  |       | 2025-11-20 | successor of sprint 03's BLOCKED CTest item.                                    |
 | [[id:C2E401C5-3F2B-4910-A91A-82DCF1B826E1][Build and packaging]]           | DONE  |       | 2025-11-20 | Windows install end-to-end, =localtime= fix, shutdown crash, sqlgen leak fixes. |
@@ -57,7 +57,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                  | State | Start |        End | Theme                                                                                  |
+| Story                  | State | Start |        End | Description |
 |------------------------+-------+-------+------------+----------------------------------------------------------------------------------------|
 | [[id:2A9269E4-049A-49C3-9354-F26C95390E1F][UI polish and branding]] | DONE  |       | 2025-11-22 | splash, Fluent icons, application icon, window-management defaults.                    |
 | [[id:1E99EEE4-DCA5-4384-942E-0CE28B0A467C][Currencies UI]]          | DONE  |       | 2025-11-25 | export, edit, add, history, multi-select. Pattern-setter for later reference-data UIs. |
@@ -65,7 +65,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** LLMs
 
 #+ATTR_HTML: :class hug-leading
-| Story                           | State | Start |        End | Theme                                                            |
+| Story                           | State | Start |        End | Description |
 |---------------------------------+-------+-------+------------+------------------------------------------------------------------|
 | [[id:50B83CE1-6E12-44E7-AFEB-F6BAC09DDC14][Claude Code skills introduction]] | DONE  |       | 2025-11-15 | first skill, CMake deploy targets, weaving analysis.             |
 | [[id:F8D6459D-71D3-4BAE-8ECE-43201CD2B8BA][LLM code review and refactor]]    | DONE  |       | 2025-11-28 | review pass + Dogen-layout restructure + per-component PlantUML. |
@@ -73,14 +73,14 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Documentation
 
 #+ATTR_HTML: :class hug-leading
-| Story                | State | Start |        End | Theme                                                                          |
+| Story                | State | Start |        End | Description |
 |----------------------+-------+-------+------------+--------------------------------------------------------------------------------|
 | [[id:13E4F41F-82E1-400A-9C84-E60A587E2647][Documentation polish]] | DONE  |       | 2025-11-30 | website restructure following the weaving analysis, Doxygen main-page refresh. |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                  | State | Start |        End | Theme                                                      |
+| Story                  | State | Start |        End | Description |
 |------------------------+-------+-------+------------+------------------------------------------------------------|
 | [[id:D0A1C624-DC57-424E-A958-279F68956976][Sprint 04 housekeeping]] | DONE  |       | 2025-11-30 | backlog refinement plus a new pie-chart resourcing report. |
 

--- a/doc/agile/versions/v0/sprint_04/sprint.org
+++ b/doc/agile/versions/v0/sprint_04/sprint.org
@@ -23,58 +23,66 @@ UI; introduce the Claude Code skills layer.
 
 * Status
 
-| Field          | Value                                                                                                                                                                      |
-|----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| State          | DONE                                                                                                                                                                       |
-| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]]                                                                                                                     |
-| Previous       | [[id:3BC3B9ED-60C8-4A86-A6F1-925E58C74B6E][Sprint 03]]                                                                                                                     |
-| Start          | 2025-11-07                                                                                                                                                                 |
-| End (expected) | 2025-11-16                                                                                                                                                                 |
-| Now            | Sprint closed 2025-11-30. LLM-driven review pass complete across the first three components; currencies UI feature-complete; the Claude Code skills layer is in the build. |
-| Waiting on     | Nothing.                                                                                                                                                                   |
-| Next           | [[id:2429DB80-EC7B-482C-9FF3-4D1933035863][Sprint 05]]                                                                                                                     |
-| Release Notes  | [[id:142E1574-03BE-435F-AABB-6E4504C32D28][Release notes]]                                                                                                                                                                          |
-| Last touched   | 2025-11-30                                                                                                                                                                 |
+| Field          | Value         |
+|----------------+---------------|
+| State          | DONE          |
+| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]]     |
+| Previous       | [[id:3BC3B9ED-60C8-4A86-A6F1-925E58C74B6E][Sprint 03]]     |
+| Start          | 2025-11-07    |
+| End (expected) | 2025-11-16    |
+| Now            | Nothing.      |
+| Waiting on     | Nothing.      |
+| Next           | [[id:2429DB80-EC7B-482C-9FF3-4D1933035863][Sprint 05]]     |
+| Release Notes  | [[id:142E1574-03BE-435F-AABB-6E4504C32D28][Release notes]] |
+| Last touched   | 2025-11-30    |
+
+** Achievements
+
+- LLM-driven review pass complete across the first three components;
+- currencies UI feature-complete;
+- the Claude Code skills layer is in the build.
 
 * Stories
+
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
 
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                        | State | Start      | End        | Theme                                                                           |
-|------------------------------------------------------------------------------+-------+------------+------------+---------------------------------------------------------------------------------|
-| [[id:A9055A54-AE06-4CC4-8B51-2CB9627E0D5A][Test infrastructure follow-up]]   | DONE  |            | 2025-11-20 | successor of sprint 03's BLOCKED CTest item.                                    |
-| [[id:C2E401C5-3F2B-4910-A91A-82DCF1B826E1][Build and packaging]]             | DONE  |            | 2025-11-20 | Windows install end-to-end, =localtime= fix, shutdown crash, sqlgen leak fixes. |
+| Story                         | State | Start |        End | Theme                                                                           |
+|-------------------------------+-------+-------+------------+---------------------------------------------------------------------------------|
+| [[id:A9055A54-AE06-4CC4-8B51-2CB9627E0D5A][Test infrastructure follow-up]] | DONE  |       | 2025-11-20 | successor of sprint 03's BLOCKED CTest item.                                    |
+| [[id:C2E401C5-3F2B-4910-A91A-82DCF1B826E1][Build and packaging]]           | DONE  |       | 2025-11-20 | Windows install end-to-end, =localtime= fix, shutdown crash, sqlgen leak fixes. |
 
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                        | State | Start      | End        | Theme                                                                                  |
-|------------------------------------------------------------------------------+-------+------------+------------+----------------------------------------------------------------------------------------|
-| [[id:2A9269E4-049A-49C3-9354-F26C95390E1F][UI polish and branding]]          | DONE  |            | 2025-11-22 | splash, Fluent icons, application icon, window-management defaults.                    |
-| [[id:1E99EEE4-DCA5-4384-942E-0CE28B0A467C][Currencies UI]]                   | DONE  |            | 2025-11-25 | export, edit, add, history, multi-select. Pattern-setter for later reference-data UIs. |
+| Story                  | State | Start |        End | Theme                                                                                  |
+|------------------------+-------+-------+------------+----------------------------------------------------------------------------------------|
+| [[id:2A9269E4-049A-49C3-9354-F26C95390E1F][UI polish and branding]] | DONE  |       | 2025-11-22 | splash, Fluent icons, application icon, window-management defaults.                    |
+| [[id:1E99EEE4-DCA5-4384-942E-0CE28B0A467C][Currencies UI]]          | DONE  |       | 2025-11-25 | export, edit, add, history, multi-select. Pattern-setter for later reference-data UIs. |
 
 ** LLMs
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                        | State | Start      | End        | Theme                                                            |
-|------------------------------------------------------------------------------+-------+------------+------------+------------------------------------------------------------------|
-| [[id:50B83CE1-6E12-44E7-AFEB-F6BAC09DDC14][Claude Code skills introduction]] | DONE  |            | 2025-11-15 | first skill, CMake deploy targets, weaving analysis.             |
-| [[id:F8D6459D-71D3-4BAE-8ECE-43201CD2B8BA][LLM code review and refactor]]    | DONE  |            | 2025-11-28 | review pass + Dogen-layout restructure + per-component PlantUML. |
+| Story                           | State | Start |        End | Theme                                                            |
+|---------------------------------+-------+-------+------------+------------------------------------------------------------------|
+| [[id:50B83CE1-6E12-44E7-AFEB-F6BAC09DDC14][Claude Code skills introduction]] | DONE  |       | 2025-11-15 | first skill, CMake deploy targets, weaving analysis.             |
+| [[id:F8D6459D-71D3-4BAE-8ECE-43201CD2B8BA][LLM code review and refactor]]    | DONE  |       | 2025-11-28 | review pass + Dogen-layout restructure + per-component PlantUML. |
 
 ** Documentation
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                        | State | Start      | End        | Theme                                                                          |
-|------------------------------------------------------------------------------+-------+------------+------------+--------------------------------------------------------------------------------|
-| [[id:13E4F41F-82E1-400A-9C84-E60A587E2647][Documentation polish]]            | DONE  |            | 2025-11-30 | website restructure following the weaving analysis, Doxygen main-page refresh. |
+| Story                | State | Start |        End | Theme                                                                          |
+|----------------------+-------+-------+------------+--------------------------------------------------------------------------------|
+| [[id:13E4F41F-82E1-400A-9C84-E60A587E2647][Documentation polish]] | DONE  |       | 2025-11-30 | website restructure following the weaving analysis, Doxygen main-page refresh. |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                        | State | Start      | End        | Theme                                                      |
-|------------------------------------------------------------------------------+-------+------------+------------+------------------------------------------------------------|
-| [[id:D0A1C624-DC57-424E-A958-279F68956976][Sprint 04 housekeeping]]          | DONE  |            | 2025-11-30 | backlog refinement plus a new pie-chart resourcing report. |
+| Story                  | State | Start |        End | Theme                                                      |
+|------------------------+-------+-------+------------+------------------------------------------------------------|
+| [[id:D0A1C624-DC57-424E-A958-279F68956976][Sprint 04 housekeeping]] | DONE  |       | 2025-11-30 | backlog refinement plus a new pie-chart resourcing report. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_05/sprint.org
+++ b/doc/agile/versions/v0/sprint_05/sprint.org
@@ -39,17 +39,49 @@ skills layer.
 
 * Stories
 
+** Infrastructure
+
 #+ATTR_HTML: :class hug-leading
-| Story                                                                           | State | Start      | End        | Theme                                                                                                   |
-|---------------------------------------------------------------------------------+-------+------------+------------+---------------------------------------------------------------------------------------------------------|
-| [[id:DE3EEE9F-331E-440C-B62C-ABDEFE1D87E2][Sprint 05 housekeeping]]             | DONE  |            | 2025-12-01 | backlog, AI sprint summary, OCR notebooks.                                                              |
-| [[id:656EABB7-C9D1-4FDD-8CAC-0AB77ADCD9B2][Claude Code skills expansion]]       | DONE  |            | 2025-11-17 | new-sprint skill, release-notes skill, project-planning support.                                        |
-| [[id:69C49095-A91F-41D9-9D7E-0E9478143E93][Valgrind leaks follow-up]]           | DONE  |            | 2025-11-25 | successor of sprint 03's OpenSSL BLOCKED item; sweeps up sqlgen residuals and comms-test leaks.         |
+| Story                                                                           | State | Start      | End        | Theme                                                                                           |
+|---------------------------------------------------------------------------------+-------+------------+------------+-------------------------------------------------------------------------------------------------|
+| [[id:69C49095-A91F-41D9-9D7E-0E9478143E93][Valgrind leaks follow-up]]           | DONE  |            | 2025-11-25 | successor of sprint 03's OpenSSL BLOCKED item; sweeps up sqlgen residuals and comms-test leaks. |
 | [[id:A465D630-5972-484B-A2E8-AD1F91657103][Authentication bootstrap follow-up]] | DONE  |            | 2025-11-22 | successor of sprint 03's POSTPONED bootstrap workflow; adds delete-account and the feature-flags split. |
-| [[id:645DF0B4-51B5-40BC-BE07-0AB986111653][Infrastructure features]]            | DONE  |            | 2025-11-20 | detached-mode default; database configuration unified across console and Qt.                            |
-| [[id:7BE09D1C-E25A-4783-A911-C37DEC55CC43][CLI / REPL reshape]]                 | DONE  |            | 2025-11-25 | entity-first command syntax across CLI and REPL; synchronous REPL sockets.                              |
-| [[id:9836E113-DEA9-4605-AE1B-9B0C955B6B73][Currencies UI polish]]               | DONE  |            | 2025-11-28 | JSON parsing, merged save_currency message, XML-import dialog.                                          |
-| [[id:3A763AFB-22F3-4E9A-B121-A71997221C3F][Documentation and diagrams]]         | DONE  |            | 2025-12-01 | UML refresh after the reshape; per-component diagram links.                                             |
+| [[id:645DF0B4-51B5-40BC-BE07-0AB986111653][Infrastructure features]]            | DONE  |            | 2025-11-20 | detached-mode default; database configuration unified across console and Qt.                    |
+
+** Product
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                           | State | Start      | End        | Theme                                                                 |
+|---------------------------------------------------------------------------------+-------+------------+------------+-----------------------------------------------------------------------|
+| [[id:9836E113-DEA9-4605-AE1B-9B0C955B6B73][Currencies UI polish]]               | DONE  |            | 2025-11-28 | JSON parsing, merged save_currency message, XML-import dialog.        |
+
+** Tooling
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                           | State | Start      | End        | Theme                                                                      |
+|---------------------------------------------------------------------------------+-------+------------+------------+----------------------------------------------------------------------------|
+| [[id:7BE09D1C-E25A-4783-A911-C37DEC55CC43][CLI / REPL reshape]]                 | DONE  |            | 2025-11-25 | entity-first command syntax across CLI and REPL; synchronous REPL sockets. |
+
+** LLMs
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                           | State | Start      | End        | Theme                                                            |
+|---------------------------------------------------------------------------------+-------+------------+------------+------------------------------------------------------------------|
+| [[id:656EABB7-C9D1-4FDD-8CAC-0AB77ADCD9B2][Claude Code skills expansion]]       | DONE  |            | 2025-11-17 | new-sprint skill, release-notes skill, project-planning support. |
+
+** Documentation
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                           | State | Start      | End        | Theme                                                      |
+|---------------------------------------------------------------------------------+-------+------------+------------+------------------------------------------------------------|
+| [[id:3A763AFB-22F3-4E9A-B121-A71997221C3F][Documentation and diagrams]]         | DONE  |            | 2025-12-01 | UML refresh after the reshape; per-component diagram links. |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                           | State | Start      | End        | Theme                                      |
+|---------------------------------------------------------------------------------+-------+------------+------------+--------------------------------------------|
+| [[id:DE3EEE9F-331E-440C-B62C-ABDEFE1D87E2][Sprint 05 housekeeping]]             | DONE  |            | 2025-12-01 | backlog, AI sprint summary, OCR notebooks. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_05/sprint.org
+++ b/doc/agile/versions/v0/sprint_05/sprint.org
@@ -24,64 +24,73 @@ skills layer.
 
 * Status
 
-| Field          | Value                                                                                                                                                                                                |
-|----------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| State          | DONE                                                                                                                                                                                                 |
-| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]]                                                                                                                                               |
-| Previous       | [[id:38DAA167-E791-48FB-AFEB-1813615037DE][Sprint 04]]                                                                                                                                               |
-| Start          | 2025-11-16                                                                                                                                                                                           |
-| End (expected) | 2025-12-01                                                                                                                                                                                           |
-| Now            | Sprint closed 2025-12-01. Bootstrap workflow live; CLI/REPL reshape landed; currency messaging collapsed to =save_currency=; skills layer grew to cover sprint-opening and release-notes generation. |
-| Waiting on     | Nothing.                                                                                                                                                                                             |
-| Next           | [[id:06CB9D8B-92D5-4C51-A1D7-B73B22EB93E8][Sprint 06]]                                                                                                                                               |
-| Release Notes  | [[id:D642B102-262B-44EF-9C4C-29326D3B2AF6][Release notes]]                                                                                                                                                                                                    |
-| Last touched   | 2025-12-01                                                                                                                                                                                           |
+| Field          | Value         |
+|----------------+---------------|
+| State          | DONE          |
+| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]]     |
+| Previous       | [[id:38DAA167-E791-48FB-AFEB-1813615037DE][Sprint 04]]     |
+| Start          | 2025-11-16    |
+| End (expected) | 2025-12-01    |
+| Now            | Nothing.      |
+| Waiting on     | Nothing.      |
+| Next           | [[id:06CB9D8B-92D5-4C51-A1D7-B73B22EB93E8][Sprint 06]]     |
+| Release Notes  | [[id:D642B102-262B-44EF-9C4C-29326D3B2AF6][Release notes]] |
+| Last touched   | 2025-12-01    |
+
+** Achievements
+
+- Bootstrap workflow live;
+- CLI/REPL reshape landed;
+- currency messaging collapsed to =save_currency=;
+- skills layer grew to cover sprint-opening and release-notes generation.
 
 * Stories
+
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
 
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                           | State | Start      | End        | Theme                                                                                           |
-|---------------------------------------------------------------------------------+-------+------------+------------+-------------------------------------------------------------------------------------------------|
-| [[id:69C49095-A91F-41D9-9D7E-0E9478143E93][Valgrind leaks follow-up]]           | DONE  |            | 2025-11-25 | successor of sprint 03's OpenSSL BLOCKED item; sweeps up sqlgen residuals and comms-test leaks. |
-| [[id:A465D630-5972-484B-A2E8-AD1F91657103][Authentication bootstrap follow-up]] | DONE  |            | 2025-11-22 | successor of sprint 03's POSTPONED bootstrap workflow; adds delete-account and the feature-flags split. |
-| [[id:645DF0B4-51B5-40BC-BE07-0AB986111653][Infrastructure features]]            | DONE  |            | 2025-11-20 | detached-mode default; database configuration unified across console and Qt.                    |
+| Story                              | State | Start |        End | Theme                                                                                                   |
+|------------------------------------+-------+-------+------------+---------------------------------------------------------------------------------------------------------|
+| [[id:69C49095-A91F-41D9-9D7E-0E9478143E93][Valgrind leaks follow-up]]           | DONE  |       | 2025-11-25 | successor of sprint 03's OpenSSL BLOCKED item; sweeps up sqlgen residuals and comms-test leaks.         |
+| [[id:A465D630-5972-484B-A2E8-AD1F91657103][Authentication bootstrap follow-up]] | DONE  |       | 2025-11-22 | successor of sprint 03's POSTPONED bootstrap workflow; adds delete-account and the feature-flags split. |
+| [[id:645DF0B4-51B5-40BC-BE07-0AB986111653][Infrastructure features]]            | DONE  |       | 2025-11-20 | detached-mode default; database configuration unified across console and Qt.                            |
 
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                           | State | Start      | End        | Theme                                                                 |
-|---------------------------------------------------------------------------------+-------+------------+------------+-----------------------------------------------------------------------|
-| [[id:9836E113-DEA9-4605-AE1B-9B0C955B6B73][Currencies UI polish]]               | DONE  |            | 2025-11-28 | JSON parsing, merged save_currency message, XML-import dialog.        |
+| Story                | State | Start |        End | Theme                                                          |
+|----------------------+-------+-------+------------+----------------------------------------------------------------|
+| [[id:9836E113-DEA9-4605-AE1B-9B0C955B6B73][Currencies UI polish]] | DONE  |       | 2025-11-28 | JSON parsing, merged save_currency message, XML-import dialog. |
 
 ** Tooling
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                           | State | Start      | End        | Theme                                                                      |
-|---------------------------------------------------------------------------------+-------+------------+------------+----------------------------------------------------------------------------|
-| [[id:7BE09D1C-E25A-4783-A911-C37DEC55CC43][CLI / REPL reshape]]                 | DONE  |            | 2025-11-25 | entity-first command syntax across CLI and REPL; synchronous REPL sockets. |
+| Story              | State | Start |        End | Theme                                                                      |
+|--------------------+-------+-------+------------+----------------------------------------------------------------------------|
+| [[id:7BE09D1C-E25A-4783-A911-C37DEC55CC43][CLI / REPL reshape]] | DONE  |       | 2025-11-25 | entity-first command syntax across CLI and REPL; synchronous REPL sockets. |
 
 ** LLMs
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                           | State | Start      | End        | Theme                                                            |
-|---------------------------------------------------------------------------------+-------+------------+------------+------------------------------------------------------------------|
-| [[id:656EABB7-C9D1-4FDD-8CAC-0AB77ADCD9B2][Claude Code skills expansion]]       | DONE  |            | 2025-11-17 | new-sprint skill, release-notes skill, project-planning support. |
+| Story                        | State | Start |        End | Theme                                                            |
+|------------------------------+-------+-------+------------+------------------------------------------------------------------|
+| [[id:656EABB7-C9D1-4FDD-8CAC-0AB77ADCD9B2][Claude Code skills expansion]] | DONE  |       | 2025-11-17 | new-sprint skill, release-notes skill, project-planning support. |
 
 ** Documentation
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                           | State | Start      | End        | Theme                                                      |
-|---------------------------------------------------------------------------------+-------+------------+------------+------------------------------------------------------------|
-| [[id:3A763AFB-22F3-4E9A-B121-A71997221C3F][Documentation and diagrams]]         | DONE  |            | 2025-12-01 | UML refresh after the reshape; per-component diagram links. |
+| Story                      | State | Start |        End | Theme                                                       |
+|----------------------------+-------+-------+------------+-------------------------------------------------------------|
+| [[id:3A763AFB-22F3-4E9A-B121-A71997221C3F][Documentation and diagrams]] | DONE  |       | 2025-12-01 | UML refresh after the reshape; per-component diagram links. |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                           | State | Start      | End        | Theme                                      |
-|---------------------------------------------------------------------------------+-------+------------+------------+--------------------------------------------|
-| [[id:DE3EEE9F-331E-440C-B62C-ABDEFE1D87E2][Sprint 05 housekeeping]]             | DONE  |            | 2025-12-01 | backlog, AI sprint summary, OCR notebooks. |
+| Story                  | State | Start |        End | Theme                                      |
+|------------------------+-------+-------+------------+--------------------------------------------|
+| [[id:DE3EEE9F-331E-440C-B62C-ABDEFE1D87E2][Sprint 05 housekeeping]] | DONE  |       | 2025-12-01 | backlog, AI sprint summary, OCR notebooks. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_05/sprint.org
+++ b/doc/agile/versions/v0/sprint_05/sprint.org
@@ -39,10 +39,10 @@ skills layer.
 
 ** Achievements
 
-- Bootstrap workflow live;
-- CLI/REPL reshape landed;
-- currency messaging collapsed to =save_currency=;
-- skills layer grew to cover sprint-opening and release-notes generation.
+- Bootstrap workflow live.
+- CLI/REPL reshape landed.
+- Currency messaging collapsed to =save_currency=.
+- Skills layer grew to cover sprint-opening and release-notes generation.
 
 * Stories
 
@@ -51,7 +51,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                              | State | Start |        End | Theme                                                                                                   |
+| Story                              | State | Start |        End | Description |
 |------------------------------------+-------+-------+------------+---------------------------------------------------------------------------------------------------------|
 | [[id:69C49095-A91F-41D9-9D7E-0E9478143E93][Valgrind leaks follow-up]]           | DONE  |       | 2025-11-25 | successor of sprint 03's OpenSSL BLOCKED item; sweeps up sqlgen residuals and comms-test leaks.         |
 | [[id:A465D630-5972-484B-A2E8-AD1F91657103][Authentication bootstrap follow-up]] | DONE  |       | 2025-11-22 | successor of sprint 03's POSTPONED bootstrap workflow; adds delete-account and the feature-flags split. |
@@ -60,35 +60,35 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                | State | Start |        End | Theme                                                          |
+| Story                | State | Start |        End | Description |
 |----------------------+-------+-------+------------+----------------------------------------------------------------|
 | [[id:9836E113-DEA9-4605-AE1B-9B0C955B6B73][Currencies UI polish]] | DONE  |       | 2025-11-28 | JSON parsing, merged save_currency message, XML-import dialog. |
 
 ** Tooling
 
 #+ATTR_HTML: :class hug-leading
-| Story              | State | Start |        End | Theme                                                                      |
+| Story              | State | Start |        End | Description |
 |--------------------+-------+-------+------------+----------------------------------------------------------------------------|
 | [[id:7BE09D1C-E25A-4783-A911-C37DEC55CC43][CLI / REPL reshape]] | DONE  |       | 2025-11-25 | entity-first command syntax across CLI and REPL; synchronous REPL sockets. |
 
 ** LLMs
 
 #+ATTR_HTML: :class hug-leading
-| Story                        | State | Start |        End | Theme                                                            |
+| Story                        | State | Start |        End | Description |
 |------------------------------+-------+-------+------------+------------------------------------------------------------------|
 | [[id:656EABB7-C9D1-4FDD-8CAC-0AB77ADCD9B2][Claude Code skills expansion]] | DONE  |       | 2025-11-17 | new-sprint skill, release-notes skill, project-planning support. |
 
 ** Documentation
 
 #+ATTR_HTML: :class hug-leading
-| Story                      | State | Start |        End | Theme                                                       |
+| Story                      | State | Start |        End | Description |
 |----------------------------+-------+-------+------------+-------------------------------------------------------------|
 | [[id:3A763AFB-22F3-4E9A-B121-A71997221C3F][Documentation and diagrams]] | DONE  |       | 2025-12-01 | UML refresh after the reshape; per-component diagram links. |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                  | State | Start |        End | Theme                                      |
+| Story                  | State | Start |        End | Description |
 |------------------------+-------+-------+------------+--------------------------------------------|
 | [[id:DE3EEE9F-331E-440C-B62C-ABDEFE1D87E2][Sprint 05 housekeeping]] | DONE  |       | 2025-12-01 | backlog, AI sprint summary, OCR notebooks. |
 

--- a/doc/agile/versions/v0/sprint_06/sprint.org
+++ b/doc/agile/versions/v0/sprint_06/sprint.org
@@ -44,12 +44,11 @@ later sprints with the codegen-driven approach.)
 
 ** Achievements
 
-- Session cancellation live;
-- variability is its own service;
-- comms substrate has handshake/protocol split and retry;
-- logging migrated to =std::string_view= (with the inevitable post-migration
-  cleanup);
-- two predecessor links from sprint 05 closed.
+- Session cancellation live.
+- Variability is its own service.
+- Comms substrate has handshake/protocol split and retry.
+- Logging migrated to =std::string_view= (with the inevitable post-migration cleanup).
+- Two predecessor links from sprint 05 closed.
 
 * Stories
 
@@ -58,7 +57,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                            | State | Start      | End        | Theme                                                                                                      |
+| Story                                                                            | State | Start      | End        | Description |
 |----------------------------------------------------------------------------------+-------+------------+------------+------------------------------------------------------------------------------------------------------------|
 | [[id:4B50A7E5-D862-47A6-AEBE-353CAD55B058][Session lifecycle follow-up]]         | DONE  |            | 2025-12-04 | successor of sprint 05's authentication bootstrap; lands session cancellation + logout + client heartbeat. |
 | [[id:88971AFE-E0B4-4E54-B0D7-B1C627C2F239][Comms robustness]]                    | DONE  |            | 2025-12-10 | split protocol, handshake service, multi-thread coverage, retry-with-give-up.                              |
@@ -68,7 +67,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                            | State | Start      | End        | Theme                                                              |
+| Story                                                                            | State | Start      | End        | Description |
 |----------------------------------------------------------------------------------+-------+------------+------------+--------------------------------------------------------------------|
 | [[id:55C35962-46A0-4353-93AD-FC15BF847C7E][Variability service]]                 | DONE  |            | 2025-12-08 | feature-flag service end-to-end.                                   |
 | [[id:50BB2ACB-5687-4BAD-B03A-12AF606E8EAB][Bootstrap polish]]                    | DONE  |            | 2025-12-13 | context to DB, drop bootstrap flag, manifest password-validation knob. |
@@ -76,14 +75,14 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Tooling
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                            | State | Start      | End        | Theme                                                                                           |
+| Story                                                                            | State | Start      | End        | Description |
 |----------------------------------------------------------------------------------+-------+------------+------------+-------------------------------------------------------------------------------------------------|
 | [[id:06C56CA2-9846-4DC9-B2F3-271BF4F084CE][CLI entity syntax follow-up]]         | DONE  |            | 2025-12-13 | successor of sprint 05's CLI/REPL reshape; mops up snags and adds top-level shell login/logout. |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                            | State | Start      | End        | Theme                                   |
+| Story                                                                            | State | Start      | End        | Description |
 |----------------------------------------------------------------------------------+-------+------------+------------+-----------------------------------------|
 | [[id:193A779F-A313-414C-9236-D075B84A2F67][Sprint 06 housekeeping]]              | DONE  |            | 2025-12-15 | backlog, AI summary via the skill, OCR. |
 

--- a/doc/agile/versions/v0/sprint_06/sprint.org
+++ b/doc/agile/versions/v0/sprint_06/sprint.org
@@ -44,17 +44,37 @@ later sprints with the codegen-driven approach.)
 
 * Stories
 
+** Infrastructure
+
 #+ATTR_HTML: :class hug-leading
 | Story                                                                            | State | Start      | End        | Theme                                                                                                      |
 |----------------------------------------------------------------------------------+-------+------------+------------+------------------------------------------------------------------------------------------------------------|
-| [[id:193A779F-A313-414C-9236-D075B84A2F67][Sprint 06 housekeeping]]              | DONE  |            | 2025-12-15 | backlog, AI summary via the skill, OCR.                                                                    |
 | [[id:4B50A7E5-D862-47A6-AEBE-353CAD55B058][Session lifecycle follow-up]]         | DONE  |            | 2025-12-04 | successor of sprint 05's authentication bootstrap; lands session cancellation + logout + client heartbeat. |
 | [[id:88971AFE-E0B4-4E54-B0D7-B1C627C2F239][Comms robustness]]                    | DONE  |            | 2025-12-10 | split protocol, handshake service, multi-thread coverage, retry-with-give-up.                              |
-| [[id:55C35962-46A0-4353-93AD-FC15BF847C7E][Variability service]]                 | DONE  |            | 2025-12-08 | feature-flag service end-to-end.                                                                           |
 | [[id:D9C5FCEF-DA11-45DA-B7FB-2A7B62C8AA0B][Logging refactor (std::string_view)]] | DONE  |            | 2025-12-12 | migration + fallout.                                                                                       |
-| [[id:50BB2ACB-5687-4BAD-B03A-12AF606E8EAB][Bootstrap polish]]                    | DONE  |            | 2025-12-13 | context to DB, drop bootstrap flag, manifest password-validation knob.                                     |
-| [[id:06C56CA2-9846-4DC9-B2F3-271BF4F084CE][CLI entity syntax follow-up]]         | DONE  |            | 2025-12-13 | successor of sprint 05's CLI/REPL reshape; mops up snags and adds top-level shell login/logout.            |
 | [[id:DBB7EEAB-C8E3-4AF9-B04F-E54FABD34A8F][Infrastructure features]]             | DONE  |            | 2025-12-15 | event bus, system tray, past-timepoint faker.                                                              |
+
+** Product
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                            | State | Start      | End        | Theme                                                              |
+|----------------------------------------------------------------------------------+-------+------------+------------+--------------------------------------------------------------------|
+| [[id:55C35962-46A0-4353-93AD-FC15BF847C7E][Variability service]]                 | DONE  |            | 2025-12-08 | feature-flag service end-to-end.                                   |
+| [[id:50BB2ACB-5687-4BAD-B03A-12AF606E8EAB][Bootstrap polish]]                    | DONE  |            | 2025-12-13 | context to DB, drop bootstrap flag, manifest password-validation knob. |
+
+** Tooling
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                            | State | Start      | End        | Theme                                                                                           |
+|----------------------------------------------------------------------------------+-------+------------+------------+-------------------------------------------------------------------------------------------------|
+| [[id:06C56CA2-9846-4DC9-B2F3-271BF4F084CE][CLI entity syntax follow-up]]         | DONE  |            | 2025-12-13 | successor of sprint 05's CLI/REPL reshape; mops up snags and adds top-level shell login/logout. |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                            | State | Start      | End        | Theme                                   |
+|----------------------------------------------------------------------------------+-------+------------+------------+-----------------------------------------|
+| [[id:193A779F-A313-414C-9236-D075B84A2F67][Sprint 06 housekeeping]]              | DONE  |            | 2025-12-15 | backlog, AI summary via the skill, OCR. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_06/sprint.org
+++ b/doc/agile/versions/v0/sprint_06/sprint.org
@@ -29,20 +29,31 @@ later sprints with the codegen-driven approach.)
 
 * Status
 
-| Field          | Value                                                                                                                                                                                                                                                                          |
-|----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| State          | DONE                                                                                                                                                                                                                                                                           |
-| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]]                                                                                                                                                                                                                         |
-| Previous       | [[id:2429DB80-EC7B-482C-9FF3-4D1933035863][Sprint 05]]                                                                                                                                                                                                                         |
-| Start          | 2025-12-01                                                                                                                                                                                                                                                                     |
-| End (expected) | 2025-12-13                                                                                                                                                                                                                                                                     |
-| Now            | Sprint closed 2025-12-15. Session cancellation live; variability is its own service; comms substrate has handshake/protocol split and retry; logging migrated to =std::string_view= (with the inevitable post-migration cleanup); two predecessor links from sprint 05 closed. |
-| Waiting on     | Nothing.                                                                                                                                                                                                                                                                       |
-| Next           | [[id:A79D42AF-1B38-43EE-9607-848A4A84C09A][Sprint 07]]                                                                                                                                                                                                                         |
-| Release Notes  | [[id:8E209DC9-E432-4E2A-89AC-81A91E11A43D][Release notes]]                                                                                                                                                                                                                                                                              |
-| Last touched   | 2025-12-15                                                                                                                                                                                                                                                                     |
+| Field          | Value         |
+|----------------+---------------|
+| State          | DONE          |
+| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]]     |
+| Previous       | [[id:2429DB80-EC7B-482C-9FF3-4D1933035863][Sprint 05]]     |
+| Start          | 2025-12-01    |
+| End (expected) | 2025-12-13    |
+| Now            | Nothing.      |
+| Waiting on     | Nothing.      |
+| Next           | [[id:A79D42AF-1B38-43EE-9607-848A4A84C09A][Sprint 07]]     |
+| Release Notes  | [[id:8E209DC9-E432-4E2A-89AC-81A91E11A43D][Release notes]] |
+| Last touched   | 2025-12-15    |
+
+** Achievements
+
+- Session cancellation live;
+- variability is its own service;
+- comms substrate has handshake/protocol split and retry;
+- logging migrated to =std::string_view= (with the inevitable post-migration
+  cleanup);
+- two predecessor links from sprint 05 closed.
 
 * Stories
+
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
 
 ** Infrastructure
 

--- a/doc/agile/versions/v0/sprint_07/sprint.org
+++ b/doc/agile/versions/v0/sprint_07/sprint.org
@@ -39,6 +39,11 @@ telemetry as first-class components, and tidy the build platform.
 
 ** Achievements
 
+- Accounts broadened into a proper IAM component with RBAC.
+- Roles and permissions layer live end-to-end.
+- Currencies history view polished; Qt UX improved across the board.
+- Wt and HTTP stack introduced as the web presentation tier.
+- Observability and telemetry established as first-class components.
 
 * Stories
 

--- a/doc/agile/versions/v0/sprint_07/sprint.org
+++ b/doc/agile/versions/v0/sprint_07/sprint.org
@@ -52,7 +52,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                       | State | Start |        End | Theme                                                                                |
+| Story                       | State | Start |        End | Description |
 |-----------------------------+-------+-------+------------+--------------------------------------------------------------------------------------|
 | [[id:BB39ECBD-1EA5-4D53-A117-A0C88E0463C1][Build platform follow-up]]    | DONE  |       | 2025-12-18 | WSL setup, prebuilt Qt, Windows clang build breaks. Continues from sprint 04.        |
 | [[id:B306F938-F939-44CA-9D69-6FAEDBF91C08][Comms features]]              | DONE  |       | 2025-12-25 | optional compression, =LISTEN=/=NOTIFY= through the shell, type traits for messages. |
@@ -62,7 +62,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                     | State | Start |        End | Theme                                                                    |
+| Story                     | State | Start |        End | Description |
 |---------------------------+-------+-------+------------+--------------------------------------------------------------------------|
 | [[id:818B6261-1780-4FB3-AA89-DA02C91DA363][Currencies history polish]] | DONE  |       | 2025-12-20 | visual distinction for the active version, revert action, country flags. |
 | [[id:72F723F4-378C-4E0A-B6F1-6BA3C29F5BEA][Qt UX polish]]              | DONE  |       | 2025-12-22 | account management UI, exit confirmation, relative-time formatting.      |
@@ -72,7 +72,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                  | State | Start |        End | Theme                                                           |
+| Story                  | State | Start |        End | Description |
 |------------------------+-------+-------+------------+-----------------------------------------------------------------|
 | [[id:A5060B3B-A3C0-40FF-B5D3-36ED1E74B609][Sprint 07 housekeeping]] | DONE  |       | 2025-12-30 | recurring per-sprint chores: backlog, AI summary, notebook OCR. |
 

--- a/doc/agile/versions/v0/sprint_07/sprint.org
+++ b/doc/agile/versions/v0/sprint_07/sprint.org
@@ -39,18 +39,32 @@ telemetry as first-class components, and tidy the build platform.
 
 * Stories
 
+** Infrastructure
+
 #+ATTR_HTML: :class hug-leading
 | Story                                                                    | State | Start      | End        | Theme                                                                                |
 |--------------------------------------------------------------------------+-------+------------+------------+--------------------------------------------------------------------------------------|
-| [[id:A5060B3B-A3C0-40FF-B5D3-36ED1E74B609][Sprint 07 housekeeping]]      | DONE  |            | 2025-12-30 | recurring per-sprint chores: backlog, AI summary, notebook OCR.                      |
 | [[id:BB39ECBD-1EA5-4D53-A117-A0C88E0463C1][Build platform follow-up]]    | DONE  |            | 2025-12-18 | WSL setup, prebuilt Qt, Windows clang build breaks. Continues from sprint 04.        |
-| [[id:818B6261-1780-4FB3-AA89-DA02C91DA363][Currencies history polish]]   | DONE  |            | 2025-12-20 | visual distinction for the active version, revert action, country flags.             |
-| [[id:72F723F4-378C-4E0A-B6F1-6BA3C29F5BEA][Qt UX polish]]                | DONE  |            | 2025-12-22 | account management UI, exit confirmation, relative-time formatting.                  |
 | [[id:B306F938-F939-44CA-9D69-6FAEDBF91C08][Comms features]]              | DONE  |            | 2025-12-25 | optional compression, =LISTEN=/=NOTIFY= through the shell, type traits for messages. |
-| [[id:6B57C190-4BB7-4F63-BF3D-7FB6D81D8D94][Accounts to IAM]]             | DONE  |            | 2025-12-25 | rename =ores.accounts= to =ores.iam=, add lock, password reset, sign-up.             |
-| [[id:6255BC9F-95BC-4FC7-98C8-6060B8679B85][Roles and permissions]]       | DONE  |            | 2025-12-28 | RBAC core, enforcement, Qt UI.                                                       |
 | [[id:8C4C8429-9328-46DD-88EF-27689FB556F2][Observability and telemetry]] | DONE  |            | 2025-12-28 | new components, MaxMind replacement.                                                 |
 | [[id:DB625C07-811A-4A61-8DE8-910B29913744][Wt and HTTP introduction]]    | DONE  |            | 2025-12-30 | Wt scaffolding, HTTP entry point.                                                    |
+
+** Product
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                    | State | Start      | End        | Theme                                                                    |
+|--------------------------------------------------------------------------+-------+------------+------------+--------------------------------------------------------------------------|
+| [[id:818B6261-1780-4FB3-AA89-DA02C91DA363][Currencies history polish]]   | DONE  |            | 2025-12-20 | visual distinction for the active version, revert action, country flags. |
+| [[id:72F723F4-378C-4E0A-B6F1-6BA3C29F5BEA][Qt UX polish]]                | DONE  |            | 2025-12-22 | account management UI, exit confirmation, relative-time formatting.      |
+| [[id:6B57C190-4BB7-4F63-BF3D-7FB6D81D8D94][Accounts to IAM]]             | DONE  |            | 2025-12-25 | rename =ores.accounts= to =ores.iam=, add lock, password reset, sign-up. |
+| [[id:6255BC9F-95BC-4FC7-98C8-6060B8679B85][Roles and permissions]]       | DONE  |            | 2025-12-28 | RBAC core, enforcement, Qt UI.                                           |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                    | State | Start      | End        | Theme                                                           |
+|--------------------------------------------------------------------------+-------+------------+------------+-----------------------------------------------------------------|
+| [[id:A5060B3B-A3C0-40FF-B5D3-36ED1E74B609][Sprint 07 housekeeping]]      | DONE  |            | 2025-12-30 | recurring per-sprint chores: backlog, AI summary, notebook OCR. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_07/sprint.org
+++ b/doc/agile/versions/v0/sprint_07/sprint.org
@@ -24,47 +24,52 @@ telemetry as first-class components, and tidy the build platform.
 
 * Status
 
-| Field          | Value                                                  |
-|----------------+--------------------------------------------------------|
-| State          | DONE                                                   |
-| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]] |
-| Previous       | [[id:06CB9D8B-92D5-4C51-A1D7-B73B22EB93E8][Sprint 06]] |
-| Start          | 2025-12-13                                             |
-| End (expected) | 2025-12-30                                             |
-| Now            | Sprint closed 2025-12-30.                              |
-| Waiting on     | Nothing.                                               |
-| Next           | [[id:49C4E380-68EE-4D80-839A-41311A99C734][Sprint 08]] |
-| Release Notes  | [[id:596C2583-C27B-4570-885B-808C227D6911][Release notes]]                                                      |
-| Last touched   | 2025-12-30                                             |
+| Field          | Value         |
+|----------------+---------------|
+| State          | DONE          |
+| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]]     |
+| Previous       | [[id:06CB9D8B-92D5-4C51-A1D7-B73B22EB93E8][Sprint 06]]     |
+| Start          | 2025-12-13    |
+| End (expected) | 2025-12-30    |
+| Now            | Nothing.      |
+| Waiting on     | Nothing.      |
+| Next           | [[id:49C4E380-68EE-4D80-839A-41311A99C734][Sprint 08]]     |
+| Release Notes  | [[id:596C2583-C27B-4570-885B-808C227D6911][Release notes]] |
+| Last touched   | 2025-12-30    |
+
+** Achievements
+
 
 * Stories
+
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
 
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                    | State | Start      | End        | Theme                                                                                |
-|--------------------------------------------------------------------------+-------+------------+------------+--------------------------------------------------------------------------------------|
-| [[id:BB39ECBD-1EA5-4D53-A117-A0C88E0463C1][Build platform follow-up]]    | DONE  |            | 2025-12-18 | WSL setup, prebuilt Qt, Windows clang build breaks. Continues from sprint 04.        |
-| [[id:B306F938-F939-44CA-9D69-6FAEDBF91C08][Comms features]]              | DONE  |            | 2025-12-25 | optional compression, =LISTEN=/=NOTIFY= through the shell, type traits for messages. |
-| [[id:8C4C8429-9328-46DD-88EF-27689FB556F2][Observability and telemetry]] | DONE  |            | 2025-12-28 | new components, MaxMind replacement.                                                 |
-| [[id:DB625C07-811A-4A61-8DE8-910B29913744][Wt and HTTP introduction]]    | DONE  |            | 2025-12-30 | Wt scaffolding, HTTP entry point.                                                    |
+| Story                       | State | Start |        End | Theme                                                                                |
+|-----------------------------+-------+-------+------------+--------------------------------------------------------------------------------------|
+| [[id:BB39ECBD-1EA5-4D53-A117-A0C88E0463C1][Build platform follow-up]]    | DONE  |       | 2025-12-18 | WSL setup, prebuilt Qt, Windows clang build breaks. Continues from sprint 04.        |
+| [[id:B306F938-F939-44CA-9D69-6FAEDBF91C08][Comms features]]              | DONE  |       | 2025-12-25 | optional compression, =LISTEN=/=NOTIFY= through the shell, type traits for messages. |
+| [[id:8C4C8429-9328-46DD-88EF-27689FB556F2][Observability and telemetry]] | DONE  |       | 2025-12-28 | new components, MaxMind replacement.                                                 |
+| [[id:DB625C07-811A-4A61-8DE8-910B29913744][Wt and HTTP introduction]]    | DONE  |       | 2025-12-30 | Wt scaffolding, HTTP entry point.                                                    |
 
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                    | State | Start      | End        | Theme                                                                    |
-|--------------------------------------------------------------------------+-------+------------+------------+--------------------------------------------------------------------------|
-| [[id:818B6261-1780-4FB3-AA89-DA02C91DA363][Currencies history polish]]   | DONE  |            | 2025-12-20 | visual distinction for the active version, revert action, country flags. |
-| [[id:72F723F4-378C-4E0A-B6F1-6BA3C29F5BEA][Qt UX polish]]                | DONE  |            | 2025-12-22 | account management UI, exit confirmation, relative-time formatting.      |
-| [[id:6B57C190-4BB7-4F63-BF3D-7FB6D81D8D94][Accounts to IAM]]             | DONE  |            | 2025-12-25 | rename =ores.accounts= to =ores.iam=, add lock, password reset, sign-up. |
-| [[id:6255BC9F-95BC-4FC7-98C8-6060B8679B85][Roles and permissions]]       | DONE  |            | 2025-12-28 | RBAC core, enforcement, Qt UI.                                           |
+| Story                     | State | Start |        End | Theme                                                                    |
+|---------------------------+-------+-------+------------+--------------------------------------------------------------------------|
+| [[id:818B6261-1780-4FB3-AA89-DA02C91DA363][Currencies history polish]] | DONE  |       | 2025-12-20 | visual distinction for the active version, revert action, country flags. |
+| [[id:72F723F4-378C-4E0A-B6F1-6BA3C29F5BEA][Qt UX polish]]              | DONE  |       | 2025-12-22 | account management UI, exit confirmation, relative-time formatting.      |
+| [[id:6B57C190-4BB7-4F63-BF3D-7FB6D81D8D94][Accounts to IAM]]           | DONE  |       | 2025-12-25 | rename =ores.accounts= to =ores.iam=, add lock, password reset, sign-up. |
+| [[id:6255BC9F-95BC-4FC7-98C8-6060B8679B85][Roles and permissions]]     | DONE  |       | 2025-12-28 | RBAC core, enforcement, Qt UI.                                           |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                    | State | Start      | End        | Theme                                                           |
-|--------------------------------------------------------------------------+-------+------------+------------+-----------------------------------------------------------------|
-| [[id:A5060B3B-A3C0-40FF-B5D3-36ED1E74B609][Sprint 07 housekeeping]]      | DONE  |            | 2025-12-30 | recurring per-sprint chores: backlog, AI summary, notebook OCR. |
+| Story                  | State | Start |        End | Theme                                                           |
+|------------------------+-------+-------+------------+-----------------------------------------------------------------|
+| [[id:A5060B3B-A3C0-40FF-B5D3-36ED1E74B609][Sprint 07 housekeeping]] | DONE  |       | 2025-12-30 | recurring per-sprint chores: backlog, AI summary, notebook OCR. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_08/sprint.org
+++ b/doc/agile/versions/v0/sprint_08/sprint.org
@@ -39,6 +39,15 @@ skills to make the next entity cheaper.
 | Release Notes  | [[id:67E62E6F-F85E-48E1-8099-4E6AE3E0872B][Release notes]]                                                                                                        |
 | Last touched   | 2026-01-11                                                                                               |
 
+** Achievements
+
+- Countries landed as the first proper reference-data entity end-to-end.
+- Database schema and seeding overhauled; TimescaleDB tier detection in place.
+- Native pagination adopted across list views (sqlgen 0.6.0).
+- Change management infrastructure landed: reason codes with UI.
+- Entity-creator skills suite extended to Qt, shell, HTTP, Wt, and CLI surfaces.
+- Wt/HTTP validated and documented as the second presentation tier.
+
 * Stories
 
 For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].

--- a/doc/agile/versions/v0/sprint_08/sprint.org
+++ b/doc/agile/versions/v0/sprint_08/sprint.org
@@ -41,6 +41,8 @@ skills to make the next entity cheaper.
 
 * Stories
 
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
+
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading

--- a/doc/agile/versions/v0/sprint_08/sprint.org
+++ b/doc/agile/versions/v0/sprint_08/sprint.org
@@ -41,20 +41,40 @@ skills to make the next entity cheaper.
 
 * Stories
 
+** Infrastructure
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                             | State   | Start      | End        | Theme                                                                                    |
+|-----------------------------------------------------------------------------------+---------+------------+------------+------------------------------------------------------------------------------------------|
+| [[id:42E6C351-795F-48AA-A435-EB3D1C9B6704][Database schema and seeding overhaul]] | DONE    |            | 2025-12-31 | rerun SQL from scratch with TimescaleDB tier detection; remove code seeders.             |
+| [[id:DA77FB50-27E8-4B42-A826-CAB289C7826E][Comms substrate evolution]]            | DONE    |            | 2026-01-11 | composable options, rename =ores.shell= → =ores.comms.shell=, dynamic channel discovery. |
+| [[id:40D153E3-4A87-44B6-B605-1E3E28A44D03][Native pagination support]]            | DONE    |            | 2026-01-07 | adopt sqlgen 0.6.0.                                                                      |
+| [[id:13FBE901-B255-49F7-88C3-13B2A2506BF3][Wt and HTTP review]]                   | DONE    |            | 2026-01-06 | validate the sprint-07 surfaces; document the HTTP service.                              |
+| [[id:150E3C44-AADB-48C8-A11E-322B44A0357A][Change management infrastructure]]     | DONE    |            | 2026-01-11 | reasons base + UI.                                                                       |
+| [[id:CD9E9D04-44D2-4D0D-95CE-719D55C40DA4][Observability follow-up]]              | BACKLOG |            |            | review pass only; three implementation tasks carry forward.                              |
+
+** Product
+
 #+ATTR_HTML: :class hug-leading
 | Story                                                                             | State   | Start      | End        | Theme                                                                                      |
 |-----------------------------------------------------------------------------------+---------+------------+------------+--------------------------------------------------------------------------------------------|
-| [[id:F40E0162-A092-4716-A256-206FDBA93452][Sprint 08 housekeeping]]               | DONE    |            | 2026-01-11 | backlog refinement, OCR scans; AI summary deferred.                                        |
-| [[id:42E6C351-795F-48AA-A435-EB3D1C9B6704][Database schema and seeding overhaul]] | DONE    |            | 2025-12-31 | rerun SQL from scratch with TimescaleDB tier detection; remove code seeders.               |
 | [[id:CB564C6A-F248-4740-8D1C-A1BE148CE576][Qt UX polish]]                         | DONE    |            | 2026-01-11 | validate holiday features; assorted dialog fixes; log-viewer UI; accounts polish deferred. |
-| [[id:DA77FB50-27E8-4B42-A826-CAB289C7826E][Comms substrate evolution]]            | DONE    |            | 2026-01-11 | composable options, rename =ores.shell= → =ores.comms.shell=, dynamic channel discovery.   |
-| [[id:40D153E3-4A87-44B6-B605-1E3E28A44D03][Native pagination support]]            | DONE    |            | 2026-01-07 | adopt sqlgen 0.6.0.                                                                        |
-| [[id:13FBE901-B255-49F7-88C3-13B2A2506BF3][Wt and HTTP review]]                   | DONE    |            | 2026-01-06 | validate the sprint-07 surfaces; document the HTTP service.                                |
-| [[id:150E3C44-AADB-48C8-A11E-322B44A0357A][Change management infrastructure]]     | DONE    |            | 2026-01-11 | reasons base + UI.                                                                         |
 | [[id:501C05B5-AA7F-4807-A4F2-627B857CE2AA][Reference data: countries]]            | DONE    |            | 2026-01-11 | first proper refdata entity, end-to-end.                                                   |
-| [[id:B302B2B6-13F8-49CC-A6AF-88418668BE31][Entity-creator skills suite]]          | DONE    |            | 2026-01-11 | Qt, shell, HTTP (incl. recipes), Wt, CLI.                                                  |
 | [[id:77211166-9316-40C0-88D6-C92F983A00B5][Books domain modelling analysis]]      | DONE    |            | 2026-01-11 | strategic next-modelling effort.                                                           |
-| [[id:CD9E9D04-44D2-4D0D-95CE-719D55C40DA4][Observability follow-up]]              | BACKLOG |            |            | review pass only; three implementation tasks carry forward.                                |
+
+** LLMs
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                             | State   | Start      | End        | Theme                                     |
+|-----------------------------------------------------------------------------------+---------+------------+------------+-------------------------------------------|
+| [[id:B302B2B6-13F8-49CC-A6AF-88418668BE31][Entity-creator skills suite]]          | DONE    |            | 2026-01-11 | Qt, shell, HTTP (incl. recipes), Wt, CLI. |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                             | State   | Start      | End        | Theme                                               |
+|-----------------------------------------------------------------------------------+---------+------------+------------+-----------------------------------------------------|
+| [[id:F40E0162-A092-4716-A256-206FDBA93452][Sprint 08 housekeeping]]               | DONE    |            | 2026-01-11 | backlog refinement, OCR scans; AI summary deferred. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_08/sprint.org
+++ b/doc/agile/versions/v0/sprint_08/sprint.org
@@ -55,7 +55,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                             | State   | Start      | End        | Theme                                                                                    |
+| Story                                                                             | State   | Start      | End        | Description |
 |-----------------------------------------------------------------------------------+---------+------------+------------+------------------------------------------------------------------------------------------|
 | [[id:42E6C351-795F-48AA-A435-EB3D1C9B6704][Database schema and seeding overhaul]] | DONE    |            | 2025-12-31 | rerun SQL from scratch with TimescaleDB tier detection; remove code seeders.             |
 | [[id:DA77FB50-27E8-4B42-A826-CAB289C7826E][Comms substrate evolution]]            | DONE    |            | 2026-01-11 | composable options, rename =ores.shell= → =ores.comms.shell=, dynamic channel discovery. |
@@ -67,7 +67,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                             | State   | Start      | End        | Theme                                                                                      |
+| Story                                                                             | State   | Start      | End        | Description |
 |-----------------------------------------------------------------------------------+---------+------------+------------+--------------------------------------------------------------------------------------------|
 | [[id:CB564C6A-F248-4740-8D1C-A1BE148CE576][Qt UX polish]]                         | DONE    |            | 2026-01-11 | validate holiday features; assorted dialog fixes; log-viewer UI; accounts polish deferred. |
 | [[id:501C05B5-AA7F-4807-A4F2-627B857CE2AA][Reference data: countries]]            | DONE    |            | 2026-01-11 | first proper refdata entity, end-to-end.                                                   |
@@ -76,14 +76,14 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** LLMs
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                             | State   | Start      | End        | Theme                                     |
+| Story                                                                             | State   | Start      | End        | Description |
 |-----------------------------------------------------------------------------------+---------+------------+------------+-------------------------------------------|
 | [[id:B302B2B6-13F8-49CC-A6AF-88418668BE31][Entity-creator skills suite]]          | DONE    |            | 2026-01-11 | Qt, shell, HTTP (incl. recipes), Wt, CLI. |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                             | State   | Start      | End        | Theme                                               |
+| Story                                                                             | State   | Start      | End        | Description |
 |-----------------------------------------------------------------------------------+---------+------------+------------+-----------------------------------------------------|
 | [[id:F40E0162-A092-4716-A256-206FDBA93452][Sprint 08 housekeeping]]               | DONE    |            | 2026-01-11 | backlog refinement, OCR scans; AI summary deferred. |
 

--- a/doc/agile/versions/v0/sprint_09/sprint.org
+++ b/doc/agile/versions/v0/sprint_09/sprint.org
@@ -44,18 +44,38 @@ coverage of the entities that landed in earlier sprints.
 
 * Stories
 
+** Infrastructure
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                  | State   | Start      | End        | Theme                                                                                |
+|----------------------------------------------------------------------------------------+---------+------------+------------+--------------------------------------------------------------------------------------|
+| [[id:E7DDB653-CEAA-4922-B0F9-8BD5393A747E][Engineering hygiene]]                       | DONE    |            | 2026-01-14 | model refresh + pr-manager skill + valgrind fixes; documentation refactor postponed. |
+| [[id:8C29B0E8-64EA-4F32-ADD0-59419769BCD4][Security module]]                           | DONE    |            | 2026-01-13 | ores.security with RAII OpenSSL.                                                     |
+| [[id:AACC71E6-3DEE-47D2-B77C-E0B4847260BD][Connection management]]                     | DONE    |            | 2026-01-15 | ores.connections + Connection Browser MDI + modernised login dialog.                 |
+| [[id:61485635-64BA-4C31-A35B-2F60D7FB41AA][Database naming refactor]]                  | DONE    |            | 2026-01-14 | ores.risk → ores.refdata; =<component>_<entity>_<suffix>= across the schema.         |
+
+** Product
+
 #+ATTR_HTML: :class hug-leading
 | Story                                                                                  | State   | Start      | End        | Theme                                                                                   |
 |----------------------------------------------------------------------------------------+---------+------------+------------+-----------------------------------------------------------------------------------------|
-| [[id:1E7A8ABC-1ABC-4A37-BDCE-1D8DFB9D21FF][Sprint 09 housekeeping]]                    | DONE    |            | 2026-01-20 | backlog + OCR.                                                                          |
-| [[id:09A8D544-22F3-491A-82A9-306B1AA7C756][CLI entity coverage]]                       | DONE    |            | 2026-01-12 | list/delete commands for the five entities the CLI was missing; helper-driven refactor. |
-| [[id:E7DDB653-CEAA-4922-B0F9-8BD5393A747E][Engineering hygiene]]                       | DONE    |            | 2026-01-14 | model refresh + pr-manager skill + valgrind fixes; documentation refactor postponed.    |
-| [[id:8C29B0E8-64EA-4F32-ADD0-59419769BCD4][Security module]]                           | DONE    |            | 2026-01-13 | ores.security with RAII OpenSSL.                                                        |
-| [[id:AACC71E6-3DEE-47D2-B77C-E0B4847260BD][Connection management]]                     | DONE    |            | 2026-01-15 | ores.connections + Connection Browser MDI + modernised login dialog.                    |
-| [[id:61485635-64BA-4C31-A35B-2F60D7FB41AA][Database naming refactor]]                  | DONE    |            | 2026-01-14 | ores.risk → ores.refdata; =<component>_<entity>_<suffix>= across the schema.            |
 | [[id:3579AB5E-D5D8-45AE-8CB5-00AD1C58644F][Data Quality subsystem and Data Librarian]] | DONE    |            | 2026-01-20 | the flagship of the sprint.                                                             |
 | [[id:ABD80EC4-E7E4-4BB2-B5AE-4FC7F8C46FD3][Qt visual refresh]]                         | DONE    |            | 2026-01-20 | icon-enum + theme refactor.                                                             |
 | [[id:EF555D10-3FD3-4928-8E43-E63284D7706F][Party database groundwork]]                 | BACKLOG |            |            | table structure only; postponed.                                                        |
+
+** Tooling
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                  | State   | Start      | End        | Theme                                                                                   |
+|----------------------------------------------------------------------------------------+---------+------------+------------+-----------------------------------------------------------------------------------------|
+| [[id:09A8D544-22F3-491A-82A9-306B1AA7C756][CLI entity coverage]]                       | DONE    |            | 2026-01-12 | list/delete commands for the five entities the CLI was missing; helper-driven refactor. |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                  | State   | Start      | End        | Theme          |
+|----------------------------------------------------------------------------------------+---------+------------+------------+----------------|
+| [[id:1E7A8ABC-1ABC-4A37-BDCE-1D8DFB9D21FF][Sprint 09 housekeeping]]                    | DONE    |            | 2026-01-20 | backlog + OCR. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_09/sprint.org
+++ b/doc/agile/versions/v0/sprint_09/sprint.org
@@ -42,6 +42,15 @@ coverage of the entities that landed in earlier sprints.
 | Release Notes  | [[id:B366C8FE-240E-493D-8D18-747BE840870A][Release notes]]                                                                                                                                                          |
 | Last touched   | 2026-01-20                                                                                                                                                 |
 
+** Achievements
+
+- Data Quality subsystem and Data Librarian established as flagship features.
+- ores.security module introduced with RAII OpenSSL.
+- Connection management (ores.connections) live with Connection Browser MDI.
+- Database renamed ores.risk → ores.refdata; consistent component_entity naming enforced.
+- CLI list/delete coverage extended to five entities.
+- Qt icon-enum and theme refactored for consistent visual identity.
+
 * Stories
 
 For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].

--- a/doc/agile/versions/v0/sprint_09/sprint.org
+++ b/doc/agile/versions/v0/sprint_09/sprint.org
@@ -58,7 +58,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                  | State   | Start      | End        | Theme                                                                                |
+| Story                                                                                  | State   | Start      | End        | Description |
 |----------------------------------------------------------------------------------------+---------+------------+------------+--------------------------------------------------------------------------------------|
 | [[id:E7DDB653-CEAA-4922-B0F9-8BD5393A747E][Engineering hygiene]]                       | DONE    |            | 2026-01-14 | model refresh + pr-manager skill + valgrind fixes; documentation refactor postponed. |
 | [[id:8C29B0E8-64EA-4F32-ADD0-59419769BCD4][Security module]]                           | DONE    |            | 2026-01-13 | ores.security with RAII OpenSSL.                                                     |
@@ -68,7 +68,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                  | State   | Start      | End        | Theme                                                                                   |
+| Story                                                                                  | State   | Start      | End        | Description |
 |----------------------------------------------------------------------------------------+---------+------------+------------+-----------------------------------------------------------------------------------------|
 | [[id:3579AB5E-D5D8-45AE-8CB5-00AD1C58644F][Data Quality subsystem and Data Librarian]] | DONE    |            | 2026-01-20 | the flagship of the sprint.                                                             |
 | [[id:ABD80EC4-E7E4-4BB2-B5AE-4FC7F8C46FD3][Qt visual refresh]]                         | DONE    |            | 2026-01-20 | icon-enum + theme refactor.                                                             |
@@ -77,14 +77,14 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Tooling
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                  | State   | Start      | End        | Theme                                                                                   |
+| Story                                                                                  | State   | Start      | End        | Description |
 |----------------------------------------------------------------------------------------+---------+------------+------------+-----------------------------------------------------------------------------------------|
 | [[id:09A8D544-22F3-491A-82A9-306B1AA7C756][CLI entity coverage]]                       | DONE    |            | 2026-01-12 | list/delete commands for the five entities the CLI was missing; helper-driven refactor. |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                  | State   | Start      | End        | Theme          |
+| Story                                                                                  | State   | Start      | End        | Description |
 |----------------------------------------------------------------------------------------+---------+------------+------------+----------------|
 | [[id:1E7A8ABC-1ABC-4A37-BDCE-1D8DFB9D21FF][Sprint 09 housekeeping]]                    | DONE    |            | 2026-01-20 | backlog + OCR. |
 

--- a/doc/agile/versions/v0/sprint_09/sprint.org
+++ b/doc/agile/versions/v0/sprint_09/sprint.org
@@ -44,6 +44,8 @@ coverage of the entities that landed in earlier sprints.
 
 * Stories
 
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
+
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading

--- a/doc/agile/versions/v0/sprint_10/sprint.org
+++ b/doc/agile/versions/v0/sprint_10/sprint.org
@@ -57,14 +57,14 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                              | State   | Start      | End        | Theme                                                 |
+| Story                                                                              | State   | Start      | End        | Description |
 |------------------------------------------------------------------------------------+---------+------------+------------+-------------------------------------------------------|
 | [[id:5BAFBEB2-C875-4655-BB78-801A3BF65022][Schema polish]]                         | DONE    |            | 2026-01-26 | layer cleanup, rounding types, icon labels, mapping artefact. |
 
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                              | State   | Start      | End        | Theme                                                                                                               |
+| Story                                                                              | State   | Start      | End        | Description |
 |------------------------------------------------------------------------------------+---------+------------+------------+---------------------------------------------------------------------------------------------------------------------|
 | [[id:700D4325-2AD1-4E0D-B6AF-900ABBE1A66E][Party schemes and FPML reference data]] | DONE    |            | 2026-01-23 | 13 types via FpML codegen + DQ artefact workflow; GLEIF subset. Continues from sprint 09 party-database groundwork. |
 | [[id:2A572D8A-644C-40D9-87D2-7A49A9C07D1B][Image cache polish]]                    | DONE    |            | 2026-01-23 | reload on new datasets; incremental loading via =modified_since=.                                                   |
@@ -77,7 +77,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Tooling
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                              | State   | Start      | End        | Theme                                                                            |
+| Story                                                                              | State   | Start      | End        | Description |
 |------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------|
 | [[id:49A3B815-B5E9-4B3D-9213-100BF96C266D][Codegen infrastructure]]                | DONE    |            | 2026-01-24 | simple in-tree codegen; domain-types SQL; ER diagram from SQL.                   |
 | [[id:38B6DDDF-C02B-4072-B599-41AB3BCC9C28][SQL directory refactor]]                | DONE    |            | 2026-01-24 | create/, drop/, populate/ by component; safer teardown; admin naming convention. |
@@ -85,14 +85,14 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Documentation
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                              | State   | Start      | End        | Theme                                                                       |
+| Story                                                                              | State   | Start      | End        | Description |
 |------------------------------------------------------------------------------------+---------+------------+------------+-----------------------------------------------------------------------------|
 | [[id:EBC22454-356D-4B6C-A3BE-E8EDFD858FCA][External data reorganisation]]          | DONE    |            | 2026-01-24 | domain-specific subdirectories + manifests; coding schemes via DQ pipeline. |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                              | State   | Start      | End        | Theme                            |
+| Story                                                                              | State   | Start      | End        | Description |
 |------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------|
 | [[id:61F6AB0B-BB2E-43E7-9735-447A7E3D55DE][Sprint 10 housekeeping]]                | DONE    |            | 2026-01-27 | backlog + OCR + misspell-CI fix. |
 

--- a/doc/agile/versions/v0/sprint_10/sprint.org
+++ b/doc/agile/versions/v0/sprint_10/sprint.org
@@ -43,6 +43,8 @@ Wizard that uses them.
 
 * Stories
 
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
+
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading

--- a/doc/agile/versions/v0/sprint_10/sprint.org
+++ b/doc/agile/versions/v0/sprint_10/sprint.org
@@ -43,21 +43,47 @@ Wizard that uses them.
 
 * Stories
 
+** Infrastructure
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                              | State   | Start      | End        | Theme                                                 |
+|------------------------------------------------------------------------------------+---------+------------+------------+-------------------------------------------------------|
+| [[id:5BAFBEB2-C875-4655-BB78-801A3BF65022][Schema polish]]                         | DONE    |            | 2026-01-26 | layer cleanup, rounding types, icon labels, mapping artefact. |
+
+** Product
+
 #+ATTR_HTML: :class hug-leading
 | Story                                                                              | State   | Start      | End        | Theme                                                                                                               |
 |------------------------------------------------------------------------------------+---------+------------+------------+---------------------------------------------------------------------------------------------------------------------|
-| [[id:61F6AB0B-BB2E-43E7-9735-447A7E3D55DE][Sprint 10 housekeeping]]                | DONE    |            | 2026-01-27 | backlog + OCR + misspell-CI fix.                                                                                    |
-| [[id:49A3B815-B5E9-4B3D-9213-100BF96C266D][Codegen infrastructure]]                | DONE    |            | 2026-01-24 | simple in-tree codegen; domain-types SQL; ER diagram from SQL.                                                      |
 | [[id:700D4325-2AD1-4E0D-B6AF-900ABBE1A66E][Party schemes and FPML reference data]] | DONE    |            | 2026-01-23 | 13 types via FpML codegen + DQ artefact workflow; GLEIF subset. Continues from sprint 09 party-database groundwork. |
 | [[id:2A572D8A-644C-40D9-87D2-7A49A9C07D1B][Image cache polish]]                    | DONE    |            | 2026-01-23 | reload on new datasets; incremental loading via =modified_since=.                                                   |
-| [[id:EBC22454-356D-4B6C-A3BE-E8EDFD858FCA][External data reorganisation]]          | DONE    |            | 2026-01-24 | domain-specific subdirectories + manifests; coding schemes via DQ pipeline.                                         |
-| [[id:38B6DDDF-C02B-4072-B599-41AB3BCC9C28][SQL directory refactor]]                | DONE    |            | 2026-01-24 | create/, drop/, populate/ by component; safer teardown; admin naming convention.                                    |
 | [[id:A1571428-C1BD-4FD1-9434-21CE5B1A6154][ORE XML codegen]]                       | DONE    |            | 2026-01-27 | =ores.ore= + xsdcpp + Windows MSVC fix.                                                                             |
-| [[id:5BAFBEB2-C875-4655-BB78-801A3BF65022][Schema polish]]                         | DONE    |            | 2026-01-26 | layer cleanup, rounding types, icon labels, mapping artefact.                                                       |
 | [[id:2D3D3854-748E-4DF7-8BBE-E6498C598C2D][Dataset bundles and provisioning]]      | DONE    |            | 2026-01-27 | metadata/production schema split, bundles, System Provisioner Wizard.                                               |
 | [[id:75442A55-DBBB-4BC1-875E-981679E05621][Librarian polish]]                      | DONE    |            | 2026-01-27 | sprint-09 PR-review fix-up.                                                                                         |
 | [[id:4C7782D0-1382-4FED-A9F3-C209A45CAF7E][FPML export and import groundwork]]     | BACKLOG |            |            | =ores.fpml= scaffolded; export/import postponed.                                                                    |
 | [[id:85F8DC6C-1ACD-4610-A877-B0FDBA871254][Compute grid analysis (BOINC-based)]]   | BACKLOG |            |            | design pass; implementation deferred.                                                                               |
+
+** Tooling
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                              | State   | Start      | End        | Theme                                                                            |
+|------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------|
+| [[id:49A3B815-B5E9-4B3D-9213-100BF96C266D][Codegen infrastructure]]                | DONE    |            | 2026-01-24 | simple in-tree codegen; domain-types SQL; ER diagram from SQL.                   |
+| [[id:38B6DDDF-C02B-4072-B599-41AB3BCC9C28][SQL directory refactor]]                | DONE    |            | 2026-01-24 | create/, drop/, populate/ by component; safer teardown; admin naming convention. |
+
+** Documentation
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                              | State   | Start      | End        | Theme                                                                       |
+|------------------------------------------------------------------------------------+---------+------------+------------+-----------------------------------------------------------------------------|
+| [[id:EBC22454-356D-4B6C-A3BE-E8EDFD858FCA][External data reorganisation]]          | DONE    |            | 2026-01-24 | domain-specific subdirectories + manifests; coding schemes via DQ pipeline. |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                              | State   | Start      | End        | Theme                            |
+|------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------|
+| [[id:61F6AB0B-BB2E-43E7-9735-447A7E3D55DE][Sprint 10 housekeeping]]                | DONE    |            | 2026-01-27 | backlog + OCR + misspell-CI fix. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_10/sprint.org
+++ b/doc/agile/versions/v0/sprint_10/sprint.org
@@ -41,6 +41,15 @@ Wizard that uses them.
 | Release Notes  | [[id:ECB9453A-BBAB-4EA0-993F-862E7899DFC7][Release notes]]                                                                                                                             |
 | Last touched   | 2026-01-27                                                                                                                    |
 
+** Achievements
+
+- ORE XML codegen established (ores.ore + xsdcpp; MSVC-compatible).
+- 13 FPML party-scheme types generated via the new party codegen path.
+- Dataset bundles and System Provisioner Wizard landed.
+- In-tree codegen infrastructure with domain-types SQL and ER diagram generation.
+- SQL directory reorganised into create/, drop/, populate/ per component.
+- Metadata/production schema split established.
+
 * Stories
 
 For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].

--- a/doc/agile/versions/v0/sprint_11/sprint.org
+++ b/doc/agile/versions/v0/sprint_11/sprint.org
@@ -43,6 +43,8 @@ metadata, eventing).
 
 * Stories
 
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
+
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading

--- a/doc/agile/versions/v0/sprint_11/sprint.org
+++ b/doc/agile/versions/v0/sprint_11/sprint.org
@@ -41,6 +41,15 @@ metadata, eventing).
 | Release Notes  | [[id:B0269759-8AB2-4856-8EAD-B1E57C0AB7FB][Release notes]]                                                                                                                             |
 | Last touched   | 2026-02-06                                                                                                                    |
 
+** Achievements
+
+- Multi-tenant architecture established end-to-end: schema, seeding, RLS, and per-request context.
+- Each test isolated in its own tenant via tenancy-based test isolation.
+- Telemetry database sink introduced (ores.telemetry.database).
+- Service accounts and audit trail with performed_by stamping across all mutations.
+- sqlgen improved with libpq audit and upstream bound-params work.
+- Tenancy validated and enforced across shell, librarian, DQ, and eventing surfaces.
+
 * Stories
 
 For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].

--- a/doc/agile/versions/v0/sprint_11/sprint.org
+++ b/doc/agile/versions/v0/sprint_11/sprint.org
@@ -57,7 +57,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                     | State | Start      | End        | Theme                                                               |
+| Story                                                                                     | State | Start      | End        | Description |
 |-------------------------------------------------------------------------------------------+-------+------------+------------+---------------------------------------------------------------------|
 | [[id:0A69CB02-19DF-4DF7-BEDD-81C57A604737][Engineering hygiene]]                          | DONE  |            | 2026-02-06 | past review comments; apt-get retry; vcpkg cache fix.               |
 | [[id:B726D4EA-4E80-4D54-A5CC-0CD895CE883C][Database role split and schema consolidation]] | DONE  |            | 2026-01-31 | preconditions: RBAC, single public schema, SQL tree tidy-up.        |
@@ -72,14 +72,14 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Tooling
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                     | State | Start      | End        | Theme                                             |
+| Story                                                                                     | State | Start      | End        | Description |
 |-------------------------------------------------------------------------------------------+-------+------------+------------+---------------------------------------------------|
 | [[id:18CCF6C9-7D23-48B3-9D4D-2A8AEB4EE30D][sqlgen improvements]]                          | DONE  |            | 2026-02-06 | libpq audit; upstream notice + bound-params work. |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                     | State | Start      | End        | Theme           |
+| Story                                                                                     | State | Start      | End        | Description |
 |-------------------------------------------------------------------------------------------+-------+------------+------------+-----------------|
 | [[id:572C63F9-9A87-40FB-8609-8D4D7C1CCD39][Sprint 11 housekeeping]]                       | DONE  |            | 2026-02-06 | backlog + OCR.  |
 

--- a/doc/agile/versions/v0/sprint_11/sprint.org
+++ b/doc/agile/versions/v0/sprint_11/sprint.org
@@ -43,20 +43,34 @@ metadata, eventing).
 
 * Stories
 
+** Infrastructure
+
 #+ATTR_HTML: :class hug-leading
 | Story                                                                                     | State | Start      | End        | Theme                                                               |
 |-------------------------------------------------------------------------------------------+-------+------------+------------+---------------------------------------------------------------------|
-| [[id:572C63F9-9A87-40FB-8609-8D4D7C1CCD39][Sprint 11 housekeeping]]                       | DONE  |            | 2026-02-06 | backlog + OCR.                                                      |
 | [[id:0A69CB02-19DF-4DF7-BEDD-81C57A604737][Engineering hygiene]]                          | DONE  |            | 2026-02-06 | past review comments; apt-get retry; vcpkg cache fix.               |
 | [[id:B726D4EA-4E80-4D54-A5CC-0CD895CE883C][Database role split and schema consolidation]] | DONE  |            | 2026-01-31 | preconditions: RBAC, single public schema, SQL tree tidy-up.        |
 | [[id:F6748DA4-E8D7-48B6-B91F-BC05E68F53D8][Tenancy foundation]]                           | DONE  |            | 2026-02-01 | schema, seeding, login/test plumbing.                               |
 | [[id:1EFF8C9C-E4C2-49CC-A563-BB91923EC406][Tenancy-based test isolation]]                 | DONE  |            | 2026-02-01 | tenant_context service, per-test tenants, RLS.                      |
 | [[id:467E909E-CEAC-4829-8688-D43179D38F18][Tenancy codegen and entity types]]             | DONE  |            | 2026-02-03 | Mustache templates, pgTAP, C++ tenant entities, protocol bump 26.1. |
-| [[id:18CCF6C9-7D23-48B3-9D4D-2A8AEB4EE30D][sqlgen improvements]]                          | DONE  |            | 2026-02-06 | libpq audit; upstream notice + bound-params work.                   |
 | [[id:2920A00E-538D-455E-9013-44A1C3A7ED36][Telemetry database sink]]                      | DONE  |            | 2026-02-03 | ores.telemetry.database; test logging; three-tier tenant lifecycle. |
 | [[id:B23BFD60-4604-4D43-92B3-3EF3E1D5DBE6][Service accounts and audit]]                   | DONE  |            | 2026-02-04 | account_type + performed_by audit field + telemetry deadlock fix.   |
 | [[id:976A2745-6728-435E-970E-D1205D46DC7A][Per-request tenant context]]                   | DONE  |            | 2026-02-06 | security fix; tenant_id wrapper; system tenant nil → max UUID.      |
 | [[id:52BBEA16-0344-4299-88BA-EC6A341FBD21][Validate tenancy across surfaces]]             | DONE  |            | 2026-02-06 | shell, librarian, DQ metadata, eventing.                            |
+
+** Tooling
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                     | State | Start      | End        | Theme                                             |
+|-------------------------------------------------------------------------------------------+-------+------------+------------+---------------------------------------------------|
+| [[id:18CCF6C9-7D23-48B3-9D4D-2A8AEB4EE30D][sqlgen improvements]]                          | DONE  |            | 2026-02-06 | libpq audit; upstream notice + bound-params work. |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                     | State | Start      | End        | Theme           |
+|-------------------------------------------------------------------------------------------+-------+------------+------------+-----------------|
+| [[id:572C63F9-9A87-40FB-8609-8D4D7C1CCD39][Sprint 11 housekeeping]]                       | DONE  |            | 2026-02-06 | backlog + OCR.  |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_12/sprint.org
+++ b/doc/agile/versions/v0/sprint_12/sprint.org
@@ -43,29 +43,49 @@ out the largest v0 sprint to date.
 
 * Stories
 
+** Infrastructure
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                            | State   | Start      | End        | Theme                                                                              |
+|--------------------------------------------------------------------------------------------------+---------+------------+------------+------------------------------------------------------------------------------------|
+| [[id:4CE5CC79-DC9B-491F-A8F7-F635DE33D55A][Test coverage and FK-aware generators]]               | DONE    |            | 2026-02-11 | back over 50% coverage; KVP-context proposal sown.                                 |
+| [[id:74A0B830-2F12-406F-9550-961098C11DC6][Infrastructure cleanup]]                              | DONE    |            | 2026-02-12 | merge databases away; OSX CI back.                                                 |
+| [[id:C431B464-A3BC-4D9C-B33A-7C5B247EBEA4][Party-level RLS isolation]]                           | DONE    |            | 2026-02-15 | second RLS layer; visible party set; party_counterparties as first scoped junction. |
+| [[id:2901CE42-268C-4ADE-A3E4-CF6E01B8668E][Audit trail and system account]]                      | DONE    |            | 2026-02-17 | modified_by vs performed_by; system account; KVP generation context.               |
+| [[id:C8C45097-7420-438D-9026-6BEC0285CD66][Caching analysis]]                                    | BACKLOG |            |            | POSTPONED.                                                                         |
+
+** Product
+
 #+ATTR_HTML: :class hug-leading
 | Story                                                                                            | State   | Start      | End        | Theme                                                                                                                      |
 |--------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------------------------------|
-| [[id:8F521A37-BEC0-469E-AF32-87DF684DE3B2][Sprint 12 housekeeping]]                              | DONE    |            | 2026-02-20 | backlog + OCR.                                                                                                             |
-| [[id:E8004B20-AE81-4D48-A677-CDE07A300E92][sqlgen follow-up]]                                    | ?       |            |            | BLOCKED on vcpkg.                                                                                                          |
 | [[id:5B48D17B-F510-4458-8FB9-95832F9782C2][Qt and eventing polish]]                              | DONE    |            | 2026-02-10 | shell widget; name-based roles; several small fixes.                                                                       |
-| [[id:4CE5CC79-DC9B-491F-A8F7-F635DE33D55A][Test coverage and FK-aware generators]]               | DONE    |            | 2026-02-11 | back over 50% coverage; KVP-context proposal sown.                                                                         |
-| [[id:74A0B830-2F12-406F-9550-961098C11DC6][Infrastructure cleanup]]                              | DONE    |            | 2026-02-12 | merge databases away; OSX CI back.                                                                                         |
 | [[id:76D84778-4544-4EE6-A17A-033019DBACB0][Party database and domain]]                           | DONE    |            | 2026-02-09 | implement party + counterparty + identifier + contact-info end-to-end. Continues from sprint 09 party_database_groundwork. |
 | [[id:253CE971-C0F3-43C3-980C-276233250B86][GLEIF data integration]]                              | DONE    |            | 2026-02-13 | datasets, central banks, LEI-to-BIC. Continues from sprint 10 party_schemes_and_fpml_data.                                 |
 | [[id:D0E2FB0D-24F0-4FA4-A403-872E01E60FB6][Multi-party brainstorm and short codes]]              | DONE    |            | 2026-02-14 | design + pagination + mnemonic short codes + identifier split.                                                             |
 | [[id:AF7112BA-BF04-4B6B-AE2F-8FB1C7B362FE][Counterparty pagination and polish]]                  | DONE    |            | 2026-02-14 | pagination, business centres, identifier cardinality.                                                                      |
 | [[id:D40D5971-C864-4449-91AD-CA8AB949A4A6][System and customer party]]                           | DONE    |            | 2026-02-11 | Internal type + WRLD BC; optional dataset members.                                                                         |
 | [[id:00E6E192-A255-4C94-8FCC-15826F7E33AE][Tenant administration]]                               | DONE    |            | 2026-02-12 | party_types lookup; RLS-aware test provisioning; tenant-type rename; CLI; Super Admin.                                     |
-| [[id:C431B464-A3BC-4D9C-B33A-7C5B247EBEA4][Party-level RLS isolation]]                           | DONE    |            | 2026-02-15 | second RLS layer; visible party set; party_counterparties as first scoped junction.                                        |
-| [[id:2901CE42-268C-4ADE-A3E4-CF6E01B8668E][Audit trail and system account]]                      | DONE    |            | 2026-02-17 | modified_by vs performed_by; system account; KVP generation context.                                                       |
 | [[id:EAF03BE3-D1EC-4EC4-B18B-4F1C6F35926A][Tenant provisioning wizards]]                         | DONE    |            | 2026-02-16 | root-party invariant; GLEIF + synthetic; gating; UX polish; first-login onboarding.                                        |
 | [[id:3AFC713A-754E-42DC-AE10-022AC1DFDABA][Entity modelling: books, portfolios, business units]] | DONE    |            | 2026-02-19 | modelling pass; business-centre coding scheme; portfolio impl.                                                             |
 | [[id:5886FFA7-170F-471C-A9DB-37996E650CB6][GLEIF evaluation wizard and party hierarchy]]         | DONE    |            | 2026-02-19 | wizard + graph viz.                                                                                                        |
 | [[id:84545FFF-58E6-4C97-821C-0D3BB0375F08][Advanced counterparty dialog]]                        | DONE    |            | 2026-02-19 | five-tab layout + strategy-pattern refactor.                                                                               |
 | [[id:6AAEA401-96A8-4027-8887-375B978771B3][Qt column handling centralisation]]                   | DONE    |            | 2026-02-19 | ColumnMetadata pattern across 24 list windows.                                                                             |
-| [[id:C8C45097-7420-438D-9026-6BEC0285CD66][Caching analysis]]                                    | BACKLOG |            |            | POSTPONED.                                                                                                                 |
 | [[id:BD4110C2-FDF7-47B0-A726-F4CD83DED8E5][FSM and trade support]]                               | DONE    |            | 2026-02-20 | generic Postgres FSM + trade envelope; ores.trade → ores.trading rename.                                                   |
+
+** Tooling
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                            | State   | Start      | End        | Theme                     |
+|--------------------------------------------------------------------------------------------------+---------+------------+------------+---------------------------|
+| [[id:E8004B20-AE81-4D48-A677-CDE07A300E92][sqlgen follow-up]]                                    | ?       |            |            | BLOCKED on vcpkg.         |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                            | State   | Start      | End        | Theme           |
+|--------------------------------------------------------------------------------------------------+---------+------------+------------+-----------------|
+| [[id:8F521A37-BEC0-469E-AF32-87DF684DE3B2][Sprint 12 housekeeping]]                              | DONE    |            | 2026-02-20 | backlog + OCR.  |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_12/sprint.org
+++ b/doc/agile/versions/v0/sprint_12/sprint.org
@@ -43,6 +43,8 @@ out the largest v0 sprint to date.
 
 * Stories
 
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
+
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading

--- a/doc/agile/versions/v0/sprint_12/sprint.org
+++ b/doc/agile/versions/v0/sprint_12/sprint.org
@@ -41,6 +41,15 @@ out the largest v0 sprint to date.
 | Release Notes  | [[id:79707B34-5D13-49AC-89B3-A993C96779C8][Release notes]]                                                                                                                                                                                               |
 | Last touched   | 2026-02-20                                                                                                                                                                                      |
 
+** Achievements
+
+- Party and counterparty domain established end-to-end with RLS isolation.
+- GLEIF data integrated: datasets, central banks, LEI-to-BIC, provisioning wizards, and hierarchy graph.
+- FSM and trade envelope landed; component renamed ores.trade → ores.trading.
+- Books, portfolios, and business units modelled.
+- Five-tab advanced counterparty dialog and Qt column handling centralised across 24 list windows.
+- Multi-tenant provisioning wizards with root-party invariant and GLEIF/synthetic paths.
+
 * Stories
 
 For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].

--- a/doc/agile/versions/v0/sprint_12/sprint.org
+++ b/doc/agile/versions/v0/sprint_12/sprint.org
@@ -57,7 +57,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                            | State   | Start      | End        | Theme                                                                              |
+| Story                                                                                            | State   | Start      | End        | Description |
 |--------------------------------------------------------------------------------------------------+---------+------------+------------+------------------------------------------------------------------------------------|
 | [[id:4CE5CC79-DC9B-491F-A8F7-F635DE33D55A][Test coverage and FK-aware generators]]               | DONE    |            | 2026-02-11 | back over 50% coverage; KVP-context proposal sown.                                 |
 | [[id:74A0B830-2F12-406F-9550-961098C11DC6][Infrastructure cleanup]]                              | DONE    |            | 2026-02-12 | merge databases away; OSX CI back.                                                 |
@@ -68,7 +68,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                            | State   | Start      | End        | Theme                                                                                                                      |
+| Story                                                                                            | State   | Start      | End        | Description |
 |--------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------------------------------|
 | [[id:5B48D17B-F510-4458-8FB9-95832F9782C2][Qt and eventing polish]]                              | DONE    |            | 2026-02-10 | shell widget; name-based roles; several small fixes.                                                                       |
 | [[id:76D84778-4544-4EE6-A17A-033019DBACB0][Party database and domain]]                           | DONE    |            | 2026-02-09 | implement party + counterparty + identifier + contact-info end-to-end. Continues from sprint 09 party_database_groundwork. |
@@ -87,14 +87,14 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Tooling
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                            | State   | Start      | End        | Theme                     |
+| Story                                                                                            | State   | Start      | End        | Description |
 |--------------------------------------------------------------------------------------------------+---------+------------+------------+---------------------------|
 | [[id:E8004B20-AE81-4D48-A677-CDE07A300E92][sqlgen follow-up]]                                    | ?       |            |            | BLOCKED on vcpkg.         |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                            | State   | Start      | End        | Theme           |
+| Story                                                                                            | State   | Start      | End        | Description |
 |--------------------------------------------------------------------------------------------------+---------+------------+------------+-----------------|
 | [[id:8F521A37-BEC0-469E-AF32-87DF684DE3B2][Sprint 12 housekeeping]]                              | DONE    |            | 2026-02-20 | backlog + OCR.  |
 

--- a/doc/agile/versions/v0/sprint_13/sprint.org
+++ b/doc/agile/versions/v0/sprint_13/sprint.org
@@ -44,18 +44,25 @@ portfolios / trades.
 
 * Stories
 
+** Infrastructure
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                        | State   | Start      | End        | Theme                                                             |
+|----------------------------------------------------------------------------------------------+---------+------------+------------+-------------------------------------------------------------------|
+| [[id:7B926ACE-57F6-414D-8F3E-568175041F87][Provenance and actor]]                            | DONE    |            | 2026-02-21 | performed_by / modified_by stamping tightened; current_actor GUC. |
+| [[id:6F799AF2-9844-4CB6-9E9C-A57C06ECBF23][Session telemetry plotting]]                      | DONE    |            | 2026-02-22 | RTT + bytes hypertable + QChartView.                              |
+| [[id:DF3B299E-7FED-4411-B257-125ED35C3A9E][Party isolation for books / portfolios / trades]] | DONE    |            | 2026-02-24 | RLS extended.                                                     |
+
+** Product
+
 #+ATTR_HTML: :class hug-leading
 | Story                                                                                        | State   | Start      | End        | Theme                                                                         |
 |----------------------------------------------------------------------------------------------+---------+------------+------------+-------------------------------------------------------------------------------|
-| [[id:90161BF2-67F0-4542-899C-5D844A3F6F95][Sprint 13 housekeeping]]                          | DONE    |            | 2026-02-24 | backlog + two-step release notes.                                             |
 | [[id:6AC2981B-BA0A-4916-A2C1-6B5A816A9148][FSM consolidation into DQ]]                       | DONE    |            | 2026-02-20 | moves FSM under DQ. Continues from sprint 12 fsm_and_trade_support.           |
 | [[id:EC6D8E8D-4421-412A-9331-9BBA5B542D54][Detail dialogs modernisation]]                    | DONE    |            | 2026-02-25 | tabbed dialogs + toolbar removal.                                             |
-| [[id:7B926ACE-57F6-414D-8F3E-568175041F87][Provenance and actor]]                            | DONE    |            | 2026-02-21 | performed_by / modified_by stamping tightened; current_actor GUC.             |
-| [[id:6F799AF2-9844-4CB6-9E9C-A57C06ECBF23][Session telemetry plotting]]                      | DONE    |            | 2026-02-22 | RTT + bytes hypertable + QChartView.                                          |
 | [[id:956FCD0E-41C3-46E4-9895-B64B4C143E6D][Account-party management and login]]              | DONE    |            | 2026-02-23 | multi-party login picker. Continues from sprint 12 party_level_rls_isolation. |
 | [[id:7AE49D47-624C-41C6-8C07-CDBEB71D85EC][Refdata taxonomy work]]                           | DONE    |            | 2026-02-24 | rounding type, currency taxonomy split, asset-class naming.                   |
 | [[id:19EE14C8-952D-42D6-9AE1-ECEA45A5EFCF][Business centre polish]]                          | DONE    |            | 2026-02-22 | city_name + flag fixes.                                                       |
-| [[id:DF3B299E-7FED-4411-B257-125ED35C3A9E][Party isolation for books / portfolios / trades]] | DONE    |            | 2026-02-24 | RLS extended.                                                                 |
 | [[id:EE315A6F-8933-4738-AE3F-E63CBBF57F03][Connection browser environments]]                 | DONE    |            | 2026-02-24 | environment + connection split.                                               |
 | [[id:8A04DE16-6BDD-4696-9F04-122C92692D59][Portfolio explorer]]                              | DONE    |            | 2026-02-25 | combined tree + trade table.                                                  |
 | [[id:68C577A4-B33E-47CB-953F-F3D90A4440D6][Trade import mapping analysis]]                   | DONE    |            | 2026-02-25 | design pass.                                                                  |
@@ -63,6 +70,13 @@ portfolios / trades.
 | [[id:A0B6C877-2FAD-457A-B0C2-000D3F707A5B][Scheduling subsystem]]                            | DONE    |            | 2026-02-27 | protocol + lib + queue.                                                       |
 | [[id:0251593A-0D85-49C4-AEE1-7AAC673978B7][Batch operations]]                                | DONE    |            | 2026-02-28 | atomic save + delete.                                                         |
 | [[id:241A6DE6-8978-4DAF-A052-7E1CF06A8FC8][Party-level refdata restrictions]]                | BACKLOG |            |            | BACKLOG framework only.                                                       |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                        | State   | Start      | End        | Theme                             |
+|----------------------------------------------------------------------------------------------+---------+------------+------------+-----------------------------------|
+| [[id:90161BF2-67F0-4542-899C-5D844A3F6F95][Sprint 13 housekeeping]]                          | DONE    |            | 2026-02-24 | backlog + two-step release notes. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_13/sprint.org
+++ b/doc/agile/versions/v0/sprint_13/sprint.org
@@ -58,7 +58,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                        | State   | Start      | End        | Theme                                                             |
+| Story                                                                                        | State   | Start      | End        | Description |
 |----------------------------------------------------------------------------------------------+---------+------------+------------+-------------------------------------------------------------------|
 | [[id:7B926ACE-57F6-414D-8F3E-568175041F87][Provenance and actor]]                            | DONE    |            | 2026-02-21 | performed_by / modified_by stamping tightened; current_actor GUC. |
 | [[id:6F799AF2-9844-4CB6-9E9C-A57C06ECBF23][Session telemetry plotting]]                      | DONE    |            | 2026-02-22 | RTT + bytes hypertable + QChartView.                              |
@@ -67,7 +67,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                        | State   | Start      | End        | Theme                                                                         |
+| Story                                                                                        | State   | Start      | End        | Description |
 |----------------------------------------------------------------------------------------------+---------+------------+------------+-------------------------------------------------------------------------------|
 | [[id:6AC2981B-BA0A-4916-A2C1-6B5A816A9148][FSM consolidation into DQ]]                       | DONE    |            | 2026-02-20 | moves FSM under DQ. Continues from sprint 12 fsm_and_trade_support.           |
 | [[id:EC6D8E8D-4421-412A-9331-9BBA5B542D54][Detail dialogs modernisation]]                    | DONE    |            | 2026-02-25 | tabbed dialogs + toolbar removal.                                             |
@@ -85,7 +85,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                        | State   | Start      | End        | Theme                             |
+| Story                                                                                        | State   | Start      | End        | Description |
 |----------------------------------------------------------------------------------------------+---------+------------+------------+-----------------------------------|
 | [[id:90161BF2-67F0-4542-899C-5D844A3F6F95][Sprint 13 housekeeping]]                          | DONE    |            | 2026-02-24 | backlog + two-step release notes. |
 

--- a/doc/agile/versions/v0/sprint_13/sprint.org
+++ b/doc/agile/versions/v0/sprint_13/sprint.org
@@ -44,6 +44,8 @@ portfolios / trades.
 
 * Stories
 
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
+
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading

--- a/doc/agile/versions/v0/sprint_13/sprint.org
+++ b/doc/agile/versions/v0/sprint_13/sprint.org
@@ -42,6 +42,15 @@ portfolios / trades.
 | Release Notes  | [[id:0B0A8BDA-2DB1-4222-825E-493B1D5A68F0][Release notes]]                                                                                                                                                                   |
 | Last touched   | 2026-02-28                                                                                                                                                          |
 
+** Achievements
+
+- Scheduling subsystem landed: protocol, library, and queue.
+- Multi-party login picker and account-party management live.
+- FSM consolidated into DQ; portfolio explorer combining tree and trade table.
+- Tabbed dialog pattern adopted across all detail dialogs.
+- RLS extended to books, portfolios, and trades.
+- Batch operations (atomic save and delete) and session telemetry plotting established.
+
 * Stories
 
 For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].

--- a/doc/agile/versions/v0/sprint_14/sprint.org
+++ b/doc/agile/versions/v0/sprint_14/sprint.org
@@ -45,22 +45,42 @@ ORE Import Wizard, CMake preset suffixes.
 
 * Stories
 
+** Infrastructure
+
 #+ATTR_HTML: :class hug-leading
 | Story                                                                                     | State   | Start      | End        | Theme                                                                                          |
 |-------------------------------------------------------------------------------------------+---------+------------+------------+------------------------------------------------------------------------------------------------|
-| [[id:7DCF008E-33A5-4493-8FF2-ABE1E7D78053][Sprint 14 housekeeping]]                       | DONE    |            | 2026-03-12 | backlog refinement.                                                                            |
-| [[id:F80BAD05-2E66-458D-9223-1DB0A83EF694][ORE import wizard]]                            | DONE    |            | 2026-03-01 | seven-page directory-scan wizard. Continues from sprint 13 trade_import_analysis.              |
-| [[id:84559B48-546B-4724-BDD0-53DBFCA2C24A][Reporting subsystem]]                          | DONE    |            | 2026-03-03 | design + schema + domain + messaging + repo + Qt UI with cron widget.                          |
-| [[id:86927EBE-880C-42E4-8C94-E4705C4A622A][Trade status FSM]]                             | DONE    |            | 2026-03-02 | status FSM + activity_type taxonomy.                                                           |
-| [[id:4D9869DA-72CE-4B92-BB19-91C274CA7A2B][CLI domain layer]]                             | DONE    |            | 2026-03-03 | domain sub-menu in CLI syntax.                                                                 |
 | [[id:7B45BE68-3970-4657-B2A3-F24151156AC7][pgmq queue management and messaging UI]]       | DONE    |            | 2026-03-03 | first MQ UI.                                                                                   |
 | [[id:ED082D5A-4AFB-4BF9-81DB-8712F881DDE3][Custom MQ tables and in-process scheduler]]    | DONE    |            | 2026-03-04 | replace external extensions. Continues from sprint 13 scheduling_subsystem.                    |
-| [[id:9C57D467-3F17-469A-A245-5F57E6B20784][Party codename]]                               | DONE    |            | 2026-03-12 | adjective_noun + two race-condition fixes.                                                     |
 | [[id:1DE357FF-7139-49FD-BC97-B30CD095EF53][JWT RS256 in ores.security]]                   | DONE    |            | 2026-03-04 | centralised JWT with RS256.                                                                    |
 | [[id:55BF0070-33C2-4F1D-986F-A787138942F6][NNG message broker attempt]]                   | DONE    |            | 2026-03-12 | partially built; hook-up cancelled in favour of NATS.                                          |
 | [[id:05CBD9FA-B1F2-4B53-8F83-2952A892C94D][CMake preset build-tool suffixes]]             | DONE    |            | 2026-03-10 | explicit Ninja / Make naming.                                                                  |
 | [[id:23D1F2BB-D2D3-423A-8167-657098E30542][NATS migration]]                               | DONE    |            | 2026-03-18 | the pivot. Binary protocol replaced with NATS request/reply + JetStream; 10 services migrated. |
-| [[id:05CFEF69-F80B-437F-AEEE-3881E4FE96F1][Trade import mapping dialog (second attempt)]] | BACKLOG |            |            | BACKLOG; postponed again. Continues from sprint 13 trade_import_dialog.                        |
+
+** Product
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                     | State   | Start      | End        | Theme                                                                             |
+|-------------------------------------------------------------------------------------------+---------+------------+------------+-----------------------------------------------------------------------------------|
+| [[id:F80BAD05-2E66-458D-9223-1DB0A83EF694][ORE import wizard]]                            | DONE    |            | 2026-03-01 | seven-page directory-scan wizard. Continues from sprint 13 trade_import_analysis. |
+| [[id:84559B48-546B-4724-BDD0-53DBFCA2C24A][Reporting subsystem]]                          | DONE    |            | 2026-03-03 | design + schema + domain + messaging + repo + Qt UI with cron widget.             |
+| [[id:86927EBE-880C-42E4-8C94-E4705C4A622A][Trade status FSM]]                             | DONE    |            | 2026-03-02 | status FSM + activity_type taxonomy.                                              |
+| [[id:9C57D467-3F17-469A-A245-5F57E6B20784][Party codename]]                               | DONE    |            | 2026-03-12 | adjective_noun + two race-condition fixes.                                        |
+| [[id:05CFEF69-F80B-437F-AEEE-3881E4FE96F1][Trade import mapping dialog (second attempt)]] | BACKLOG |            |            | BACKLOG; postponed again. Continues from sprint 13 trade_import_dialog.           |
+
+** Tooling
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                     | State   | Start      | End        | Theme                              |
+|-------------------------------------------------------------------------------------------+---------+------------+------------+------------------------------------|
+| [[id:4D9869DA-72CE-4B92-BB19-91C274CA7A2B][CLI domain layer]]                             | DONE    |            | 2026-03-03 | domain sub-menu in CLI syntax.     |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                     | State   | Start      | End        | Theme               |
+|-------------------------------------------------------------------------------------------+---------+------------+------------+---------------------|
+| [[id:7DCF008E-33A5-4493-8FF2-ABE1E7D78053][Sprint 14 housekeeping]]                       | DONE    |            | 2026-03-12 | backlog refinement. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_14/sprint.org
+++ b/doc/agile/versions/v0/sprint_14/sprint.org
@@ -43,6 +43,15 @@ ORE Import Wizard, CMake preset suffixes.
 | Release Notes  | [[id:0875ADA0-D41A-4A2E-94A3-9E51CB78FD96][Release notes]]                                                                                                                                                                                            |
 | Last touched   | 2026-03-19                                                                                                                                                                                   |
 
+** Achievements
+
+- NATS adopted as the messaging substrate; 10 services migrated from binary protocol.
+- ORE Import Wizard landed: seven-page directory-scan wizard.
+- Reporting subsystem complete: schema, domain, messaging, repo, and Qt UI.
+- JWT RS256 centralised in ores.security.
+- Trade status FSM and activity_type taxonomy established.
+- CLI domain layer introduced.
+
 * Stories
 
 For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].

--- a/doc/agile/versions/v0/sprint_14/sprint.org
+++ b/doc/agile/versions/v0/sprint_14/sprint.org
@@ -45,6 +45,8 @@ ORE Import Wizard, CMake preset suffixes.
 
 * Stories
 
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
+
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading

--- a/doc/agile/versions/v0/sprint_14/sprint.org
+++ b/doc/agile/versions/v0/sprint_14/sprint.org
@@ -59,7 +59,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                     | State   | Start      | End        | Theme                                                                                          |
+| Story                                                                                     | State   | Start      | End        | Description |
 |-------------------------------------------------------------------------------------------+---------+------------+------------+------------------------------------------------------------------------------------------------|
 | [[id:7B45BE68-3970-4657-B2A3-F24151156AC7][pgmq queue management and messaging UI]]       | DONE    |            | 2026-03-03 | first MQ UI.                                                                                   |
 | [[id:ED082D5A-4AFB-4BF9-81DB-8712F881DDE3][Custom MQ tables and in-process scheduler]]    | DONE    |            | 2026-03-04 | replace external extensions. Continues from sprint 13 scheduling_subsystem.                    |
@@ -71,7 +71,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                     | State   | Start      | End        | Theme                                                                             |
+| Story                                                                                     | State   | Start      | End        | Description |
 |-------------------------------------------------------------------------------------------+---------+------------+------------+-----------------------------------------------------------------------------------|
 | [[id:F80BAD05-2E66-458D-9223-1DB0A83EF694][ORE import wizard]]                            | DONE    |            | 2026-03-01 | seven-page directory-scan wizard. Continues from sprint 13 trade_import_analysis. |
 | [[id:84559B48-546B-4724-BDD0-53DBFCA2C24A][Reporting subsystem]]                          | DONE    |            | 2026-03-03 | design + schema + domain + messaging + repo + Qt UI with cron widget.             |
@@ -82,14 +82,14 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Tooling
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                     | State   | Start      | End        | Theme                              |
+| Story                                                                                     | State   | Start      | End        | Description |
 |-------------------------------------------------------------------------------------------+---------+------------+------------+------------------------------------|
 | [[id:4D9869DA-72CE-4B92-BB19-91C274CA7A2B][CLI domain layer]]                             | DONE    |            | 2026-03-03 | domain sub-menu in CLI syntax.     |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                     | State   | Start      | End        | Theme               |
+| Story                                                                                     | State   | Start      | End        | Description |
 |-------------------------------------------------------------------------------------------+---------+------------+------------+---------------------|
 | [[id:7DCF008E-33A5-4493-8FF2-ABE1E7D78053][Sprint 14 housekeeping]]                       | DONE    |            | 2026-03-12 | backlog refinement. |
 

--- a/doc/agile/versions/v0/sprint_15/sprint.org
+++ b/doc/agile/versions/v0/sprint_15/sprint.org
@@ -42,6 +42,15 @@ FX, bond, credit).
 | Release Notes  | [[id:39CDAA48-85B3-4E2E-9519-3BD44C3B7AEB][Release notes]]                                                             |
 | Last touched   | 2026-03-30                                                    |
 
+** Achievements
+
+- Compute grid (BOINC-inspired) implemented, observed, and polished end-to-end.
+- API/core architecture split: 10 service libraries refactored into =*.api= + =*.core=.
+- CDM instrument domain models for rates, FX, credit, and bond.
+- ORE import bugs fixed under real-data conditions.
+- PostgreSQL roles environment-isolated with prefixes.
+- =feature_flags= replaced by unified =system_settings=.
+
 * Stories
 
 For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].

--- a/doc/agile/versions/v0/sprint_15/sprint.org
+++ b/doc/agile/versions/v0/sprint_15/sprint.org
@@ -44,24 +44,38 @@ FX, bond, credit).
 
 * Stories
 
+** Infrastructure
+
 #+ATTR_HTML: :class hug-leading
 | Story                                                                                    | State | Start      | End        | Theme                                                                   |
 |------------------------------------------------------------------------------------------+-------+------------+------------+-------------------------------------------------------------------------|
-| [[id:DF3C08D8-A11E-4E2E-908A-5BD0DDC29626][Sprint 15 housekeeping]]                      | DONE  |            | 2026-03-24 | backlog refinement.                                                     |
-| [[id:FD12BBD4-BD95-454A-A636-5F22C928C4D1][Fix ORE import bugs]]                         | DONE  |            | 2026-03-19 | real-data shakedown of the sprint-14 wizard.                            |
-| [[id:7B5E0C11-8C1F-4D91-ADEA-2596197CD0D4][Loading indicator on entity list windows]]    | DONE  |            | 2026-03-20 | UI consistency.                                                         |
 | [[id:BFAC3A00-1684-4546-B10B-5BA358B5A867][Unified system_settings]]                     | DONE  |            | 2026-03-20 | replace feature_flags.                                                  |
-| [[id:3ED3CA4D-8709-4F70-A1A8-1FF287ADB8BF][Compute grid implementation]]                 | DONE  |            | 2026-03-21 | the sprint's mission. Continues from sprint 10 compute_grid_analysis.   |
 | [[id:679DA033-934A-4330-951F-5016675CC8AF][Compute grid observability]]                  | DONE  |            | 2026-03-21 | telemetry + RAG dashboard.                                              |
 | [[id:169B15A7-442B-44FD-8E54-436FEC8340A6][JWT refresh]]                                 | DONE  |            | 2026-03-21 | closes the loop on sprint-14 RS256.                                     |
-| [[id:0DCEDAE5-E5F0-4AF8-AE85-37C7618237A6][Compute grid polish and E2E fixes]]           | DONE  |            | 2026-03-26 | real-data testing + loading-lifecycle refactor.                         |
 | [[id:84FCA31B-B6A8-444F-9EA9-33515D50645F][NATS service discovery for HTTP base URL]]    | DONE  |            | 2026-03-22 | and the architecture migration plan.                                    |
 | [[id:7631C4D3-43C5-4238-A180-337BEA863C7F][API/core architecture migration]]             | DONE  |            | 2026-03-23 | 10 service libraries split into *.api + *.core.                         |
 | [[id:BC195CB4-4CBF-4D9D-8685-8CE3304DA3FE][Engineering hygiene]]                         | DONE  |            | 2026-03-25 | sccache cache bloat, tenant_id in tests, ORES_PRESET + start-client.sh. |
 | [[id:4837265A-934C-4CFC-9F7A-EDC3F86F37C6][Generators to api layer + http.server split]] | DONE  |            | 2026-03-25 | cross-cutting cleanup completing the migration.                         |
 | [[id:1AF340AA-FB79-4870-BC13-0DD2FC75AF2B][Environment isolation for database roles]]    | DONE  |            | 2026-03-25 | prefixed PostgreSQL roles.                                              |
-| [[id:F8E6374B-AAAF-4D50-98CE-844DA4558172][CDM instrument domain models]]                | DONE  |            | 2026-03-30 | rates / FX / credit / bond, in four phases.                             |
-| [[id:2AA3562A-9E27-4EFC-A2A0-492098F9EBBB][Badges to database (phase 1)]]                | DONE  |            | 2026-03-28 | DB-driven badge metadata.                                               |
+
+** Product
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                    | State | Start      | End        | Theme                                                                 |
+|------------------------------------------------------------------------------------------+-------+------------+------------+-----------------------------------------------------------------------|
+| [[id:FD12BBD4-BD95-454A-A636-5F22C928C4D1][Fix ORE import bugs]]                         | DONE  |            | 2026-03-19 | real-data shakedown of the sprint-14 wizard.                          |
+| [[id:7B5E0C11-8C1F-4D91-ADEA-2596197CD0D4][Loading indicator on entity list windows]]    | DONE  |            | 2026-03-20 | UI consistency.                                                       |
+| [[id:3ED3CA4D-8709-4F70-A1A8-1FF287ADB8BF][Compute grid implementation]]                 | DONE  |            | 2026-03-21 | the sprint's mission. Continues from sprint 10 compute_grid_analysis. |
+| [[id:0DCEDAE5-E5F0-4AF8-AE85-37C7618237A6][Compute grid polish and E2E fixes]]           | DONE  |            | 2026-03-26 | real-data testing + loading-lifecycle refactor.                       |
+| [[id:F8E6374B-AAAF-4D50-98CE-844DA4558172][CDM instrument domain models]]                | DONE  |            | 2026-03-30 | rates / FX / credit / bond, in four phases.                           |
+| [[id:2AA3562A-9E27-4EFC-A2A0-492098F9EBBB][Badges to database (phase 1)]]                | DONE  |            | 2026-03-28 | DB-driven badge metadata.                                             |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                    | State | Start      | End        | Theme               |
+|------------------------------------------------------------------------------------------+-------+------------+------------+---------------------|
+| [[id:DF3C08D8-A11E-4E2E-908A-5BD0DDC29626][Sprint 15 housekeeping]]                      | DONE  |            | 2026-03-24 | backlog refinement. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_15/sprint.org
+++ b/doc/agile/versions/v0/sprint_15/sprint.org
@@ -44,6 +44,8 @@ FX, bond, credit).
 
 * Stories
 
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
+
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading

--- a/doc/agile/versions/v0/sprint_15/sprint.org
+++ b/doc/agile/versions/v0/sprint_15/sprint.org
@@ -58,7 +58,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                    | State | Start      | End        | Theme                                                                   |
+| Story                                                                                    | State | Start      | End        | Description |
 |------------------------------------------------------------------------------------------+-------+------------+------------+-------------------------------------------------------------------------|
 | [[id:BFAC3A00-1684-4546-B10B-5BA358B5A867][Unified system_settings]]                     | DONE  |            | 2026-03-20 | replace feature_flags.                                                  |
 | [[id:679DA033-934A-4330-951F-5016675CC8AF][Compute grid observability]]                  | DONE  |            | 2026-03-21 | telemetry + RAG dashboard.                                              |
@@ -72,7 +72,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                    | State | Start      | End        | Theme                                                                 |
+| Story                                                                                    | State | Start      | End        | Description |
 |------------------------------------------------------------------------------------------+-------+------------+------------+-----------------------------------------------------------------------|
 | [[id:FD12BBD4-BD95-454A-A636-5F22C928C4D1][Fix ORE import bugs]]                         | DONE  |            | 2026-03-19 | real-data shakedown of the sprint-14 wizard.                          |
 | [[id:7B5E0C11-8C1F-4D91-ADEA-2596197CD0D4][Loading indicator on entity list windows]]    | DONE  |            | 2026-03-20 | UI consistency.                                                       |
@@ -84,7 +84,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                    | State | Start      | End        | Theme               |
+| Story                                                                                    | State | Start      | End        | Description |
 |------------------------------------------------------------------------------------------+-------+------------+------------+---------------------|
 | [[id:DF3C08D8-A11E-4E2E-908A-5BD0DDC29626][Sprint 15 housekeeping]]                      | DONE  |            | 2026-03-24 | backlog refinement. |
 

--- a/doc/agile/versions/v0/sprint_16/sprint.org
+++ b/doc/agile/versions/v0/sprint_16/sprint.org
@@ -51,6 +51,16 @@ The largest v0 sprint to date (157h, 89 tasks across 22 stories).
 | Release Notes  | [[id:88484BF4-AC03-4058-98DF-2D769C0D6223][Release notes]]                                                      |
 | Last touched   | 2026-04-17                                             |
 
+** Achievements
+
+- ORE import pipeline complete: dispatch pipeline, mappers for every instrument family, supporting files, and golden roundtrip tests.
+- Workflow engine established with generalised event-driven FSM and party provisioning saga.
+- Market data subsystem end-to-end: parser, schema, repo, service, and Qt UI.
+- Qt plugin architecture introduced with 7 domain plugins split from the monolith.
+- Service lifecycle controller with unified NATS heartbeat landed.
+- Reporting and analytics: DQ-sourced report definitions and pricing engine.
+- ~20 Windows portability fixes landed.
+
 * Stories
 
 For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].

--- a/doc/agile/versions/v0/sprint_16/sprint.org
+++ b/doc/agile/versions/v0/sprint_16/sprint.org
@@ -53,12 +53,26 @@ The largest v0 sprint to date (157h, 89 tasks across 22 stories).
 
 * Stories
 
+** Infrastructure
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                 | State | Start      | End        | Theme                                                                                           |
+|---------------------------------------------------------------------------------------+-------+------------+------------+-------------------------------------------------------------------------------------------------|
+| [[id:2FAF5366-2FED-4FBE-99F2-8CB46CA84AEB][Party isolation RLS policies]]             | DONE  |            | 2026-04-09 | close the gaps. Continues from sprint 13 party_isolation_books_portfolios_trades.               |
+| [[id:7399693E-F61B-4E3D-B37C-F53F3CE5A197][Generic object storage API]]               | DONE  |            | 2026-04-03 | ores.storage + compute grid migration.                                                          |
+| [[id:014352D4-AAA5-48E7-903D-C06B5B4F7D62][Service lifecycle controller]]             | DONE  |            | 2026-04-08 | ores.controller + unified NATS heartbeat. Continues from sprint 15 compute_grid_ observability. |
+| [[id:38C972E1-2DD2-41AE-A770-800FEE90D1E6][Qt plugin architecture]]                   | DONE  |            | 2026-04-09 | ores.qt.api + 7 domain plugins.                                                                 |
+| [[id:BA5268AF-DF0E-4338-A6CE-1D5F84E1166D][Nats-Session-Id]]                          | DONE  |            | 2026-04-01 | session-level correlation.                                                                      |
+| [[id:1997CCEF-3E2F-44C9-AB1C-9435A646BD61][UTC-everywhere timestamp policy]]          | DONE  |            | 2026-04-08 | canonical UTC API.                                                                              |
+| [[id:CEF64A10-082E-447F-8A39-F8F60D984F11][Windows portability fixes]]                | DONE  |            | 2026-04-11 | ~20 fixes surfaced by Windows builds.                                                           |
+| [[id:2C3A9E28-68DC-4BF1-8EB7-5C4379E5C248][Engineering hygiene]]                      | DONE  |            | 2026-04-07 | clock_cast, nodiscard, codegen profiles, menu repositioning.                                    |
+
+** Product
+
 #+ATTR_HTML: :class hug-leading
 | Story                                                                                 | State | Start      | End        | Theme                                                                                                                 |
 |---------------------------------------------------------------------------------------+-------+------------+------------+-----------------------------------------------------------------------------------------------------------------------|
-| [[id:C1DB4C7A-16D7-4289-A457-A6C6CE5C8B5C][Sprint 16 housekeeping]]                   | DONE  |            | 2026-04-17 | backlog refinement.                                                                                                   |
 | [[id:FFC60DB1-B82A-4C8A-961E-2C6720379508][Asset class and product_type unification]] | DONE  |            | 2026-04-03 | rename + analysis + implementation.                                                                                   |
-| [[id:2FAF5366-2FED-4FBE-99F2-8CB46CA84AEB][Party isolation RLS policies]]             | DONE  |            | 2026-04-09 | close the gaps. Continues from sprint 13 party_isolation_books_portfolios_trades.                                     |
 | [[id:4FCD03AC-51AD-47AD-8203-FAEFAA4211B9][Workflow engine]]                          | DONE  |            | 2026-04-06 | scaffold + FSM state UUIDs + generalised event-driven engine.                                                         |
 | [[id:C0ED556B-57A4-4BCE-9196-70BCF4FD0D63][Party provisioning saga]]                  | DONE  |            | 2026-03-31 | first concrete saga + UX.                                                                                             |
 | [[id:87599263-BD70-42CF-B653-0803E12F4D0B][Workflow monitor]]                         | DONE  |            | 2026-04-11 | Qt plugin + late fixes.                                                                                               |
@@ -67,17 +81,17 @@ The largest v0 sprint to date (157h, 89 tasks across 22 stories).
 | [[id:43F68B11-1870-46DB-BFC3-C5FBC83FE6CF][ORE golden roundtrip tests]]               | DONE  |            | 2026-03-31 | three test PRs.                                                                                                       |
 | [[id:FB0471F1-6BD2-4955-AC39-15D7800BB973][ORE portfolio export]]                     | DONE  |            | 2026-04-01 | exporter + Qt actions.                                                                                                |
 | [[id:47CE4C06-2C59-4B8B-89B3-232D04B2DA23][Market data subsystem]]                    | DONE  |            | 2026-04-01 | parser + schema + repo + service + Qt UI.                                                                             |
-| [[id:7399693E-F61B-4E3D-B37C-F53F3CE5A197][Generic object storage API]]               | DONE  |            | 2026-04-03 | ores.storage + compute grid migration.                                                                                |
 | [[id:08D2B499-53CE-4B1C-92CF-A7C26D036EC9][Reporting and analytics]]                  | DONE  |            | 2026-04-07 | DQ-sourced report defs + execution workflow + analytics pricing engine. Continues from sprint 14 reporting_subsystem. |
 | [[id:1490E130-08F9-4D43-8F80-D7E0F5022FBD][Trade detail dialog unification]]          | DONE  |            | 2026-04-07 | six instrument family merges + IInstrumentForm registry.                                                              |
 | [[id:CE26E56B-944F-4C89-B5A9-E0DABF521908][Per-type instrument tables]]               | DONE  |            | 2026-04-10 | rates / FX / equity. Continues from sprint 15 cdm_instruments.                                                        |
-| [[id:014352D4-AAA5-48E7-903D-C06B5B4F7D62][Service lifecycle controller]]             | DONE  |            | 2026-04-08 | ores.controller + unified NATS heartbeat. Continues from sprint 15 compute_grid_ observability.                       |
-| [[id:38C972E1-2DD2-41AE-A770-800FEE90D1E6][Qt plugin architecture]]                   | DONE  |            | 2026-04-09 | ores.qt.api + 7 domain plugins.                                                                                       |
 | [[id:2D496A77-5238-4B5B-8CC6-C61FC59FA9C1][Scheduler UI complete]]                    | DONE  |            | 2026-04-11 | Job Instances + Monitor.                                                                                              |
-| [[id:BA5268AF-DF0E-4338-A6CE-1D5F84E1166D][Nats-Session-Id]]                          | DONE  |            | 2026-04-01 | session-level correlation.                                                                                            |
-| [[id:1997CCEF-3E2F-44C9-AB1C-9435A646BD61][UTC-everywhere timestamp policy]]          | DONE  |            | 2026-04-08 | canonical UTC API.                                                                                                    |
-| [[id:CEF64A10-082E-447F-8A39-F8F60D984F11][Windows portability fixes]]                | DONE  |            | 2026-04-11 | ~20 fixes surfaced by Windows builds.                                                                                 |
-| [[id:2C3A9E28-68DC-4BF1-8EB7-5C4379E5C248][Engineering hygiene]]                      | DONE  |            | 2026-04-07 | clock_cast, nodiscard, codegen profiles, menu repositioning.                                                          |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                 | State | Start      | End        | Theme               |
+|---------------------------------------------------------------------------------------+-------+------------+------------+---------------------|
+| [[id:C1DB4C7A-16D7-4289-A457-A6C6CE5C8B5C][Sprint 16 housekeeping]]                   | DONE  |            | 2026-04-17 | backlog refinement. |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_16/sprint.org
+++ b/doc/agile/versions/v0/sprint_16/sprint.org
@@ -68,7 +68,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                 | State | Start      | End        | Theme                                                                                           |
+| Story                                                                                 | State | Start      | End        | Description |
 |---------------------------------------------------------------------------------------+-------+------------+------------+-------------------------------------------------------------------------------------------------|
 | [[id:2FAF5366-2FED-4FBE-99F2-8CB46CA84AEB][Party isolation RLS policies]]             | DONE  |            | 2026-04-09 | close the gaps. Continues from sprint 13 party_isolation_books_portfolios_trades.               |
 | [[id:7399693E-F61B-4E3D-B37C-F53F3CE5A197][Generic object storage API]]               | DONE  |            | 2026-04-03 | ores.storage + compute grid migration.                                                          |
@@ -82,7 +82,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                 | State | Start      | End        | Theme                                                                                                                 |
+| Story                                                                                 | State | Start      | End        | Description |
 |---------------------------------------------------------------------------------------+-------+------------+------------+-----------------------------------------------------------------------------------------------------------------------|
 | [[id:FFC60DB1-B82A-4C8A-961E-2C6720379508][Asset class and product_type unification]] | DONE  |            | 2026-04-03 | rename + analysis + implementation.                                                                                   |
 | [[id:4FCD03AC-51AD-47AD-8203-FAEFAA4211B9][Workflow engine]]                          | DONE  |            | 2026-04-06 | scaffold + FSM state UUIDs + generalised event-driven engine.                                                         |
@@ -101,7 +101,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                 | State | Start      | End        | Theme               |
+| Story                                                                                 | State | Start      | End        | Description |
 |---------------------------------------------------------------------------------------+-------+------------+------------+---------------------|
 | [[id:C1DB4C7A-16D7-4289-A457-A6C6CE5C8B5C][Sprint 16 housekeeping]]                   | DONE  |            | 2026-04-17 | backlog refinement. |
 

--- a/doc/agile/versions/v0/sprint_16/sprint.org
+++ b/doc/agile/versions/v0/sprint_16/sprint.org
@@ -53,6 +53,8 @@ The largest v0 sprint to date (157h, 89 tasks across 22 stories).
 
 * Stories
 
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
+
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading

--- a/doc/agile/versions/v0/sprint_17/sprint.org
+++ b/doc/agile/versions/v0/sprint_17/sprint.org
@@ -42,27 +42,53 @@ history to the v2 cybernetic information architecture.
 
 * Stories
 
+** Infrastructure
+
 #+ATTR_HTML: :class hug-leading
 | Story                                        | State |      Start |        End | Theme                                                                        |
 |----------------------------------------------+-------+------------+------------+------------------------------------------------------------------------------|
 | [[id:7D84E735-7DFE-4215-AF00-A1F4C9323BDA][Windows portability fixes]]                    | DONE  | 2026-04-18 | 2026-04-22 | WiX limits, libpq link, OpenSSL, PostgreSQL CMake target, vcpkg Qt feature.  |
 | [[id:FBE68713-40C1-4B1D-A228-1C55AB4ABC34][MSVC C1202 constexpr depth fixes]]             | DONE  | 2026-05-05 | 2026-05-21 | Trade struct decomposition + constexpr limit raises across all TUs.          |
 | [[id:32852964-D407-43A9-BD94-A6524BB73A8E][Symbol visibility migration]]                  | DONE  | 2026-05-14 | 2026-05-21 | -fvisibility=hidden; export macros; plugin isolation; static CLI/shell libs. |
-| [[id:00CCC0DC-200C-4951-81E0-6AA93B1503FC][FX forward E2E and equity per-type migration]] | DONE  | 2026-04-22 | 2026-05-01 | FX forward ORE import wired end-to-end; equity per-type tables completed.    |
-| [[id:F607B8CE-5D33-424F-A7C2-7ED0243D4728][ORE conventions import]]                       | DONE  | 2026-04-22 | 2026-05-11 | Seven convention types via codegen; deposit_convention; CLI import Phase 3.  |
-| [[id:66109AE6-1C44-405D-B4D6-08164C457C25][ORE domain roundtrip]]                         | DONE  | 2026-05-07 | 2026-05-08 | Roundtrip command + baseline + all four ORE XML document types.              |
-| [[id:E62BF8DD-FD3B-4283-A1A9-3FAF1F7A1703][Import/export cleanup]]                        | DONE  | 2026-05-02 | 2026-05-06 | Composite legs, pure parser, batch fetches, export_result wrappers.          |
 | [[id:E762DA90-B92A-41E1-AD4D-29018F17AF32][Strict service table isolation]]               | DONE  | 2026-05-14 | 2026-05-16 | SECURITY DEFINER validators; IAM party cache; dead DML grant removal.        |
-| [[id:25F0A34B-C547-4550-943B-E8F517EB0F6C][SQL codegen drift remediation]]                | DONE  | 2026-05-14 | 2026-05-17 | All remaining hand-crafted SQL replaced; profile dispatch fixed.             |
-| [[id:7030AB78-B8F1-425C-83EF-A6F9EBF218A8][Workflow engine hardening]]                    | DONE  | 2026-05-15 | 2026-05-19 | Package renames, error reporting, pg_notify fix, shutdown latency.           |
-| [[id:77BF049F-ED38-4998-AFA3-672E25895F9A][Workspace]]                                    | DONE  | 2026-05-19 | 2026-05-20 | Bitemporal schema, service, UI, codegen propagation, Data Workshop.          |
-| [[id:DC1EFFD8-B983-48C7-835B-71333AECE016][DQ publish pattern]]                           | DONE  | 2026-05-19 | 2026-05-20 | Publish-from-DQ wizard; async PublishDatasetsDialog; IAM logging.            |
-| [[id:E16BEABB-CC59-4D6C-B216-DACC1E922047][Compute and GLEIF]]                            | DONE  | 2026-04-18 | 2026-04-28 | GLEIF bundle wiring; per-triplet packages; per-platform uploads.             |
-| [[id:D148B46A-AD14-4391-8B64-46DCFE95C5F1][Qt UI polish]]                                 | DONE  | 2026-04-20 | 2026-05-20 | JWT URL discovery, currency combos, login filter, menu simplification.       |
 | [[id:CC9A5F89-EA6E-46EC-9F95-8891BD1C1A8E][Refdata tenant_id strong-type migration]]      | DONE  | 2026-05-20 | 2026-05-20 | 11 party domain types migrated to utility::uuid::tenant_id.                  |
-| [[id:17C590D4-04F0-43C5-9EA5-F89C40C82A4C][PlantUML and modeling refresh]]                | DONE  | 2026-05-19 | 2026-05-20 | Generation script + bulk diagram refresh + component docs to v2.             |
-| [[id:063862A1-C02C-4F76-A212-576A57423F0F][v2 documentation architecture]]                | DONE  | 2026-04-18 | 2026-05-20 | Port sprints 01-16 to v2; site theme; GitHub Pages.                          |
-| [[id:A5ABED76-B4F5-4E37-8CCC-220D360501B4][Sprint 17 housekeeping]]                       | DONE  | 2026-04-18 | 2026-05-18 | vcpkg, ccache-action, get-cmake, setup-clang bumps.                          |
+
+** Product
+
+#+ATTR_HTML: :class hug-leading
+| Story                                        | State |      Start |        End | Theme                                                                       |
+|----------------------------------------------+-------+------------+------------+-----------------------------------------------------------------------------|
+| [[id:00CCC0DC-200C-4951-81E0-6AA93B1503FC][FX forward E2E and equity per-type migration]] | DONE  | 2026-04-22 | 2026-05-01 | FX forward ORE import wired end-to-end; equity per-type tables completed.   |
+| [[id:F607B8CE-5D33-424F-A7C2-7ED0243D4728][ORE conventions import]]                       | DONE  | 2026-04-22 | 2026-05-11 | Seven convention types via codegen; deposit_convention; CLI import Phase 3. |
+| [[id:66109AE6-1C44-405D-B4D6-08164C457C25][ORE domain roundtrip]]                         | DONE  | 2026-05-07 | 2026-05-08 | Roundtrip command + baseline + all four ORE XML document types.             |
+| [[id:E62BF8DD-FD3B-4283-A1A9-3FAF1F7A1703][Import/export cleanup]]                        | DONE  | 2026-05-02 | 2026-05-06 | Composite legs, pure parser, batch fetches, export_result wrappers.         |
+| [[id:7030AB78-B8F1-425C-83EF-A6F9EBF218A8][Workflow engine hardening]]                    | DONE  | 2026-05-15 | 2026-05-19 | Package renames, error reporting, pg_notify fix, shutdown latency.          |
+| [[id:77BF049F-ED38-4998-AFA3-672E25895F9A][Workspace]]                                    | DONE  | 2026-05-19 | 2026-05-20 | Bitemporal schema, service, UI, codegen propagation, Data Workshop.         |
+| [[id:DC1EFFD8-B983-48C7-835B-71333AECE016][DQ publish pattern]]                           | DONE  | 2026-05-19 | 2026-05-20 | Publish-from-DQ wizard; async PublishDatasetsDialog; IAM logging.           |
+| [[id:E16BEABB-CC59-4D6C-B216-DACC1E922047][Compute and GLEIF]]                            | DONE  | 2026-04-18 | 2026-04-28 | GLEIF bundle wiring; per-triplet packages; per-platform uploads.            |
+| [[id:D148B46A-AD14-4391-8B64-46DCFE95C5F1][Qt UI polish]]                                 | DONE  | 2026-04-20 | 2026-05-20 | JWT URL discovery, currency combos, login filter, menu simplification.      |
+
+** Tooling
+
+#+ATTR_HTML: :class hug-leading
+| Story                                        | State |      Start |        End | Theme                                                            |
+|----------------------------------------------+-------+------------+------------+------------------------------------------------------------------|
+| [[id:25F0A34B-C547-4550-943B-E8F517EB0F6C][SQL codegen drift remediation]]                | DONE  | 2026-05-14 | 2026-05-17 | All remaining hand-crafted SQL replaced; profile dispatch fixed. |
+
+** Documentation
+
+#+ATTR_HTML: :class hug-leading
+| Story                                        | State |      Start |        End | Theme                                                                    |
+|----------------------------------------------+-------+------------+------------+--------------------------------------------------------------------------|
+| [[id:17C590D4-04F0-43C5-9EA5-F89C40C82A4C][PlantUML and modeling refresh]]                | DONE  | 2026-05-19 | 2026-05-20 | Generation script + bulk diagram refresh + component docs to v2.         |
+| [[id:063862A1-C02C-4F76-A212-576A57423F0F][v2 documentation architecture]]                | DONE  | 2026-04-18 | 2026-05-20 | Port sprints 01-16 to v2; site theme; GitHub Pages.                      |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                        | State |      Start |        End | Theme                                                  |
+|----------------------------------------------+-------+------------+------------+--------------------------------------------------------|
+| [[id:A5ABED76-B4F5-4E37-8CCC-220D360501B4][Sprint 17 housekeeping]]                       | DONE  | 2026-04-18 | 2026-05-18 | vcpkg, ccache-action, get-cmake, setup-clang bumps.    |
 
 * Charts
 

--- a/doc/agile/versions/v0/sprint_17/sprint.org
+++ b/doc/agile/versions/v0/sprint_17/sprint.org
@@ -42,6 +42,8 @@ history to the v2 cybernetic information architecture.
 
 * Stories
 
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
+
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading

--- a/doc/agile/versions/v0/sprint_17/sprint.org
+++ b/doc/agile/versions/v0/sprint_17/sprint.org
@@ -40,6 +40,16 @@ history to the v2 cybernetic information architecture.
 | Capture        | [[id:14606A1B-2742-DE34-F813-B4E3B736AEF1][capture.org]]   |
 | Last touched   | 2026-05-21                                                 |
 
+** Achievements
+
+- Workspace feature landed: bitemporal schema, service, UI, codegen propagation, and Data Workshop.
+- ORE conventions import: seven convention types via codegen; CLI import Phase 3 complete.
+- ORE domain roundtrip command with baseline and all four ORE XML document types.
+- Symbol visibility migrated project-wide (=-fvisibility=hidden=, export macros, plugin isolation).
+- MSVC C1202 constexpr depth resolved; Windows portability completed.
+- All hand-crafted SQL replaced by codegen; SQL codegen drift closed.
+- v2 documentation architecture: sprints 01–16 ported; site theme and GitHub Pages live.
+
 * Stories
 
 For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].

--- a/doc/agile/versions/v0/sprint_17/sprint.org
+++ b/doc/agile/versions/v0/sprint_17/sprint.org
@@ -57,7 +57,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                        | State |      Start |        End | Theme                                                                        |
+| Story                                        | State |      Start |        End | Description |
 |----------------------------------------------+-------+------------+------------+------------------------------------------------------------------------------|
 | [[id:7D84E735-7DFE-4215-AF00-A1F4C9323BDA][Windows portability fixes]]                    | DONE  | 2026-04-18 | 2026-04-22 | WiX limits, libpq link, OpenSSL, PostgreSQL CMake target, vcpkg Qt feature.  |
 | [[id:FBE68713-40C1-4B1D-A228-1C55AB4ABC34][MSVC C1202 constexpr depth fixes]]             | DONE  | 2026-05-05 | 2026-05-21 | Trade struct decomposition + constexpr limit raises across all TUs.          |
@@ -68,7 +68,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                        | State |      Start |        End | Theme                                                                       |
+| Story                                        | State |      Start |        End | Description |
 |----------------------------------------------+-------+------------+------------+-----------------------------------------------------------------------------|
 | [[id:00CCC0DC-200C-4951-81E0-6AA93B1503FC][FX forward E2E and equity per-type migration]] | DONE  | 2026-04-22 | 2026-05-01 | FX forward ORE import wired end-to-end; equity per-type tables completed.   |
 | [[id:F607B8CE-5D33-424F-A7C2-7ED0243D4728][ORE conventions import]]                       | DONE  | 2026-04-22 | 2026-05-11 | Seven convention types via codegen; deposit_convention; CLI import Phase 3. |
@@ -83,14 +83,14 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Tooling
 
 #+ATTR_HTML: :class hug-leading
-| Story                                        | State |      Start |        End | Theme                                                            |
+| Story                                        | State |      Start |        End | Description |
 |----------------------------------------------+-------+------------+------------+------------------------------------------------------------------|
 | [[id:25F0A34B-C547-4550-943B-E8F517EB0F6C][SQL codegen drift remediation]]                | DONE  | 2026-05-14 | 2026-05-17 | All remaining hand-crafted SQL replaced; profile dispatch fixed. |
 
 ** Documentation
 
 #+ATTR_HTML: :class hug-leading
-| Story                                        | State |      Start |        End | Theme                                                                    |
+| Story                                        | State |      Start |        End | Description |
 |----------------------------------------------+-------+------------+------------+--------------------------------------------------------------------------|
 | [[id:17C590D4-04F0-43C5-9EA5-F89C40C82A4C][PlantUML and modeling refresh]]                | DONE  | 2026-05-19 | 2026-05-20 | Generation script + bulk diagram refresh + component docs to v2.         |
 | [[id:063862A1-C02C-4F76-A212-576A57423F0F][v2 documentation architecture]]                | DONE  | 2026-04-18 | 2026-05-20 | Port sprints 01-16 to v2; site theme; GitHub Pages.                      |
@@ -98,7 +98,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                        | State |      Start |        End | Theme                                                  |
+| Story                                        | State |      Start |        End | Description |
 |----------------------------------------------+-------+------------+------------+--------------------------------------------------------|
 | [[id:A5ABED76-B4F5-4E37-8CCC-220D360501B4][Sprint 17 housekeeping]]                       | DONE  | 2026-04-18 | 2026-05-18 | vcpkg, ccache-action, get-cmake, setup-clang bumps.    |
 

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -49,7 +49,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                                | State   | Start      | End        | Theme                                                                                              |
+| Story                                                                                                | State   | Start      | End        | Description |
 |------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
 | [[id:C42C3563-671F-4721-8CE8-5EE05925255F][Build and publish user manual PDF via CMake]]      | STARTED | 2026-05-24 |            | =deploy_manual= target builds =user_manual.org= to PDF; commit and link the result.               |
 | [[id:D495A1B3-7677-4884-935F-1B6E6D65C983][ORE sample data]]                                  | BACKLOG | 2026-05-24 |            | Source or generate representative ORE input files for integration testing.                         |
@@ -63,7 +63,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Tooling
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                                | State   | Start      | End        | Theme                                                                                              |
+| Story                                                                                                | State   | Start      | End        | Description |
 |------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
 | [[id:8BA366D7-B43F-4E5B-B4AD-A40C7E28881B][ores.compass repository compass tool]]             | DONE    | 2026-05-24 | 2026-05-24 | Python repository compass: temporal orientation, semantic doc search, agile scaffolding.           |
 | [[id:468387DD-0D6F-49B4-9F82-BD179DCB1CC1][ores.compass Locate — temporal orientation]]       | DONE    | 2026-05-24 | 2026-05-24 | =where=/=status=: report current version, sprint, and in-flight stories and tasks from the graph. |
@@ -79,7 +79,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                                | State   | Start      | End        | Theme                                                                                              |
+| Story                                                                                                | State   | Start      | End        | Description |
 |------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
 | [[id:22AA37FA-23A0-406E-B05B-B11BB3E83874][Product backlog refinement]]                       | DONE    | 2026-05-24 | 2026-05-24 | Build backlog-refiner and sprint-planner skills/recipes; set sprint 18 mission.                    |
 | [[id:16851249-2FB0-443E-83E0-55D6B8051272][Sprint health review — System 2 analysis]]         | DONE    | 2026-05-25 | 2026-05-26 | =sprint-reviewer= skill writes a structured health-check section into =sprint.org=.               |
@@ -90,7 +90,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** LLMs
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                                | State   | Start      | End        | Theme                                                                                              |
+| Story                                                                                                | State   | Start      | End        | Description |
 |------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
 | [[id:7225526E-DCDB-4DC6-A95D-22C7117E5EAA][Port Tufte visualisation skill into ORE Studio]]   | DONE    | 2026-05-25 | 2026-05-25 | Convert =tufte-viz= SKILL and two Tufte reference docs to org-mode; install and catalogue.        |
 | [[id:3D1935DC-562C-4AA3-A352-AC1BC037DFDD][Runbook support]]                                  | DONE    | 2026-05-26 | 2026-05-26 | Add runbook document type: named composition of recipes for repeatable multi-step operations.      |
@@ -101,7 +101,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Documentation
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                                | State   | Start      | End        | Theme                                                                                              |
+| Story                                                                                                | State   | Start      | End        | Description |
 |------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
 | [[id:4E375DD6-E300-4A0A-BD20-3D06AC8ED7A1][Port domain concept notes to knowledge documents]] | STARTED | 2026-05-25 |            | Tidy personal finance/ORE domain notes into v2 knowledge docs; align with ORE Studio terms.       |
 | [[id:9AE5466D-E627-4587-BBEB-6D89E732ACE2][System model readability]]                         | DONE    | 2026-05-26 | 2026-05-28 | Add layer blurbs and table-based component inventory to the system model.                          |
@@ -112,7 +112,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                                | State   | Start      | End        | Theme                                                                                              |
+| Story                                                                                                | State   | Start      | End        | Description |
 |------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
 | [[id:A4BEF88C-1372-46CE-864B-C30AC3BE95EB][Inline org-roam export into ores.lisp]]            | DONE    | 2026-05-22 | 2026-05-22 | Vendor =org-roam-export.el= into =ores.lisp= so the CI site build is self-contained.              |
 | [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D8][Resolve RFL complexity issues]]                    | DONE    | 2026-05-23 | 2026-05-24 | Permanently resolve MSVC C1202 and Clang expression nesting limits via structural isolation.       |

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -89,6 +89,7 @@ In execution order.
 | [[id:FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6][Refactor story task lists to a status table]]                           | STARTED | 2026-05-28 |            | Replace bullet-list Tasks section in story docs with a Task/State/Start/End/Description table. |
 | [[id:AD6B59E1-A267-4927-A3FF-D624BB123658][Move .build-*.el scripts to ores.lisp]]                                 | DONE    | 2026-05-28 | 2026-05-28 | Relocate build scripts from repo root into ores.lisp/src/ with ores- naming. |
 | [[id:8AA261FC-B334-45A8-9954-85DD4BECEA45][Improve cybernetics documentation]]                                      | STARTED | 2026-05-28 |            | Add VSM overview page, expand Cybernetic Levels with context and limitations, link compass. |
+| [[id:03EC9465-AE25-4404-9B7E-B0C25A3CBE28][Sprint theme grouping]]                                                 | STARTED | 2026-05-28 |            | Introduce theme subheadings into sprint.org to group stories by area. |
 
 * Health Review
 

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -44,52 +44,84 @@ Enable end-to-end [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][ORE]] imports into 
 
 * Stories
 
-In execution order.
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
+
+** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                           | State   | Start      | End        | Theme                                                                                        |
-|-------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------|
-| [[id:A4BEF88C-1372-46CE-864B-C30AC3BE95EB][Inline org-roam export into ores.lisp]]   | DONE    | 2026-05-22 | 2026-05-22 | Vendor =org-roam-export.el= into =ores.lisp= so the CI site build is self-contained.        |
-| [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D8][Resolve RFL complexity issues]]           | DONE    | 2026-05-23 | 2026-05-24 | Permanently resolve MSVC C1202 and Clang expression nesting limits via structural isolation. |
-| [[id:0A2CB5BD-67B8-4096-BAC4-8E110333893A][SQLite CLI quality-of-life setup]]         | DONE    | 2026-05-24 | 2026-05-24 | Committed, commented =.sqliterc= for readable, non-wrapping =sqlite3= shell output.          |
-| [[id:BAF1DEAE-59DF-49AB-BFCD-E6D09496DA43][Lock down uppercase UUID invariant]]      | DONE    | 2026-05-24 | 2026-05-24 | Close the remaining code paths that can emit lowercase UUIDs into the doc graph.             |
-| [[id:22AA37FA-23A0-406E-B05B-B11BB3E83874][Product backlog refinement]]              | DONE    | 2026-05-24 | 2026-05-24 | Build backlog-refiner and sprint-planner skills/recipes; set sprint 18 mission.              |
-| [[id:C42C3563-671F-4721-8CE8-5EE05925255F][Build and publish user manual PDF via CMake]] | STARTED | 2026-05-24 |            | =deploy_manual= target builds =user_manual.org= to PDF; commit and link the result.         |
-| [[id:8BA366D7-B43F-4E5B-B4AD-A40C7E28881B][ores.compass repository compass tool]]   | DONE    | 2026-05-24 | 2026-05-24 | Python repository compass: temporal orientation, semantic doc search, agile scaffolding.        |
-| [[id:468387DD-0D6F-49B4-9F82-BD179DCB1CC1][ores.compass Locate — temporal orientation]] | DONE | 2026-05-24 | 2026-05-24 | =where=/=status=: report current version, sprint, and in-flight stories and tasks from the graph. |
-| [[id:D84B1122-30DC-4BCF-9C90-73403FAAECD9][ores.compass Scaffold — agile authoring]] | DONE    | 2026-05-24 | 2026-05-24 | =add story/task/sprint/recipe=: create agile artefacts from the CLI by calling ores.codegen as a library. |
-| [[id:D495A1B3-7677-4884-935F-1B6E6D65C983][ORE sample data]]                         | BACKLOG | 2026-05-24 |            | Source or generate representative ORE input files for integration testing.                   |
-| [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]]     | BACKLOG | 2026-05-24 |            | Enable end-to-end execution of ORE sample files from a workspace.                            |
-| [[id:84C10B13-51E2-4D8D-B82A-F38F8DB10E86][Work through all types for ORE Example 1]] | BACKLOG | 2026-05-24 |          | Implement every ORE instrument and market-data type needed for Example 1.                    |
-| [[id:4941A490-0D66-4F09-9B1F-3BC928022A41][Fix instruments not visible in UI]]       | BACKLOG | 2026-05-24 |            | Instruments not showing in UI — investigate import/display path and fix.                     |
-| [[id:B3EBD70C-DAFA-4854-92F3-54E7D90D22C7][Qt: instrument creation in TradeDetailDialog]] | BACKLOG | 2026-05-24 |      | Create/associate instruments directly from TradeDetailDialog.                                |
-| [[id:7EF64A67-EB1C-4F79-9FF2-1C59DD6146AB][Track PRs per task and surface in compass where]] | DONE    | 2026-05-24 | 2026-05-24 | PRs table in task docs; =compass where --prs= fetches live PR status via =gh=.          |
-| [[id:026AA423-68A1-43A1-8F2A-D9D3D6379E6C][Add org-roam index links to compass.org folder entries]] | DONE | 2026-05-24 | 2026-05-24 | Each folder in compass.org links to its index file; missing index files created. |
-| [[id:A2B3BFD0-F44C-48F3-BB01-6BAECB851356][Remove unused GitHub Actions workflows]] | DONE | 2026-05-24 | 2026-05-24 | Delete the four dormant Gemini workflows; PR review stays via the gemini-code-assist app. |
-| [[id:15CE567F-489C-4A80-9CEC-27FCF95E5C36][ores.compass Product Backlog — next and deferred listing]] | BACKLOG | 2026-05-24 | | =compass backlog= lists next/deferred captures with counts, mirroring =where= in-flight display. |
-| [[id:8D295781-33E7-4812-AAC6-134BD7CD0DDC][Rebuild org-roam DB independently from CMake]]       | BACKLOG | 2026-05-24 | | Extract org-roam sync into =.build-org-roam.el=; add =rebuild_org_roam_db= cmake target.   |
-| [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                         | DONE    | 2026-05-24 | 2026-05-25 | Replace broken per-mode ores.lisp with an env-aware emacs-dashboard console for all dev commands. |
-| [[id:7225526E-DCDB-4DC6-A95D-22C7117E5EAA][Port Tufte visualisation skill into ORE Studio]]     | DONE    | 2026-05-25 | 2026-05-25 | Convert =tufte-viz= SKILL and two Tufte reference docs to org-mode; install and catalogue. |
-| [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][compass cross-worktree status (global where)]] | DONE    | 2026-05-25 | 2026-05-25 | Show what every git worktree is doing (branch/story/task/PR) so parallel agents don't collide. |
-| [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][compass goto: start a unit of work in one command]] | DONE | 2026-05-25 | 2026-05-25 | One command: fetch main, branch, scaffold linked story+task, print next steps. |
-| [[id:16851249-2FB0-443E-83E0-55D6B8051272][Sprint health review — System 2 analysis]]           | DONE    | 2026-05-25 | 2026-05-26 | =sprint-reviewer= skill writes a structured health-check section into =sprint.org=. |
-| [[id:C3B6F514-559F-4038-A1D7-947BC9F7F398][Add Downloads and Agile nav entries to the site]]    | BACKLOG | 2026-05-25 | | =doc/downloads.org= with release table; =Downloads= and =Agile= links in site nav.         |
-| [[id:4E375DD6-E300-4A0A-BD20-3D06AC8ED7A1][Port domain concept notes to knowledge documents]]      | STARTED | 2026-05-25 | | Tidy personal finance/ORE domain notes into v2 knowledge docs; align with ORE Studio terms. |
-| [[id:9AE5466D-E627-4587-BBEB-6D89E732ACE2][System model readability]]                         | DONE    | 2026-05-26 | 2026-05-28 | Add layer blurbs and table-based component inventory to the system model. |
-| [[id:3D1935DC-562C-4AA3-A352-AC1BC037DFDD][Runbook support]]                                  | DONE    | 2026-05-26 | 2026-05-26 | Add runbook document type: named composition of recipes for repeatable multi-step operations. |
-| [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Compass PR review management]]                      | BACKLOG | 2026-05-26 |            | Add compass review list/reply/resolve subcommands wrapping gh API. |
-| [[id:CC7CEDA1-A3F1-4E4E-BDE9-5DAF0D5BCD23][Detect and report NATS disconnection]] | BACKLOG | 2026-05-26 | | Client should detect when NATS or backend services drop mid-session and show a connection-lost state with reconnect. |
-| [[id:5B7C4B18-3CF2-4546-A73E-95F46228DBD2][Fix account registration NATS SSL error]] | BACKLOG | 2026-05-26 | | Registration fails with "NATS connect failed: SSL Error"; fix the registration path's NATS/TLS config. |
-| [[id:8BD3D28A-C5A1-4F8D-A685-1BC6EBF5C812][Sprint health charts]]                            | DONE    | 2026-05-26 | 2026-05-26 | Generate daily charts of PRs, commits, story completions, and line churn using gnuplot. |
-| [[id:A388F0C8-0804-420F-A542-2C929CFCEC92][Document NATS: technology overview, system integration, and recipes]] | DONE    | 2026-05-26 | 2026-05-26 | NATS knowledge page, system model section, per-component subject tables, and NATS recipes. |
-| [[id:E6CC19FC-5469-45BD-AA87-9CDBB23A4A7F][Per-sprint capture workflow: individual files and compass integration]] | STARTED | 2026-05-27 | | captures/ folder per sprint; compass capture command; wontdo backlog bucket. |
-| [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]]                                 | DONE    | 2026-05-28 | 2026-05-28 | Add compass skill type, update skill-creation recipe, create run-runbook skill. |
-| [[id:5D11EB95-8B20-4A11-B9A6-C883C9E4B0CF][Document deduplication recipe]]                                         | DONE    | 2026-05-28 | 2026-05-28 | Generalised recipe for merging duplicate docs; applied to duplicate sprint health review runbooks. |
-| [[id:76F0DB10-084D-4A72-A585-5DE660884677][PlantUML integration: recipe and codegen scaffold]]                     | DONE    | 2026-05-28 | 2026-05-28 | PlantUML how-to recipe; compass add diagram scaffold; standard licence header convention. |
-| [[id:FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6][Refactor story task lists to a status table]]                           | STARTED | 2026-05-28 |            | Replace bullet-list Tasks section in story docs with a Task/State/Start/End/Description table. |
-| [[id:AD6B59E1-A267-4927-A3FF-D624BB123658][Move .build-*.el scripts to ores.lisp]]                                 | DONE    | 2026-05-28 | 2026-05-28 | Relocate build scripts from repo root into ores.lisp/src/ with ores- naming. |
-| [[id:8AA261FC-B334-45A8-9954-85DD4BECEA45][Improve cybernetics documentation]]                                      | STARTED | 2026-05-28 |            | Add VSM overview page, expand Cybernetic Levels with context and limitations, link compass. |
-| [[id:03EC9465-AE25-4404-9B7E-B0C25A3CBE28][Sprint theme grouping]]                                                 | STARTED | 2026-05-28 |            | Introduce theme subheadings into sprint.org to group stories by area. |
+| Story                                                                                                | State   | Start      | End        | Theme                                                                                              |
+|------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
+| [[id:C42C3563-671F-4721-8CE8-5EE05925255F][Build and publish user manual PDF via CMake]]      | STARTED | 2026-05-24 |            | =deploy_manual= target builds =user_manual.org= to PDF; commit and link the result.               |
+| [[id:D495A1B3-7677-4884-935F-1B6E6D65C983][ORE sample data]]                                  | BACKLOG | 2026-05-24 |            | Source or generate representative ORE input files for integration testing.                         |
+| [[id:34671668-4AEA-46E5-AB28-59DFB169F68E][Add support for running ORE samples]]              | BACKLOG | 2026-05-24 |            | Enable end-to-end execution of ORE sample files from a workspace.                                 |
+| [[id:84C10B13-51E2-4D8D-B82A-F38F8DB10E86][Work through all types for ORE Example 1]]         | BACKLOG | 2026-05-24 |            | Implement every ORE instrument and market-data type needed for Example 1.                          |
+| [[id:4941A490-0D66-4F09-9B1F-3BC928022A41][Fix instruments not visible in UI]]                | BACKLOG | 2026-05-24 |            | Instruments not showing in UI — investigate import/display path and fix.                           |
+| [[id:B3EBD70C-DAFA-4854-92F3-54E7D90D22C7][Qt: instrument creation in TradeDetailDialog]]     | BACKLOG | 2026-05-24 |            | Create/associate instruments directly from TradeDetailDialog.                                      |
+| [[id:CC7CEDA1-A3F1-4E4E-BDE9-5DAF0D5BCD23][Detect and report NATS disconnection]]             | BACKLOG | 2026-05-26 |            | Client should detect when NATS or backend services drop mid-session and show a connection-lost state with reconnect. |
+| [[id:5B7C4B18-3CF2-4546-A73E-95F46228DBD2][Fix account registration NATS SSL error]]          | BACKLOG | 2026-05-26 |            | Registration fails with "NATS connect failed: SSL Error"; fix the registration path's NATS/TLS config. |
+
+** Tooling
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                                | State   | Start      | End        | Theme                                                                                              |
+|------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
+| [[id:8BA366D7-B43F-4E5B-B4AD-A40C7E28881B][ores.compass repository compass tool]]             | DONE    | 2026-05-24 | 2026-05-24 | Python repository compass: temporal orientation, semantic doc search, agile scaffolding.           |
+| [[id:468387DD-0D6F-49B4-9F82-BD179DCB1CC1][ores.compass Locate — temporal orientation]]       | DONE    | 2026-05-24 | 2026-05-24 | =where=/=status=: report current version, sprint, and in-flight stories and tasks from the graph. |
+| [[id:D84B1122-30DC-4BCF-9C90-73403FAAECD9][ores.compass Scaffold — agile authoring]]          | DONE    | 2026-05-24 | 2026-05-24 | =add story/task/sprint/recipe=: create agile artefacts from the CLI by calling ores.codegen as a library. |
+| [[id:7EF64A67-EB1C-4F79-9FF2-1C59DD6146AB][Track PRs per task and surface in compass where]]  | DONE    | 2026-05-24 | 2026-05-24 | PRs table in task docs; =compass where --prs= fetches live PR status via =gh=.                    |
+| [[id:026AA423-68A1-43A1-8F2A-D9D3D6379E6C][Add org-roam index links to compass.org folder entries]] | DONE    | 2026-05-24 | 2026-05-24 | Each folder in compass.org links to its index file; missing index files created.             |
+| [[id:15CE567F-489C-4A80-9CEC-27FCF95E5C36][ores.compass Product Backlog — next and deferred listing]] | BACKLOG | 2026-05-24 |       | =compass backlog= lists next/deferred captures with counts, mirroring =where= in-flight display.  |
+| [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][compass cross-worktree status (global where)]]     | DONE    | 2026-05-25 | 2026-05-25 | Show what every git worktree is doing (branch/story/task/PR) so parallel agents don't collide.    |
+| [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][compass goto: start a unit of work in one command]] | DONE   | 2026-05-25 | 2026-05-25 | One command: fetch main, branch, scaffold linked story+task, print next steps.                    |
+| [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Compass PR review management]]                     | BACKLOG | 2026-05-26 |            | Add compass review list/reply/resolve subcommands wrapping gh API.                                |
+| [[id:E6CC19FC-5469-45BD-AA87-9CDBB23A4A7F][Per-sprint capture workflow: individual files and compass integration]] | STARTED | 2026-05-27 | | captures/ folder per sprint; compass capture command; wontdo backlog bucket.           |
+
+** Agile
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                                | State   | Start      | End        | Theme                                                                                              |
+|------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
+| [[id:22AA37FA-23A0-406E-B05B-B11BB3E83874][Product backlog refinement]]                       | DONE    | 2026-05-24 | 2026-05-24 | Build backlog-refiner and sprint-planner skills/recipes; set sprint 18 mission.                    |
+| [[id:16851249-2FB0-443E-83E0-55D6B8051272][Sprint health review — System 2 analysis]]         | DONE    | 2026-05-25 | 2026-05-26 | =sprint-reviewer= skill writes a structured health-check section into =sprint.org=.               |
+| [[id:8BD3D28A-C5A1-4F8D-A685-1BC6EBF5C812][Sprint health charts]]                             | DONE    | 2026-05-26 | 2026-05-26 | Generate daily charts of PRs, commits, story completions, and line churn using gnuplot.           |
+| [[id:FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6][Refactor story task lists to a status table]]      | STARTED | 2026-05-28 |            | Replace bullet-list Tasks section in story docs with a Task/State/Start/End/Description table.    |
+| [[id:03EC9465-AE25-4404-9B7E-B0C25A3CBE28][Sprint theme grouping]]                            | STARTED | 2026-05-28 |            | Introduce theme subheadings into sprint.org to group stories by area.                             |
+
+** LLMs
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                                | State   | Start      | End        | Theme                                                                                              |
+|------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
+| [[id:7225526E-DCDB-4DC6-A95D-22C7117E5EAA][Port Tufte visualisation skill into ORE Studio]]   | DONE    | 2026-05-25 | 2026-05-25 | Convert =tufte-viz= SKILL and two Tufte reference docs to org-mode; install and catalogue.        |
+| [[id:3D1935DC-562C-4AA3-A352-AC1BC037DFDD][Runbook support]]                                  | DONE    | 2026-05-26 | 2026-05-26 | Add runbook document type: named composition of recipes for repeatable multi-step operations.      |
+| [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]]            | DONE    | 2026-05-28 | 2026-05-28 | Add compass skill type, update skill-creation recipe, create run-runbook skill.                    |
+| [[id:5D11EB95-8B20-4A11-B9A6-C883C9E4B0CF][Document deduplication recipe]]                    | DONE    | 2026-05-28 | 2026-05-28 | Generalised recipe for merging duplicate docs; applied to duplicate sprint health review runbooks. |
+| [[id:76F0DB10-084D-4A72-A585-5DE660884677][PlantUML integration: recipe and codegen scaffold]] | DONE   | 2026-05-28 | 2026-05-28 | PlantUML how-to recipe; compass add diagram scaffold; standard licence header convention.          |
+
+** Documentation
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                                | State   | Start      | End        | Theme                                                                                              |
+|------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
+| [[id:4E375DD6-E300-4A0A-BD20-3D06AC8ED7A1][Port domain concept notes to knowledge documents]] | STARTED | 2026-05-25 |            | Tidy personal finance/ORE domain notes into v2 knowledge docs; align with ORE Studio terms.       |
+| [[id:9AE5466D-E627-4587-BBEB-6D89E732ACE2][System model readability]]                         | DONE    | 2026-05-26 | 2026-05-28 | Add layer blurbs and table-based component inventory to the system model.                          |
+| [[id:A388F0C8-0804-420F-A542-2C929CFCEC92][Document NATS: technology overview, system integration, and recipes]] | DONE | 2026-05-26 | 2026-05-26 | NATS knowledge page, system model section, per-component subject tables, and NATS recipes. |
+| [[id:C3B6F514-559F-4038-A1D7-947BC9F7F398][Add Downloads and Agile nav entries to the site]]  | BACKLOG | 2026-05-25 |            | =doc/downloads.org= with release table; =Downloads= and =Agile= links in site nav.                |
+| [[id:8AA261FC-B334-45A8-9954-85DD4BECEA45][Improve cybernetics documentation]]                | STARTED | 2026-05-28 |            | Add VSM overview page, expand Cybernetic Levels with context and limitations, link compass.        |
+
+** Infrastructure
+
+#+ATTR_HTML: :class hug-leading
+| Story                                                                                                | State   | Start      | End        | Theme                                                                                              |
+|------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
+| [[id:A4BEF88C-1372-46CE-864B-C30AC3BE95EB][Inline org-roam export into ores.lisp]]            | DONE    | 2026-05-22 | 2026-05-22 | Vendor =org-roam-export.el= into =ores.lisp= so the CI site build is self-contained.              |
+| [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D8][Resolve RFL complexity issues]]                    | DONE    | 2026-05-23 | 2026-05-24 | Permanently resolve MSVC C1202 and Clang expression nesting limits via structural isolation.       |
+| [[id:0A2CB5BD-67B8-4096-BAC4-8E110333893A][SQLite CLI quality-of-life setup]]                 | DONE    | 2026-05-24 | 2026-05-24 | Committed, commented =.sqliterc= for readable, non-wrapping =sqlite3= shell output.               |
+| [[id:BAF1DEAE-59DF-49AB-BFCD-E6D09496DA43][Lock down uppercase UUID invariant]]               | DONE    | 2026-05-24 | 2026-05-24 | Close the remaining code paths that can emit lowercase UUIDs into the doc graph.                   |
+| [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                       | DONE    | 2026-05-24 | 2026-05-25 | Replace broken per-mode ores.lisp with an env-aware emacs-dashboard console for all dev commands. |
+| [[id:A2B3BFD0-F44C-48F3-BB01-6BAECB851356][Remove unused GitHub Actions workflows]]           | DONE    | 2026-05-24 | 2026-05-24 | Delete the four dormant Gemini workflows; PR review stays via the gemini-code-assist app.         |
+| [[id:8D295781-33E7-4812-AAC6-134BD7CD0DDC][Rebuild org-roam DB independently from CMake]]     | BACKLOG | 2026-05-24 |            | Extract org-roam sync into =.build-org-roam.el=; add =rebuild_org_roam_db= cmake target.         |
+| [[id:AD6B59E1-A267-4927-A3FF-D624BB123658][Move .build-*.el scripts to ores.lisp]]            | DONE    | 2026-05-28 | 2026-05-28 | Relocate build scripts from repo root into ores.lisp/src/ with ores- naming.                      |
 
 * Health Review
 

--- a/doc/agile/versions/v0/sprint_18/sprint_theme_grouping/story.org
+++ b/doc/agile/versions/v0/sprint_18/sprint_theme_grouping/story.org
@@ -1,0 +1,66 @@
+:PROPERTIES:
+:ID: 03EC9465-AE25-4404-9B7E-B0C25A3CBE28
+:END:
+#+title: Story: Sprint theme grouping
+#+description: Introduce theme subheadings into sprint.org to group stories by area and surface emerging patterns in the backlog.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :agile:sprint:readability:sprint_18:v0:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+The =* Stories= table in each =sprint.org= is a single flat list with no
+structural grouping. As sprints grow, it becomes impossible to answer "what
+themes are we working on?" without reading every row. This story introduces
+theme subheadings: each =* Stories= section is split into =**= sub-sections,
+one per theme, each containing its own table. Themes are agreed once and
+applied uniformly to all sprint backlog files.
+
+The proposal is six themes:
+
+- *ORE / Product* — end-user features: ORE types, samples, imports, UI.
+- *Compass / Tooling* — =ores.compass= CLI commands and developer tooling.
+- *Agile Process* — sprint management, health tracking, captures, planning.
+- *LLM / Skills* — runbooks, skills, recipes, LLM-facing tooling.
+- *Knowledge / Documentation* — knowledge graph, system model, docs, site.
+- *Build / Infrastructure* — build system, CI/CD, tooling hygiene.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                                |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]] |
+| Now           | Theme proposal agreed; applying to sprint backlogs. |
+| Waiting on    | Nothing.                               |
+| Next          | Apply theme subheadings to all sprint.org files.   |
+| Last touched  | 2026-05-28                             |
+
+* Acceptance
+
+- Six theme subheadings defined and agreed.
+- =sprint_18/sprint.org= =* Stories= section restructured with =**= theme
+  subheadings, each containing the relevant table rows.
+- All other sprint =sprint.org= files (sprints 01–17) updated the same way.
+- =compass where= and =compass where --prs= continue to read correctly after
+  the structural change.
+
+* Tasks
+
+In execution order:
+
+- [[id:DF939E90-497C-4332-A30E-B528049D6F71][Implement sprint theme grouping]]
+
+* Decisions
+
+* Out of scope
+
+- Introducing formal "epics" as separate doc-graph nodes — themes are
+  subheadings only; no new document type is needed.
+- Changing the column schema of the story table rows.

--- a/doc/agile/versions/v0/sprint_18/sprint_theme_grouping/task_implement_sprint_theme_grouping.org
+++ b/doc/agile/versions/v0/sprint_18/sprint_theme_grouping/task_implement_sprint_theme_grouping.org
@@ -1,0 +1,74 @@
+:PROPERTIES:
+:ID: DF939E90-497C-4332-A30E-B528049D6F71
+:END:
+#+title: Task: Implement Sprint theme grouping
+#+description: Initial task for: Sprint theme grouping
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :sprint_theme_grouping:sprint_18:v0:
+#+owner: marco
+#+branch: feature/sprint-theme-grouping
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:03EC9465-AE25-4404-9B7E-B0C25A3CBE28][Sprint theme grouping]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Apply theme subheadings to =sprint.org= files so each sprint's =* Stories=
+section is split into =**= sub-sections — one per agreed theme — each
+containing its own table. Agreed themes:
+
+1. *ORE / Product* — end-user features: ORE types, samples, imports, UI.
+2. *Compass / Tooling* — =ores.compass= CLI commands and developer tooling.
+3. *Agile Process* — sprint management, health tracking, captures, planning.
+4. *LLM / Skills* — runbooks, skills, recipes, LLM-facing tooling.
+5. *Knowledge / Documentation* — knowledge graph, system model, docs, site.
+6. *Build / Infrastructure* — build system, CI/CD, tooling hygiene.
+
+Apply to current sprint first; then back-fill all prior sprint files.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                                |
+| Parent story | [[id:03EC9465-AE25-4404-9B7E-B0C25A3CBE28][Sprint theme grouping]] |
+| Now          | Themes agreed; applying to sprint 18.  |
+| Waiting on   | Nothing.                               |
+| Next         | Apply to sprints 01–17.                |
+| Last touched | 2026-05-28                             |
+
+* Acceptance
+
+- All agreed themes documented in the parent story =* Goal=.
+- =sprint_18/sprint.org= =* Stories= uses =**= theme subheadings.
+- All prior sprint files (sprints 01–17) updated the same way.
+- "In execution order" prose retained under each sub-heading where applicable.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/sprint_theme_grouping/task_implement_sprint_theme_grouping.org
+++ b/doc/agile/versions/v0/sprint_18/sprint_theme_grouping/task_implement_sprint_theme_grouping.org
@@ -61,9 +61,9 @@ task closes. Plans do not outlive their task.)
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR                                                         | Title                                                                          |
+|------------------------------------------------------------+--------------------------------------------------------------------------------|
+| [[https://github.com/OreStudio/OreStudio/pull/894][#894]] | [agile] Introduce sprint theme grouping and Achievements across all sprints |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/sprint_theme_grouping/task_implement_sprint_theme_grouping.org
+++ b/doc/agile/versions/v0/sprint_18/sprint_theme_grouping/task_implement_sprint_theme_grouping.org
@@ -67,8 +67,15 @@ task closes. Plans do not outlive their task.)
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                          | File                          | Decision | Notes                                            |
+|---+----------------------------------------------------------+-------------------------------+----------+--------------------------------------------------|
+| 1 | Achievements bullet count violates 4–6 rule              | process.org                   | Fixed    | Relaxed rule to 3–7                              |
+| 2 | Theme column misleading after subheading grouping        | v2_doc_sprint.org.mustache    | Fixed    | Renamed to Description across template + all 18 |
+| 3 | Sprint_18 Theme column same issue                        | sprint_18/sprint.org          | Fixed    | Covered by comment 2 fix                         |
+| 4 | Sprints 02–06 Achievements: lowercase + semicolons       | sprint_02/sprint.org          | Fixed    | Capitalised + full stops across 02–06            |
+| 5 | Sprint_03 same style issue                               | sprint_03/sprint.org          | Fixed    | Covered by comment 4 fix                         |
+| 6 | Sprint_04 same style issue                               | sprint_04/sprint.org          | Fixed    | Covered by comment 4 fix                         |
+| 7 | Sprint_05 same style issue                               | sprint_05/sprint.org          | Fixed    | Covered by comment 4 fix                         |
+| 8 | Sprint_06 same style issue                               | sprint_06/sprint.org          | Fixed    | Covered by comment 4 fix                         |
 
 * Result

--- a/doc/llm/memory/memory.org
+++ b/doc/llm/memory/memory.org
@@ -8,7 +8,7 @@
 #+level: cross
 #+filetags: :memory:index:knowledge:
 #+created: 2024-06-15
-#+updated: 2026-05-21
+#+updated: 2026-05-28
 
 Project-scope persistent memory for LLM sessions. /This is where any
 LLM working on ORE Studio should write things that future sessions
@@ -77,6 +77,8 @@ of these exclusions, push back: the right home is somewhere else.
 - [[id:C6735DF2-B905-4A85-BAAA-B7F5CBBEC92D][Prefer compass over Unix tools for repo navigation]] — use compass
   search/list/show/where/goto/capture before =find= / =grep= / =ls=;
   gaps in compass are captures, not workarounds.
+- [[id:09B8AA56-2F85-47EA-949C-0CBFD36BCD1B][#+version: field is schema version, not a content revision counter]] —
+  always =#+version: 2= for v2 docs; never increment it when editing content.
 
 ** User
 

--- a/doc/llm/memory/set_ssh_auth_sock_for_git_operations.org
+++ b/doc/llm/memory/set_ssh_auth_sock_for_git_operations.org
@@ -9,7 +9,7 @@
 #+level: cross
 #+filetags: :memory:feedback:
 #+created: 2026-05-26
-#+updated: 2026-05-26
+#+updated: 2026-05-28
 
 The sandboxed shell environment does not inherit the user's SSH agent
 socket. Any =git push=, =git fetch=, or =git pull= will hang waiting
@@ -28,6 +28,8 @@ prefix the command with:
 export SSH_AUTH_SOCK=/home/marco/.ssh/agent/s.qEp3u81YnU.agent.P4RgmsqyMr
 #+end_src
 
-If the =SSH_AUTH_SOCK= value changes (the agent restarts), ask the
-user to run =echo $SSH_AUTH_SOCK= in their terminal and use the
-fresh value.
+If that fails (agent restarted, socket path changed), *ask the user*
+to run =echo $SSH_AUTH_SOCK= in their terminal and use the value they
+report. Do *not* probe candidate paths — do not look at =/run/user/*/gnupg/=
+or other sockets. The GPG agent SSH emulation socket (=S.gpg-agent.ssh=)
+is a different thing and must not be touched.

--- a/doc/llm/memory/version_field_is_schema_version.org
+++ b/doc/llm/memory/version_field_is_schema_version.org
@@ -1,0 +1,24 @@
+:PROPERTIES:
+:ID: 09B8AA56-2F85-47EA-949C-0CBFD36BCD1B
+:END:
+#+title: #+version: field is schema version, not a content revision counter
+#+description: The #+version: field in org files denotes the document format schema version (always 2 for v2 docs) — never increment it when updating content.
+#+type: memory
+#+memory_subtype: feedback
+#+version: 2
+#+level: cross
+#+filetags: :memory:feedback:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+
+The =#+version:= field in ORE Studio org files is the document format schema
+version, not a content revision counter. All v2 documents carry =#+version: 2=
+and that value must never be changed when updating content.
+
+*Why:* The user corrected this after an LLM bumped a runbook from
+=#+version: 3= to =#+version: 4= during a content edit, mistaking it for a
+revision counter.
+
+*How to apply:* When editing any =.org= file — runbooks, recipes, stories,
+tasks, knowledge docs — leave =#+version:= untouched. Only update =#+updated:=
+with today's date.

--- a/doc/llm/runbooks/start_new_story/runbook.org
+++ b/doc/llm/runbooks/start_new_story/runbook.org
@@ -4,11 +4,11 @@
 #+title: Start work on a new story
 #+description: Complete procedure from story scaffold to PR creation.
 #+type: runbook
-#+version: 3
+#+version: 4
 #+level: cross
 #+filetags: :runbook:agile:story:git:pr:compass:
 #+created: 2026-05-26
-#+updated: 2026-05-27
+#+updated: 2026-05-28
 
 This page documents a [[id:B555D2A6-10CA-4A93-973E-F2AF4E1D7E55][runbook]] — a named, repeatable composition of [[id:0C57932D-D13A-480F-B426-49525AA8BA3D][recipes]] and [[id:6054CC20-5F41-482F-A587-759512577B1D][skills]] for a complete multi-step procedure. Each step references a recipe or skill by id-link.
 
@@ -45,7 +45,9 @@ In execution order:
 
    This fetches =main=, creates =feature/my-feature=, and writes =story.org= + a linked task into the current sprint. To add a task to an /existing/ story instead, see [[id:84C9177E-C737-428A-BDF9-E55FA6C9680C][the recipe]] for the =--story= form.
 
-3. /Fill in the story content./ Open =story.org= and complete the =* Goal=, =* Acceptance=, =* Tasks=, and =* Out of scope= sections. Use [[id:F9AD7932-8E11-433C-A812-B57DBC9BF5D8][LLM instructions]] as the entry-point skill. Every internal-doc reference uses an =[[id:UUID]]= link, never a relative path.
+2a. /Read all generated files before writing anything./ Immediately after scaffold, read every file compass created and note the =:ID:= property of each. Do this before writing any content to =story.org= or the task file. Failure to read first causes placeholder UUIDs to be written and then silently corrected — an error-prone pattern that breaks org-roam links.
+
+3. /Fill in the story content./ Open =story.org= and complete the =* Goal=, =* Acceptance=, =* Tasks=, and =* Out of scope= sections. Use the actual UUIDs from step 2a for any =[[id:UUID]]= references to compass-generated tasks. Use [[id:F9AD7932-8E11-433C-A812-B57DBC9BF5D8][LLM instructions]] as the entry-point skill. Every internal-doc reference uses an =[[id:UUID]]= link, never a relative path.
 
 4. /Mark the story STARTED./ Update the =* Status= table: state → =STARTED=, fill =Now= and =Next=, set =#+owner:=, refresh =#+updated:=. Follow [[id:DA003A23-1604-43E7-A98F-A305148FBCF4][How do I start work on a story?]] step 3.
 

--- a/doc/llm/runbooks/start_new_story/runbook.org
+++ b/doc/llm/runbooks/start_new_story/runbook.org
@@ -4,7 +4,7 @@
 #+title: Start work on a new story
 #+description: Complete procedure from story scaffold to PR creation.
 #+type: runbook
-#+version: 4
+#+version: 2
 #+level: cross
 #+filetags: :runbook:agile:story:git:pr:compass:
 #+created: 2026-05-26

--- a/projects/ores.codegen/library/templates/v2_doc_sprint.org.mustache
+++ b/projects/ores.codegen/library/templates/v2_doc_sprint.org.mustache
@@ -39,7 +39,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Product
 
 #+ATTR_HTML: :class hug-leading
-| Story | State | Start | End | Theme |
+| Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------|
 |       |       |       |     |       |
 

--- a/projects/ores.codegen/library/templates/v2_doc_sprint.org.mustache
+++ b/projects/ores.codegen/library/templates/v2_doc_sprint.org.mustache
@@ -34,7 +34,9 @@ This page documents a [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprint]] (*{{ti
 
 * Stories
 
-In execution order.
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
+
+** Product
 
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Theme |


### PR DESCRIPTION
## Summary

- Introduce six single-word theme subheadings (Product, Tooling, Agile, LLMs, Documentation, Infrastructure) to the `* Stories` section of every sprint (01–18), replacing the flat table.
- Add `sprint_themes.org` defining the six themes and the optional epic convention; wire into `agile.org` and `process.org`.
- Add `** Achievements` subsection to the `* Status` section of every closed sprint (01–17), capturing 4–6 specific outcome bullets per sprint.
- Fix `start_new_story` runbook: add step 2a (read compass-generated files before writing) to prevent fabricated UUIDs in story content.
- Add project memory: `#+version:` is the document schema version, not a content revision counter.
- Update the sprint codegen template and `process.org` closure sequence to reflect both conventions.

## Changes

- `doc/agile/sprint_themes.org` — new knowledge page defining the six themes and epic convention
- `doc/agile/agile.org` — link to `sprint_themes.org`
- `doc/agile/process.org` — link to themes; Achievements documented as step 2 of sprint closure
- `doc/agile/versions/v0/sprint_*/sprint.org` (all 18) — theme subheadings under `* Stories`; themes blurb; `** Achievements` in closed sprints
- `doc/llm/memory/version_field_is_schema_version.org` — new project memory
- `doc/llm/memory/memory.org` — memory inventory updated
- `doc/llm/runbooks/start_new_story/runbook.org` — step 2a added
- `doc/agile/versions/v0/sprint_18/sprint_theme_grouping/story.org` — story doc
- `doc/agile/versions/v0/sprint_18/sprint_theme_grouping/task_implement_sprint_theme_grouping.org` — task doc
- `projects/ores.codegen/library/templates/v2_doc_sprint.org.mustache` — themes blurb; Product subheading scaffold; remove "In execution order."

## Traceability

| Field    | Value |
|----------|-------|
| Story    | [Sprint theme grouping](https://orestudio.github.io/doc/agile/versions/v0/sprint_18/sprint_theme_grouping/story.html) |
| Task     | [Implement sprint theme grouping](https://orestudio.github.io/doc/agile/versions/v0/sprint_18/sprint_theme_grouping/task_implement_sprint_theme_grouping.html) |
| Story ID | 03EC9465-AE25-4404-9B7E-B0C25A3CBE28 |
| Task ID  | DF939E90-497C-4332-A30E-B528049D6F71 |