### PR TITLE
[doc] Review ores.lisp and ores.codegen component overviews

### DIFF
--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/story.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/story.org
@@ -49,10 +49,10 @@ This story makes the tooling reachable and useful:
 |---------------+--------------------------------------------------------------------------|
 | State         | STARTED                                                                  |
 | Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                                                                |
-| Now           | Story scaffolded; tasks defined; ready to begin T1.                      |
+| Now           | T4 in progress — reviewing ores.lisp and ores.codegen overviews.         |
 | Waiting on    | Nothing.                                                                 |
-| Next          | T1: add Tooling section to knowledge.org and write developer scripts doc.|
-| Last touched  | 2026-05-28                                                               |
+| Next          | Complete T4 and open PR; then T5.                                        |
+| Last touched  | 2026-05-29                                                               |
 
 * Acceptance
 
@@ -74,10 +74,11 @@ This story makes the tooling reachable and useful:
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:546C6CDA-6A59-445B-8385-1BD3C5AFC871][Task: Add Tooling section to knowledge.org and developer scripts doc]] | BACKLOG | | | Add * Tooling section to knowledge.org; write Developer scripts knowledge doc cataloguing scripts/ and linking to tool component overviews. |
-| [[id:74DA0C54-ED8C-4CF5-B0C1-93799B15C174][Task: Overhaul ores.compass component overview]] | BACKLOG | | | Extend the component overview with a section per command pillar (Locate, Search, Scaffold, Fleet, Goto, Backlog), each with a prose description and a recipe table. |
-| [[id:35B4022E-5025-4F8A-BE00-1A13EF0DAD55][Task: Add scripts section to ores.sql component overview]] | BACKLOG | | | Add * Scripts section with a subsection per lifecycle and utility script, purpose paragraph, and recipe table where applicable. |
-| [[id:A728AED1-6DFF-4167-B72D-EEEF2A55E8EE][Task: Review and link ores.lisp and ores.codegen overviews]] | BACKLOG | | | Review both overviews for gaps, wire into the new Tooling section in knowledge.org, and confirm all tools are navigable from the architecture pages. |
+| [[id:546C6CDA-6A59-445B-8385-1BD3C5AFC871][Task: Add Tooling section to knowledge.org and developer scripts doc]] | DONE | | | Add * Tooling section to knowledge.org; write Developer scripts knowledge doc cataloguing scripts/ and linking to tool component overviews. |
+| [[id:74DA0C54-ED8C-4CF5-B0C1-93799B15C174][Task: Overhaul ores.compass component overview]] | DONE | | | Extend the component overview with a section per command pillar (Locate, Search, Scaffold, Fleet, Goto, Backlog), each with a prose description and a recipe table. |
+| [[id:35B4022E-5025-4F8A-BE00-1A13EF0DAD55][Task: Add scripts section to ores.sql component overview]] | DONE | | | Add * Scripts section with a subsection per lifecycle and utility script, purpose paragraph, and recipe table where applicable. |
+| [[id:A728AED1-6DFF-4167-B72D-EEEF2A55E8EE][Task: Review and link ores.lisp and ores.codegen overviews]] | STARTED | | | Review both overviews for gaps, wire into the new Tooling section in knowledge.org, and confirm all tools are navigable from the architecture pages. |
+| [[id:FF5FEF54-E937-4879-B66C-1C1AB22E4316][Task: Standardise script naming to snake_case]] | BACKLOG | | | Rename parse-test-results.sh and convert-to-unix.sh to snake_case to match all other scripts in scripts/. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_add_ores_sql_scripts_section.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_add_ores_sql_scripts_section.org
@@ -43,12 +43,12 @@ columns: Script | Purpose | Notes. Link to any related recipes in
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                                |
+| State        | DONE                                   |
 | Parent story | [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]] |
-| Now          | Writing Scripts section in component overview. |
-| Waiting on   | Nothing.                               |
-| Next         | Open PR.                               |
-| Last touched | 2026-05-28                               |
+| Now          | Done. PR #911 merged.                  |
+| Waiting on   | —                                      |
+| Next         | —                                      |
+| Last touched | 2026-05-29                             |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_add_ores_sql_scripts_section.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_add_ores_sql_scripts_section.org
@@ -45,7 +45,7 @@ columns: Script | Purpose | Notes. Link to any related recipes in
 |--------------+----------------------------------------|
 | State        | DONE                                   |
 | Parent story | [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]] |
-| Now          | Done. PR #911 merged.                  |
+| Now          | Nothing.                               |
 | Waiting on   | —                                      |
 | Next         | —                                      |
 | Last touched | 2026-05-29                             |

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_review_codegen_lisp_overviews.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_review_codegen_lisp_overviews.org
@@ -9,7 +9,7 @@
 #+filetags: :tooling_documentation:sprint_18:v0:
 #+owner: marco
 #+branch: feature/review-codegen-lisp-overviews
-#+pr:
+#+pr: 913
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-28
@@ -67,7 +67,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/913][#913]] | [doc] Review ores.lisp and ores.codegen component overviews |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_review_codegen_lisp_overviews.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_review_codegen_lisp_overviews.org
@@ -42,12 +42,12 @@ scripts doc or raise a capture.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                                |
 | Parent story | [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]] |
