### PR TITLE
Scaffold rfl complexity fix: story decisions and task stubs

### DIFF
--- a/.github/workflows/canary-linux.yml
+++ b/.github/workflows/canary-linux.yml
@@ -28,6 +28,7 @@ on:  # yamllint disable-line rule:truthy
     paths-ignore:
       - 'doc/**'
       - '.claude/**'
+      - 'assets/**'
 
 jobs:
   build:
@@ -48,6 +49,13 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force || true
+          # Additional unused runtimes
+          sudo rm -rf /opt/hostedtoolcache/Ruby
+          sudo rm -rf /opt/hostedtoolcache/node
+          sudo rm -rf /opt/hostedtoolcache/go
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/lib/jvm
+          sudo rm -rf /usr/local/share/boost
           echo "=== Disk space after cleanup ==="
           df -h
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,6 +49,13 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force || true
+          # Additional unused runtimes
+          sudo rm -rf /opt/hostedtoolcache/Ruby
+          sudo rm -rf /opt/hostedtoolcache/node
+          sudo rm -rf /opt/hostedtoolcache/go
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/lib/jvm
+          sudo rm -rf /usr/local/share/boost
           echo "=== Disk space after cleanup ==="
           df -h
 

--- a/.github/workflows/continuous-linux.yml
+++ b/.github/workflows/continuous-linux.yml
@@ -28,6 +28,7 @@ on:  # yamllint disable-line rule:truthy
     paths-ignore:
       - 'doc/**'
       - '.claude/**'
+      - 'assets/**'
     tags:
       - '*'
   workflow_dispatch:
@@ -63,6 +64,13 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force || true
+          # Additional unused runtimes
+          sudo rm -rf /opt/hostedtoolcache/Ruby
+          sudo rm -rf /opt/hostedtoolcache/node
+          sudo rm -rf /opt/hostedtoolcache/go
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/lib/jvm
+          sudo rm -rf /usr/local/share/boost
           echo "=== Disk space after cleanup ==="
           df -h
 

--- a/.github/workflows/continuous-macos.yml
+++ b/.github/workflows/continuous-macos.yml
@@ -28,6 +28,7 @@ on:  # yamllint disable-line rule:truthy
     paths-ignore:
       - 'doc/**'
       - '.claude/**'
+      - 'assets/**'
     tags:
       - '*'
   workflow_dispatch:

--- a/.github/workflows/continuous-windows.yml
+++ b/.github/workflows/continuous-windows.yml
@@ -28,6 +28,7 @@ on:  # yamllint disable-line rule:truthy
     paths-ignore:
       - 'doc/**'
       - '.claude/**'
+      - 'assets/**'
     tags:
       - '*'
   workflow_dispatch:

--- a/.github/workflows/nightly-linux.yml
+++ b/.github/workflows/nightly-linux.yml
@@ -77,6 +77,13 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force || true
+          # Additional unused runtimes
+          sudo rm -rf /opt/hostedtoolcache/Ruby
+          sudo rm -rf /opt/hostedtoolcache/node
+          sudo rm -rf /opt/hostedtoolcache/go
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/lib/jvm
+          sudo rm -rf /usr/local/share/boost
           echo "=== Disk space after cleanup ==="
           df -h
 

--- a/.github/workflows/ore_coverage.yml
+++ b/.github/workflows/ore_coverage.yml
@@ -18,8 +18,16 @@ name: ORE Domain Roundtrip Check
 on:  # yamllint disable-line rule:truthy
   push:
     branches: ["main"]
+    paths-ignore:
+      - 'doc/**'
+      - '.claude/**'
+      - 'assets/**'
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - 'doc/**'
+      - '.claude/**'
+      - 'assets/**'
 
   workflow_dispatch:
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
@@ -108,15 +108,26 @@ C++ polymorphic holders (=IInstrumentForm= virtual interface, all form subclasse
 =ores.ore.service= importer. Those uses are correct C++ =std::variant= use with no rfl
 involvement, and the types remain as domain types.
 
-** IInstrumentForm variant interface is a functional hack
+** Variant use: import/export vs. display
 
-Each concrete form (e.g. =BondInstrumentForm=) is a concrete type that handles exactly one
-instrument family. Yet =IInstrumentForm::populate_from_instrument= takes
-=const trade_instrument&=, forcing every form to do a runtime =std::get_if= check that
-should never fail. The caller already knows the concrete type (it chose which form to
-create); passing the full variant is fake generality that creates unnecessary coupling and
-keeps the variant in the call path. The correct design gives each form a typed =populate=
-method and moves the dispatch to the call site. Tracked in task 4.
+=trade_instrument= and the sub-variants are correct for *import and export*: bulk processing
+of heterogeneous instruments where the type is genuinely unknown at the processing site.
+They remain for that use.
+
+For the *display* path, the type is known from Phase 1 (=product_type= + =trade_type=)
+before the instrument is even read. Packaging the result into a =trade_instrument= variant
+just to immediately unpack it is unnecessary indirection. The display path is redesigned
+to eliminate the variant entirely:
+
+- =getTradeInstrument= takes an =IInstrumentFormPopulator&= and returns
+  =std::optional<domain::trade>=. It never constructs a =trade_instrument= value.
+- =IInstrumentFormPopulator= is a pure-abstract interface with one =populate= overload per
+  concrete leaf instrument type (~28 overloads; default no-ops).
+- Each form implements its relevant overload(s). Forms never receive a variant.
+- =TradeController= creates the right form via the factory, then passes it as the
+  populator to =getTradeInstrument=. The call site never dispatches on the instrument type.
+
+Tracked in tasks 2 and 4.
 
 ** Logging requirement
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
@@ -2,7 +2,7 @@
 :ID: 7763D0EE-A500-4497-9B2D-973C02ADC739
 :END:
 #+title: Story: Fix rfl complexity failure (Windows + macOS CI)
-#+description: Fix ClientManagerTradeDetail.cpp rfl::Literal 502-field compile failure on MSVC and Clang to restore Windows and macOS CI builds.
+#+description: Eliminate the rfl::AddTagsToVariants 502-field Literal from the Qt client instrument parse path by renaming the protocol, rewriting the client TU with type-dispatched reads, adding tests, and refactoring the IInstrumentForm interface to remove the variant.
 #+type: story
 #+level: s2
 #+filetags: :ci:windows:macos:rfl:ores_qt_api:infrastructure:sprint_19:v0:
@@ -14,35 +14,130 @@ This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id
 
 * Goal
 
-Windows and macOS CI builds are green: =ClientManagerTradeDetail.cpp= compiles on both MSVC and
-Clang after splitting or restructuring the =rfl::Literal= 502-field type that exceeds each
-compiler's template/constexpr depth limit.
+Restore Windows and macOS CI by permanently eliminating =rfl::AddTagsToVariants= from the
+Qt client's instrument parse path. The Sprint 18 triple-isolation workaround (TU split +
+two-phase parse + =-fbracket-depth=1024=) moved the 502-field =rfl::Literal= into a dedicated
+TU but did not remove it; MSVC C1202 and Clang's fold-expression nesting limit both still
+fire. The correct fix is to replace variant-based rfl parsing with a type-dispatched read
+that uses =trade.classification.product_type= and =trade.classification.trade_type= — the
+same discriminators the server already uses — to read each concrete leaf instrument struct
+directly, with no variant and no =AddTagsToVariants=.
+
+The story also corrects naming (=get_trade_detail= → =get_trade_instrument=) and removes the
+accumulated hacks from Sprint 18. A follow-on task refactors =IInstrumentForm= to remove
+the variant from the Qt UI boundary as well, since the variant serves no purpose there.
 
 * Status
 
