### PR TITLE
[agile] Open sprint 19

### DIFF
--- a/.github/workflows/continuous-linux.yml
+++ b/.github/workflows/continuous-linux.yml
@@ -230,4 +230,4 @@ jobs:
         uses: actions/upload-artifact@v7.0.1
         with:
           name: ${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja
-          path: ./build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja/packages/orestudio_0.0.18_amd64.deb
+          path: ./build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja/packages/orestudio_0.0.19_amd64.deb

--- a/.github/workflows/continuous-macos.yml
+++ b/.github/workflows/continuous-macos.yml
@@ -172,4 +172,4 @@ jobs:
         uses: actions/upload-artifact@v7.0.1
         with:
           name: ${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja
-          path: ./build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja/packages/OreStudio-0.0.18-Darwin.dmg
+          path: ./build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja/packages/OreStudio-0.0.19-Darwin.dmg

--- a/.github/workflows/continuous-windows.yml
+++ b/.github/workflows/continuous-windows.yml
@@ -208,4 +208,4 @@ jobs:
         uses: actions/upload-artifact@v7.0.1
         with:
           name: ${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja
-          path: ./build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja/packages/OreStudio-0.0.18-win64.*
+          path: ./build/output/${{matrix.family}}-${{matrix.compiler}}-${{matrix.buildtype}}-ninja/packages/OreStudio-0.0.19-win64.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ message(STATUS "CMake Version: ${CMAKE_VERSION}")
 enable_testing()
 configure_file(CTestCustom.cmake CTestCustom.cmake COPYONLY)
 
-project(OreStudio VERSION 0.0.18 LANGUAGES CXX
+project(OreStudio VERSION 0.0.19 LANGUAGES CXX
     DESCRIPTION "UI and other utilities for the Open Source Risk Engine (ORE).")
 
 # Copy all binaries into the publish directory.

--- a/doc/agile/agile.org
+++ b/doc/agile/agile.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :agile:index:knowledge:
 #+created: 2024-06-15
-#+updated: 2026-05-24
+#+updated: 2026-05-29
 
 This is the entry point to the agile information architecture. Work flows as
 ideas in the [[id:D4219199-7B17-4A89-B4BC-6019738642DA][product backlog]], promoted into a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] when a [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprint]] pulls them in,
@@ -33,8 +33,8 @@ state transitions generically — it is not agile-specific. Agile is the loop
 | Field           | Value     |
 |-----------------+-----------|
 | Current Version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][v0]]        |
-| Current Sprint  | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]] |
-| Next sprint     | Sprint 19 |
+| Current Sprint  | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
+| Next sprint     | Sprint 20 |
 
 * See also
 

--- a/doc/agile/versions/v0/sprint_19/open_sprint_19/story.org
+++ b/doc/agile/versions/v0/sprint_19/open_sprint_19/story.org
@@ -1,0 +1,51 @@
+:PROPERTIES:
+:ID: A48DEC19-E769-4C71-AC0B-434B551DC801
+:END:
+#+title: Story: Open sprint 19
+#+description: Scaffold sprint 19, wire into version manifest, and open PR.
+#+type: story
+#+level: s2
+#+filetags: :agile:sprint:process:v0:sprint_19:
+#+created: 2026-05-29
+#+updated: 2026-05-29
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Sprint 19 is open: sprint.org scaffolded with mission and Previous wired to sprint 18, version.org updated with sprint 19 entry, and agile.org current-sprint pointer updated.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
+| Now           | Scaffolding sprint 19 and wiring into version manifest. |
+| Waiting on    | Nothing.                               |
+| Next          | Open PR.                               |
+| Last touched  | 2026-05-29                               |
+
+* Acceptance
+
+- Sprint 19 folder exists with a filled mission.
+- Previous field in sprint.org points to [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]].
+- version.org lists sprint 19.
+- agile.org Current Sprint points to sprint 19.
+- =compass goto= extended with sprint/story/task modes; [[id:47032D2E-4922-4A43-B594-AD76F0213E10][Open a new sprint]] runbook updated.
+- PR open; site builds cleanly.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:5F388610-0F72-4A03-A8D9-67ADD371924A][Open new sprint]] | STARTED | 2026-05-29 | | Follow the [[id:47032D2E-4922-4A43-B594-AD76F0213E10][Open a new sprint]] runbook. |
+| [[id:D397393C-2836-430E-88F7-8C220C6CCBC6][Add compass goto sprint support]] | BACKLOG | | | Extend goto with sprint/story/task modes; update runbook. |
+
+* Decisions
+
+* Out of scope
+
+- Version bump (separate PR per the recipe).
+- vcpkg submodule update (separate commit).