-| Now          | Not yet started.                       |
+| Now          | Reviewing ores.lisp and ores.codegen overviews for gaps; filling in-place. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-05-28                               |
+| Next         | Open PR.                               |
+| Last touched | 2026-05-29                             |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_review_codegen_lisp_overviews.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_review_codegen_lisp_overviews.org
@@ -73,6 +73,7 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | DONE task's =Now= field should be =Nothing.= not descriptive prose. | task_add_ores_sql_scripts_section.org | Accept | Fixed in c980b6e7b. |
+| 2 | Empty PRs/Review tables should be omitted from new task docs. | task_standardise_script_naming.org | Decline | Standard template convention — all task docs start with these sections. |
 
 * Result

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_standardise_script_naming.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_standardise_script_naming.org
@@ -1,0 +1,75 @@
+:PROPERTIES:
+:ID: FF5FEF54-E937-4879-B66C-1C1AB22E4316
+:END:
+#+title: Task: Standardise script naming to snake_case
+#+description: Rename parse-test-results.sh and convert-to-unix.sh in scripts/ to snake_case to match all other scripts in the directory.
+#+type: task
+#+version: 2
+#+level: s1
+#+filetags: :tooling_documentation:sprint_18:v0:
+#+owner: marco
+#+branch: feature/standardise-script-naming
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-29
+#+updated: 2026-05-29
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Two scripts in =scripts/= use hyphens in their names, deviating from
+the snake_case convention used by all other scripts:
+
+- =parse-test-results.sh= → =parse_test_results.sh=
+- =convert-to-unix.sh= → =convert_to_unix.sh=
+
+Rename both scripts and update every reference site. Known references:
+
+- =projects/ores.testing/modeling/database_integration.org=
+- =doc/knowledge/architecture/developer_scripts.org=
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                                |
+| Parent story | [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-05-29                             |
+
+* Acceptance
+
+- =scripts/parse-test-results.sh= is renamed to =scripts/parse_test_results.sh=.
+- =scripts/convert-to-unix.sh= is renamed to =scripts/convert_to_unix.sh=.
+- All references in =projects/ores.testing/modeling/database_integration.org= and =doc/knowledge/architecture/developer_scripts.org= are updated.
+- No other files reference the old hyphenated names.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+Raised after a review comment on PR #907 flagged inconsistent script
+naming. Renaming deferred to a separate task to keep T1 focused.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/projects/ores.codegen/modeling/component_overview.org
+++ b/projects/ores.codegen/modeling/component_overview.org
@@ -175,6 +175,12 @@ harness.  See [[id:F27E5DF7-6223-4B6F-80A5-CEFBEB1BC756][Component architecture]
   generator.
 - [[id:3153AA4B-23D4-4111-9710-5A4971102EDC][How do I create a new v2 doc?]] — operational recipe for the
   org-document generator.
+- [[id:B6C5D4E3-F2A1-4B0C-8D9E-0F1A2B3C4D5E][How do I create a new entity?]] — end-to-end walkthrough using the
+  codegen profiles to scaffold a new domain entity.
+- [[id:0806C8FB-43D2-497E-900D-5F2E0B3472FD][How do I create a component overview?]] — recipe for generating a
+  component overview org document via =generate_v2_doc.sh=.
+- [[id:D8F4E2B1-9A7C-4E8D-8F3B-C2E5B4A6D7E8][How do I add a new document type?]] — recipe for extending the v2
+  document system with a new template and type.
 - =docs/cpp_generation_analysis.md= — deep analysis of the C++
   generation paths.
 - =docs/v2_doc_generator.md= — full CLI reference for

--- a/projects/ores.lisp/modeling/component_overview.org
+++ b/projects/ores.lisp/modeling/component_overview.org
@@ -43,6 +43,13 @@ ergonomics.
 - Compilation buffers for build, site, services, and DB scripts.
 - Org-roam HTML export artefacts (via =ores-org-roam-export=).
 
+* Entry points
+
+- =M-x ores/dashboard= — primary developer console; opens the =ORES Dashboard= card layout.
+- =M-x ores-db/list-databases= — tabulated database browser; list, connect, kill, teardown, and recreate.
+- =M-x ores-shell= — launch (or switch to) an =ores.shell= REPL comint buffer.
+- =M-x ores/capture= — capture a product-backlog note via =compass.sh capture --note= (CLI-driven; for interactive Org Capture use yasnippet trigger =cap= in an =.org= buffer).
+
 * Source files
 
 - =ores-env.el= — parses the checkout =.env= file into an alist and exposes


### PR DESCRIPTION
## Summary

- **ores.lisp**: adds a missing `* Entry points` section listing the four main `M-x` entry points (`ores/dashboard`, `ores-db/list-databases`, `ores-shell`, `ores/capture`) — the only component overview without one.
- **ores.codegen**: links three previously absent recipes in `* See also` (How do I create a new entity?, How do I create a component overview?, How do I add a new document type?).
- Agile: marks T1/T2/T3 DONE in story table, starts T4, adds the T5 task doc (standardise-script-naming, deferred from the T1 review comment).

Part of the [Tooling documentation](https://github.com/OreStudio/OreStudio/issues) story (sprint 18).

## Test plan

- [ ] Verify `* Entry points` section appears in ores.lisp overview with correct M-x command names.
- [ ] Verify ores.codegen `* See also` lists the three new recipe links with correct IDs.
- [ ] Verify story task table shows T1/T2/T3 DONE, T4 STARTED, T5 BACKLOG.
- [ ] Verify T5 task doc exists with correct ID and branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)