### PR TITLE
[doc] Add Commands section to ores.compass component overview

### DIFF
--- a/doc/agile/versions/v0/sprint_18/capture.org
+++ b/doc/agile/versions/v0/sprint_18/capture.org
@@ -19,7 +19,11 @@ All entries drained 2026-05-28 — filed into product backlog via bulk capture r
 
 * New
 
-(empty — all entries have been drained)
+
+
+- add a recipe: how do i build the site locally to mirror how do i serve the
+  site locally. cross reference them.
+- org-timestamps need to be written into the build directory.
 
 * Drained
 

--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -32,8 +32,8 @@ Enable end-to-end [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][ORE]] imports into 
 | Field          | Value                                                     |
 |----------------+-----------------------------------------------------------|
 | State          | STARTED                                                   |
-| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]]    |
-| Previous       | [[id:A2B8A670-3B02-11F1-BCE2-4B06F4BBA5D7][Sprint 17]]    |
+| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]]                                                 |
+| Previous       | [[id:A2B8A670-3B02-11F1-BCE2-4B06F4BBA5D7][Sprint 17]]                                                 |
 | Start          | 2026-05-22                                                |
 | End (expected) | 2026-05-28                                                |
 | Now            | Sprint in flight.                                         |
@@ -63,77 +63,78 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 ** Tooling
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                                | State   | Start      | End        | Description |
-|------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
-| [[id:8BA366D7-B43F-4E5B-B4AD-A40C7E28881B][ores.compass repository compass tool]]             | DONE    | 2026-05-24 | 2026-05-24 | Python repository compass: temporal orientation, semantic doc search, agile scaffolding.           |
-| [[id:468387DD-0D6F-49B4-9F82-BD179DCB1CC1][ores.compass Locate — temporal orientation]]       | DONE    | 2026-05-24 | 2026-05-24 | =where=/=status=: report current version, sprint, and in-flight stories and tasks from the graph. |
-| [[id:D84B1122-30DC-4BCF-9C90-73403FAAECD9][ores.compass Scaffold — agile authoring]]          | DONE    | 2026-05-24 | 2026-05-24 | =add story/task/sprint/recipe=: create agile artefacts from the CLI by calling ores.codegen as a library. |
-| [[id:7EF64A67-EB1C-4F79-9FF2-1C59DD6146AB][Track PRs per task and surface in compass where]]  | DONE    | 2026-05-24 | 2026-05-24 | PRs table in task docs; =compass where --prs= fetches live PR status via =gh=.                    |
-| [[id:026AA423-68A1-43A1-8F2A-D9D3D6379E6C][Add org-roam index links to compass.org folder entries]] | DONE    | 2026-05-24 | 2026-05-24 | Each folder in compass.org links to its index file; missing index files created.             |
-| [[id:15CE567F-489C-4A80-9CEC-27FCF95E5C36][ores.compass Product Backlog — next and deferred listing]] | BACKLOG | 2026-05-24 |       | =compass backlog= lists next/deferred captures with counts, mirroring =where= in-flight display.  |
-| [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][compass cross-worktree status (global where)]]     | DONE    | 2026-05-25 | 2026-05-25 | Show what every git worktree is doing (branch/story/task/PR) so parallel agents don't collide.    |
-| [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][compass goto: start a unit of work in one command]] | DONE   | 2026-05-25 | 2026-05-25 | One command: fetch main, branch, scaffold linked story+task, print next steps.                    |
-| [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Compass PR review management]]                     | BACKLOG | 2026-05-26 |            | Add compass review list/reply/resolve subcommands wrapping gh API.                                |
-| [[id:47FD2F81-2143-4C35-9AC1-5A3A9D4AF975][compass goto --kind flag]]                         | DONE    | 2026-05-28 | 2026-05-28 | Add --kind hotfix to compass goto for hotfix/ branches; update runbook, recipe, docs.             |
-| [[id:E6CC19FC-5469-45BD-AA87-9CDBB23A4A7F][Per-sprint capture workflow: individual files and compass integration]] | STARTED | 2026-05-27 | | captures/ folder per sprint; compass capture command; wontdo backlog bucket.           |
+| Story                                                                 | State   |      Start |        End | Description                                                                                               |
+|-----------------------------------------------------------------------+---------+------------+------------+-----------------------------------------------------------------------------------------------------------|
+| [[id:8BA366D7-B43F-4E5B-B4AD-A40C7E28881B][ores.compass repository compass tool]]                                  | DONE    | 2026-05-24 | 2026-05-24 | Python repository compass: temporal orientation, semantic doc search, agile scaffolding.                  |
+| [[id:468387DD-0D6F-49B4-9F82-BD179DCB1CC1][ores.compass Locate — temporal orientation]]                            | DONE    | 2026-05-24 | 2026-05-24 | =where=/=status=: report current version, sprint, and in-flight stories and tasks from the graph.         |
+| [[id:D84B1122-30DC-4BCF-9C90-73403FAAECD9][ores.compass Scaffold — agile authoring]]                               | DONE    | 2026-05-24 | 2026-05-24 | =add story/task/sprint/recipe=: create agile artefacts from the CLI by calling ores.codegen as a library. |
+| [[id:7EF64A67-EB1C-4F79-9FF2-1C59DD6146AB][Track PRs per task and surface in compass where]]                       | DONE    | 2026-05-24 | 2026-05-24 | PRs table in task docs; =compass where --prs= fetches live PR status via =gh=.                            |
+| [[id:026AA423-68A1-43A1-8F2A-D9D3D6379E6C][Add org-roam index links to compass.org folder entries]]                | DONE    | 2026-05-24 | 2026-05-24 | Each folder in compass.org links to its index file; missing index files created.                          |
+| [[id:15CE567F-489C-4A80-9CEC-27FCF95E5C36][ores.compass Product Backlog — next and deferred listing]]              | BACKLOG | 2026-05-24 |            | =compass backlog= lists next/deferred captures with counts, mirroring =where= in-flight display.          |
+| [[id:CB368AF8-3144-4CFF-B782-05CDF87366A6][compass cross-worktree status (global where)]]                          | DONE    | 2026-05-25 | 2026-05-25 | Show what every git worktree is doing (branch/story/task/PR) so parallel agents don't collide.            |
+| [[id:C0B87858-4EDA-40F3-B4DF-1CDEA5CC712E][compass goto: start a unit of work in one command]]                     | DONE    | 2026-05-25 | 2026-05-25 | One command: fetch main, branch, scaffold linked story+task, print next steps.                            |
+| [[id:166E8E44-1573-4DE2-825F-A6037A302AE9][Compass PR review management]]                                          | BACKLOG | 2026-05-26 |            | Add compass review list/reply/resolve subcommands wrapping gh API.                                        |
+| [[id:47FD2F81-2143-4C35-9AC1-5A3A9D4AF975][compass goto --kind flag]]                                              | DONE    | 2026-05-28 | 2026-05-28 | Add --kind hotfix to compass goto for hotfix/ branches; update runbook, recipe, docs.                     |
+| [[id:E6CC19FC-5469-45BD-AA87-9CDBB23A4A7F][Per-sprint capture workflow: individual files and compass integration]] | STARTED | 2026-05-27 |            | captures/ folder per sprint; compass capture command; wontdo backlog bucket.                              |
 
 ** Agile
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                                | State   | Start      | End        | Description |
-|------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
-| [[id:22AA37FA-23A0-406E-B05B-B11BB3E83874][Product backlog refinement]]                       | DONE    | 2026-05-24 | 2026-05-24 | Build backlog-refiner and sprint-planner skills/recipes; set sprint 18 mission.                    |
-| [[id:16851249-2FB0-443E-83E0-55D6B8051272][Sprint health review — System 2 analysis]]         | DONE    | 2026-05-25 | 2026-05-26 | =sprint-reviewer= skill writes a structured health-check section into =sprint.org=.               |
-| [[id:8BD3D28A-C5A1-4F8D-A685-1BC6EBF5C812][Sprint health charts]]                             | DONE    | 2026-05-26 | 2026-05-26 | Generate daily charts of PRs, commits, story completions, and line churn using gnuplot.           |
-| [[id:FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6][Refactor story task lists to a status table]]      | STARTED | 2026-05-28 |            | Replace bullet-list Tasks section in story docs with a Task/State/Start/End/Description table.    |
-| [[id:03EC9465-AE25-4404-9B7E-B0C25A3CBE28][Sprint theme grouping]]                            | STARTED | 2026-05-28 |            | Introduce theme subheadings into sprint.org to group stories by area.                             |
-| [[id:185845E7-4CF9-416E-A923-894868A757A0][Hotfix handling]]                                  | DONE    | 2026-05-28 | 2026-05-28 | Hotfix runbook, branching recipe update, and Hotfixes section in sprint template.                 |
+| Story                                       | State   |      Start |        End | Description                                                                                    |
+|---------------------------------------------+---------+------------+------------+------------------------------------------------------------------------------------------------|
+| [[id:22AA37FA-23A0-406E-B05B-B11BB3E83874][Product backlog refinement]]                  | DONE    | 2026-05-24 | 2026-05-24 | Build backlog-refiner and sprint-planner skills/recipes; set sprint 18 mission.                |
+| [[id:16851249-2FB0-443E-83E0-55D6B8051272][Sprint health review — System 2 analysis]]    | DONE    | 2026-05-25 | 2026-05-26 | =sprint-reviewer= skill writes a structured health-check section into =sprint.org=.            |
+| [[id:8BD3D28A-C5A1-4F8D-A685-1BC6EBF5C812][Sprint health charts]]                        | DONE    | 2026-05-26 | 2026-05-26 | Generate daily charts of PRs, commits, story completions, and line churn using gnuplot.        |
+| [[id:FFF169EC-0B35-4800-8BEE-1CF7D0DEE8D6][Refactor story task lists to a status table]] | STARTED | 2026-05-28 |            | Replace bullet-list Tasks section in story docs with a Task/State/Start/End/Description table. |
+| [[id:03EC9465-AE25-4404-9B7E-B0C25A3CBE28][Sprint theme grouping]]                       | STARTED | 2026-05-28 |            | Introduce theme subheadings into sprint.org to group stories by area.                          |
+| [[id:185845E7-4CF9-416E-A923-894868A757A0][Hotfix handling]]                             | DONE    | 2026-05-28 | 2026-05-28 | Hotfix runbook, branching recipe update, and Hotfixes section in sprint template.              |
 
 ** LLMs
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                                | State   | Start      | End        | Description |
-|------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
-| [[id:7225526E-DCDB-4DC6-A95D-22C7117E5EAA][Port Tufte visualisation skill into ORE Studio]]   | DONE    | 2026-05-25 | 2026-05-25 | Convert =tufte-viz= SKILL and two Tufte reference docs to org-mode; install and catalogue.        |
-| [[id:3D1935DC-562C-4AA3-A352-AC1BC037DFDD][Runbook support]]                                  | DONE    | 2026-05-26 | 2026-05-26 | Add runbook document type: named composition of recipes for repeatable multi-step operations.      |
-| [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]]            | DONE    | 2026-05-28 | 2026-05-28 | Add compass skill type, update skill-creation recipe, create run-runbook skill.                    |
-| [[id:5D11EB95-8B20-4A11-B9A6-C883C9E4B0CF][Document deduplication recipe]]                    | DONE    | 2026-05-28 | 2026-05-28 | Generalised recipe for merging duplicate docs; applied to duplicate sprint health review runbooks. |
-| [[id:76F0DB10-084D-4A72-A585-5DE660884677][PlantUML integration: recipe and codegen scaffold]] | DONE   | 2026-05-28 | 2026-05-28 | PlantUML how-to recipe; compass add diagram scaffold; standard licence header convention.          |
-| [[id:AE1E893D-8E5C-4DB7-BB71-492F1A65374D][Document ORE Studio as an LLM-first system]]       | DONE    | 2026-05-28 | 2026-05-28 | LLM-first philosophy page and Claude Code tool page; update llm.org index.                        |
+| Story                                             | State |      Start |        End | Description                                                                                        |
+|---------------------------------------------------+-------+------------+------------+----------------------------------------------------------------------------------------------------|
+| [[id:7225526E-DCDB-4DC6-A95D-22C7117E5EAA][Port Tufte visualisation skill into ORE Studio]]    | DONE  | 2026-05-25 | 2026-05-25 | Convert =tufte-viz= SKILL and two Tufte reference docs to org-mode; install and catalogue.         |
+| [[id:3D1935DC-562C-4AA3-A352-AC1BC037DFDD][Runbook support]]                                   | DONE  | 2026-05-26 | 2026-05-26 | Add runbook document type: named composition of recipes for repeatable multi-step operations.      |
+| [[id:E3C798C8-87E9-47E1-88F5-1BE6C8532BBE][Improve LLM runbook and skill tooling]]             | DONE  | 2026-05-28 | 2026-05-28 | Add compass skill type, update skill-creation recipe, create run-runbook skill.                    |
+| [[id:5D11EB95-8B20-4A11-B9A6-C883C9E4B0CF][Document deduplication recipe]]                     | DONE  | 2026-05-28 | 2026-05-28 | Generalised recipe for merging duplicate docs; applied to duplicate sprint health review runbooks. |
+| [[id:76F0DB10-084D-4A72-A585-5DE660884677][PlantUML integration: recipe and codegen scaffold]] | DONE  | 2026-05-28 | 2026-05-28 | PlantUML how-to recipe; compass add diagram scaffold; standard licence header convention.          |
+| [[id:AE1E893D-8E5C-4DB7-BB71-492F1A65374D][Document ORE Studio as an LLM-first system]]        | DONE  | 2026-05-28 | 2026-05-28 | LLM-first philosophy page and Claude Code tool page; update llm.org index.                         |
 
 ** Documentation
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                                | State   | Start      | End        | Description |
-|------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
-| [[id:4E375DD6-E300-4A0A-BD20-3D06AC8ED7A1][Port domain concept notes to knowledge documents]] | STARTED | 2026-05-25 |            | Tidy personal finance/ORE domain notes into v2 knowledge docs; align with ORE Studio terms.       |
-| [[id:28D38DB8-0310-4E46-9946-3EE285E1624B][Doc format cleanup: migrate v1 docs and remove v2 branding]] | STARTED | 2026-05-28 | | Audit active docs lacking frontmatter; rename all v2-branded scripts, templates, and docs. |
-| [[id:9AE5466D-E627-4587-BBEB-6D89E732ACE2][System model readability]]                         | DONE    | 2026-05-26 | 2026-05-28 | Add layer blurbs and table-based component inventory to the system model.                          |
-| [[id:A388F0C8-0804-420F-A542-2C929CFCEC92][Document NATS: technology overview, system integration, and recipes]] | DONE | 2026-05-26 | 2026-05-26 | NATS knowledge page, system model section, per-component subject tables, and NATS recipes. |
-| [[id:C3B6F514-559F-4038-A1D7-947BC9F7F398][Add Downloads and Agile nav entries to the site]]  | BACKLOG | 2026-05-25 |            | =doc/downloads.org= with release table; =Downloads= and =Agile= links in site nav.                |
-| [[id:8AA261FC-B334-45A8-9954-85DD4BECEA45][Improve cybernetics documentation]]                | STARTED | 2026-05-28 |            | Add VSM overview page, expand Cybernetic Levels with context and limitations, link compass.        |
-| [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]]                            | STARTED | 2026-05-28 |            | Add Tooling section to knowledge.org; developer scripts doc; overhaul compass, sql, lisp, codegen overviews. |
-| [[id:FD317B6C-F50F-4A35-81CC-A3B2BE3493C0][Add Emacs and org-roam knowledge pages]]           | DONE    | 2026-05-28 | 2026-05-28 | Create Emacs, org-roam, and Zettelkasten knowledge pages; expand ores.lisp; update orientation.    |
+| Story                                                               | State   |      Start |        End | Description                                                                                                  |
+|---------------------------------------------------------------------+---------+------------+------------+--------------------------------------------------------------------------------------------------------------|
+| [[id:C42C3563-671F-4721-8CE8-5EE05925255F][Build and publish user manual PDF via CMake]]                         | STARTED | 2026-05-24 |            | =deploy_manual= target builds =user_manual.org= to PDF; commit and link the result.                          |
+| [[id:4E375DD6-E300-4A0A-BD20-3D06AC8ED7A1][Port domain concept notes to knowledge documents]]                    | STARTED | 2026-05-25 |            | Tidy personal finance/ORE domain notes into v2 knowledge docs; align with ORE Studio terms.                  |
+| [[id:28D38DB8-0310-4E46-9946-3EE285E1624B][Doc format cleanup: migrate v1 docs and remove v2 branding]]          | STARTED | 2026-05-28 |            | Audit active docs lacking frontmatter; rename all v2-branded scripts, templates, and docs.                   |
+| [[id:9AE5466D-E627-4587-BBEB-6D89E732ACE2][System model readability]]                                            | DONE    | 2026-05-26 | 2026-05-28 | Add layer blurbs and table-based component inventory to the system model.                                    |
+| [[id:A388F0C8-0804-420F-A542-2C929CFCEC92][Document NATS: technology overview, system integration, and recipes]] | DONE    | 2026-05-26 | 2026-05-26 | NATS knowledge page, system model section, per-component subject tables, and NATS recipes.                   |
+| [[id:C3B6F514-559F-4038-A1D7-947BC9F7F398][Add Downloads and Agile nav entries to the site]]                     | BACKLOG | 2026-05-25 |            | =doc/downloads.org= with release table; =Downloads= and =Agile= links in site nav.                           |
+| [[id:8AA261FC-B334-45A8-9954-85DD4BECEA45][Improve cybernetics documentation]]                                   | STARTED | 2026-05-28 |            | Add VSM overview page, expand Cybernetic Levels with context and limitations, link compass.                  |
+| [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]]                                               | STARTED | 2026-05-28 |            | Add Tooling section to knowledge.org; developer scripts doc; overhaul compass, sql, lisp, codegen overviews. |
+| [[id:FD317B6C-F50F-4A35-81CC-A3B2BE3493C0][Add Emacs and org-roam knowledge pages]]                              | DONE    | 2026-05-28 | 2026-05-28 | Create Emacs, org-roam, and Zettelkasten knowledge pages; expand ores.lisp; update orientation.              |
 
 ** Infrastructure
 
 #+ATTR_HTML: :class hug-leading
