### PR TITLE
[doc] Add Emacs, org-roam and Zettelkasten knowledge pages

### DIFF
--- a/doc/agile/versions/v0/sprint_18/emacs_and_org_roam_docs/story.org
+++ b/doc/agile/versions/v0/sprint_18/emacs_and_org_roam_docs/story.org
@@ -1,0 +1,69 @@
+:PROPERTIES:
+:ID: FD317B6C-F50F-4A35-81CC-A3B2BE3493C0
+:END:
+#+title: Story: Add Emacs and org-roam knowledge pages
+#+description: Create knowledge pages for Emacs setup and org-roam usage; expand ores.lisp component overview; update orientation.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :emacs:org_roam:documentation:knowledge:sprint_18:v0:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Create standalone knowledge pages for [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]], [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]], and
+[[id:E3B70401-5142-4ACC-A61F-1BBF19F8470F][Zettelkasten]] so that contributors and LLMs have a durable, in-repo
+reference for the documentation toolchain. Expand the
+[[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]] component overview with a dashboard functionality table and
+links to the new pages. Replace the verbose org-roam preamble in
+[[id:C0CF98E8-082F-2F04-2533-94B2DA9BE3D2][Orientation]] with concise links to the new pages.
+
+* Status
+
+| Field         | Value                                                                             |
+|---------------+-----------------------------------------------------------------------------------|
+| State         | STARTED                                                                           |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                          |
+| Now           | In progress.                                                                      |
+| Waiting on    | Nothing.                                                                          |
+| Next          | Implement documentation changes.                                                  |
+| Last touched  | 2026-05-28                                                                        |
+
+* Acceptance
+
+- [ ] =doc/knowledge/documentation/emacs.org= created: one-paragraph Emacs
+  overview, ORE Studio developer setup, builds table (=deploy_site=,
+  =deploy_manual=, =deploy_skills=, =deploy_settings=, =deploy_plan=), link
+  to [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]].
+- [ ] =doc/knowledge/documentation/org_roam.org= created: what org-roam does,
+  how we use it, the three knowledge-graph hacks (id-locations, headline
+  anchor advice, batch SQLite export), org-roam-ui integration; links to
+  [[https://www.orgroam.com/manual.html][org-roam manual]] and [[id:E3B70401-5142-4ACC-A61F-1BBF19F8470F][Zettelkasten]].
+- [ ] =doc/knowledge/documentation/zettelkasten.org= created: method
+  description, why ORE Studio uses it, atomic-note discipline; links to
+  org-roam and org-roam manual.
+- [ ] [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]] component overview expanded: dashboard functionality table,
+  links to [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]] and [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]] in =* See also=.
+- [ ] [[id:C0CF98E8-082F-2F04-2533-94B2DA9BE3D2][Orientation]] preamble note condensed to a brief paragraph linking to
+  [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]] and [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]].
+- [ ] =doc/knowledge/knowledge.org= index updated with a new
+  =* Documentation tooling= section listing all three pages.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:B9934B96-E28F-4431-A504-3E0BA1D4BD14][Implement Add Emacs and org-roam knowledge pages]] | STARTED | 2026-05-28 | | Create three knowledge pages, expand ores.lisp component, update orientation. |
+
+* Decisions
+
+* Out of scope
+
+- Documentation on how to /install/ Emacs or org-roam — link to upstream
+  docs instead.
+- Interactive org-roam features (=org-roam-node-find=, capture templates,
+  dailies) — covered by the org-roam manual.

--- a/doc/agile/versions/v0/sprint_18/emacs_and_org_roam_docs/story.org
+++ b/doc/agile/versions/v0/sprint_18/emacs_and_org_roam_docs/story.org
@@ -26,11 +26,11 @@ links to the new pages. Replace the verbose org-roam preamble in
 
 | Field         | Value                                                                             |
 |---------------+-----------------------------------------------------------------------------------|
-| State         | STARTED                                                                           |
+| State         | DONE                                                                              |
 | Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                          |
-| Now           | In progress.                                                                      |
+| Now           | PR #904 merged.                                                                   |
 | Waiting on    | Nothing.                                                                          |
