### PR TITLE
[agile] Document ** Hotfixes section in sprint_themes.org

### DIFF
--- a/doc/agile/sprint_themes.org
+++ b/doc/agile/sprint_themes.org
@@ -32,6 +32,15 @@ capability.
 | Documentation  | Knowledge graph, system model, diagrams, site content, user manual.      |
 | Infrastructure | Build system, CI/CD, test infrastructure, database infrastructure, comms substrate, security primitives, compiler/platform work. |
 
+** Hotfixes
+
+A sprint's =* Stories= section also contains a =** Hotfixes= subsection
+after the six theme subsections. It is not a theme — it is a holding area
+for emergency fixes that must land outside the normal planned-work flow.
+A hotfix story is created with =compass goto --slug hotfix_<thing>= and
+lands here rather than under one of the six themes. See
+[[id:0CED1212-6763-4238-B861-9740C62AE499][Handle a hotfix]] for the full procedure.
+
 ** Epics
 
 An epic is an optional =***= sub-subheading inside a theme for a cluster


### PR DESCRIPTION
## Summary

- Documents the `** Hotfixes` subsection in `sprint_themes.org`, clarifying it is not a theme but a holding area for emergency fixes that land outside the normal planned-work flow.
- Explains that hotfix stories are scaffolded with `compass goto --slug hotfix_<thing>` and land in `** Hotfixes` rather than under one of the six sprint themes.
- References the Handle a hotfix runbook (`id:0CED1212-6763-4238-B861-9740C62AE499`) for the full procedure.

## Test plan

- [ ] `sprint_themes.org` renders correctly in the knowledge graph site.
- [ ] The `** Hotfixes` section appears between the Epics section and `* See also`.
- [ ] The runbook org-link resolves to `doc/llm/runbooks/hotfix/runbook.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)