### PR TITLE
[codegen] Fix component_include/component_core in auxiliary domain entity models

### DIFF
--- a/doc/agile/versions/v0/sprint_19/commission_currency/story.org
+++ b/doc/agile/versions/v0/sprint_19/commission_currency/story.org
@@ -74,7 +74,7 @@ auxiliary type (=rounding_type=, =monetary_nature=, =currency_market_tier=).
 |------+-------+-------+-----+-------------|
 | [[id:000FCB22-B1ED-4E09-AB47-03EB8A361B41][Appraise currency across all layers and produce evaluation checklist]] | DONE | 2026-05-29 | 2026-05-29 | Assess each layer; produce reusable entity evaluation checklist. |
 | [[id:F66CC098-A23B-4ECC-96A4-A99AF94BA838][Verify currency SQL against evaluation checklist]] | DONE | 2026-05-29 | 2026-05-29 | Inspect DDL against DB-layer checklist criteria; fix any gaps. |
-| [[id:E8890097-FAE9-40F8-B823-FCE23BAFD6C5][Verify and fix codegen for currency and auxiliaries]] | BLOCKED | | | Run codegen; diff output; fix missing currency_domain_entity.json. Blocked by [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]]. |
+| [[id:E8890097-FAE9-40F8-B823-FCE23BAFD6C5][Verify and fix codegen for currency and auxiliaries]] | DONE | 2026-05-29 | 2026-05-30 | SQL zero-diff; component path fix in three auxiliaries; currency_domain_entity.json confirmed unnecessary; C++ drift filed. |
 | [[id:1816FAA3-B987-4307-B265-EBF6EDEE93AA][Verify and fix currency CLI commands]] | DONE | 2026-05-29 | 2026-05-29 | Confirm list/add/remove exist; implement missing; run against live service. |
 | [[id:3D394DE4-7101-4E4B-A774-DD583BC5F0B0][Verify currency shell commands and NATS integration]] | BACKLOG | | | Run list/add/remove/history in shell; validates NATS end-to-end. |
 | [[id:E276A541-93EA-46EC-8CD8-D40803FEE587][Verify currency Qt UI end-to-end post-NATS]] | BACKLOG | | | Manually test MDI list, detail, history, delete, eventing. |

--- a/doc/agile/versions/v0/sprint_19/commission_currency/story.org
+++ b/doc/agile/versions/v0/sprint_19/commission_currency/story.org
@@ -26,12 +26,12 @@ same checklist applies.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BLOCKED                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | Blocked on codegen refactoring; SQL and CLI verified. |
-| Waiting on    | [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]] |
-| Next          | Resume once codegen story is complete; pick up shell and Qt tasks. |
-| Last touched  | 2026-05-29                               |
+| Now           | Codegen task done; shell/NATS/Qt tasks next. |
+| Waiting on    | Nothing.                              |
+| Next          | Pick up shell + NATS verification task. |
+| Last touched  | 2026-05-30                               |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_19/commission_currency/task_verify_codegen.org
+++ b/doc/agile/versions/v0/sprint_19/commission_currency/task_verify_codegen.org
@@ -35,7 +35,7 @@ no drift has accumulated across the other three entities.
 |--------------+----------------------------------------------------|
 | State        | DONE                                               |
 | Parent story | [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]]                            |
-| Now          | Complete. SQL zero-diff; C++ drift documented; currency confirmed unnecessary. |
+| Now          | Nothing.                                                                      |
 | Waiting on   |                                                    |
 | Next         | Nothing.                                           |
 | Last touched | 2026-05-30                                         |
@@ -59,6 +59,7 @@ no drift has accumulated across the other three entities.
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
 | 1 | No issues found | — | N/A | Gemini: no feedback, review clean. PR #930 round 1. |
+| 2 | =Now= field should be =Nothing.= not a summary when state is DONE | task_verify_codegen.org | Fixed | PR #939 round 1. Matches project convention. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/commission_currency/task_verify_codegen.org
+++ b/doc/agile/versions/v0/sprint_19/commission_currency/task_verify_codegen.org
@@ -9,10 +9,10 @@
 #+owner: marco
 #+branch: feature/commission-currency
 #+pr:
-#+blocked_on: C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D
-#+blocked_since: 2026-05-29
+#+blocked_on:
+#+blocked_since:
 #+created: 2026-05-29
-#+updated: 2026-05-29
+#+updated: 2026-05-30
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] story. It captures the goal, current status, acceptance, and any notes or results.
@@ -31,14 +31,14 @@ no drift has accumulated across the other three entities.
 
 * Status
 
