### PR TITLE
[tooling] Add --kind flag to compass goto for hotfix branches

### DIFF
--- a/doc/agile/sprint_themes.org
+++ b/doc/agile/sprint_themes.org
@@ -32,6 +32,15 @@ capability.
 | Documentation  | Knowledge graph, system model, diagrams, site content, user manual.      |
 | Infrastructure | Build system, CI/CD, test infrastructure, database infrastructure, comms substrate, security primitives, compiler/platform work. |
 
+** Hotfixes
+
+A sprint's =* Stories= section also contains a =** Hotfixes= subsection
+after the six theme subsections. It is not a theme — it is a holding area
+for emergency fixes that must land outside the normal planned-work flow.
+A hotfix story is created with =compass goto --slug <thing> --kind hotfix=
+and lands here rather than under one of the six themes. See
+[[id:0CED1212-6763-4238-B861-9740C62AE499][Handle a hotfix]] for the full procedure.
+
 ** Epics
 
 An epic is an optional =***= sub-subheading inside a theme for a cluster

--- a/doc/agile/versions/v0/sprint_18/compass_goto_kind/story.org
+++ b/doc/agile/versions/v0/sprint_18/compass_goto_kind/story.org
@@ -1,0 +1,53 @@
+:PROPERTIES:
+:ID: 47FD2F81-2143-4C35-9AC1-5A3A9D4AF975
+:END:
+#+title: Story: compass goto --kind flag
+#+description: Add --kind flag to compass goto to support hotfix/ branches following standard Gitflow conventions.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :compass:tooling:hotfix:sprint_18:v0:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Enable =compass goto= to create =hotfix/<slug>= branches (standard
+Gitflow convention) in addition to the default =feature/<slug>=, via a
+=--kind= flag. Removes the previous =feature/hotfix-= workaround.
+
+* Status
+
+| Field         | Value                                                                        |
+|---------------+------------------------------------------------------------------------------|
+| State         | DONE                                                                         |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                    |
+| Now           | Nothing.                                                                     |
+| Waiting on    | Nothing.                                                                     |
+| Next          | Nothing.                                                                     |
+| Last touched  | 2026-05-28                                                                   |
+
+* Acceptance
+
+- =compass goto --kind hotfix --slug <thing> ...= creates =hotfix/<thing>=.
+- =compass goto= without =--kind= still creates =feature/<slug>= (no regression).
+- =--kind invalid= is rejected with a choices error.
+- Hotfix runbook, branching recipe, compass memory, and =sprint_themes.org= all reference =hotfix/<thing>= and =--kind hotfix=.
+
+* Tasks
+
+| Task                                                                                              | State | Start      | End        | Description                                        |
+|---------------------------------------------------------------------------------------------------+-------+------------+------------+----------------------------------------------------|
+| [[id:F54948C6-CB8A-432F-B0E7-99089B3F0E1D][Implement compass goto --kind flag]] | DONE  | 2026-05-28 | 2026-05-28 | Add --kind to cmd_goto and update all docs.        |
+
+* Decisions
+
+- =hotfix/= prefix chosen over =feature/hotfix-= to follow standard Gitflow conventions; a hotfix is not a feature.
+- =--kind= chosen over =--prefix= (mechanical) or =--branch-type= (verbose) as it is short and semantic.
+
+* Out of scope
+
+- Additional kinds (e.g. =release/=, =bugfix/=) — can be added to the =choices= list later.