-| Story                                                                                                | State   | Start      | End        | Description |
-|------------------------------------------------------------------------------------------------------+---------+------------+------------+----------------------------------------------------------------------------------------------------|
-| [[id:A4BEF88C-1372-46CE-864B-C30AC3BE95EB][Inline org-roam export into ores.lisp]]            | DONE    | 2026-05-22 | 2026-05-22 | Vendor =org-roam-export.el= into =ores.lisp= so the CI site build is self-contained.              |
-| [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D8][Resolve RFL complexity issues]]                    | DONE    | 2026-05-23 | 2026-05-24 | Permanently resolve MSVC C1202 and Clang expression nesting limits via structural isolation.       |
-| [[id:0A2CB5BD-67B8-4096-BAC4-8E110333893A][SQLite CLI quality-of-life setup]]                 | DONE    | 2026-05-24 | 2026-05-24 | Committed, commented =.sqliterc= for readable, non-wrapping =sqlite3= shell output.               |
-| [[id:BAF1DEAE-59DF-49AB-BFCD-E6D09496DA43][Lock down uppercase UUID invariant]]               | DONE    | 2026-05-24 | 2026-05-24 | Close the remaining code paths that can emit lowercase UUIDs into the doc graph.                   |
-| [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                       | DONE    | 2026-05-24 | 2026-05-25 | Replace broken per-mode ores.lisp with an env-aware emacs-dashboard console for all dev commands. |
-| [[id:A2B3BFD0-F44C-48F3-BB01-6BAECB851356][Remove unused GitHub Actions workflows]]           | DONE    | 2026-05-24 | 2026-05-24 | Delete the four dormant Gemini workflows; PR review stays via the gemini-code-assist app.         |
-| [[id:8D295781-33E7-4812-AAC6-134BD7CD0DDC][Rebuild org-roam DB independently from CMake]]     | BACKLOG | 2026-05-24 |            | Extract org-roam sync into =.build-org-roam.el=; add =rebuild_org_roam_db= cmake target.         |
-| [[id:AD6B59E1-A267-4927-A3FF-D624BB123658][Move .build-*.el scripts to ores.lisp]]            | DONE    | 2026-05-28 | 2026-05-28 | Relocate build scripts from repo root into ores.lisp/src/ with ores- naming.                      |
+| Story                                        | State   |      Start |        End | Description                                                                                       |
+|----------------------------------------------+---------+------------+------------+---------------------------------------------------------------------------------------------------|
+| [[id:A4BEF88C-1372-46CE-864B-C30AC3BE95EB][Inline org-roam export into ores.lisp]]        | DONE    | 2026-05-22 | 2026-05-22 | Vendor =org-roam-export.el= into =ores.lisp= so the CI site build is self-contained.              |
+| [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D8][Resolve RFL complexity issues]]                | DONE    | 2026-05-23 | 2026-05-24 | Permanently resolve MSVC C1202 and Clang expression nesting limits via structural isolation.      |
+| [[id:0A2CB5BD-67B8-4096-BAC4-8E110333893A][SQLite CLI quality-of-life setup]]             | DONE    | 2026-05-24 | 2026-05-24 | Committed, commented =.sqliterc= for readable, non-wrapping =sqlite3= shell output.               |
+| [[id:BAF1DEAE-59DF-49AB-BFCD-E6D09496DA43][Lock down uppercase UUID invariant]]           | DONE    | 2026-05-24 | 2026-05-24 | Close the remaining code paths that can emit lowercase UUIDs into the doc graph.                  |
+| [[id:8E5543CD-AD7C-41B5-A7EA-F2DC534F5248][ORE Studio Emacs dashboard]]                   | DONE    | 2026-05-24 | 2026-05-25 | Replace broken per-mode ores.lisp with an env-aware emacs-dashboard console for all dev commands. |
+| [[id:A2B3BFD0-F44C-48F3-BB01-6BAECB851356][Remove unused GitHub Actions workflows]]       | DONE    | 2026-05-24 | 2026-05-24 | Delete the four dormant Gemini workflows; PR review stays via the gemini-code-assist app.         |
+| [[id:8D295781-33E7-4812-AAC6-134BD7CD0DDC][Rebuild org-roam DB independently from CMake]] | BACKLOG | 2026-05-24 |            | Extract org-roam sync into =.build-org-roam.el=; add =rebuild_org_roam_db= cmake target.          |
+| [[id:AD6B59E1-A267-4927-A3FF-D624BB123658][Move .build-*.el scripts to ores.lisp]]        | DONE    | 2026-05-28 | 2026-05-28 | Relocate build scripts from repo root into ores.lisp/src/ with ores- naming.                      |
 
 * Health Review
 
