### PR TITLE
[docs] Document ORE Studio as an LLM-first system

### DIFF
--- a/doc/agile/versions/v0/sprint_18/llm_first_system_docs/story.org
+++ b/doc/agile/versions/v0/sprint_18/llm_first_system_docs/story.org
@@ -26,11 +26,11 @@ this, and =llm.org= is updated to surface them.
 
 | Field         | Value                                                     |
 |---------------+-----------------------------------------------------------|
-| State         | STARTED                                                   |
+| State         | DONE                                                      |
 | Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]    |
-| Now           | Writing LLM-first philosophy page and Claude Code page.   |
+| Now           | Complete.                                                 |
 | Waiting on    | Nothing.                                                  |
-| Next          | Wire both pages into llm.org index.                       |
+| Next          | Nothing.                                                  |
 | Last touched  | 2026-05-28                                                |
 
 * Acceptance
@@ -47,8 +47,8 @@ this, and =llm.org= is updated to surface them.
 
 | Task                                                                                                | State   | Start      | End        | Description                                                         |
 |-----------------------------------------------------------------------------------------------------+---------+------------+------------+---------------------------------------------------------------------|
-| [[id:EA2E3D00-DD80-4D98-8700-3C801E7A4978][Task: Write LLM-first system philosophy page]]    | STARTED | 2026-05-28 |            | =doc/llm/llm_first.org= covering philosophy, audience, and tooling. |
-| [[id:1F23819A-7B4F-4409-9880-DC01C9A3C231][Task: Add Claude Code knowledge page]]            | BACKLOG | 2026-05-28 |            | =doc/llm/claude_code.org=; wire into llm.org.                       |
+| [[id:EA2E3D00-DD80-4D98-8700-3C801E7A4978][Task: Write LLM-first system philosophy page]]    | DONE    | 2026-05-28 | 2026-05-28 | =doc/llm/llm_first.org= covering philosophy, audience, and tooling. |
+| [[id:1F23819A-7B4F-4409-9880-DC01C9A3C231][Task: Add Claude Code knowledge page]]            | DONE    | 2026-05-28 | 2026-05-28 | =doc/llm/claude_code.org=; wire into llm.org.                       |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_18/llm_first_system_docs/story.org
+++ b/doc/agile/versions/v0/sprint_18/llm_first_system_docs/story.org
@@ -1,0 +1,58 @@
+:PROPERTIES:
+:ID: AE1E893D-8E5C-4DB7-BB71-492F1A65374D
+:END:
+#+title: Story: Document ORE Studio as an LLM-first system
+#+description: Add LLM-first philosophy page and Claude Code tool page to doc/llm/; update llm.org index to surface both.
+#+type: story
+#+version: 2
+#+level: s2
+#+filetags: :llm:documentation:claude_code:sprint_18:v0:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Make explicit that ORE Studio is an LLM-first system: primary
+development is done by LLMs working under human direction; docs are
+written to be equally useful to human readers and AI agents; Claude
+Code is the primary tool but contributions from any LLM following the
+project instructions are accepted. Two new knowledge pages capture
+this, and =llm.org= is updated to surface them.
+
+* Status
+
+| Field         | Value                                                     |
+|---------------+-----------------------------------------------------------|
+| State         | STARTED                                                   |
+| Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]    |
+| Now           | Writing LLM-first philosophy page and Claude Code page.   |
+| Waiting on    | Nothing.                                                  |
+| Next          | Wire both pages into llm.org index.                       |
+| Last touched  | 2026-05-28                                                |
+
+* Acceptance
+
+- =doc/llm/llm_first.org= exists: explains LLM-first development
+  philosophy, dual human/LLM audience, Claude as primary tool, open
+  to any compliant LLM.
+- =doc/llm/claude_code.org= exists: two paragraphs defining Claude
+  Code (the Anthropic CLI), links to =claude_code_settings.org=.
+- =llm.org= component overview table and =* See also= updated to
+  reference both new pages.
+
+* Tasks
+
+| Task                                                                                                | State   | Start      | End        | Description                                                         |
+|-----------------------------------------------------------------------------------------------------+---------+------------+------------+---------------------------------------------------------------------|
+| [[id:EA2E3D00-DD80-4D98-8700-3C801E7A4978][Task: Write LLM-first system philosophy page]]    | STARTED | 2026-05-28 |            | =doc/llm/llm_first.org= covering philosophy, audience, and tooling. |
+| [[id:1F23819A-7B4F-4409-9880-DC01C9A3C231][Task: Add Claude Code knowledge page]]            | BACKLOG | 2026-05-28 |            | =doc/llm/claude_code.org=; wire into llm.org.                       |
+
+* Decisions
+
+* Out of scope
+
+- Per-LLM onboarding guides (Gemini, GPT, etc.) — covered by the
+  existing =llm_instructions.org= which any LLM must follow.