--- a/doc/agile/versions/v0/sprint_19/open_sprint_19/story.org
+++ b/doc/agile/versions/v0/sprint_19/open_sprint_19/story.org
@@ -40,7 +40,7 @@ Sprint 19 is open: sprint.org scaffolded with mission and Previous wired to spri
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:5F388610-0F72-4A03-A8D9-67ADD371924A][Open new sprint]] | STARTED | 2026-05-29 | | Follow the [[id:47032D2E-4922-4A43-B594-AD76F0213E10][Open a new sprint]] runbook. |
+| [[id:5F388610-0F72-4A03-A8D9-67ADD371924A][Open new sprint]] | DONE | 2026-05-29 | 2026-05-29 | Follow the [[id:47032D2E-4922-4A43-B594-AD76F0213E10][Open a new sprint]] runbook. |
 | [[id:D397393C-2836-430E-88F7-8C220C6CCBC6][Add compass goto sprint support]] | BACKLOG | | | Extend goto with sprint/story/task modes; update runbook. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_19/open_sprint_19/task_add_compass_goto_sprint_support.org
+++ b/doc/agile/versions/v0/sprint_19/open_sprint_19/task_add_compass_goto_sprint_support.org
@@ -1,0 +1,68 @@
+:PROPERTIES:
+:ID: D397393C-2836-430E-88F7-8C220C6CCBC6
+:END:
+#+title: Task: Add compass goto sprint support
+#+description: Extend compass goto with sprint/story/task modes so opening a new sprint, adding a story to it, and adding a task can all be done via a single entry point.
+#+type: task
+#+level: s1
+#+filetags: :agile:sprint:compass:process:open_sprint_19:v0:sprint_19:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-29
+#+updated: 2026-05-29
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:A48DEC19-E769-4C71-AC0B-434B551DC801][Open sprint 19]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+=compass goto= gains sprint/story/task modes so the full sprint-open ceremony
+is a single entry point: =compass goto sprint= scaffolds the sprint, a story,
+and a task; =compass goto story= adds a story+task to the current sprint;
+=compass goto task= adds a task to an existing story. The [[id:47032D2E-4922-4A43-B594-AD76F0213E10][Open a new sprint]]
+runbook is updated to reference =compass goto sprint=.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:A48DEC19-E769-4C71-AC0B-434B551DC801][Open sprint 19]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Task: Open new sprint (needs PR merged first). |
+| Next         | Design goto sprint/story/task mode dispatch in compass.py. |
+| Last touched | 2026-05-29                               |
+
+* Acceptance
+
+- =compass goto sprint --slug sprint_NN --title "..." --description "..." --tags "..."= creates the sprint, a first story, and a task on a fresh feature branch.
+- =compass goto story= (existing behaviour, renamed from default) creates story+task in the current sprint.
+- =compass goto task= (formerly =compass goto --story=) adds a task to an existing story.
+- [[id:47032D2E-4922-4A43-B594-AD76F0213E10][Open a new sprint]] runbook step 3 updated to reference =compass goto sprint=.
+- [[id:1E666848-A785-437E-A463-3D5A0DA0765F][How do I open a new sprint?]] recipe updated with =goto sprint= example.
+- Existing =--story= and bare =compass goto= invocations remain backward-compatible.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/open_sprint_19/task_open_new_sprint.org
+++ b/doc/agile/versions/v0/sprint_19/open_sprint_19/task_open_new_sprint.org
@@ -8,7 +8,7 @@
 #+filetags: :agile:sprint:process:open_sprint_19:v0:sprint_19:
 #+owner: marco
 #+branch: feature/open-sprint-19
