### PR TITLE
[agile] Scaffold tooling documentation story (sprint 18)

### DIFF
--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -110,6 +110,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | [[id:A388F0C8-0804-420F-A542-2C929CFCEC92][Document NATS: technology overview, system integration, and recipes]] | DONE | 2026-05-26 | 2026-05-26 | NATS knowledge page, system model section, per-component subject tables, and NATS recipes. |
 | [[id:C3B6F514-559F-4038-A1D7-947BC9F7F398][Add Downloads and Agile nav entries to the site]]  | BACKLOG | 2026-05-25 |            | =doc/downloads.org= with release table; =Downloads= and =Agile= links in site nav.                |
 | [[id:8AA261FC-B334-45A8-9954-85DD4BECEA45][Improve cybernetics documentation]]                | STARTED | 2026-05-28 |            | Add VSM overview page, expand Cybernetic Levels with context and limitations, link compass.        |
+| [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]]                            | STARTED | 2026-05-28 |            | Add Tooling section to knowledge.org; developer scripts doc; overhaul compass, sql, lisp, codegen overviews. |
 
 ** Infrastructure
 

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/story.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/story.org
@@ -1,0 +1,105 @@
+:PROPERTIES:
+:ID: 304F8600-3A5B-434F-87C4-10DDA973E47F
+:END:
+#+title: Story: Tooling documentation
+#+description: Add a Tooling section to knowledge.org, a developer scripts doc, overhaul the ores.compass component overview with per-command sections and recipe links, add a scripts section to ores.sql, and review ores.lisp and ores.codegen overviews.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :docs:knowledge:tooling:compass:sql:lisp:codegen:sprint_18:v0:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+The developer tooling — =ores.compass=, =ores.codegen=, =ores.lisp=,
+=ores.sql=, and the standalone scripts in =scripts/= — is unreachable from
+the architecture pages. There is no "Tooling" layer in
+[[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]], and the component overviews that do exist vary widely in
+depth. The =ores.compass= overview describes architecture but gives no
+per-command guidance; =ores.sql= lists entry points without describing
+what any script does; the standalone scripts in =scripts/= are
+undocumented entirely.
+
+This story makes the tooling reachable and useful:
+
+1. A new =* Tooling= section in [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] provides a single entry
+   point, with a =Developer scripts= knowledge doc cataloguing the
+   standalone =scripts/= scripts and linking out to each tool's
+   component overview.
+
+2. The [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] overview gains one section per command pillar
+   (Locate, Search, Scaffold, Fleet, Goto, Backlog), each with a prose
+   description of purpose and behaviour, and a table of related recipes.
+
+3. The [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]] overview gains a =* Scripts= section with a subsection
+   per script (lifecycle scripts + utility scripts), each with a
+   purpose paragraph and a table of related recipes.
+
+4. The [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]] and [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] overviews are reviewed: gaps filled,
+   wired into the new Tooling section, and confirmed navigable from the
+   architecture pages.
+
+* Status
+
+| Field         | Value                                                                    |
+|---------------+--------------------------------------------------------------------------|
+| State         | STARTED                                                                  |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                                                                |
+| Now           | Story scaffolded; tasks defined; ready to begin T1.                      |
+| Waiting on    | Nothing.                                                                 |
+| Next          | T1: add Tooling section to knowledge.org and write developer scripts doc.|
+| Last touched  | 2026-05-28                                                               |
+
+* Acceptance
+
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] has a =* Tooling= section linking to: the developer scripts
+  doc, [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]], [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]], [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]], and [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]].
+- A =Developer scripts= knowledge doc exists under
+  =doc/knowledge/architecture/= cataloguing every standalone script in
+  =scripts/= by purpose group, with links to =ores.sql= and =ores.compass=
+  for their respective script families.
+- [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] component overview has a section per command pillar, each
+  with a prose paragraph and a recipe table.
+- [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]] component overview has a =* Scripts= section with a subsection
+  per script and a recipe table where applicable.
+- [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]] and [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] overviews are complete and linked from the
+  Tooling section.
+- The site builds clean after all changes.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:546C6CDA-6A59-445B-8385-1BD3C5AFC871][Task: Add Tooling section to knowledge.org and developer scripts doc]] | BACKLOG | | | Add * Tooling section to knowledge.org; write Developer scripts knowledge doc cataloguing scripts/ and linking to tool component overviews. |
+| [[id:74DA0C54-ED8C-4CF5-B0C1-93799B15C174][Task: Overhaul ores.compass component overview]] | BACKLOG | | | Extend the component overview with a section per command pillar (Locate, Search, Scaffold, Fleet, Goto, Backlog), each with a prose description and a recipe table. |
+| [[id:35B4022E-5025-4F8A-BE00-1A13EF0DAD55][Task: Add scripts section to ores.sql component overview]] | BACKLOG | | | Add * Scripts section with a subsection per lifecycle and utility script, purpose paragraph, and recipe table where applicable. |
+| [[id:A728AED1-6DFF-4167-B72D-EEEF2A55E8EE][Task: Review and link ores.lisp and ores.codegen overviews]] | BACKLOG | | | Review both overviews for gaps, wire into the new Tooling section in knowledge.org, and confirm all tools are navigable from the architecture pages. |
+
+* Decisions
+
+- /Tooling section in knowledge.org, not a separate index page./ A new
+  =* Tooling= section alongside Domain and Architecture is the lightest
+  viable change: no new files, immediate discoverability, consistent
+  with the existing structure.
+- /Developer scripts doc under architecture/, not a new top-level
+  folder. The scripts doc is reference material that fits the existing
+  =doc/knowledge/architecture/= pattern. A =doc/tooling/= top-level
+  directory would be a larger structural change with no clear benefit
+  at this stage.
+- /Four tasks, not one./ Each task targets a different component and
+  can be reviewed and merged independently. The Tooling section task
+  (T1) is a prerequisite for the others only in the sense that it
+  creates the entry point; the component overhaul tasks are otherwise
+  independent.
+
+* Out of scope
+
+- Documenting domain-component scripts (e.g. per-service migration
+  scripts) — those belong in their own component overviews.
+- Automated script documentation generated from source comments.
+- Documenting =build/scripts/= (CI/build infrastructure scripts) — a
+  separate story if needed.

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_add_ores_sql_scripts_section.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_add_ores_sql_scripts_section.org
@@ -52,7 +52,10 @@ columns: Script | Purpose | Notes. Link to any related recipes in
 
 * Acceptance
 
