### PR TITLE
[doc] Add refactor_codegen_cpp story and update sprint_19 tooling

### DIFF
--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/story.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/story.org
@@ -1,0 +1,194 @@
+:PROPERTIES:
+:ID: 3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E
+:END:
+#+title: Story: Refactor ores.codegen C++ generation
+#+description: Audit and resolve all drift between C++ templates and production files; fix template bugs; fix model consistency; register all C++ components in the CLI; achieve zero-diff regeneration across all domain entities.
+#+type: story
+#+level: s2
+#+filetags: :tooling:codegen:sprint_19:v0:
+#+branch: feature/refactor-codegen-cpp
+#+created: 2026-05-30
+#+updated: 2026-05-30
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+The SQL refactoring ([[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]]) established a clean invariant: running
+=codegen.sh regenerate --component refdata --profile sql= produces zero diff against the
+repository. The C++ side of ores.codegen has the same problems at larger scale — and no
+equivalent invariant.
+
+The C++ generation system today:
+
+- *60 C++ templates* organised into 8 facets (domain, repository, service, protocol,
+  generator, Qt, CMake, utilities).
+- *75 domain_entity.json models* across at least 8 component pairs (refdata, trading, iam,
+  dq, analytics, reporting, compute, workspace/scheduler/...).
+- *~1,746 production C++ files* in 8 API+Core projects.
+- *No "regenerate all"* command: =manifest.py= has no C++ component entries; there is no
+  single command that regenerates all C++ for a component.
+- *Known template bug*: the include guard template emits =ORES_REFDATA_DOMAIN_*= instead
+  of =ORES_REFDATA_API_DOMAIN_*= for models that use =component_include= — corrupting
+  every include guard in the component.
+- *Model inconsistency*: approximately 70% of the 75 models lack explicit
+  =component_include= / =component_core= fields. Three auxiliary refdata models were fixed
+  in [[id:E8890097-FAE9-40F8-B823-FCE23BAFD6C5][Verify and fix codegen for currency and auxiliaries]]; the rest are unverified.
+- *Template drift*: templates have evolved since the production files were last regenerated.
+  A sample of three auxiliary refdata entities revealed 42 files differing, including a
+  method rename (=find_type= → =get_type=) with callers across four other components, and
+  removal of =save_types()= / =remove_types()= batch methods that are actively used.
+
+This story applies the same discipline the SQL refactoring applied: audit the full
+variation, fix the tooling, and achieve zero diff between template output and the
+repository for every registered component.
+
+** What we want
+
+*1. A comprehensive drift catalog*
+
+Every one of the 75 =_domain_entity.json= models run through =codegen.py generate --model
+X --profile all-cpp=. All diffs collected and categorised as:
+
+- *clean* — zero diff; template and production agree.
+- *cosmetic* — whitespace, comment rewrap, or copyright year only.
+- *additive* — new method or member added by template; no production API removed.
+- *breaking* — existing production API renamed, removed, or signature-changed.
+- *path-error* — output written to wrong directory (=component_include= / =component_core=
+  missing or wrong).
+
+The catalog is the primary deliverable of Task 1 and unblocks all subsequent tasks.
+
+*2. Bug-free templates*
+
+The include guard regression is fixed. All other systematic template bugs found during
+the audit are also fixed. After fixes, dry-run across all 75 models produces no path
+errors and no malformed include guards.
+
+*3. Consistent models*
+
+All 75 =_domain_entity.json= models have correct =component_include= and =component_core=
+fields. No model relies on a default that resolves to a wrong directory.
+
+*4. A complete C++ component registry*
+
+=manifest.py= has entries for every component that has =_domain_entity.json= models.
+Running =codegen.sh regenerate --component X --profile all-cpp= is a valid command for
+every registered component.
+
+*5. Explicit decisions on breaking drift*
+
+For every breaking change found in the audit, one of two outcomes is recorded:
+
+- *Template frozen*: the template is updated to preserve the existing production API
+  (e.g., keep =find_type=, keep =save_types= / =remove_types=).
+- *Production updated*: the production files are regenerated and all callers across
+  other components are updated in the same PR.
+
+No breaking change is silently discarded.
+
+*6. Zero-diff invariant*
+
+After all decisions are applied, running =codegen.sh regenerate --component X --profile
+all-cpp= for every registered component produces zero diff. CI passes.
+
+** What is NOT in scope
+
+- Qt UI templates (=cpp_qt_*.mustache=) — the Qt layer has its own variability and is a
+  separate story.
+- CMake file regeneration — =CMakeLists.txt= files are not pure template output and are
+  managed separately.
+- Creating new =_domain_entity.json= models for entities that currently have none (e.g.,
+  =currency=, complex trading entities).
+- Changing C++ API design or introducing new template features — templates are corrected
+  for bugs only.
+- The =_domain_entity.json= → SQL path for domain entities (party, book, counterparty,
+  etc.) — this path uses =sql_schema_domain_entity_create.mustache= and is unchanged.
+
+** Pilot component
+
+Refdata is the pilot. Once refdata achieves zero diff, the same process is applied to
+trading, iam, dq, and all remaining components.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                                |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                              |
+| Now           | Story created; not yet started.        |
+| Waiting on    | Nothing.                               |
+| Next          | Start Task 1: audit C++ template drift. |
+| Last touched  | 2026-05-30                             |
+
+* Acceptance
+
+- Drift catalog produced: every one of the 75 =_domain_entity.json= models classified
+  as clean / cosmetic / additive / breaking / path-error.
+- Include guard regression fixed in template; all other template bugs found in audit fixed.
+- All 75 models have verified =component_include= / =component_core= fields.
+- =manifest.py= has C++ component entries for every component with domain entity models.
+- Every breaking change has an explicit decision (template frozen or production updated).
+- =codegen.sh regenerate --component X --profile all-cpp= produces zero diff for all
+  registered components.
+- CI passes.
+- Site builds cleanly.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:A4C9D7F2-3E5B-4A1C-8F6D-9B2E7A4C1D8F][Audit C++ template drift and build drift catalog]] | BACKLOG | | | Run codegen for all 75 domain_entity models; collect diffs; classify as clean / cosmetic / additive / breaking / path-error. |
+| [[id:F7B3E1D9-6A4C-4F2B-7E8D-1C5A9B3F7D2E][Fix C++ template bugs]] | BACKLOG | | | Fix include guard regression and any other systematic template bugs found in the audit. |
+| [[id:D2E8F4A1-9B3C-4D7F-6A5B-8E1C7D3F9A2B][Fix model consistency and register C++ components in manifest.py]] | BACKLOG | | | Verify and fix component_include/component_core in all 75 models; add all components to manifest.py. |
+| [[id:B5F1C8D3-4A7E-4B2F-9D6C-3E8A1B5D7C4F][Resolve breaking API drift]] | BACKLOG | | | For each breaking change in the drift catalog, decide: freeze template or update production code and callers. |
+| [[id:C8A4D7F1-2E6B-4C3A-8F9D-5B1E3C8D2F7A][Apply safe drift and verify zero diff across all components]] | BACKLOG | | | Apply cosmetic and additive diffs component by component; apply any decided production updates; confirm zero diff and CI green. |
+
+* Notes
+
+** Known breaking changes from the three-entity sample
+
+A dry run on =rounding_type=, =monetary_nature=, and =currency_market_tier= (the three
+auxiliary refdata entities) produced 42 files differing. The following breaking changes
+were observed:
+
+| Change | Details | Callers affected |
+|--------+---------+------------------|
+| Method rename: =find_type= → =get_type= | Service layer method to locate a type by code | =ores.analytics.core=, =ores.iam.core=, =ores.trading.core=, =ores.reporting.core=, =ores.refdata.core= |
+| Include guard regression | =ORES_REFDATA_DOMAIN_*= instead of =ORES_REFDATA_API_DOMAIN_*= | All 75 models using =component_include= |
+| =save_types()= removal | Batch write removed from repository/service | =ores.trading.core= (8 services), =ores.refdata.core= (6 services), =ores.iam.core= (1 service) |
+| =remove_types()= removal | Batch delete removed from repository/service | Same callers as above |
+| =stamp()= removal | Service implementations no longer stamp records | Unknown |
+| =display_order = 0= default | Initializer added to domain type | Cosmetic/additive |
+
+The include guard regression is a template bug (always wrong); the others are template
+evolution that diverged from the production API. All will be classified and decided in
+Tasks 1 and 4.
+
+** Component-to-project mapping
+
+Based on the audit, the known component-to-project mappings are:
+
+| Component in model | =component_include= | =component_core= |
+|--------------------+---------------------+------------------|
+| =refdata= | =refdata.api= | =refdata.core= |
+| =trading= | =trading.api= | =trading.core= |
+| =iam= | =iam.api= | =iam.core= |
+| =dq= | =dq.api= | =dq.core= |
+| =analytics= | =analytics.api= (TBC) | =analytics.core= (TBC) |
+| =reporting= | =reporting.api= (TBC) | =reporting.core= (TBC) |
+
+The =component= field alone resolves to =projects/ores.<component>/= which does not match
+the production project layout for any of the above. Every model must have explicit
+=component_include= / =component_core= fields.
+
+** Scale relative to SQL refactoring
+
+| Dimension | SQL refactoring | C++ refactoring |
+|-----------+-----------------+-----------------|
+| Templates | 2 → 1 (unified) | 60 (fix bugs, no merging) |
+| Models | 10 | 75 |
+| Output files | ~30 SQL files | ~1,746 C++ files |
+| Components | 1 (refdata pilot) | 8+ component pairs |
+| Breaking changes | None | 4+ known |

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_apply_safe_drift.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_apply_safe_drift.org
@@ -61,7 +61,7 @@ A zero exit code from =git diff= for every component is the acceptance gate.
 |--------------+----------------------------------------|
 | State        | BACKLOG                                |
 | Parent story | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] |