-#+pr:
+#+pr: 924
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-29
@@ -50,7 +50,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/924][#924]] | Open sprint 19 |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/open_sprint_19/task_open_new_sprint.org
+++ b/doc/agile/versions/v0/sprint_19/open_sprint_19/task_open_new_sprint.org
@@ -1,0 +1,61 @@
+:PROPERTIES:
+:ID: 5F388610-0F72-4A03-A8D9-67ADD371924A
+:END:
+#+title: Task: Open new sprint
+#+description: Follow the open-a-new-sprint runbook: scaffold sprint 19, fill mission, wire version manifest, update agile index, PR.
+#+type: task
+#+level: s1
+#+filetags: :agile:sprint:process:open_sprint_19:v0:sprint_19:
+#+owner: marco
+#+branch: feature/open-sprint-19
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-29
+#+updated: 2026-05-29
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:A48DEC19-E769-4C71-AC0B-434B551DC801][Open sprint 19]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Sprint 19 wired into the version manifest and agile index; sprint.org mission and Previous field filled; PR open.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:A48DEC19-E769-4C71-AC0B-434B551DC801][Open sprint 19]] |
+| Now          | Wiring sprint 19 into version.org and agile.org. |
+| Waiting on   | Nothing.                               |
+| Next         | Commit and open PR.                    |
+| Last touched | 2026-05-29                               |
+
+* Acceptance
+
+- version.org has sprint 19 entry.
+- agile.org Current Sprint updated.
+- sprint.org has mission and Previous filled.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/open_sprint_19/task_open_new_sprint.org
+++ b/doc/agile/versions/v0/sprint_19/open_sprint_19/task_open_new_sprint.org
@@ -25,11 +25,11 @@ Sprint 19 wired into the version manifest and agile index; sprint.org mission an
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                                 |
 | Parent story | [[id:A48DEC19-E769-4C71-AC0B-434B551DC801][Open sprint 19]] |
-| Now          | Wiring sprint 19 into version.org and agile.org. |
+| Now          | Done.                                  |
 | Waiting on   | Nothing.                               |
-| Next         | Commit and open PR.                    |
+| Next         | Nothing.                               |
 | Last touched | 2026-05-29                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_19/open_sprint_19/task_open_new_sprint.org