--- a/doc/agile/versions/v0/sprint_18/llm_first_system_docs/task_add_claude_code_page.org
+++ b/doc/agile/versions/v0/sprint_18/llm_first_system_docs/task_add_claude_code_page.org
@@ -65,3 +65,6 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+PR #906 merged. =doc/llm/claude_code.org= written and wired into =llm.org=
+component table and =* See also=.

--- a/doc/agile/versions/v0/sprint_18/llm_first_system_docs/task_add_claude_code_page.org
+++ b/doc/agile/versions/v0/sprint_18/llm_first_system_docs/task_add_claude_code_page.org
@@ -1,0 +1,67 @@
+:PROPERTIES:
+:ID: 1F23819A-7B4F-4409-9880-DC01C9A3C231
+:END:
+#+title: Task: Add Claude Code knowledge page
+#+description: Two-paragraph knowledge doc defining Claude Code (the Anthropic CLI), linking to settings; wire into llm.org.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :llm_first_system_docs:sprint_18:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:AE1E893D-8E5C-4DB7-BB71-492F1A65374D][Document ORE Studio as an LLM-first system]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Write =doc/llm/claude_code.org= — a short knowledge page (two to three
+paragraphs) that defines Claude Code as a tool: what it is (the
+Anthropic CLI for Claude, the AI assistant powering ORE Studio's
+primary development workflow), how it is used here, and where to find
+its configuration. Link to =claude_code_settings.org= and wire the
+page into =llm.org=.
+
+* Status
+
+| Field        | Value                                                             |
+|--------------+-------------------------------------------------------------------|
+| State        | BACKLOG                                                           |
+| Parent story | [[id:AE1E893D-8E5C-4DB7-BB71-492F1A65374D][Document ORE Studio as an LLM-first system]] |
+| Now          | Waiting for llm_first.org task to complete first.                 |
+| Waiting on   | [[id:EA2E3D00-DD80-4D98-8700-3C801E7A4978][Task: Write LLM-first system philosophy page]] |
+| Next         | Scaffold claude_code.org; wire into llm.org.                      |
+| Last touched | 2026-05-28                                                        |
+
+* Acceptance
+
+- =doc/llm/claude_code.org= exists with v2 frontmatter and org-roam ID.
+- Defines Claude Code in 2-3 paragraphs; links to =claude_code_settings.org=.
+- =llm.org= component table and =* See also= reference both new pages.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/llm_first_system_docs/task_add_claude_code_page.org
+++ b/doc/agile/versions/v0/sprint_18/llm_first_system_docs/task_add_claude_code_page.org
@@ -54,9 +54,9 @@ task closes. Plans do not outlive their task.)
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR  | Title                                                  |
+|-----+--------------------------------------------------------|
+| 906 | [docs] Document ORE Studio as an LLM-first system      |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/llm_first_system_docs/task_add_claude_code_page.org
+++ b/doc/agile/versions/v0/sprint_18/llm_first_system_docs/task_add_claude_code_page.org
@@ -31,11 +31,11 @@ page into =llm.org=.
 
 | Field        | Value                                                             |
 |--------------+-------------------------------------------------------------------|
-| State        | BACKLOG                                                           |
+| State        | DONE                                                              |
 | Parent story | [[id:AE1E893D-8E5C-4DB7-BB71-492F1A65374D][Document ORE Studio as an LLM-first system]] |