-| Field         | Value                                  |
-|---------------+----------------------------------------|
-| State         | STARTED                                                                           |
-| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                         |
-| Now           | Implementing split of 502-field Literal type.                                     |
-| Waiting on    | Nothing.                                                                          |
-| Next          | PR and review.                                                                    |
-| Last touched  | 2026-05-29                                                                        |
+| Field         | Value                                                                                         |
+|---------------+-----------------------------------------------------------------------------------------------|
+| State         | STARTED                                                                                       |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                                       |
+| Now           | Scaffolding task on branch; architecture agreed; implementation tasks queued.                 |
+| Waiting on    | Gemini review of scaffolding PR.                                                              |
+| Next          | Task 2 (rename + rewrite) once scaffolding PR merges.                                        |
+| Last touched  | 2026-05-29                                                                                    |
 
 * Acceptance
 
-- Windows CI: no =C1202= recursive type error in =ClientManagerTradeDetail.cpp=.
+- Windows CI: no =C1202= recursive type error anywhere in =ores.qt.api=.
 - macOS CI: no fold-expression nesting limit error in =rfl/internal/StringLiteral.hpp=.
 - Linux CI: unaffected (still green).
-- PR merged; both Windows and macOS artefacts produced by CI.
+- =ClientManagerTradeInstrument.cpp= contains no =rfl::AddTagsToVariants= include or use.
+- =get_trade_detail_response_base= and =get_trade_detail_instrument_wrapper= are deleted.
+- Round-trip tests pass for FX, rates/swap, equity, bond, credit, commodity, composite, scripted.
+- =IInstrumentForm::populate_from_instrument(const trade_instrument&)= is replaced by
+  type-specific =populate= overloads on each concrete form.
+- Logging: every parse branch logs at =debug= on entry and on success; deserialise errors
+  log at =error= with the raw JSON fragment and the error message.
 
 * Tasks
 
-| Task                                                                                                                        | State   | Start      | End | Description                                               |
-|-----------------------------------------------------------------------------------------------------------------------------+---------+------------+-----+-----------------------------------------------------------|
-| [[id:9212966F-87AC-4B72-B708-8ED5BA253431][Split rfl::Literal 502-field type to fix Windows and macOS CI]] | STARTED | 2026-05-29 |     | Restructure 502-field Literal to fit MSVC/Clang limits. |
+| Task                                                                                                                                               | State   | Start      | End | Description                                                                     |
+|----------------------------------------------------------------------------------------------------------------------------------------------------+---------+------------+-----+---------------------------------------------------------------------------------|
+| [[id:9212966F-87AC-4B72-B708-8ED5BA253431][Scaffold: document architecture and create task stubs]]                     | STARTED | 2026-05-29 |     | Update story decisions, create task stubs; PR for Gemini architecture review.   |
+| [[id:06C98C06-F950-483A-997B-89AED70D1238][Rename get_trade_detail → get_trade_instrument and rewrite parse path]]    | BACKLOG |            |     | Rename protocol types, delete workarounds, rewrite client TU with dispatch.     |
+| [[id:F9E5967D-77E7-49E3-9806-74AF22D26191][Write round-trip tests for instrument parse dispatch]]                      | BACKLOG |            |     | One test per instrument family; serialize server-side, verify client dispatch.  |
+| [[id:5C955A5E-0130-40D7-B77F-B41F4F526B79][Refactor IInstrumentForm to type-specific populate methods]]                | BACKLOG |            |     | Remove trade_instrument variant from the Qt UI boundary; typed populate per form.|
+
+* Decisions
+
+** Root cause
+
+=rfl::AddTagsToVariants= on =trade_instrument= (a =std::variant= of 9 alternatives, two of
+which are themselves variants — =fx_instrument_variant= (7 types),
+=equity_instrument_variant= (9 types) — and one of which wraps =rates_instrument_variant=
+(9 types)) collects the union of all field names across ~30 leaf structs into a single
+=rfl::Literal<f1, …, f502>=. =rfl::internal::no_duplicate_field_names= then performs an
+O(N²) constexpr string-equality check over all 502 names:
+
+- *MSVC*: =C1202= — recursive type or function dependency too complex (hard limit, no flag).
+- *Clang*: fold-expression nesting exceeds =-fbracket-depth= (set to 1024; the Literal itself
+  saturates it with 502 constructor args).
+- *Linux GCC*: unaffected; more permissive depth limits.
+
+** Discriminator already present
+
+=trade.classification.product_type= (family: =fx=, =swap=, =bond=, …) and
+=trade.classification.trade_type= (leaf: ="FxForward"=, ="VanillaSwap"=, ="EquityOption"=,
+…) are already read in Phase 1. The server uses the same =(product_type, trade_type)= pair
+in =populate_instruments_for_trades= to bucket instrument IDs. After Phase 1 the client
+knows the exact leaf type; =AddTagsToVariants= is not needed.
+
+** Protocol rename
+
+=get_trade_detail_*= renamed to =get_trade_instrument_*=. Rationale: the existing
+=get_trades_response= already carries full trade metadata. This request adds the
+*instrument* — not "more trade detail". The old name implied a richer trade view; the new
+name states the actual purpose. NATS subject: =trading.v1.trades.detail= →
+=trading.v1.trades.instrument=. No backwards-compatibility concern (internal protocol).
+
+** Workaround types deleted
+
+=get_trade_detail_response_base= and =get_trade_detail_instrument_wrapper= were Sprint 18
+parse-implementation artefacts bolted onto the protocol header. They are not protocol
+concepts and are deleted. Phase 1 uses a file-local struct inside
+=ClientManagerTradeInstrument.cpp=.
+
+** Variant types retained
+
+=trade_instrument=, =fx_instrument_variant=, =equity_instrument_variant=, and
+=rates_instrument_variant= are NOT deleted. They are used throughout =ores.qt.trading= as
+C++ polymorphic holders (=IInstrumentForm= virtual interface, all form subclasses,
+=ImportTradeDialog=, =OreImporter=) and in =ores.ore.core= mappers and
+=ores.ore.service= importer. Those uses are correct C++ =std::variant= use with no rfl
+involvement, and the types remain as domain types.
+
+** IInstrumentForm variant interface is a functional hack
+
+Each concrete form (e.g. =BondInstrumentForm=) is a concrete type that handles exactly one
+instrument family. Yet =IInstrumentForm::populate_from_instrument= takes
+=const trade_instrument&=, forcing every form to do a runtime =std::get_if= check that
+should never fail. The caller already knows the concrete type (it chose which form to
+create); passing the full variant is fake generality that creates unnecessary coupling and
+keeps the variant in the call path. The correct design gives each form a typed =populate=
+method and moves the dispatch to the call site. Tracked in task 4.
+
+** Logging requirement
+
+All parse branches must log at the correct level:
+- =debug= on entry to each phase and on successful parse, including the resolved
+  =(product_type, trade_type)= pair.
+- =warn= for unknown =(product_type, trade_type)= combinations that fall through the
+  dispatch (monostate result).
+- =error= on any deserialise failure, including the raw JSON fragment and the full rfl
+  error message.
+
+** export_portfolio latent issue
+
+=export_portfolio_response= contains =vector<trade_export_item>= where each item has
+=trade_instrument instrument=. The generic =process_authenticated_request= template reads
+it with =AddTagsToVariants=. This path is not fixed by this story (it is Linux-only in
+practice today) but is a known latent issue for a future story.
 
 * See also
 
