### PR TITLE
[doc] Add Tooling section to knowledge.org and developer scripts doc

### DIFF
--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org
@@ -38,11 +38,11 @@ The Tooling section in =knowledge.org= must also link to [[id:6F7A122F-BC0F-4F3E
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                                |
 | Parent story | [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]] |
-| Now          | Not yet started.                       |
+| Now          | Implementing Tooling section and developer scripts doc. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Open PR.                               |
 | Last touched | 2026-05-28                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org
@@ -9,7 +9,7 @@
 #+filetags: :tooling_documentation:sprint_18:v0:
 #+owner: marco
 #+branch: feature/tooling-documentation
-#+pr: 903
+#+pr: 907
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-28
@@ -63,7 +63,8 @@ task closes. Plans do not outlive their task.)
 
 | PR  | Title                                                 |
 |-----+-------------------------------------------------------|
-| 903 | [agile] Scaffold tooling documentation story (sprint 18) |
+| 903 | [agile] Scaffold tooling documentation story (sprint 18)           |
+| 907 | [doc] Add Tooling section to knowledge.org and developer scripts doc |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org
@@ -70,6 +70,7 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary                               | File                                     | Decision | Notes                      |
 |---+-----------------------------------------------+------------------------------------------+----------+----------------------------|
-| 1 | Acceptance criteria section empty (all 4 tasks) | task_implement_tooling_documentation.org | Accept   | Fixed in 8ef145efe          |
+| 1 | Acceptance criteria section empty (all 4 tasks)              | task_implement_tooling_documentation.org | Accept  | Fixed in 8ef145efe           |
+| 2 | Inconsistent script naming (hyphens vs underscores)           | developer_scripts.org                    | Decline | Doc reflects actual filenames; rename is a separate task. |
 
 * Result

--- a/doc/knowledge/architecture/developer_scripts.org
+++ b/doc/knowledge/architecture/developer_scripts.org
@@ -1,0 +1,63 @@
+:PROPERTIES:
+:ID: BA6F2BF1-E16E-4E80-A3D0-CACC30FA04DB
+:END:
+#+title: Developer scripts
+#+description: Inventory of standalone scripts in scripts/, grouped by purpose, with descriptions and notes on Python/shell companion pairs.
+#+type: knowledge
+#+version: 2
+#+level: cross
+#+filetags: :knowledge:architecture:tooling:scripts:
+#+created: 2026-05-28
+#+updated: 2026-05-28
+
+The =scripts/= directory at the repository root holds standalone automation
+scripts that support the build, test, and documentation workflows. These are
+distinct from component-level scripts (e.g. [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]], [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]]) which live
+inside their respective =projects/<component>/= trees and are documented in
+those component overviews.
+
+Where a Python script and a shell wrapper share a purpose, both are listed
+together; the shell script delegates to the Python one and provides a
+convenient entry point for CI or Make targets.
+
+* Sprint metrics and reporting
+
+Scripts that extract data from git history, agile docs, and test runs to
+produce reports and charts used in sprint health reviews.
+
+| Script | Purpose | Notes |
+|--------+---------+-------|
+| =sprint_metrics.py= | Extracts per-sprint metrics from git history and agile doc state changes; outputs CSV files consumed by gnuplot chart scripts. | Companion gnuplot scripts: =sprint_line_churn.gnuplot=, =sprint_pr_cycle.gnuplot=, =sprint_prs_commits.gnuplot=, =sprint_stories_done.gnuplot=. |
+| =parse_test_results.py= | Parses Catch2 XML test-result files; extracts per-suite statistics and failure details. | Python; shell wrapper: =parse-test-results.sh=. Used by the [[id:F6E88DCC-9240-4632-A9A3-9F36F79C9262][How do I monitor a PR until green?]] recipe. |
+| =parse-test-results.sh= | Shell wrapper for =parse_test_results.py=; runs the parser from the repo root with standard arguments. | Delegates to =parse_test_results.py=. |
+
+* Validation and quality
+
+Scripts that validate artefacts against external standards or committed baselines.
+
+| Script | Purpose | Notes |
+|--------+---------+-------|
+| =validate_ore_examples.sh= | Validates every XML file in =external/ore/examples/= against the ORE XSD schema. | Used as a pre-import gate; see the ORE import plan for context. |
+| =ore_domain_roundtrip_check.py= | Compares committed roundtrip outputs in =assets/test_data/domain_roundtrip/= against upstream ORE originals; reports per-file and per-entity fidelity for Portfolio and CurrencyConfig document types. | Standalone Python; no shell companion. |
+
+* Documentation generation
+
+Scripts that generate or transform documentation artefacts.
+
+| Script | Purpose | Notes |
+|--------+---------+-------|
+| =generate_protocol_docs.py= | Reads protocol metadata and generates comprehensive protocol documentation in org-mode format. | Standalone Python; output lives in =doc/= subdirectories. |
+| =backfill_story_task_tables.py= | Back-fills the =* Tasks= section in sprint story docs, replacing bullet-list entries with org-mode tables. | One-shot migration script; safe to re-run with =--dry-run=. |
+
+* Utilities
+
+General-purpose helper scripts not tied to a specific workflow.
+
+| Script | Purpose | Notes |
+|--------+---------+-------|
+| =convert-to-unix.sh= | Converts text files in a given project root from DOS to Unix line endings using =dos2unix=. | Accepts an optional path argument; defaults to =.=. Excludes =vcpkg/= and =output/=. |
+
+* See also
+
+- [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] — repository compass tool with its own script family (=compass.sh=, =compass.py=), documented in the component overview.
+- [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]] — database lifecycle management; see its =* Scripts= section for the full inventory of lifecycle and utility scripts.

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -8,7 +8,7 @@
 #+level: cross
 #+filetags: :knowledge:index:
 #+created: 2024-06-15
