### PR TITLE
Sprint 18 housekeeping: task record and inbox memory

### DIFF
--- a/doc/agile/versions/v0/sprint_18/doc_format_cleanup/task_drop_version_field.org
+++ b/doc/agile/versions/v0/sprint_18/doc_format_cleanup/task_drop_version_field.org
@@ -8,7 +8,7 @@
 #+filetags: :doc_format_cleanup:sprint_18:v0:
 #+owner: marco
 #+branch: feature/drop-version-field
-#+pr:
+#+pr: 914
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-29
@@ -64,14 +64,14 @@ task closes. Plans do not outlive their task.)
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR                                                           | Title                                                     |
+|--------------------------------------------------------------+-----------------------------------------------------------|
+| [[https://github.com/OreStudio/OreStudio/pull/914][#914]] | Drop #+version: field from all org files and templates    |
 
 * Review
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| — | No comments     |      |          |       |
 
 * Result

--- a/doc/llm/memory/capture_goes_to_inbox.org
+++ b/doc/llm/memory/capture_goes_to_inbox.org
@@ -1,0 +1,17 @@
+:PROPERTIES:
+:ID: 19570253-D852-4D14-A72B-B13FDF0651B7
+:END:
+#+title: New captures go to the inbox bucket
+#+description: When filing a new capture, use the inbox bucket, not near or far.
+#+type: memory
+#+memory_subtype: feedback
+#+level: cross
+#+filetags: :memory:feedback:
+#+created: 2026-05-29
+#+updated: 2026-05-29
+
+New captures always go into =doc/agile/product_backlog/inbox/=, not =near/= or =far/=.
+
+*Why:* The inbox is the triage entry point; near and far are for captures that have already been reviewed and placed. Filing directly to near/far skips the triage step.
+
+*How to apply:* When using =compass add capture= or =generate_doc.sh --type capture=, always pass =--parent-dir doc/agile/product_backlog/inbox=. Move to near or far only after explicit triage with the user.

--- a/doc/llm/memory/memory.org
+++ b/doc/llm/memory/memory.org
@@ -56,6 +56,7 @@ of these exclusions, push back: the right home is somewhere else.
 - [[id:F9B796DF-2C06-42EF-AACF-D69E53621FF9][Do not re-export ORES_* env vars in Bash tool calls]].
 - [[id:46F83AC1-F41F-4878-9A1D-2E49742E1BFE][Always use codegen to create new documents]] — never write =.org= files
   directly; use =generate_doc.sh= to scaffold them.
+- [[id:19570253-D852-4D14-A72B-B13FDF0651B7][New captures go to the inbox bucket]] — =--parent-dir doc/agile/product_backlog/inbox=; triage to near/far separately.
 - [[id:7F176058-4FF7-4731-920B-26FE318E338F][Always use compass to create agile artefacts]] — never write task/story files
   manually; always scaffold with =compass add=.
 - [[id:387016AD-42CF-4830-B504-F255F6A7D1AB][Check recipes before searching for how to do something]] — =doc/recipes/=


### PR DESCRIPTION
## Summary

- Records PR #914 in the drop-version-field task doc
- Adds memory `capture_goes_to_inbox.org`: new captures always go to `inbox/`, not `near/` or `far/`; wires it into `memory.org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)