### PR TITLE
[agile] Fix: escape [[url][#NNN]] in task doc review table (CI hotfix)

### DIFF
--- a/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_backfill_sprint18_story_task_tables.org
+++ b/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_backfill_sprint18_story_task_tables.org
@@ -67,7 +67,7 @@ task closes. Plans do not outlive their task.)
 | # | Comment summary                                                                  | File                              | Decision | Notes                                                     |
 |---+----------------------------------------------------------------------------------+-----------------------------------+----------+-----------------------------------------------------------|
 | 1 | Regex [^\]]+ silently drops tasks with bracketed titles                          | backfill_story_task_tables.py     | Accept   | Fixed to .*? in commit; 18 sprint_17 stories corrected    |
-| 2 | CI failure: [[url][#NNN]] in table description resolved by org publisher as link | sprint_18/backlog_refinement/story.org | Accept   | Escaped to =[[url][#NNN]]= in c9b82f37e                   |
+| 2 | CI failure: =[[url][#NNN]]= in table description resolved by org publisher as link | sprint_18/backlog_refinement/story.org | Accept   | Escaped to =[[url][#NNN]]= in c9b82f37e                   |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_backfill_sprint18_story_task_tables.org
+++ b/doc/agile/versions/v0/sprint_18/refactor_task_list_to_table/task_backfill_sprint18_story_task_tables.org
@@ -68,6 +68,7 @@ task closes. Plans do not outlive their task.)
 |---+----------------------------------------------------------------------------------+-----------------------------------+----------+-----------------------------------------------------------|
 | 1 | Regex [^\]]+ silently drops tasks with bracketed titles                          | backfill_story_task_tables.py     | Accept   | Fixed to .*? in commit; 18 sprint_17 stories corrected    |
 | 2 | CI failure: =[[url][#NNN]]= in table description resolved by org publisher as link | sprint_18/backlog_refinement/story.org | Accept   | Escaped to =[[url][#NNN]]= in c9b82f37e                   |
+| 3 | Same =[[url][#NNN]]= issue in this task's Review table (CI round 2)                | task_backfill_sprint18_story_task_tables.org | Accept   | Fixed in 138d99b71                                        |
 
 * Result
 


### PR DESCRIPTION
## Summary

- PR #895 was merged with an unescaped `[[url][#NNN]]` literal example
  in the `* Review` table of `task_backfill_sprint18_story_task_tables.org`.
- The org-html publisher treats `[[url][...]]` as a link target and
  fails with _Unable to resolve link: "url"_, breaking the site build.
- This hotfix cherry-picks the two fix commits from the feature branch
  that didn't make it into the merge.

## Changes

| File | Change |
|------|--------|
| `task_backfill_sprint18_story_task_tables.org` | Escape row-2 comment text `[[url][#NNN]]` → `=[[url][#NNN]]=` |
| `task_backfill_sprint18_story_task_tables.org` | Add review round 3 row recording this CI failure |

## Test plan

- [ ] Site build (Product website) passes on CI
- [ ] No other `[[url][...]]` literals left unescaped in table rows

## Traceability

| Field | Value |
|-------|-------|
| Story-ID | FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6 |
| Task-ID | 3F5D9276-12DB-4A6B-A355-95E26AFA1CBD |

🤖 Generated with [Claude Code](https://claude.com/claude-code)