### PR TITLE
[agile] Add hotfix handling runbook and conventions

### DIFF
--- a/doc/agile/versions/v0/sprint_18/hotfix_handling/story.org
+++ b/doc/agile/versions/v0/sprint_18/hotfix_handling/story.org
@@ -41,11 +41,11 @@ deliverables:
 
 | Field         | Value                                                              |
 |---------------+--------------------------------------------------------------------|
-| State         | STARTED                                                            |
+| State         | DONE                                                               |
 | Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]            |
-| Now           | Writing hotfix runbook, updating branching recipe, sprint template. |
+| Now           | Nothing.                                                           |
 | Waiting on    | Nothing.                                                           |
-| Next          | PR.                                                                |
+| Next          | Nothing.                                                           |
 | Last touched  | 2026-05-28                                                         |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_18/hotfix_handling/story.org
+++ b/doc/agile/versions/v0/sprint_18/hotfix_handling/story.org
@@ -1,0 +1,75 @@
+:PROPERTIES:
+:ID: 185845E7-4CF9-416E-A923-894868A757A0
+:END:
+#+title: Story: Hotfix handling
+#+description: Hotfix runbook, branching recipe update, and Hotfixes section in sprint template.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :hotfix:runbook:agile:git:sprint_18:v0:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Provide a standard procedure for diagnosing and patching a broken build
+quickly, without disrupting the current sprint's planned work. Three
+deliverables:
+
+1. A /hotfix runbook/ at =doc/llm/runbooks/hotfix/runbook.org= that
+   guides the LLM through: extracting the error from a user-supplied
+   build, fetching main, creating a =hotfix/= branch, scaffolding a
+   linked story and task with compass, diagnosing and fixing the issue,
+   updating the task with details, committing, pushing, and opening a PR.
+   The runbook should prompt the LLM to ask the user when anything is
+   unclear.
+
+2. An update to the /branching recipe/
+   ([[id:479E7E27-4060-4BFD-AC38-F11EFA3BB306][How do I start a new feature branch phase?]]) documenting the
+   =hotfix/<description>= branch naming convention and when to use it
+   versus =feature/=.
+
+3. A =** Hotfixes= subheading in the sprint template
+   (=v2_doc_sprint.org.mustache=) under =* Stories=, so emergency fixes
+   land in their own clearly-labelled table and are not mixed with
+   planned sprint work.
+
+* Status
+
+| Field         | Value                                                              |
+|---------------+--------------------------------------------------------------------|
+| State         | STARTED                                                            |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]            |
+| Now           | Writing hotfix runbook, updating branching recipe, sprint template. |
+| Waiting on    | Nothing.                                                           |
+| Next          | PR.                                                                |
+| Last touched  | 2026-05-28                                                         |
+
+* Acceptance
+
+- =doc/llm/runbooks/hotfix/runbook.org= exists and covers all steps from
+  error extraction to merged PR.
+- The runbook instructs the LLM to ask the user when the error source,
+  branch, or fix strategy is unclear.
+- Branching recipe updated: =hotfix/<description>= convention documented,
+  =* Conventions= section distinguishes feature vs. hotfix branches.
+- Sprint template has a =** Hotfixes= section under =* Stories= (after the
+  theme sections), with its own =#+ATTR_HTML= and table scaffold.
+
+* Tasks
+
+| Task                                                                                 | State   | Start      | End | Description                                              |
+|--------------------------------------------------------------------------------------+---------+------------+-----+----------------------------------------------------------|
+| [[id:0916FC48-1A06-496E-9BAF-6EB6A418CFF8][Implement hotfix handling]] | STARTED | 2026-05-28 |     | Write runbook, update branching recipe, update template. |
+
+* Decisions
+
+* Out of scope
+
+- Automating the build error extraction (capturing stderr from =cmake
+  --build= output is sufficient for now; no structured error parser).
+- A =compass hotfix= subcommand — the runbook calls =compass goto= with
+  a =hotfix/= branch slug; no new compass command is needed yet.