--
+- =projects/ores.sql/modeling/component_overview.org= has a =* Scripts= section.
+- The section is organized into =** Lifecycle scripts= and =** Utility scripts= subsections.
+- Each subsection contains an introductory paragraph and a table with columns: Script | Purpose | Notes.
+- Related recipes in =doc/recipes/sql/= are linked via Org-mode ID links.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_add_ores_sql_scripts_section.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_add_ores_sql_scripts_section.org
@@ -1,0 +1,77 @@
+:PROPERTIES:
+:ID: 35B4022E-5025-4F8A-BE00-1A13EF0DAD55
+:END:
+#+title: Task: Add scripts section to ores.sql component overview
+#+description: Add a * Scripts section to the ores.sql component overview with a subsection per lifecycle and utility script, a purpose paragraph, and a recipe table where applicable.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :tooling_documentation:sprint_18:v0:
+#+owner: marco
+#+branch: feature/add-ores-sql-scripts-section
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add a =* Scripts= section to [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]] component overview
+(=projects/ores.sql/modeling/component_overview.org=) documenting all
+scripts in =projects/ores.sql/=. Organise into two subsections:
+
+- =** Lifecycle scripts= — the top-level scripts that manage database
+  creation, teardown, recreation, and migration
+  (=recreate_database.sh=, =setup_database.sh=, =teardown_database.sh=,
+  =run_sql.sh=, =drop_database.sh=, =reset_system.sh=,
+  =reset_tenant.sh=, =recreate_env.sh=, =teardown_env.sh=).
+- =** Utility scripts= — scripts under =utility/= for validation,
+  inspection, and ad-hoc operations (=validate_schemas.sh=,
+  =validate_env_version.sh=, =dump_database_version.sh=,
+  =recreate_entity.sh=, =kill_db_connections.sh=,
+  =check_db_connections.sh=, =list_databases.sh=, =show_roles.sh=).
+
+Each subsection has a paragraph introducing the group and a table with
+columns: Script | Purpose | Notes. Link to any related recipes in
+=doc/recipes/sql/= via =[[id:UUID][Title]]=.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-05-28                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org
@@ -47,7 +47,9 @@ The Tooling section in =knowledge.org= must also link to [[id:6F7A122F-BC0F-4F3E
 
 * Acceptance
 
--
+- =doc/knowledge/knowledge.org= contains a =* Tooling= section linking to the developer scripts doc and the component overviews of =ores.compass=, =ores.codegen=, =ores.lisp=, and =ores.sql=.
+- A new =Developer scripts= knowledge doc is created at =doc/knowledge/architecture/developer_scripts.org=.
+- The developer scripts doc catalogues standalone scripts in =scripts/= grouped by purpose with descriptions and links to respective component overviews.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org
@@ -1,0 +1,72 @@
+:PROPERTIES:
+:ID: 546C6CDA-6A59-445B-8385-1BD3C5AFC871
+:END:
+#+title: Task: Add Tooling section to knowledge.org and developer scripts doc
+#+description: Add a * Tooling section to knowledge.org and write a Developer scripts knowledge doc cataloguing scripts/ and linking to tool component overviews.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :tooling_documentation:sprint_18:v0:
+#+owner: marco
+#+branch: feature/tooling-documentation
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add a =* Tooling= section to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] (=doc/knowledge/knowledge.org=)
+alongside the existing Domain and Architecture sections. Write a new
+=Developer scripts= knowledge doc at
+=doc/knowledge/architecture/developer_scripts.org= that:
+
+- Catalogues every standalone script in =scripts/= grouped by purpose
+  (metrics/reporting, validation, CI support, agile tooling).
+- Provides a one-paragraph description per script and notes the
+  corresponding Python script where a shell wrapper exists.
+- Links to [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]] and [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] for their respective script families.
+
+The Tooling section in =knowledge.org= must also link to [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]],
+[[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]], [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]], and [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]] component overviews directly.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-05-28                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org
@@ -9,7 +9,7 @@
 #+filetags: :tooling_documentation:sprint_18:v0:
 #+owner: marco
 #+branch: feature/tooling-documentation