-| Next          | Implement documentation changes.                                                  |
+| Next          | Done.                                                                             |
 | Last touched  | 2026-05-28                                                                        |
 
 * Acceptance
@@ -57,7 +57,7 @@ links to the new pages. Replace the verbose org-roam preamble in
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:B9934B96-E28F-4431-A504-3E0BA1D4BD14][Implement Add Emacs and org-roam knowledge pages]] | STARTED | 2026-05-28 | | Create three knowledge pages, expand ores.lisp component, update orientation. |
+| [[id:B9934B96-E28F-4431-A504-3E0BA1D4BD14][Implement Add Emacs and org-roam knowledge pages]] | DONE | 2026-05-28 | 2026-05-28 | Create three knowledge pages, expand ores.lisp component, update orientation. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_18/emacs_and_org_roam_docs/task_implement_emacs_and_org_roam_docs.org
+++ b/doc/agile/versions/v0/sprint_18/emacs_and_org_roam_docs/task_implement_emacs_and_org_roam_docs.org
@@ -62,7 +62,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/904][#904]] | [doc] Add Emacs, org-roam and Zettelkasten knowledge pages |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/emacs_and_org_roam_docs/task_implement_emacs_and_org_roam_docs.org
+++ b/doc/agile/versions/v0/sprint_18/emacs_and_org_roam_docs/task_implement_emacs_and_org_roam_docs.org
@@ -30,11 +30,11 @@ note in [[id:C0CF98E8-082F-2F04-2533-94B2DA9BE3D2][Orientation]] to a brief link
 
 | Field        | Value                                                                              |
 |--------------+------------------------------------------------------------------------------------|
-| State        | STARTED                                                                            |
+| State        | DONE                                                                               |
 | Parent story | [[id:FD317B6C-F50F-4A35-81CC-A3B2BE3493C0][Add Emacs and org-roam knowledge pages]] |
-| Now          | In progress.                                                                       |
+| Now          | PR #904 merged.                                                                    |
 | Waiting on   | Nothing.                                                                           |
-| Next         | Raise PR.                                                                          |
+| Next         | Done.                                                                              |
 | Last touched | 2026-05-28                                                                         |
 
 * Acceptance
@@ -68,6 +68,8 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | =rendered= nil guard missing in org-html-headline advice | =org_roam.org= l.94 | Accepted | Fixed in =cad504f0a= |
+| 2 | Recursive scan covers build/git dirs — note inefficiency | =org_roam.org= l.71 | Accepted | Added clarifying note in =cad504f0a= |
+| 3 | Build output path duplicated across =org_roam.org= and =emacs.org= | =org_roam.org= l.120 | Accepted | Removed from =org_roam.org=; link to =emacs.org= in =cad504f0a= |
 
 * Result

--- a/doc/agile/versions/v0/sprint_18/emacs_and_org_roam_docs/task_implement_emacs_and_org_roam_docs.org
+++ b/doc/agile/versions/v0/sprint_18/emacs_and_org_roam_docs/task_implement_emacs_and_org_roam_docs.org
@@ -1,0 +1,73 @@
+:PROPERTIES:
+:ID: B9934B96-E28F-4431-A504-3E0BA1D4BD14
+:END:
+#+title: Task: Implement Add Emacs and org-roam knowledge pages
+#+description: Initial task for: Add Emacs and org-roam knowledge pages
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :emacs_and_org_roam_docs:sprint_18:v0:
+#+owner: marco
+#+branch: feature/emacs-and-org-roam-docs
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:FD317B6C-F50F-4A35-81CC-A3B2BE3493C0][Add Emacs and org-roam knowledge pages]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Create three knowledge pages (Emacs, org-roam, Zettelkasten) under
+=doc/knowledge/documentation/=; expand the [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]] component overview
+with a dashboard table and links to the new pages; condense the org-roam
+note in [[id:C0CF98E8-082F-2F04-2533-94B2DA9BE3D2][Orientation]] to a brief linked paragraph; add a
+=* Documentation tooling= section to the knowledge index.
+
+* Status
+
+| Field        | Value                                                                              |
+|--------------+------------------------------------------------------------------------------------|
+| State        | STARTED                                                                            |
+| Parent story | [[id:FD317B6C-F50F-4A35-81CC-A3B2BE3493C0][Add Emacs and org-roam knowledge pages]] |
+| Now          | In progress.                                                                       |
+| Waiting on   | Nothing.                                                                           |
+| Next         | Raise PR.                                                                          |
+| Last touched | 2026-05-28                                                                         |
+
+* Acceptance
+
+- [ ] =doc/knowledge/documentation/emacs.org= — Emacs overview, setup, builds
+  table, links to [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]], [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]], [[id:E3B70401-5142-4ACC-A61F-1BBF19F8470F][Zettelkasten]].
+- [ ] =doc/knowledge/documentation/org_roam.org= — what org-roam does, our
+  usage, three hacks, org-roam-ui integration, links to manual and [[id:E3B70401-5142-4ACC-A61F-1BBF19F8470F][Zettelkasten]].
+- [ ] =doc/knowledge/documentation/zettelkasten.org= — method, why we use it,
+  atomic-note discipline, links to org-roam.
+- [ ] [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]] component overview: dashboard functionality table; =* See also=
+  links to [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]] and [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]].
+- [ ] [[id:C0CF98E8-082F-2F04-2533-94B2DA9BE3D2][Orientation]] preamble condensed; links to [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]] and [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]].
+- [ ] =doc/knowledge/knowledge.org= — new =* Documentation tooling= section.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -113,6 +113,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | [[id:C3B6F514-559F-4038-A1D7-947BC9F7F398][Add Downloads and Agile nav entries to the site]]  | BACKLOG | 2026-05-25 |            | =doc/downloads.org= with release table; =Downloads= and =Agile= links in site nav.                |
 | [[id:8AA261FC-B334-45A8-9954-85DD4BECEA45][Improve cybernetics documentation]]                | STARTED | 2026-05-28 |            | Add VSM overview page, expand Cybernetic Levels with context and limitations, link compass.        |
 | [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]]                            | STARTED | 2026-05-28 |            | Add Tooling section to knowledge.org; developer scripts doc; overhaul compass, sql, lisp, codegen overviews. |
