### PR TITLE
[agile] Scaffold sprint planning

### DIFF
--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -41,6 +41,7 @@ For the definitions of the themes see [[id:A064D838-F127-4DD6-BB42-9A7902039AEE]
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:A48DEC19-E769-4C71-AC0B-434B551DC801][Open sprint 19]] | STARTED | 2026-05-29 | | Scaffold sprint 19, wire version manifest, PR. |
+| [[id:2A6F5FE2-8C50-494F-948F-6BA519075FA9][Sprint planning]] | STARTED | 2026-05-29 | | Select stories from backlog, size tasks, confirm mission. |
 
 * Health Review
 

--- a/doc/agile/versions/v0/sprint_19/sprint_planning/story.org
+++ b/doc/agile/versions/v0/sprint_19/sprint_planning/story.org
@@ -40,8 +40,6 @@ Sprint 19 has a selected, sized set of stories pulled from the product backlog, 
 |------+-------+-------+-----+-------------|
 | [[id:4AE688F2-298A-4070-B422-6C22F238EC9E][Run sprint planning session]] | STARTED | 2026-05-29 | | Select stories, size tasks, confirm mission. |
 
-* Decisions
-
 * Out of scope
 
 - Version bump (already done).

--- a/doc/agile/versions/v0/sprint_19/sprint_planning/story.org
+++ b/doc/agile/versions/v0/sprint_19/sprint_planning/story.org
@@ -1,0 +1,48 @@
+:PROPERTIES:
+:ID: 2A6F5FE2-8C50-494F-948F-6BA519075FA9
+:END:
+#+title: Story: Sprint planning
+#+description: Plan sprint 19: select stories from the product backlog, size tasks, and confirm the sprint mission.
+#+type: story
+#+level: s2
+#+filetags: :agile:sprint:planning:v0:sprint_19:
+#+created: 2026-05-29
+#+updated: 2026-05-29
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Sprint 19 has a selected, sized set of stories pulled from the product backlog, each broken into tasks and wired into the sprint, with the sprint mission confirmed.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | STARTED                              |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
+| Now           | Running sprint planning session.       |
+| Waiting on    | Nothing.                               |
+| Next          | Open PR.                               |
+| Last touched  | 2026-05-29                               |
+
+* Acceptance
+
+- Stories selected from the product backlog and wired into sprint 19.
+- Each story has at least one task sized and ready to start.
+- Sprint mission confirmed.
+- PR open; site builds cleanly.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:4AE688F2-298A-4070-B422-6C22F238EC9E][Run sprint planning session]] | STARTED | 2026-05-29 | | Select stories, size tasks, confirm mission. |
+
+* Decisions
+
+* Out of scope
+
+- Version bump (already done).
+- Story implementation (this story only plans the sprint).

--- a/doc/agile/versions/v0/sprint_19/sprint_planning/task_implement_sprint_planning.org
+++ b/doc/agile/versions/v0/sprint_19/sprint_planning/task_implement_sprint_planning.org
@@ -1,0 +1,62 @@
+:PROPERTIES:
+:ID: 4AE688F2-298A-4070-B422-6C22F238EC9E
+:END:
+#+title: Task: Run sprint planning session
+#+description: Initial task for: Sprint planning
+#+type: task
+#+level: s1
+#+filetags: :sprint_planning:sprint_19:v0:
+#+owner: marco
+#+branch: feature/sprint-planning
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-29
+#+updated: 2026-05-29
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:2A6F5FE2-8C50-494F-948F-6BA519075FA9][Sprint planning]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Sprint 19 stories selected from the product backlog, each broken into tasks, wired into sprint.org, and the sprint mission confirmed.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:2A6F5FE2-8C50-494F-948F-6BA519075FA9][Sprint planning]] |
+| Now          | Running planning session with user.    |
+| Waiting on   | Nothing.                               |
+| Next         | Commit stories and open PR.            |
+| Last touched | 2026-05-29                               |
+
+* Acceptance
+
+- Stories from backlog promoted into sprint 19.
+- Each story has at least one task.
+- sprint.org Stories table updated.
+- PR open.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/sprint_planning/task_implement_sprint_planning.org
+++ b/doc/agile/versions/v0/sprint_19/sprint_planning/task_implement_sprint_planning.org
@@ -45,8 +45,6 @@ Sprint 19 stories selected from the product backlog, each broken into tasks, wir
 distilled into the parent story's =* Decisions= and cleared when the
 task closes. Plans do not outlive their task.)
 
-* Notes
-
 * PRs
 
 | PR | Title |
@@ -58,5 +56,3 @@ task closes. Plans do not outlive their task.)
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
 |   |                 |      |          |       |
-
-* Result

--- a/doc/agile/versions/v0/sprint_19/sprint_planning/task_implement_sprint_planning.org
+++ b/doc/agile/versions/v0/sprint_19/sprint_planning/task_implement_sprint_planning.org
@@ -55,4 +55,6 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Remove empty * Decisions | story.org | Accepted | Fixed in 2fe9db030 |
+| 2 | Remove empty * Notes | task_implement_sprint_planning.org | Accepted | Fixed in 2fe9db030 |
+| 3 | Remove empty * Result | task_implement_sprint_planning.org | Accepted | Fixed in 2fe9db030 |

--- a/doc/agile/versions/v0/sprint_19/sprint_planning/task_implement_sprint_planning.org
+++ b/doc/agile/versions/v0/sprint_19/sprint_planning/task_implement_sprint_planning.org
@@ -8,7 +8,7 @@
 #+filetags: :sprint_planning:sprint_19:v0:
 #+owner: marco
 #+branch: feature/sprint-planning
-#+pr:
+#+pr: 925
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-29
@@ -51,7 +51,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/925][#925]] | [agile] Sprint planning |
 
 * Review
 


### PR DESCRIPTION
## Summary

Scaffolds the Sprint planning story for sprint 19 — creates the story and task docs, marks both STARTED, and wires the story into the sprint. The actual planning session (selecting backlog stories, sizing tasks) follows in a subsequent PR.

## Changes

- Scaffold `sprint_planning/story.org` and `task_implement_sprint_planning.org` (both STARTED)
- Wire story into `sprint_19/sprint.org` Stories table

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Sprint planning](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/sprint_planning/story.html) | 2A6F5FE2-8C50-494F-948F-6BA519075FA9 |
| Task | [Run sprint planning session](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/sprint_planning/task_implement_sprint_planning.html) | 4AE688F2-298A-4070-B422-6C22F238EC9E |