+++ b/doc/agile/versions/v0/sprint_19/open_sprint_19/task_open_new_sprint.org
@@ -56,6 +56,6 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Remove empty Hotfixes section | sprint_19/sprint.org | Accepted | Fixed in fe4e5c3a0 |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -1,0 +1,95 @@
+:PROPERTIES:
+:ID: 76AE36A4-A3ED-4F48-BDA0-977B362F2238
+:END:
+#+title: Sprint 19
+#+description: Sprint 19 — restore Windows/macOS CI builds and advance ORE pipeline product stories.
+#+type: sprint
+#+level: s3
+#+filetags: :v0:
+#+created: 2026-05-29
+#+updated: 2026-05-29
+#+todo: STARTED | DONE
+
+This page documents a [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprint]] (*Sprint 19*) of ORE Studio. It captures the sprint's mission, current status, and the stories that compose it. For the surrounding context — version goals, sprint order, and product identity — see [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]].
+
+* Mission
+
+Restore Windows and macOS CI builds and advance ORE pipeline product stories.
+
+* Status
+
+| Field          | Value                                  |
+|----------------+----------------------------------------|
+| State          | STARTED                              |
+| Parent version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]] |
+| Previous       | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]] |
+| Start          | 2026-05-29                               |
+| End (expected) |                                        |
+| Now            | Sprint in flight.                      |
+| Waiting on     | Nothing.                               |
+| Next           | Pick the first story.                  |
+| Release Notes  | Added at end of sprint.                |
+| Last touched   | 2026-05-29                               |
+
+* Stories
+
+For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Themes]].
+
+** Product
+
+#+ATTR_HTML: :class hug-leading
+| Story | State | Start | End | Description |
+|-------+-------+-------+-----+-------------|
+| [[id:A48DEC19-E769-4C71-AC0B-434B551DC801][Open sprint 19]] | STARTED | 2026-05-29 | | Scaffold sprint 19, wire version manifest, PR. |
+
+** Hotfixes
+
+#+ATTR_HTML: :class hug-leading
+| Story | State | Start | End | Description |
+|-------+-------+-------+-----+-------------|
+|       |       |       |     |             |
+
+* Health Review
+
+(Run =sprint-reviewer= to generate this section.)
+
+* Charts
+
+Charts generated via [[id:6F3D9B1A-5C7E-4A2D-8F1B-3C9D7E5F2A1B][sprint_charts cmake target]].
+
+** PRs & Commits per Day
+
+Dual-axis bar chart. PRs (left axis) and commits (right axis) per day.
+A high commits-to-PR ratio may indicate scope creep.
+
+#+attr_html: :width 100%
+[[file:prs_commits.png]]
+
+** Daily Line Churn
+
+Lines added (green) and deleted (red) per day. Building work produces
+mostly additions; refactoring produces a mix. Days with no churn may
+indicate blockers.
+
+#+attr_html: :width 100%
+[[file:line_churn.png]]
+
+** PR Cycle Time
+
+Hours from PR open to merge, one bar per PR. Long bars indicate
+review bottlenecks. Generated only when PR data is available.
+
+#+attr_html: :width 100%
+[[file:pr_cycle.png]]
+
+** Cumulative Stories Done
+
+Line chart tracking stories marked DONE during the sprint.
+Steady upward slope is healthy; plateauing signals a stall.
+
+#+attr_html: :width 100%
+[[file:stories_done.png]]
+
+* Retrospective
+
+(Filled at sprint close.)

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -42,13 +42,6 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 |-------+-------+-------+-----+-------------|
 | [[id:A48DEC19-E769-4C71-AC0B-434B551DC801][Open sprint 19]] | STARTED | 2026-05-29 | | Scaffold sprint 19, wire version manifest, PR. |
 
-** Hotfixes
-
-#+ATTR_HTML: :class hug-leading
-| Story | State | Start | End | Description |
-|-------+-------+-------+-----+-------------|
-|       |       |       |     |             |
-
 * Health Review
 
 (Run =sprint-reviewer= to generate this section.)

--- a/doc/agile/versions/v0/version.org
+++ b/doc/agile/versions/v0/version.org
@@ -43,9 +43,9 @@ results graphically inside ORE Studio.
 | Field        | Value                                                       |
 |--------------+-------------------------------------------------------------|
 | State        | STARTED                                                     |
-| Now          | Sprint 18 closed; sprint 19 not yet started.                |
+| Now          | Sprint 19 open; restoring CI builds and advancing ORE pipeline. |
 | Waiting on   | Nothing.                                                    |
-| Next         | Plan and open sprint 19.                                    |
+| Next         | Work sprint 19 stories.                                     |
 | Last touched | 2026-05-29                                                  |
 
 * Sprints