-| Now          | Waiting for llm_first.org task to complete first.                 |
-| Waiting on   | [[id:EA2E3D00-DD80-4D98-8700-3C801E7A4978][Task: Write LLM-first system philosophy page]] |
-| Next         | Scaffold claude_code.org; wire into llm.org.                      |
+| Now          | Complete.                                                         |
+| Waiting on   | Nothing.                                                          |
+| Next         | Nothing.                                                          |
 | Last touched | 2026-05-28                                                        |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_18/llm_first_system_docs/task_implement_llm_first_system_docs.org
+++ b/doc/agile/versions/v0/sprint_18/llm_first_system_docs/task_implement_llm_first_system_docs.org
@@ -31,11 +31,11 @@ contributions from any LLM accepted provided they follow
 
 | Field        | Value                                                             |
 |--------------+-------------------------------------------------------------------|
-| State        | STARTED                                                           |
+| State        | DONE                                                              |
 | Parent story | [[id:AE1E893D-8E5C-4DB7-BB71-492F1A65374D][Document ORE Studio as an LLM-first system]] |
-| Now          | Writing llm_first.org.                                            |
+| Now          | Complete.                                                         |
 | Waiting on   | Nothing.                                                          |
-| Next         | Wire into llm.org; then start Claude Code page task.              |
+| Next         | Nothing.                                                          |
 | Last touched | 2026-05-28                                                        |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_18/llm_first_system_docs/task_implement_llm_first_system_docs.org
+++ b/doc/agile/versions/v0/sprint_18/llm_first_system_docs/task_implement_llm_first_system_docs.org
@@ -55,14 +55,14 @@ task closes. Plans do not outlive their task.)
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR  | Title                                                  |
+|-----+--------------------------------------------------------|
+| 906 | [docs] Document ORE Studio as an LLM-first system      |
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                                  | File            | Decision | Notes                                              |
+|---+------------------------------------------------------------------+-----------------+----------+----------------------------------------------------|
+| 1 | Avoid duplicating .claude/ paths; reference claude_code.org instead | llm_first.org | Accept   | Fixed in e63d844e0 — replaced paths with id-link reference |
 
 * Result

--- a/doc/agile/versions/v0/sprint_18/llm_first_system_docs/task_implement_llm_first_system_docs.org
+++ b/doc/agile/versions/v0/sprint_18/llm_first_system_docs/task_implement_llm_first_system_docs.org
@@ -66,3 +66,7 @@ task closes. Plans do not outlive their task.)
 | 1 | Avoid duplicating .claude/ paths; reference claude_code.org instead | llm_first.org | Accept   | Fixed in e63d844e0 — replaced paths with id-link reference |
 
 * Result
+
+PR #906 merged. =doc/llm/llm_first.org= written and wired into =llm.org=.
+One Gemini comment accepted: removed duplicated =.claude/= paths in favour
+of an id-link reference to =claude_code.org=.

