### PR TITLE
[agile] Run sprint planning session

### DIFF
--- a/doc/agile/versions/v0/sprint_19/sprint_planning/story.org
+++ b/doc/agile/versions/v0/sprint_19/sprint_planning/story.org
@@ -24,7 +24,7 @@ Sprint 19 has a selected, sized set of stories pulled from the product backlog, 
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
 | Now           | Running sprint planning session.       |
 | Waiting on    | Nothing.                               |
-| Next          | Open PR.                               |
+| Next          | Complete planning session; open PR.    |
 | Last touched  | 2026-05-29                               |
 
 * Acceptance
@@ -38,7 +38,8 @@ Sprint 19 has a selected, sized set of stories pulled from the product backlog, 
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:4AE688F2-298A-4070-B422-6C22F238EC9E][Run sprint planning session]] | STARTED | 2026-05-29 | | Select stories, size tasks, confirm mission. |
+| [[id:4AE688F2-298A-4070-B422-6C22F238EC9E][Scaffold sprint planning story]] | DONE | 2026-05-29 | 2026-05-29 | Scaffold story and task docs, wire into sprint, open PR. |
+| [[id:CCA36502-635B-4F0F-BD1B-6D394571C483][Run sprint planning session]] | STARTED | 2026-05-29 | | Select stories from backlog, size tasks, confirm mission. |
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_19/sprint_planning/task_run_sprint_planning_session.org
+++ b/doc/agile/versions/v0/sprint_19/sprint_planning/task_run_sprint_planning_session.org
@@ -1,0 +1,52 @@
+:PROPERTIES:
+:ID: CCA36502-635B-4F0F-BD1B-6D394571C483
+:END:
+#+title: Task: Run sprint planning session
+#+description: Select stories from the product backlog, promote into sprint 19, size into tasks, and confirm the sprint mission.
+#+type: task
+#+level: s1
+#+filetags: :sprint_planning:sprint_19:v0:
+#+owner: marco
+#+branch: feature/run-sprint-planning-session
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-29
+#+updated: 2026-05-29
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:2A6F5FE2-8C50-494F-948F-6BA519075FA9][Sprint planning]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Sprint 19 stories selected from the product backlog, promoted into the sprint, each broken into tasks, and the sprint mission confirmed.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:2A6F5FE2-8C50-494F-948F-6BA519075FA9][Sprint planning]] |
+| Now          | Running planning session with user.    |
+| Waiting on   | Nothing.                               |
+| Next         | Commit promoted stories; open PR.      |
+| Last touched | 2026-05-29                               |
+
+* Acceptance
+
+- Stories selected from backlog and wired into sprint 19 Stories table.
+- Each promoted story has at least one task.
+- Sprint mission confirmed in sprint.org.
+- PR open; site builds cleanly.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |

--- a/doc/agile/versions/v0/sprint_19/sprint_planning/task_run_sprint_planning_session.org
+++ b/doc/agile/versions/v0/sprint_19/sprint_planning/task_run_sprint_planning_session.org
@@ -8,7 +8,7 @@
 #+filetags: :sprint_planning:sprint_19:v0:
 #+owner: marco
 #+branch: feature/run-sprint-planning-session
-#+pr:
+#+pr: 926
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-29
@@ -43,7 +43,7 @@ Sprint 19 stories selected from the product backlog, promoted into the sprint, e
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/926][#926]] | [agile] Run sprint planning session |
 
 * Review
 


### PR DESCRIPTION
## Summary

Adds the "Run sprint planning session" task to the Sprint planning story. This is the task that drives the actual planning work — selecting stories from the backlog, promoting them into sprint 19, and sizing into tasks.

## Changes

- Add `task_run_sprint_planning_session.org` (STARTED) under sprint_planning story
- Update story Tasks table: scaffold task marked DONE, new task wired in

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Sprint planning](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/sprint_planning/story.html) | 2A6F5FE2-8C50-494F-948F-6BA519075FA9 |
| Task | [Run sprint planning session](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/sprint_planning/task_run_sprint_planning_session.html) | CCA36502-635B-4F0F-BD1B-6D394571C483 |