+| [[id:FD317B6C-F50F-4A35-81CC-A3B2BE3493C0][Add Emacs and org-roam knowledge pages]]           | DONE    | 2026-05-28 | 2026-05-28 | Create Emacs, org-roam, and Zettelkasten knowledge pages; expand ores.lisp; update orientation.    |
 
 ** Infrastructure
 

--- a/doc/knowledge/documentation/emacs.org
+++ b/doc/knowledge/documentation/emacs.org
@@ -1,0 +1,79 @@
+:PROPERTIES:
+:ID: DF6F1D17-2199-472C-868E-1E50D0887AAD
+:END:
+#+title: Emacs
+#+description: Emacs as used in ORE Studio — editor overview, developer setup, and the build targets that Emacs drives.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :emacs:tooling:documentation:knowledge:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+
+* Summary
+
+GNU Emacs is the extensible, self-documenting text editor that serves as
+ORE Studio's primary authoring and build environment. All documentation is
+written in [[https://orgmode.org/][Org mode]], Emacs's structured plain-text format, and all build
+targets that produce the website, manuals, skills, and settings are
+implemented as Emacs Lisp scripts run in batch mode via =emacs -Q --script=.
+The interactive developer console ([[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]]) also lives inside Emacs,
+providing a card-based dashboard for every day-to-day operation. No part of
+the production system depends on Emacs; it is strictly a developer and
+documentation toolchain.
+
+* Detail
+
+** Overview of Emacs
+
+GNU Emacs, first released in 1984, is a programmable text editor whose
+central design principle is /self-documentation/: every key binding,
+variable, and function can be inspected, modified, or replaced at runtime
+using Emacs Lisp. This makes it well-suited to a project whose documentation
+and tooling evolve together — a new convention can be enforced immediately
+by adding a short Lisp function, with no external build pipeline required.
+ORE Studio exploits two Emacs subsystems in particular: Org mode (structured
+text, tables, literate programming via Babel, HTML/PDF export) and
+[[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]] (the knowledge graph and id-link resolution layer).
+
+** Our setup
+
+Developers load ORE Studio into Emacs by evaluating =ores-env.el=, which
+reads the checkout-local =.env= file and exposes helper functions for
+finding the project root and per-preset paths. The remaining modules —
+=ores-dashboard=, =ores-db=, =ores-shell=, =ores-babel=, =ores-prodigy=,
+=ores-capture=, and =ores-org-roam-export= — are then loaded on demand or
+as part of the dashboard initialisation. The entry point for interactive
+use is =M-x ores/dashboard=.
+
+The knowledge graph (all =.org= files under =doc/=) is kept as the
+org-roam database at =.org-roam.db= in the repo root. org-roam synchronises
+this database whenever a developer opens or saves a file; the database is
+the authoritative source for id-link resolution both in interactive Emacs
+sessions and during batch site builds.
+
+** Build targets
+
+All Emacs-driven builds are invoked as CMake custom targets using
+=emacs -Q --script=. The =-Q= flag suppresses the user's personal init
+file so builds are reproducible across machines.
+
+| CMake target      | Script                        | What it produces                                                             |
+|-------------------+-------------------------------+------------------------------------------------------------------------------|
+| =deploy_site=     | =ores-build-site.el=          | Full documentation website published to =build/output/site/OreStudio=; includes org → HTML export, org-roam-ui graph, and graph JSON. |
+| =deploy_manual=   | =ores-build-manual.el=        | User manual PDF from =doc/manual/user_guide/user_manual.org= via LaTeX.     |
+| =deploy_skills=   | =ores-build-skills.el=        | Claude Code skills tangled from Org Babel blocks into =.claude/skills/=.    |
+| =deploy_settings= | =ores-build-settings.el=      | Claude Code settings JSON tangled from =doc/llm/claude_code_settings.org= into =.claude/settings.json=. |
+| =deploy_plan=     | =ores-build-plan.el=          | TaskJuggler project plan tangled and exported from the agile docs.           |
+
+The site build is the most involved: it syncs the org-roam database,
+publishes every =.org= file recursively via =ox-publish=, copies the
+pre-built org-roam-ui static bundle from =external/org-roam-ui=, injects
+the site navigation header into the graph page, and exports the graph data
+as JSON from the SQLite database so org-roam-ui can visualise it statically.
+
+* See also
+
+- [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]] — the Emacs Lisp component: dashboard, DB browser, shell integration, all source files described.
+- [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]] — how the knowledge graph is built and how id-links work across the site.
+- [[id:E3B70401-5142-4ACC-A61F-1BBF19F8470F][Zettelkasten]] — the note-taking method that motivates the id-link graph structure.