--- a/doc/agile/versions/v0/sprint_18/llm_first_system_docs/task_implement_llm_first_system_docs.org
+++ b/doc/agile/versions/v0/sprint_18/llm_first_system_docs/task_implement_llm_first_system_docs.org
@@ -1,0 +1,68 @@
+:PROPERTIES:
+:ID: EA2E3D00-DD80-4D98-8700-3C801E7A4978
+:END:
+#+title: Task: Write LLM-first system philosophy page
+#+description: Initial task for: Document ORE Studio as an LLM-first system
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :llm_first_system_docs:sprint_18:v0:
+#+owner: marco
+#+branch: feature/llm-first-system-docs
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:AE1E893D-8E5C-4DB7-BB71-492F1A65374D][Document ORE Studio as an LLM-first system]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Write =doc/llm/llm_first.org= — a knowledge page that articulates
+ORE Studio's LLM-first development model: LLMs as the primary means
+of development, working under human direction; documentation written
+to serve both human and LLM readers; Claude Code as the primary tool;
+contributions from any LLM accepted provided they follow
+=llm_instructions.org=.
+
+* Status
+
+| Field        | Value                                                             |
+|--------------+-------------------------------------------------------------------|
+| State        | STARTED                                                           |
+| Parent story | [[id:AE1E893D-8E5C-4DB7-BB71-492F1A65374D][Document ORE Studio as an LLM-first system]] |
+| Now          | Writing llm_first.org.                                            |
+| Waiting on   | Nothing.                                                          |
+| Next         | Wire into llm.org; then start Claude Code page task.              |
+| Last touched | 2026-05-28                                                        |
+
+* Acceptance
+
+- =doc/llm/llm_first.org= exists with v2 frontmatter and org-roam ID.
+- Covers: LLM-first philosophy, dual human/LLM audience, Claude as
+  primary tool, open to any compliant LLM.
+- Linked from =llm.org= =* See also=.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -99,6 +99,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]]            | DONE    | 2026-05-28 | 2026-05-28 | Add compass skill type, update skill-creation recipe, create run-runbook skill.                    |
 | [[id:5D11EB95-8B20-4A11-B9A6-C883C9E4B0CF][Document deduplication recipe]]                    | DONE    | 2026-05-28 | 2026-05-28 | Generalised recipe for merging duplicate docs; applied to duplicate sprint health review runbooks. |
 | [[id:76F0DB10-084D-4A72-A585-5DE660884677][PlantUML integration: recipe and codegen scaffold]] | DONE   | 2026-05-28 | 2026-05-28 | PlantUML how-to recipe; compass add diagram scaffold; standard licence header convention.          |
+| [[id:AE1E893D-8E5C-4DB7-BB71-492F1A65374D][Document ORE Studio as an LLM-first system]]       | STARTED | 2026-05-28 |            | LLM-first philosophy page and Claude Code tool page; update llm.org index.                        |
 
 ** Documentation
 

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -99,7 +99,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]]            | DONE    | 2026-05-28 | 2026-05-28 | Add compass skill type, update skill-creation recipe, create run-runbook skill.                    |
 | [[id:5D11EB95-8B20-4A11-B9A6-C883C9E4B0CF][Document deduplication recipe]]                    | DONE    | 2026-05-28 | 2026-05-28 | Generalised recipe for merging duplicate docs; applied to duplicate sprint health review runbooks. |
 | [[id:76F0DB10-084D-4A72-A585-5DE660884677][PlantUML integration: recipe and codegen scaffold]] | DONE   | 2026-05-28 | 2026-05-28 | PlantUML how-to recipe; compass add diagram scaffold; standard licence header convention.          |
-| [[id:AE1E893D-8E5C-4DB7-BB71-492F1A65374D][Document ORE Studio as an LLM-first system]]       | STARTED | 2026-05-28 |            | LLM-first philosophy page and Claude Code tool page; update llm.org index.                        |
+| [[id:AE1E893D-8E5C-4DB7-BB71-492F1A65374D][Document ORE Studio as an LLM-first system]]       | DONE    | 2026-05-28 | 2026-05-28 | LLM-first philosophy page and Claude Code tool page; update llm.org index.                        |
 
 ** Documentation
 