-| Now          | Nothing.                               |
+| Now          | Not yet started.                       |
 | Waiting on   | [[id:B5F1C8D3-4A7E-4B2F-9D6C-3E8A1B5D7C4F][Resolve breaking API drift]] |
 | Next         | Start once all breaking changes are resolved. |
 | Last touched | 2026-05-30                             |
@@ -86,6 +86,7 @@ A zero exit code from =git diff= for every component is the acceptance gate.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
+| 1 | =Now= field should be =Not yet started.= for BACKLOG tasks, not =Nothing.= | task_apply_safe_drift.org | Fixed | PR #940 round 1. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_apply_safe_drift.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_apply_safe_drift.org
@@ -1,0 +1,92 @@
+:PROPERTIES:
+:ID: C8A4D7F1-2E6B-4C3A-8F9D-5B1E3C8D2F7A
+:END:
+#+title: Task: Apply safe drift and verify zero diff across all components
+#+description: Apply all cosmetic and additive diffs component by component; apply any decided production updates from the breaking changes task; confirm zero-diff regeneration for all registered components and CI green.
+#+type: task
+#+level: s1
+#+filetags: :refactor_codegen_cpp:sprint_19:v0:
+#+owner: marco
+#+branch: feature/refactor-codegen-cpp
+#+pr:
+#+blocked_on: B5F1C8D3-4A7E-4B2F-9D6C-3E8A1B5D7C4F
+#+blocked_since:
+#+created: 2026-05-30
+#+updated: 2026-05-30
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+With template bugs fixed ([[id:F7B3E1D9-6A4C-4F2B-7E8D-1C5A9B3F7D2E][Fix C++ template bugs]]), models corrected ([[id:D2E8F4A1-9B3C-4D7F-6A5B-8E1C7D3F9A2B][Fix model consistency
+and register C++ components in manifest.py]]), and all breaking change decisions made
+([[id:B5F1C8D3-4A7E-4B2F-9D6C-3E8A1B5D7C4F][Resolve breaking API drift]]), this task applies the remaining safe drift component by
+component and confirms the zero-diff invariant.
+
+** Process per component
+
+For each registered component (refdata first, then trading, iam, dq, and others):
+
+1. Run =codegen.sh regenerate --component X --profile all-cpp=.
+2. Run =git diff --stat=.
+3. If diff is non-zero: categorise the remaining changes. All should be cosmetic or
+   additive at this point (breaking changes were resolved in Task 4).
+4. Review the diff; if it matches expectations, accept it and commit.
+5. Run the CI suite (or at minimum =cmake --build= + =ctest=) to confirm no regressions.
+6. Record: component name, files changed, diff summary, CI result.
+
+** Pilot: refdata
+
+Refdata is done first. Three of its auxiliary domain entity models already have correct
+=component_include= / =component_core= (fixed in PR #939). Remaining refdata domain
+entities (book, counterparty, party, etc.) may need cosmetic updates.
+
+** Final verification
+
+After all components are done:
+
+#+begin_example
+for component in refdata-cpp trade-cpp dq-cpp iam-cpp ...; do
+    codegen.sh regenerate --component ${component} --profile all-cpp
+    git diff --exit-code   # must be zero
+done
+#+end_example
+
+A zero exit code from =git diff= for every component is the acceptance gate.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                                |
+| Parent story | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] |
+| Now          | Nothing.                               |
+| Waiting on   | [[id:B5F1C8D3-4A7E-4B2F-9D6C-3E8A1B5D7C4F][Resolve breaking API drift]] |
+| Next         | Start once all breaking changes are resolved. |
+| Last touched | 2026-05-30                             |
+
+* Acceptance
+
+- All registered components regenerate with zero diff (=git diff --exit-code= passes).
+- CI passes after each component regeneration.
+- Per-component summary recorded in =* Result=: files changed, diff line count.
+- =codegen.sh regenerate --component X --profile all-cpp= is documented as the canonical
+  regeneration command in =architecture.org=.
+- Findings recorded in =* Result= section.
+- Site builds cleanly.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+
+* Result
+
+(Populated when task is complete.)

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_audit_cpp_drift.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_audit_cpp_drift.org
@@ -1,0 +1,76 @@
+:PROPERTIES:
+:ID: A4C9D7F2-3E5B-4A1C-8F6D-9B2E7A4C1D8F
+:END:
+#+title: Task: Audit C++ template drift and build drift catalog
+#+description: Run codegen for all 75 _domain_entity.json models; collect diffs against the repo; classify each diff as clean / cosmetic / additive / breaking / path-error; produce a catalog table.
+#+type: task
+#+level: s1
+#+filetags: :refactor_codegen_cpp:sprint_19:v0:
+#+owner: marco
+#+branch: feature/refactor-codegen-cpp
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-30
+#+updated: 2026-05-30
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Run =codegen.py generate --model X --profile all-cpp= for every =_domain_entity.json=
+model in =projects/ores.codegen/models/=. Collect the diff between what the generator
+produces and what is currently in the repository. Classify each per-model diff as one of:
+
+| Category | Definition |
+|----------+------------|
+| =clean= | Zero diff. Template and production agree byte-for-byte. |
+| =cosmetic= | Whitespace, comment rewrap, copyright year, or other non-semantic changes only. |
+| =additive= | New method, member, or construct added; no existing production API removed or renamed. |
+| =breaking= | Existing production API renamed, removed, or signature-changed. |
+| =path-error= | Generator writes to wrong directory due to missing or incorrect =component_include= / =component_core=. |
+
+A model may fall into multiple categories (e.g., =additive= + =breaking=). The primary
+category is the worst one present.
+
+The catalog is the primary deliverable that drives every subsequent task in the story.
+It makes the full scope visible before any code is changed.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                                |
+| Parent story | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] |
+| Now          | Nothing.                               |
+| Waiting on   | Nothing.                               |
+| Next         | Start once story branch is created.    |
+| Last touched | 2026-05-30                             |
+
+* Acceptance
+
+- All 75 =_domain_entity.json= models processed.
+- Per-model classification recorded in the =* Result= drift catalog table.
+- All breaking changes itemised with: method name, change type, and affected callers (file
+  paths and component names).
+- All path-errors itemised with: model file, current =component= value, and the correct
+  =component_include= / =component_core= target.
+- Known issues from [[id:E8890097-FAE9-40F8-B823-FCE23BAFD6C5][Verify and fix codegen for currency and auxiliaries]] confirmed or updated.
+- Findings recorded in =* Result= section.
+- Site builds cleanly.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+
+* Result
+
+(Populated when task is complete.)

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_audit_cpp_drift.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_audit_cpp_drift.org
@@ -43,7 +43,7 @@ It makes the full scope visible before any code is changed.
 |--------------+----------------------------------------|
 | State        | BACKLOG                                |
 | Parent story | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] |