-#+updated: 2026-05-21
+#+updated: 2026-05-28
 
 Durable, cross-cutting knowledge that outlives any sprint. Each entry
 is a single-topic page — a definition, a convention, an explanation of
@@ -89,6 +89,27 @@ How the codebase is put together.
   and system class diagrams.
 - [[id:496DC90B-8951-42A6-A63E-B1762DF496C6][PlantUML ER diagram conventions]] — styling for the SQL schema
   ER diagram.
+
+* Tooling
+
+Developer tools, scripts, and automation that support the build, test, and
+documentation workflows. These are not user-facing features — they are the
+instruments contributors reach for to get work done.
+
+- [[id:BA6F2BF1-E16E-4E80-A3D0-CACC30FA04DB][Developer scripts]] — inventory of the standalone scripts in =scripts/=,
+  grouped by purpose (metrics/reporting, validation, documentation
+  generation, utilities), with a description of each script and notes on
+  companion Python/shell pairs.
+- [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] — the Python repository compass: temporal orientation,
+  semantic doc search, and agile scaffolding over the org-roam graph.
+  Primary quality-of-life aid for both human contributors and LLM agents.
+- [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] — Python + Mustache code generator producing SQL, C++, and
+  v2 org documents from JSON models.
+- [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]] — Emacs Lisp developer tooling: dashboard, database browser,
+  shell integration, and org-roam export pipeline.
+- [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]] — PostgreSQL schema, migration scripts, role provisioning, and
+  database lifecycle management. See the =* Scripts= section in the
+  component overview for the full script inventory.
 
 * UI
 


### PR DESCRIPTION
## Summary

Implements T1 of the Tooling documentation story: adds a new `* Tooling` section
to `knowledge.org` and creates a `Developer scripts` knowledge document.

## Changes

- `doc/knowledge/knowledge.org` — new `* Tooling` section (after Architecture,
  before UI) linking to the developer scripts doc, ores.compass, ores.codegen,
  ores.lisp, and ores.sql component overviews.
- `doc/knowledge/architecture/developer_scripts.org` — new knowledge doc
  cataloguing all standalone scripts in `scripts/` grouped into four categories:
  Sprint metrics and reporting, Validation and quality, Documentation generation,
  and Utilities. Each entry has a purpose description and notes on companion
  Python/shell pairs and related docs.
- `doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org`
  — status updated to STARTED.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Tooling documentation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/tooling_documentation/story.html) | 304F8600-3A5B-434F-87C4-10DDA973E47F |
| Task (T1) | [Task: Add Tooling section to knowledge.org and developer scripts doc](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.html) | 546C6CDA-6A59-445B-8385-1BD3C5AFC871 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)