--- a/doc/llm/claude_code.org
+++ b/doc/llm/claude_code.org
@@ -1,0 +1,63 @@
+:PROPERTIES:
+:ID: 9AE40093-3BBF-44F7-818D-C8CA7C8D7F83
+:END:
+#+title: Claude Code
+#+description: Claude Code is Anthropic's CLI for Claude, the AI assistant that is ORE Studio's primary development tool. This page defines the tool and links to its configuration.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :llm:claude_code:tooling:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+
+* Summary
+
+Claude Code is Anthropic's official CLI for Claude — the AI assistant
+that drives ORE Studio's day-to-day development. It runs inside the
+repository, reads =CLAUDE.md= at session start, and has access to a
+curated set of tools and permissions defined in
+[[id:2D83251F-0E24-4B97-B736-08F710316634][Claude Code Settings]]. Project-specific configuration lives under
+=.claude/=; skills, runbooks, and recipes give Claude Code the
+context it needs to act without hand-holding at each step.
+
+* Detail
+
+** What Claude Code is
+
+Claude Code (=claude= CLI) is Anthropic's interactive agent for
+software engineering tasks. Unlike a plain chat interface, Claude Code
+operates directly on the filesystem — it reads files, edits code, runs
+shell commands, and opens pull requests. It is invoked from the
+repository root; =CLAUDE.md= is the mandatory entry point it reads at
+the start of every session.
+
+** How it is used in ORE Studio
+
+ORE Studio uses Claude Code as its primary development tool. Humans
+set goals, review work, and make architectural decisions; Claude Code
+executes — writing code, authoring documentation, opening PRs, and
+responding to review comments. The agile process (sprint → story →
+task → PR) is the handoff boundary: a human approves a story's
+acceptance criteria, and Claude Code implements and delivers it.
+
+Session configuration is layered: =.claude/settings.json= controls
+the tool permission allow-list and sandbox overrides; =.claude/skills/=
+contains task-shaped playbooks; =doc/llm/runbooks/= contains
+multi-step procedures; and =doc/recipes/= holds individual how-tos
+with executable shell blocks. Claude Code reads these as needed to
+orient itself and act correctly.
+
+** Configuration
+
+The permission allow-list and sandbox overrides are maintained as a
+literate org document and generated via org-babel tangle. Never edit
+=.claude/settings.json= directly; regenerate it with the
+=deploy_settings= CMake target. Full details in
+[[id:2D83251F-0E24-4B97-B736-08F710316634][Claude Code Settings]].
+
+* See also
+
+- [[id:2D83251F-0E24-4B97-B736-08F710316634][Claude Code Settings]] — permission allow-list and sandbox configuration.
+- [[id:3B7C30A5-A421-4EEF-ADA8-C20D4AB54BB6][LLM-first system]] — the philosophy behind LLM-driven development.
+- [[id:F9AD7932-8E11-433C-A812-B57DBC9BF5D8][LLM instructions]] — mandatory first read for every Claude Code session.
+- [[id:94F9949A-1580-4D47-9331-AA0597543C99][LLM Configuration and Artefacts]] — full LLM support stack.

--- a/doc/llm/llm.org
+++ b/doc/llm/llm.org
@@ -19,6 +19,8 @@ when to use it, and where to find it.
 
 | Component    | Grain              | Shape                       | Example                                                   |
 |--------------+--------------------+-----------------------------+-----------------------------------------------------------|
+| [[id:3B7C30A5-A421-4EEF-ADA8-C20D4AB54BB6][LLM-first]]   | Philosophy          | How LLMs drive development  | LLMs execute; humans direct; docs serve both audiences    |
+| [[id:9AE40093-3BBF-44F7-818D-C8CA7C8D7F83][Claude Code]]  | Primary tool        | Anthropic CLI for Claude     | Reads =CLAUDE.md=; edits code, opens PRs, runs commands   |
 | [[id:F9AD7932-8E11-433C-A812-B57DBC9BF5D8][Instructions]] | Entry point         | Session-level rules and links | Mandatory first read for every LLM session                |
 | [[id:B555D2A6-10CA-4A93-973E-F2AF4E1D7E55][Runbooks]]     | Multi-step procedure | Composition of recipes       | "Start work on a new story" (7 steps, story → PR)         |
 | [[id:0C57932D-D13A-480F-B426-49525AA8BA3D][Recipes]]      | Single operation    | How-to with executable shell | "How do I create a PR?"                                   |
@@ -100,6 +102,8 @@ time.
 
 * See also
 
+- [[id:3B7C30A5-A421-4EEF-ADA8-C20D4AB54BB6][LLM-first system]] — ORE Studio's LLM-first development philosophy.
+- [[id:9AE40093-3BBF-44F7-818D-C8CA7C8D7F83][Claude Code]] — the primary development tool and its configuration.
 - [[id:F9AD7932-8E11-433C-A812-B57DBC9BF5D8][LLM instructions]] — entry point; read before acting.
 - [[id:B69989F6-19E1-430D-AC6D-B2416E4C433F][Compass]] — top-level map of =doc/=.
 - [[id:C0CF98E8-082F-2F04-2533-94B2DA9BE3D2][Orientation]] — navigation by reader intent.