--- a/doc/agile/versions/v0/sprint_18/compass_goto_kind/task_implement_compass_goto_kind.org
+++ b/doc/agile/versions/v0/sprint_18/compass_goto_kind/task_implement_compass_goto_kind.org
@@ -1,0 +1,63 @@
+:PROPERTIES:
+:ID: F54948C6-CB8A-432F-B0E7-99089B3F0E1D
+:END:
+#+title: Task: Implement compass goto --kind flag
+#+description: Add --kind argument to cmd_goto, update hotfix runbook, branching recipe, compass memory, and sprint_themes.org.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :compass_goto_kind:sprint_18:v0:
+#+owner: marco
+#+branch: feature/compass-goto-kind
+#+pr: 902
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:47FD2F81-2143-4C35-9AC1-5A3A9D4AF975][compass goto --kind flag]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add =--kind= argument to =cmd_goto= in =compass.py= with values =feature=
+(default) and =hotfix=; derive the branch prefix from =args.kind= in both
+new-story and existing-story modes. Update the hotfix runbook, branching
+recipe, compass commands memory, and =sprint_themes.org= to use =hotfix/<slug>=
+and =--kind hotfix= throughout.
+
+* Status
+
+| Field        | Value                                                                        |
+|--------------+------------------------------------------------------------------------------|
+| State        | DONE                                                                         |
+| Parent story | [[id:47FD2F81-2143-4C35-9AC1-5A3A9D4AF975][compass goto --kind flag]]    |
+| Now          | Nothing.                                                                     |
+| Waiting on   | Nothing.                                                                     |
+| Next         | Nothing.                                                                     |
+| Last touched | 2026-05-28                                                                   |
+
+* Acceptance
+
+- =compass goto --kind hotfix --slug thing ...= produces =hotfix/thing=.
+- Default (no =--kind=) still produces =feature/<slug>=.
+- Invalid =--kind= value rejected by argparse choices validation.
+- All docs updated: runbook, branching recipe, memory, =sprint_themes.org=.
+
+* Plan
+
+* Notes
+
+* PRs
+
+| PR                                                          | Title                                                     |
+|-------------------------------------------------------------+-----------------------------------------------------------|
+| [[https://github.com/OreStudio/OreStudio/pull/902][#902]] | [tooling] Add --kind flag to compass goto for hotfix branches |
+
+* Review
+
+| # | Comment summary                                              | File        | Decision | Notes                                                          |
+|---+--------------------------------------------------------------+-------------+----------+----------------------------------------------------------------|
+| 1 | 7 comments: revert to feature/hotfix- convention            | various      | Declined | Deliberate design change to standard Gitflow hotfix/ prefix    |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -74,6 +74,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][compass cross-worktree status (global where)]]     | DONE    | 2026-05-25 | 2026-05-25 | Show what every git worktree is doing (branch/story/task/PR) so parallel agents don't collide.    |
 | [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][compass goto: start a unit of work in one command]] | DONE   | 2026-05-25 | 2026-05-25 | One command: fetch main, branch, scaffold linked story+task, print next steps.                    |
 | [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Compass PR review management]]                     | BACKLOG | 2026-05-26 |            | Add compass review list/reply/resolve subcommands wrapping gh API.                                |
+| [[id:47FD2F81-2143-4C35-9AC1-5A3A9D4AF975][compass goto --kind flag]]                         | DONE    | 2026-05-28 | 2026-05-28 | Add --kind hotfix to compass goto for hotfix/ branches; update runbook, recipe, docs.             |
 | [[id:E6CC19FC-5469-45BD-AA87-9CDBB23A4A7F][Per-sprint capture workflow: individual files and compass integration]] | STARTED | 2026-05-27 | | captures/ folder per sprint; compass capture command; wontdo backlog bucket.           |
 
 ** Agile

--- a/doc/llm/memory/compass_basic_commands.org
+++ b/doc/llm/memory/compass_basic_commands.org
@@ -29,6 +29,8 @@ Core commands:
 
 - *Goto* (start a new story+branch in one step):
   =compass.sh goto --slug my_slug --title "Title" --description "..." --tags "tag1:tag2"=
