### PR TITLE
[codegen] Implement unified SQL template

### DIFF
--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_sql/story.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_sql/story.org
@@ -112,9 +112,9 @@ fidelity is required; whitespace normalisation is acceptable.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | CLI scaffold complete; unified template next. |
-| Waiting on    | Nothing.                                      |
-| Next          | Implement unified SQL template.               |
+| Now           | Unified template implemented; parity verified for all 10 refdata entities. |
+| Waiting on    | Nothing.                                                                    |
+| Next          | Migrate refdata entity models to new format.                                |
 | Last touched  | 2026-05-29                               |
 
 * Acceptance
@@ -136,8 +136,8 @@ fidelity is required; whitespace normalisation is acceptable.
 |------+-------+-------+-----+-------------|
 | [[id:49584C75-48E5-41E3-8C5F-B413E9443A72][Survey SQL variation and define unified model format]] | DONE | 2026-05-29 | 2026-05-29 | Audit all generated SQL files; enumerate every variation; define the =table= model schema and CLI interface. |
 | [[id:C72BF572-EE74-4F95-9B44-9CCF2AC0B04A][Implement =codegen.py= CLI scaffold]] | DONE | 2026-05-29 | 2026-05-29 | Argparse structure, entry point, package layout, logging; subcommand stubs; venv wiring. |
-| Implement unified SQL template | BACKLOG | | | Write =sql_schema_create.mustache=; add =table= model-type support in generator; verify parity for all refdata entities. |
-| Migrate refdata entity models to new format | BACKLOG | | | Convert all =_entity.json= models; run parity check (zero logical diff); update =codegen.py= component manifest. |
+| [[id:ADBAD96B-264D-4850-B812-E4ADF544AD81][Implement unified SQL template]] | STARTED | 2026-05-29 | | Write =sql_schema_create.mustache=; add =table= model-type support in generator; verify parity for all refdata entities. |
+| Migrate refdata entity models to new format | BACKLOG | | | Convert all =_entity.json= models to =_table.json=; retire =refdata-table= component alias; run parity check. |
 | Retire =generate_refdata_schema.sh= | BACKLOG | | | Delete script; update any CI or Makefile references; document replacement in =README.md=. |
 
 * Notes

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_sql/task_implement_template.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_sql/task_implement_template.org
@@ -58,9 +58,17 @@ current SQL files in =projects/ores.sql/create/refdata/=.
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                             | File            | Decision | Notes                                         |
+|---+-------------------------------------------------------------+-----------------+----------+-----------------------------------------------|
+| 1 | Guard empty-string check on primary_key.is_text             | template        | Accept   | Kept quoted identifiers for consistency       |
+| 2 | Missing scope_tenant validation block                       | template        | Accept   | Full block added                              |
+| 3 | Missing scope_tenant header comment                         | template        | Accept   | Added                                         |
+| 4 | Default order_by to PK column; drop tenant_scope fallback   | generator.py    | Accept   | Added default; removed .get() fallback        |
+| 5 | Add has_any_coding_scheme; drop coding_scheme fallback      | generator.py    | Accept   | Added flag; removed .get() fallback           |
+| 6 | Use has_any_coding_scheme to unify coding-scheme block      | template        | Accept   | Two duplicate blocks merged into one          |
+| 7 | Conditionally quote default value based on is_text          | template        | Accept   | Added is_text/^is_text branches               |
+
+Round 1 addressed in commit d32ea690a.
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_sql/task_implement_template.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_sql/task_implement_template.org
@@ -54,7 +54,7 @@ current SQL files in =projects/ores.sql/create/refdata/=.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/936][#936]] | [codegen] Implement unified SQL template |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_sql/task_implement_template.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_sql/task_implement_template.org
@@ -1,0 +1,104 @@
+:PROPERTIES:
+:ID: ADBAD96B-264D-4850-B812-E4ADF544AD81
+:END:
+#+title: Task: Implement unified SQL template
+#+description: Write sql_schema_create.mustache; add table model-type support in generator.py; create 10 refdata _table.json models; verify zero logical diff against current SQL files.
+#+type: task
+#+level: s1
+#+filetags: :refactor_codegen_sql:sprint_19:v0:
+#+owner: marco
+#+branch: feature/refactor-codegen-sql
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-29
+#+updated: 2026-05-29
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Create =sql_schema_create.mustache= as the unified SQL template that replaces both
+=sql_schema_table_create.mustache= and the SQL portion of
+=sql_schema_domain_entity_create.mustache=. Add =table= model-type support to
+=generator.py= and =profiles.json=. Define 10 =_table.json= models for all refdata
+entities in the new format. Verify that running =codegen.sh regenerate
+--component refdata-table --profile sql= produces zero logical diff against the
+current SQL files in =projects/ores.sql/create/refdata/=.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]] |
+| Now          | Implementation complete; awaiting PR review. |
+| Waiting on   | Nothing.                                     |
+| Next         | Migrate refdata entity models to new format. |
+| Last touched | 2026-05-29                               |
+
+* Acceptance
+
+- =sql_schema_create.mustache= exists at =projects/ores.codegen/library/templates/=.
+- =generator.py= recognises =*_table.json= files as model type =table=.
+- =profiles.json= maps =sql= profile to =sql_schema_create.mustache= for =table= model type.
+- 10 =*_table.json= model files exist in =projects/ores.codegen/models/refdata/=.
+- =codegen.sh regenerate --component refdata-table --profile sql --dry-run= prints all 10 output paths.
+- Running the actual regeneration produces zero logical diff (only template name comment changes) against the current repo SQL files.
+- All four =both= tenant-scope entities (currency, currency_market_tier, monetary_nature, rounding_type) generate =IN (p_tenant_id, ores_utility_system_tenant_id_fn())= validation logic.
+- =party_id_scheme= generates the =check ("max_cardinality" is null or "max_cardinality" > 0)= constraint correctly.
+- Site builds cleanly.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Implementation complete. Files created/modified:
+
+#+begin_example
+projects/ores.codegen/
+  library/
+    templates/
+      sql_schema_create.mustache           new unified template
+    profiles.json                          added "table" to sql profile
+  models/refdata/
+    book_status_table.json                 new (system scope, display_order)
+    contact_type_table.json                new (system scope, display_order)
+    currency_table.json                    new (both scope, nullable coding_scheme, image_id)
+    currency_market_tier_table.json        new (both scope, default=g10)
+    monetary_nature_table.json             new (both scope, default=fiat)
+    party_id_scheme_table.json             new (system scope, check_constraints)
+    party_status_table.json                new (system scope, display_order)
+    party_type_table.json                  new (system scope, display_order)
+    purpose_type_table.json                new (system scope, display_order)
+    rounding_type_table.json               new (both scope, default=Closest)
+  src/
+    codegen/
+      generate.py                          added "table" to --profile all safety check
+      manifest.py                          added refdata-table component
+    generator.py                           is_table_model(), get_model_type(), resolve_output_path(),
+                                           table special processing, sql_check_constraints pre-render
+#+end_example
+
+Key design decisions:
+
+- =_table.json= suffix convention analogous to =_entity.json=, =_domain_entity.json=, etc.
+- Three-way tenant scope (=system= / =both= / =tenant=) replaces the binary =system_tenant_validation= flag; pre-computed as boolean flags in generator preprocessing for Mustache consumption.
+- Check constraints pre-rendered as a single string (=sql_check_constraints=) in generator preprocessing to avoid pystache whitespace issues with adjacent section tags.
+- =refdata-table= component added to manifest for parity verification; replaces =refdata= once Task 4 (migration) is complete.
+- Notify triggers for =table= model types are NOT generated by =sql_schema_create.mustache= — they continue to be generated by the existing =sql_schema_notify_trigger.mustache= from domain entity models.
+
+Parity result: all 10 entities produce zero logical diff. Only cosmetic differences:
+- Template name in the =AUTO-GENERATED= comment header (=sql_schema_table_create.mustache= → =sql_schema_create.mustache=).
+- Validation function comment wording (explanatory text, not SQL logic).