--- a/doc/llm/llm_first.org
+++ b/doc/llm/llm_first.org
@@ -52,10 +52,8 @@ immediately know what it is, where it fits, and how to act on it.
 ** Primary tool: Claude Code
 
 [[id:9AE40093-3BBF-44F7-818D-C8CA7C8D7F83][Claude Code]] (Anthropic's CLI for Claude) is the tool used for day-to-day
-development. Project-specific configuration lives in =.claude/=:
-=settings.json= controls tool permissions, =skills/= contains
-task-shaped playbooks, and =CLAUDE.md= is the entry point Claude Code
-reads at session start.
+development. Configuration, permissions, and session behaviour are
+described in [[id:9AE40093-3BBF-44F7-818D-C8CA7C8D7F83][Claude Code]] and its associated [[id:2D83251F-0E24-4B97-B736-08F710316634][settings]].
 
 ** Contributing from other LLMs
 

--- a/doc/llm/llm_first.org
+++ b/doc/llm/llm_first.org
@@ -1,0 +1,74 @@
+:PROPERTIES:
+:ID: 3B7C30A5-A421-4EEF-ADA8-C20D4AB54BB6
+:END:
+#+title: ORE Studio as an LLM-first system
+#+description: ORE Studio is built and maintained primarily by LLMs under human direction. This page explains the philosophy, the dual human/LLM audience, and how contributions work.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :llm:philosophy:development:knowledge:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+
+* Summary
+
+ORE Studio is an /LLM-first/ system: large language models are the
+primary means of development, working under human direction. All
+documentation is written to be equally useful to human readers and AI
+agents. [[id:9AE40093-3BBF-44F7-818D-C8CA7C8D7F83][Claude Code]] is the primary tool, but any LLM that can follow the
+project's [[id:F9AD7932-8E11-433C-A812-B57DBC9BF5D8][LLM instructions]] is welcome to contribute.
+
+* Detail
+
+** What LLM-first means
+
+ORE Studio does not treat LLMs as a convenience layer bolted on top of
+a human workflow. The project is /designed/ so that an LLM session
+starting from scratch can orient itself, pick up work, implement it,
+and raise a PR without human hand-holding at each step. The
+[[id:F9AD7932-8E11-433C-A812-B57DBC9BF5D8][LLM instructions]] are the mandatory entry point; the
+[[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][compass tool]] provides live orientation; [[id:0C57932D-D13A-480F-B426-49525AA8BA3D][recipes]],
+[[id:B555D2A6-10CA-4A93-973E-F2AF4E1D7E55][runbooks]], and [[id:6054CC20-5F41-482F-A587-759512577B1D][skills]] encode every repeatable operation.
+
+** Human direction, LLM execution
+
+Humans set goals, review work, and make architectural decisions.
+LLMs execute: they write code, author documentation, open PRs, respond
+to review comments, and close stories. The agile process
+([[id:1737C00C-699A-475A-BC94-743C6CDA1001][sprint]], story, task, PR) is the handoff boundary — a human approves a
+story's goal and acceptance criteria; an LLM implements and delivers
+it.
+
+** Documentation for two audiences
+
+Every document in ORE Studio is written to serve both readers. For
+humans: clear prose, navigable headings, worked examples. For LLMs:
+consistent =#+type:= and =#+description:= frontmatter, org-roam
+=:ID:= properties on every node, =[[id:UUID][Title]]= cross-references
+that can be resolved by the doc graph, and executable =#+begin_src sh=
+blocks in recipes. The structured format lets an LLM load a page and
+immediately know what it is, where it fits, and how to act on it.
+
+** Primary tool: Claude Code
+
+[[id:9AE40093-3BBF-44F7-818D-C8CA7C8D7F83][Claude Code]] (Anthropic's CLI for Claude) is the tool used for day-to-day
+development. Project-specific configuration lives in =.claude/=:
+=settings.json= controls tool permissions, =skills/= contains
+task-shaped playbooks, and =CLAUDE.md= is the entry point Claude Code
+reads at session start.
+
+** Contributing from other LLMs
+
+ORE Studio accepts contributions from any LLM, not just Claude. The
+only requirement is that the LLM reads and follows
+[[id:F9AD7932-8E11-433C-A812-B57DBC9BF5D8][LLM instructions]] before acting. Commit trailers identify the
+contributing model (=Co-Authored-By:= with the model name and
+=noreply@anthropic.com= / =noreply@google.com= etc.); see
+[[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][commit conventions]] for the exact format.
+
+* See also
+
+- [[id:F9AD7932-8E11-433C-A812-B57DBC9BF5D8][LLM instructions]] — mandatory first read for every LLM session.
+- [[id:9AE40093-3BBF-44F7-818D-C8CA7C8D7F83][Claude Code]] — the primary development tool.
+- [[id:94F9949A-1580-4D47-9331-AA0597543C99][LLM Configuration and Artefacts]] — the full LLM support stack.
+- [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][Compass]] — orientation and navigation tool for LLM sessions.

--- a/doc/meta/cybernetics.org
+++ b/doc/meta/cybernetics.org
@@ -27,7 +27,7 @@ identity (S5).
 
 ** Origins
 
-Cybernetics was coined by Norbert Wiener in 1948 to describe the study
+Cybernetics was coined by [[https://en.wikipedia.org/wiki/Norbert_Wiener][Norbert Wiener]] in 1948 to describe the study
 of control and communication in animals and machines. The word derives
 from the Greek /kybernetes/ (steersman). Wiener noticed that effective
 regulation — whether in a thermostat, a nervous system, or a factory
@@ -57,7 +57,7 @@ measures the current state, and a feedback loop that closes the gap.
 
 ** Stafford Beer and management cybernetics
 
-Beer applied Wiener's framework to human organisations in the 1950s–70s.
+[[https://en.wikipedia.org/wiki/Stafford_Beer][Stafford Beer]] applied Wiener's framework to human organisations in the 1950s–70s.
 His central question was: why do large organisations so frequently fail
 to regulate themselves? His answer: they are not structured to produce
 the variety necessary to absorb the variety of their environments. A
@@ -77,11 +77,11 @@ product identity play in the development process. The mapping is
 intentionally loose — the point is not to implement VSM faithfully but
 to borrow its language for separating concerns:
 
-- Concerns that change within hours belong to S1 (task execution).
-- Concerns that change within days belong to S2 (story orchestration).
-- Concerns that change within weeks belong to S3 (sprint management).
-- Concerns that change within months belong to S4 (version planning).
-- Concerns that are durable belong to S5 (product identity).
+- Concerns that change within hours belong to [[id:B544713A-BA23-4D5A-9CEE-084212D7C8BA][S1 Agent]] (task execution).
+- Concerns that change within days belong to [[id:EECA6981-3240-44D9-ADA7-4B8C64A76B44][S2 Orchestrator]] (story orchestration).
+- Concerns that change within weeks belong to [[id:F1D99662-C6B1-4839-92E1-D061CCF6B83F][S3 Sprint Planner]] (sprint management).
+- Concerns that change within months belong to [[id:66EB6824-52B8-4603-B302-F805DA9EC443][S4 Version Planner]] (version planning).
+- Concerns that are durable belong to [[id:5CAD21DA-21FB-460B-9286-8998B4C6EF52][S5 Identity Steward]] (product identity).
 
 For where this mapping aligns with and departs from canonical VSM, see
 the /Connection to and divergence from the VSM/ section of [[id:926B916E-A57E-498E-99AB-720B583C0362][Cybernetic Levels]].
@@ -90,3 +90,5 @@ the /Connection to and divergence from the VSM/ section of [[id:926B916E-A57E-49
 
 - [[id:B730ECAB-A0BF-4894-9275-C0F4199272E3][Viable System Model]] — Beer's five-system model in detail.
 - [[id:926B916E-A57E-498E-99AB-720B583C0362][Cybernetic Levels]] — how ORE Studio maps S1–S5 onto its agile roles.
+- [[https://en.wikipedia.org/wiki/Norbert_Wiener][Norbert Wiener (Wikipedia)]] — founder of cybernetics.
+- [[https://en.wikipedia.org/wiki/Stafford_Beer][Stafford Beer (Wikipedia)]] — developer of management cybernetics and the VSM.

--- a/doc/meta/document_types.org
+++ b/doc/meta/document_types.org
@@ -10,6 +10,26 @@
 #+created: 2026-05-18
 #+updated: 2026-05-18
 
+Every =.org= file in ORE Studio carries a =#+type:= field that places it
+in a shared taxonomy. The taxonomy exists for three reasons. First,
+/structural contracts/: each type defines exactly which sections,
+frontmatter fields, and lifecycle (if any) a document must carry — an
+LLM or human loading any file immediately knows what shape it is and
+what rules apply. Second, /queryability/: =#+type:= is the primary
+filter for =compass list=, =grep=, and the audit scripts, making it
+possible to ask "all knowledge docs on security" or "every in-flight
+task" without noise from unrelated file shapes. Third, /level
+alignment/: types map to [[id:926B916E-A57E-498E-99AB-720B583C0362][cybernetic levels]] — =task= to S1, =story= to S2,
+=sprint= to S3, =version= to S4, =product_identity= to S5 — so the
+type of a document tells you who owns it and at what time horizon. The
+=#+description:= field, capped at 120 characters, is the load-bearing
+summary every index and search reads first; it is as important as the
+type itself.
+
+The full vocabulary of types is in =* Document types= below. The rules
+for standard frontmatter, state, linking, and tags apply across all
+types and are defined in the sections that precede it.
+
 * Creating documents
 
 Never hand-write frontmatter or IDs. Use the generator:

--- a/doc/orientation.org
+++ b/doc/orientation.org
@@ -115,7 +115,5 @@ Skim [[id:B69989F6-19E1-430D-AC6D-B2416E4C433F][Compass]] for orientation if you
 
 * See also
 
-External documentation generated from the codebase:
-
-- [[https://orestudio.github.io/OreStudio/doxygen/html/index.html][Doxygen]] — low-level C++ API reference, regenerated on every
-  release.
+- [[id:5B271351-399A-4BD7-A096-E5DF1EDAD8F5][Developer Links]] — external resources: GitHub, Doxygen, Discord, CDash, and CI.
+- [[id:B69989F6-19E1-430D-AC6D-B2416E4C433F][Compass]] — top-level map of =doc/=.


### PR DESCRIPTION
## Summary

- Add `doc/llm/llm_first.org`: explains ORE Studio's LLM-first development model — LLMs as primary execution, human direction at the sprint/story boundary, dual human/LLM documentation audience, Claude Code as primary tool, open to any compliant LLM
- Add `doc/llm/claude_code.org`: defines Claude Code (Anthropic CLI for Claude), how it is used in ORE Studio, configuration via `.claude/settings.json`, links to Claude Code Settings
- Update `doc/llm/llm.org`: add both new pages to component overview table and `See also`
- Mark story and both tasks DONE in agile artefacts

## Story / Tasks

- Story-ID: AE1E893D-8E5C-4DB7-BB71-492F1A65374D
- Task-ID: EA2E3D00-DD80-4D98-8700-3C801E7A4978 (Write LLM-first system philosophy page)
- Task-ID: 1F23819A-7B4F-4409-9880-DC01C9A3C231 (Add Claude Code knowledge page)

## Test plan

- [ ] `doc/llm/llm_first.org` exists with v2 frontmatter and org-roam ID
- [ ] `doc/llm/claude_code.org` exists with v2 frontmatter and org-roam ID, links to `claude_code_settings.org`
- [ ] `doc/llm/llm.org` component table references both new pages
- [ ] `doc/llm/llm.org` See also references both new pages
- [ ] Story and both tasks show State = DONE

🤖 Generated with [Claude Code](https://claude.com/claude-code)