### PR TITLE
[agile] Close Tooling documentation story

### DIFF
--- a/doc/agile/versions/v0/sprint_18/sprint.org
+++ b/doc/agile/versions/v0/sprint_18/sprint.org
@@ -112,7 +112,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | [[id:A388F0C8-0804-420F-A542-2C929CFCEC92][Document NATS: technology overview, system integration, and recipes]] | DONE    | 2026-05-26 | 2026-05-26 | NATS knowledge page, system model section, per-component subject tables, and NATS recipes.                   |
 | [[id:C3B6F514-559F-4038-A1D7-947BC9F7F398][Add Downloads and Agile nav entries to the site]]                     | BACKLOG | 2026-05-25 |            | =doc/downloads.org= with release table; =Downloads= and =Agile= links in site nav.                           |
 | [[id:8AA261FC-B334-45A8-9954-85DD4BECEA45][Improve cybernetics documentation]]                                   | STARTED | 2026-05-28 |            | Add VSM overview page, expand Cybernetic Levels with context and limitations, link compass.                  |
-| [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]]                                               | STARTED | 2026-05-28 |            | Add Tooling section to knowledge.org; developer scripts doc; overhaul compass, sql, lisp, codegen overviews. |
+| [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]]                                               | DONE    | 2026-05-28 | 2026-05-29 | Add Tooling section to knowledge.org; developer scripts doc; overhaul compass, sql, lisp, codegen overviews. |
 | [[id:FD317B6C-F50F-4A35-81CC-A3B2BE3493C0][Add Emacs and org-roam knowledge pages]]                              | DONE    | 2026-05-28 | 2026-05-28 | Create Emacs, org-roam, and Zettelkasten knowledge pages; expand ores.lisp; update orientation.              |
 
 ** Infrastructure

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/story.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/story.org
@@ -46,11 +46,11 @@ This story makes the tooling reachable and useful:
 
 | Field         | Value                                                                    |
 |---------------+--------------------------------------------------------------------------|
-| State         | STARTED                                                                  |
+| State         | DONE                                                                     |
 | Parent sprint | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]]                                                                |
-| Now           | T5 in progress — renaming hyphenated scripts to snake_case.              |
-| Waiting on    | Nothing.                                                                 |
-| Next          | Complete T5 and open PR.                                                 |
+| Now           | Nothing.                                                                 |
+| Waiting on    | —                                                                        |
+| Next          | —                                                                        |
 | Last touched  | 2026-05-29                                                               |
 
 * Acceptance
@@ -77,7 +77,7 @@ This story makes the tooling reachable and useful:
 | [[id:74DA0C54-ED8C-4CF5-B0C1-93799B15C174][Task: Overhaul ores.compass component overview]] | DONE | | | Extend the component overview with a section per command pillar (Locate, Search, Scaffold, Fleet, Goto, Backlog), each with a prose description and a recipe table. |
 | [[id:35B4022E-5025-4F8A-BE00-1A13EF0DAD55][Task: Add scripts section to ores.sql component overview]] | DONE | | | Add * Scripts section with a subsection per lifecycle and utility script, purpose paragraph, and recipe table where applicable. |
 | [[id:A728AED1-6DFF-4167-B72D-EEEF2A55E8EE][Task: Review and link ores.lisp and ores.codegen overviews]] | DONE | | | Review both overviews for gaps, wire into the new Tooling section in knowledge.org, and confirm all tools are navigable from the architecture pages. |
-| [[id:FF5FEF54-E937-4879-B66C-1C1AB22E4316][Task: Standardise script naming to snake_case]] | STARTED | | | Rename parse-test-results.sh and convert-to-unix.sh to snake_case to match all other scripts in scripts/. |
+| [[id:FF5FEF54-E937-4879-B66C-1C1AB22E4316][Task: Standardise script naming to snake_case]] | DONE | | | Rename parse-test-results.sh and convert-to-unix.sh to snake_case to match all other scripts in scripts/. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_18/tooling_documentation/task_standardise_script_naming.org
+++ b/doc/agile/versions/v0/sprint_18/tooling_documentation/task_standardise_script_naming.org
@@ -35,11 +35,11 @@ Rename both scripts and update every reference site. Known references:
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                                |
+| State        | DONE                                   |
 | Parent story | [[id:304F8600-3A5B-434F-87C4-10DDA973E47F][Tooling documentation]] |
-| Now          | Renaming scripts and updating references. |
-| Waiting on   | Nothing.                               |
-| Next         | Open PR.                               |
+| Now          | Nothing.                               |
+| Waiting on   | —                                      |
+| Next         | —                                      |
 | Last touched | 2026-05-29                             |
 
 * Acceptance


### PR DESCRIPTION
## Summary

Marks the [Tooling documentation](https://github.com/OreStudio/OreStudio) story (sprint 18) as DONE after all 5 tasks merged:

- T1 (#907) — Tooling section in knowledge.org + developer scripts doc
- T2 (#909) — ores.compass component overview overhaul
- T3 (#911) — ores.sql Scripts section
- T4 (#913) — ores.lisp and ores.codegen overview review
- T5 (#915) — Standardise script naming to snake_case

Updates: T5 task doc → DONE, story.org → DONE, sprint.org end date set to 2026-05-29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)