@@ -74,6 +74,7 @@ the current sprint; the rest are closed.
 | [[id:1C778CE6-25D6-429B-920E-D08A2CE9A0A6][Sprint 16]] | 2026-03-30 | 2026-04-17 | ORE import e2e; workflow engine; market data; Qt plugins; Windows portability. |
 | [[id:A2B8A670-3B02-11F1-BCE2-4B06F4BBA5D7][Sprint 17]] | 2026-04-18 |            | Windows/MSVC portability, symbol visibility, ORE conventions, workspace, DQ publish, service isolation, SQL codegen, Qt UI, v2 docs. |
 | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]] | 2026-05-22 | 2026-05-29 | Compass CLI, LLM-first docs, agile artefact improvements; ORE pipeline deferred. |
+| [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] | 2026-05-29 |            | Restore Windows/macOS CI builds; advance ORE pipeline product stories.           |
 
 * Release scope
 

--- a/doc/llm/runbooks/handle_pr_review_round/runbook.org
+++ b/doc/llm/runbooks/handle_pr_review_round/runbook.org
@@ -33,7 +33,9 @@ In execution order:
    gh pr checks <N>
    #+end_src
 
-   If any check is failing, identify and fix the root cause first — as a separate commit — before looking at review comments. A CI failure may explain or supersede some review comments. If CI is green or only pending, proceed; pending checks will be re-verified after the push.
+   - If any check is *failing*, identify and fix the root cause first — as a separate commit — before looking at review comments. A CI failure may explain or supersede some review comments.
+   - If checks are *pending / running*, notify the user and proceed to step 3; CI will be re-verified after fixes are pushed (step 7).
+   - If CI is *green*, proceed immediately.
 
 3. /Read the comments./ Follow [[id:26C1DC06-82D2-46C4-94D6-DF9231BA171B][How do I address PR review comments?]] step 1: =gh pr view <N> --comments= and =gh api .../comments=.
 

--- a/doc/llm/runbooks/open_a_new_sprint/runbook.org
+++ b/doc/llm/runbooks/open_a_new_sprint/runbook.org
@@ -29,9 +29,9 @@ In execution order:
 
 2. /Close the current sprint./ Mark the sprint =DONE=, update the version's sprint table, and commit.
 
-3. /Scaffold the new sprint./ Use [[id:1E666848-A785-437E-A463-3D5A0DA0765F][How do I open a new sprint?]] to create the sprint folder, =sprint.org=, and wire it into the version.
+3. /Scaffold the new sprint./ Use [[id:1E666848-A785-437E-A463-3D5A0DA0765F][How do I open a new sprint?]] to create the sprint folder, =sprint.org=, wire it into the version, and update the vcpkg submodule to latest.
 
-4. /Bump the project version./ Follow [[id:E9F98DA1-CF33-4B53-BC4D-A034C652F3B0][How do I bump the project version?]] to update CMake version strings and tags.
+4. /Bump the project version./ Follow [[id:E9F98DA1-CF33-4B53-BC4D-A034C652F3B0][How do I bump the project version?]] to update CMake version strings and tags. Land this as a separate commit on the same PR as step 3 — do not open a second PR.
 
 5. /Commit and PR./ Use [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][ORE Studio commit conventions]] and follow [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][How do I create a PR?]] — title =[COMPONENT] Description=, body sections Summary / Changes / Traceability.
 

--- a/doc/llm/runbooks/open_a_new_sprint/runbook.org
+++ b/doc/llm/runbooks/open_a_new_sprint/runbook.org
@@ -33,7 +33,7 @@ In execution order:
 
 4. /Bump the project version./ Follow [[id:E9F98DA1-CF33-4B53-BC4D-A034C652F3B0][How do I bump the project version?]] to update CMake version strings and tags.
 
-5. /Commit and PR./ Use [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][ORE Studio commit conventions]] and [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][create a PR]].
+5. /Commit and PR./ Use [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][ORE Studio commit conventions]] and follow [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][How do I create a PR?]] — title =[COMPONENT] Description=, body sections Summary / Changes / Traceability.
 
 * Postconditions
 

--- a/doc/llm/runbooks/start_new_story/runbook.org
+++ b/doc/llm/runbooks/start_new_story/runbook.org
@@ -54,7 +54,7 @@ In execution order:
 
 6. /Commit the status change./ Use [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][ORE Studio commit conventions]]: =[agile] Mark <story> STARTED= with a =Co-Authored-By:= trailer.
 
