### PR TITLE
[hotfix] Fix broken org-roam link in rfl CI failure capture

### DIFF
--- a/doc/agile/product_backlog/inbox/fix_rfl_complexity_failure_in_clientmanagertradede.org
+++ b/doc/agile/product_backlog/inbox/fix_rfl_complexity_failure_in_clientmanagertradede.org
@@ -105,7 +105,7 @@ Clang default fold/bracket depth: 256. Possible workaround: -fbracket-depth=512
 
 - Failing file: =projects/ores.qt.api/src/ClientManagerTradeDetail.cpp=
 - Failing type: =ores::trading::messaging::get_trade_detail_instrument_wrapper=
-- Prior fix story: [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D7][Resolve RFL complexity issues]] — same pattern, different TUs
+- Prior fix story: [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D8][Resolve RFL complexity issues]] — same pattern, different TUs
 
 * See also
 


### PR DESCRIPTION
## Summary

One-character UUID typo in the rfl CI failure capture introduced in PR #922
breaks the site build: link used `...D7` but the actual Resolve RFL complexity
issues story ID ends `...D8`.

## Changes

- Fix `[[id:D8B1A670-...-4B06F4BBA5D7]]` → `[[id:D8B1A670-...-4B06F4BBA5D8]]`
  in `doc/agile/product_backlog/inbox/fix_rfl_complexity_failure_in_clientmanagertradede.org`