-| Field        | Value                                  |
-|--------------+----------------------------------------|
-| State        | BLOCKED                              |
-| Parent story | [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] |
-| Now          | Nothing.                               |
-| Waiting on   | [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]] |
-| Next         | Resume once codegen SQL unification story is complete. |
-| Last touched | 2026-05-29                               |
+| Field        | Value                                              |
+|--------------+----------------------------------------------------|
+| State        | DONE                                               |
+| Parent story | [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]]                            |
+| Now          | Complete. SQL zero-diff; C++ drift documented; currency confirmed unnecessary. |
+| Waiting on   |                                                    |
+| Next         | Nothing.                                           |
+| Last touched | 2026-05-30                                         |
 
 * Acceptance
 
@@ -52,7 +52,7 @@ no drift has accumulated across the other three entities.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| #939 | [codegen] Fix component_include/component_core in auxiliary domain entity models |
 
 * Review
 
@@ -64,26 +64,63 @@ no drift has accumulated across the other three entities.
 
 ** Summary
 
-Blocked. Analysis revealed that the codegen system is not in a state that supports safe
-parity verification for currency or the auxiliaries. Two issues found:
+Done. Blockers cleared after [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]] merged.
 
-*Issue 1 — Component naming mismatch:* Running =all-cpp= on the auxiliary type
-=_domain_entity.json= models (=rounding_type=, =monetary_nature=,
-=currency_market_tier=) writes C++ files to =projects/ores.refdata/= (new untracked
-directory) instead of =projects/ores.refdata.api/= and =projects/ores.refdata.core/=
-where the production code lives. "Zero git diff" was a false negative — new untracked
-files do not appear in =git diff=. The spurious directory was deleted. The models need
-=component_include= / =component_core= corrections before a valid parity check is
-possible.
+*** SQL parity — PASS
 
-*Issue 2 — Two SQL templates with inconsistent variability:* The current
-=sql_schema_table_create.mustache= (for =_entity.json= models) cannot reproduce the
-actual validation functions in the generated SQL for the three auxiliary types. The SQL
-files use =tenant_id in (p_tenant_id, system_tenant)= but the template only supports
-either =system= or =p_tenant_id= (not both). The source SQL is the ground truth; the
-template is inconsistent with what it originally generated.
+=codegen.sh regenerate --component refdata --profile sql= regenerated all 10 refdata
+SQL files including =currency=, =rounding_type=, =monetary_nature=, and
+=currency_market_tier=. Zero git diff. The unified template and =_table.json= models
+produce byte-identical SQL.
 
-*Conclusion:* Codegen verification is blocked on [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]].
-The =currency_domain_entity.json= gap remains; it will be created as part of that
-story once the unified model format and template are in place.
+*** currency_domain_entity.json — Confirmed unnecessary
+
+Currency is significantly more complex than the three auxiliary types. Its C++ layer
+includes versioned entities (=currency_version=, =currency_version_history=), a
+=party_currency= junction, event types, protocol headers, generators, and tests.
+None of this can be generated from the current domain entity templates, which target
+simple CRUD patterns. The currency C++ code is hand-crafted and maintained manually.
+Creating =currency_domain_entity.json= would produce partial files that diverge from
+the existing implementation and would mislead future maintainers.
+
+*Decision:* =currency_domain_entity.json= is not created. The SQL schema is covered
+by =currency_table.json=.
+
+*** Component path fix — three auxiliary models
+
+=component_include= / =component_core= were missing from the three auxiliary
+=_domain_entity.json= models, causing =--profile all-cpp= to write to an untracked
+=projects/ores.refdata/= directory rather than the correct production locations.
+Fields added to all three:
+
+| Model                             | Fix                                                           |
+|-----------------------------------+---------------------------------------------------------------|
+| =rounding_type_domain_entity.json=    | Added =component_include: "refdata.api"=, =component_core: "refdata.core"= |
+| =monetary_nature_domain_entity.json=  | Same                                                          |
+| =currency_market_tier_domain_entity.json= | Same                                                      |
+
+Output paths after fix:
+- =projects/ores.refdata.api/include/ores.refdata.api/...=
+- =projects/ores.refdata.core/include/ores.refdata.core/...=
+
+*** C++ template drift — deliberate divergence filed
+
+After path correction, running =--profile all-cpp= for the three auxiliaries produces
+a 42-file diff against the repo. The diff includes:
+
+| Change | Details |
+|--------+---------|
+| Include guard regression | Template emits =ORES_REFDATA_DOMAIN_*= instead of =ORES_REFDATA_API_DOMAIN_*= (template bug) |
+| Method rename | =find_type= → =get_type= across all three auxiliaries |
+| =stamp()= removal | Service implementations no longer call =stamp()= |
+| Batch method removal | =save_types()= and =remove_types()= removed from repositories |
+| =display_order = 0= | Default initializer added to domain type |
+
+The =find_type= → =get_type= rename has callers in =ores.analytics.core=,
+=ores.iam.core=, =ores.trading.core=, =ores.reporting.core=, and =ores.refdata.core=.
+Applying the diff blindly would break the C++ build. The C++ files are reverted to
+HEAD. A separate story will address C++ template drift safely across all domain entities.
+
+*Decision:* Deliberate divergence. C++ files left at current repo state. Template
+drift filed as a capture for the C++ codegen tidy-up story.
 