-7. /Push and open a PR./ Push with =git push -u origin <branch>=, then [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][create a PR]] with a structured body (Summary, Changes, Story/Task UUIDs, Story/Task page links). Record the PR number in the task's =* PRs= table.
+7. /Push and open a PR./ Push with =git push -u origin <branch>=, then follow [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][How do I create a PR?]] — title format =[COMPONENT] Description=, body sections Summary / Changes / Traceability (Markdown table with Artefact, Link, full UUID). Record the PR number in the task's =* PRs= table.
 
 * Postconditions
 

--- a/doc/recipes/cmake/how_do_i_bump_the_project_version.org
+++ b/doc/recipes/cmake/how_do_i_bump_the_project_version.org
@@ -9,8 +9,7 @@
 #+created: 2026-05-21
 #+updated: 2026-05-21
 
-The version bump is housekeeping that always accompanies [[id:1E666848-A785-437E-A463-3D5A0DA0765F][opening a new
-sprint]]. Land it as a separate commit on the same sprint-open PR.
+The version bump is housekeeping that always accompanies [[id:47032D2E-4922-4A43-B594-AD76F0213E10][Open a new sprint]]. Land it as a separate commit on the same sprint-open PR.
 
 * Question
 

--- a/doc/recipes/cmake/how_do_i_bump_the_project_version.org
+++ b/doc/recipes/cmake/how_do_i_bump_the_project_version.org
@@ -9,8 +9,8 @@
 #+created: 2026-05-21
 #+updated: 2026-05-21
 
-The version bump is housekeeping that often follows [[id:1E666848-A785-437E-A463-3D5A0DA0765F][opening a new
-sprint]] but is independent of it — do it as its own PR.
+The version bump is housekeeping that always accompanies [[id:1E666848-A785-437E-A463-3D5A0DA0765F][opening a new
+sprint]]. Land it as a separate commit on the same sprint-open PR.
 
 * Question
 
@@ -66,8 +66,7 @@ Five files carry the version string. Edit them as a single commit.
 
    Expect zero matches.
 
-7. /Commit/ as =[build] Bump version to 0.0.<NEW>= and open the PR
-   via [[id:545D6B43-17FC-0234-FF2B-AB6565695616][PR Manager]].
+7. /Commit/ as =[build] Bump version to 0.0.<NEW>= on the sprint-open branch. No separate PR needed.
 
 * Script
 

--- a/readme.org
+++ b/readme.org
@@ -22,7 +22,7 @@
 #+html: <a href="https://visualstudio.microsoft.com/vs/whatsnew/"><img alt="MSVC Version" src="https://img.shields.io/badge/MSVC-2022-blue.svg"/></a>
 #+html: <a href="https://doc.qt.io/qt-6/"><img alt="Qt6" src="https://img.shields.io/badge/Qt-6-blue"/></a>
 #+html: <a href="https://orestudio.github.io/OreStudio/doxygen/html/index.html"><img alt="Doxygen" src="https://raw.githubusercontent.com/OreStudio/OreStudio/main/assets/images/doxygen_badge.svg"/></a>
-#+html: <a href="https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_18/sprint.html"><img alt="Agile Sprint" src="https://img.shields.io/badge/Sprint-18-blue.svg"/></a>
+#+html: <a href="https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/sprint.html"><img alt="Agile Sprint" src="https://img.shields.io/badge/Sprint-19-blue.svg"/></a>
 #+html: <a href="https://www.gnu.org/software/emacs/"><img alt="GNU Emacs" src="https://img.shields.io/static/v1?logo=gnuemacs&logoColor=fafafa&label=Made%20with&message=GNU%20Emacs&color=7F5AB6&style=flat"/></a>
 #+html: <a href="https://discord.gg/ztAaxmsnUJ"><img alt="Discord" src="https://img.shields.io/discord/1254062142626332732?color=5865F2&amp;logo=discord&amp;logoColor=white"/></a>
 #+html: <a href="https://github.com/OreStudio/OreStudio/pulse"><img alt="Commit Activity" src="https://img.shields.io/github/commit-activity/m/OreStudio/OreStudio"/></a>