-#+pr:
+#+pr: 903
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-28
@@ -59,9 +59,9 @@ task closes. Plans do not outlive their task.)
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR  | Title                                                 |
+|-----+-------------------------------------------------------|
+| 903 | [agile] Scaffold tooling documentation story (sprint 18) |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org
@@ -67,8 +67,8 @@ task closes. Plans do not outlive their task.)
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                               | File                                     | Decision | Notes                      |
+|---+-----------------------------------------------+------------------------------------------+----------+----------------------------|
+| 1 | Acceptance criteria section empty (all 4 tasks) | task_implement_tooling_documentation.org | Accept   | Fixed in 8ef145efe          |
 
 * Result

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_overhaul_compass_component_overview.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_overhaul_compass_component_overview.org
@@ -56,7 +56,9 @@ sections are preserved; the new pillar sections are appended as a new
 
 * Acceptance
 
--
+- =projects/ores.compass/modeling/component_overview.org= has a new =* Commands= heading before =* Dependencies=.
+- The =* Commands= section contains subsections for each command pillar (Locate, Search, Navigate, Scaffold, Fleet, Goto, Backlog).
+- Each pillar subsection contains a purpose paragraph, key command forms/flags, and a table of related recipes.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_overhaul_compass_component_overview.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_overhaul_compass_component_overview.org
@@ -1,0 +1,81 @@
+:PROPERTIES:
+:ID: 74DA0C54-ED8C-4CF5-B0C1-93799B15C174
+:END:
+#+title: Task: Overhaul ores.compass component overview
+#+description: Extend the ores.compass component overview with a section per command pillar (Locate, Search, Scaffold, Fleet, Goto, Backlog), each with a prose description and a recipe table.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :tooling_documentation:sprint_18:v0:
+#+owner: marco
+#+branch: feature/overhaul-compass-component-overview
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Extend [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] component overview
+(=projects/ores.compass/modeling/component_overview.org=) with a
+dedicated section for each command pillar:
+
+| Pillar   | Commands                          |
+|----------+-----------------------------------|
+| Locate   | =where=, =status=                 |
+| Search   | =find= / =search=, =index=        |
+| Navigate | =list=, =show=                    |
+| Scaffold | =add=                             |
+| Fleet    | =fleet=                           |
+| Goto     | =goto=                            |
+| Backlog  | =inbox=, =next=, =deferred=, =discarded= |
+
+Each section should contain:
+- A paragraph describing the pillar's purpose and behaviour.
+- Key command forms and flags (as a small table or code block).
+- A table of related recipes linking via =[[id:UUID][Title]]=.
+
+The existing Summary/Capabilities/Inputs/Outputs/Dependencies/Structure
+sections are preserved; the new pillar sections are appended as a new
+=* Commands= heading before =* Dependencies=.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-05-28                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_review_codegen_lisp_overviews.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_review_codegen_lisp_overviews.org
@@ -1,0 +1,76 @@
+:PROPERTIES:
+:ID: A728AED1-6DFF-4167-B72D-EEEF2A55E8EE
+:END:
+#+title: Task: Review and link ores.lisp and ores.codegen overviews
+#+description: Review ores.lisp and ores.codegen component overviews for completeness, fill gaps, and ensure both are linked from the new Tooling section in knowledge.org.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :tooling_documentation:sprint_18:v0:
+#+owner: marco
+#+branch: feature/review-codegen-lisp-overviews
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Review [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]] and [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] component overviews and ensure they
+are complete, accurate, and reachable from the new =* Tooling= section
+in [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
+
+For each component:
+1. Read the existing overview and check for gaps against the source
+   (missing commands, outdated entry points, absent recipe links).
+2. Fill any gaps in-place — no structural rewrites unless the content
+   is fundamentally wrong.
+3. Confirm the component is linked from =knowledge.org= =* Tooling=
+   (T1 adds those links; this task verifies and plugs any that T1
+   missed).
+
+Additionally: check whether any other developer tool in the repo
+(e.g. =build/scripts/=, any project-level scripts not covered by T1
+or T3) should be catalogued. If found, add them to the developer
+scripts doc or raise a capture.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-05-28                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_review_codegen_lisp_overviews.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_review_codegen_lisp_overviews.org
@@ -51,7 +51,9 @@ scripts doc or raise a capture.
 
 * Acceptance
 
--
+- =ores.lisp= and =ores.codegen= component overviews are reviewed and updated for completeness.
+- Both overviews are verified to be linked from the =* Tooling= section in =knowledge.org=.
+- Any additional developer tools or project-level scripts are catalogued or captured.
 
 * Plan
 

--- a/doc/compass.org
+++ b/doc/compass.org
@@ -16,6 +16,24 @@ contact; come back to it any time you need to remember where something lives.
 The =meta/= subdirectory defines the /contract/ every document follows; this
 file explains the layout that contract sits inside.
 
+#+begin_note
+*A note on the compass tool*
+
+The word "Compass" names both this document and a Python CLI tool,
+[[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]], that lives in =projects/ores.compass/=. Both share the
+same intent — orientation inside the repository — but operate
+differently: this document is a static map a human reads; the tool
+computes orientation on demand against the live org-roam graph and
+offers quality-of-life shortcuts for both humans and LLMs. A human
+uses it to search docs (=compass find "query"=), inspect what is in
+flight (=compass where=), or start a unit of work without manually
+creating branches and files (=compass goto=). An LLM uses it to
+resolve doc references without hallucinating paths, discover recipes
+before generating one from scratch, and scaffold agile artefacts with
+correct frontmatter. Where this document tells you /where things are/,
+the tool /gets you there/.
+#+end_note
+
 * Folder layout
 
 #+begin_example

--- a/doc/orientation.org
+++ b/doc/orientation.org
@@ -87,6 +87,14 @@ Before generating any document, read the contract:
 4. [[id:47341FC6-B8FB-499E-AAE0-F4EE0ABFDA05][Glossary]] — load it into context so the terms you encounter
    later resolve.
 
+The [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] tool (=./projects/ores.compass/compass.sh=) is your
+primary quality-of-life aid inside this repository. It was designed
+explicitly for both human contributors and LLM agents: humans use it
+to avoid manual branch/file creation; LLMs use it to resolve doc
+references, discover existing recipes, and scaffold artefacts with
+correct frontmatter instead of guessing paths or UUIDs. When in doubt,
+reach for =compass= before reaching for =grep= or =find=.
+
 When you need to /find/ something in the doc graph:
 
 - [[id:D1AE0786-5F2F-4437-8449-0E480C278A1B][How do I find docs matching a pattern?]] — =compass list= over


### PR DESCRIPTION
## Summary

- Scaffolds the **Tooling documentation** story for sprint 18.
- Defines 4 independent tasks, each targeting a different component or documentation layer.
- Wires the story into the sprint's Documentation theme table.
- Adds a note to `compass.org` and `orientation.org` explaining `ores.compass` as the primary quality-of-life aid for both humans and LLMs.

## Changes

- `doc/agile/versions/v0/sprint_18/tooling_documentation/story.org` — new story doc
- `doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org` — T1: Add Tooling section to knowledge.org
- `doc/agile/versions/v0/sprint_18/tooling_documentation/task_overhaul_compass_component_overview.org` — T2: Overhaul ores.compass overview
- `doc/agile/versions/v0/sprint_18/tooling_documentation/task_add_ores_sql_scripts_section.org` — T3: Add scripts section to ores.sql
- `doc/agile/versions/v0/sprint_18/tooling_documentation/task_review_codegen_lisp_overviews.org` — T4: Review ores.lisp / ores.codegen overviews
- `doc/agile/versions/v0/sprint_18/sprint.org` — adds story row to Documentation theme table
- `doc/compass.org` — adds note disambiguating the `ores.compass` CLI tool
- `doc/orientation.org` — adds ores.compass quality-of-life paragraph in LLM section

## Tasks

| # | Task | Branch |
|---|------|--------|
| T1 | Add Tooling section to knowledge.org + developer scripts doc | `feature/tooling-documentation` |
| T2 | Overhaul ores.compass component overview (per-command pillar sections) | `feature/overhaul-compass-component-overview` |
| T3 | Add scripts section to ores.sql component overview | `feature/add-ores-sql-scripts-section` |
| T4 | Review and link ores.lisp and ores.codegen overviews | `feature/review-codegen-lisp-overviews` |

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Tooling documentation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/tooling_documentation/story.html) | 304F8600-3A5B-434F-87C4-10DDA973E47F |
| Task (T1) | [Task: Add Tooling section to knowledge.org and developer scripts doc](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.html) | 546C6CDA-6A59-445B-8385-1BD3C5AFC871 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)