--- a/projects/ores.codegen/models/refdata/currency_market_tier_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/currency_market_tier_domain_entity.json
@@ -1,112 +1,170 @@
 {
-  "domain_entity": {
-    "schema": "public",
-    "component": "refdata",
-    "entity_singular": "currency_market_tier",
-    "entity_plural": "currency_market_tiers",
-    "entity_title": "Currency Market Tier",
-    "brief": "Classification of currency by market tier.",
-    "description": "Reference data defining valid currency market tier classifications.\nValues include: G10, Emerging, Exotic, Frontier, Historical.",
-
-    "primary_key": {
-      "column": "code",
-      "type": "text",
-      "cpp_type": "std::string",
-      "description": "Unique currency market tier code.",
-      "detail": "Examples: 'G10', 'Emerging', 'Exotic', 'Frontier', 'Historical'."
-    },
-
-    "natural_keys": [
-      {
-        "column": "name",
-        "type": "text",
-        "cpp_type": "std::string",
-        "description": "Human-readable name for the currency market tier.",
-        "generator_expr": "std::string(faker::word::adjective()) + \" Market Tier\""
-      }
-    ],
-
-    "columns": [
-      {
-        "name": "description",
-        "type": "text",
-        "cpp_type": "std::string",
-        "nullable": false,
-        "description": "Detailed description of the currency market tier.",
-        "generator_expr": "std::string(faker::lorem::sentence())"
-      },
-      {
-        "name": "display_order",
-        "type": "integer",
-        "cpp_type": "int",
-        "nullable": false,
-        "description": "Order for UI display purposes.",
-        "generator_expr": "faker::number::integer(1, 100)"
-      }
-    ],
-
-    "sql": {
-      "tablename": "ores_refdata_currency_market_tiers_tbl"
-    },
-
-    "repository": {
-      "entity_singular_short": "type",
-      "entity_plural_short": "types",
-      "entity_singular_words": "currency market tier",
-      "entity_plural_words": "currency market tiers"
-    },
-
-    "cpp": {
-      "includes": {
-        "domain": ["<chrono>", "<string>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
-      },
-      "iterator_var": "mt",
-      "table_display": [
-        {"column": "code", "header": "Code"},
-        {"column": "name", "header": "Name"},
-        {"column": "description", "header": "Description"},
-        {"column": "display_order", "header": "Order"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
-      ]
-    },
-
-    "qt": {
-      "domain_include": "ores.refdata/domain/currency_market_tier.hpp",
-      "domain_class": "refdata::domain::currency_market_tier",
-      "protocol_include": "ores.refdata/messaging/protocol.hpp",
-      "collection_name": "types",
-      "item_var": "type",
-      "key_field": "code",
-      "has_uuid_primary_key": false,
-
-      "get_request_class": "refdata::messaging::get_currency_market_tiers_request",
-      "get_response_class": "refdata::messaging::get_currency_market_tiers_response",
-      "get_message_type": "get_currency_market_tiers_request",
-      "save_request_class": "refdata::messaging::save_currency_market_tier_request",
-      "save_response_class": "refdata::messaging::save_currency_market_tier_response",
-      "save_message_type": "save_currency_market_tier_request",
-      "delete_request_class": "refdata::messaging::delete_currency_market_tier_request",
-      "delete_response_class": "refdata::messaging::delete_currency_market_tier_response",
-      "delete_message_type": "delete_currency_market_tier_request",
-      "history_request_class": "refdata::messaging::get_currency_market_tier_history_request",
-      "history_response_class": "refdata::messaging::get_currency_market_tier_history_response",
-      "history_message_type": "get_currency_market_tier_history_request",
-
-      "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 150},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 300},
-        {"enum_name": "DisplayOrder", "field": "display_order", "header": "Order", "is_int": true, "width": 80},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
-      ],
-
-      "settings_group": "CurrencyMarketTierListWindow",
-      "window_title": "Currency Market Tiers",
-      "icon": "Chart"
+    "domain_entity": {
+        "schema": "public",
+        "component": "refdata",
+        "entity_singular": "currency_market_tier",
+        "entity_plural": "currency_market_tiers",
+        "entity_title": "Currency Market Tier",
+        "brief": "Classification of currency by market tier.",
+        "description": "Reference data defining valid currency market tier classifications.\nValues include: G10, Emerging, Exotic, Frontier, Historical.",
+        "primary_key": {
+            "column": "code",
+            "type": "text",
+            "cpp_type": "std::string",
+            "description": "Unique currency market tier code.",
+            "detail": "Examples: 'G10', 'Emerging', 'Exotic', 'Frontier', 'Historical'."
+        },
+        "natural_keys": [
+            {
+                "column": "name",
+                "type": "text",
+                "cpp_type": "std::string",
+                "description": "Human-readable name for the currency market tier.",
+                "generator_expr": "std::string(faker::word::adjective()) + \" Market Tier\""
+            }
+        ],
+        "columns": [
+            {
+                "name": "description",
+                "type": "text",
+                "cpp_type": "std::string",
+                "nullable": false,
+                "description": "Detailed description of the currency market tier.",
+                "generator_expr": "std::string(faker::lorem::sentence())"
+            },
+            {
+                "name": "display_order",
+                "type": "integer",
+                "cpp_type": "int",
+                "nullable": false,
+                "description": "Order for UI display purposes.",
+                "generator_expr": "faker::number::integer(1, 100)"
+            }
+        ],
+        "sql": {
+            "tablename": "ores_refdata_currency_market_tiers_tbl"
+        },
+        "repository": {
+            "entity_singular_short": "type",
+            "entity_plural_short": "types",
+            "entity_singular_words": "currency market tier",
+            "entity_plural_words": "currency market tiers"
+        },
+        "cpp": {
+            "includes": {
+                "domain": [
+                    "<chrono>",
+                    "<string>"
+                ],
+                "entity": [
+                    "<string>",
+                    "\"sqlgen/Timestamp.hpp\""
+                ]
+            },
+            "iterator_var": "mt",
+            "table_display": [
+                {
+                    "column": "code",
+                    "header": "Code"
+                },
+                {
+                    "column": "name",
+                    "header": "Name"
+                },
+                {
+                    "column": "description",
+                    "header": "Description"
+                },
+                {
+                    "column": "display_order",
+                    "header": "Order"
+                },
+                {
+                    "column": "modified_by",
+                    "header": "Modified By"
+                },
+                {
+                    "column": "version",
+                    "header": "Version"
+                }
+            ]
+        },
+        "qt": {
+            "domain_include": "ores.refdata/domain/currency_market_tier.hpp",
+            "domain_class": "refdata::domain::currency_market_tier",
+            "protocol_include": "ores.refdata/messaging/protocol.hpp",
+            "collection_name": "types",
+            "item_var": "type",
+            "key_field": "code",
+            "has_uuid_primary_key": false,
+            "get_request_class": "refdata::messaging::get_currency_market_tiers_request",
+            "get_response_class": "refdata::messaging::get_currency_market_tiers_response",
+            "get_message_type": "get_currency_market_tiers_request",
+            "save_request_class": "refdata::messaging::save_currency_market_tier_request",
+            "save_response_class": "refdata::messaging::save_currency_market_tier_response",
+            "save_message_type": "save_currency_market_tier_request",
+            "delete_request_class": "refdata::messaging::delete_currency_market_tier_request",
+            "delete_response_class": "refdata::messaging::delete_currency_market_tier_response",
+            "delete_message_type": "delete_currency_market_tier_request",
+            "history_request_class": "refdata::messaging::get_currency_market_tier_history_request",
+            "history_response_class": "refdata::messaging::get_currency_market_tier_history_response",
+            "history_message_type": "get_currency_market_tier_history_request",
+            "columns": [
+                {
+                    "enum_name": "Code",
+                    "field": "code",
+                    "header": "Code",
+                    "is_string": true,
+                    "width": 150
+                },
+                {
+                    "enum_name": "Name",
+                    "field": "name",
+                    "header": "Name",
+                    "is_string": true,
+                    "width": 200
+                },
+                {
+                    "enum_name": "Description",
+                    "field": "description",
+                    "header": "Description",
+                    "is_string": true,
+                    "width": 300
+                },
+                {
+                    "enum_name": "DisplayOrder",
+                    "field": "display_order",
+                    "header": "Order",
+                    "is_int": true,
+                    "width": 80
+                },
+                {
+                    "enum_name": "Version",
+                    "field": "version",
+                    "header": "Version",
+                    "is_int": true,
+                    "width": 80
+                },
+                {
+                    "enum_name": "ModifiedBy",
+                    "field": "modified_by",
+                    "header": "Modified By",
+                    "is_string": true,
+                    "width": 120
+                },
+                {
+                    "enum_name": "RecordedAt",
+                    "field": "recorded_at",
+                    "header": "Recorded At",
+                    "is_timestamp": true,
+                    "width": 150
+                }
+            ],
+            "settings_group": "CurrencyMarketTierListWindow",
+            "window_title": "Currency Market Tiers",
+            "icon": "Chart"
+        },
+        "component_include": "refdata.api",
+        "component_core": "refdata.core"
     }
-  }
 }

--- a/projects/ores.codegen/models/refdata/monetary_nature_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/monetary_nature_domain_entity.json
@@ -1,112 +1,170 @@
 {
-  "domain_entity": {
-    "schema": "public",
-    "component": "refdata",
-    "entity_singular": "monetary_nature",
-    "entity_plural": "monetary_natures",
-    "entity_title": "Monetary Nature",
-    "brief": "Monetary nature of the currency.",
-    "description": "Reference data defining valid monetary natures for currencies.\nValues include: Fiat, Commodity, Synthetic, Supranational.",
-
-    "primary_key": {
-      "column": "code",
-      "type": "text",
-      "cpp_type": "std::string",
-      "description": "Unique monetary nature code.",
-      "detail": "Examples: 'Fiat', 'Commodity', 'Synthetic', 'Supranational'."
-    },
-
-    "natural_keys": [
-      {
-        "column": "name",
-        "type": "text",
-        "cpp_type": "std::string",
-        "description": "Human-readable name for the monetary nature.",
-        "generator_expr": "std::string(faker::word::adjective()) + \" Monetary Nature\""
-      }
-    ],
-
-    "columns": [
-      {
-        "name": "description",
-        "type": "text",
-        "cpp_type": "std::string",
-        "nullable": false,
-        "description": "Detailed description of the monetary nature.",
-        "generator_expr": "std::string(faker::lorem::sentence())"
-      },
-      {
-        "name": "display_order",
-        "type": "integer",
-        "cpp_type": "int",
-        "nullable": false,
-        "description": "Order for UI display purposes.",
-        "generator_expr": "faker::number::integer(1, 100)"
-      }
-    ],
-
-    "sql": {
-      "tablename": "ores_refdata_monetary_natures_tbl"
-    },
-
-    "repository": {
-      "entity_singular_short": "type",
-      "entity_plural_short": "types",
-      "entity_singular_words": "monetary nature",
-      "entity_plural_words": "monetary natures"
-    },
-
-    "cpp": {
-      "includes": {
-        "domain": ["<chrono>", "<string>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
-      },
-      "iterator_var": "mn",
-      "table_display": [
-        {"column": "code", "header": "Code"},
-        {"column": "name", "header": "Name"},
-        {"column": "description", "header": "Description"},
-        {"column": "display_order", "header": "Order"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
-      ]
-    },
-
-    "qt": {
-      "domain_include": "ores.refdata/domain/monetary_nature.hpp",
-      "domain_class": "refdata::domain::monetary_nature",
-      "protocol_include": "ores.refdata/messaging/protocol.hpp",
-      "collection_name": "types",
-      "item_var": "type",
-      "key_field": "code",
-      "has_uuid_primary_key": false,
-
-      "get_request_class": "refdata::messaging::get_monetary_natures_request",
-      "get_response_class": "refdata::messaging::get_monetary_natures_response",
-      "get_message_type": "get_monetary_natures_request",
-      "save_request_class": "refdata::messaging::save_monetary_nature_request",
-      "save_response_class": "refdata::messaging::save_monetary_nature_response",
-      "save_message_type": "save_monetary_nature_request",
-      "delete_request_class": "refdata::messaging::delete_monetary_nature_request",
-      "delete_response_class": "refdata::messaging::delete_monetary_nature_response",
-      "delete_message_type": "delete_monetary_nature_request",
-      "history_request_class": "refdata::messaging::get_monetary_nature_history_request",
-      "history_response_class": "refdata::messaging::get_monetary_nature_history_response",
-      "history_message_type": "get_monetary_nature_history_request",
-
-      "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 150},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 300},
-        {"enum_name": "DisplayOrder", "field": "display_order", "header": "Order", "is_int": true, "width": 80},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
-      ],
-
-      "settings_group": "MonetaryNatureListWindow",
-      "window_title": "Monetary Natures",
-      "icon": "Classification"
+    "domain_entity": {
+        "schema": "public",
+        "component": "refdata",
+        "entity_singular": "monetary_nature",
+        "entity_plural": "monetary_natures",
+        "entity_title": "Monetary Nature",
+        "brief": "Monetary nature of the currency.",
+        "description": "Reference data defining valid monetary natures for currencies.\nValues include: Fiat, Commodity, Synthetic, Supranational.",
+        "primary_key": {
+            "column": "code",
+            "type": "text",
+            "cpp_type": "std::string",
+            "description": "Unique monetary nature code.",
+            "detail": "Examples: 'Fiat', 'Commodity', 'Synthetic', 'Supranational'."
+        },
+        "natural_keys": [
+            {
+                "column": "name",
+                "type": "text",
+                "cpp_type": "std::string",
+                "description": "Human-readable name for the monetary nature.",
+                "generator_expr": "std::string(faker::word::adjective()) + \" Monetary Nature\""
+            }
+        ],
+        "columns": [
+            {
+                "name": "description",
+                "type": "text",
+                "cpp_type": "std::string",
+                "nullable": false,
+                "description": "Detailed description of the monetary nature.",
+                "generator_expr": "std::string(faker::lorem::sentence())"
+            },
+            {
+                "name": "display_order",
+                "type": "integer",
+                "cpp_type": "int",
+                "nullable": false,
+                "description": "Order for UI display purposes.",
+                "generator_expr": "faker::number::integer(1, 100)"
+            }
+        ],
+        "sql": {
+            "tablename": "ores_refdata_monetary_natures_tbl"
+        },
+        "repository": {
+            "entity_singular_short": "type",
+            "entity_plural_short": "types",
+            "entity_singular_words": "monetary nature",
+            "entity_plural_words": "monetary natures"
+        },
+        "cpp": {
+            "includes": {
+                "domain": [
+                    "<chrono>",
+                    "<string>"
+                ],
+                "entity": [
+                    "<string>",
+                    "\"sqlgen/Timestamp.hpp\""
+                ]
+            },
+            "iterator_var": "mn",
+            "table_display": [
+                {
+                    "column": "code",
+                    "header": "Code"
+                },
+                {
+                    "column": "name",
+                    "header": "Name"
+                },
+                {
+                    "column": "description",
+                    "header": "Description"
+                },
+                {
+                    "column": "display_order",
+                    "header": "Order"
+                },
+                {
+                    "column": "modified_by",
+                    "header": "Modified By"
+                },
+                {
+                    "column": "version",
+                    "header": "Version"
+                }
+            ]
+        },
+        "qt": {
+            "domain_include": "ores.refdata/domain/monetary_nature.hpp",
+            "domain_class": "refdata::domain::monetary_nature",
+            "protocol_include": "ores.refdata/messaging/protocol.hpp",
+            "collection_name": "types",
+            "item_var": "type",
+            "key_field": "code",
+            "has_uuid_primary_key": false,
+            "get_request_class": "refdata::messaging::get_monetary_natures_request",
+            "get_response_class": "refdata::messaging::get_monetary_natures_response",
+            "get_message_type": "get_monetary_natures_request",
+            "save_request_class": "refdata::messaging::save_monetary_nature_request",
+            "save_response_class": "refdata::messaging::save_monetary_nature_response",
+            "save_message_type": "save_monetary_nature_request",
+            "delete_request_class": "refdata::messaging::delete_monetary_nature_request",
+            "delete_response_class": "refdata::messaging::delete_monetary_nature_response",
+            "delete_message_type": "delete_monetary_nature_request",
+            "history_request_class": "refdata::messaging::get_monetary_nature_history_request",
+            "history_response_class": "refdata::messaging::get_monetary_nature_history_response",
+            "history_message_type": "get_monetary_nature_history_request",
+            "columns": [
+                {
+                    "enum_name": "Code",
+                    "field": "code",
+                    "header": "Code",
+                    "is_string": true,
+                    "width": 150
+                },
+                {
+                    "enum_name": "Name",
+                    "field": "name",
+                    "header": "Name",
+                    "is_string": true,
+                    "width": 200
+                },
+                {
+                    "enum_name": "Description",
+                    "field": "description",
+                    "header": "Description",
+                    "is_string": true,
+                    "width": 300
+                },
+                {
+                    "enum_name": "DisplayOrder",
+                    "field": "display_order",
+                    "header": "Order",
+                    "is_int": true,
+                    "width": 80
+                },
+                {
+                    "enum_name": "Version",
+                    "field": "version",
+                    "header": "Version",
+                    "is_int": true,
+                    "width": 80
+                },
+                {
+                    "enum_name": "ModifiedBy",
+                    "field": "modified_by",
+                    "header": "Modified By",
+                    "is_string": true,
+                    "width": 120
+                },
+                {
+                    "enum_name": "RecordedAt",
+                    "field": "recorded_at",
+                    "header": "Recorded At",
+                    "is_timestamp": true,
+                    "width": 150
+                }
+            ],
+            "settings_group": "MonetaryNatureListWindow",
+            "window_title": "Monetary Natures",
+            "icon": "Classification"
+        },
+        "component_include": "refdata.api",
+        "component_core": "refdata.core"
     }
-  }
 }

--- a/projects/ores.codegen/models/refdata/rounding_type_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/rounding_type_domain_entity.json
@@ -1,112 +1,170 @@
 {
-  "domain_entity": {
-    "schema": "public",
-    "component": "refdata",
-    "entity_singular": "rounding_type",
-    "entity_plural": "rounding_types",
-    "entity_title": "Rounding Type",
-    "brief": "Valid rounding methods per ORE XML schema.",
-    "description": "Reference data table defining valid rounding method classifications.\nValues match xs:enumeration in ORE's currencyconfig.xsd.\n\nRounding types are managed by the system tenant and are used to\nspecify how currency amounts are rounded in financial calculations.",
-
-    "primary_key": {
-      "column": "code",
-      "type": "text",
-      "cpp_type": "std::string",
-      "description": "Unique rounding type code.",
-      "detail": "Examples: 'Up', 'Down', 'Closest', 'Floor', 'Ceiling'."
-    },
-
-    "natural_keys": [
-      {
-        "column": "name",
-        "type": "text",
-        "cpp_type": "std::string",
-        "description": "Human-readable name for the rounding type.",
-        "generator_expr": "std::string(faker::word::adjective()) + \" Rounding\""
-      }
-    ],
-
-    "columns": [
-      {
-        "name": "description",
-        "type": "text",
-        "cpp_type": "std::string",
-        "nullable": false,
-        "description": "Detailed description of the rounding type with numeric examples.",
-        "generator_expr": "std::string(faker::lorem::sentence())"
-      },
-      {
-        "name": "display_order",
-        "type": "integer",
-        "cpp_type": "int",
-        "nullable": false,
-        "description": "Order for UI display purposes.",
-        "generator_expr": "faker::number::integer(1, 100)"
-      }
-    ],
-
-    "sql": {
-      "tablename": "ores_refdata_rounding_types_tbl"
-    },
-
-    "repository": {
-      "entity_singular_short": "type",
-      "entity_plural_short": "types",
-      "entity_singular_words": "rounding type",
-      "entity_plural_words": "rounding types"
-    },
-
-    "cpp": {
-      "includes": {
-        "domain": ["<chrono>", "<string>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
-      },
-      "iterator_var": "rt",
-      "table_display": [
-        {"column": "code", "header": "Code"},
-        {"column": "name", "header": "Name"},
-        {"column": "description", "header": "Description"},
-        {"column": "display_order", "header": "Order"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
-      ]
-    },
-
-    "qt": {
-      "domain_include": "ores.refdata/domain/rounding_type.hpp",
-      "domain_class": "refdata::domain::rounding_type",
-      "protocol_include": "ores.refdata/messaging/rounding_type_protocol.hpp",
-      "collection_name": "types",
-      "item_var": "type",
-      "key_field": "code",
-      "has_uuid_primary_key": false,
-
-      "get_request_class": "refdata::messaging::get_rounding_types_request",
-      "get_response_class": "refdata::messaging::get_rounding_types_response",
-      "get_message_type": "get_rounding_types_request",
-      "save_request_class": "refdata::messaging::save_rounding_type_request",
-      "save_response_class": "refdata::messaging::save_rounding_type_response",
-      "save_message_type": "save_rounding_type_request",
-      "delete_request_class": "refdata::messaging::delete_rounding_type_request",
-      "delete_response_class": "refdata::messaging::delete_rounding_type_response",
-      "delete_message_type": "delete_rounding_type_request",
-      "history_request_class": "refdata::messaging::get_rounding_type_history_request",
-      "history_response_class": "refdata::messaging::get_rounding_type_history_response",
-      "history_message_type": "get_rounding_type_history_request",
-
-      "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 150},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 300},
-        {"enum_name": "DisplayOrder", "field": "display_order", "header": "Order", "is_int": true, "width": 80},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
-      ],
-
-      "settings_group": "RoundingTypeListWindow",
-      "window_title": "Rounding Types",
-      "icon": "Tag"
+    "domain_entity": {
+        "schema": "public",
+        "component": "refdata",
+        "entity_singular": "rounding_type",
+        "entity_plural": "rounding_types",
+        "entity_title": "Rounding Type",
+        "brief": "Valid rounding methods per ORE XML schema.",
+        "description": "Reference data table defining valid rounding method classifications.\nValues match xs:enumeration in ORE's currencyconfig.xsd.\n\nRounding types are managed by the system tenant and are used to\nspecify how currency amounts are rounded in financial calculations.",
+        "primary_key": {
+            "column": "code",
+            "type": "text",
+            "cpp_type": "std::string",
+            "description": "Unique rounding type code.",
+            "detail": "Examples: 'Up', 'Down', 'Closest', 'Floor', 'Ceiling'."
+        },
+        "natural_keys": [
+            {
+                "column": "name",
+                "type": "text",
+                "cpp_type": "std::string",
+                "description": "Human-readable name for the rounding type.",
+                "generator_expr": "std::string(faker::word::adjective()) + \" Rounding\""
+            }
+        ],
+        "columns": [
+            {
+                "name": "description",
+                "type": "text",
+                "cpp_type": "std::string",
+                "nullable": false,
+                "description": "Detailed description of the rounding type with numeric examples.",
+                "generator_expr": "std::string(faker::lorem::sentence())"
+            },
+            {
+                "name": "display_order",
+                "type": "integer",
+                "cpp_type": "int",
+                "nullable": false,
+                "description": "Order for UI display purposes.",
+                "generator_expr": "faker::number::integer(1, 100)"
+            }
+        ],
+        "sql": {
+            "tablename": "ores_refdata_rounding_types_tbl"
+        },
+        "repository": {
+            "entity_singular_short": "type",
+            "entity_plural_short": "types",
+            "entity_singular_words": "rounding type",
+            "entity_plural_words": "rounding types"
+        },
+        "cpp": {
+            "includes": {
+                "domain": [
+                    "<chrono>",
+                    "<string>"
+                ],
+                "entity": [
+                    "<string>",
+                    "\"sqlgen/Timestamp.hpp\""
+                ]
+            },
+            "iterator_var": "rt",
+            "table_display": [
+                {
+                    "column": "code",
+                    "header": "Code"
+                },
+                {
+                    "column": "name",
+                    "header": "Name"
+                },
+                {
+                    "column": "description",
+                    "header": "Description"
+                },
+                {
+                    "column": "display_order",
+                    "header": "Order"
+                },
+                {
+                    "column": "modified_by",
+                    "header": "Modified By"
+                },
+                {
+                    "column": "version",
+                    "header": "Version"
+                }
+            ]
+        },
+        "qt": {
+            "domain_include": "ores.refdata/domain/rounding_type.hpp",
+            "domain_class": "refdata::domain::rounding_type",
+            "protocol_include": "ores.refdata/messaging/rounding_type_protocol.hpp",
+            "collection_name": "types",
+            "item_var": "type",
+            "key_field": "code",
+            "has_uuid_primary_key": false,
+            "get_request_class": "refdata::messaging::get_rounding_types_request",
+            "get_response_class": "refdata::messaging::get_rounding_types_response",
+            "get_message_type": "get_rounding_types_request",
+            "save_request_class": "refdata::messaging::save_rounding_type_request",
+            "save_response_class": "refdata::messaging::save_rounding_type_response",
+            "save_message_type": "save_rounding_type_request",
+            "delete_request_class": "refdata::messaging::delete_rounding_type_request",
+            "delete_response_class": "refdata::messaging::delete_rounding_type_response",
+            "delete_message_type": "delete_rounding_type_request",
+            "history_request_class": "refdata::messaging::get_rounding_type_history_request",
+            "history_response_class": "refdata::messaging::get_rounding_type_history_response",
+            "history_message_type": "get_rounding_type_history_request",
+            "columns": [
+                {
+                    "enum_name": "Code",
+                    "field": "code",
+                    "header": "Code",
+                    "is_string": true,
+                    "width": 150
+                },
+                {
+                    "enum_name": "Name",
+                    "field": "name",
+                    "header": "Name",
+                    "is_string": true,
+                    "width": 200
+                },
+                {
+                    "enum_name": "Description",
+                    "field": "description",
+                    "header": "Description",
+                    "is_string": true,
+                    "width": 300
+                },
+                {
+                    "enum_name": "DisplayOrder",
+                    "field": "display_order",
+                    "header": "Order",
+                    "is_int": true,
+                    "width": 80
+                },
+                {
+                    "enum_name": "Version",
+                    "field": "version",
+                    "header": "Version",
+                    "is_int": true,
+                    "width": 80
+                },
+                {
+                    "enum_name": "ModifiedBy",
+                    "field": "modified_by",
+                    "header": "Modified By",
+                    "is_string": true,
+                    "width": 120
+                },
+                {
+                    "enum_name": "RecordedAt",
+                    "field": "recorded_at",
+                    "header": "Recorded At",
+                    "is_timestamp": true,
+                    "width": 150
+                }
+            ],
+            "settings_group": "RoundingTypeListWindow",
+            "window_title": "Rounding Types",
+            "icon": "Tag"
+        },
+        "component_include": "refdata.api",
+        "component_core": "refdata.core"
     }
-  }
 }


### PR DESCRIPTION
## Summary

- Add `component_include: "refdata.api"` and `component_core: "refdata.core"` to the three auxiliary `_domain_entity.json` models (`rounding_type`, `monetary_nature`, `currency_market_tier`)
- Without these fields, `--profile all-cpp` wrote to an untracked `projects/ores.refdata/` directory rather than `projects/ores.refdata.api/` + `projects/ores.refdata.core/`
- SQL parity confirmed: zero diff after regenerating all 10 refdata models
- `currency_domain_entity.json` confirmed unnecessary (documented justification: currency is hand-crafted with versioned entities and complex structures beyond template capability)
- C++ template drift (42 files) documented as deliberate divergence in task result; will be addressed in a separate C++ codegen tidy-up story

## Test plan

- [ ] SQL codegen zero-diff: `codegen.sh regenerate --component refdata --profile sql` + `git diff`
- [ ] Dry-run C++ for auxiliaries shows correct output paths (`ores.refdata.api/`, `ores.refdata.core/`)
- [ ] Site builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)