--- a/projects/ores.codegen/library/profiles.json
+++ b/projects/ores.codegen/library/profiles.json
@@ -2,7 +2,7 @@
   "profiles": {
     "sql": {
       "description": "SQL schema creation scripts",
-      "model_types": ["domain_entity", "junction", "schema"],
+      "model_types": ["domain_entity", "junction", "schema", "table"],
       "templates": [
         {
           "template": "sql_schema_domain_entity_create.mustache",
@@ -33,6 +33,11 @@
           "template": "sql_schema_table_create.mustache",
           "output": "projects/ores.sql/create/{component}/{component}_{entity_plural}_create.sql",
           "model_types": ["schema"]
+        },
+        {
+          "template": "sql_schema_create.mustache",
+          "output": "projects/ores.sql/create/{component}/{component}_{entity_plural}_create.sql",
+          "model_types": ["table"]
         }
       ]
     },

--- a/projects/ores.codegen/library/templates/sql_schema_create.mustache
+++ b/projects/ores.codegen/library/templates/sql_schema_create.mustache
@@ -1,0 +1,304 @@
+{{! Unified template for bi-temporal entity table (table model format) }}
+{{{sql_license}}}
+/*
+ * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
+ * Template: sql_schema_create.mustache
+ * To modify, update the template and regenerate.
+ */
+
+-- =============================================================================
+-- {{table.description}}
+-- =============================================================================
+
+create table if not exists "{{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl" (
+    "{{table.primary_key.column}}" {{table.primary_key.type}} not null,
+{{#table.has_tenant_id}}
+    "tenant_id" uuid not null,
+{{/table.has_tenant_id}}
+    "version" integer not null,
+{{#table.columns}}
+    "{{name}}" {{type}}{{#nullable}} null{{/nullable}}{{^nullable}} not null{{/nullable}}{{#default}} default {{default}}{{/default}},
+{{/table.columns}}
+{{#table.has_coding_scheme}}
+    "coding_scheme_code" text not null,
+{{/table.has_coding_scheme}}
+{{#table.has_nullable_coding_scheme}}
+    "coding_scheme_code" text,
+{{/table.has_nullable_coding_scheme}}
+{{#table.has_image_id}}
+    "image_id" uuid,
+{{/table.has_image_id}}
+    "modified_by" text not null,
+    "performed_by" text not null,
+    "change_reason_code" text not null,
+    "change_commentary" text not null,
+    "valid_from" timestamp with time zone not null,
+    "valid_to" timestamp with time zone not null,
+{{#table.has_coding_scheme}}
+{{#table.has_tenant_id}}
+    primary key (tenant_id, {{table.primary_key.column}}, coding_scheme_code, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        {{table.primary_key.column}} WITH =,
+        coding_scheme_code WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+{{/table.has_tenant_id}}
+{{^table.has_tenant_id}}
+    primary key ({{table.primary_key.column}}, coding_scheme_code, valid_from, valid_to),
+    exclude using gist (
+        {{table.primary_key.column}} WITH =,
+        coding_scheme_code WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+{{/table.has_tenant_id}}
+{{/table.has_coding_scheme}}
+{{^table.has_coding_scheme}}
+{{#table.has_tenant_id}}
+    primary key (tenant_id, {{table.primary_key.column}}, valid_from, valid_to),
+    exclude using gist (
+        tenant_id WITH =,
+        {{table.primary_key.column}} WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+{{/table.has_tenant_id}}
+{{^table.has_tenant_id}}
+    primary key ({{table.primary_key.column}}, valid_from, valid_to),
+    exclude using gist (
+        {{table.primary_key.column}} WITH =,
+        tstzrange(valid_from, valid_to) WITH &&
+    ),
+{{/table.has_tenant_id}}
+{{/table.has_coding_scheme}}
+    check ("valid_from" < "valid_to"),
+    check ("{{table.primary_key.column}}" <> ''){{#table.has_check_constraints}},
+{{{table.sql_check_constraints}}}{{/table.has_check_constraints}}
+);
+
+{{#table.has_coding_scheme}}
+{{#table.has_tenant_id}}
+create unique index if not exists {{table.entity_plural}}_version_uniq_idx
+on "{{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl" (tenant_id, {{table.primary_key.column}}, coding_scheme_code, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+{{/table.has_tenant_id}}
+{{^table.has_tenant_id}}
+create unique index if not exists {{table.entity_plural}}_version_uniq_idx
+on "{{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl" ({{table.primary_key.column}}, coding_scheme_code, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+{{/table.has_tenant_id}}
+{{/table.has_coding_scheme}}
+{{^table.has_coding_scheme}}
+{{#table.has_tenant_id}}
+create unique index if not exists {{table.entity_plural}}_version_uniq_idx
+on "{{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl" (tenant_id, {{table.primary_key.column}}, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+{{/table.has_tenant_id}}
+{{^table.has_tenant_id}}
+create unique index if not exists {{table.entity_plural}}_version_uniq_idx
+on "{{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl" ({{table.primary_key.column}}, version)
+where valid_to = ores_utility_infinity_timestamp_fn();
+{{/table.has_tenant_id}}
+{{/table.has_coding_scheme}}
+{{#table.has_tenant_id}}
+{{#table.has_coding_scheme}}
+
+create unique index if not exists {{table.entity_plural}}_{{table.primary_key.column}}_uniq_idx
+on "{{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl" (tenant_id, {{table.primary_key.column}}, coding_scheme_code)
+where valid_to = ores_utility_infinity_timestamp_fn();
+{{/table.has_coding_scheme}}
+{{^table.has_coding_scheme}}
+
+create unique index if not exists {{table.entity_plural}}_{{table.primary_key.column}}_uniq_idx
+on "{{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl" (tenant_id, {{table.primary_key.column}})
+where valid_to = ores_utility_infinity_timestamp_fn();
+{{/table.has_coding_scheme}}
+
+create index if not exists {{table.entity_plural}}_tenant_idx
+on "{{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl" (tenant_id)
+where valid_to = ores_utility_infinity_timestamp_fn();
+{{/table.has_tenant_id}}
+{{#table.indexes}}
+
+create{{#unique}} unique{{/unique}} index if not exists {{table.entity_plural}}_{{name}}_idx
+on "{{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl" ({{columns}}){{#current_only}}
+where valid_to = ores_utility_infinity_timestamp_fn(){{/current_only}};
+{{/table.indexes}}
+
+create or replace function {{table.product}}_{{table.component}}_{{table.entity_plural}}_insert_fn()
+returns trigger as $$
+declare
+    current_version integer;
+begin
+{{#table.has_tenant_id}}
+    -- Validate tenant_id
+    new.tenant_id := ores_iam_validate_tenant_fn(new.tenant_id);
+
+{{/table.has_tenant_id}}
+{{#table.has_coding_scheme}}
+    -- Validate foreign key references
+    if NEW.coding_scheme_code is not null and not exists (
+        select 1 from ores_dq_coding_schemes_tbl
+        where code = NEW.coding_scheme_code
+        and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
+        raise exception 'Invalid coding_scheme_code: %. Coding scheme must exist.', NEW.coding_scheme_code
+        using errcode = '23503';
+    end if;
+
+{{/table.has_coding_scheme}}
+{{#table.has_nullable_coding_scheme}}
+    -- Validate foreign key references
+    if NEW.coding_scheme_code is not null and not exists (
+        select 1 from ores_dq_coding_schemes_tbl
+        where code = NEW.coding_scheme_code
+        and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
+        raise exception 'Invalid coding_scheme_code: %. Coding scheme must exist.', NEW.coding_scheme_code
+        using errcode = '23503';
+    end if;
+
+{{/table.has_nullable_coding_scheme}}
+{{#table.insert_trigger.validations}}
+    -- Validate {{column}}
+    new.{{column}} := {{validation_function}}({{#table.has_tenant_id}}new.tenant_id, {{/table.has_tenant_id}}new.{{column}});
+
+{{/table.insert_trigger.validations}}
+    select version into current_version
+    from "{{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl"
+    where {{#table.has_tenant_id}}tenant_id = new.tenant_id
+      and {{/table.has_tenant_id}}{{table.primary_key.column}} = new.{{table.primary_key.column}}
+{{#table.has_coding_scheme}}
+      and coding_scheme_code = new.coding_scheme_code
+{{/table.has_coding_scheme}}
+      and valid_to = ores_utility_infinity_timestamp_fn()
+    for update;
+
+    if found then
+        if new.version != 0 and new.version != current_version then
+            raise exception 'Version conflict: expected version %, but current version is %',
+                new.version, current_version
+                using errcode = 'P0002';
+        end if;
+        new.version = current_version + 1;
+
+        update "{{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl"
+        set valid_to = current_timestamp
+        where {{#table.has_tenant_id}}tenant_id = new.tenant_id
+          and {{/table.has_tenant_id}}{{table.primary_key.column}} = new.{{table.primary_key.column}}
+{{#table.has_coding_scheme}}
+          and coding_scheme_code = new.coding_scheme_code
+{{/table.has_coding_scheme}}
+          and valid_to = ores_utility_infinity_timestamp_fn()
+          and valid_from < current_timestamp;
+    else
+        new.version = 1;
+    end if;
+
+    new.valid_from = current_timestamp;
+    new.valid_to = ores_utility_infinity_timestamp_fn();
+    new.modified_by := ores_iam_validate_account_username_fn(new.modified_by);
+    new.performed_by = coalesce(ores_iam_current_service_fn(), current_user);
+
+    return new;
+end;
+$$ language plpgsql;
+
+create or replace trigger {{table.product}}_{{table.component}}_{{table.entity_plural}}_insert_trg
+before insert on "{{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl"
+for each row
+execute function {{table.product}}_{{table.component}}_{{table.entity_plural}}_insert_fn();
+
+create or replace rule {{table.product}}_{{table.component}}_{{table.entity_plural}}_delete_rule as
+on delete to "{{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl"
+do instead
+  update "{{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl"
+  set valid_to = current_timestamp
+  where {{#table.has_tenant_id}}tenant_id = old.tenant_id
+  and {{/table.has_tenant_id}}{{table.primary_key.column}} = old.{{table.primary_key.column}}
+{{#table.has_coding_scheme}}
+  and coding_scheme_code = old.coding_scheme_code
+{{/table.has_coding_scheme}}
+  and valid_to = ores_utility_infinity_timestamp_fn();
+{{#table.has_tenant_id}}
+{{#table.validation_fn}}
+
+-- =============================================================================
+-- Validation function for {{table.entity_singular}}
+-- Validates that a {{table.primary_key.column}} exists in the {{table.entity_plural}} table.
+-- Returns the validated value, or default if null/empty.
+{{#table.validation_fn.scope_system}}
+-- Uses system tenant data (shared reference data).
+{{/table.validation_fn.scope_system}}
+{{#table.validation_fn.scope_both}}
+-- Validates against both the tenant's own data and the system tenant's canonical set.
+{{/table.validation_fn.scope_both}}
+-- =============================================================================
+create or replace function {{table.product}}_{{table.component}}_validate_{{table.entity_singular}}_fn(
+    p_tenant_id uuid,
+    p_value {{table.primary_key.type}}
+) returns {{table.primary_key.type}} as $$
+begin
+    -- Return default if null or empty
+    if p_value is null{{#table.primary_key.is_text}} or p_value = ''{{/table.primary_key.is_text}} then
+{{#table.validation_fn.default}}
+        return '{{table.validation_fn.default}}';
+{{/table.validation_fn.default}}
+{{^table.validation_fn.default}}
+        raise exception 'Invalid {{table.entity_singular}}: value cannot be null{{#table.primary_key.is_text}} or empty{{/table.primary_key.is_text}}'
+            using errcode = '23502';
+{{/table.validation_fn.default}}
+    end if;
+
+{{#table.validation_fn.scope_system}}
+    -- Allow pass-through during bootstrap (empty table)
+    if not exists (select 1 from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl limit 1) then
+        return p_value;
+    end if;
+
+    -- Validate against reference data
+    if not exists (
+        select 1 from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl
+        where tenant_id = ores_utility_system_tenant_id_fn()
+          and {{table.primary_key.column}} = p_value
+          and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
+        raise exception 'Invalid {{table.entity_singular}}: %. Must be one of: %', p_value, (
+            select string_agg({{table.primary_key.column}}::text, ', ' order by {{table.validation_fn.order_by}})
+            from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl
+            where tenant_id = ores_utility_system_tenant_id_fn()
+              and valid_to = ores_utility_infinity_timestamp_fn()
+        ) using errcode = '23503';
+    end if;
+{{/table.validation_fn.scope_system}}
+{{#table.validation_fn.scope_both}}
+    -- Allow pass-through if neither this tenant nor the system tenant has
+    -- seeded {{table.entity_plural}} yet (freshly provisioned tenant).
+    if not exists (
+        select 1 from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl
+        where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
+        limit 1
+    ) then
+        return p_value;
+    end if;
+
+    -- Validate against this tenant's values and the system tenant's canonical set.
+    if not exists (
+        select 1 from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl
+        where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
+          and {{table.primary_key.column}} = p_value
+          and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
+        raise exception 'Invalid {{table.entity_singular}}: %. Must be one of: %', p_value, (
+            select string_agg({{table.primary_key.column}}::text, ', ' order by {{table.validation_fn.order_by}})
+            from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl
+            where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
+              and valid_to = ores_utility_infinity_timestamp_fn()
+        ) using errcode = '23503';
+    end if;
+{{/table.validation_fn.scope_both}}
+
+    return p_value;
+end;
+$$ language plpgsql;
+{{/table.validation_fn}}
+{{/table.has_tenant_id}}

--- a/projects/ores.codegen/library/templates/sql_schema_create.mustache
+++ b/projects/ores.codegen/library/templates/sql_schema_create.mustache
@@ -70,8 +70,8 @@ create table if not exists "{{table.product}}_{{table.component}}_{{table.entity
     ),
 {{/table.has_tenant_id}}
 {{/table.has_coding_scheme}}
-    check ("valid_from" < "valid_to"),
-    check ("{{table.primary_key.column}}" <> ''){{#table.has_check_constraints}},
+    check ("valid_from" < "valid_to"){{#table.primary_key.is_text}},
+    check ("{{table.primary_key.column}}" <> ''){{/table.primary_key.is_text}}{{#table.has_check_constraints}},
 {{{table.sql_check_constraints}}}{{/table.has_check_constraints}}
 );
 
@@ -134,7 +134,7 @@ begin
     new.tenant_id := ores_iam_validate_tenant_fn(new.tenant_id);
 
 {{/table.has_tenant_id}}
-{{#table.has_coding_scheme}}
+{{#table.has_any_coding_scheme}}
     -- Validate foreign key references
     if NEW.coding_scheme_code is not null and not exists (
         select 1 from ores_dq_coding_schemes_tbl
@@ -145,19 +145,7 @@ begin
         using errcode = '23503';
     end if;
 
-{{/table.has_coding_scheme}}
-{{#table.has_nullable_coding_scheme}}
-    -- Validate foreign key references
-    if NEW.coding_scheme_code is not null and not exists (
-        select 1 from ores_dq_coding_schemes_tbl
-        where code = NEW.coding_scheme_code
-        and valid_to = ores_utility_infinity_timestamp_fn()
-    ) then
-        raise exception 'Invalid coding_scheme_code: %. Coding scheme must exist.', NEW.coding_scheme_code
-        using errcode = '23503';
-    end if;
-
-{{/table.has_nullable_coding_scheme}}
+{{/table.has_any_coding_scheme}}
 {{#table.insert_trigger.validations}}
     -- Validate {{column}}
     new.{{column}} := {{validation_function}}({{#table.has_tenant_id}}new.tenant_id, {{/table.has_tenant_id}}new.{{column}});
@@ -232,6 +220,9 @@ do instead
 {{#table.validation_fn.scope_both}}
 -- Validates against both the tenant's own data and the system tenant's canonical set.
 {{/table.validation_fn.scope_both}}
+{{#table.validation_fn.scope_tenant}}
+-- Validates against the tenant's own data only.
+{{/table.validation_fn.scope_tenant}}
 -- =============================================================================
 create or replace function {{table.product}}_{{table.component}}_validate_{{table.entity_singular}}_fn(
     p_tenant_id uuid,
@@ -241,7 +232,12 @@ begin
     -- Return default if null or empty
     if p_value is null{{#table.primary_key.is_text}} or p_value = ''{{/table.primary_key.is_text}} then
 {{#table.validation_fn.default}}
+{{#table.primary_key.is_text}}
         return '{{table.validation_fn.default}}';
+{{/table.primary_key.is_text}}
+{{^table.primary_key.is_text}}
+        return {{table.validation_fn.default}};
+{{/table.primary_key.is_text}}
 {{/table.validation_fn.default}}
 {{^table.validation_fn.default}}
         raise exception 'Invalid {{table.entity_singular}}: value cannot be null{{#table.primary_key.is_text}} or empty{{/table.primary_key.is_text}}'
@@ -296,6 +292,31 @@ begin
         ) using errcode = '23503';
     end if;
 {{/table.validation_fn.scope_both}}
+{{#table.validation_fn.scope_tenant}}
+    -- Allow pass-through if this tenant has no seeded {{table.entity_plural}} yet.
+    if not exists (
+        select 1 from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl
+        where tenant_id = p_tenant_id
+        limit 1
+    ) then
+        return p_value;
+    end if;
+
+    -- Validate against this tenant's values.
+    if not exists (
+        select 1 from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl
+        where tenant_id = p_tenant_id
+          and {{table.primary_key.column}} = p_value
+          and valid_to = ores_utility_infinity_timestamp_fn()
+    ) then
+        raise exception 'Invalid {{table.entity_singular}}: %. Must be one of: %', p_value, (
+            select string_agg({{table.primary_key.column}}::text, ', ' order by {{table.validation_fn.order_by}})
+            from {{table.product}}_{{table.component}}_{{table.entity_plural}}_tbl
+            where tenant_id = p_tenant_id
+              and valid_to = ores_utility_infinity_timestamp_fn()
+        ) using errcode = '23503';
+    end if;
+{{/table.validation_fn.scope_tenant}}
 
     return p_value;
 end;

--- a/projects/ores.codegen/models/refdata/book_status_table.json
+++ b/projects/ores.codegen/models/refdata/book_status_table.json
@@ -1,0 +1,33 @@
+{
+  "table": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "entity_singular": "book_status",
+    "entity_plural": "book_statuses",
+    "description": "Book Statuses - Lifecycle states for book records (Active, Closed, Frozen)",
+    "has_tenant_id": true,
+    "primary_key": {
+      "column": "code",
+      "type": "text",
+      "is_text": true
+    },
+    "columns": [
+      {"name": "name", "type": "text", "nullable": false},
+      {"name": "description", "type": "text", "nullable": false},
+      {"name": "display_order", "type": "integer", "nullable": false, "default": "0"}
+    ],
+    "coding_scheme": "none",
+    "image_id": false,
+    "validation_fn": {
+      "tenant_scope": "system",
+      "order_by": "display_order"
+    },
+    "insert_trigger": {
+      "validations": [
+        {"column": "change_reason_code", "validation_function": "ores_dq_validate_change_reason_fn"}
+      ]
+    },
+    "indexes": []
+  }
+}

--- a/projects/ores.codegen/models/refdata/contact_type_table.json
+++ b/projects/ores.codegen/models/refdata/contact_type_table.json
@@ -1,0 +1,33 @@
+{
+  "table": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "entity_singular": "contact_type",
+    "entity_plural": "contact_types",
+    "description": "Contact Types - Classification of contact information purpose (Legal, Operations, Settlement, Billing)",
+    "has_tenant_id": true,
+    "primary_key": {
+      "column": "code",
+      "type": "text",
+      "is_text": true
+    },
+    "columns": [
+      {"name": "name", "type": "text", "nullable": false},
+      {"name": "description", "type": "text", "nullable": false},
+      {"name": "display_order", "type": "integer", "nullable": false, "default": "0"}
+    ],
+    "coding_scheme": "none",
+    "image_id": false,
+    "validation_fn": {
+      "tenant_scope": "system",
+      "order_by": "display_order"
+    },
+    "insert_trigger": {
+      "validations": [
+        {"column": "change_reason_code", "validation_function": "ores_dq_validate_change_reason_fn"}
+      ]
+    },
+    "indexes": []
+  }
+}

--- a/projects/ores.codegen/models/refdata/currency_market_tier_table.json
+++ b/projects/ores.codegen/models/refdata/currency_market_tier_table.json
@@ -1,0 +1,34 @@
+{
+  "table": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "entity_singular": "currency_market_tier",
+    "entity_plural": "currency_market_tiers",
+    "description": "Currency market tier classification. Drives UI priority, liquidity expectations, and risk limits.",
+    "has_tenant_id": true,
+    "primary_key": {
+      "column": "code",
+      "type": "text",
+      "is_text": true
+    },
+    "columns": [
+      {"name": "name", "type": "text", "nullable": false},
+      {"name": "description", "type": "text", "nullable": false},
+      {"name": "display_order", "type": "integer", "nullable": false, "default": "0"}
+    ],
+    "coding_scheme": "none",
+    "image_id": false,
+    "validation_fn": {
+      "tenant_scope": "both",
+      "default": "g10",
+      "order_by": "display_order"
+    },
+    "insert_trigger": {
+      "validations": [
+        {"column": "change_reason_code", "validation_function": "ores_dq_validate_change_reason_fn"}
+      ]
+    },
+    "indexes": []
+  }
+}

--- a/projects/ores.codegen/models/refdata/currency_table.json
+++ b/projects/ores.codegen/models/refdata/currency_table.json
@@ -1,0 +1,43 @@
+{
+  "table": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "entity_singular": "currency",
+    "entity_plural": "currencies",
+    "description": "ISO 4217 currency definitions",
+    "has_tenant_id": true,
+    "primary_key": {
+      "column": "iso_code",
+      "type": "text",
+      "is_text": true
+    },
+    "columns": [
+      {"name": "name", "type": "text", "nullable": false},
+      {"name": "numeric_code", "type": "text", "nullable": false},
+      {"name": "symbol", "type": "text", "nullable": false},
+      {"name": "fraction_symbol", "type": "text", "nullable": false},
+      {"name": "fractions_per_unit", "type": "integer", "nullable": false},
+      {"name": "rounding_type", "type": "text", "nullable": false},
+      {"name": "rounding_precision", "type": "integer", "nullable": false},
+      {"name": "format", "type": "text", "nullable": false},
+      {"name": "monetary_nature", "type": "text", "nullable": false},
+      {"name": "market_tier", "type": "text", "nullable": false}
+    ],
+    "coding_scheme": "nullable",
+    "image_id": true,
+    "validation_fn": {
+      "tenant_scope": "both",
+      "order_by": "iso_code"
+    },
+    "insert_trigger": {
+      "validations": [
+        {"column": "rounding_type", "validation_function": "ores_refdata_validate_rounding_type_fn"},
+        {"column": "monetary_nature", "validation_function": "ores_refdata_validate_monetary_nature_fn"},
+        {"column": "market_tier", "validation_function": "ores_refdata_validate_currency_market_tier_fn"},
+        {"column": "change_reason_code", "validation_function": "ores_dq_validate_change_reason_fn"}
+      ]
+    },
+    "indexes": []
+  }
+}

--- a/projects/ores.codegen/models/refdata/monetary_nature_table.json
+++ b/projects/ores.codegen/models/refdata/monetary_nature_table.json
@@ -1,0 +1,34 @@
+{
+  "table": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "entity_singular": "monetary_nature",
+    "entity_plural": "monetary_natures",
+    "description": "Monetary nature classification. Defines the monetary nature of the currency.",
+    "has_tenant_id": true,
+    "primary_key": {
+      "column": "code",
+      "type": "text",
+      "is_text": true
+    },
+    "columns": [
+      {"name": "name", "type": "text", "nullable": false},
+      {"name": "description", "type": "text", "nullable": false},
+      {"name": "display_order", "type": "integer", "nullable": false, "default": "0"}
+    ],
+    "coding_scheme": "none",
+    "image_id": false,
+    "validation_fn": {
+      "tenant_scope": "both",
+      "default": "fiat",
+      "order_by": "display_order"
+    },
+    "insert_trigger": {
+      "validations": [
+        {"column": "change_reason_code", "validation_function": "ores_dq_validate_change_reason_fn"}
+      ]
+    },
+    "indexes": []
+  }
+}

--- a/projects/ores.codegen/models/refdata/party_id_scheme_table.json
+++ b/projects/ores.codegen/models/refdata/party_id_scheme_table.json
@@ -1,0 +1,39 @@
+{
+  "table": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "entity_singular": "party_id_scheme",
+    "entity_plural": "party_id_schemes",
+    "description": "Party Identifier Schemes - Classification of external identifier types (LEI, BIC, MIC, etc.) with cross-reference to DQ coding schemes.",
+    "has_tenant_id": true,
+    "primary_key": {
+      "column": "code",
+      "type": "text",
+      "is_text": true
+    },
+    "columns": [
+      {"name": "name", "type": "text", "nullable": false},
+      {"name": "description", "type": "text", "nullable": false},
+      {"name": "coding_scheme_code", "type": "text", "nullable": true},
+      {"name": "display_order", "type": "integer", "nullable": false, "default": "0"},
+      {"name": "max_cardinality", "type": "integer", "nullable": true}
+    ],
+    "coding_scheme": "none",
+    "image_id": false,
+    "check_constraints": [
+      {"expression": "\"max_cardinality\" is null or \"max_cardinality\" > 0"}
+    ],
+    "validation_fn": {
+      "tenant_scope": "system",
+      "order_by": "display_order"
+    },
+    "insert_trigger": {
+      "validations": [
+        {"column": "change_reason_code", "validation_function": "ores_dq_validate_change_reason_fn"},
+        {"column": "coding_scheme_code", "validation_function": "ores_refdata_validate_party_id_scheme_coding_scheme_fn"}
+      ]
+    },
+    "indexes": []
+  }
+}

--- a/projects/ores.codegen/models/refdata/party_status_table.json
+++ b/projects/ores.codegen/models/refdata/party_status_table.json
@@ -1,0 +1,33 @@
+{
+  "table": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "entity_singular": "party_status",
+    "entity_plural": "party_statuses",
+    "description": "Party Statuses - Lifecycle states for party and counterparty records (Active, Inactive, Suspended)",
+    "has_tenant_id": true,
+    "primary_key": {
+      "column": "code",
+      "type": "text",
+      "is_text": true
+    },
+    "columns": [
+      {"name": "name", "type": "text", "nullable": false},
+      {"name": "description", "type": "text", "nullable": false},
+      {"name": "display_order", "type": "integer", "nullable": false, "default": "0"}
+    ],
+    "coding_scheme": "none",
+    "image_id": false,
+    "validation_fn": {
+      "tenant_scope": "system",
+      "order_by": "display_order"
+    },
+    "insert_trigger": {
+      "validations": [
+        {"column": "change_reason_code", "validation_function": "ores_dq_validate_change_reason_fn"}
+      ]
+    },
+    "indexes": []
+  }
+}

--- a/projects/ores.codegen/models/refdata/party_type_table.json
+++ b/projects/ores.codegen/models/refdata/party_type_table.json
@@ -1,0 +1,33 @@
+{
+  "table": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "entity_singular": "party_type",
+    "entity_plural": "party_types",
+    "description": "Party Types - Classification of legal entities (Bank, Corporate, HedgeFund, etc.)",
+    "has_tenant_id": true,
+    "primary_key": {
+      "column": "code",
+      "type": "text",
+      "is_text": true
+    },
+    "columns": [
+      {"name": "name", "type": "text", "nullable": false},
+      {"name": "description", "type": "text", "nullable": false},
+      {"name": "display_order", "type": "integer", "nullable": false, "default": "0"}
+    ],
+    "coding_scheme": "none",
+    "image_id": false,
+    "validation_fn": {
+      "tenant_scope": "system",
+      "order_by": "display_order"
+    },
+    "insert_trigger": {
+      "validations": [
+        {"column": "change_reason_code", "validation_function": "ores_dq_validate_change_reason_fn"}
+      ]
+    },
+    "indexes": []
+  }
+}

--- a/projects/ores.codegen/models/refdata/purpose_type_table.json
+++ b/projects/ores.codegen/models/refdata/purpose_type_table.json
@@ -1,0 +1,33 @@
+{
+  "table": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "entity_singular": "purpose_type",
+    "entity_plural": "purpose_types",
+    "description": "Purpose Types - Classification of portfolio purpose (Risk, Regulatory, ClientReporting, Internal)",
+    "has_tenant_id": true,
+    "primary_key": {
+      "column": "code",
+      "type": "text",
+      "is_text": true
+    },
+    "columns": [
+      {"name": "name", "type": "text", "nullable": false},
+      {"name": "description", "type": "text", "nullable": false},
+      {"name": "display_order", "type": "integer", "nullable": false, "default": "0"}
+    ],
+    "coding_scheme": "none",
+    "image_id": false,
+    "validation_fn": {
+      "tenant_scope": "system",
+      "order_by": "display_order"
+    },
+    "insert_trigger": {
+      "validations": [
+        {"column": "change_reason_code", "validation_function": "ores_dq_validate_change_reason_fn"}
+      ]
+    },
+    "indexes": []
+  }
+}

--- a/projects/ores.codegen/models/refdata/rounding_type_table.json
+++ b/projects/ores.codegen/models/refdata/rounding_type_table.json
@@ -1,0 +1,34 @@
+{
+  "table": {
+    "schema": "public",
+    "product": "ores",
+    "component": "refdata",
+    "entity_singular": "rounding_type",
+    "entity_plural": "rounding_types",
+    "description": "Rounding Types - Valid rounding methods per ORE XML schema (roundingType)",
+    "has_tenant_id": true,
+    "primary_key": {
+      "column": "code",
+      "type": "text",
+      "is_text": true
+    },
+    "columns": [
+      {"name": "name", "type": "text", "nullable": false},
+      {"name": "description", "type": "text", "nullable": false},
+      {"name": "display_order", "type": "integer", "nullable": false, "default": "0"}
+    ],
+    "coding_scheme": "none",
+    "image_id": false,
+    "validation_fn": {
+      "tenant_scope": "both",
+      "default": "Closest",
+      "order_by": "display_order"
+    },
+    "insert_trigger": {
+      "validations": [
+        {"column": "change_reason_code", "validation_function": "ores_dq_validate_change_reason_fn"}
+      ]
+    },
+    "indexes": []
+  }
+}

--- a/projects/ores.codegen/src/codegen/generate.py
+++ b/projects/ores.codegen/src/codegen/generate.py
@@ -32,12 +32,12 @@ def _generate_single(
     profiles = gen.load_profiles(base_dir)
     model_type = gen.get_model_type(model_path.name)
 
-    # Refuse --profile all for _entity.json (schema) models: running the all
-    # profile silently overwrites production SQL with the wrong template when
-    # both _entity.json and _domain_entity.json exist for the same entity.
-    if profile == "all" and model_type == "schema":
+    # Refuse --profile all for schema/table models: running the all profile
+    # silently overwrites production SQL with the wrong template when both
+    # _entity.json/_table.json and _domain_entity.json exist for the same entity.
+    if profile == "all" and model_type in ("schema", "table"):
         log.error(
-            "--profile all is not allowed for _entity.json models. "
+            "--profile all is not allowed for _entity.json or _table.json models. "
             "Use --profile sql or --profile all-cpp explicitly to prevent "
             "accidental SQL overwrites."
         )

--- a/projects/ores.codegen/src/codegen/manifest.py
+++ b/projects/ores.codegen/src/codegen/manifest.py
@@ -17,6 +17,15 @@ COMPONENTS: Dict[str, Component] = {
         name="refdata",
         models_dir="projects/ores.codegen/models/refdata",
     ),
+    # refdata-table: same models_dir as refdata but uses the unified _table.json
+    # format.  Used for parity verification during the codegen SQL refactor story
+    # (sprint 19).  Will replace "refdata" once migration (Task 4) is complete.
+    "refdata-table": Component(
+        name="refdata",
+        models_dir="projects/ores.codegen/models/refdata",
+        entity_glob="*_table.json",
+        exclude_suffix="_domain_entity.json",
+    ),
     "trade": Component(
         name="trade",
         models_dir="projects/ores.codegen/models/trade",

--- a/projects/ores.codegen/src/generator.py
+++ b/projects/ores.codegen/src/generator.py
@@ -1281,9 +1281,10 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
         if 'insert_trigger' in table and 'validations' in table['insert_trigger']:
             _mark_last_item(table['insert_trigger']['validations'])
         # Precompute coding_scheme boolean flags
-        coding_scheme = table.get('coding_scheme', 'none')
+        coding_scheme = table['coding_scheme']
         table['has_coding_scheme'] = (coding_scheme == 'required')
         table['has_nullable_coding_scheme'] = (coding_scheme == 'nullable')
+        table['has_any_coding_scheme'] = coding_scheme in ('required', 'nullable')
         table['has_image_id'] = bool(table.get('image_id', False))
         table['has_tenant_id'] = bool(table.get('has_tenant_id', True))
         # Pre-render check constraints as a single string to avoid Mustache
@@ -1298,10 +1299,12 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
             table['sql_check_constraints'] = ''
         # Precompute tenant-scope flags for the validation function
         if 'validation_fn' in table:
-            scope = table['validation_fn'].get('tenant_scope', '')
+            scope = table['validation_fn']['tenant_scope']
             table['validation_fn']['scope_system'] = (scope == 'system')
             table['validation_fn']['scope_both'] = (scope == 'both')
             table['validation_fn']['scope_tenant'] = (scope == 'tenant')
+            if 'order_by' not in table['validation_fn']:
+                table['validation_fn']['order_by'] = table['primary_key']['column']
         data['table'] = table
 
     # Special processing for entity schema models

--- a/projects/ores.codegen/src/generator.py
+++ b/projects/ores.codegen/src/generator.py
@@ -310,6 +310,23 @@ def is_field_group_model(model_filename):
     return model_filename.endswith("_field_group.json")
 
 
+def is_table_model(model_filename):
+    """
+    Check if a model file is a unified table model.
+
+    Table models use the unified 'table' root key and are rendered by
+    sql_schema_create.mustache via the 'sql' profile.  They replace the
+    older '_entity.json' / sql_schema_table_create.mustache pipeline.
+
+    Args:
+        model_filename (str): The model filename
+
+    Returns:
+        bool: True if this is a table model
+    """
+    return model_filename.endswith("_table.json")
+
+
 def get_model_type(model_filename):
     """
     Determine the model type from the filename.
@@ -319,7 +336,7 @@ def get_model_type(model_filename):
 
     Returns:
         str: The model type ('domain_entity', 'junction', 'enum', 'schema', 'data',
-             'component', 'field_group', 'service_registry', or 'unknown')
+             'table', 'component', 'field_group', 'service_registry', or 'unknown')
     """
     if is_domain_entity_model(model_filename):
         return 'domain_entity'
@@ -327,6 +344,8 @@ def get_model_type(model_filename):
         return 'junction'
     elif is_field_group_model(model_filename):
         return 'field_group'
+    elif is_table_model(model_filename):
+        return 'table'
     elif is_service_registry_model(model_filename):
         return 'service_registry'
     elif is_component_model(model_filename):
@@ -445,6 +464,18 @@ def resolve_output_path(output_pattern, model_data, model_type):
 
         result = result.replace('{component}', name)
         result = result.replace('{component_full}', full_name)
+
+    elif model_type == 'table' and 'table' in model_data:
+        table = model_data['table']
+        component = table.get('component', 'unknown')
+        entity_singular = table.get('entity_singular', 'unknown')
+        entity_plural = table.get('entity_plural', entity_singular + 's')
+        entity_pascal = snake_to_pascal(entity_singular)
+
+        result = result.replace('{component}', component)
+        result = result.replace('{entity}', entity_singular)
+        result = result.replace('{entity_plural}', entity_plural)
+        result = result.replace('{EntityPascal}', entity_pascal)
 
     elif model_type == 'service_registry':
         # Service registry output paths are fixed — no placeholder substitution needed.
@@ -990,6 +1021,7 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
     is_component = is_component_model(model_filename)
     is_service_registry = is_service_registry_model(model_filename)
     is_field_group = is_field_group_model(model_filename)
+    is_table = is_table_model(model_filename)
 
     # Check for C++ generation flag (--cpp or cpp_ prefix in target_template)
     generate_cpp = target_template and target_template.startswith('cpp_') and not target_template.startswith('cpp_qt_')
@@ -1028,6 +1060,13 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
             templates_to_process = [target_template]
         else:
             print(f"Service registry model '{model_filename}' requires --profile service-registry")
+            return
+    elif is_table:
+        # Table models must be used via a profile (e.g. --profile sql)
+        if target_template:
+            templates_to_process = [target_template]
+        else:
+            print(f"Table model '{model_filename}' requires --profile sql")
             return
     elif is_schema_model:
         # Entity schema models use a different template set
@@ -1229,6 +1268,41 @@ def generate_from_model(model_path, data_dir, templates_dir, output_dir, is_proc
             for item in svc.get('select_prefixes', []):
                 item['psql_var'] = psql_var
         data['service_registry'] = service_registry
+
+    # Special processing for unified table models
+    if is_table and isinstance(model, dict) and 'table' in model:
+        table = model['table']
+        if 'columns' in table:
+            _mark_last_item(table['columns'])
+        if 'indexes' in table:
+            _mark_last_item(table['indexes'])
+        if 'check_constraints' in table:
+            _mark_last_item(table['check_constraints'])
+        if 'insert_trigger' in table and 'validations' in table['insert_trigger']:
+            _mark_last_item(table['insert_trigger']['validations'])
+        # Precompute coding_scheme boolean flags
+        coding_scheme = table.get('coding_scheme', 'none')
+        table['has_coding_scheme'] = (coding_scheme == 'required')
+        table['has_nullable_coding_scheme'] = (coding_scheme == 'nullable')
+        table['has_image_id'] = bool(table.get('image_id', False))
+        table['has_tenant_id'] = bool(table.get('has_tenant_id', True))
+        # Pre-render check constraints as a single string to avoid Mustache
+        # whitespace issues when inserting them after the standard checks.
+        raw_checks = table.get('check_constraints', [])
+        if raw_checks:
+            table['has_check_constraints'] = True
+            lines = [f'    check ({c["expression"]})' for c in raw_checks]
+            table['sql_check_constraints'] = ',\n'.join(lines)
+        else:
+            table['has_check_constraints'] = False
+            table['sql_check_constraints'] = ''
+        # Precompute tenant-scope flags for the validation function
+        if 'validation_fn' in table:
+            scope = table['validation_fn'].get('tenant_scope', '')
+            table['validation_fn']['scope_system'] = (scope == 'system')
+            table['validation_fn']['scope_both'] = (scope == 'both')
+            table['validation_fn']['scope_tenant'] = (scope == 'tenant')
+        data['table'] = table
 
     # Special processing for entity schema models
     if is_schema_model and isinstance(model, dict) and 'entity' in model:

--- a/projects/ores.sql/create/refdata/refdata_book_statuses_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_book_statuses_create.sql
@@ -19,7 +19,7 @@
  */
 /*
  * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
- * Template: sql_schema_table_create.mustache
+ * Template: sql_schema_create.mustache
  * To modify, update the template and regenerate.
  */
 

--- a/projects/ores.sql/create/refdata/refdata_contact_types_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_contact_types_create.sql
@@ -19,7 +19,7 @@
  */
 /*
  * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
- * Template: sql_schema_table_create.mustache
+ * Template: sql_schema_create.mustache
  * To modify, update the template and regenerate.
  */
 

--- a/projects/ores.sql/create/refdata/refdata_currencies_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_currencies_create.sql
@@ -19,7 +19,7 @@
  */
 /*
  * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
- * Template: sql_schema_table_create.mustache
+ * Template: sql_schema_create.mustache
  * To modify, update the template and regenerate.
  */
 
@@ -151,8 +151,9 @@ do instead
 
 -- =============================================================================
 -- Validation function for currency
--- Validates that a iso_code exists in the currencies table for the given tenant.
--- Returns the validated value, or raises if not found.
+-- Validates that a iso_code exists in the currencies table.
+-- Returns the validated value, or default if null/empty.
+-- Validates against both the tenant's own data and the system tenant's canonical set.
 -- =============================================================================
 create or replace function ores_refdata_validate_currency_fn(
     p_tenant_id uuid,
@@ -166,9 +167,7 @@ begin
     end if;
 
     -- Allow pass-through if neither this tenant nor the system tenant has
-    -- published any currencies yet (e.g. a freshly provisioned automation
-    -- tenant).  A global empty-table check breaks when other tenants have
-    -- currencies but this one does not.
+    -- seeded currencies yet (freshly provisioned tenant).
     if not exists (
         select 1 from ores_refdata_currencies_tbl
         where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())
@@ -177,9 +176,7 @@ begin
         return p_value;
     end if;
 
-    -- Validate against the tenant's currencies and the system tenant's currencies.
-    -- System-tenant currencies are the standard reference set (published once);
-    -- tenant-specific currencies extend them after bundle publish.
+    -- Validate against this tenant's values and the system tenant's canonical set.
     if not exists (
         select 1 from ores_refdata_currencies_tbl
         where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())

--- a/projects/ores.sql/create/refdata/refdata_currency_market_tiers_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_currency_market_tiers_create.sql
@@ -19,7 +19,7 @@
  */
 /*
  * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
- * Template: sql_schema_table_create.mustache
+ * Template: sql_schema_create.mustache
  * To modify, update the template and regenerate.
  */
 
@@ -125,7 +125,7 @@ do instead
 -- Validation function for currency_market_tier
 -- Validates that a code exists in the currency_market_tiers table.
 -- Returns the validated value, or default if null/empty.
--- Uses current tenant data.
+-- Validates against both the tenant's own data and the system tenant's canonical set.
 -- =============================================================================
 create or replace function ores_refdata_validate_currency_market_tier_fn(
     p_tenant_id uuid,
@@ -138,7 +138,7 @@ begin
     end if;
 
     -- Allow pass-through if neither this tenant nor the system tenant has
-    -- seeded market tiers yet (freshly provisioned tenant).
+    -- seeded currency_market_tiers yet (freshly provisioned tenant).
     if not exists (
         select 1 from ores_refdata_currency_market_tiers_tbl
         where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())

--- a/projects/ores.sql/create/refdata/refdata_monetary_natures_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_monetary_natures_create.sql
@@ -19,7 +19,7 @@
  */
 /*
  * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
- * Template: sql_schema_table_create.mustache
+ * Template: sql_schema_create.mustache
  * To modify, update the template and regenerate.
  */
 
@@ -125,7 +125,7 @@ do instead
 -- Validation function for monetary_nature
 -- Validates that a code exists in the monetary_natures table.
 -- Returns the validated value, or default if null/empty.
--- Uses current tenant data.
+-- Validates against both the tenant's own data and the system tenant's canonical set.
 -- =============================================================================
 create or replace function ores_refdata_validate_monetary_nature_fn(
     p_tenant_id uuid,
@@ -138,7 +138,7 @@ begin
     end if;
 
     -- Allow pass-through if neither this tenant nor the system tenant has
-    -- seeded monetary natures yet (freshly provisioned tenant).
+    -- seeded monetary_natures yet (freshly provisioned tenant).
     if not exists (
         select 1 from ores_refdata_monetary_natures_tbl
         where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())

--- a/projects/ores.sql/create/refdata/refdata_party_id_schemes_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_party_id_schemes_create.sql
@@ -19,7 +19,7 @@
  */
 /*
  * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
- * Template: sql_schema_table_create.mustache
+ * Template: sql_schema_create.mustache
  * To modify, update the template and regenerate.
  */
 

--- a/projects/ores.sql/create/refdata/refdata_party_statuses_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_party_statuses_create.sql
@@ -19,7 +19,7 @@
  */
 /*
  * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
- * Template: sql_schema_table_create.mustache
+ * Template: sql_schema_create.mustache
  * To modify, update the template and regenerate.
  */
 

--- a/projects/ores.sql/create/refdata/refdata_party_types_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_party_types_create.sql
@@ -19,7 +19,7 @@
  */
 /*
  * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
- * Template: sql_schema_table_create.mustache
+ * Template: sql_schema_create.mustache
  * To modify, update the template and regenerate.
  */
 

--- a/projects/ores.sql/create/refdata/refdata_purpose_types_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_purpose_types_create.sql
@@ -19,7 +19,7 @@
  */
 /*
  * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
- * Template: sql_schema_table_create.mustache
+ * Template: sql_schema_create.mustache
  * To modify, update the template and regenerate.
  */
 

--- a/projects/ores.sql/create/refdata/refdata_rounding_types_create.sql
+++ b/projects/ores.sql/create/refdata/refdata_rounding_types_create.sql
@@ -19,7 +19,7 @@
  */
 /*
  * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
- * Template: sql_schema_table_create.mustache
+ * Template: sql_schema_create.mustache
  * To modify, update the template and regenerate.
  */
 
@@ -123,9 +123,9 @@ do instead
 
 -- =============================================================================
 -- Validation function for rounding_type
--- Validates that a code exists in the rounding_types table for the given
--- tenant or the system tenant (which holds the canonical value set).
+-- Validates that a code exists in the rounding_types table.
 -- Returns the validated value, or default if null/empty.
+-- Validates against both the tenant's own data and the system tenant's canonical set.
 -- =============================================================================
 create or replace function ores_refdata_validate_rounding_type_fn(
     p_tenant_id uuid,
@@ -138,7 +138,7 @@ begin
     end if;
 
     -- Allow pass-through if neither this tenant nor the system tenant has
-    -- seeded rounding types yet (freshly provisioned tenant).
+    -- seeded rounding_types yet (freshly provisioned tenant).
     if not exists (
         select 1 from ores_refdata_rounding_types_tbl
         where tenant_id in (p_tenant_id, ores_utility_system_tenant_id_fn())


### PR DESCRIPTION
## Summary

- Creates `sql_schema_create.mustache` — the unified SQL template replacing `sql_schema_table_create.mustache`
- Adds `table` model type to `generator.py` (`is_table_model()`, dispatch, preprocessing); adds entry to `profiles.json`
- Defines 10 `_table.json` models for all refdata entities in the new `table` format with correct three-way tenant scope
- Regenerates all 10 refdata schema SQL files from the new template (zero logical diff; only template-name comment changes)

Key correctness fix: the old `sql_schema_table_create.mustache` used a binary `system_tenant_validation` flag that could not express the `IN (p_tenant_id, ores_utility_system_tenant_id_fn())` variant required by 4 entities (`currency`, `currency_market_tier`, `monetary_nature`, `rounding_type`). The unified template adds a `validation_fn.tenant_scope: both` path that generates the correct SQL.

## Test plan

- [x] `codegen.sh generate --model models/refdata/party_type_table.json --profile sql --dry-run` prints correct output path
- [x] `codegen.sh regenerate --component refdata-table --profile sql --dry-run` prints all 10 output paths
- [x] Full regeneration produces zero logical diff (only cosmetic comment changes) against current repo SQL files
- [x] `both`-scope entities (rounding_type, monetary_nature, currency_market_tier, currency) generate `IN (p_tenant_id, ores_utility_system_tenant_id_fn())` correctly
- [x] `party_id_scheme` generates `check ("max_cardinality" is null or "max_cardinality" > 0)` correctly
- [x] `--profile all` on `_table.json` models is rejected with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)