### PR TITLE
Add task: Split rfl::Literal 502-field type (fix Windows + macOS CI)

### DIFF
--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
@@ -22,12 +22,12 @@ compiler's template/constexpr depth limit.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
-| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | Not yet started.                       |
-| Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
-| Last touched  | 2026-05-29                               |
+| State         | STARTED                                                                           |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                         |
+| Now           | Implementing split of 502-field Literal type.                                     |
+| Waiting on    | Nothing.                                                                          |
+| Next          | PR and review.                                                                    |
+| Last touched  | 2026-05-29                                                                        |
 
 * Acceptance
 
@@ -38,9 +38,9 @@ compiler's template/constexpr depth limit.
 
 * Tasks
 
-| Task | State | Start | End | Description |
-|------+-------+-------+-----+-------------|
-|      |       |       |     |             |
+| Task                                                                                                                        | State   | Start      | End | Description                                               |
+|-----------------------------------------------------------------------------------------------------------------------------+---------+------------+-----+-----------------------------------------------------------|
+| [[id:9212966F-87AC-4B72-B708-8ED5BA253431][Split rfl::Literal 502-field type to fix Windows and macOS CI]] | STARTED | 2026-05-29 |     | Restructure 502-field Literal to fit MSVC/Clang limits. |
 
 * See also
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_split_rfl_literal_type.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_split_rfl_literal_type.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: 9212966F-87AC-4B72-B708-8ED5BA253431
+:END:
+#+title: Task: Split rfl::Literal 502-field type to fix Windows and macOS CI
+#+description: Restructure the rfl::Literal 502-field type in ClientManagerTradeDetail.cpp into smaller chunks to eliminate the MSVC C1202 and Clang fold-expression nesting failures.
+#+type: task
+#+level: s1
+#+filetags: :fix_rfl_complexity:sprint_19:v0:
+#+owner: marco
+#+branch: feature/task-split-rfl-literal-type
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-29
+#+updated: 2026-05-29
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Split or restructure the =rfl::Literal= 502-field type in
+=ores.qt.api/src/ClientManagerTradeDetail.cpp= so that MSVC and Clang can
+compile it within their template/constexpr depth limits, restoring Windows
+and macOS CI builds without affecting Linux.
+
+* Status
+
+| Field        | Value                                                                             |
+|--------------+-----------------------------------------------------------------------------------|
+| State        | STARTED                                                                           |
+| Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
+| Now          | Implementing the split/restructure of the 502-field Literal type.                 |
+| Waiting on   | Nothing.                                                                          |
+| Next         | PR and review.                                                                    |
+| Last touched | 2026-05-29                                                                        |
+
+* Acceptance
+
+- =ClientManagerTradeDetail.cpp= compiles on MSVC without =C1202= (recursive type too complex).
+- =ClientManagerTradeDetail.cpp= compiles on Clang without fold-expression nesting limit error in =rfl/internal/StringLiteral.hpp=.
+- Linux CI remains green.
+- No functional change to the =ClientManager= trade detail behaviour.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result


### PR DESCRIPTION
## Summary

- Scaffolds `task_split_rfl_literal_type.org` under the sprint 19 `fix_rfl_complexity` story
- Marks story and task STARTED
- Wires task into the story's `* Tasks` table

## Test plan

- [ ] Story shows task in `* Tasks` table
- [ ] `compass where` lists the task as STARTED

Story-ID: 7763D0EE-A500-4497-9B2D-973C02ADC739
Task-ID: 9212966F-87AC-4B72-B708-8ED5BA253431

🤖 Generated with [Claude Code](https://claude.com/claude-code)