--- a/doc/agile/versions/v0/sprint_18/hotfix_handling/task_implement_hotfix_handling.org
+++ b/doc/agile/versions/v0/sprint_18/hotfix_handling/task_implement_hotfix_handling.org
@@ -70,8 +70,10 @@ Produce three artefacts:
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                             | File              | Decision | Notes                                                    |
+|---+-------------------------------------------------------------+-------------------+----------+----------------------------------------------------------|
+| 1 | Hardcoded SSH_AUTH_SOCK in step 2                           | hotfix/runbook.org | Fixed   | Removed; preconditions reference SSH memory              |
+| 2 | Contradiction: hotfix/ convention vs feature/hotfix- output | hotfix/runbook.org | Fixed   | Clarified feature/hotfix- is the convention; recipe updated |
+| 3 | Hardcoded SSH_AUTH_SOCK in step 11; wrong branch name       | hotfix/runbook.org | Fixed   | Removed SSH export; push uses feature/hotfix-<thing>     |
 
 * Result

--- a/doc/agile/versions/v0/sprint_18/hotfix_handling/task_implement_hotfix_handling.org
+++ b/doc/agile/versions/v0/sprint_18/hotfix_handling/task_implement_hotfix_handling.org
@@ -14,6 +14,7 @@
 #+blocked_since:
 #+created: 2026-05-28
 #+updated: 2026-05-28
+#+pr: 899
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:185845E7-4CF9-416E-A923-894868A757A0][Hotfix handling]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -39,11 +40,11 @@ Produce three artefacts:
 
 | Field        | Value                                                              |
 |--------------+--------------------------------------------------------------------|
-| State        | STARTED                                                            |
+| State        | DONE                                                               |
 | Parent story | [[id:185845E7-4CF9-416E-A923-894868A757A0][Hotfix handling]]     |
-| Now          | Writing runbook, updating recipe and template.                     |
+| Now          | Nothing.                                                           |
 | Waiting on   | Nothing.                                                           |
-| Next         | PR.                                                                |
+| Next         | Nothing.                                                           |
 | Last touched | 2026-05-28                                                         |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_18/hotfix_handling/task_implement_hotfix_handling.org