-| Now          | Nothing.                               |
+| Now          | Not yet started.                       |
 | Waiting on   | Nothing.                               |
 | Next         | Start once story branch is created.    |
 | Last touched | 2026-05-30                             |
@@ -70,6 +70,7 @@ It makes the full scope visible before any code is changed.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
+| 1 | =Now= field should be =Not yet started.= for BACKLOG tasks, not =Nothing.= | task_audit_cpp_drift.org | Fixed | PR #940 round 1. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_fix_model_consistency.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_fix_model_consistency.org
@@ -64,7 +64,7 @@ must be unambiguous: =--profile sql= and =--profile all-cpp= must not interfere.
 |--------------+----------------------------------------|
 | State        | BACKLOG                                |
 | Parent story | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] |
-| Now          | Nothing.                               |
+| Now          | Not yet started.                       |
 | Waiting on   | [[id:A4C9D7F2-3E5B-4A1C-8F6D-9B2E7A4C1D8F][Audit C++ template drift]] (for confirmed path-error list). |
 | Next         | Start once drift audit is complete.    |
 | Last touched | 2026-05-30                             |
@@ -91,6 +91,7 @@ must be unambiguous: =--profile sql= and =--profile all-cpp= must not interfere.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
+| 1 | =Now= field should be =Not yet started.= for BACKLOG tasks, not =Nothing.= | task_fix_model_consistency.org | Fixed | PR #940 round 1. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_fix_model_consistency.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_fix_model_consistency.org
@@ -1,0 +1,97 @@
+:PROPERTIES:
+:ID: D2E8F4A1-9B3C-4D7F-6A5B-8E1C7D3F9A2B
+:END:
+#+title: Task: Fix model consistency and register C++ components in manifest.py
+#+description: Verify and fix component_include/component_core in all 75 domain entity models; add C++ component entries to manifest.py so codegen regenerate --component X --profile all-cpp works for every component.
+#+type: task
+#+level: s1
+#+filetags: :refactor_codegen_cpp:sprint_19:v0:
+#+owner: marco
+#+branch: feature/refactor-codegen-cpp
+#+pr:
+#+blocked_on: A4C9D7F2-3E5B-4A1C-8F6D-9B2E7A4C1D8F
+#+blocked_since:
+#+created: 2026-05-30
+#+updated: 2026-05-30
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Two related fixes that must happen before any bulk regeneration:
+
+** Part A — model consistency
+
+Approximately 70% of the 75 =_domain_entity.json= models lack explicit =component_include=
+and =component_core= fields. Without these fields, =codegen.py= defaults to the =component=
+value (e.g., =refdata=), which resolves to =projects/ores.refdata/= — a path that does not
+exist for any component. The generator silently creates that path, generating new untracked
+files instead of updating the production ones.
+
+For every model:
+1. Read the =component= field.
+2. Determine the correct =component_include= and =component_core= from the
+   component-to-project mapping table (see story notes).
+3. If the fields are absent or wrong, add / correct them.
+4. Verify via dry-run that output paths resolve to =projects/ores.<component_include>/=
+   and =projects/ores.<component_core>/=.
+
+The three auxiliary refdata models (=rounding_type=, =monetary_nature=,
+=currency_market_tier=) were fixed in [[id:E8890097-FAE9-40F8-B823-FCE23BAFD6C5][Verify and fix codegen for currency and auxiliaries]]
+and are already correct. All others are unverified.
+
+** Part B — C++ component registry
+
+=manifest.py= currently has entries only for SQL generation:
+- =refdata= → =*_table.json=
+- =trade=, =dq=, =iam= → =*_entity.json=
+
+None of these support =--profile all-cpp=. Add a C++ component entry for every component
+that has =_domain_entity.json= models. Each entry needs:
+- =name= — component short name (e.g., =refdata-cpp=, or an overloaded =refdata= that
+  selects models by suffix)
+- =models_dir= — path to the models directory
+- =entity_glob= — =*_domain_entity.json=
+
+The exact naming convention (separate =refdata-cpp= component or shared =refdata= with
+glob switching) is an open design decision to be resolved at implementation time. The CLI
+must be unambiguous: =--profile sql= and =--profile all-cpp= must not interfere.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                                |
+| Parent story | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] |
+| Now          | Nothing.                               |
+| Waiting on   | [[id:A4C9D7F2-3E5B-4A1C-8F6D-9B2E7A4C1D8F][Audit C++ template drift]] (for confirmed path-error list). |
+| Next         | Start once drift audit is complete.    |
+| Last touched | 2026-05-30                             |
+
+* Acceptance
+
+- All 75 =_domain_entity.json= models have correct =component_include= and =component_core=
+  fields (or confirmed correct defaults where the default resolves to the right path).
+- Dry-run for each model shows output paths under =projects/ores.<component_include>/= and
+  =projects/ores.<component_core>/=. No model writes to an untracked directory.
+- =manifest.py= has C++ component entries for every component that has domain entity models.
+- =codegen.sh regenerate --component X --profile all-cpp= is a valid command for each
+  registered component and lists the correct model files.
+- Findings recorded in =* Result= section.
+- Site builds cleanly.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+
+* Result
+
+(Populated when task is complete.)

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_fix_template_bugs.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_fix_template_bugs.org
@@ -1,0 +1,83 @@
+:PROPERTIES:
+:ID: F7B3E1D9-6A4C-4F2B-7E8D-1C5A9B3F7D2E
+:END:
+#+title: Task: Fix C++ template bugs
+#+description: Fix the include guard regression and any other systematic template bugs identified in the drift audit. Verify all templates produce correct output before any bulk regeneration.
+#+type: task
+#+level: s1
+#+filetags: :refactor_codegen_cpp:sprint_19:v0:
+#+owner: marco
+#+branch: feature/refactor-codegen-cpp
+#+pr:
+#+blocked_on: A4C9D7F2-3E5B-4A1C-8F6D-9B2E7A4C1D8F
+#+blocked_since:
+#+created: 2026-05-30
+#+updated: 2026-05-30
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Fix every systematic template bug identified in [[id:A4C9D7F2-3E5B-4A1C-8F6D-9B2E7A4C1D8F][Audit C++ template drift and build drift
+catalog]]. One known bug must be fixed before any bulk regeneration can start:
+
+** Known bug: include guard regression
+
+The C++ domain type header templates generate include guards using the =component_include=
+path when available. A pre-existing bug constructs the guard symbol incorrectly:
+
+- *Template emits*: =ORES_REFDATA_DOMAIN_ROUNDING_TYPE_HPP=
+- *Correct guard*: =ORES_REFDATA_API_DOMAIN_ROUNDING_TYPE_HPP=
+
+The =_API_= segment is derived from the last part of =component_include= (=refdata.api=
+→ =API=), but the current template logic drops it. This affects every model that sets
+=component_include= to a path ending in =.api=.
+
+The fix must:
+1. Locate the include guard construction in the affected header templates.
+2. Correct the symbol to include the =API= (or =CORE=) segment from =component_include=.
+3. Verify the fixed guard matches what is in the production headers.
+
+Any additional bugs found in the drift audit are fixed in this task too.
+
+Template bug fixes must be completed *before* any bulk regeneration in Task 5, because
+regenerating with a buggy template would corrupt production include guards.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                                |
+| Parent story | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] |
+| Now          | Nothing.                               |
+| Waiting on   | [[id:A4C9D7F2-3E5B-4A1C-8F6D-9B2E7A4C1D8F][Audit C++ template drift]] (for any additional bugs). |
+| Next         | Start once drift audit is complete.    |
+| Last touched | 2026-05-30                             |
+
+* Acceptance
+
+- Include guard regression fixed: =ORES_REFDATA_API_DOMAIN_*= (not =ORES_REFDATA_DOMAIN_*=)
+  generated for models with =component_include= ending in =.api=.
+- All other systematic template bugs from the drift audit fixed.
+- Dry-run across all 75 models produces no malformed include guards.
+- Template fixes verified by checking at least one production header per component.
+- No change to template behaviour for models that do not use =component_include= (guard
+  construction for those models is unchanged).
+- Findings recorded in =* Result= section.
+- Site builds cleanly.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+
+* Result
+
+(Populated when task is complete.)

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_fix_template_bugs.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_fix_template_bugs.org
@@ -50,7 +50,7 @@ regenerating with a buggy template would corrupt production include guards.
 |--------------+----------------------------------------|
 | State        | BACKLOG                                |
 | Parent story | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] |