-| # | Date       | Day   | Overall | Task                                                                    |
-|---+------------+-------+---------+-------------------------------------------------------------------------|
-| 1 | 2026-05-25 | day 4 | AMBER   | [[id:FA5A76DC-913B-481C-8D65-13F58032D950][Health review 1 — sprint 18 mid-sprint analysis]]          |
+| # |       Date | Day   | Overall | Task                                                      |
+|---+------------+-------+---------+-----------------------------------------------------------|
+| 1 | 2026-05-25 | day 4 | AMBER   | [[id:FA5A76DC-913B-481C-8D65-13F58032D950][Health review 1 — sprint 18 mid-sprint analysis]]           |
 | 2 | 2026-05-26 | day 5 | AMBER   | [[id:669DF15D-AD78-4F9A-8A53-49DF0EEC9455][Health review 2 — sprint 18 backlog audit and shape check]] |
 
 

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_implement_tooling_documentation.org
@@ -61,10 +61,10 @@ task closes. Plans do not outlive their task.)
 
 * PRs
 
-| PR  | Title                                                 |
-|-----+-------------------------------------------------------|
-| 903 | [agile] Scaffold tooling documentation story (sprint 18)           |
-| 907 | [doc] Add Tooling section to knowledge.org and developer scripts doc |
+| PR | Title                                                                |
+|----+----------------------------------------------------------------------|
+| [[https://github.com/OreStudio/OreStudio/pull/903][#903]] | [agile] Scaffold tooling documentation story (sprint 18)             |
+| [[https://github.com/OreStudio/OreStudio/pull/907][#907]] | [doc] Add Tooling section to knowledge.org and developer scripts doc |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_overhaul_compass_component_overview.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_overhaul_compass_component_overview.org
@@ -47,11 +47,11 @@ sections are preserved; the new pillar sections are appended as a new
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                                |
 | Parent story | [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]] |
-| Now          | Not yet started.                       |
+| Now          | Writing Commands section in component overview. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Open PR.                               |
 | Last touched | 2026-05-28                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_overhaul_compass_component_overview.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_overhaul_compass_component_overview.org
@@ -76,8 +76,10 @@ task closes. Plans do not outlive their task.)
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                            | File                   | Decision | Notes                                           |
+|---+--------------------------------------------+------------------------+----------+-------------------------------------------------|
+| 1 | "v2 documents" branding in Scaffold pillar | component_overview.org | Accept   | Fixed in 2c3498e44                              |
+| 2 | Navigate missing recipe table              | component_overview.org | Decline  | No Navigate recipes exist yet; omit is correct. |
+| 3 | Backlog missing recipe table               | component_overview.org | Decline  | Same — no Backlog recipes exist yet.            |
 
 * Result

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_overhaul_compass_component_overview.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_overhaul_compass_component_overview.org
@@ -70,9 +70,9 @@ task closes. Plans do not outlive their task.)
 
 * PRs
 
-| PR  | Title                                                          |
-|-----+----------------------------------------------------------------|
-| 909 | [doc] Add Commands section to ores.compass component overview  |
+| PR | Title                                                          |
+|----+----------------------------------------------------------------|
+| [[https://github.com/OreStudio/OreStudio/pull/909][#909]] | [doc] Add Commands section to ores.compass component overview  |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_overhaul_compass_component_overview.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_overhaul_compass_component_overview.org
@@ -9,7 +9,7 @@
 #+filetags: :tooling_documentation:sprint_18:v0:
 #+owner: marco
 #+branch: feature/overhaul-compass-component-overview
-#+pr:
+#+pr: 909
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-28
@@ -70,9 +70,9 @@ task closes. Plans do not outlive their task.)
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR  | Title                                                          |
+|-----+----------------------------------------------------------------|
+| 909 | [doc] Add Commands section to ores.compass component overview  |
 
 * Review
 

--- a/doc/recipes/github/how_do_i_create_a_pr.org
+++ b/doc/recipes/github/how_do_i_create_a_pr.org
@@ -57,13 +57,14 @@ EOF
    matches =[COMPONENT] Description=.
 
 4. /Record the PR in the task./ Open the task's =* PRs= table and add
-   a row with the PR number and title. The table carries the canonical
-   record — =compass where --prs= reads it to fetch live status:
+   a row with the PR number (as a URL link) and title. The table carries
+   the canonical record — =compass where --prs= reads it to fetch live
+   status:
 
    #+begin_example
-   | PR  | Title                         |
-   |-----+-------------------------------|
-   | 123 | [component] One-line description |
+   | PR | Title                            |
+   |----+----------------------------------|
+   | [[https://github.com/OreStudio/OreStudio/pull/123][#123]] | [component] One-line description |
    #+end_example
 
 * Conventions

--- a/projects/ores.compass/modeling/component_overview.org
+++ b/projects/ores.compass/modeling/component_overview.org
@@ -8,7 +8,7 @@
 #+level: cross
 #+filetags: :compass:tooling:python:docs:agile:
 #+created: 2026-05-24
-#+updated: 2026-05-24
+#+updated: 2026-05-28
 
 * Diagram
 
@@ -94,6 +94,135 @@ Pillars (the first three drawn from the Sprint 18 capture =* Tools=):
   =add <type> [flags]= (Scaffold); =fleet [-f pretty|json]= (Fleet); and
   =goto= (Goto) — new story (=--slug/--title/--description=) or existing
   story (=--story <id-or-slug> --task-slug --task=); =--dry-run= for both.
+
+* Commands
+
+Each command pillar groups the subcommands that share a purpose. The shell
+entry point for all commands is =projects/ores.compass/compass.sh=; run it
+from the repository root.
+
+** Locate
+
+Reports temporal position: which version, which sprint, and which stories
+and tasks are currently in flight (=State: STARTED=). Reads the agile tree
+directly — no database or =org-roam= sync needed.
+
+| Form | Description |
+|------+-------------|
+| =compass where= | Print current version, sprint, and all STARTED stories and tasks (human-readable). |
+| =compass status -f json= | Same output as structured JSON for tooling or LLM consumption. |
+
+| Recipe | Description |
+|--------+-------------|
+| [[id:41E5F9A8-1C2B-4ECA-8EA0-1ABBAB0B6A31][How do I see where we are?]] | Full walkthrough of =where= and =status=. |
+
+** Search
+
+Full-text search over the org-roam documentation graph via a local SQLite
+FTS5 cache (=.compass.db=). The cache must be built with =index= before the
+first search, and refreshed whenever docs change. =find= is an alias for
+=search=.
+
+| Form | Description |
+|------+-------------|
+| =compass search "query"= | Return the top matching docs (default: 10, pretty format). |
+| =compass search "query" -l 5= | Cap results at 5. |
+| =compass search "query" -f line= | Machine-readable output: one =UUID "path" "match"= per line. |
+| =compass search "query" -f json= | Structured JSON array (uuid, path, title, olp, tags, snippet). |
+| =compass index= | Build or incrementally refresh the FTS5 cache from =org-roam.db=. |
+| =compass index --rebuild= | Discard the cache and rebuild from scratch. |
+| =compass debug= | Inspect the raw cache contents. |
+| =compass debug -f glossary= | Show cache in glossary format. |
+
+| Recipe | Description |
+|--------+-------------|
+| [[id:BDA8F7FB-5CEC-42D8-BC78-766BBC8D4285][How do I search docs with compass?]] | Query syntax, output formats, and FTS5 tips. |
+| [[id:DEAC11AE-3753-49FA-994A-98594162A605][How do I index notes for compass?]] | When and how to run =index= and =index --rebuild=. |
+
+** Navigate
+
+Inspect and filter the live documentation graph without a search query.
+=list= filters by metadata; =show= dives into one document. Neither
+requires =org-roam.db= or the FTS5 cache.
+
+| Form | Description |
+|------+-------------|
+| =compass list= | List every addressable doc (UUID, type, title, path). |
+| =compass list --type recipe= | Filter by =#+type:=. |
+| =compass list --tag sprint_18= | Filter by filetag. |
+| =compass list --regex "sql"= | Filter by regex against title or description. |
+| =compass list --under doc/recipes= | Restrict to docs under a path prefix. |
+| =compass list --sort updated= | Sort by =#+updated:= date. |
+| =compass list --paths= | One path per line — useful for piping into =grep= / =xargs=. |
+| =compass show <uuid-or-prefix>= | Print one doc: metadata, blurb, outgoing links, incoming links. |
+
+** Scaffold
+
+Creates new v2 documents by calling [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] as a library. Two
+subcommands: =add= scaffolds any doc type from a template; =capture=
+creates and files captures into the product backlog inbox.
+
+| Form | Description |
+|------+-------------|
+| =compass add story --slug S --title "T" --description "D"= | Scaffold a story in the current sprint. |
+| =compass add task --parent-dir <story-dir> --slug S --title "T"= | Scaffold a task under an existing story. |
+| =compass add sprint --slug sprint_NN --title "Sprint NN"= | Scaffold a new sprint. |
+| =compass add recipe --slug how_do_i_x --title "How do I X?"= | Scaffold a recipe doc. |
+| =compass capture --note "..."= | Parse freeform text and create a structured capture in =inbox/=. |
+| =compass capture file <slug> next= | Move a capture from =inbox/= to =next/=. |
+| =compass capture file <slug> deferred= | Move a capture to =deferred/=. |
+| =compass capture file <slug> discarded= | Move a capture to =discarded/=. |
+
+| Recipe | Description |
+|--------+-------------|
+| [[id:5B670808-D28B-4818-A2FA-EA5220D35E8D][How do I add a doc with compass?]] | Scaffold stories, tasks, sprints, and recipes via =add=. |
+| [[id:7072D39C-9607-48F9-8EE6-50E8647DB8ED][How do I capture ideas from freeform text?]] | Parse raw notes into filed captures via =capture=. |
+
+** Fleet
+
+Gives a cross-worktree status snapshot: for each git worktree, shows the
+current branch, the story and task it maps to (via =#+branch:= in the task
+doc), and the open PR with its live CI state. Useful for coordinating
+parallel work across multiple checkouts or LLM agents.
+
+| Form | Description |
+|------+-------------|
+| =compass fleet= | Human-readable worktree status table. |
+| =compass fleet -f json= | Structured JSON array for tooling consumption. |
+
+| Recipe | Description |
+|--------+-------------|
+| [[id:0D378978-7CF1-45F5-896F-63E281CC02CB][How do I see what every worktree is doing?]] | Walkthrough of =fleet= output and when to use it. |
+
+** Goto
+
+Starts a unit of work in one command: fetches =main=, creates a feature
+branch, scaffolds the linked story and task (via Scaffold/codegen), and
+prints the remaining manual steps. Two modes: new story, or add a task to
+an existing story.
+
+| Form | Description |
+|------+-------------|
+| =compass goto --slug S --title "T" --description "D" --tags "t"= | New story mode: create story + task, branch, and print next steps. |
+| =compass goto --story <id-or-slug> --task-slug S --task "T"= | Add-task mode: add a task to an existing story and branch. |
+| =compass goto ... --dry-run= | Preview all actions without making changes. |
+| =compass goto ... --base <ref>= | Override the base branch (default: =origin/main=). |
+
+| Recipe | Description |
+|--------+-------------|
+| [[id:84C9177E-C737-428A-BDF9-E55FA6C9680C][How do I start a unit of work with compass?]] | Full walkthrough of both =goto= modes. |
+
+** Backlog
+
+Lists captures from the product backlog buckets. Read-only views — use
+=capture file= (Scaffold pillar) to move entries between buckets.
+
+| Form | Description |
+|------+-------------|
+| =compass inbox= | List captures in =product_backlog/inbox/=. |
+| =compass next= | List captures in =product_backlog/next/=. |
+| =compass deferred= | List captures in =product_backlog/deferred/=. |
+| =compass discarded= | List captures in =product_backlog/discarded/=. |
 
 * Dependencies
 

--- a/projects/ores.compass/modeling/component_overview.org
+++ b/projects/ores.compass/modeling/component_overview.org
@@ -158,7 +158,7 @@ requires =org-roam.db= or the FTS5 cache.
 
 ** Scaffold
 
-Creates new v2 documents by calling [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] as a library. Two
+Creates new documents by calling [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] as a library. Two
 subcommands: =add= scaffolds any doc type from a template; =capture=
 creates and files captures into the product backlog inbox.
 


### PR DESCRIPTION
## Summary

Implements T2 of the Tooling documentation story: adds a `* Commands` section
to the ores.compass component overview, one subsection per command pillar,
each with a purpose paragraph, command-form table, and recipe links.

## Changes

- `projects/ores.compass/modeling/component_overview.org` — new `* Commands`
  section (inserted before `* Dependencies`) with seven subsections:
  Locate, Search, Navigate, Scaffold, Fleet, Goto, Backlog. Each subsection
  has a purpose paragraph, a table of key command forms and flags, and a
  recipe table linked via org-roam IDs.
- `doc/agile/versions/v0/sprint_18/tooling_documentation/task_overhaul_compass_component_overview.org`
  — status updated to STARTED.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Tooling documentation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/tooling_documentation/story.html) | 304F8600-3A5B-434F-87C4-10DDA973E47F |
| Task (T2) | [Task: Overhaul ores.compass component overview](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/tooling_documentation/task_overhaul_compass_component_overview.html) | 74DA0C54-ED8C-4CF5-B0C1-93799B15C174 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)