-- [[id:367D0D5F-24BB-4AA1-B784-D79E95C15A16][Fix rfl complexity failure in ClientManagerTradeDetail (capture)]] — source capture with full error detail.
-- [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D8][Resolve RFL complexity issues]] — sprint 18 predecessor story; same structural-isolation pattern.
+- [[id:367D0D5F-24BB-4AA1-B784-D79E95C15A16][Fix rfl complexity failure in ClientManagerTradeDetail (capture)]] — exact MSVC C1202 and Clang error messages.
+- [[id:D75F4921-B431-4E78-99AB-62A47F761D1D][Investigation: MSVC C1202 and rfl complexity]] — root-cause analysis; O(N²) check, triple-isolation recommendation.
+- [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D8][Resolve RFL complexity issues]] — sprint 18 predecessor; same structural-isolation pattern.
+- [[https://github.com/getml/reflect-cpp/issues/350][reflect-cpp issue #350]] — upstream tracking.

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_instrument_parse_tests.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_instrument_parse_tests.org
@@ -1,0 +1,116 @@
+:PROPERTIES:
+:ID: F9E5967D-77E7-49E3-9806-74AF22D26191
+:END:
+#+title: Task: Write round-trip tests for instrument parse dispatch
+#+description: For each instrument family and representative leaf types, serialize a get_trade_instrument_response server-side (with rfl::AddTagsToVariants as the server does), feed the JSON through the new client dispatch logic, and assert the assembled trade_export_item holds the expected instrument with correct field values.
+#+type: task
+#+level: s1
+#+filetags: :fix_rfl_complexity:sprint_19:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: 06C98C06-F950-483A-997B-89AED70D1238
+#+blocked_since:
+#+created: 2026-05-29
+#+updated: 2026-05-29
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Validate the new instrument parse dispatch with round-trip tests that exercise the full
+server → client JSON path. Tests must compile and pass on Linux, Windows (MSVC), and macOS
+(Clang) — their compilation on MSVC/Clang is itself evidence that =AddTagsToVariants= has
+been successfully eliminated from the client parse path.
+
+* Status
+
+| Field        | Value                                                                               |
+|--------------+-------------------------------------------------------------------------------------|
+| State        | BACKLOG                                                                             |
+| Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
+| Now          | —                                                                                   |
+| Waiting on   | Task 2 merged ([[id:06C98C06-F950-483A-997B-89AED70D1238][rename + rewrite]]). |
+| Next         | Begin once task 2 PR is green.                                                      |
+| Last touched | 2026-05-29                                                                          |
+
+* Acceptance
+
+- At least one test per instrument family: bond, credit, commodity, scripted, composite,
+  FX (at least 2 leaf types: forward + one option), rates/swap (at least 2 leaf types:
+  FRA + vanilla swap), equity (at least 2 leaf types: option + forward).
+- Each test serializes a fully-populated response struct using
+  =rfl::json::write<rfl::AddTagsToVariants>= (matching server behaviour), then calls the
+  new client parse function, and asserts:
+  - =trade_export_item.instrument= holds the expected =std::variant= alternative.
+  - Key instrument fields round-trip correctly (instrument_id, a family-specific field).
+  - =trade_export_item.trade.classification.product_type= matches.
+- A test for an unknown =(product_type, trade_type)= combination asserts the instrument is
+  =std::monostate= and that a =warn= log was emitted.
+- A test for a malformed instrument JSON asserts the call returns =std::nullopt= and that
+  an =error= log was emitted.
+- All tests compile with MSVC (no =C1202=) and Clang (no fold-expression error).
+
+* Plan
+
+(Transient.)
+
+** Test structure
+
+One test fixture (or test file) per family is sufficient. Tests live in the
+=ores.qt.api= test target alongside existing tests.
+
+Pattern per test:
+
+#+begin_src cpp
+// 1. Build a response the way the server does
+messaging::get_trade_instrument_response resp{
+    .success = true,
+    .trade   = make_test_trade(product_type::fx, "FxForward"),
+    .instrument = fx_instrument_variant{make_fx_forward()}
+};
+
+// 2. Serialize as the server does
+const auto json = rfl::json::write<rfl::AddTagsToVariants>(resp);
+
+// 3. Run client parse
+auto result = parse_trade_instrument(json);  // the new function under test
+
+// 4. Assert
+ASSERT_TRUE(result.has_value());
+auto* fx_fwd = std::get_if<fx_instrument_variant>(&result->instrument);
+ASSERT_NE(fx_fwd, nullptr);
+auto* fwd = std::get_if<fx_forward_instrument>(fx_fwd);
+ASSERT_NE(fwd, nullptr);
+EXPECT_EQ(fwd->currency_pair, "EURUSD");
+#+end_src
+
+** Leaf types to cover
+
+| Family   | Leaf types to test                       |
+|----------+------------------------------------------|
+| Bond     | =bond_instrument=                        |
+| Credit   | =credit_instrument=                      |
+| Commodity| =commodity_instrument=                   |
+| Scripted | =scripted_instrument=                    |
+| Composite| =composite_instrument_data= (with legs)  |
+| FX       | =fx_forward_instrument=, =fx_vanilla_option_instrument= |
+| Rates    | =fra_instrument=, =vanilla_swap_instrument= (with legs) |
+| Equity   | =equity_option_instrument=, =equity_forward_instrument= |
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_refactor_instrument_form_interface.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_refactor_instrument_form_interface.org
@@ -20,23 +20,28 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 * Goal
 
 The current =IInstrumentForm::populate_from_instrument(const trade_instrument&)= interface
-is architecturally incorrect: each concrete form already knows its instrument type (it is,
-for example, =BondInstrumentForm=), yet it receives the full 9-alternative =trade_instrument=
-variant and immediately discards 8 alternatives via =std::get_if=. The runtime check can
-never legitimately fail — if it does, it is a programming error that the current interface
-silently swallows.
+is architecturally incorrect: each concrete form already knows its instrument type, yet it
+receives a 9-alternative variant and discards 8 of them via =std::get_if=. The check can
+never legitimately fail — if it does, it is a programming error the interface silently
+swallows.
 
-This task removes the fake generality:
+Task 2 eliminates the variant from the parse path by introducing =IInstrumentFormPopulator=
+— a pure-abstract interface with one =populate= overload per concrete leaf instrument type.
+This task wires the forms to that interface, completing the removal of the variant from the
+entire display path:
 
-1. Replace the virtual =populate_from_instrument(const trade_instrument&)= in
-   =IInstrumentForm= with type-specific =populate= overloads (non-virtual) on each concrete
-   form. The base class retains all other shared lifecycle methods (=show=, =hide=, =save=,
-   validation, etc.).
-2. Move the dispatch to the call sites (=TradeController=, =TradeDetailDialog=), which
-   already know =(product_type, trade_type)= from the =trade_export_item= produced by
-   task 2. The call site calls the right form's =populate= directly.
-3. Remove =trade_instrument= and the sub-variant =std::get_if= calls from every form
-   implementation file.
+1. Each concrete form (or a thin controller wrapper) implements the relevant
+   =IInstrumentFormPopulator::populate= overload(s) for its type.
+2. Remove the old =populate_from_instrument(const trade_instrument&)= virtual method from
+   =IInstrumentForm= and every subclass.
+3. Remove all =std::get_if<trade_instrument>=, =std::get_if<fx_instrument_variant>=, and
+   =std::get_if<equity_instrument_variant>= calls from form implementation files.
+4. Update =TradeController= and =TradeDetailDialog= to pass the form as an
+   =IInstrumentFormPopulator&= to =getTradeInstrument=, replacing the old populate call.
+
+After this task: no form header or implementation file includes =trade_instrument.hpp= or
+any sub-variant header for the purpose of population. The variant exists only in
+import/export paths where the type is genuinely unknown at the processing site.
 
 * Status
 
@@ -52,15 +57,14 @@ This task removes the fake generality:
 * Acceptance
 
 - =IInstrumentForm= has no =populate_from_instrument(const trade_instrument&)= method.
-- Each concrete form has a typed =populate= method (or constructor argument) for its
-  specific instrument type(s).
-- No form implementation file uses =std::get_if<trade_instrument>= or
-  =std::get_if<fx_instrument_variant>= or =std::get_if<equity_instrument_variant>=.
-- =IInstrumentForm.hpp= does not include =trade_instrument.hpp=.
-- Call sites (=TradeController=, =TradeDetailDialog=) dispatch explicitly using
-  =(product_type, trade_type)= and call the correct form's =populate= directly.
-- All existing behaviour preserved; no UI regression.
-- The change does not introduce any new rfl usage.
+- Each concrete form implements the relevant =IInstrumentFormPopulator= overload(s).
+- No form =.hpp= or =.cpp= file calls =std::get_if= on =trade_instrument=,
+  =fx_instrument_variant=, or =equity_instrument_variant=.
+- =IInstrumentForm.hpp= does not include =trade_instrument.hpp= or any sub-variant header.
+- =TradeController= and =TradeDetailDialog= pass =*this= (or a wrapper) as an
+  =IInstrumentFormPopulator&= to =getTradeInstrument=; no separate populate call needed.
+- All existing UI behaviour preserved; no regression.
+- No new rfl usage introduced.
 
 * Plan
 
@@ -86,48 +90,42 @@ Call sites:
 
 ** Design
 
-=IInstrumentForm= base: remove =populate_from_instrument= from the virtual interface. Add a
-non-virtual helper to the base if any shared pre-population setup is needed.
+=IInstrumentFormPopulator= (introduced in task 2, lives in =ores.qt.api=): pure-abstract
+interface with one =populate= overload per concrete leaf type. Default implementations are
+no-ops so only relevant overloads need to be defined.
 
-Each concrete form: add the typed method, e.g.:
-
-#+begin_src cpp
-// BondInstrumentForm.hpp
-void populate(const trading::domain::bond_instrument& instr);
-
-// FxForwardInstrumentForm.hpp (or FxInstrumentForm for all FX forwards)
-void populate(const trading::domain::fx_forward_instrument& instr);
-#+end_src
-
-Call site dispatch (in =TradeController=):
+Each concrete form implements the relevant overload(s). Example:
 
 #+begin_src cpp
-// form_ is already the right concrete form, created by the factory
-switch (bundle.trade.classification.product_type) {
-case product_type::bond:
-    static_cast<BondInstrumentForm*>(form_)->populate(
-        std::get<bond_instrument>(bundle.instrument));
-    break;
-// … etc.
-}
+// BondInstrumentForm.hpp — inherits IInstrumentForm AND IInstrumentFormPopulator
+void populate(const trading::domain::bond_instrument& instr) override;
+
+// FxInstrumentForm.hpp — handles all FX leaf types via separate overloads
+void populate(const trading::domain::fx_forward_instrument& instr) override;
+void populate(const trading::domain::fx_vanilla_option_instrument& instr) override;
+// … etc. for all 7 FX leaf types
 #+end_src
 
-Or, since the call site has the concrete form pointer via the factory, it can use
-=std::visit= on =bundle.instrument= with a typed visitor — keeping the dispatch logic in
-one place.
+Call site (=TradeController=, =TradeDetailDialog=): create the right form as before via
+the factory, then pass it directly as the populator:
+
+#+begin_src cpp
+// factory already creates the concrete form from product_type / trade_type
+auto* form = form_factory_.create(product_type, trade_type);
+auto trade_opt = clientManager_->getTradeInstrument(trade_id, *form);
+// form is now populated; no variant, no dispatch at the call site
+#+end_src
+
+=getTradeInstrument= calls the right =populate= overload inside its dispatch switch.
+The call site never sees the instrument type — it just gets the trade back and the form
+is already populated.
 
 ** Note on FX and equity sub-variants
 
-=FxInstrumentForm= currently dispatches internally on =fx_instrument_variant=. After this
-refactor, the call site receives the =fx_instrument_variant= alternative from the
-=trade_instrument= variant and can either:
-
-- Pass the =fx_instrument_variant= directly to a shared =FxInstrumentForm::populate(const fx_instrument_variant&)= (the form then dispatches internally to its sub-panels), OR
-- Dispatch at the call site to type-specific sub-forms.
-
-The simpler option (variant passed to the form) is acceptable for =fx_instrument_variant=
-and =equity_instrument_variant= since those sub-variants do not interact with rfl. Decision
-deferred to implementation.
+Because =IInstrumentFormPopulator= has one overload per leaf type (e.g.
+=fx_forward_instrument=, =fx_vanilla_option_instrument=, …), =FxInstrumentForm= overrides
+each FX leaf overload individually. There is no need to pass an =fx_instrument_variant= to
+the form at all — each leaf type is dispatched directly. Same for equity and rates.
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_refactor_instrument_form_interface.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_refactor_instrument_form_interface.org
@@ -1,0 +1,146 @@
+:PROPERTIES:
+:ID: 5C955A5E-0130-40D7-B77F-B41F4F526B79
+:END:
+#+title: Task: Refactor IInstrumentForm to type-specific populate methods
+#+description: Replace the IInstrumentForm::populate_from_instrument(const trade_instrument&) virtual interface with type-specific populate overloads on each concrete form. Remove the trade_instrument variant from the Qt UI boundary; dispatch at the call site using the product_type and trade_type already known from the parse result.
+#+type: task
+#+level: s1
+#+filetags: :fix_rfl_complexity:sprint_19:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: F9E5967D-77E7-49E3-9806-74AF22D26191
+#+blocked_since:
+#+created: 2026-05-29
+#+updated: 2026-05-29
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The current =IInstrumentForm::populate_from_instrument(const trade_instrument&)= interface
+is architecturally incorrect: each concrete form already knows its instrument type (it is,
+for example, =BondInstrumentForm=), yet it receives the full 9-alternative =trade_instrument=
+variant and immediately discards 8 alternatives via =std::get_if=. The runtime check can
+never legitimately fail — if it does, it is a programming error that the current interface
+silently swallows.
+
+This task removes the fake generality:
+
+1. Replace the virtual =populate_from_instrument(const trade_instrument&)= in
+   =IInstrumentForm= with type-specific =populate= overloads (non-virtual) on each concrete
+   form. The base class retains all other shared lifecycle methods (=show=, =hide=, =save=,
+   validation, etc.).
+2. Move the dispatch to the call sites (=TradeController=, =TradeDetailDialog=), which
+   already know =(product_type, trade_type)= from the =trade_export_item= produced by
+   task 2. The call site calls the right form's =populate= directly.
+3. Remove =trade_instrument= and the sub-variant =std::get_if= calls from every form
+   implementation file.
+
+* Status
+
+| Field        | Value                                                                               |
+|--------------+-------------------------------------------------------------------------------------|
+| State        | BACKLOG                                                                             |
+| Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
+| Now          | —                                                                                   |
+| Waiting on   | Task 3 merged ([[id:F9E5967D-77E7-49E3-9806-74AF22D26191][tests]]).               |
+| Next         | Begin once tests PR is green.                                                       |
+| Last touched | 2026-05-29                                                                          |
+
+* Acceptance
+
+- =IInstrumentForm= has no =populate_from_instrument(const trade_instrument&)= method.
+- Each concrete form has a typed =populate= method (or constructor argument) for its
+  specific instrument type(s).
+- No form implementation file uses =std::get_if<trade_instrument>= or
+  =std::get_if<fx_instrument_variant>= or =std::get_if<equity_instrument_variant>=.
+- =IInstrumentForm.hpp= does not include =trade_instrument.hpp=.
+- Call sites (=TradeController=, =TradeDetailDialog=) dispatch explicitly using
+  =(product_type, trade_type)= and call the correct form's =populate= directly.
+- All existing behaviour preserved; no UI regression.
+- The change does not introduce any new rfl usage.
+
+* Plan
+
+(Transient.)
+
+** Affected files
+
+=IInstrumentForm.hpp= and every subclass:
+
+- =FxInstrumentForm= (and all 6 other FX form subclasses)
+- =SwapInstrumentForm=
+- =BondInstrumentForm=
+- =CreditInstrumentForm=
+- =CommodityInstrumentForm=
+- =CompositeInstrumentForm=
+- =ScriptedInstrumentForm=
+- =EquityInstrumentForm= (and relevant equity sub-forms)
+
+Call sites:
+
+- =TradeController.cpp= — receives =trade_export_item= from =getTradeInstrument=; dispatch here.
+- =TradeDetailDialog.cpp= — receives =trade_export_item=; dispatch here.
+
+** Design
+
+=IInstrumentForm= base: remove =populate_from_instrument= from the virtual interface. Add a
+non-virtual helper to the base if any shared pre-population setup is needed.
+
+Each concrete form: add the typed method, e.g.:
+
+#+begin_src cpp
+// BondInstrumentForm.hpp
+void populate(const trading::domain::bond_instrument& instr);
+
+// FxForwardInstrumentForm.hpp (or FxInstrumentForm for all FX forwards)
+void populate(const trading::domain::fx_forward_instrument& instr);
+#+end_src
+
+Call site dispatch (in =TradeController=):
+
+#+begin_src cpp
+// form_ is already the right concrete form, created by the factory
+switch (bundle.trade.classification.product_type) {
+case product_type::bond:
+    static_cast<BondInstrumentForm*>(form_)->populate(
+        std::get<bond_instrument>(bundle.instrument));
+    break;
+// … etc.
+}
+#+end_src
+
+Or, since the call site has the concrete form pointer via the factory, it can use
+=std::visit= on =bundle.instrument= with a typed visitor — keeping the dispatch logic in
+one place.
+
+** Note on FX and equity sub-variants
+
+=FxInstrumentForm= currently dispatches internally on =fx_instrument_variant=. After this
+refactor, the call site receives the =fx_instrument_variant= alternative from the
+=trade_instrument= variant and can either:
+
+- Pass the =fx_instrument_variant= directly to a shared =FxInstrumentForm::populate(const fx_instrument_variant&)= (the form then dispatches internally to its sub-panels), OR
+- Dispatch at the call site to type-specific sub-forms.
+
+The simpler option (variant passed to the form) is acceptable for =fx_instrument_variant=
+and =equity_instrument_variant= since those sub-variants do not interact with rfl. Decision
+deferred to implementation.
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_rename_and_rewrite_parse_path.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_rename_and_rewrite_parse_path.org
@@ -143,29 +143,57 @@ struct response_envelope {
 #+end_src
 
 Phase 2 — concrete dispatch (no =AddTagsToVariants=, no variant, direct populator call).
-Mirrors =populate_instruments_for_trades= in =trade_handler.hpp=:
+Mirrors =populate_instruments_for_trades= in =trade_handler.hpp=.
+
+Named wrapper structs are defined in an anonymous namespace at the top of the TU (types
+cannot be defined inline inside a template argument list in C++):
+
+#+begin_src cpp
+namespace {
+// Flat types
+struct bond_wrapper      { domain::bond_instrument instrument; };
+struct credit_wrapper    { domain::credit_instrument instrument; };
+struct commodity_wrapper { domain::commodity_instrument instrument; };
+struct scripted_wrapper  { domain::scripted_instrument instrument; };
+
+// with_legs types
+struct composite_wrapper {
+    domain::composite_instrument instrument;
+    std::vector<domain::composite_leg> legs;
+};
+struct fra_wrapper           { domain::fra_instrument instrument;
+                               std::vector<domain::swap_leg> legs; };
+struct vanilla_swap_wrapper  { domain::vanilla_swap_instrument instrument;
+                               std::vector<domain::swap_leg> legs; };
+// … one wrapper per rates leaf type
+
+struct fx_forward_wrapper         { domain::fx_forward_instrument instrument; };
+struct fx_vanilla_option_wrapper  { domain::fx_vanilla_option_instrument instrument; };
+// … one wrapper per FX leaf type
+
+struct equity_option_wrapper  { domain::equity_option_instrument instrument; };
+// … one wrapper per equity leaf type
+} // namespace
+#+end_src
+
+Dispatch:
 
 #+begin_src
 switch product_type:
-  bond      → rfl::json::read<struct { bond_instrument instrument; }>(raw)
-              → populator.populate(w->instrument)
-  credit    → rfl::json::read<struct { credit_instrument instrument; }>(raw)
-              → populator.populate(w->instrument)
-  commodity → … same pattern
-  scripted  → … same pattern
-  composite → rfl::json::read<struct { composite_instrument instrument;
-                                        vector<composite_leg> legs; }>(raw)
-              → populator.populate(w->instrument, std::move(w->legs))
+  bond      → rfl::json::read<bond_wrapper>(raw)      → populator.populate(w->instrument)
+  credit    → rfl::json::read<credit_wrapper>(raw)    → populator.populate(w->instrument)
+  commodity → rfl::json::read<commodity_wrapper>(raw) → populator.populate(w->instrument)
+  scripted  → rfl::json::read<scripted_wrapper>(raw)  → populator.populate(w->instrument)
+  composite → rfl::json::read<composite_wrapper>(raw) → populator.populate(w->instrument, std::move(w->legs))
   fx        → switch trade_type
-              → rfl::json::read<struct { fx_forward_instrument instrument; }>(raw)
-              → populator.populate(w->instrument)
-              (7 FX leaf types, one branch each)
-  equity    → switch trade_type → … (9 equity leaf types)
+              → rfl::json::read<fx_forward_wrapper>(raw)        → populator.populate(w->instrument)
+              → rfl::json::read<fx_vanilla_option_wrapper>(raw) → populator.populate(w->instrument)
+              … (7 FX leaf types, one branch each)
+  equity    → switch trade_type → … (9 equity leaf types, same pattern)
   swap      → switch trade_type
-              → rfl::json::read<struct { ConcreteRatesType instrument;
-                                         vector<swap_leg> legs; }>(raw)
-              → populator.populate(w->instrument, std::move(w->legs))
-              (9 rates leaf types)
+              → rfl::json::read<fra_wrapper>(raw)          → populator.populate(w->instrument, std::move(w->legs))
+              → rfl::json::read<vanilla_swap_wrapper>(raw) → populator.populate(w->instrument, std::move(w->legs))
+              … (9 rates leaf types)
   unknown   → log warn; return nullopt
 #+end_src
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_rename_and_rewrite_parse_path.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_rename_and_rewrite_parse_path.org
@@ -35,6 +35,14 @@ Replace the Sprint 18 two-phase-parse workaround with a correct architectural fi
    and reads the specific concrete leaf struct directly — no =AddTagsToVariants=, no
    variant in the parse path.
 
+The key architectural principle for the display path: *the type is known by the time the
+instrument is read*, so the instrument must never be packaged into a =trade_instrument=
+variant. The =getTradeInstrument= return type must not include a =trade_instrument= field.
+The concrete instrument is delivered directly to whoever needs it.
+
+This is in contrast to import/export, where many heterogeneous instruments are processed
+without a known type at the processing site — that path correctly retains the variant.
+
 * Status
 
 | Field        | Value                                                                               |
@@ -58,6 +66,9 @@ Replace the Sprint 18 two-phase-parse workaround with a correct architectural fi
 - =TradeController.cpp=: calls =getTradeInstrument=.
 - =CMakeLists.txt=: source list updated.
 - =ClientManagerTradeInstrument.cpp= contains zero =AddTagsToVariants= references.
+- =ClientManagerTradeInstrument.cpp= constructs zero =trade_instrument= values.
+- =getTradeInstrument= return type is =std::optional<trading::domain::trade>=; no variant.
+- =IInstrumentFormPopulator= interface exists with one overload per leaf instrument type.
 - Linux CI green after the change.
 - Logging: =debug= on entry to Phase 1 and Phase 2 (including resolved type strings);
   =warn= for unknown =(product_type, trade_type)= (monostate result);
@@ -79,6 +90,43 @@ Replace the Sprint 18 two-phase-parse workaround with a correct architectural fi
 | =ores.qt.api/CMakeLists.txt=                                                | Updated source list.                                    |
 | =ores.qt.trading/src/TradeController.cpp=                                   | Update call site.                                       |
 
+** Return type design
+
+=getTradeInstrument= must not return =trade_export_item= — that struct contains
+=trade_instrument instrument= (a variant) which would immediately reintroduce the variant
+into the display path.
+
+Instead, =getTradeInstrument= takes an =IInstrumentFormPopulator&= (defined below) and
+returns only the trade:
+
+#+begin_src cpp
+// ClientManager.hpp
+std::optional<trading::domain::trade>
+getTradeInstrument(const std::string& trade_id,
+                   IInstrumentFormPopulator& populator);
+#+end_src
+
+=IInstrumentFormPopulator= is a pure abstract interface (defined in =ores.qt.api=) with one
+overload per concrete leaf instrument type. Default implementations do nothing — a concrete
+form only overrides the overload(s) it handles:
+
+#+begin_src cpp
+// ores.qt.api/include/ores.qt/IInstrumentFormPopulator.hpp
+struct IInstrumentFormPopulator {
+    virtual ~IInstrumentFormPopulator() = default;
+    virtual void populate(const trading::domain::fx_forward_instrument&)          {}
+    virtual void populate(const trading::domain::fx_vanilla_option_instrument&)   {}
+    // … one overload per leaf type (~28 total)
+    virtual void populate(const trading::domain::bond_instrument&)                {}
+    virtual void populate(const trading::domain::vanilla_swap_instrument&,
+                          std::vector<trading::domain::swap_leg> legs)            {}
+    // legs passed alongside for with_legs types
+};
+#+end_src
+
+Each concrete form (or its controller) implements the relevant overload. No form ever sees
+=trade_instrument= or any sub-variant.
+
 ** Parse path design
 
 Phase 1 — envelope (file-local struct, no instrument field):
@@ -94,39 +142,35 @@ struct response_envelope {
 } // namespace
 #+end_src
 
-Phase 2 — concrete dispatch (no =AddTagsToVariants=, no variant in the parse path).
+Phase 2 — concrete dispatch (no =AddTagsToVariants=, no variant, direct populator call).
 Mirrors =populate_instruments_for_trades= in =trade_handler.hpp=:
 
 #+begin_src
 switch product_type:
   bond      → rfl::json::read<struct { bond_instrument instrument; }>(raw)
+              → populator.populate(w->instrument)
   credit    → rfl::json::read<struct { credit_instrument instrument; }>(raw)
-  commodity → rfl::json::read<struct { commodity_instrument instrument; }>(raw)
-  scripted  → rfl::json::read<struct { scripted_instrument instrument; }>(raw)
+              → populator.populate(w->instrument)
+  commodity → … same pattern
+  scripted  → … same pattern
   composite → rfl::json::read<struct { composite_instrument instrument;
                                         vector<composite_leg> legs; }>(raw)
-  fx        → switch trade_type → rfl::json::read<struct { fx_forward_instrument instrument; }>(raw)
-                                  rfl::json::read<struct { fx_vanilla_option_instrument instrument; }>(raw)
-                                  … (7 FX leaf types)
+              → populator.populate(w->instrument, std::move(w->legs))
+  fx        → switch trade_type
+              → rfl::json::read<struct { fx_forward_instrument instrument; }>(raw)
+              → populator.populate(w->instrument)
+              (7 FX leaf types, one branch each)
   equity    → switch trade_type → … (9 equity leaf types)
-  swap      → switch trade_type → rfl::json::read<struct { ConcreteRatesType instrument;
-                                                            vector<swap_leg> legs; }>(raw)
-                                  … (9 rates leaf types)
-  unknown   → log warn; return monostate
+  swap      → switch trade_type
+              → rfl::json::read<struct { ConcreteRatesType instrument;
+                                         vector<swap_leg> legs; }>(raw)
+              → populator.populate(w->instrument, std::move(w->legs))
+              (9 rates leaf types)
+  unknown   → log warn; return nullopt
 #+end_src
 
-Assemble the =trade_instrument= variant from the concrete result:
-#+begin_src cpp
-// e.g. for FX forward:
-trade_instrument ti = fx_instrument_variant{std::move(w->instrument)};
-// e.g. for vanilla swap:
-trade_instrument ti = swap_instrument_data{
-    .instrument = rates_instrument_variant{std::move(w->instrument)},
-    .legs       = std::move(w->legs)
-};
-#+end_src
-
-Return =trade_export_item{.trade = std::move(base.trade), .instrument = std::move(ti)}=.
+No =trade_instrument= variant is ever constructed. The concrete value is read and dispatched
+directly to the populator in the same switch branch. Return =base.trade=.
 
 ** Logging specification
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_rename_and_rewrite_parse_path.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_rename_and_rewrite_parse_path.org
@@ -1,0 +1,162 @@
+:PROPERTIES:
+:ID: 06C98C06-F950-483A-997B-89AED70D1238
+:END:
+#+title: Task: Rename get_trade_detail → get_trade_instrument and rewrite parse path
+#+description: Rename all get_trade_detail_* protocol types to get_trade_instrument_*, delete Sprint 18 workaround types, rename ClientManagerTradeDetail.cpp, and rewrite the client parse path to dispatch on (product_type, trade_type) reading concrete leaf structs directly — eliminating rfl::AddTagsToVariants and the 502-field Literal.
+#+type: task
+#+level: s1
+#+filetags: :fix_rfl_complexity:sprint_19:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: 9212966F-87AC-4B72-B708-8ED5BA253431
+#+blocked_since:
+#+created: 2026-05-29
+#+updated: 2026-05-29
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Replace the Sprint 18 two-phase-parse workaround with a correct architectural fix:
+
+1. Rename =get_trade_detail_*= protocol types to =get_trade_instrument_*= and update the
+   NATS subject to =trading.v1.trades.instrument=.
+2. Delete =get_trade_detail_response_base= and =get_trade_detail_instrument_wrapper= from
+   =trade_protocol.hpp= — they were parse artefacts, not protocol concepts.
+3. Update the server-side subscription (=registrar_trades.cpp=) and handler method name
+   (=trade_handler.hpp=).
+4. Rename =ClientManagerTradeDetail.cpp= → =ClientManagerTradeInstrument.cpp= and
+   =getTradeDetail= → =getTradeInstrument= throughout.
+5. Rewrite the client TU: Phase 1 reads a file-local envelope struct
+   ={bool success, string message, trade trade}= (rfl silently skips the =instrument= JSON
+   key); Phase 2 dispatches on =(product_type, trade_type)= from the trade classification
+   and reads the specific concrete leaf struct directly — no =AddTagsToVariants=, no
+   variant in the parse path.
+
+* Status
+
+| Field        | Value                                                                               |
+|--------------+-------------------------------------------------------------------------------------|
+| State        | BACKLOG                                                                             |
+| Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
+| Now          | —                                                                                   |
+| Waiting on   | Scaffolding PR merged ([[id:9212966F-87AC-4B72-B708-8ED5BA253431][Task 1]]).         |
+| Next         | Begin once scaffolding PR is green.                                                 |
+| Last touched | 2026-05-29                                                                          |
+
+* Acceptance
+
+- =trade_protocol.hpp=: =get_trade_instrument_request/response= present; =get_trade_detail_*=
+  types absent; workaround types absent.
+- NATS subject: =trading.v1.trades.instrument=.
+- =registrar_trades.cpp=: subscription uses new subject and calls =h.instrument(…)=.
+- =trade_handler.hpp=: =instrument()= method present; =detail()= absent; response type updated.
+- =ClientManagerTradeInstrument.cpp= present; =ClientManagerTradeDetail.cpp= deleted.
+- =ClientManager.hpp=: =getTradeInstrument= declared; =getTradeDetail= absent.
+- =TradeController.cpp=: calls =getTradeInstrument=.
+- =CMakeLists.txt=: source list updated.
+- =ClientManagerTradeInstrument.cpp= contains zero =AddTagsToVariants= references.
+- Linux CI green after the change.
+- Logging: =debug= on entry to Phase 1 and Phase 2 (including resolved type strings);
+  =warn= for unknown =(product_type, trade_type)= (monostate result);
+  =error= on any =rfl::json::read= failure with the rfl error message.
+
+* Plan
+
+(Transient. Distilled into the parent story's =* Decisions= and cleared when the task closes.)
+
+** Files to change
+
+| File                                                                        | Change                                                  |
+|-----------------------------------------------------------------------------+---------------------------------------------------------|
+| =ores.trading.api/include/…/messaging/trade_protocol.hpp=                  | Rename types; delete workarounds; update NATS subject.  |
+| =ores.trading.core/src/messaging/registrar_trades.cpp=                      | Use new subject constant and call =h.instrument()=.     |
+| =ores.trading.core/include/…/messaging/trade_handler.hpp=                   | Rename =detail()= → =instrument()=; update response type.|
+| =ores.qt.api/include/ores.qt/ClientManager.hpp=                             | Rename =getTradeDetail= → =getTradeInstrument=.         |
+| =ores.qt.api/src/ClientManagerTradeDetail.cpp= → =ClientManagerTradeInstrument.cpp= | Full rewrite; see design below.                 |
+| =ores.qt.api/CMakeLists.txt=                                                | Updated source list.                                    |
+| =ores.qt.trading/src/TradeController.cpp=                                   | Update call site.                                       |
+
+** Parse path design
+
+Phase 1 — envelope (file-local struct, no instrument field):
+
+#+begin_src cpp
+namespace {
+struct response_envelope {
+    bool success = false;
+    std::string message;
+    ores::trading::domain::trade trade;
+    // instrument key present in JSON but absent here — rfl skips it silently
+};
+} // namespace
+#+end_src
+
+Phase 2 — concrete dispatch (no =AddTagsToVariants=, no variant in the parse path).
+Mirrors =populate_instruments_for_trades= in =trade_handler.hpp=:
+
+#+begin_src
+switch product_type:
+  bond      → rfl::json::read<struct { bond_instrument instrument; }>(raw)
+  credit    → rfl::json::read<struct { credit_instrument instrument; }>(raw)
+  commodity → rfl::json::read<struct { commodity_instrument instrument; }>(raw)
+  scripted  → rfl::json::read<struct { scripted_instrument instrument; }>(raw)
+  composite → rfl::json::read<struct { composite_instrument instrument;
+                                        vector<composite_leg> legs; }>(raw)
+  fx        → switch trade_type → rfl::json::read<struct { fx_forward_instrument instrument; }>(raw)
+                                  rfl::json::read<struct { fx_vanilla_option_instrument instrument; }>(raw)
+                                  … (7 FX leaf types)
+  equity    → switch trade_type → … (9 equity leaf types)
+  swap      → switch trade_type → rfl::json::read<struct { ConcreteRatesType instrument;
+                                                            vector<swap_leg> legs; }>(raw)
+                                  … (9 rates leaf types)
+  unknown   → log warn; return monostate
+#+end_src
+
+Assemble the =trade_instrument= variant from the concrete result:
+#+begin_src cpp
+// e.g. for FX forward:
+trade_instrument ti = fx_instrument_variant{std::move(w->instrument)};
+// e.g. for vanilla swap:
+trade_instrument ti = swap_instrument_data{
+    .instrument = rates_instrument_variant{std::move(w->instrument)},
+    .legs       = std::move(w->legs)
+};
+#+end_src
+
+Return =trade_export_item{.trade = std::move(base.trade), .instrument = std::move(ti)}=.
+
+** Logging specification
+
+#+begin_src cpp
+// Phase 1 entry
+BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: phase 1 parse";
+// Phase 1 success
+BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: product_type=" << to_string(pt)
+                            << " trade_type=" << ttc;
+// Phase 2 entry per branch
+BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading fx_forward_instrument";
+// Deserialise error
+BOOST_LOG_SEV(lg(), error) << "getTradeInstrument: deserialise failed: " << result.error().what();
+// Unknown type
+BOOST_LOG_SEV(lg(), warn)  << "getTradeInstrument: unknown (product_type, trade_type) — ("
+                            << to_string(pt) << ", " << ttc << "); returning monostate";
+#+end_src
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_split_rfl_literal_type.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_split_rfl_literal_type.org
@@ -167,14 +167,14 @@ Swap/composite cases note: =swap_instrument_data = with_legs<rates_instrument_va
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR  | Title                                                      |
+|-----+------------------------------------------------------------|
+| 931 | Scaffold rfl complexity fix: story decisions and task stubs |
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                                   | File                                  | Decision | Notes                                              |
+|---+-------------------------------------------------------------------+---------------------------------------+----------+----------------------------------------------------|
+| 1 | Inline struct defs in template args are invalid C++ (Gemini R1)   | task_rename_and_rewrite_parse_path.org | Accept   | Replaced with named wrappers in anon namespace; resolved. |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_split_rfl_literal_type.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_split_rfl_literal_type.org
@@ -1,8 +1,8 @@
 :PROPERTIES:
 :ID: 9212966F-87AC-4B72-B708-8ED5BA253431
 :END:
-#+title: Task: Split rfl::Literal 502-field type to fix Windows and macOS CI
-#+description: Restructure the rfl::Literal 502-field type in ClientManagerTradeDetail.cpp into smaller chunks to eliminate the MSVC C1202 and Clang fold-expression nesting failures.
+#+title: Task: Scaffold — document architecture and create task stubs for rfl fix
+#+description: Update story decisions with root-cause analysis and architectural choices; repurpose this task as the scaffolding PR; create task stubs for rename/rewrite, tests, and IInstrumentForm refactor. PR for Gemini architecture review before any code changes.
 #+type: task
 #+level: s1
 #+filetags: :fix_rfl_complexity:sprint_19:v0:
@@ -19,10 +19,9 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-Split or restructure the =rfl::Literal= 502-field type in
-=ores.qt.api/src/ClientManagerTradeDetail.cpp= so that MSVC and Clang can
-compile it within their template/constexpr depth limits, restoring Windows
-and macOS CI builds without affecting Linux.
+Capture the architectural analysis in the story, create task stubs for all
+planned work, and produce a PR that Gemini can review to validate the approach
+before any code changes are made. No production code is changed in this task.
 
 * Status
 
@@ -30,25 +29,141 @@ and macOS CI builds without affecting Linux.
 |--------------+-----------------------------------------------------------------------------------|
 | State        | STARTED                                                                           |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
-| Now          | Implementing the split/restructure of the 502-field Literal type.                 |
+| Now          | Writing story decisions and task stubs; PR for architecture review.               |
 | Waiting on   | Nothing.                                                                          |
-| Next         | PR and review.                                                                    |
+| Next         | PR review by Gemini; then task 2 begins.                                          |
 | Last touched | 2026-05-29                                                                        |
 
 * Acceptance
 
-- =ClientManagerTradeDetail.cpp= compiles on MSVC without =C1202= (recursive type too complex).
-- =ClientManagerTradeDetail.cpp= compiles on Clang without fold-expression nesting limit error in =rfl/internal/StringLiteral.hpp=.
-- Linux CI remains green.
-- No functional change to the =ClientManager= trade detail behaviour.
+- =story.org= contains a complete =* Decisions= section covering root cause, discriminator,
+  protocol rename rationale, workaround deletion, variant retention, logging requirement,
+  and export_portfolio latent issue.
+- Task stubs exist for: rename/rewrite, tests, and IInstrumentForm refactor.
+- PR opened and ready for Gemini architecture review.
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+(Transient. Distilled into the parent story's =* Decisions= section above.)
+
+The architectural analysis and implementation plan are captured in [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][the story's Decisions section]].
+This task's deliverable is the scaffolding PR: updated story + task stubs.
+
+** Steps
+
+1. Update =story.org= with =* Decisions= section (done).
+2. Repurpose this task file as the scaffolding task (done).
+3. Create task stub files for tasks 2–4 (done).
+4. Commit; open PR on =feature/task-split-rfl-literal-type=.
+
+** Background decisions (moved to story)
+
+- The 502-field =rfl::Literal= is produced by =rfl::AddTagsToVariants= on
+  =trade_instrument= (9 top-level alternatives, two of which are themselves
+  variants: =fx_instrument_variant= (7 types) and =equity_instrument_variant=
+  (9 types), and =swap_instrument_data= wraps =rates_instrument_variant= (9
+  types)). MSVC C1202 and Clang fold-expression limits both fire on that single
+  type.
+
+- The discriminator we need already exists: =trade.classification.product_type=
+  (family: =fx=, =swap=, =bond=, …) and =trade.classification.trade_type=
+  (leaf: ="FxForward"=, ="VanillaSwap"=, ="EquityOption"=, …) are read in
+  Phase 1. After Phase 1 the client knows the exact leaf type — no
+  =AddTagsToVariants= is needed.
+
+- The protocol type is renamed =get_trade_detail_*= → =get_trade_instrument_*=
+  to accurately reflect its purpose (fetch the instrument for a trade, not a
+  richer trade view). No backwards-compatibility concern: internal NATS
+  protocol.
+
+- The two Sprint 18 workaround types (=get_trade_detail_response_base= and
+  =get_trade_detail_instrument_wrapper=) are deleted — they were parse
+  implementation artefacts, not protocol concepts.
+
+- The =trade_instrument=, =fx_instrument_variant=, =equity_instrument_variant=,
+  and =rates_instrument_variant= variant types are NOT deleted. They are used
+  throughout =ores.qt.trading= as C++ polymorphic holders
+  (=IInstrumentForm= interface, all form subclasses, importer). That use is
+  correct and involves no rfl. What is eliminated is
+  =rfl::json::read<…, rfl::AddTagsToVariants>= on the =get_trade_instrument=
+  client parse path.
+
+** Step 1 — Rename protocol types (=trade_protocol.hpp=)
+
+- =get_trade_detail_request= → =get_trade_instrument_request=; NATS subject
+  ="trading.v1.trades.instrument"=.
+- =get_trade_detail_response= → =get_trade_instrument_response=; keep
+  =trade_instrument instrument= field (server writes it, client does not read
+  this struct directly).
+- Delete =get_trade_detail_response_base=.
+- Delete =get_trade_detail_instrument_wrapper=.
+
+** Step 2 — Update server NATS registration (=registrar_trades.cpp=)
+
+- =get_trade_detail_request::nats_subject= → =get_trade_instrument_request::nats_subject=.
+- =h.detail(…)= → =h.instrument(…)=.
+
+** Step 3 — Update =trade_handler.hpp=
+
+- Rename =detail()= → =instrument()=.
+- =get_trade_detail_response= → =get_trade_instrument_response= at the
+  declaration and construction site.
+
+** Step 4 — Rename and rewrite the Qt client TU
+
+File: =ClientManagerTradeDetail.cpp= → =ClientManagerTradeInstrument.cpp=.
+
+Method: =getTradeDetail= → =getTradeInstrument=.
+
+New parse logic (no =AddTagsToVariants= anywhere):
+
+1. *Phase 1 — envelope read.* A file-local struct
+   ={bool success, string message, trade trade}= reads the JSON. rfl silently
+   skips the =instrument= JSON key (extra keys are ignored on read). Extract
+   =product_type= and =trade_type= from =base.trade.classification=.
+
+2. *Phase 2 — concrete instrument read.* Switch on =(product_type,
+   trade_type)=, mirroring the server-side dispatch in
+   =populate_instruments_for_trades=. For each branch, a file-local struct
+   ={ConcreteType instrument}= (or ={ConcreteType instrument; vector<Leg> legs}=
+   for swap/composite) reads the raw JSON. rfl matches by field name; the
+   server's type tag is an extra JSON key and is silently ignored.
+
+3. *Assemble.* Wrap the concrete value into the appropriate =trade_instrument=
+   alternative and return =trade_export_item{.trade=…, .instrument=…}=.
+
+Swap/composite cases note: =swap_instrument_data = with_legs<rates_instrument_variant, swap_leg>=, so the Phase 2 struct is ={ConcreteRatesType instrument; vector<swap_leg> legs}= and the result is assembled as =rates_instrument_variant{v}= → =swap_instrument_data{.instrument=…, .legs=…}=.
+
+** Step 5 — Update =ClientManager.hpp=
+
+- Rename =getTradeDetail= → =getTradeInstrument= in the public declaration and
+  its doc comment.
+
+** Step 6 — Update caller (=TradeController.cpp=)
+
+- =clientManager_->getTradeDetail(id)= → =clientManager_->getTradeInstrument(id)=.
+
+** Step 7 — Update =CMakeLists.txt= in =ores.qt.api=
+
+- Replace =ClientManagerTradeDetail.cpp= with =ClientManagerTradeInstrument.cpp=
+  in the source list.
+
+** Step 8 — Write tests
+
+- One test per instrument family (at minimum FX, rates/swap, equity, and one
+  flat type such as bond).
+- Each test: construct a =get_trade_instrument_response= with a known concrete
+  instrument → serialize with =rfl::json::write<rfl::AddTagsToVariants>= (same
+  as server) → run through the new dispatch logic → assert the assembled
+  =trade_export_item.instrument= holds the expected alternative with correct
+  fields.
+- Tests live alongside the existing =ores.qt.api= test suite.
 
 * Notes
+
+- [[id:D75F4921-B431-4E78-99AB-62A47F761D1D][Investigation: MSVC C1202 and rfl complexity]] — root-cause analysis; O(N²) field-uniqueness check, triple-isolation recommendation.
+- [[id:367D0D5F-24BB-4AA1-B784-D79E95C15A16][Fix rfl complexity failure in ClientManagerTradeDetail (capture)]] — exact MSVC C1202 and Clang fold-expression error messages.
+- [[https://github.com/getml/reflect-cpp/issues/350][reflect-cpp issue #350]] — upstream tracking.
 
 * PRs
 


### PR DESCRIPTION
## Summary

- Deep analysis of the 502-field `rfl::Literal` CI failure on MSVC (C1202) and Clang (fold-expression nesting limit).
- Architectural decision: replace `rfl::AddTagsToVariants` variant parsing with type-dispatched reads using `(product_type, trade_type)` — discriminators already present in Phase 1.
- Rename `get_trade_detail_*` → `get_trade_instrument_*`; delete Sprint 18 workaround types.
- Four tasks scaffolded for sequential delivery: rename+rewrite, tests, IInstrumentForm refactor.

**No production code changed in this PR.** This is a docs-and-design PR for architecture review before implementation begins.

## What to review

- `story.org` — root cause, decisions, acceptance criteria, logging requirement, latent export_portfolio issue.
- `task_rename_and_rewrite_parse_path.org` — parse path design (Phase 1 envelope + Phase 2 dispatch table), logging spec, file list.
- `task_instrument_parse_tests.org` — test strategy and leaf-type coverage.
- `task_refactor_instrument_form_interface.org` — IInstrumentForm typed-populate design.

## Test plan

- [ ] Story decisions are accurate and complete.
- [ ] Phase 2 dispatch table covers all `(product_type, trade_type)` combinations from `populate_instruments_for_trades`.
- [ ] Logging spec is appropriate (debug/warn/error levels).
- [ ] Task ordering and blocked-on chain is correct.
- [ ] No concerns about the architectural approach before implementation begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)