-| Now          | Nothing.                               |
+| Now          | Not yet started.                       |
 | Waiting on   | [[id:A4C9D7F2-3E5B-4A1C-8F6D-9B2E7A4C1D8F][Audit C++ template drift]] (for any additional bugs). |
 | Next         | Start once drift audit is complete.    |
 | Last touched | 2026-05-30                             |
@@ -77,6 +77,7 @@ regenerating with a buggy template would corrupt production include guards.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
+| 1 | =Now= field should be =Not yet started.= for BACKLOG tasks, not =Nothing.= | task_fix_template_bugs.org | Fixed | PR #940 round 1. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_resolve_breaking_changes.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_resolve_breaking_changes.org
@@ -56,7 +56,7 @@ that some of these are not present across all entities. Final decisions are reco
 |--------------+----------------------------------------|
 | State        | BACKLOG                                |
 | Parent story | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] |
-| Now          | Nothing.                               |
+| Now          | Not yet started.                       |
 | Waiting on   | [[id:A4C9D7F2-3E5B-4A1C-8F6D-9B2E7A4C1D8F][Audit C++ template drift]] (for complete breaking change list). |
 | Next         | Start once drift audit is complete.    |
 | Last touched | 2026-05-30                             |
@@ -83,6 +83,7 @@ that some of these are not present across all entities. Final decisions are reco
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
+| 1 | =Now= field should be =Not yet started.= for BACKLOG tasks, not =Nothing.= | task_resolve_breaking_changes.org | Fixed | PR #940 round 1. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_resolve_breaking_changes.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_resolve_breaking_changes.org
@@ -1,0 +1,89 @@
+:PROPERTIES:
+:ID: B5F1C8D3-4A7E-4B2F-9D6C-3E8A1B5D7C4F
+:END:
+#+title: Task: Resolve breaking API drift
+#+description: For every breaking change in the drift catalog, make an explicit decision: freeze the template to preserve the existing API, or update production code and all callers. No breaking change is silently discarded.
+#+type: task
+#+level: s1
+#+filetags: :refactor_codegen_cpp:sprint_19:v0:
+#+owner: marco
+#+branch: feature/refactor-codegen-cpp
+#+pr:
+#+blocked_on: A4C9D7F2-3E5B-4A1C-8F6D-9B2E7A4C1D8F
+#+blocked_since:
+#+created: 2026-05-30
+#+updated: 2026-05-30
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The drift audit ([[id:A4C9D7F2-3E5B-4A1C-8F6D-9B2E7A4C1D8F][Audit C++ template drift and build drift catalog]]) identifies all breaking
+changes: existing production API renamed, removed, or signature-changed. For each one,
+make and record an explicit decision.
+
+Two outcomes are possible per breaking change:
+
+| Decision | Meaning | Action |
+|----------+---------+--------|
+| *Template frozen* | The production API is the contract; the template is wrong. | Revert the template change so it matches the production file. Document what was reverted and why. |
+| *Production updated* | The template represents the improved design; production must follow. | Update all callers of the old API across all components. Regenerate affected files. Verify CI. |
+
+"Production updated" decisions can only be made for changes where:
+1. The caller update is tractable (no widespread caller network, or callers can be updated
+   in the same PR).
+2. The new API is strictly better (not just different).
+3. The change does not break any user-facing contract (CLI, shell, Qt UI).
+
+** Known breaking changes from the three-entity sample
+
+| Change | Tentative decision | Rationale |
+|--------+--------------------+-----------|
+| =find_type= → =get_type= rename | Template frozen (keep =find_type=) | Callers in 5+ components; rename is cosmetic; high risk with no functional benefit. |
+| =save_types()= removal | Template frozen (keep =save_types=) | Actively used in messaging handlers across trading, refdata, iam; removal breaks NATS ingestion. |
+| =remove_types()= removal | Template frozen (keep =remove_types=) | Same handler usage as =save_types=. |
+| =stamp()= removal | Verify in audit | Need to confirm whether =stamp()= is used in callers before deciding. |
+| =display_order = 0= default | Additive (not breaking) | Does not remove any existing API; classify as additive in audit. |
+
+These are tentative. The drift audit may reveal additional breaking changes or may confirm
+that some of these are not present across all entities. Final decisions are recorded in the
+=* Result= section of this task.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                                |
+| Parent story | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] |
+| Now          | Nothing.                               |
+| Waiting on   | [[id:A4C9D7F2-3E5B-4A1C-8F6D-9B2E7A4C1D8F][Audit C++ template drift]] (for complete breaking change list). |
+| Next         | Start once drift audit is complete.    |
+| Last touched | 2026-05-30                             |
+
+* Acceptance
+
+- Every breaking change from the drift catalog has a recorded decision (template frozen or
+  production updated).
+- For "template frozen" decisions: the template is updated to match the production API;
+  the decision and rationale are recorded.
+- For "production updated" decisions: all callers across all components are updated; CI
+  passes; the update scope and affected files are recorded.
+- No breaking change is left in an ambiguous or unresolved state.
+- Findings recorded in =* Result= section.
+- Site builds cleanly.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+
+* Result
+
+(Populated when task is complete.)

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -67,7 +67,8 @@ and file backlog captures for Wt and HTTP gaps. One story per entity.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]] | STARTED | 2026-05-29 | | Unified SQL template + model format + codegen.py CLI replacing all generate_*_schema.sh scripts. |
+| [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]] | DONE | 2026-05-29 | 2026-05-30 | Unified SQL template + model format + codegen.py CLI replacing all generate_*_schema.sh scripts. |
+| [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] | BACKLOG | | | Audit and resolve all drift between C++ templates and production files; fix template bugs; fix model consistency; zero-diff invariant. |
 
 ** Agile
 

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -47,7 +47,7 @@ and file backlog captures for Wt and HTTP gaps. One story per entity.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] | BLOCKED | | | Verify Qt + shell + CLI (existing); manual; Wt/HTTP captures. Blocked on [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][codegen story]]. |
+| [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] | STARTED | | | Verify Qt + shell + CLI (existing); manual; Wt/HTTP captures. Codegen task done; shell/NATS/Qt next. |
 | [[id:F0FC905B-6A70-486F-A23F-0064B6A3EE75][Commission: country]] | BACKLOG | | | Verify Qt + shell + CLI (existing); manual; Wt/HTTP captures. |
 | [[id:FA87AB1F-E0ED-4AC3-A41E-43321626B77C][Commission: party]] | BACKLOG | | | Verify Qt; implement shell + CLI; manual; Wt/HTTP captures. |
 | [[id:59583AFF-7657-4F79-BB7E-2086BCA04A91][Commission: party_type]] | BACKLOG | | | Verify Qt; implement shell + CLI; manual; Wt/HTTP captures. |


### PR DESCRIPTION
## Summary

- New story: **Refactor ores.codegen C++ generation** (broad-scope, 5 tasks)
  - Task 1: Audit C++ template drift and build drift catalog (75 models × all-cpp)
  - Task 2: Fix C++ template bugs (include guard regression + others from audit)
  - Task 3: Fix model consistency + register C++ components in manifest.py
  - Task 4: Resolve breaking API drift (find_type rename, save_types/remove_types removal)
  - Task 5: Apply safe drift and verify zero diff across all components
- Mark `refactor_codegen_sql` story as DONE in sprint.org (it was still STARTED)
- Add C++ story to sprint 19 Tooling section

## Context

The SQL refactoring (sprint 19, PR #934–#938) established a zero-diff invariant for SQL generation. This story does the same for C++: ~75 domain entity models, ~1,746 production C++ files across 8 component pairs. Known issues include an include guard regression and template drift with breaking API changes (method renames, batch method removals) that have callers across 5+ components.

## Test plan

- [ ] Site builds cleanly
- [ ] All 6 new org files have valid structure and correct UUIDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)