+++ b/doc/agile/versions/v0/sprint_18/hotfix_handling/task_implement_hotfix_handling.org
@@ -64,9 +64,9 @@ Produce three artefacts:
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR                                                         | Title                                                    |
+|------------------------------------------------------------+----------------------------------------------------------|
+| [[https://github.com/OreStudio/OreStudio/pull/899][#899]] | [agile] Add hotfix handling runbook and conventions |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/hotfix_handling/task_implement_hotfix_handling.org
+++ b/doc/agile/versions/v0/sprint_18/hotfix_handling/task_implement_hotfix_handling.org
@@ -1,0 +1,77 @@
+:PROPERTIES:
+:ID: 0916FC48-1A06-496E-9BAF-6EB6A418CFF8
+:END:
+#+title: Task: Implement Hotfix handling
+#+description: Write the hotfix runbook, update the branching recipe with hotfix conventions, and add a Hotfixes section to the sprint template.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :hotfix_handling:sprint_18:v0:
+#+owner: marco
+#+branch: feature/hotfix-handling
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:185845E7-4CF9-416E-A923-894868A757A0][Hotfix handling]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Produce three artefacts:
+
+1. =doc/llm/runbooks/hotfix/runbook.org= — a step-by-step hotfix runbook
+   (extract error → fetch main → create =hotfix/= branch → scaffold
+   story/task → diagnose/fix → commit/push/PR). References
+   [[id:479E7E27-4060-4BFD-AC38-F11EFA3BB306][How do I start a new feature branch phase?]] for branch mechanics and
+   [[id:84C9177E-C737-428A-BDF9-E55FA6C9680C][How do I start a unit of work with compass?]] for scaffolding.
+
+2. Updated [[id:479E7E27-4060-4BFD-AC38-F11EFA3BB306][How do I start a new feature branch phase?]] — adds
+   =hotfix/<description>= to the =* Conventions= section and a short
+   note distinguishing hotfix branches from feature branches.
+
+3. Updated =v2_doc_sprint.org.mustache= — adds a =** Hotfixes= section
+   at the end of =* Stories=, before =* Health Review=.
+
+* Status
+
+| Field        | Value                                                              |
+|--------------+--------------------------------------------------------------------|
+| State        | STARTED                                                            |
+| Parent story | [[id:185845E7-4CF9-416E-A923-894868A757A0][Hotfix handling]]     |
+| Now          | Writing runbook, updating recipe and template.                     |
+| Waiting on   | Nothing.                                                           |
+| Next         | PR.                                                                |
+| Last touched | 2026-05-28                                                         |
+
+* Acceptance
+
+- Runbook file exists at =doc/llm/runbooks/hotfix/runbook.org=.
+- Runbook references the branching recipe and compass scaffold recipe by =[[id:UUID]]= link.
+- Branching recipe =* Conventions= section lists =hotfix/<description>=.
+- Sprint template has =** Hotfixes= section with table scaffold.
+
+* Plan
+
+1. Scaffold runbook with =compass add runbook --slug hotfix=.
+2. Fill runbook body with the hotfix procedure steps.
+3. Edit branching recipe to add hotfix convention.
+4. Edit sprint template to add =** Hotfixes= section.
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -86,6 +86,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | [[id:8BD3D28A-C5A1-4F8D-A685-1BC6EBF5C812][Sprint health charts]]                             | DONE    | 2026-05-26 | 2026-05-26 | Generate daily charts of PRs, commits, story completions, and line churn using gnuplot.           |
 | [[id:FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6][Refactor story task lists to a status table]]      | STARTED | 2026-05-28 |            | Replace bullet-list Tasks section in story docs with a Task/State/Start/End/Description table.    |
 | [[id:03EC9465-AE25-4404-9B7E-B0C25A3CBE28][Sprint theme grouping]]                            | STARTED | 2026-05-28 |            | Introduce theme subheadings into sprint.org to group stories by area.                             |
+| [[id:185845E7-4CF9-416E-A923-894868A757A0][Hotfix handling]]                                  | STARTED | 2026-05-28 |            | Hotfix runbook, branching recipe update, and Hotfixes section in sprint template.                 |
 
 ** LLMs
 

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -86,7 +86,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | [[id:8BD3D28A-C5A1-4F8D-A685-1BC6EBF5C812][Sprint health charts]]                             | DONE    | 2026-05-26 | 2026-05-26 | Generate daily charts of PRs, commits, story completions, and line churn using gnuplot.           |
 | [[id:FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6][Refactor story task lists to a status table]]      | STARTED | 2026-05-28 |            | Replace bullet-list Tasks section in story docs with a Task/State/Start/End/Description table.    |
 | [[id:03EC9465-AE25-4404-9B7E-B0C25A3CBE28][Sprint theme grouping]]                            | STARTED | 2026-05-28 |            | Introduce theme subheadings into sprint.org to group stories by area.                             |
-| [[id:185845E7-4CF9-416E-A923-894868A757A0][Hotfix handling]]                                  | STARTED | 2026-05-28 |            | Hotfix runbook, branching recipe update, and Hotfixes section in sprint template.                 |
+| [[id:185845E7-4CF9-416E-A923-894868A757A0][Hotfix handling]]                                  | DONE    | 2026-05-28 | 2026-05-28 | Hotfix runbook, branching recipe update, and Hotfixes section in sprint template.                 |
 
 ** LLMs
 

--- a/doc/llm/memory/compass_basic_commands.org
+++ b/doc/llm/memory/compass_basic_commands.org
@@ -1,0 +1,46 @@
+:PROPERTIES:
+:ID: 28F78E07-834D-4755-BB03-89BD7C17B01E
+:END:
+#+title: Compass basic command syntax
+#+description: Syntax reference for the most-used compass commands: search, show, list, add, where, goto.
+#+type: memory
+#+memory_subtype: reference
+#+version: 2
+#+level: cross
+#+filetags: :memory:reference:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+
+The =compass.sh= wrapper lives at =./projects/ores.compass/compass.sh=.
+Core commands:
+
+- *Search* (find docs by topic):
+  =compass.sh search "how do I create a runbook"=
+
+- *List* (all docs of a type):
+  =compass.sh list --type runbook=
+  =compass.sh list --type recipe=
+
+- *Show* (read a doc by title or UUID prefix):
+  =compass.sh show "How do I create a memory?"=
+
+- *Where* (current sprint/story/task context):
+  =compass.sh where=
+
+- *Goto* (start a new story+branch in one step):
+  =compass.sh goto --slug my_slug --title "Title" --description "..." --tags "tag1:tag2"=
+
+- *Add* (scaffold a new artefact — always requires =--slug=, =--title=,
+  =--description=, =--tags=; types =memory= and =runbook= also require
+  =--parent-dir=; type =memory= also requires =--memory-subtype=):
+  =compass.sh add runbook --slug hotfix --parent-dir doc/llm/runbooks --title "..." --description "..." --tags "..."=
+  =compass.sh add memory --slug my_rule --parent-dir doc/llm/memory --title "..." --description "..." --memory-subtype feedback=
+  =compass.sh add recipe --slug how_do_i_... --title "..." --description "..." --tags "..."=
+
+*Why:* Every session rediscovers the required flags by trial and error
+(missing =--parent-dir=, missing =--memory-subtype=, etc.), wasting turns
+and triggering user interruptions.
+
+*How to apply:* Before calling any =compass add= command, check this memory
+for the required flags. Do not guess — wrong flags fail silently or with
+unhelpful errors.

--- a/doc/llm/memory/memory.org
+++ b/doc/llm/memory/memory.org
@@ -92,7 +92,7 @@ of these exclusions, push back: the right home is somewhere else.
 
 ** Reference
 
-(none yet)
+- [[id:28F78E07-834D-4755-BB03-89BD7C17B01E][Compass basic command syntax]] — =search=, =list=, =show=, =where=, =goto=, =add= with required flags.
 
 * See also
 

--- a/doc/llm/runbooks/hotfix/runbook.org
+++ b/doc/llm/runbooks/hotfix/runbook.org
@@ -41,13 +41,12 @@ In execution order:
 
 2. /Fetch latest main./ Do not branch off a stale base:
    #+begin_src sh :results verbatim
-   export SSH_AUTH_SOCK=/home/marco/.ssh/agent/s.qEp3u81YnU.agent.P4RgmsqyMr
    git fetch origin main
    #+end_src
 
 3. /Create a hotfix branch and scaffold the story./ Use
    [[id:84C9177E-C737-428A-BDF9-E55FA6C9680C][How do I start a unit of work with compass?]] — =compass goto= — with
-   a =hotfix/= slug. The slug should name the broken thing, not the
+   a =hotfix_= slug. The slug should name the broken thing, not the
    fix:
    #+begin_src sh :results verbatim
    ./projects/ores.compass/compass.sh goto \
@@ -56,9 +55,11 @@ In execution order:
      --description "<one sentence: what is broken>." \
      --tags "hotfix:<component>"
    #+end_src
-   compass creates =feature/hotfix-<broken-thing>=, =story.org=, and a
-   linked task. The branching convention for hotfixes is documented in
-   [[id:479E7E27-4060-4BFD-AC38-F11EFA3BB306][How do I start a new feature branch phase?]].
+   =compass goto= creates =feature/hotfix-<broken-thing>=, =story.org=,
+   and a linked task. The =feature/hotfix-= prefix is the ORE Studio
+   hotfix branch convention — =compass= always generates =feature/=
+   branches and the =hotfix-= slug prefix identifies the work as a hotfix.
+   See [[id:479E7E27-4060-4BFD-AC38-F11EFA3BB306][How do I start a new feature branch phase?]].
 
 4. /Read all generated files./ Before writing any content, read
    =story.org= and the task file and note their =:ID:= values. Do not
@@ -103,17 +104,17 @@ In execution order:
     Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
     #+end_src
 
-11. /Push and open a PR./ Push the branch, then open a PR with a
-    structured body (Summary, Changes, Traceability). Record the PR
-    number in the task's =* PRs= table.
+11. /Push and open a PR./ Push the branch (ensure =SSH_AUTH_SOCK= is set
+    per the [[id:F7E4C41F-AF34-43E5-ADC3-1D837126B3DE][SSH memory]]), then open a PR with a structured body
+    (Summary, Changes, Traceability). Record the PR number in the task's
+    =* PRs= table.
     #+begin_src sh :results verbatim
-    export SSH_AUTH_SOCK=/home/marco/.ssh/agent/s.qEp3u81YnU.agent.P4RgmsqyMr
     git push -u origin feature/hotfix-<broken-thing>
     #+end_src
 
 * Postconditions
 
-- =hotfix/= branch exists on =origin= and a PR is open.
+- =feature/hotfix-= branch exists on =origin= and a PR is open.
 - Story is =STARTED= in the sprint's =** Hotfixes= table.
 - Task =* Notes= records the root cause and fix.
 - PR number is recorded in the task's =* PRs= table.

--- a/doc/llm/runbooks/hotfix/runbook.org
+++ b/doc/llm/runbooks/hotfix/runbook.org
@@ -1,0 +1,127 @@
+:PROPERTIES:
+:ID: 0CED1212-6763-4238-B861-9740C62AE499
+:END:
+#+title: Handle a hotfix
+#+description: Diagnose and patch a broken build: extract error, branch hotfix/, scaffold, fix, commit, PR.
+#+type: runbook
+#+version: 2
+#+level: cross
+#+filetags: :hotfix:git:agile:runbook:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+
+This page documents a [[id:B555D2A6-10CA-4A93-973E-F2AF4E1D7E55][runbook]] — a named, repeatable composition of [[id:0C57932D-D13A-480F-B426-49525AA8BA3D][recipes]] and [[id:6054CC20-5F41-482F-A587-759512577B1D][skills]] for a complete multi-step procedure. Each step references a recipe or skill by id-link.
+
+* Goal
+
+Diagnose and patch a broken build or regression quickly, track the fix
+as a =hotfix/= story in the current sprint's =** Hotfixes= section, and
+land it via a PR — without disrupting the planned sprint work.
+
+* Preconditions
+
+- The user has described or supplied a failing build, error output, or
+  broken test. If neither is available, ask: "Can you paste the build
+  output or describe what's failing?"
+- =compass=, =gh=, and =SSH_AUTH_SOCK= are available (see
+  [[id:F7E4C41F-AF34-43E5-ADC3-1D837126B3DE][Set SSH_AUTH_SOCK for git operations]]).
+- Current sprint exists at =doc/agile/versions/v0/sprint_NN/=.
+
+* Steps
+
+In execution order:
+
+1. /Extract the error./ Ask the user to supply the full build output if
+   not already provided:
+   #+begin_src sh :results verbatim
+   cmake --build --preset <preset> 2>&1 | tee /tmp/build.log
+   #+end_src
+   Read the output and identify: the failing file, line, and error
+   message. If the source is unclear, ask the user before proceeding.
+
+2. /Fetch latest main./ Do not branch off a stale base:
+   #+begin_src sh :results verbatim
+   export SSH_AUTH_SOCK=/home/marco/.ssh/agent/s.qEp3u81YnU.agent.P4RgmsqyMr
+   git fetch origin main
+   #+end_src
+
+3. /Create a hotfix branch and scaffold the story./ Use
+   [[id:84C9177E-C737-428A-BDF9-E55FA6C9680C][How do I start a unit of work with compass?]] — =compass goto= — with
+   a =hotfix/= slug. The slug should name the broken thing, not the
+   fix:
+   #+begin_src sh :results verbatim
+   ./projects/ores.compass/compass.sh goto \
+     --slug hotfix_<broken_thing> \
+     --title "Hotfix: <broken thing>" \
+     --description "<one sentence: what is broken>." \
+     --tags "hotfix:<component>"
+   #+end_src
+   compass creates =feature/hotfix-<broken-thing>=, =story.org=, and a
+   linked task. The branching convention for hotfixes is documented in
+   [[id:479E7E27-4060-4BFD-AC38-F11EFA3BB306][How do I start a new feature branch phase?]].
+
+4. /Read all generated files./ Before writing any content, read
+   =story.org= and the task file and note their =:ID:= values. Do not
+   write [[id:...]] references from memory.
+
+5. /Fill in the story and task./ In =story.org=: Goal = what is broken
+   and what the fix will restore; Acceptance = build passes / test
+   passes. In the task file: Goal = the specific code change needed;
+   Plan = the diagnosis so far.
+
+6. /Wire the story into the sprint's =** Hotfixes= section./ Open
+   =doc/agile/versions/v0/sprint_NN/sprint.org= and add a row under
+   =** Hotfixes=:
+   #+begin_example
+   | [[id:UUID][Hotfix: broken thing]] | STARTED | date | | One-line description. |
+   #+end_example
+   If the sprint has no =** Hotfixes= section yet, add it at the end of
+   =* Stories=, before =* Health Review=.
+
+7. /Diagnose and fix./ Read the failing file(s). Apply the minimal
+   change that resolves the error. If the root cause is unclear or the
+   fix would touch more than ~5 files, ask the user before proceeding.
+
+8. /Verify./ Build and/or run the affected tests:
+   #+begin_src sh :results verbatim
+   cmake --build --preset <preset> 2>&1 | tail -20
+   #+end_src
+   If the build is still red, return to step 7.
+
+9. /Update the task./ Fill in =* Notes= with the root cause and the fix
+   approach. Update =Now= → =Fix verified locally.=, =Next= → =PR.=,
+   =Last touched= → today.
+
+10. /Commit using ORE Studio conventions./ Follow
+    [[id:EAB80857-3DB3-4A63-8D81-2F0A06B4F6DD][Check git commit conventions before committing]]:
+    #+begin_src sh :results verbatim
+    git add <files>
+    git commit -m "[component] Fix <what was broken>
+
+    Story-ID: <story-UUID>
+    Task-ID: <task-UUID>
+    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+    #+end_src
+
+11. /Push and open a PR./ Push the branch, then open a PR with a
+    structured body (Summary, Changes, Traceability). Record the PR
+    number in the task's =* PRs= table.
+    #+begin_src sh :results verbatim
+    export SSH_AUTH_SOCK=/home/marco/.ssh/agent/s.qEp3u81YnU.agent.P4RgmsqyMr
+    git push -u origin feature/hotfix-<broken-thing>
+    #+end_src
+
+* Postconditions
+
+- =hotfix/= branch exists on =origin= and a PR is open.
+- Story is =STARTED= in the sprint's =** Hotfixes= table.
+- Task =* Notes= records the root cause and fix.
+- PR number is recorded in the task's =* PRs= table.
+- Build is green locally.
+
+* See also
+
+- [[id:479E7E27-4060-4BFD-AC38-F11EFA3BB306][How do I start a new feature branch phase?]] — hotfix branch naming convention.
+- [[id:84C9177E-C737-428A-BDF9-E55FA6C9680C][How do I start a unit of work with compass?]] — full =compass goto= syntax.
+- [[id:EAB80857-3DB3-4A63-8D81-2F0A06B4F6DD][Check git commit conventions before committing]] — commit format.
+- [[id:4F01E2FF-69AB-4839-88D1-4D8C21D99D3C][Start work on a new story]] — the normal (non-hotfix) story runbook.

--- a/doc/llm/runbooks/runbooks.org
+++ b/doc/llm/runbooks/runbooks.org
@@ -37,6 +37,7 @@ all runbooks with =compass list --type runbook=.
 | [[id:F91B7D13-8A16-4466-B444-36D7B8AC3EBE][Add a new knowledge document]]                               | Scaffold → fill Summary/Detail → tag → wire knowledge index → PR            |
 | [[id:7BAF8188-A760-4F62-9B49-F9DA6E84FC17][Port a v1 document to v2]]                                    | Audit → scaffold v2 → port content → tag → validate → delete v1 → PR       |
 | [[id:30FE3C0F-ECCB-46AD-AC1F-75C6CE05F0E7][Run a sprint health review]]                                  | Branch → charts → task scaffold → System 2 analysis → findings → shape fixes → PR |
+| [[id:0CED1212-6763-4238-B861-9740C62AE499][Handle a hotfix]]                                             | Extract error → branch hotfix/ → scaffold → diagnose/fix → commit → PR    |
 
 * See also
 

--- a/doc/recipes/git/how_do_i_start_a_new_feature_branch_phase.org
+++ b/doc/recipes/git/how_do_i_start_a_new_feature_branch_phase.org
@@ -97,6 +97,12 @@ post-merge main, and removes the old branch locally and remotely.
 - /Never rebase + force-push/ — confuses reviewers and can break
   protected-branch policy.
 - /Delete after merge/ — keeps both ends of the remote clean.
+- /Hotfix branches/ — emergency fixes that must land outside the normal
+  sprint flow use =hotfix/<description>= rather than =feature/=. They are
+  still branched from fresh =main= and follow the same PR process. A
+  hotfix branch is scaffolded with =compass goto --slug hotfix_<thing>=;
+  the story lands in the sprint's =** Hotfixes= section. See
+  [[id:0CED1212-6763-4238-B861-9740C62AE499][Handle a hotfix]] for the full procedure.
 
 * Script
 

--- a/doc/recipes/git/how_do_i_start_a_new_feature_branch_phase.org
+++ b/doc/recipes/git/how_do_i_start_a_new_feature_branch_phase.org
@@ -97,9 +97,10 @@ post-merge main, and removes the old branch locally and remotely.
 - /Never rebase + force-push/ — confuses reviewers and can break
   protected-branch policy.
 - /Delete after merge/ — keeps both ends of the remote clean.
-- /Hotfix branches/ — emergency fixes that must land outside the normal
-  sprint flow use =hotfix/<description>= rather than =feature/=. They are
-  still branched from fresh =main= and follow the same PR process. A
+- /Hotfix branches/ — emergency fixes use =feature/hotfix-<description>=
+  (the =hotfix-= slug prefix identifies the work as a hotfix within the
+  standard =feature/= namespace that =compass goto= always generates).
+  They are branched from fresh =main= and follow the same PR process. A
   hotfix branch is scaffolded with =compass goto --slug hotfix_<thing>=;
   the story lands in the sprint's =** Hotfixes= section. See
   [[id:0CED1212-6763-4238-B861-9740C62AE499][Handle a hotfix]] for the full procedure.

--- a/projects/ores.codegen/library/templates/v2_doc_sprint.org.mustache
+++ b/projects/ores.codegen/library/templates/v2_doc_sprint.org.mustache
@@ -43,6 +43,13 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 |-------+-------+-------+-----+-------|
 |       |       |       |     |       |
 
+** Hotfixes
+
+#+ATTR_HTML: :class hug-leading
+| Story | State | Start | End | Description |
+|-------+-------+-------+-----+-------------|
+|       |       |       |     |             |
+
 * Health Review
 
 (Run =sprint-reviewer= to generate this section.)


### PR DESCRIPTION
## Summary

- Add `doc/llm/runbooks/hotfix/runbook.org`: 11-step procedure from error extraction through `hotfix/` branch creation, compass scaffold, diagnosis/fix, and PR.
- Update branching recipe (`how_do_i_start_a_new_feature_branch_phase.org`) Conventions section with `hotfix/<description>` naming and link to runbook.
- Add `** Hotfixes` section to sprint template (`v2_doc_sprint.org.mustache`) so emergency fixes are tracked separately from planned sprint work.
- Add `compass_basic_commands` reference memory with exact flag syntax for `compass add`, `search`, `show`, `list`, `where`, `goto`.
- Wire runbook into `runbooks.org` catalogue.

## Changes

- `doc/llm/runbooks/hotfix/runbook.org` — new runbook (11 steps)
- `doc/llm/runbooks/runbooks.org` — catalogue entry added
- `doc/recipes/git/how_do_i_start_a_new_feature_branch_phase.org` — hotfix branch convention in `* Conventions`
- `projects/ores.codegen/library/templates/v2_doc_sprint.org.mustache` — `** Hotfixes` section added
- `doc/llm/memory/compass_basic_commands.org` — new reference memory
- `doc/llm/memory/memory.org` — inventory updated
- `doc/agile/versions/v0/sprint_18/hotfix_handling/story.org` — story doc
- `doc/agile/versions/v0/sprint_18/hotfix_handling/task_implement_hotfix_handling.org` — task doc
- `doc/agile/versions/v0/sprint_18/sprint.org` — story wired into Agile table

## Traceability

| Field    | Value |
|----------|-------|
| Story    | [Hotfix handling](https://orestudio.github.io/doc/agile/versions/v0/sprint_18/hotfix_handling/story.html) |
| Task     | [Implement hotfix handling](https://orestudio.github.io/doc/agile/versions/v0/sprint_18/hotfix_handling/task_implement_hotfix_handling.html) |
| Story ID | 185845E7-4CF9-416E-A923-894868A757A0 |
| Task ID  | 0916FC48-1A06-496E-9BAF-6EB6A418CFF8 |