+  For a hotfix branch (=hotfix/<slug>= instead of =feature/<slug>=):
+  =compass.sh goto --slug broken_thing --kind hotfix --title "Hotfix: ..." --description "..." --tags "hotfix:..."=
 
 - *Add* (scaffold a new artefact — always requires =--slug=, =--title=,
   =--description=, =--tags=; types =memory= and =runbook= also require

--- a/doc/llm/runbooks/hotfix/runbook.org
+++ b/doc/llm/runbooks/hotfix/runbook.org
@@ -46,20 +46,18 @@ In execution order:
 
 3. /Create a hotfix branch and scaffold the story./ Use
    [[id:84C9177E-C737-428A-BDF9-E55FA6C9680C][How do I start a unit of work with compass?]] — =compass goto= — with
-   a =hotfix_= slug. The slug should name the broken thing, not the
-   fix:
+   =--kind hotfix=. The slug names the broken thing, not the fix:
    #+begin_src sh :results verbatim
    ./projects/ores.compass/compass.sh goto \
-     --slug hotfix_<broken_thing> \
+     --slug <broken_thing> \
+     --kind hotfix \
      --title "Hotfix: <broken thing>" \
      --description "<one sentence: what is broken>." \
      --tags "hotfix:<component>"
    #+end_src
-   =compass goto= creates =feature/hotfix-<broken-thing>=, =story.org=,
-   and a linked task. The =feature/hotfix-= prefix is the ORE Studio
-   hotfix branch convention — =compass= always generates =feature/=
-   branches and the =hotfix-= slug prefix identifies the work as a hotfix.
-   See [[id:479E7E27-4060-4BFD-AC38-F11EFA3BB306][How do I start a new feature branch phase?]].
+   =compass goto --kind hotfix= creates =hotfix/<broken-thing>=,
+   =story.org=, and a linked task. See
+   [[id:479E7E27-4060-4BFD-AC38-F11EFA3BB306][How do I start a new feature branch phase?]].
 
 4. /Read all generated files./ Before writing any content, read
    =story.org= and the task file and note their =:ID:= values. Do not
@@ -109,12 +107,12 @@ In execution order:
     (Summary, Changes, Traceability). Record the PR number in the task's
     =* PRs= table.
     #+begin_src sh :results verbatim
-    git push -u origin feature/hotfix-<broken-thing>
+    git push -u origin hotfix/<broken-thing>
     #+end_src
 
 * Postconditions
 
-- =feature/hotfix-= branch exists on =origin= and a PR is open.
+- =hotfix/= branch exists on =origin= and a PR is open.
 - Story is =STARTED= in the sprint's =** Hotfixes= table.
 - Task =* Notes= records the root cause and fix.
 - PR number is recorded in the task's =* PRs= table.

--- a/doc/recipes/git/how_do_i_start_a_new_feature_branch_phase.org
+++ b/doc/recipes/git/how_do_i_start_a_new_feature_branch_phase.org
@@ -97,12 +97,10 @@ post-merge main, and removes the old branch locally and remotely.
 - /Never rebase + force-push/ — confuses reviewers and can break
   protected-branch policy.
 - /Delete after merge/ — keeps both ends of the remote clean.
-- /Hotfix branches/ — emergency fixes use =feature/hotfix-<description>=
-  (the =hotfix-= slug prefix identifies the work as a hotfix within the
-  standard =feature/= namespace that =compass goto= always generates).
-  They are branched from fresh =main= and follow the same PR process. A
-  hotfix branch is scaffolded with =compass goto --slug hotfix_<thing>=;
-  the story lands in the sprint's =** Hotfixes= section. See
+- /Hotfix branches/ — emergency fixes use =hotfix/<description>=,
+  created with =compass goto --slug <thing> --kind hotfix=.
+  They are branched from fresh =main= and follow the same PR process.
+  The story lands in the sprint's =** Hotfixes= section. See
   [[id:0CED1212-6763-4238-B861-9740C62AE499][Handle a hotfix]] for the full procedure.
 
 * Script

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -1138,12 +1138,15 @@ def resolve_story(ident):
 def cmd_goto(argv):
     """Start a unit of work in one command. Two modes:
 
-      new story:      --slug --title --description [--tags] [--task]
-      existing story: --story <id-or-slug> --task-slug --task [--description]
+      new story:      --slug --title --description [--tags] [--task] [--kind]
+      existing story: --story <id-or-slug> --task-slug --task [--description] [--kind]
 
-    Both fetch main, create a feature branch, scaffold the task (and the
-    story, in new-story mode) via codegen, set the task #+branch, and print
-    the remaining manual steps."""
+    Both fetch main, create a branch, scaffold the task (and the story, in
+    new-story mode) via codegen, set the task #+branch, and print the
+    remaining manual steps.
+
+    --kind controls the branch prefix: feature (default) → feature/<slug>,
+    hotfix → hotfix/<slug>."""
     ap = argparse.ArgumentParser(prog="compass goto",
                                  description="Fetch main, branch, scaffold a story/task, print next steps.")
     ap.add_argument("--story", default="", help="existing story (UUID/prefix or folder slug) — existing-story mode")
@@ -1154,6 +1157,8 @@ def cmd_goto(argv):
     ap.add_argument("--task", default="", help="task title (default in new mode: 'Implement <title>')")
     ap.add_argument("--task-slug", default="", help="existing-story mode: task slug (drives the branch)")
     ap.add_argument("--base", default="origin/main", help="branch base (default: origin/main)")
+    ap.add_argument("--kind", default="feature", choices=["feature", "hotfix"],
+                    help="branch kind: feature (default) or hotfix — sets the branch prefix")
     ap.add_argument("--dry-run", action="store_true", help="print the plan without executing")
     args = ap.parse_args(argv)
 
@@ -1178,7 +1183,7 @@ def cmd_goto(argv):
         new_story = None
         task_slug, task_title = args.task_slug, args.task
         task_desc = args.description or f"Task for: {story_title}"
-        branch = "feature/" + task_slug.replace("_", "-")
+        branch = args.kind + "/" + task_slug.replace("_", "-")
     else:
         # --- new-story mode ---
         if not (args.slug and args.title and args.description):
@@ -1191,7 +1196,7 @@ def cmd_goto(argv):
         task_slug = "implement_" + args.slug
         task_title = args.task or f"Implement {args.title}"
         task_desc = f"Initial task for: {args.title}"
-        branch = "feature/" + args.slug.replace("_", "-")
+        branch = args.kind + "/" + args.slug.replace("_", "-")
 
     task_path = Path(PROJECT_ROOT) / story_dir / f"task_{task_slug}.org"
 


### PR DESCRIPTION
## Summary

- Adds `--kind` to `compass goto` with values `feature` (default) and `hotfix`.
- Default behaviour is unchanged: `--kind feature` produces `feature/<slug>` as before.
- `--kind hotfix` produces `hotfix/<slug>`, following standard Gitflow conventions instead of the previous `feature/hotfix-<slug>` workaround.
- Updates the hotfix runbook, branching recipe, compass commands memory, and `sprint_themes.org` to use the new flag and correct `hotfix/` prefix.
- Supersedes PR #901.

## Changes

- `projects/ores.compass/src/compass.py` — `--kind` argument added; branch prefix derived from `args.kind` in both new-story and existing-story modes.
- `doc/llm/runbooks/hotfix/runbook.org` — step 3 uses `--kind hotfix`; push command and postconditions use `hotfix/<thing>`.
- `doc/recipes/git/how_do_i_start_a_new_feature_branch_phase.org` — Conventions section updated to `hotfix/<description>`.
- `doc/llm/memory/compass_basic_commands.org` — goto entry documents `--kind hotfix` usage.
- `doc/agile/sprint_themes.org` — Hotfixes section added with correct `--kind hotfix` command.

## Test plan

- [ ] `compass goto --slug test --title T --description D --dry-run` still produces `feature/test`.
- [ ] `compass goto --slug broken_thing --kind hotfix --title T --description D --dry-run` produces `hotfix/broken-thing`.
- [ ] `compass goto --kind invalid` is rejected with a choices error.
- [ ] Branching recipe and runbook reference `hotfix/<thing>` consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)