--- a/doc/knowledge/documentation/org_roam.org
+++ b/doc/knowledge/documentation/org_roam.org
@@ -75,6 +75,10 @@ This writes a fresh =.org-id-locations-file= at the repo root on every
 build, derived entirely from the files in the working tree. The file is
 =.gitignore=d (it's machine-specific absolute paths) but is always
 regenerated before =org-publish-all= so every =[[id:UUID]]= link resolves.
+The recursive scan covers the entire repo root; =build/=, =.git/=, and
+=vcpkg/= directories rarely contain =.org= files so the scan is fast in
+practice. The subsequent =org-roam-db-sync= step applies its own
+=org-roam-file-exclude-regexp= to keep build artefacts out of the database.
 
 *** Advice on =org-html-headline= for id-link anchors
 
@@ -88,7 +92,7 @@ an empty anchor to every heading that carries an =:ID:= property:
 (defun ores/org-html-headline-id-anchor (orig-fun headline contents info)
   (let ((rendered (funcall orig-fun headline contents info))
         (uuid (org-element-property :ID headline)))
-    (if uuid
+    (if (and rendered uuid)
         (concat (format "<a id=\"ID-%s\" class=\"id-anchor\"></a>\n" uuid)
                 rendered)
       rendered)))
@@ -116,9 +120,10 @@ is stable across org-roam minor versions.
 org-roam-ui is a React application that must be compiled from source.
 Checking a compiled build into =external/org-roam-ui= avoids needing
 Node.js or npm on the CI runner. The site build copies this pre-built bundle
-to =build/output/site/OreStudio/graph/=, patches the graph page's
-=<head>= to include the ORE Studio stylesheet and nav bar, and writes the
-generated =graphdata.json= alongside it.
+to the =graph/= subdirectory of the site output (see the =deploy_site= row
+in [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]] for the full output path), patches the graph page's =<head>= to
+include the ORE Studio stylesheet and nav bar, and writes the generated
+=graphdata.json= alongside it.
 
 * See also
 

--- a/doc/knowledge/documentation/org_roam.org
+++ b/doc/knowledge/documentation/org_roam.org
@@ -1,0 +1,128 @@
+:PROPERTIES:
+:ID: C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED
+:END:
+#+title: org-roam
+#+description: How ORE Studio uses org-roam — knowledge graph, id-links, the hacks that make the static site work, and the org-roam-ui integration.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :org_roam:documentation:knowledge:emacs:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+
+* Summary
+
+[[https://www.orgroam.com/][org-roam]] is an [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]] package that implements a [[id:E3B70401-5142-4ACC-A61F-1BBF19F8470F][Zettelkasten]]-style
+knowledge graph over plain =.org= files, maintaining a SQLite database of
+nodes, tags, and links. ORE Studio uses org-roam as the backbone of its
+entire documentation system: every =.org= file in the repo is a node in the
+graph, cross-document references use =[[id:UUID][Title]]= links that survive
+file renames, and the graph is published as an interactive visualisation
+alongside the static documentation site. To make this work in a CI/batch
+context (no user home directory, no interactive Emacs), several non-obvious
+workarounds are required; they are described below.
+
+* Detail
+
+** What org-roam does
+
+org-roam indexes every =.org= file under =org-roam-directory= into a SQLite
+database (=.org-roam.db=). Each file that carries a =:ID:= property in its
+=:PROPERTIES:= drawer becomes a /node/ in the graph; headings can also be
+nodes. The database records the UUID, title, tags (from =#+filetags:=),
+and outgoing links of every node. This gives three things:
+
+1. *Id-link navigation* — =[[id:UUID][Title]]= links resolve to the right
+   file and heading regardless of where either file is located in the
+   directory tree.
+2. *Back-links* — org-roam knows which nodes link /to/ a given node,
+   enabling the =org-roam-buffer= to show incoming references for any open
+   file.
+3. *Graph export* — the link and tag tables in the SQLite database can be
+   exported to JSON and rendered as an interactive force-directed graph via
+   [[https://github.com/org-roam/org-roam-ui][org-roam-ui]].
+
+** How we use it
+
+Every document in =doc/= and every component overview in =projects/*/modeling/=
+is an org-roam node. The ORE Studio conventions layer on top of org-roam:
+the =#+type:=, =#+version:=, and =#+level:= frontmatter fields are ORE
+Studio conventions, not org-roam fields, but org-roam indexes them as
+document properties and =compass= queries them via the same SQLite database.
+The full documentation graph is therefore traversable both by an interactive
+Emacs developer (via =org-roam-buffer= and =org-roam-node-find=) and by the
+LLM toolchain (via =compass search/show/list=).
+
+** The knowledge graph "hacks"
+
+Making org-roam work in a reproducible batch build required several departures
+from the standard interactive setup. These are sometimes called "hacks"
+because they bypass assumptions baked into the org-roam ecosystem:
+
+*** Repo-root org-id locations file
+
+Standard org-roam stores the id-to-file mapping in
+=~/.emacs.d/.org-id-locations=. In batch mode (CI runner, colleague's
+machine) that file either does not exist or maps a different checkout path.
+The site build script sets:
+
+#+begin_src emacs-lisp
+(setq org-id-locations-file (expand-file-name "./.org-id-locations-file"))
+(org-id-update-id-locations (directory-files-recursively "." "\\.org$"))
+#+end_src
+
+This writes a fresh =.org-id-locations-file= at the repo root on every
+build, derived entirely from the files in the working tree. The file is
+=.gitignore=d (it's machine-specific absolute paths) but is always
+regenerated before =org-publish-all= so every =[[id:UUID]]= link resolves.
+
+*** Advice on =org-html-headline= for id-link anchors
+
+Org's HTML exporter rewrites =[[id:UUID]]= links to =href="#ID-UUID"= in
+the output HTML, but does not automatically add a corresponding
+=id="ID-UUID"= attribute to the target heading. Browsers therefore cannot
+scroll to the target. The site build advises =org-html-headline= to prepend
+an empty anchor to every heading that carries an =:ID:= property:
+
+#+begin_src emacs-lisp
+(defun ores/org-html-headline-id-anchor (orig-fun headline contents info)
+  (let ((rendered (funcall orig-fun headline contents info))
+        (uuid (org-element-property :ID headline)))
+    (if uuid
+        (concat (format "<a id=\"ID-%s\" class=\"id-anchor\"></a>\n" uuid)
+                rendered)
+      rendered)))
+(advice-add 'org-html-headline :around #'ores/org-html-headline-id-anchor)
+#+end_src
+
+The idea for this fix was adapted from community discussion in the org-roam
+forums and the [[https://github.com/cunene/emacs-config][cunene emacs config]].
+
+*** Batch SQLite graph export (no full org-roam load)
+
+The org-roam-ui graph visualisation requires a JSON file (=graphdata.json=)
+describing every node and link in the database. Generating this normally
+requires a fully initialised org-roam session, which is expensive and
+fragile in batch mode. =ores-org-roam-export.el= instead reads the SQLite
+database directly using Emacs 29+'s built-in =sqlite-open= support —
+without loading =org-roam= itself — and emits the JSON in org-roam-ui's
+expected format. This code was originally lifted from the
+[[https://github.com/cunene/emacs-config][cunene emacs config]] and adapted
+to run as a standalone script. The approach works because the database schema
+is stable across org-roam minor versions.
+
+*** Pre-built org-roam-ui static bundle
+
+org-roam-ui is a React application that must be compiled from source.
+Checking a compiled build into =external/org-roam-ui= avoids needing
+Node.js or npm on the CI runner. The site build copies this pre-built bundle
+to =build/output/site/OreStudio/graph/=, patches the graph page's
+=<head>= to include the ORE Studio stylesheet and nav bar, and writes the
+generated =graphdata.json= alongside it.
+
+* See also
+
+- [[https://www.orgroam.com/manual.html][org-roam manual]] — full reference for org-roam commands, configuration, and concepts.
+- [[id:E3B70401-5142-4ACC-A61F-1BBF19F8470F][Zettelkasten]] — the note-taking method that motivates the id-link graph structure.
+- [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]] — the editor that hosts org-roam and drives all documentation builds.
+- [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]] — the =ores-org-roam-export.el= source and all other Emacs Lisp modules.

--- a/doc/knowledge/documentation/zettelkasten.org
+++ b/doc/knowledge/documentation/zettelkasten.org
@@ -1,0 +1,78 @@
+:PROPERTIES:
+:ID: E3B70401-5142-4ACC-A61F-1BBF19F8470F
+:END:
+#+title: Zettelkasten
+#+description: The Zettelkasten note-taking method — atomic notes, unique identifiers, and emergent structure — as applied to the ORE Studio knowledge graph.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :zettelkasten:documentation:knowledge:org_roam:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+
+* Summary
+
+Zettelkasten (/German: slip-box/) is a knowledge-management method developed
+by sociologist Niklas Luhmann, who used it to produce an extraordinary volume
+of academic work over several decades. Its two key principles are that each
+note captures exactly one idea (the /atomic note/ discipline) and that every
+note is permanently addressable by a unique identifier, enabling a web of
+typed links to emerge across the collection. ORE Studio uses Zettelkasten as
+the conceptual foundation for its documentation graph: every =.org= file
+carries a UUID =:ID:= property, files link to each other with
+=[[id:UUID][Title]]= references, and [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]] maintains the index and
+back-link database that makes the graph navigable.
+
+* Detail
+
+** The method
+
+Luhmann's physical slip-box contained tens of thousands of index cards, each
+with a unique alphanumeric address. A new note was not filed by subject but
+placed wherever it could be cross-referenced to an existing note; the
+address was written at the top and outgoing references were written inline.
+Over time the collection self-organised into dense clusters of related ideas
+connected by an explicit link graph — something that no hierarchical filing
+system produces automatically.
+
+The digital Zettelkasten community has translated these principles into
+plain-text formats: each note is a single file, the unique identifier is a
+UUID or timestamp, and links between files replace the handwritten references
+on cards. The emergent structure from following links reveals which ideas are
+central (high in-degree) and which are peripheral, without the author ever
+imposing a top-down taxonomy.
+
+** Why ORE Studio uses it
+
+ORE Studio's documentation spans domain concepts (ORE instrument types,
+interest rate curves), architecture decisions (component split, CMake
+conventions), agile artefacts (stories, tasks, sprints), LLM instructions,
+recipes, and manuals. A hierarchical directory structure alone cannot
+represent the cross-cutting links: a concept defined in =doc/knowledge/=
+is referenced from =doc/agile/= tasks, from =doc/recipes/=, and from
+=doc/manual/=. Treating the documentation as a Zettelkasten graph means:
+
+- Any page can link to any other page by UUID — location in the directory
+  tree is not part of the link and files can be moved without breaking
+  references.
+- The knowledge graph visualisation ([[https://github.com/org-roam/org-roam-ui][org-roam-ui]]) immediately reveals
+  which concepts are central to the project and which are peripheral.
+- LLMs can navigate the graph programmatically: =compass show <UUID>= prints
+  a node's outgoing and incoming links, giving instant traversal without
+  reading every file.
+
+** The atomic note discipline
+
+The most important constraint is the one hardest to maintain: each file
+should capture one idea, not a collection of loosely related ones. When a
+file grows, the right response is usually to extract a sub-topic into a new
+file and link to it, not to add another section. ORE Studio enforces this
+weakly — the document types (knowledge, recipe, component overview, task,
+story) are each scoped to a single subject — but within each type the author
+must resist the temptation to include tangential detail.
+
+* See also
+
+- [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]] — the Emacs package that implements Zettelkasten over =.org= files in ORE Studio.
+- [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]] — the editor that hosts org-roam and drives all documentation builds.
+- [[https://www.orgroam.com/manual.html#A-Brief-Introduction-to-the-Zettelkasten-Method][org-roam manual: A Brief Introduction to the Zettelkasten Method]] — the method described from the org-roam perspective.

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -108,6 +108,18 @@ Authentication, authorisation, and tenancy.
 - [[id:3CAA394F-E84C-3434-331B-6E664F7E84D2][Role-Based Access Control]] — the RBAC model that backs IAM:
   roles compose permissions, the assignment graph.
 
+* Documentation tooling
+
+The tools ORE Studio uses to author, publish, and navigate its documentation.
+
+- [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]] — editor overview, our developer setup, and the CMake build
+  targets (=deploy_site=, =deploy_manual=, =deploy_skills=, =deploy_settings=)
+  that Emacs batch scripts drive.
+- [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]] — how the knowledge graph is built, how id-links resolve across
+  the static site, and the non-obvious hacks that make it work in CI.
+- [[id:E3B70401-5142-4ACC-A61F-1BBF19F8470F][Zettelkasten]] — the atomic-note method that motivates the graph structure
+  and id-link discipline across every =.org= file.
+
 * External reference
 
 Concepts and systems we don't own — captured here so other docs can

--- a/doc/orientation.org
+++ b/doc/orientation.org
@@ -16,14 +16,14 @@ every convention is described there. The journeys below tell you /where to go
 after that/, depending on what you came here to do.
 
 #+begin_note
-*Preamble: A note on org-roam*
+*Preamble: Emacs and org-roam*
 
-Before we proceed, a note on [[https://www.orgroam.com/manual.html][org-roam]] as we use it *extensively* in ORE Studio.
-You should be able to browse the HTML documentation without even knowing about
-org-roam; but i you want to access the full power of the documentation system,
-I'm afraid you need to be on Emacs and have org-roam installed. Sadly, I cannot
-spend time explaining org-roam since it only makes sense to Emacs users but
-think of it as [[https://www.orgroam.com/manual.html#A-Brief-Introduction-to-the-Zettelkasten-Method][Zettletasken]] over the org-mode markup format.
+ORE Studio is authored in [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]] and the entire documentation graph is managed
+by [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]]. You can browse the HTML site without installing either, but to
+navigate the graph interactively, follow back-links, or run the build targets
+you will need Emacs with org-roam. Read the linked pages for a full account
+of our setup, the build targets Emacs drives, and how the org-roam knowledge
+graph works.
 #+end_note
 
 * I am new to this project

--- a/projects/ores.lisp/modeling/component_overview.org
+++ b/projects/ores.lisp/modeling/component_overview.org
@@ -87,8 +87,29 @@ ergonomics.
 - =prodigy= — service process management.
 - =compilation-mode= (Emacs built-in) — script output buffers.
 
+* Dashboard functionality
+
+The =ORES Dashboard= buffer is divided into cards. Each card groups related
+actions under a short heading and maps them to single-keystroke bindings.
+
+| Card        | Key(s)       | What it does                                                                 |
+|-------------+--------------+------------------------------------------------------------------------------|
+| Environment | =e=          | Display the loaded =.env= values (label, preset, credentials).              |
+| Database    | =d=, =k=, =t=, =r= | Connect to a DB, kill connections, teardown schema, recreate schema.  |
+| Services    | =p=          | Open Prodigy process manager (NATS, HTTP server, domain services).          |
+| Compass     | =c=          | Run a =compass search= query; output appears in the output pane.            |
+| Build       | =b=          | Invoke =cmake --build= for the current preset.                              |
+| Site        | =s=          | Run =deploy_site= (Emacs batch, org → HTML + graph export).                 |
+| Skills      | =S=          | Run =deploy_skills= (tangle Claude Code skills from Org Babel blocks).      |
+| Bookmarks   | =o=          | Jump to a frequently-used file or directory.                                |
+| Links       | =l=          | Open a curated list of project web links (GitHub, site, Doxygen).           |
+| Shell       | =x=          | Launch (or switch to) an =ores.shell= REPL comint buffer.                   |
+| NATS        | =n=          | Send a test NATS message or open the NATS monitoring page.                  |
+
 * See also
 
+- [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]] — editor overview and the build targets (=deploy_site=, =deploy_manual=, etc.) that =ores.lisp= scripts drive.
+- [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]] — the knowledge graph layer that =ores-org-roam-export.el= exports.
 - [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] — architectural context.
 - [[id:D0876A24-69BA-F484-ED9B-71CD3AA8710C][ores.shell]] — the REPL that the dashboard launches.
 - [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]] — database scripts invoked by the dashboard.


### PR DESCRIPTION
## Summary

Creates three standalone knowledge pages under `doc/knowledge/documentation/` to give contributors and LLMs a durable in-repo reference for the documentation toolchain. Expands the ores.lisp component overview with a dashboard functionality table. Condenses the verbose org-roam preamble in Orientation to a concise linked paragraph.

## Changes

- `doc/knowledge/documentation/emacs.org` — new: Emacs overview, ORE Studio developer setup, builds table (five CMake targets and what each produces), links to ores.lisp and org-roam.
- `doc/knowledge/documentation/org_roam.org` — new: what org-roam does, how we use it, three hacks (repo-root id-locations file, `org-html-headline` anchor advice, batch SQLite graph export), org-roam-ui integration; links to manual and Zettelkasten.
- `doc/knowledge/documentation/zettelkasten.org` — new: Luhmann's method, why ORE Studio uses it, the atomic-note discipline; links back to org-roam.
- `projects/ores.lisp/modeling/component_overview.org` — dashboard functionality table (11 cards with keys and descriptions); `See also` links to Emacs and org-roam pages.
- `doc/orientation.org` — preamble note condensed from a rambling paragraph to one focused sentence with id-links.
- `doc/knowledge/knowledge.org` — new `* Documentation tooling` section listing all three pages.
- `doc/agile/versions/v0/sprint_18/sprint.org` — story wired into the Documentation section.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Add Emacs and org-roam knowledge pages](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/emacs_and_org_roam_docs/story.html) | FD317B6C-F50F-4A35-81CC-A3B2BE3493C0 |
| Task | [Implement Add Emacs and org-roam knowledge pages](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/emacs_and_org_roam_docs/task_implement_emacs_and_org_roam_docs.html) | B9934B96-E28F-4431-A504-3E0BA1D4BD14 |