@@ -40,7 +40,7 @@
 #+html: <a href="https://github.com/OreStudio/OreStudio/actions/workflows/continuous-windows.yml"><img alt="Continuous Windows" src="https://github.com/OreStudio/OreStudio/actions/workflows/continuous-windows.yml/badge.svg"/></a>
 #+html: <a href="https://github.com/OreStudio/OreStudio/actions/workflows/continuous-macos.yml"><img alt="Continuous MacOS.yml" src="https://github.com/OreStudio/OreStudio/actions/workflows/continuous-macos.yml/badge.svg"/></a>
 #+html: <a href="https://github.com/OreStudio/OreStudio/actions/workflows/nightly-linux.yml"><img alt="Nightly Linux" src="https://github.com/OreStudio/OreStudio/actions/workflows/nightly-linux.yml/badge.svg"/></a>
-#+html: <a href="https://github.com/OreStudio/OreStudio/commits/main"><img alt="Commits" src= "https://img.shields.io/github/commits-since/OreStudio/OreStudio/v0.0.17.svg"/></a>
+#+html: <a href="https://github.com/OreStudio/OreStudio/commits/main"><img alt="Commits" src= "https://img.shields.io/github/commits-since/OreStudio/OreStudio/v0.0.18.svg"/></a>
 #+html: <a href="https://github.com/OreStudio/OreStudio/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/OreStudio/OreStudio/total.svg"/></a>
 #+html: <a href="https://github.com/OreStudio/OreStudio/releases"><img alt="Releases" src="https://img.shields.io/github/release/OreStudio/OreStudio.svg"/></a>
 #+html: <a href="https://deepwiki.com/OreStudio/OreStudio"><img alt="Ask DeepWiki" src="https://deepwiki.com/badge.svg"/></a>
@@ -54,7 +54,7 @@ running ORE — persistent storage for inputs and outputs, CRUD management, and 
 simple three-layer architecture (client / service / [[https://www.postgresql.org/][PostgreSQL]]) designed to be
 easy to understand and extend. ORE Studio was started by [[https://mcraveiro.github.io/][Marco Craveiro]].
 
-[[./assets/images/ore_studio-v0.0.17.png]]
+[[./assets/images/ore_studio-v0.0.18.png]]
 
 The project is built for people who want to *learn quantitative finance by
 building*. All the heavy mathematical lifting stays in ORE and QuantLib; ORE

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
     "name": "ores",
     "description": "GUI for Open Source Risk Engine (ORE)",
-    "version-string": "0.0.18",
+    "version-string": "0.0.19",
     "dependencies": [
         "openssl",
         {


### PR DESCRIPTION
## Summary

Opens sprint 19: scaffolds the sprint folder, fills the mission, wires sprint 19 into the version manifest and agile index, and creates the tracking story with two tasks (open new sprint + add compass goto sprint support).

## Changes

- Scaffold `doc/agile/versions/v0/sprint_19/sprint.org` with mission and Previous → Sprint 18
- Story: Open sprint 19 (STARTED) with task: Open new sprint (STARTED)
- Task: Add compass goto sprint support (BACKLOG) — extend goto with sprint/story/task modes
- Wire sprint 19 into `version.org` (new row) and `agile.org` (Current Sprint updated)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Open sprint 19](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/open_sprint_19/story.html) | A48DEC19-E769-4C71-AC0B-434B551DC801 |
| Task | [Open new sprint](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/open_sprint_19/task_open_new_sprint.html) | 5F388610-0F72-4A03-A8D9-67ADD371924A |