### PR TITLE
[codegen] Fix model consistency and register cpp components (Task 2)

### DIFF
--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_fix_model_consistency.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_fix_model_consistency.org
@@ -62,11 +62,11 @@ must be unambiguous: =--profile sql= and =--profile all-cpp= must not interfere.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                                |
+| State        | DONE                                   |
 | Parent story | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] |
-| Now          | Not yet started.                       |
-| Waiting on   | [[id:A4C9D7F2-3E5B-4A1C-8F6D-9B2E7A4C1D8F][Audit C++ template drift]] (for confirmed path-error list). |
-| Next         | Start once drift audit is complete.    |
+| Now          | Nothing.                               |
+| Waiting on   | Nothing.                               |
+| Next         | Task 3: Fix C++ template bugs.         |
 | Last touched | 2026-05-30                             |
 
 * Acceptance
@@ -95,4 +95,56 @@ must be unambiguous: =--profile sql= and =--profile all-cpp= must not interfere.
 
 * Result
 
-(Populated when task is complete.)
+** Part A — model consistency
+
+42 =_domain_entity.json= models updated to add =component_include= and =component_core=.
+One model excluded: =database/database_info= (flat component; =ores.database= has no
+api/core split and generates to the correct path without these fields).
+
+Component mapping applied:
+
+| Component | component_include | component_core | Models fixed |
+|-----------+-------------------+----------------+--------------|
+| analytics | (already set) | (already set) | 0 |
+| compute | =compute.api= | =compute.core= | 6 |
+| controller | =controller.api= | =controller.core= | 2 |
+| database | n/a — flat component | n/a | 0 |
+| dq | =dq.api= | =dq.core= | 4 |
+| iam | =iam.api= | =iam.core= | 4 |
+| refdata | =refdata.api= | =refdata.core= | 11 |
+| reporting | =reporting.api= | =reporting.core= | 3 |
+| scheduler | =scheduler.api= | =scheduler.core= | 1 |
+| trading | =trading.api= | =trading.core= | 9 |
+| workflow | =workflow.api= | =workflow.core= | 2 |
+| workspace | (already set) | (already set) | 0 |
+| *Total* | | | *42* |
+
+Spot-checked with =--dry-run=: compute/app → =ores.compute.api=, iam/tenant →
+=ores.iam.api=, refdata/party → =ores.refdata.api=, trading/leg_type →
+=ores.trading.api=, workflow/workflow_instance → =ores.workflow.api=. All correct.
+
+** Part B — C++ component registry
+
+=manifest.py= extended with 12 new C++ component entries (one per component that has
+=_domain_entity.json= models). The =Component.exclude_suffix= field now supports =None=
+meaning "no exclusion"; =generate.py= updated to handle this. =exclude_suffix=""= was
+wrong — =str.endswith("")= is always =True=, excluding every file.
+
+| Component name | models_dir | Models |
+|----------------+------------+--------|
+| =analytics-cpp= | =models/analytics= | 4 |
+| =compute-cpp= | =models/compute= | 6 |
+| =controller-cpp= | =models/controller= | 2 |
+| =database-cpp= | =models/database= | 1 |
+| =dq-cpp= | =models/dq= | 4 |
+| =iam-cpp= | =models/iam= | 4 |
+| =refdata-cpp= | =models/refdata= | 25 |
+| =reporting-cpp= | =models/reporting= | 4 |
+| =scheduler-cpp= | =models/scheduler= | 1 |
+| =trading-cpp= | =models/trading= | 21 |
+| =workflow-cpp= | =models/workflow= | 2 |
+| =workspace-cpp= | =models/workspace= | 1 |
+| *Total* | | *75* |
+
+All 12 components verified: =codegen.py regenerate --component X --profile all-cpp --dry-run=
+produces zero errors and zero warnings for every component.

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_fix_model_consistency.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_fix_model_consistency.org
@@ -85,7 +85,7 @@ must be unambiguous: =--profile sql= and =--profile all-cpp= must not interfere.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/943][#943]] | [codegen] Fix model consistency and register cpp components (Task 2) |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_fix_model_consistency.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_fix_model_consistency.org
@@ -92,6 +92,7 @@ must be unambiguous: =--profile sql= and =--profile all-cpp= must not interfere.
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
 | 1 | =Now= field should be =Not yet started.= for BACKLOG tasks, not =Nothing.= | task_fix_model_consistency.org | Fixed | PR #940 round 1. |
+| 2 | =exclude_suffix= type hint should be =Optional[str]= since it can now be =None= | manifest.py | Fixed | PR #943 round 1. |
 
 * Result
 

--- a/projects/ores.codegen/models/compute/app_domain_entity.json
+++ b/projects/ores.codegen/models/compute/app_domain_entity.json
@@ -3,20 +3,20 @@
     "schema": "public",
     "product": "ores",
     "component": "compute",
+    "component_include": "compute.api",
+    "component_core": "compute.core",
     "entity_singular": "app",
     "entity_plural": "apps",
     "entity_title": "App",
     "has_tenant_id": true,
     "brief": "A registered application engine in the compute grid.",
     "description": "Represents the high-level definition of an engine that can be executed on\ngrid nodes (e.g., ORE_STUDIO, LLAMA_CPP, LEDGER). The BOINC equivalent of 'app'.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
       "cpp_type": "boost::uuids::uuid",
       "description": "UUID primary key for the app."
     },
-
     "natural_keys": [
       {
         "column": "name",
@@ -25,7 +25,6 @@
         "description": "Unique application identifier, e.g. 'ORE_STUDIO', 'LLAMA_CPP', 'LEDGER'."
       }
     ],
-
     "columns": [
       {
         "name": "description",
@@ -35,25 +34,23 @@
         "description": "Human-readable description of the application engine."
       }
     ],
-
     "sql": {
       "tablename": "ores_compute_apps_tbl"
     },
-
     "repository": {
       "entity_singular_short": "app",
       "entity_plural_short": "apps",
       "entity_singular_words": "compute app",
       "entity_plural_words": "compute apps"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<string>"]
+        "domain": [
+          "<string>"
+        ]
       },
       "iterator_var": "a"
     },
-
     "qt": {
       "domain_include": "ores.compute/domain/app.hpp",
       "domain_class": "compute::domain::app",
@@ -63,17 +60,38 @@
       "key_field": "name",
       "has_uuid_primary_key": true,
       "has_pagination": true,
-
       "get_request_class": "compute::messaging::list_apps_request",
       "get_response_class": "compute::messaging::list_apps_response",
-
       "columns": [
-        {"enum_name": "Name",        "field": "name",        "header": "Name",        "is_string": true, "width": 160},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 300},
-        {"enum_name": "Version",     "field": "version",     "header": "Version",     "is_int": true,    "width": 60},
-        {"enum_name": "ModifiedBy",  "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120}
+        {
+          "enum_name": "Name",
+          "field": "name",
+          "header": "Name",
+          "is_string": true,
+          "width": 160
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 300
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 60
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        }
       ],
-
       "settings_group": "AppListWindow",
       "window_title": "Compute Apps",
       "icon": "Apps"

--- a/projects/ores.codegen/models/compute/app_version_domain_entity.json
+++ b/projects/ores.codegen/models/compute/app_version_domain_entity.json
@@ -3,20 +3,20 @@
     "schema": "public",
     "product": "ores",
     "component": "compute",
+    "component_include": "compute.api",
+    "component_core": "compute.core",
     "entity_singular": "app_version",
     "entity_plural": "app_versions",
     "entity_title": "App Version",
     "has_tenant_id": true,
     "brief": "A versioned wrapper+engine bundle for a compute grid application.",
-    "description": "Combines a specific wrapper version with a specific engine version. The BOINC\nequivalent of 'app_version'. Per-platform package artefacts are tracked in\nores_compute_app_version_platforms_tbl — each (app_version, platform) row owns\nthe URI of its own packaged bundle.",
-
+    "description": "Combines a specific wrapper version with a specific engine version. The BOINC\nequivalent of 'app_version'. Per-platform package artefacts are tracked in\nores_compute_app_version_platforms_tbl \u2014 each (app_version, platform) row owns\nthe URI of its own packaged bundle.",
     "primary_key": {
       "column": "id",
       "type": "uuid",
       "cpp_type": "boost::uuids::uuid",
       "description": "UUID primary key for the app version."
     },
-
     "columns": [
       {
         "name": "app_id",
@@ -48,7 +48,6 @@
         "description": "Minimum RAM in MB required by the node to run this app version."
       }
     ],
-
     "indexes": [
       {
         "name": "app_id",
@@ -57,25 +56,24 @@
         "current_only": true
       }
     ],
-
     "sql": {
       "tablename": "ores_compute_app_versions_tbl"
     },
-
     "repository": {
       "entity_singular_short": "app_version",
       "entity_plural_short": "app_versions",
       "entity_singular_words": "app version",
       "entity_plural_words": "app versions"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<string>", "<boost/uuid/uuid.hpp>"]
+        "domain": [
+          "<string>",
+          "<boost/uuid/uuid.hpp>"
+        ]
       },
       "iterator_var": "av"
     },
-
     "qt": {
       "domain_include": "ores.compute/domain/app_version.hpp",
       "domain_class": "compute::domain::app_version",
@@ -85,19 +83,52 @@
       "key_field": "wrapper_version",
       "has_uuid_primary_key": true,
       "has_pagination": true,
-
       "get_request_class": "compute::messaging::list_app_versions_request",
       "get_response_class": "compute::messaging::list_app_versions_response",
-
       "columns": [
-        {"enum_name": "AppId",          "field": "app_id",          "header": "App ID",          "is_uuid": true,   "width": 160},
-        {"enum_name": "WrapperVersion", "field": "wrapper_version", "header": "Wrapper Version", "is_string": true, "width": 120},
-        {"enum_name": "EngineVersion",  "field": "engine_version",  "header": "Engine Version",  "is_string": true, "width": 120},
-        {"enum_name": "MinRamMb",       "field": "min_ram_mb",      "header": "Min RAM (MB)",    "is_int": true,    "width": 90},
-        {"enum_name": "Version",        "field": "version",         "header": "Version",         "is_int": true,    "width": 60},
-        {"enum_name": "ModifiedBy",     "field": "modified_by",     "header": "Modified By",     "is_string": true, "width": 120}
+        {
+          "enum_name": "AppId",
+          "field": "app_id",
+          "header": "App ID",
+          "is_uuid": true,
+          "width": 160
+        },
+        {
+          "enum_name": "WrapperVersion",
+          "field": "wrapper_version",
+          "header": "Wrapper Version",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "EngineVersion",
+          "field": "engine_version",
+          "header": "Engine Version",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "MinRamMb",
+          "field": "min_ram_mb",
+          "header": "Min RAM (MB)",
+          "is_int": true,
+          "width": 90
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 60
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        }
       ],
-
       "settings_group": "AppVersionListWindow",
       "window_title": "App Versions",
       "icon": "Code"

--- a/projects/ores.codegen/models/compute/batch_domain_entity.json
+++ b/projects/ores.codegen/models/compute/batch_domain_entity.json
@@ -3,20 +3,20 @@
     "schema": "public",
     "product": "ores",
     "component": "compute",
+    "component_include": "compute.api",
+    "component_core": "compute.core",
     "entity_singular": "batch",
     "entity_plural": "batches",
     "entity_title": "Batch",
     "has_tenant_id": true,
     "brief": "A logical grouping of workunits forming a financial computation batch.",
     "description": "Tracks the lifecycle of a collection of workunits that together constitute a\nfinancial computation (e.g., a risk report run). The Assimilator monitors\nbatch completion to trigger downstream report generation.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
       "cpp_type": "boost::uuids::uuid",
       "description": "UUID primary key for the batch."
     },
-
     "natural_keys": [
       {
         "column": "external_ref",
@@ -25,7 +25,6 @@
         "description": "External reference linking this batch to the originating finance system or project."
       }
     ],
-
     "columns": [
       {
         "name": "status",
@@ -36,25 +35,23 @@
         "description": "Lifecycle status: open, processing, assimilating, or closed."
       }
     ],
-
     "sql": {
       "tablename": "ores_compute_batches_tbl"
     },
-
     "repository": {
       "entity_singular_short": "batch",
       "entity_plural_short": "batches",
       "entity_singular_words": "compute batch",
       "entity_plural_words": "compute batches"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<string>"]
+        "domain": [
+          "<string>"
+        ]
       },
       "iterator_var": "b"
     },
-
     "qt": {
       "domain_include": "ores.compute/domain/batch.hpp",
       "domain_class": "compute::domain::batch",
@@ -64,17 +61,38 @@
       "key_field": "external_ref",
       "has_uuid_primary_key": true,
       "has_pagination": true,
-
       "get_request_class": "compute::messaging::list_batches_request",
       "get_response_class": "compute::messaging::list_batches_response",
-
       "columns": [
-        {"enum_name": "ExternalRef", "field": "external_ref", "header": "Reference",   "is_string": true, "width": 200},
-        {"enum_name": "Status",      "field": "status",       "header": "Status",      "is_string": true, "width": 100},
-        {"enum_name": "Version",     "field": "version",      "header": "Version",     "is_int": true,    "width": 60},
-        {"enum_name": "ModifiedBy",  "field": "modified_by",  "header": "Modified By", "is_string": true, "width": 120}
+        {
+          "enum_name": "ExternalRef",
+          "field": "external_ref",
+          "header": "Reference",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Status",
+          "field": "status",
+          "header": "Status",
+          "is_string": true,
+          "width": 100
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 60
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        }
       ],
-
       "settings_group": "BatchListWindow",
       "window_title": "Compute Batches",
       "icon": "TextBulletListSquare"

--- a/projects/ores.codegen/models/compute/host_domain_entity.json
+++ b/projects/ores.codegen/models/compute/host_domain_entity.json
@@ -3,20 +3,20 @@
     "schema": "public",
     "product": "ores",
     "component": "compute",
+    "component_include": "compute.api",
+    "component_core": "compute.core",
     "entity_singular": "host",
     "entity_plural": "hosts",
     "entity_title": "Host",
     "has_tenant_id": true,
     "brief": "A registered compute node in the distributed grid.",
     "description": "Represents a physical or virtual machine that participates in the BOINC-inspired\ncompute grid. Tracks hardware capabilities, heartbeat, and accumulated credit.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
       "cpp_type": "boost::uuids::uuid",
       "description": "UUID primary key for the host."
     },
-
     "natural_keys": [
       {
         "column": "external_id",
@@ -25,7 +25,6 @@
         "description": "User-defined name or hostname for the node."
       }
     ],
-
     "columns": [
       {
         "name": "location",
@@ -73,25 +72,25 @@
         "description": "Accumulated work units successfully processed by this host."
       }
     ],
-
     "sql": {
       "tablename": "ores_compute_hosts_tbl"
     },
-
     "repository": {
       "entity_singular_short": "host",
       "entity_plural_short": "hosts",
       "entity_singular_words": "compute host",
       "entity_plural_words": "compute hosts"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<string>", "<cstdint>", "<chrono>"]
+        "domain": [
+          "<string>",
+          "<cstdint>",
+          "<chrono>"
+        ]
       },
       "iterator_var": "h"
     },
-
     "qt": {
       "domain_include": "ores.compute/domain/host.hpp",
       "domain_class": "compute::domain::host",
@@ -101,22 +100,73 @@
       "key_field": "external_id",
       "has_uuid_primary_key": true,
       "has_pagination": true,
-
       "get_request_class": "compute::messaging::list_hosts_request",
       "get_response_class": "compute::messaging::list_hosts_response",
-
       "columns": [
-        {"enum_name": "ExternalId",   "field": "external_id",   "header": "Host ID",       "is_string": true,    "width": 180},
-        {"enum_name": "Location",     "field": "location",      "header": "Location",      "is_string": true,    "width": 120},
-        {"enum_name": "CpuCount",     "field": "cpu_count",     "header": "CPUs",          "is_int": true,       "width": 60},
-        {"enum_name": "RamMb",        "field": "ram_mb",        "header": "RAM (MB)",      "is_int": true,       "width": 80},
-        {"enum_name": "GpuType",      "field": "gpu_type",      "header": "GPU",           "is_string": true,    "width": 100},
-        {"enum_name": "LastRpcTime",  "field": "last_rpc_time", "header": "Last Heartbeat","is_timestamp": true, "width": 140},
-        {"enum_name": "CreditTotal",  "field": "credit_total",  "header": "Credits",       "is_int": true,       "width": 80},
-        {"enum_name": "Version",      "field": "version",       "header": "Version",       "is_int": true,       "width": 60},
-        {"enum_name": "ModifiedBy",   "field": "modified_by",   "header": "Modified By",   "is_string": true,    "width": 120}
+        {
+          "enum_name": "ExternalId",
+          "field": "external_id",
+          "header": "Host ID",
+          "is_string": true,
+          "width": 180
+        },
+        {
+          "enum_name": "Location",
+          "field": "location",
+          "header": "Location",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "CpuCount",
+          "field": "cpu_count",
+          "header": "CPUs",
+          "is_int": true,
+          "width": 60
+        },
+        {
+          "enum_name": "RamMb",
+          "field": "ram_mb",
+          "header": "RAM (MB)",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "GpuType",
+          "field": "gpu_type",
+          "header": "GPU",
+          "is_string": true,
+          "width": 100
+        },
+        {
+          "enum_name": "LastRpcTime",
+          "field": "last_rpc_time",
+          "header": "Last Heartbeat",
+          "is_timestamp": true,
+          "width": 140
+        },
+        {
+          "enum_name": "CreditTotal",
+          "field": "credit_total",
+          "header": "Credits",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 60
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        }
       ],
-
       "settings_group": "HostListWindow",
       "window_title": "Compute Hosts",
       "icon": "Desktop"

--- a/projects/ores.codegen/models/compute/result_domain_entity.json
+++ b/projects/ores.codegen/models/compute/result_domain_entity.json
@@ -3,20 +3,20 @@
     "schema": "public",
     "product": "ores",
     "component": "compute",
+    "component_include": "compute.api",
+    "component_core": "compute.core",
     "entity_singular": "result",
     "entity_plural": "results",
     "entity_title": "Result",
     "has_tenant_id": true,
     "brief": "A specific execution instance of a workunit assigned to a host.",
     "description": "Bridges the workunit definition and the actual execution on a grid node.\nTracks PGMQ lease state, server-side lifecycle (Inactive/Unsent/InProgress/Done),\nand the location of output data. The BOINC equivalent of 'result'.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
       "cpp_type": "boost::uuids::uuid",
       "description": "UUID primary key for the result."
     },
-
     "columns": [
       {
         "name": "workunit_id",
@@ -69,7 +69,6 @@
         "description": "Timestamp when the output was received by the server pool."
       }
     ],
-
     "indexes": [
       {
         "name": "workunit_id",
@@ -90,25 +89,26 @@
         "current_only": true
       }
     ],
-
     "sql": {
       "tablename": "ores_compute_results_tbl"
     },
-
     "repository": {
       "entity_singular_short": "result",
       "entity_plural_short": "results",
       "entity_singular_words": "compute result",
       "entity_plural_words": "compute results"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<string>", "<cstdint>", "<chrono>", "<boost/uuid/uuid.hpp>"]
+        "domain": [
+          "<string>",
+          "<cstdint>",
+          "<chrono>",
+          "<boost/uuid/uuid.hpp>"
+        ]
       },
       "iterator_var": "r"
     },
-
     "qt": {
       "domain_include": "ores.compute/domain/result.hpp",
       "domain_class": "compute::domain::result",
@@ -118,21 +118,66 @@
       "key_field": "modified_by",
       "has_uuid_primary_key": true,
       "has_pagination": true,
-
       "get_request_class": "compute::messaging::list_results_request",
       "get_response_class": "compute::messaging::list_results_response",
-
       "columns": [
-        {"enum_name": "WorkunitId",  "field": "workunit_id",  "header": "Workunit ID",  "is_uuid": true,      "width": 160},
-        {"enum_name": "HostId",      "field": "host_id",      "header": "Host ID",      "is_uuid": true,      "width": 160},
-        {"enum_name": "ServerState", "field": "server_state", "header": "State",        "is_int": true,       "width": 70},
-        {"enum_name": "Outcome",     "field": "outcome",      "header": "Outcome",      "is_int": true,       "width": 70},
-        {"enum_name": "OutputUri",   "field": "output_uri",   "header": "Output URI",   "is_string": true,    "width": 200},
-        {"enum_name": "ReceivedAt",  "field": "received_at",  "header": "Received At",  "is_timestamp": true, "width": 140},
-        {"enum_name": "Version",     "field": "version",      "header": "Version",      "is_int": true,       "width": 60},
-        {"enum_name": "ModifiedBy",  "field": "modified_by",  "header": "Modified By",  "is_string": true,    "width": 120}
+        {
+          "enum_name": "WorkunitId",
+          "field": "workunit_id",
+          "header": "Workunit ID",
+          "is_uuid": true,
+          "width": 160
+        },
+        {
+          "enum_name": "HostId",
+          "field": "host_id",
+          "header": "Host ID",
+          "is_uuid": true,
+          "width": 160
+        },
+        {
+          "enum_name": "ServerState",
+          "field": "server_state",
+          "header": "State",
+          "is_int": true,
+          "width": 70
+        },
+        {
+          "enum_name": "Outcome",
+          "field": "outcome",
+          "header": "Outcome",
+          "is_int": true,
+          "width": 70
+        },
+        {
+          "enum_name": "OutputUri",
+          "field": "output_uri",
+          "header": "Output URI",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "ReceivedAt",
+          "field": "received_at",
+          "header": "Received At",
+          "is_timestamp": true,
+          "width": 140
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 60
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        }
       ],
-
       "settings_group": "ResultListWindow",
       "window_title": "Results",
       "icon": "CheckmarkCircle"

--- a/projects/ores.codegen/models/compute/workunit_domain_entity.json
+++ b/projects/ores.codegen/models/compute/workunit_domain_entity.json
@@ -3,20 +3,20 @@
     "schema": "public",
     "product": "ores",
     "component": "compute",
+    "component_include": "compute.api",
+    "component_core": "compute.core",
     "entity_singular": "workunit",
     "entity_plural": "workunits",
     "entity_title": "Workunit",
     "has_tenant_id": true,
     "brief": "An abstract job template within a compute batch.",
-    "description": "Defines the problem to be solved: which app version to use, where the input\ndata lives, and how many times to run it for redundancy. The BOINC equivalent\nof 'workunit'. Does not track execution state — that belongs to results.",
-
+    "description": "Defines the problem to be solved: which app version to use, where the input\ndata lives, and how many times to run it for redundancy. The BOINC equivalent\nof 'workunit'. Does not track execution state \u2014 that belongs to results.",
     "primary_key": {
       "column": "id",
       "type": "uuid",
       "cpp_type": "boost::uuids::uuid",
       "description": "UUID primary key for the workunit."
     },
-
     "columns": [
       {
         "name": "batch_id",
@@ -70,7 +70,6 @@
         "description": "FK to the validated canonical result; NULL until the Validator accepts a result."
       }
     ],
-
     "indexes": [
       {
         "name": "batch_id",
@@ -85,25 +84,24 @@
         "current_only": true
       }
     ],
-
     "sql": {
       "tablename": "ores_compute_workunits_tbl"
     },
-
     "repository": {
       "entity_singular_short": "workunit",
       "entity_plural_short": "workunits",
       "entity_singular_words": "workunit",
       "entity_plural_words": "workunits"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<string>", "<boost/uuid/uuid.hpp>"]
+        "domain": [
+          "<string>",
+          "<boost/uuid/uuid.hpp>"
+        ]
       },
       "iterator_var": "wu"
     },
-
     "qt": {
       "domain_include": "ores.compute/domain/workunit.hpp",
       "domain_class": "compute::domain::workunit",
@@ -113,20 +111,59 @@
       "key_field": "input_uri",
       "has_uuid_primary_key": true,
       "has_pagination": true,
-
       "get_request_class": "compute::messaging::list_workunits_request",
       "get_response_class": "compute::messaging::list_workunits_response",
-
       "columns": [
-        {"enum_name": "BatchId",         "field": "batch_id",         "header": "Batch ID",         "is_uuid": true,   "width": 160},
-        {"enum_name": "AppVersionId",    "field": "app_version_id",   "header": "App Version ID",   "is_uuid": true,   "width": 160},
-        {"enum_name": "InputUri",        "field": "input_uri",        "header": "Input URI",        "is_string": true, "width": 200},
-        {"enum_name": "Priority",        "field": "priority",         "header": "Priority",         "is_int": true,    "width": 70},
-        {"enum_name": "TargetRedundancy","field": "target_redundancy","header": "Redundancy",       "is_int": true,    "width": 80},
-        {"enum_name": "Version",         "field": "version",          "header": "Version",          "is_int": true,    "width": 60},
-        {"enum_name": "ModifiedBy",      "field": "modified_by",      "header": "Modified By",      "is_string": true, "width": 120}
+        {
+          "enum_name": "BatchId",
+          "field": "batch_id",
+          "header": "Batch ID",
+          "is_uuid": true,
+          "width": 160
+        },
+        {
+          "enum_name": "AppVersionId",
+          "field": "app_version_id",
+          "header": "App Version ID",
+          "is_uuid": true,
+          "width": 160
+        },
+        {
+          "enum_name": "InputUri",
+          "field": "input_uri",
+          "header": "Input URI",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Priority",
+          "field": "priority",
+          "header": "Priority",
+          "is_int": true,
+          "width": 70
+        },
+        {
+          "enum_name": "TargetRedundancy",
+          "field": "target_redundancy",
+          "header": "Redundancy",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 60
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        }
       ],
-
       "settings_group": "WorkunitListWindow",
       "window_title": "Workunits",
       "icon": "FlashFlow"

--- a/projects/ores.codegen/models/controller/service_definition_domain_entity.json
+++ b/projects/ores.codegen/models/controller/service_definition_domain_entity.json
@@ -3,20 +3,20 @@
     "schema": "public",
     "product": "ores",
     "component": "controller",
+    "component_include": "controller.api",
+    "component_core": "controller.core",
     "entity_singular": "service_definition",
     "entity_plural": "service_definitions",
     "entity_title": "Service Definition",
     "has_tenant_id": false,
     "brief": "Desired state configuration for a managed ORE Studio service.",
     "description": "Represents a Kubernetes-style Deployment: the desired configuration for a\nnamed service, including how many replicas to run, the binary name, restart\npolicy, and whether the service is enabled. This is a bitemporal table so\nthat the full history of configuration changes is preserved for audit.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
       "cpp_type": "boost::uuids::uuid",
       "description": "UUID primary key for the service definition."
     },
-
     "natural_keys": [
       {
         "column": "service_name",
@@ -25,7 +25,6 @@
         "description": "Unique name of the service (e.g. ores.iam.service)."
       }
     ],
-
     "columns": [
       {
         "name": "binary_name",
@@ -74,25 +73,23 @@
         "description": "Optional command-line argument template; NULL means use the default launch arguments."
       }
     ],
-
     "sql": {
       "tablename": "ores_controller_service_definitions_tbl"
     },
-
     "repository": {
       "entity_singular_short": "service_definition",
       "entity_plural_short": "service_definitions",
       "entity_singular_words": "service definition",
       "entity_plural_words": "service definitions"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<string>"]
+        "domain": [
+          "<string>"
+        ]
       },
       "iterator_var": "sd"
     },
-
     "qt": {
       "domain_include": "ores.controller/domain/service_definition.hpp",
       "domain_class": "controller::domain::service_definition",
@@ -102,21 +99,66 @@
       "key_field": "service_name",
       "has_uuid_primary_key": true,
       "has_pagination": false,
-
       "get_request_class": "controller::messaging::list_service_definitions_request",
       "get_response_class": "controller::messaging::list_service_definitions_response",
-
       "columns": [
-        {"enum_name": "ServiceName",      "field": "service_name",      "header": "Service",         "is_string": true, "width": 200},
-        {"enum_name": "BinaryName",       "field": "binary_name",       "header": "Binary",          "is_string": true, "width": 180},
-        {"enum_name": "DesiredReplicas",  "field": "desired_replicas",  "header": "Replicas",        "is_int": true,    "width": 70},
-        {"enum_name": "RestartPolicy",    "field": "restart_policy",    "header": "Restart Policy",  "is_string": true, "width": 100},
-        {"enum_name": "MaxRestartCount",  "field": "max_restart_count", "header": "Max Restarts",    "is_int": true,    "width": 90},
-        {"enum_name": "Enabled",          "field": "enabled",           "header": "Enabled",         "is_int": true,    "width": 60},
-        {"enum_name": "Version",          "field": "version",           "header": "Version",         "is_int": true,    "width": 60},
-        {"enum_name": "ModifiedBy",       "field": "modified_by",       "header": "Modified By",     "is_string": true, "width": 120}
+        {
+          "enum_name": "ServiceName",
+          "field": "service_name",
+          "header": "Service",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "BinaryName",
+          "field": "binary_name",
+          "header": "Binary",
+          "is_string": true,
+          "width": 180
+        },
+        {
+          "enum_name": "DesiredReplicas",
+          "field": "desired_replicas",
+          "header": "Replicas",
+          "is_int": true,
+          "width": 70
+        },
+        {
+          "enum_name": "RestartPolicy",
+          "field": "restart_policy",
+          "header": "Restart Policy",
+          "is_string": true,
+          "width": 100
+        },
+        {
+          "enum_name": "MaxRestartCount",
+          "field": "max_restart_count",
+          "header": "Max Restarts",
+          "is_int": true,
+          "width": 90
+        },
+        {
+          "enum_name": "Enabled",
+          "field": "enabled",
+          "header": "Enabled",
+          "is_int": true,
+          "width": 60
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 60
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        }
       ],
-
       "settings_group": "ServiceDefinitionListWindow",
       "window_title": "Service Definitions",
       "icon": "Server"

--- a/projects/ores.codegen/models/controller/service_instance_domain_entity.json
+++ b/projects/ores.codegen/models/controller/service_instance_domain_entity.json
@@ -3,22 +3,21 @@
     "schema": "public",
     "product": "ores",
     "component": "controller",
+    "component_include": "controller.api",
+    "component_core": "controller.core",
     "entity_singular": "service_instance",
     "entity_plural": "service_instances",
     "entity_title": "Service Instance",
     "has_tenant_id": false,
     "brief": "Operational state of a single running replica of a managed service.",
     "description": "Represents a Kubernetes-style Pod: one concrete running instance of a\nservice definition. Tracks the OS process ID, lifecycle phase, start/stop\ntimes, and how many times the instance has been restarted. Non-temporal:\nonly the current state is kept here; history is captured in service_events.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
       "cpp_type": "boost::uuids::uuid",
       "description": "UUID primary key for the service instance."
     },
-
     "natural_keys": [],
-
     "columns": [
       {
         "name": "service_name",
@@ -73,25 +72,24 @@
         "description": "Number of times this instance has been automatically restarted."
       }
     ],
-
     "sql": {
       "tablename": "ores_controller_service_instances_tbl"
     },
-
     "repository": {
       "entity_singular_short": "service_instance",
       "entity_plural_short": "service_instances",
       "entity_singular_words": "service instance",
       "entity_plural_words": "service instances"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<string>", "<chrono>"]
+        "domain": [
+          "<string>",
+          "<chrono>"
+        ]
       },
       "iterator_var": "si"
     },
-
     "qt": {
       "domain_include": "ores.controller/domain/service_instance.hpp",
       "domain_class": "controller::domain::service_instance",
@@ -101,20 +99,59 @@
       "key_field": "id",
       "has_uuid_primary_key": true,
       "has_pagination": false,
-
       "get_request_class": "controller::messaging::list_service_instances_request",
       "get_response_class": "controller::messaging::list_service_instances_response",
-
       "columns": [
-        {"enum_name": "ServiceName",   "field": "service_name",   "header": "Service",       "is_string": true,    "width": 200},
-        {"enum_name": "ReplicaIndex",  "field": "replica_index",  "header": "Replica",       "is_int": true,       "width": 60},
-        {"enum_name": "Phase",         "field": "phase",          "header": "Phase",         "is_string": true,    "width": 80},
-        {"enum_name": "Pid",           "field": "pid",            "header": "PID",           "is_int": true,       "width": 70},
-        {"enum_name": "StartedAt",     "field": "started_at",     "header": "Started",       "is_timestamp": true, "width": 140},
-        {"enum_name": "StoppedAt",     "field": "stopped_at",     "header": "Stopped",       "is_timestamp": true, "width": 140},
-        {"enum_name": "RestartCount",  "field": "restart_count",  "header": "Restarts",      "is_int": true,       "width": 70}
+        {
+          "enum_name": "ServiceName",
+          "field": "service_name",
+          "header": "Service",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "ReplicaIndex",
+          "field": "replica_index",
+          "header": "Replica",
+          "is_int": true,
+          "width": 60
+        },
+        {
+          "enum_name": "Phase",
+          "field": "phase",
+          "header": "Phase",
+          "is_string": true,
+          "width": 80
+        },
+        {
+          "enum_name": "Pid",
+          "field": "pid",
+          "header": "PID",
+          "is_int": true,
+          "width": 70
+        },
+        {
+          "enum_name": "StartedAt",
+          "field": "started_at",
+          "header": "Started",
+          "is_timestamp": true,
+          "width": 140
+        },
+        {
+          "enum_name": "StoppedAt",
+          "field": "stopped_at",
+          "header": "Stopped",
+          "is_timestamp": true,
+          "width": 140
+        },
+        {
+          "enum_name": "RestartCount",
+          "field": "restart_count",
+          "header": "Restarts",
+          "is_int": true,
+          "width": 70
+        }
       ],
-
       "settings_group": "ServiceInstanceListWindow",
       "window_title": "Service Instances",
       "icon": "Server"

--- a/projects/ores.codegen/models/dq/badge_definition_domain_entity.json
+++ b/projects/ores.codegen/models/dq/badge_definition_domain_entity.json
@@ -3,13 +3,14 @@
     "schema": "public",
     "product": "ores",
     "component": "dq",
+    "component_include": "dq.api",
+    "component_core": "dq.core",
     "has_tenant_id": true,
     "entity_singular": "badge_definition",
     "entity_plural": "badge_definitions",
     "entity_title": "Badge Definition",
     "brief": "Visual definition for a badge, including colours, label, and severity.",
     "description": "The badge catalogue. Each entry defines the complete visual presentation\nof a badge: display label, tooltip, background colour, text colour,\nseverity level, and an optional Bootstrap CSS class hint for Wt.\n\nBadge definitions are the single source of truth for all badge visual\nmetadata across Qt and Wt. They are loaded at client startup as\nreference data and looked up at render time via BadgeCache.",
-
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -17,7 +18,6 @@
       "description": "Unique badge definition code.",
       "detail": "Examples: 'active', 'locked', 'fsm_draft', 'login_online'."
     },
-
     "natural_keys": [
       {
         "column": "name",
@@ -27,7 +27,6 @@
         "generator_expr": "std::string(faker::word::adjective())"
       }
     ],
-
     "columns": [
       {
         "name": "description",
@@ -70,7 +69,7 @@
         "cpp_type": "std::string",
         "nullable": true,
         "description": "Optional Bootstrap CSS class hint for Wt rendering.",
-        "detail": "Example: 'badge bg-success'. Qt ignores this field. Nullable — Wt falls back to inline style from background_colour/text_colour when absent.",
+        "detail": "Example: 'badge bg-success'. Qt ignores this field. Nullable \u2014 Wt falls back to inline style from background_colour/text_colour when absent.",
         "generator_expr": "std::optional<std::string>{}"
       },
       {
@@ -82,36 +81,64 @@
         "generator_expr": "faker::number::integer(1, 100)"
       }
     ],
-
     "sql": {
       "tablename": "ores_dq_badge_definitions_tbl"
     },
-
     "repository": {
       "entity_singular_short": "definition",
       "entity_plural_short": "definitions",
       "entity_singular_words": "badge definition",
       "entity_plural_words": "badge definitions"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<optional>", "<string>"],
-        "entity": ["<optional>", "<string>", "\"sqlgen/Timestamp.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<optional>",
+          "<string>"
+        ],
+        "entity": [
+          "<optional>",
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\""
+        ]
       },
       "iterator_var": "bd",
       "table_display": [
-        {"column": "code", "header": "Code"},
-        {"column": "name", "header": "Name"},
-        {"column": "background_colour", "header": "Background"},
-        {"column": "text_colour", "header": "Text"},
-        {"column": "severity_code", "header": "Severity"},
-        {"column": "display_order", "header": "Order"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "code",
+          "header": "Code"
+        },
+        {
+          "column": "name",
+          "header": "Name"
+        },
+        {
+          "column": "background_colour",
+          "header": "Background"
+        },
+        {
+          "column": "text_colour",
+          "header": "Text"
+        },
+        {
+          "column": "severity_code",
+          "header": "Severity"
+        },
+        {
+          "column": "display_order",
+          "header": "Order"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.dq/domain/badge_definition.hpp",
       "domain_class": "dq::domain::badge_definition",
@@ -120,7 +147,6 @@
       "item_var": "definition",
       "key_field": "code",
       "has_uuid_primary_key": false,
-
       "get_request_class": "dq::messaging::get_badge_definitions_request",
       "get_response_class": "dq::messaging::get_badge_definitions_response",
       "get_message_type": "get_badge_definitions_request",
@@ -133,20 +159,78 @@
       "history_request_class": "dq::messaging::get_badge_definition_history_request",
       "history_response_class": "dq::messaging::get_badge_definition_history_response",
       "history_message_type": "get_badge_definition_history_request",
-
       "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 150},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 150},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 250},
-        {"enum_name": "BackgroundColour", "field": "background_colour", "header": "Background", "is_string": true, "width": 100},
-        {"enum_name": "TextColour", "field": "text_colour", "header": "Text", "is_string": true, "width": 80},
-        {"enum_name": "SeverityCode", "field": "severity_code", "header": "Severity", "is_string": true, "width": 100},
-        {"enum_name": "DisplayOrder", "field": "display_order", "header": "Order", "is_int": true, "width": 80},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Code",
+          "field": "code",
+          "header": "Code",
+          "is_string": true,
+          "width": 150
+        },
+        {
+          "enum_name": "Name",
+          "field": "name",
+          "header": "Name",
+          "is_string": true,
+          "width": 150
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 250
+        },
+        {
+          "enum_name": "BackgroundColour",
+          "field": "background_colour",
+          "header": "Background",
+          "is_string": true,
+          "width": 100
+        },
+        {
+          "enum_name": "TextColour",
+          "field": "text_colour",
+          "header": "Text",
+          "is_string": true,
+          "width": 80
+        },
+        {
+          "enum_name": "SeverityCode",
+          "field": "severity_code",
+          "header": "Severity",
+          "is_string": true,
+          "width": 100
+        },
+        {
+          "enum_name": "DisplayOrder",
+          "field": "display_order",
+          "header": "Order",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "BadgeDefinitionListWindow",
       "window_title": "Badge Definitions",
       "icon": "Tag"

--- a/projects/ores.codegen/models/dq/badge_severity_domain_entity.json
+++ b/projects/ores.codegen/models/dq/badge_severity_domain_entity.json
@@ -3,13 +3,14 @@
     "schema": "public",
     "product": "ores",
     "component": "dq",
+    "component_include": "dq.api",
+    "component_core": "dq.core",
     "has_tenant_id": true,
     "entity_singular": "badge_severity",
     "entity_plural": "badge_severities",
     "entity_title": "Badge Severity",
     "brief": "Severity levels for badge visual classification.",
     "description": "Reference data defining severity levels used to classify badges.\nCodes align with Bootstrap 5 contextual classes so Wt rendering\nrequires no translation layer.\n\nValues: secondary, info, success, warning, danger, primary.",
-
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -17,7 +18,6 @@
       "description": "Unique severity code.",
       "detail": "Examples: 'secondary', 'info', 'success', 'warning', 'danger', 'primary'."
     },
-
     "natural_keys": [
       {
         "column": "name",
@@ -27,7 +27,6 @@
         "generator_expr": "std::string(faker::word::adjective()) + \" Severity\""
       }
     ],
-
     "columns": [
       {
         "name": "description",
@@ -46,34 +45,54 @@
         "generator_expr": "faker::number::integer(1, 100)"
       }
     ],
-
     "sql": {
       "tablename": "ores_dq_badge_severities_tbl"
     },
-
     "repository": {
       "entity_singular_short": "severity",
       "entity_plural_short": "severities",
       "entity_singular_words": "badge severity",
       "entity_plural_words": "badge severities"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\""
+        ]
       },
       "iterator_var": "bs",
       "table_display": [
-        {"column": "code", "header": "Code"},
-        {"column": "name", "header": "Name"},
-        {"column": "description", "header": "Description"},
-        {"column": "display_order", "header": "Order"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "code",
+          "header": "Code"
+        },
+        {
+          "column": "name",
+          "header": "Name"
+        },
+        {
+          "column": "description",
+          "header": "Description"
+        },
+        {
+          "column": "display_order",
+          "header": "Order"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.dq/domain/badge_severity.hpp",
       "domain_class": "dq::domain::badge_severity",
@@ -82,7 +101,6 @@
       "item_var": "severity",
       "key_field": "code",
       "has_uuid_primary_key": false,
-
       "get_request_class": "dq::messaging::get_badge_severities_request",
       "get_response_class": "dq::messaging::get_badge_severities_response",
       "get_message_type": "get_badge_severities_request",
@@ -95,17 +113,57 @@
       "history_request_class": "dq::messaging::get_badge_severity_history_request",
       "history_response_class": "dq::messaging::get_badge_severity_history_response",
       "history_message_type": "get_badge_severity_history_request",
-
       "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 120},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 150},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 300},
-        {"enum_name": "DisplayOrder", "field": "display_order", "header": "Order", "is_int": true, "width": 80},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Code",
+          "field": "code",
+          "header": "Code",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "Name",
+          "field": "name",
+          "header": "Name",
+          "is_string": true,
+          "width": 150
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 300
+        },
+        {
+          "enum_name": "DisplayOrder",
+          "field": "display_order",
+          "header": "Order",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "BadgeSeverityListWindow",
       "window_title": "Badge Severities",
       "icon": "Award"

--- a/projects/ores.codegen/models/dq/code_domain_domain_entity.json
+++ b/projects/ores.codegen/models/dq/code_domain_domain_entity.json
@@ -3,13 +3,14 @@
     "schema": "public",
     "product": "ores",
     "component": "dq",
+    "component_include": "dq.api",
+    "component_core": "dq.core",
     "has_tenant_id": true,
     "entity_singular": "code_domain",
     "entity_plural": "code_domains",
     "entity_title": "Code Domain",
     "brief": "A named namespace for disambiguating enum codes across entity types.",
-    "description": "A code domain is a classification registry that names the context in\nwhich a code value exists. It disambiguates identical codes used in\ndifferent entity types — e.g. 'ACTIVE' in party_status vs 'ACTIVE'\nin book_status.\n\nCode domains are reusable beyond badges: any future system needing\nto namespace code values (validation rules, audit customisation, etc.)\ncan reference this table.",
-
+    "description": "A code domain is a classification registry that names the context in\nwhich a code value exists. It disambiguates identical codes used in\ndifferent entity types \u2014 e.g. 'ACTIVE' in party_status vs 'ACTIVE'\nin book_status.\n\nCode domains are reusable beyond badges: any future system needing\nto namespace code values (validation rules, audit customisation, etc.)\ncan reference this table.",
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -17,7 +18,6 @@
       "description": "Unique code domain identifier.",
       "detail": "Examples: 'party_status', 'book_type', 'fsm_state', 'dq_nature'."
     },
-
     "natural_keys": [
       {
         "column": "name",
@@ -27,7 +27,6 @@
         "generator_expr": "std::string(faker::word::noun()) + \" Domain\""
       }
     ],
-
     "columns": [
       {
         "name": "description",
@@ -46,34 +45,54 @@
         "generator_expr": "faker::number::integer(1, 100)"
       }
     ],
-
     "sql": {
       "tablename": "ores_dq_code_domains_tbl"
     },
-
     "repository": {
       "entity_singular_short": "domain",
       "entity_plural_short": "domains",
       "entity_singular_words": "code domain",
       "entity_plural_words": "code domains"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\""
+        ]
       },
       "iterator_var": "cd",
       "table_display": [
-        {"column": "code", "header": "Code"},
-        {"column": "name", "header": "Name"},
-        {"column": "description", "header": "Description"},
-        {"column": "display_order", "header": "Order"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "code",
+          "header": "Code"
+        },
+        {
+          "column": "name",
+          "header": "Name"
+        },
+        {
+          "column": "description",
+          "header": "Description"
+        },
+        {
+          "column": "display_order",
+          "header": "Order"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.dq/domain/code_domain.hpp",
       "domain_class": "dq::domain::code_domain",
@@ -82,7 +101,6 @@
       "item_var": "domain",
       "key_field": "code",
       "has_uuid_primary_key": false,
-
       "get_request_class": "dq::messaging::get_code_domains_request",
       "get_response_class": "dq::messaging::get_code_domains_response",
       "get_message_type": "get_code_domains_request",
@@ -95,17 +113,57 @@
       "history_request_class": "dq::messaging::get_code_domain_history_request",
       "history_response_class": "dq::messaging::get_code_domain_history_response",
       "history_message_type": "get_code_domain_history_request",
-
       "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 150},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 300},
-        {"enum_name": "DisplayOrder", "field": "display_order", "header": "Order", "is_int": true, "width": 80},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Code",
+          "field": "code",
+          "header": "Code",
+          "is_string": true,
+          "width": 150
+        },
+        {
+          "enum_name": "Name",
+          "field": "name",
+          "header": "Name",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 300
+        },
+        {
+          "enum_name": "DisplayOrder",
+          "field": "display_order",
+          "header": "Order",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "CodeDomainListWindow",
       "window_title": "Code Domains",
       "icon": "Grid"

--- a/projects/ores.codegen/models/dq/dataset_bundle_domain_entity.json
+++ b/projects/ores.codegen/models/dq/dataset_bundle_domain_entity.json
@@ -3,13 +3,14 @@
     "schema": "public",
     "product": "ores",
     "component": "dq",
+    "component_include": "dq.api",
+    "component_core": "dq.core",
     "has_tenant_id": true,
     "entity_singular": "dataset_bundle",
     "entity_plural": "dataset_bundles",
     "entity_title": "Dataset Bundle",
     "brief": "A named collection of datasets designed to work together.",
     "description": "Installing a bundle gets the system into a ready state with a coherent set\nof reference data. Bundles provide a way to group related datasets that\nshould be installed together.\n\nExamples:\n- \"slovaris\": Synthetic reference data for development and testing\n- \"base\": Industry-standard reference data (ISO + FpML) for production\n- \"crypto\": Base system plus cryptocurrency reference data",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
@@ -17,7 +18,6 @@
       "description": "UUID uniquely identifying this bundle.",
       "detail": "This is the surrogate key for the bundle."
     },
-
     "natural_keys": [
       {
         "column": "code",
@@ -35,7 +35,6 @@
         "generator_expr": "std::string(faker::word::adjective()) + \" \" + std::string(faker::word::noun()) + \" Bundle\""
       }
     ],
-
     "columns": [
       {
         "name": "description",
@@ -46,33 +45,52 @@
         "generator_expr": "std::string(faker::lorem::sentence())"
       }
     ],
-
     "sql": {
       "tablename": "ores_dq_dataset_bundles_tbl"
     },
-
     "repository": {
       "entity_singular_short": "bundle",
       "entity_plural_short": "bundles",
       "entity_singular_words": "dataset bundle",
       "entity_plural_words": "dataset bundles"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>", "<boost/uuid/uuid.hpp>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\"", "\"sqlgen/PrimaryKey.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>",
+          "<boost/uuid/uuid.hpp>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\"",
+          "\"sqlgen/PrimaryKey.hpp\""
+        ]
       },
       "iterator_var": "b",
       "table_display": [
-        {"column": "code", "header": "Code"},
-        {"column": "name", "header": "Name"},
-        {"column": "description", "header": "Description"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "code",
+          "header": "Code"
+        },
+        {
+          "column": "name",
+          "header": "Name"
+        },
+        {
+          "column": "description",
+          "header": "Description"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.dq/domain/dataset_bundle.hpp",
       "domain_class": "dq::domain::dataset_bundle",
@@ -81,7 +99,6 @@
       "item_var": "bundle",
       "key_field": "code",
       "has_uuid_primary_key": true,
-
       "get_request_class": "dq::messaging::get_dataset_bundles_request",
       "get_response_class": "dq::messaging::get_dataset_bundles_response",
       "get_message_type": "get_dataset_bundles_request",
@@ -94,16 +111,50 @@
       "history_request_class": "dq::messaging::get_dataset_bundle_history_request",
       "history_response_class": "dq::messaging::get_dataset_bundle_history_response",
       "history_message_type": "get_dataset_bundle_history_request",
-
       "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 150},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 300},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Code",
+          "field": "code",
+          "header": "Code",
+          "is_string": true,
+          "width": 150
+        },
+        {
+          "enum_name": "Name",
+          "field": "name",
+          "header": "Name",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 300
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "DatasetBundleListWindow",
       "window_title": "Dataset Bundles",
       "icon": "Folder"

--- a/projects/ores.codegen/models/iam/account_type_domain_entity.json
+++ b/projects/ores.codegen/models/iam/account_type_domain_entity.json
@@ -2,12 +2,13 @@
   "domain_entity": {
     "schema": "public",
     "component": "iam",
+    "component_include": "iam.api",
+    "component_core": "iam.core",
     "entity_singular": "account_type",
     "entity_plural": "account_types",
     "entity_title": "Account Type",
     "brief": "Classification of account types.",
     "description": "Reference data table defining valid account type classifications.\nExamples: 'user', 'service', 'algorithm', 'llm'.\n\nAccount types are managed by the system tenant and are used to\ncategorise accounts for different purposes. User accounts can login\nwith passwords, while service accounts authenticate via sessions only.",
-
     "primary_key": {
       "column": "type",
       "type": "text",
@@ -15,7 +16,6 @@
       "description": "Unique type code.",
       "detail": "Examples: 'user', 'service', 'algorithm', 'llm'."
     },
-
     "natural_keys": [
       {
         "column": "name",
@@ -25,7 +25,6 @@
         "generator_expr": "std::string(faker::word::adjective()) + \" Account\""
       }
     ],
-
     "columns": [
       {
         "name": "description",
@@ -44,34 +43,54 @@
         "generator_expr": "faker::number::integer(1, 100)"
       }
     ],
-
     "sql": {
       "tablename": "ores_iam_account_types_tbl"
     },
-
     "repository": {
       "entity_singular_short": "type",
       "entity_plural_short": "types",
       "entity_singular_words": "account type",
       "entity_plural_words": "account types"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\""
+        ]
       },
       "iterator_var": "at",
       "table_display": [
-        {"column": "type", "header": "Type"},
-        {"column": "name", "header": "Name"},
-        {"column": "description", "header": "Description"},
-        {"column": "display_order", "header": "Order"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "type",
+          "header": "Type"
+        },
+        {
+          "column": "name",
+          "header": "Name"
+        },
+        {
+          "column": "description",
+          "header": "Description"
+        },
+        {
+          "column": "display_order",
+          "header": "Order"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.iam/domain/account_type.hpp",
       "domain_class": "iam::domain::account_type",
@@ -80,7 +99,6 @@
       "item_var": "account_type",
       "key_field": "type",
       "has_uuid_primary_key": false,
-
       "get_request_class": "iam::messaging::get_account_types_request",
       "get_response_class": "iam::messaging::get_account_types_response",
       "get_message_type": "get_account_types_request",
@@ -93,26 +111,83 @@
       "history_request_class": "iam::messaging::get_account_type_history_request",
       "history_response_class": "iam::messaging::get_account_type_history_response",
       "history_message_type": "get_account_type_history_request",
-
       "detail_fields": [
-        {"field": "type", "label": "Type", "widget": "codeEdit", "type": "line_edit",
-         "is_key": true, "is_required": true, "placeholder": "Enter account type code"},
-        {"field": "name", "label": "Name", "widget": "nameEdit", "type": "line_edit",
-         "is_required": true, "placeholder": "Enter display name"},
-        {"field": "description", "label": "Description", "widget": "descriptionEdit",
-         "type": "text_edit", "placeholder": "Enter a description"}
+        {
+          "field": "type",
+          "label": "Type",
+          "widget": "codeEdit",
+          "type": "line_edit",
+          "is_key": true,
+          "is_required": true,
+          "placeholder": "Enter account type code"
+        },
+        {
+          "field": "name",
+          "label": "Name",
+          "widget": "nameEdit",
+          "type": "line_edit",
+          "is_required": true,
+          "placeholder": "Enter display name"
+        },
+        {
+          "field": "description",
+          "label": "Description",
+          "widget": "descriptionEdit",
+          "type": "text_edit",
+          "placeholder": "Enter a description"
+        }
       ],
-
       "columns": [
-        {"enum_name": "Type", "field": "type", "header": "Type", "is_string": true, "width": 120},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 300},
-        {"enum_name": "DisplayOrder", "field": "display_order", "header": "Order", "is_int": true, "width": 80},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Type",
+          "field": "type",
+          "header": "Type",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "Name",
+          "field": "name",
+          "header": "Name",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 300
+        },
+        {
+          "enum_name": "DisplayOrder",
+          "field": "display_order",
+          "header": "Order",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "AccountTypeListWindow",
       "window_title": "Account Types",
       "icon": "Tag"

--- a/projects/ores.codegen/models/iam/tenant_domain_entity.json
+++ b/projects/ores.codegen/models/iam/tenant_domain_entity.json
@@ -3,13 +3,14 @@
     "schema": "public",
     "product": "ores",
     "component": "iam",
+    "component_include": "iam.api",
+    "component_core": "iam.core",
     "entity_singular": "tenant",
     "entity_plural": "tenants",
     "entity_title": "Tenant",
     "has_tenant_id": true,
     "brief": "A tenant representing an isolated organisation or the system platform.",
     "description": "Core entity for multi-tenancy support. Each tenant represents an isolated\norganisation with its own users, roles, and data. The system tenant (UUID all zeros)\nis a special tenant used for shared reference data and system administration.\n\nTenants are identified by:\n- id: UUID primary key (SQL also has tenant_id = id for self-reference)\n- code: Unique text code for stable referencing (e.g., 'system', 'acme')\n- hostname: Unique hostname for tenant routing during login",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
@@ -18,7 +19,6 @@
       "detail": "The system tenant has UUID 00000000-0000-0000-0000-000000000000. In SQL, tenant_id = id for tenant records.",
       "skip_uuid_check": true
     },
-
     "natural_keys": [
       {
         "column": "code",
@@ -29,7 +29,6 @@
         "generator_expr": "std::string(faker::word::noun()) + \"_tenant\""
       }
     ],
-
     "columns": [
       {
         "name": "name",
@@ -72,7 +71,6 @@
         "generator_expr": "\"active\""
       }
     ],
-
     "sql": {
       "tablename": "ores_iam_tenants_tbl",
       "system_scope": true,
@@ -100,7 +98,6 @@
         "status = 'terminated'"
       ]
     },
-
     "indexes": [
       {
         "name": "hostname_uniq",
@@ -109,31 +106,58 @@
         "current_only": true
       }
     ],
-
     "repository": {
       "entity_singular_short": "tenant",
       "entity_plural_short": "tenants",
       "entity_singular_words": "tenant",
       "entity_plural_words": "tenants"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>", "<optional>", "<boost/uuid/uuid.hpp>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\"", "\"sqlgen/PrimaryKey.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>",
+          "<optional>",
+          "<boost/uuid/uuid.hpp>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\"",
+          "\"sqlgen/PrimaryKey.hpp\""
+        ]
       },
       "iterator_var": "t",
       "table_display": [
-        {"column": "code", "header": "Code"},
-        {"column": "name", "header": "Name"},
-        {"column": "type", "header": "Type"},
-        {"column": "hostname", "header": "Hostname"},
-        {"column": "status", "header": "Status"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "code",
+          "header": "Code"
+        },
+        {
+          "column": "name",
+          "header": "Name"
+        },
+        {
+          "column": "type",
+          "header": "Type"
+        },
+        {
+          "column": "hostname",
+          "header": "Hostname"
+        },
+        {
+          "column": "status",
+          "header": "Status"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.iam/domain/tenant.hpp",
       "domain_class": "iam::domain::tenant",
@@ -142,7 +166,6 @@
       "item_var": "tenant",
       "key_field": "code",
       "has_uuid_primary_key": true,
-
       "get_request_class": "iam::messaging::get_tenants_request",
       "get_response_class": "iam::messaging::get_tenants_response",
       "get_message_type": "get_tenants_request",
@@ -155,31 +178,104 @@
       "history_request_class": "iam::messaging::get_tenant_history_request",
       "history_response_class": "iam::messaging::get_tenant_history_response",
       "history_message_type": "get_tenant_history_request",
-
       "detail_fields": [
-        {"field": "code", "label": "Code", "widget": "codeEdit", "type": "line_edit",
-         "is_key": true, "is_required": true, "placeholder": "Enter tenant code"},
-        {"field": "name", "label": "Name", "widget": "nameEdit", "type": "line_edit",
-         "is_required": true, "placeholder": "Enter display name"},
-        {"field": "type", "label": "Type", "widget": "typeEdit", "type": "line_edit",
-         "placeholder": "Enter tenant type"},
-        {"field": "hostname", "label": "Hostname", "widget": "hostnameEdit", "type": "line_edit",
-         "placeholder": "Enter hostname"},
-        {"field": "status", "label": "Status", "widget": "statusEdit", "type": "line_edit",
-         "placeholder": "Enter status"}
+        {
+          "field": "code",
+          "label": "Code",
+          "widget": "codeEdit",
+          "type": "line_edit",
+          "is_key": true,
+          "is_required": true,
+          "placeholder": "Enter tenant code"
+        },
+        {
+          "field": "name",
+          "label": "Name",
+          "widget": "nameEdit",
+          "type": "line_edit",
+          "is_required": true,
+          "placeholder": "Enter display name"
+        },
+        {
+          "field": "type",
+          "label": "Type",
+          "widget": "typeEdit",
+          "type": "line_edit",
+          "placeholder": "Enter tenant type"
+        },
+        {
+          "field": "hostname",
+          "label": "Hostname",
+          "widget": "hostnameEdit",
+          "type": "line_edit",
+          "placeholder": "Enter hostname"
+        },
+        {
+          "field": "status",
+          "label": "Status",
+          "widget": "statusEdit",
+          "type": "line_edit",
+          "placeholder": "Enter status"
+        }
       ],
-
       "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 120},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 200},
-        {"enum_name": "Type", "field": "type", "header": "Type", "is_string": true, "width": 100},
-        {"enum_name": "Hostname", "field": "hostname", "header": "Hostname", "is_string": true, "width": 180},
-        {"enum_name": "Status", "field": "status", "header": "Status", "is_string": true, "width": 100},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Code",
+          "field": "code",
+          "header": "Code",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "Name",
+          "field": "name",
+          "header": "Name",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Type",
+          "field": "type",
+          "header": "Type",
+          "is_string": true,
+          "width": 100
+        },
+        {
+          "enum_name": "Hostname",
+          "field": "hostname",
+          "header": "Hostname",
+          "is_string": true,
+          "width": 180
+        },
+        {
+          "enum_name": "Status",
+          "field": "status",
+          "header": "Status",
+          "is_string": true,
+          "width": 100
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "TenantListWindow",
       "window_title": "Tenants",
       "icon": "Building"

--- a/projects/ores.codegen/models/iam/tenant_status_domain_entity.json
+++ b/projects/ores.codegen/models/iam/tenant_status_domain_entity.json
@@ -2,12 +2,13 @@
   "domain_entity": {
     "schema": "public",
     "component": "iam",
+    "component_include": "iam.api",
+    "component_core": "iam.core",
     "entity_singular": "tenant_status",
     "entity_plural": "tenant_statuses",
     "entity_title": "Tenant Status",
     "brief": "Tenant lifecycle status definitions.",
     "description": "Reference data table defining valid tenant lifecycle statuses.\nExamples: 'active', 'suspended', 'terminated'.\n\nTenant statuses are managed by the system tenant and control\ntenant access and capabilities.",
-
     "primary_key": {
       "column": "status",
       "type": "text",
@@ -15,7 +16,6 @@
       "description": "Unique status code.",
       "detail": "Examples: 'active', 'suspended', 'terminated'."
     },
-
     "natural_keys": [
       {
         "column": "name",
@@ -25,7 +25,6 @@
         "generator_expr": "std::string(faker::word::adjective()) + \" Status\""
       }
     ],
-
     "columns": [
       {
         "name": "description",
@@ -44,34 +43,54 @@
         "generator_expr": "faker::number::integer(1, 100)"
       }
     ],
-
     "sql": {
       "tablename": "ores_iam_tenant_statuses_tbl"
     },
-
     "repository": {
       "entity_singular_short": "status",
       "entity_plural_short": "statuses",
       "entity_singular_words": "tenant status",
       "entity_plural_words": "tenant statuses"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\""
+        ]
       },
       "iterator_var": "ts",
       "table_display": [
-        {"column": "status", "header": "Status"},
-        {"column": "name", "header": "Name"},
-        {"column": "description", "header": "Description"},
-        {"column": "display_order", "header": "Order"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "status",
+          "header": "Status"
+        },
+        {
+          "column": "name",
+          "header": "Name"
+        },
+        {
+          "column": "description",
+          "header": "Description"
+        },
+        {
+          "column": "display_order",
+          "header": "Order"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.iam/domain/tenant_status.hpp",
       "domain_class": "iam::domain::tenant_status",
@@ -80,7 +99,6 @@
       "item_var": "tenant_status",
       "key_field": "status",
       "has_uuid_primary_key": false,
-
       "get_request_class": "iam::messaging::get_tenant_statuses_request",
       "get_response_class": "iam::messaging::get_tenant_statuses_response",
       "get_message_type": "get_tenant_statuses_request",
@@ -93,26 +111,83 @@
       "history_request_class": "iam::messaging::get_tenant_status_history_request",
       "history_response_class": "iam::messaging::get_tenant_status_history_response",
       "history_message_type": "get_tenant_status_history_request",
-
       "detail_fields": [
-        {"field": "status", "label": "Status", "widget": "codeEdit", "type": "line_edit",
-         "is_key": true, "is_required": true, "placeholder": "Enter status code"},
-        {"field": "name", "label": "Name", "widget": "nameEdit", "type": "line_edit",
-         "is_required": true, "placeholder": "Enter display name"},
-        {"field": "description", "label": "Description", "widget": "descriptionEdit",
-         "type": "text_edit", "placeholder": "Enter a description"}
+        {
+          "field": "status",
+          "label": "Status",
+          "widget": "codeEdit",
+          "type": "line_edit",
+          "is_key": true,
+          "is_required": true,
+          "placeholder": "Enter status code"
+        },
+        {
+          "field": "name",
+          "label": "Name",
+          "widget": "nameEdit",
+          "type": "line_edit",
+          "is_required": true,
+          "placeholder": "Enter display name"
+        },
+        {
+          "field": "description",
+          "label": "Description",
+          "widget": "descriptionEdit",
+          "type": "text_edit",
+          "placeholder": "Enter a description"
+        }
       ],
-
       "columns": [
-        {"enum_name": "Status", "field": "status", "header": "Status", "is_string": true, "width": 120},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 300},
-        {"enum_name": "DisplayOrder", "field": "display_order", "header": "Order", "is_int": true, "width": 80},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Status",
+          "field": "status",
+          "header": "Status",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "Name",
+          "field": "name",
+          "header": "Name",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 300
+        },
+        {
+          "enum_name": "DisplayOrder",
+          "field": "display_order",
+          "header": "Order",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "TenantStatusListWindow",
       "window_title": "Tenant Statuses",
       "icon": "CircleCheck"

--- a/projects/ores.codegen/models/iam/tenant_type_domain_entity.json
+++ b/projects/ores.codegen/models/iam/tenant_type_domain_entity.json
@@ -2,12 +2,13 @@
   "domain_entity": {
     "schema": "public",
     "component": "iam",
+    "component_include": "iam.api",
+    "component_core": "iam.core",
     "entity_singular": "tenant_type",
     "entity_plural": "tenant_types",
     "entity_title": "Tenant Type",
     "brief": "Classification of tenant types.",
     "description": "Reference data table defining valid tenant type classifications.\nExamples: 'organisation', 'platform', 'sandbox'.\n\nTenant types are managed by the system tenant and are used to\ncategorise tenants for different purposes.",
-
     "primary_key": {
       "column": "type",
       "type": "text",
@@ -15,7 +16,6 @@
       "description": "Unique type code.",
       "detail": "Examples: 'organisation', 'platform'."
     },
-
     "natural_keys": [
       {
         "column": "name",
@@ -25,7 +25,6 @@
         "generator_expr": "std::string(faker::word::adjective()) + \" Tenant\""
       }
     ],
-
     "columns": [
       {
         "name": "description",
@@ -44,34 +43,54 @@
         "generator_expr": "faker::number::integer(1, 100)"
       }
     ],
-
     "sql": {
       "tablename": "ores_iam_tenant_types_tbl"
     },
-
     "repository": {
       "entity_singular_short": "type",
       "entity_plural_short": "types",
       "entity_singular_words": "tenant type",
       "entity_plural_words": "tenant types"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\""
+        ]
       },
       "iterator_var": "tt",
       "table_display": [
-        {"column": "type", "header": "Type"},
-        {"column": "name", "header": "Name"},
-        {"column": "description", "header": "Description"},
-        {"column": "display_order", "header": "Order"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "type",
+          "header": "Type"
+        },
+        {
+          "column": "name",
+          "header": "Name"
+        },
+        {
+          "column": "description",
+          "header": "Description"
+        },
+        {
+          "column": "display_order",
+          "header": "Order"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.iam/domain/tenant_type.hpp",
       "domain_class": "iam::domain::tenant_type",
@@ -80,7 +99,6 @@
       "item_var": "tenant_type",
       "key_field": "type",
       "has_uuid_primary_key": false,
-
       "get_request_class": "iam::messaging::get_tenant_types_request",
       "get_response_class": "iam::messaging::get_tenant_types_response",
       "get_message_type": "get_tenant_types_request",
@@ -93,26 +111,83 @@
       "history_request_class": "iam::messaging::get_tenant_type_history_request",
       "history_response_class": "iam::messaging::get_tenant_type_history_response",
       "history_message_type": "get_tenant_type_history_request",
-
       "detail_fields": [
-        {"field": "type", "label": "Type", "widget": "codeEdit", "type": "line_edit",
-         "is_key": true, "is_required": true, "placeholder": "Enter tenant type code"},
-        {"field": "name", "label": "Name", "widget": "nameEdit", "type": "line_edit",
-         "is_required": true, "placeholder": "Enter display name"},
-        {"field": "description", "label": "Description", "widget": "descriptionEdit",
-         "type": "text_edit", "placeholder": "Enter a description"}
+        {
+          "field": "type",
+          "label": "Type",
+          "widget": "codeEdit",
+          "type": "line_edit",
+          "is_key": true,
+          "is_required": true,
+          "placeholder": "Enter tenant type code"
+        },
+        {
+          "field": "name",
+          "label": "Name",
+          "widget": "nameEdit",
+          "type": "line_edit",
+          "is_required": true,
+          "placeholder": "Enter display name"
+        },
+        {
+          "field": "description",
+          "label": "Description",
+          "widget": "descriptionEdit",
+          "type": "text_edit",
+          "placeholder": "Enter a description"
+        }
       ],
-
       "columns": [
-        {"enum_name": "Type", "field": "type", "header": "Type", "is_string": true, "width": 120},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 300},
-        {"enum_name": "DisplayOrder", "field": "display_order", "header": "Order", "is_int": true, "width": 80},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Type",
+          "field": "type",
+          "header": "Type",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "Name",
+          "field": "name",
+          "header": "Name",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 300
+        },
+        {
+          "enum_name": "DisplayOrder",
+          "field": "display_order",
+          "header": "Order",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "TenantTypeListWindow",
       "window_title": "Tenant Types",
       "icon": "Tag"

--- a/projects/ores.codegen/models/refdata/business_unit_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/business_unit_domain_entity.json
@@ -3,13 +3,14 @@
     "schema": "public",
     "product": "ores",
     "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
     "has_tenant_id": true,
     "entity_singular": "business_unit",
     "entity_plural": "business_units",
     "entity_title": "Business Unit",
     "brief": "Internal organizational unit within a party.",
     "description": "Represents internal organizational units (e.g., desks, departments, branches).\nSupports hierarchical structure via self-referencing parent_business_unit_id.\nEach unit belongs to a top-level legal entity (party).",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
@@ -17,7 +18,6 @@
       "description": "UUID uniquely identifying this business unit.",
       "detail": "Surrogate key for the business unit record."
     },
-
     "natural_keys": [
       {
         "column": "party_id",
@@ -36,7 +36,6 @@
         "generator_expr": "std::string(faker::company::name()) + \" Desk\""
       }
     ],
-
     "columns": [
       {
         "name": "parent_business_unit_id",
@@ -66,34 +65,56 @@
         "generator_expr": "std::string(\"GBLO\")"
       }
     ],
-
     "sql": {
       "tablename": "ores_refdata_business_units_tbl"
     },
-
     "repository": {
       "entity_singular_short": "business_unit",
       "entity_plural_short": "business_units",
       "entity_singular_words": "business unit",
       "entity_plural_words": "business units"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>", "<boost/uuid/uuid.hpp>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\"", "\"sqlgen/PrimaryKey.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>",
+          "<boost/uuid/uuid.hpp>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\"",
+          "\"sqlgen/PrimaryKey.hpp\""
+        ]
       },
       "iterator_var": "bu",
       "table_display": [
-        {"column": "party_id", "header": "Party"},
-        {"column": "unit_name", "header": "Unit Name"},
-        {"column": "unit_code", "header": "Code"},
-        {"column": "business_centre_code", "header": "Business Centre"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "party_id",
+          "header": "Party"
+        },
+        {
+          "column": "unit_name",
+          "header": "Unit Name"
+        },
+        {
+          "column": "unit_code",
+          "header": "Code"
+        },
+        {
+          "column": "business_centre_code",
+          "header": "Business Centre"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.refdata/domain/business_unit.hpp",
       "domain_class": "refdata::domain::business_unit",
@@ -116,17 +137,74 @@
       "history_response_class": "refdata::messaging::get_business_unit_history_response",
       "history_message_type": "get_business_unit_history_request",
       "detail_fields": [
-        {"field": "unit_code", "label": "Unit Code", "widget": "codeEdit", "type": "line_edit", "is_key": true, "is_required": false, "placeholder": "Enter unit code"},
-        {"field": "unit_name", "label": "Unit Name", "widget": "nameEdit", "type": "line_edit", "is_required": true, "placeholder": "Enter unit name"},
-        {"field": "business_centre_code", "label": "Business Centre", "widget": "businessCentreEdit", "type": "line_edit", "placeholder": "Enter business centre code"}
+        {
+          "field": "unit_code",
+          "label": "Unit Code",
+          "widget": "codeEdit",
+          "type": "line_edit",
+          "is_key": true,
+          "is_required": false,
+          "placeholder": "Enter unit code"
+        },
+        {
+          "field": "unit_name",
+          "label": "Unit Name",
+          "widget": "nameEdit",
+          "type": "line_edit",
+          "is_required": true,
+          "placeholder": "Enter unit name"
+        },
+        {
+          "field": "business_centre_code",
+          "label": "Business Centre",
+          "widget": "businessCentreEdit",
+          "type": "line_edit",
+          "placeholder": "Enter business centre code"
+        }
       ],
       "columns": [
-        {"enum_name": "UnitCode", "field": "unit_code", "header": "Code", "is_string": true, "width": 120},
-        {"enum_name": "UnitName", "field": "unit_name", "header": "Name", "is_string": true, "width": 250},
-        {"enum_name": "BusinessCentreCode", "field": "business_centre_code", "header": "Business Centre", "is_string": true, "width": 130},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "UnitCode",
+          "field": "unit_code",
+          "header": "Code",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "UnitName",
+          "field": "unit_name",
+          "header": "Name",
+          "is_string": true,
+          "width": 250
+        },
+        {
+          "enum_name": "BusinessCentreCode",
+          "field": "business_centre_code",
+          "header": "Business Centre",
+          "is_string": true,
+          "width": 130
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
       "settings_group": "BusinessUnitListWindow",
       "window_title": "Business Units",

--- a/projects/ores.codegen/models/refdata/contact_type_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/contact_type_domain_entity.json
@@ -2,12 +2,13 @@
   "domain_entity": {
     "schema": "public",
     "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
     "entity_singular": "contact_type",
     "entity_plural": "contact_types",
     "entity_title": "Contact Type",
     "brief": "Classification of contact information purpose.",
     "description": "Reference data table defining valid contact type classifications.\nExamples: 'Legal', 'Operations', 'Settlement', 'Billing'.\n\nContact types are managed by the system tenant and are used to\ncategorise contact information records for parties and counterparties.",
-
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -15,7 +16,6 @@
       "description": "Unique contact type code.",
       "detail": "Examples: 'Legal', 'Operations', 'Settlement'."
     },
-
     "natural_keys": [
       {
         "column": "name",
@@ -25,7 +25,6 @@
         "generator_expr": "std::string(faker::word::adjective()) + \" Contact\""
       }
     ],
-
     "columns": [
       {
         "name": "description",
@@ -44,34 +43,54 @@
         "generator_expr": "faker::number::integer(1, 100)"
       }
     ],
-
     "sql": {
       "tablename": "ores_refdata_contact_types_tbl"
     },
-
     "repository": {
       "entity_singular_short": "type",
       "entity_plural_short": "types",
       "entity_singular_words": "contact type",
       "entity_plural_words": "contact types"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\""
+        ]
       },
       "iterator_var": "ct",
       "table_display": [
-        {"column": "code", "header": "Code"},
-        {"column": "name", "header": "Name"},
-        {"column": "description", "header": "Description"},
-        {"column": "display_order", "header": "Order"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "code",
+          "header": "Code"
+        },
+        {
+          "column": "name",
+          "header": "Name"
+        },
+        {
+          "column": "description",
+          "header": "Description"
+        },
+        {
+          "column": "display_order",
+          "header": "Order"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.refdata/domain/contact_type.hpp",
       "domain_class": "refdata::domain::contact_type",
@@ -80,7 +99,6 @@
       "item_var": "type",
       "key_field": "code",
       "has_uuid_primary_key": false,
-
       "get_request_class": "refdata::messaging::get_contact_types_request",
       "get_response_class": "refdata::messaging::get_contact_types_response",
       "get_message_type": "get_contact_types_request",
@@ -93,17 +111,57 @@
       "history_request_class": "refdata::messaging::get_contact_type_history_request",
       "history_response_class": "refdata::messaging::get_contact_type_history_response",
       "history_message_type": "get_contact_type_history_request",
-
       "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 150},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 300},
-        {"enum_name": "DisplayOrder", "field": "display_order", "header": "Order", "is_int": true, "width": 80},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Code",
+          "field": "code",
+          "header": "Code",
+          "is_string": true,
+          "width": 150
+        },
+        {
+          "enum_name": "Name",
+          "field": "name",
+          "header": "Name",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 300
+        },
+        {
+          "enum_name": "DisplayOrder",
+          "field": "display_order",
+          "header": "Order",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "ContactTypeListWindow",
       "window_title": "Contact Types",
       "icon": "PersonAccounts"

--- a/projects/ores.codegen/models/refdata/counterparty_contact_information_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/counterparty_contact_information_domain_entity.json
@@ -3,6 +3,8 @@
     "schema": "public",
     "product": "ores",
     "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
     "has_tenant_id": true,
     "entity_singular": "counterparty_contact_information",
     "entity_plural": "counterparty_contact_informations",
@@ -10,7 +12,6 @@
     "natural_keys_composite_name": "cpty_contact_type",
     "brief": "Contact details for a counterparty organised by purpose.",
     "description": "Contact details for counterparties organised by purpose (Legal, Operations,\nSettlement, Billing). Each counterparty can have one contact record per type.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
@@ -18,7 +19,6 @@
       "description": "UUID uniquely identifying this contact information record.",
       "detail": "Surrogate key for the counterparty contact information record."
     },
-
     "natural_keys": [
       {
         "column": "counterparty_id",
@@ -37,7 +37,6 @@
         "generator_expr": "std::string(\"Legal\")"
       }
     ],
-
     "columns": [
       {
         "name": "street_line_1",
@@ -121,33 +120,62 @@
         "generator_expr": "std::string(\"https://example.com\")"
       }
     ],
-
     "sql": {
       "tablename": "ores_refdata_counterparty_contact_informations_tbl"
     },
-
     "repository": {
       "entity_singular_short": "counterparty_contact_information",
       "entity_plural_short": "counterparty_contact_informations",
       "entity_singular_words": "counterparty contact information",
       "entity_plural_words": "counterparty contact informations"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>", "<boost/uuid/uuid.hpp>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\"", "\"sqlgen/PrimaryKey.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>",
+          "<boost/uuid/uuid.hpp>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\"",
+          "\"sqlgen/PrimaryKey.hpp\""
+        ]
       },
       "iterator_var": "cci",
       "table_display": [
-        {"column": "counterparty_id", "header": "Counterparty"},
-        {"column": "contact_type", "header": "Type"},
-        {"column": "city", "header": "City"},
-        {"column": "country_code", "header": "Country"},
-        {"column": "phone", "header": "Phone"},
-        {"column": "email", "header": "Email"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "counterparty_id",
+          "header": "Counterparty"
+        },
+        {
+          "column": "contact_type",
+          "header": "Type"
+        },
+        {
+          "column": "city",
+          "header": "City"
+        },
+        {
+          "column": "country_code",
+          "header": "Country"
+        },
+        {
+          "column": "phone",
+          "header": "Phone"
+        },
+        {
+          "column": "email",
+          "header": "Email"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     }
   }

--- a/projects/ores.codegen/models/refdata/counterparty_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/counterparty_domain_entity.json
@@ -3,13 +3,14 @@
     "schema": "public",
     "product": "ores",
     "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
     "has_tenant_id": true,
     "entity_singular": "counterparty",
     "entity_plural": "counterparties",
     "entity_title": "Counterparty",
     "brief": "An external trading partner participating in financial transactions.",
     "description": "External trading partners and counterparties that participate in financial\ntransactions with the organisation. Counterparties form a hierarchy through\nparent_counterparty_id for group structures.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
@@ -17,7 +18,6 @@
       "description": "UUID uniquely identifying this counterparty.",
       "detail": "Surrogate key for the counterparty record."
     },
-
     "natural_keys": [
       {
         "column": "full_name",
@@ -36,7 +36,6 @@
         "generator_expr": "std::string(faker::string::alpha(6))"
       }
     ],
-
     "columns": [
       {
         "name": "party_type",
@@ -75,35 +74,62 @@
         "generator_expr": "std::string(\"Active\")"
       }
     ],
-
     "sql": {
       "tablename": "ores_refdata_counterparties_tbl"
     },
-
     "repository": {
       "entity_singular_short": "counterparty",
       "entity_plural_short": "counterparties",
       "entity_singular_words": "counterparty",
       "entity_plural_words": "counterparties"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>", "<optional>", "<boost/uuid/uuid.hpp>"],
-        "entity": ["<string>", "<optional>", "\"sqlgen/Timestamp.hpp\"", "\"sqlgen/PrimaryKey.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>",
+          "<optional>",
+          "<boost/uuid/uuid.hpp>"
+        ],
+        "entity": [
+          "<string>",
+          "<optional>",
+          "\"sqlgen/Timestamp.hpp\"",
+          "\"sqlgen/PrimaryKey.hpp\""
+        ]
       },
       "iterator_var": "cp",
       "table_display": [
-        {"column": "short_code", "header": "Code"},
-        {"column": "full_name", "header": "Name"},
-        {"column": "party_type", "header": "Type"},
-        {"column": "status", "header": "Status"},
-        {"column": "business_center_code", "header": "Business Center"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "short_code",
+          "header": "Code"
+        },
+        {
+          "column": "full_name",
+          "header": "Name"
+        },
+        {
+          "column": "party_type",
+          "header": "Type"
+        },
+        {
+          "column": "status",
+          "header": "Status"
+        },
+        {
+          "column": "business_center_code",
+          "header": "Business Center"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.refdata/domain/counterparty.hpp",
       "domain_class": "refdata::domain::counterparty",
@@ -126,26 +152,102 @@
       "history_response_class": "refdata::messaging::get_counterparty_history_response",
       "history_message_type": "get_counterparty_history_request",
       "detail_fields": [
-        {"field": "short_code", "label": "Short Code", "widget": "codeEdit", "type": "line_edit",
-         "is_key": true, "is_required": true, "placeholder": "Enter short code"},
-        {"field": "full_name", "label": "Full Name", "widget": "nameEdit", "type": "line_edit",
-         "is_required": true, "placeholder": "Enter full name"},
-        {"field": "party_type", "label": "Party Type", "widget": "partyTypeEdit", "type": "line_edit",
-         "placeholder": "Enter party type"},
-        {"field": "status", "label": "Status", "widget": "statusEdit", "type": "line_edit",
-         "placeholder": "Enter status"},
-        {"field": "business_center_code", "label": "Business Center", "widget": "businessCenterEdit",
-         "type": "line_edit", "placeholder": "Enter business center code"}
+        {
+          "field": "short_code",
+          "label": "Short Code",
+          "widget": "codeEdit",
+          "type": "line_edit",
+          "is_key": true,
+          "is_required": true,
+          "placeholder": "Enter short code"
+        },
+        {
+          "field": "full_name",
+          "label": "Full Name",
+          "widget": "nameEdit",
+          "type": "line_edit",
+          "is_required": true,
+          "placeholder": "Enter full name"
+        },
+        {
+          "field": "party_type",
+          "label": "Party Type",
+          "widget": "partyTypeEdit",
+          "type": "line_edit",
+          "placeholder": "Enter party type"
+        },
+        {
+          "field": "status",
+          "label": "Status",
+          "widget": "statusEdit",
+          "type": "line_edit",
+          "placeholder": "Enter status"
+        },
+        {
+          "field": "business_center_code",
+          "label": "Business Center",
+          "widget": "businessCenterEdit",
+          "type": "line_edit",
+          "placeholder": "Enter business center code"
+        }
       ],
       "columns": [
-        {"enum_name": "ShortCode", "field": "short_code", "header": "Code", "is_string": true, "width": 120},
-        {"enum_name": "FullName", "field": "full_name", "header": "Name", "is_string": true, "width": 250},
-        {"enum_name": "PartyType", "field": "party_type", "header": "Type", "is_string": true, "width": 120},
-        {"enum_name": "Status", "field": "status", "header": "Status", "is_string": true, "width": 100},
-        {"enum_name": "BusinessCenterCode", "field": "business_center_code", "header": "Business Center", "is_string": true, "width": 130},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "ShortCode",
+          "field": "short_code",
+          "header": "Code",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "FullName",
+          "field": "full_name",
+          "header": "Name",
+          "is_string": true,
+          "width": 250
+        },
+        {
+          "enum_name": "PartyType",
+          "field": "party_type",
+          "header": "Type",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "Status",
+          "field": "status",
+          "header": "Status",
+          "is_string": true,
+          "width": 100
+        },
+        {
+          "enum_name": "BusinessCenterCode",
+          "field": "business_center_code",
+          "header": "Business Center",
+          "is_string": true,
+          "width": 130
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
       "settings_group": "CounterpartyListWindow",
       "window_title": "Counterparties",

--- a/projects/ores.codegen/models/refdata/counterparty_identifier_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/counterparty_identifier_domain_entity.json
@@ -3,13 +3,14 @@
     "schema": "public",
     "product": "ores",
     "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
     "has_tenant_id": true,
     "entity_singular": "counterparty_identifier",
     "entity_plural": "counterparty_identifiers",
     "entity_title": "Counterparty Identifier",
     "brief": "An external identifier for a counterparty under a specific scheme.",
     "description": "External identifiers for counterparties, such as LEI codes, BIC/SWIFT codes,\nnational registration numbers, and tax identifiers. Each counterparty can have\nmultiple identifiers across different schemes.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
@@ -17,7 +18,6 @@
       "description": "UUID uniquely identifying this counterparty identifier.",
       "detail": "Surrogate key for the counterparty identifier record."
     },
-
     "natural_keys": [
       {
         "column": "counterparty_id",
@@ -36,7 +36,6 @@
         "generator_expr": "std::string(\"LEI\")"
       }
     ],
-
     "columns": [
       {
         "name": "id_value",
@@ -57,31 +56,54 @@
         "generator_expr": "std::string(\"Test identifier\")"
       }
     ],
-
     "sql": {
       "tablename": "ores_refdata_counterparty_identifiers_tbl"
     },
-
     "repository": {
       "entity_singular_short": "counterparty_identifier",
       "entity_plural_short": "counterparty_identifiers",
       "entity_singular_words": "counterparty identifier",
       "entity_plural_words": "counterparty identifiers"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>", "<boost/uuid/uuid.hpp>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\"", "\"sqlgen/PrimaryKey.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>",
+          "<boost/uuid/uuid.hpp>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\"",
+          "\"sqlgen/PrimaryKey.hpp\""
+        ]
       },
       "iterator_var": "ci",
       "table_display": [
-        {"column": "counterparty_id", "header": "Counterparty"},
-        {"column": "id_scheme", "header": "Scheme"},
-        {"column": "id_value", "header": "Value"},
-        {"column": "description", "header": "Description"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "counterparty_id",
+          "header": "Counterparty"
+        },
+        {
+          "column": "id_scheme",
+          "header": "Scheme"
+        },
+        {
+          "column": "id_value",
+          "header": "Value"
+        },
+        {
+          "column": "description",
+          "header": "Description"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     }
   }

--- a/projects/ores.codegen/models/refdata/party_contact_information_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/party_contact_information_domain_entity.json
@@ -3,13 +3,14 @@
     "schema": "public",
     "product": "ores",
     "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
     "has_tenant_id": true,
     "entity_singular": "party_contact_information",
     "entity_plural": "party_contact_informations",
     "entity_title": "Party Contact Information",
     "brief": "Contact details for a party organised by purpose.",
     "description": "Contact details for parties organised by purpose (Legal, Operations,\nSettlement, Billing). Each party can have one contact record per type.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
@@ -17,7 +18,6 @@
       "description": "UUID uniquely identifying this contact information record.",
       "detail": "Surrogate key for the party contact information record."
     },
-
     "natural_keys": [
       {
         "column": "party_id",
@@ -36,7 +36,6 @@
         "generator_expr": "std::string(\"Legal\")"
       }
     ],
-
     "columns": [
       {
         "name": "street_line_1",
@@ -120,33 +119,62 @@
         "generator_expr": "std::string(\"https://example.com\")"
       }
     ],
-
     "sql": {
       "tablename": "ores_refdata_party_contact_informations_tbl"
     },
-
     "repository": {
       "entity_singular_short": "party_contact_information",
       "entity_plural_short": "party_contact_informations",
       "entity_singular_words": "party contact information",
       "entity_plural_words": "party contact informations"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>", "<boost/uuid/uuid.hpp>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\"", "\"sqlgen/PrimaryKey.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>",
+          "<boost/uuid/uuid.hpp>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\"",
+          "\"sqlgen/PrimaryKey.hpp\""
+        ]
       },
       "iterator_var": "pci",
       "table_display": [
-        {"column": "party_id", "header": "Party"},
-        {"column": "contact_type", "header": "Type"},
-        {"column": "city", "header": "City"},
-        {"column": "country_code", "header": "Country"},
-        {"column": "phone", "header": "Phone"},
-        {"column": "email", "header": "Email"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "party_id",
+          "header": "Party"
+        },
+        {
+          "column": "contact_type",
+          "header": "Type"
+        },
+        {
+          "column": "city",
+          "header": "City"
+        },
+        {
+          "column": "country_code",
+          "header": "Country"
+        },
+        {
+          "column": "phone",
+          "header": "Phone"
+        },
+        {
+          "column": "email",
+          "header": "Email"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     }
   }

--- a/projects/ores.codegen/models/refdata/party_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/party_domain_entity.json
@@ -3,13 +3,14 @@
     "schema": "public",
     "product": "ores",
     "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
     "has_tenant_id": true,
     "entity_singular": "party",
     "entity_plural": "parties",
     "entity_title": "Party",
     "brief": "An internal legal entity participating in financial transactions.",
     "description": "Internal legal entities (the organisation and its subsidiaries) that participate\nin financial transactions. Parties form a hierarchy through parent_party_id,\nwith exactly one root party per tenant representing the organisation itself.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
@@ -17,7 +18,6 @@
       "description": "UUID uniquely identifying this party.",
       "detail": "Surrogate key for the party record."
     },
-
     "natural_keys": [
       {
         "column": "full_name",
@@ -36,7 +36,6 @@
         "generator_expr": "std::string(faker::string::alpha(6))"
       }
     ],
-
     "columns": [
       {
         "name": "party_type",
@@ -75,35 +74,62 @@
         "generator_expr": "std::string(\"Active\")"
       }
     ],
-
     "sql": {
       "tablename": "ores_refdata_parties_tbl"
     },
-
     "repository": {
       "entity_singular_short": "party",
       "entity_plural_short": "parties",
       "entity_singular_words": "party",
       "entity_plural_words": "parties"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>", "<optional>", "<boost/uuid/uuid.hpp>"],
-        "entity": ["<string>", "<optional>", "\"sqlgen/Timestamp.hpp\"", "\"sqlgen/PrimaryKey.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>",
+          "<optional>",
+          "<boost/uuid/uuid.hpp>"
+        ],
+        "entity": [
+          "<string>",
+          "<optional>",
+          "\"sqlgen/Timestamp.hpp\"",
+          "\"sqlgen/PrimaryKey.hpp\""
+        ]
       },
       "iterator_var": "p",
       "table_display": [
-        {"column": "short_code", "header": "Code"},
-        {"column": "full_name", "header": "Name"},
-        {"column": "party_type", "header": "Type"},
-        {"column": "status", "header": "Status"},
-        {"column": "business_center_code", "header": "Business Center"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "short_code",
+          "header": "Code"
+        },
+        {
+          "column": "full_name",
+          "header": "Name"
+        },
+        {
+          "column": "party_type",
+          "header": "Type"
+        },
+        {
+          "column": "status",
+          "header": "Status"
+        },
+        {
+          "column": "business_center_code",
+          "header": "Business Center"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.refdata/domain/party.hpp",
       "domain_class": "refdata::domain::party",
@@ -126,26 +152,102 @@
       "history_response_class": "refdata::messaging::get_party_history_response",
       "history_message_type": "get_party_history_request",
       "detail_fields": [
-        {"field": "short_code", "label": "Short Code", "widget": "codeEdit", "type": "line_edit",
-         "is_key": true, "is_required": true, "placeholder": "Enter short code"},
-        {"field": "full_name", "label": "Full Name", "widget": "nameEdit", "type": "line_edit",
-         "is_required": true, "placeholder": "Enter full name"},
-        {"field": "party_type", "label": "Party Type", "widget": "partyTypeEdit", "type": "line_edit",
-         "placeholder": "Enter party type"},
-        {"field": "status", "label": "Status", "widget": "statusEdit", "type": "line_edit",
-         "placeholder": "Enter status"},
-        {"field": "business_center_code", "label": "Business Center", "widget": "businessCenterEdit",
-         "type": "line_edit", "placeholder": "Enter business center code"}
+        {
+          "field": "short_code",
+          "label": "Short Code",
+          "widget": "codeEdit",
+          "type": "line_edit",
+          "is_key": true,
+          "is_required": true,
+          "placeholder": "Enter short code"
+        },
+        {
+          "field": "full_name",
+          "label": "Full Name",
+          "widget": "nameEdit",
+          "type": "line_edit",
+          "is_required": true,
+          "placeholder": "Enter full name"
+        },
+        {
+          "field": "party_type",
+          "label": "Party Type",
+          "widget": "partyTypeEdit",
+          "type": "line_edit",
+          "placeholder": "Enter party type"
+        },
+        {
+          "field": "status",
+          "label": "Status",
+          "widget": "statusEdit",
+          "type": "line_edit",
+          "placeholder": "Enter status"
+        },
+        {
+          "field": "business_center_code",
+          "label": "Business Center",
+          "widget": "businessCenterEdit",
+          "type": "line_edit",
+          "placeholder": "Enter business center code"
+        }
       ],
       "columns": [
-        {"enum_name": "ShortCode", "field": "short_code", "header": "Code", "is_string": true, "width": 120},
-        {"enum_name": "FullName", "field": "full_name", "header": "Name", "is_string": true, "width": 250},
-        {"enum_name": "PartyType", "field": "party_type", "header": "Type", "is_string": true, "width": 120},
-        {"enum_name": "Status", "field": "status", "header": "Status", "is_string": true, "width": 100},
-        {"enum_name": "BusinessCenterCode", "field": "business_center_code", "header": "Business Center", "is_string": true, "width": 130},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "ShortCode",
+          "field": "short_code",
+          "header": "Code",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "FullName",
+          "field": "full_name",
+          "header": "Name",
+          "is_string": true,
+          "width": 250
+        },
+        {
+          "enum_name": "PartyType",
+          "field": "party_type",
+          "header": "Type",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "Status",
+          "field": "status",
+          "header": "Status",
+          "is_string": true,
+          "width": 100
+        },
+        {
+          "enum_name": "BusinessCenterCode",
+          "field": "business_center_code",
+          "header": "Business Center",
+          "is_string": true,
+          "width": 130
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
       "settings_group": "PartyListWindow",
       "window_title": "Parties",

--- a/projects/ores.codegen/models/refdata/party_id_scheme_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/party_id_scheme_domain_entity.json
@@ -2,12 +2,13 @@
   "domain_entity": {
     "schema": "public",
     "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
     "entity_singular": "party_id_scheme",
     "entity_plural": "party_id_schemes",
     "entity_title": "Party ID Scheme",
     "brief": "Classification of external identifier types for parties.",
     "description": "Reference data table defining valid party identifier scheme types.\nExamples: 'LEI', 'BIC', 'MIC', 'DUNS'.\n\nParty ID schemes are managed by the system tenant. The optional\ncoding_scheme_code field cross-references the DQ coding scheme table.",
-
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -15,7 +16,6 @@
       "description": "Unique scheme code.",
       "detail": "Examples: 'LEI', 'BIC', 'MIC'."
     },
-
     "natural_keys": [
       {
         "column": "name",
@@ -25,7 +25,6 @@
         "generator_expr": "std::string(faker::word::adjective()) + \" Scheme\""
       }
     ],
-
     "columns": [
       {
         "name": "description",
@@ -53,35 +52,58 @@
         "generator_expr": "faker::number::integer(1, 100)"
       }
     ],
-
     "sql": {
       "tablename": "ores_refdata_party_id_schemes_tbl"
     },
-
     "repository": {
       "entity_singular_short": "scheme",
       "entity_plural_short": "schemes",
       "entity_singular_words": "party ID scheme",
       "entity_plural_words": "party ID schemes"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\""
+        ]
       },
       "iterator_var": "ps",
       "table_display": [
-        {"column": "code", "header": "Code"},
-        {"column": "name", "header": "Name"},
-        {"column": "description", "header": "Description"},
-        {"column": "coding_scheme_code", "header": "Coding Scheme"},
-        {"column": "display_order", "header": "Order"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "code",
+          "header": "Code"
+        },
+        {
+          "column": "name",
+          "header": "Name"
+        },
+        {
+          "column": "description",
+          "header": "Description"
+        },
+        {
+          "column": "coding_scheme_code",
+          "header": "Coding Scheme"
+        },
+        {
+          "column": "display_order",
+          "header": "Order"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.refdata/domain/party_id_scheme.hpp",
       "domain_class": "refdata::domain::party_id_scheme",
@@ -90,7 +112,6 @@
       "item_var": "scheme",
       "key_field": "code",
       "has_uuid_primary_key": false,
-
       "get_request_class": "refdata::messaging::get_party_id_schemes_request",
       "get_response_class": "refdata::messaging::get_party_id_schemes_response",
       "get_message_type": "get_party_id_schemes_request",
@@ -103,18 +124,64 @@
       "history_request_class": "refdata::messaging::get_party_id_scheme_history_request",
       "history_response_class": "refdata::messaging::get_party_id_scheme_history_response",
       "history_message_type": "get_party_id_scheme_history_request",
-
       "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 150},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 300},
-        {"enum_name": "CodingSchemeCode", "field": "coding_scheme_code", "header": "Coding Scheme", "is_string": true, "width": 150},
-        {"enum_name": "DisplayOrder", "field": "display_order", "header": "Order", "is_int": true, "width": 80},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Code",
+          "field": "code",
+          "header": "Code",
+          "is_string": true,
+          "width": 150
+        },
+        {
+          "enum_name": "Name",
+          "field": "name",
+          "header": "Name",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 300
+        },
+        {
+          "enum_name": "CodingSchemeCode",
+          "field": "coding_scheme_code",
+          "header": "Coding Scheme",
+          "is_string": true,
+          "width": 150
+        },
+        {
+          "enum_name": "DisplayOrder",
+          "field": "display_order",
+          "header": "Order",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "PartyIdSchemeListWindow",
       "window_title": "Party ID Schemes",
       "icon": "Key"

--- a/projects/ores.codegen/models/refdata/party_identifier_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/party_identifier_domain_entity.json
@@ -3,13 +3,14 @@
     "schema": "public",
     "product": "ores",
     "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
     "has_tenant_id": true,
     "entity_singular": "party_identifier",
     "entity_plural": "party_identifiers",
     "entity_title": "Party Identifier",
     "brief": "An external identifier for a party under a specific scheme.",
     "description": "External identifiers for parties, such as LEI codes, BIC/SWIFT codes,\nnational registration numbers, and tax identifiers. Each party can have\nmultiple identifiers across different schemes.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
@@ -17,7 +18,6 @@
       "description": "UUID uniquely identifying this party identifier.",
       "detail": "Surrogate key for the party identifier record."
     },
-
     "natural_keys": [
       {
         "column": "party_id",
@@ -36,7 +36,6 @@
         "generator_expr": "std::string(\"LEI\")"
       }
     ],
-
     "columns": [
       {
         "name": "id_value",
@@ -57,31 +56,54 @@
         "generator_expr": "std::string(\"Test identifier\")"
       }
     ],
-
     "sql": {
       "tablename": "ores_refdata_party_identifiers_tbl"
     },
-
     "repository": {
       "entity_singular_short": "party_identifier",
       "entity_plural_short": "party_identifiers",
       "entity_singular_words": "party identifier",
       "entity_plural_words": "party identifiers"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>", "<boost/uuid/uuid.hpp>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\"", "\"sqlgen/PrimaryKey.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>",
+          "<boost/uuid/uuid.hpp>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\"",
+          "\"sqlgen/PrimaryKey.hpp\""
+        ]
       },
       "iterator_var": "pi",
       "table_display": [
-        {"column": "party_id", "header": "Party"},
-        {"column": "id_scheme", "header": "Scheme"},
-        {"column": "id_value", "header": "Value"},
-        {"column": "description", "header": "Description"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "party_id",
+          "header": "Party"
+        },
+        {
+          "column": "id_scheme",
+          "header": "Scheme"
+        },
+        {
+          "column": "id_value",
+          "header": "Value"
+        },
+        {
+          "column": "description",
+          "header": "Description"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     }
   }

--- a/projects/ores.codegen/models/refdata/party_status_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/party_status_domain_entity.json
@@ -2,12 +2,13 @@
   "domain_entity": {
     "schema": "public",
     "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
     "entity_singular": "party_status",
     "entity_plural": "party_statuses",
     "entity_title": "Party Status",
     "brief": "Lifecycle states for party and counterparty records.",
     "description": "Reference data table defining valid party status values.\nExamples: 'Active', 'Inactive', 'Suspended'.\n\nParty statuses are managed by the system tenant and are used to\ntrack the lifecycle of party and counterparty records.",
-
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -15,7 +16,6 @@
       "description": "Unique status code.",
       "detail": "Examples: 'Active', 'Inactive', 'Suspended'."
     },
-
     "natural_keys": [
       {
         "column": "name",
@@ -25,7 +25,6 @@
         "generator_expr": "std::string(faker::word::adjective()) + \" Status\""
       }
     ],
-
     "columns": [
       {
         "name": "description",
@@ -44,34 +43,54 @@
         "generator_expr": "faker::number::integer(1, 100)"
       }
     ],
-
     "sql": {
       "tablename": "ores_refdata_party_statuses_tbl"
     },
-
     "repository": {
       "entity_singular_short": "status",
       "entity_plural_short": "statuses",
       "entity_singular_words": "party status",
       "entity_plural_words": "party statuses"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\""
+        ]
       },
       "iterator_var": "ps",
       "table_display": [
-        {"column": "code", "header": "Code"},
-        {"column": "name", "header": "Name"},
-        {"column": "description", "header": "Description"},
-        {"column": "display_order", "header": "Order"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "code",
+          "header": "Code"
+        },
+        {
+          "column": "name",
+          "header": "Name"
+        },
+        {
+          "column": "description",
+          "header": "Description"
+        },
+        {
+          "column": "display_order",
+          "header": "Order"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.refdata/domain/party_status.hpp",
       "domain_class": "refdata::domain::party_status",
@@ -80,7 +99,6 @@
       "item_var": "status",
       "key_field": "code",
       "has_uuid_primary_key": false,
-
       "get_request_class": "refdata::messaging::get_party_statuses_request",
       "get_response_class": "refdata::messaging::get_party_statuses_response",
       "get_message_type": "get_party_statuses_request",
@@ -93,17 +111,57 @@
       "history_request_class": "refdata::messaging::get_party_status_history_request",
       "history_response_class": "refdata::messaging::get_party_status_history_response",
       "history_message_type": "get_party_status_history_request",
-
       "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 150},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 300},
-        {"enum_name": "DisplayOrder", "field": "display_order", "header": "Order", "is_int": true, "width": 80},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Code",
+          "field": "code",
+          "header": "Code",
+          "is_string": true,
+          "width": 150
+        },
+        {
+          "enum_name": "Name",
+          "field": "name",
+          "header": "Name",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 300
+        },
+        {
+          "enum_name": "DisplayOrder",
+          "field": "display_order",
+          "header": "Order",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "PartyStatusListWindow",
       "window_title": "Party Statuses",
       "icon": "Flag"

--- a/projects/ores.codegen/models/refdata/party_type_domain_entity.json
+++ b/projects/ores.codegen/models/refdata/party_type_domain_entity.json
@@ -2,12 +2,13 @@
   "domain_entity": {
     "schema": "public",
     "component": "refdata",
+    "component_include": "refdata.api",
+    "component_core": "refdata.core",
     "entity_singular": "party_type",
     "entity_plural": "party_types",
     "entity_title": "Party Type",
     "brief": "Classification of legal entities participating in financial transactions.",
     "description": "Reference data table defining valid party type classifications.\nExamples: 'Bank', 'Corporate', 'HedgeFund', 'Government'.\n\nParty types are managed by the system tenant and are used to\ncategorise parties and counterparties.",
-
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -15,7 +16,6 @@
       "description": "Unique type code.",
       "detail": "Examples: 'Bank', 'Corporate', 'HedgeFund'."
     },
-
     "natural_keys": [
       {
         "column": "name",
@@ -25,7 +25,6 @@
         "generator_expr": "std::string(faker::word::adjective()) + \" Party\""
       }
     ],
-
     "columns": [
       {
         "name": "description",
@@ -44,34 +43,54 @@
         "generator_expr": "faker::number::integer(1, 100)"
       }
     ],
-
     "sql": {
       "tablename": "ores_refdata_party_types_tbl"
     },
-
     "repository": {
       "entity_singular_short": "type",
       "entity_plural_short": "types",
       "entity_singular_words": "party type",
       "entity_plural_words": "party types"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\""
+        ]
       },
       "iterator_var": "pt",
       "table_display": [
-        {"column": "code", "header": "Code"},
-        {"column": "name", "header": "Name"},
-        {"column": "description", "header": "Description"},
-        {"column": "display_order", "header": "Order"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "code",
+          "header": "Code"
+        },
+        {
+          "column": "name",
+          "header": "Name"
+        },
+        {
+          "column": "description",
+          "header": "Description"
+        },
+        {
+          "column": "display_order",
+          "header": "Order"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.refdata/domain/party_type.hpp",
       "domain_class": "refdata::domain::party_type",
@@ -80,7 +99,6 @@
       "item_var": "type",
       "key_field": "code",
       "has_uuid_primary_key": false,
-
       "get_request_class": "refdata::messaging::get_party_types_request",
       "get_response_class": "refdata::messaging::get_party_types_response",
       "get_message_type": "get_party_types_request",
@@ -93,17 +111,57 @@
       "history_request_class": "refdata::messaging::get_party_type_history_request",
       "history_response_class": "refdata::messaging::get_party_type_history_response",
       "history_message_type": "get_party_type_history_request",
-
       "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 150},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 300},
-        {"enum_name": "DisplayOrder", "field": "display_order", "header": "Order", "is_int": true, "width": 80},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Code",
+          "field": "code",
+          "header": "Code",
+          "is_string": true,
+          "width": 150
+        },
+        {
+          "enum_name": "Name",
+          "field": "name",
+          "header": "Name",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 300
+        },
+        {
+          "enum_name": "DisplayOrder",
+          "field": "display_order",
+          "header": "Order",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "PartyTypeListWindow",
       "window_title": "Party Types",
       "icon": "Tag"

--- a/projects/ores.codegen/models/reporting/concurrency_policy_domain_entity.json
+++ b/projects/ores.codegen/models/reporting/concurrency_policy_domain_entity.json
@@ -3,13 +3,14 @@
     "schema": "public",
     "product": "ores",
     "component": "reporting",
+    "component_include": "reporting.api",
+    "component_core": "reporting.core",
     "has_tenant_id": true,
     "entity_singular": "concurrency_policy",
     "entity_plural": "concurrency_policies",
     "entity_title": "Concurrency Policy",
     "brief": "Report instance concurrency behaviour when a new trigger fires.",
     "description": "Reference data table defining valid concurrency policies for report definitions.\nExamples: 'skip', 'queue', 'fail'.\n\nConcurrency policies control what happens when a scheduler trigger fires\nfor a report definition that already has a running instance.",
-
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -17,7 +18,6 @@
       "description": "Unique concurrency policy code.",
       "detail": "Examples: 'skip', 'queue', 'fail'."
     },
-
     "columns": [
       {
         "name": "name",
@@ -46,34 +46,54 @@
         "generator_expr": "faker::number::integer(1, 100)"
       }
     ],
-
     "sql": {
       "tablename": "ores_reporting_concurrency_policies_tbl"
     },
-
     "repository": {
       "entity_singular_short": "policy",
       "entity_plural_short": "policies",
       "entity_singular_words": "concurrency policy",
       "entity_plural_words": "concurrency policies"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\""
+        ]
       },
       "iterator_var": "cp",
       "table_display": [
-        {"column": "code", "header": "Code"},
-        {"column": "name", "header": "Name"},
-        {"column": "description", "header": "Description"},
-        {"column": "display_order", "header": "Order"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "code",
+          "header": "Code"
+        },
+        {
+          "column": "name",
+          "header": "Name"
+        },
+        {
+          "column": "description",
+          "header": "Description"
+        },
+        {
+          "column": "display_order",
+          "header": "Order"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.reporting/domain/concurrency_policy.hpp",
       "domain_class": "reporting::domain::concurrency_policy",
@@ -82,7 +102,6 @@
       "item_var": "policy",
       "key_field": "code",
       "has_uuid_primary_key": false,
-
       "get_request_class": "reporting::messaging::get_concurrency_policies_request",
       "get_response_class": "reporting::messaging::get_concurrency_policies_response",
       "get_message_type": "get_concurrency_policies_request",
@@ -95,26 +114,83 @@
       "history_request_class": "reporting::messaging::get_concurrency_policy_history_request",
       "history_response_class": "reporting::messaging::get_concurrency_policy_history_response",
       "history_message_type": "get_concurrency_policy_history_request",
-
       "detail_fields": [
-        {"field": "code", "label": "Code", "widget": "codeEdit", "type": "line_edit",
-         "is_key": true, "is_required": true, "placeholder": "Enter policy code"},
-        {"field": "name", "label": "Name", "widget": "nameEdit", "type": "line_edit",
-         "is_required": true, "placeholder": "Enter display name"},
-        {"field": "description", "label": "Description", "widget": "descriptionEdit",
-         "type": "text_edit", "placeholder": "Enter a description"}
+        {
+          "field": "code",
+          "label": "Code",
+          "widget": "codeEdit",
+          "type": "line_edit",
+          "is_key": true,
+          "is_required": true,
+          "placeholder": "Enter policy code"
+        },
+        {
+          "field": "name",
+          "label": "Name",
+          "widget": "nameEdit",
+          "type": "line_edit",
+          "is_required": true,
+          "placeholder": "Enter display name"
+        },
+        {
+          "field": "description",
+          "label": "Description",
+          "widget": "descriptionEdit",
+          "type": "text_edit",
+          "placeholder": "Enter a description"
+        }
       ],
-
       "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 120},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 300},
-        {"enum_name": "DisplayOrder", "field": "display_order", "header": "Order", "is_int": true, "width": 80},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Code",
+          "field": "code",
+          "header": "Code",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "Name",
+          "field": "name",
+          "header": "Name",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 300
+        },
+        {
+          "enum_name": "DisplayOrder",
+          "field": "display_order",
+          "header": "Order",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "ConcurrencyPolicyListWindow",
       "window_title": "Concurrency Policies",
       "icon": "LayoutList"

--- a/projects/ores.codegen/models/reporting/report_instance_domain_entity.json
+++ b/projects/ores.codegen/models/reporting/report_instance_domain_entity.json
@@ -3,13 +3,14 @@
     "schema": "public",
     "product": "ores",
     "component": "reporting",
+    "component_include": "reporting.api",
+    "component_core": "reporting.core",
     "entity_singular": "report_instance",
     "entity_plural": "report_instances",
     "entity_title": "Report Instance",
     "has_tenant_id": true,
     "brief": "A single execution of a report definition.",
     "description": "A single execution of a report_definition. Created automatically when the\nscheduler fires a trigger for an active definition.\n\nLifecycle is managed through the report_instance_lifecycle FSM machine.\nfsm_state_id points to the current state in ores_dq_fsm_states_tbl.\n\nstarted_at is NULL when the instance is cancelled or skipped before execution\nbegins. completed_at is NULL while running or in a terminal-before-start state.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
@@ -17,7 +18,6 @@
       "description": "UUID uniquely identifying this report instance.",
       "uuid_check_fn": "ores_utility_nil_uuid_fn()"
     },
-
     "natural_keys": [
       {
         "column": "name",
@@ -27,7 +27,6 @@
         "generator_expr": "std::string(faker::word::noun()) + \"_instance\""
       }
     ],
-
     "columns": [
       {
         "name": "description",
@@ -96,7 +95,6 @@
         "generator_expr": "std::nullopt"
       }
     ],
-
     "sql": {
       "tablename": "ores_reporting_report_instances_tbl",
       "security_definer": true,
@@ -127,17 +125,30 @@
           "select_fields": "name, description",
           "into_vars": "def_name, def_description",
           "declare_vars": [
-            {"name": "def_name",        "type": "text"},
-            {"name": "def_description", "type": "text"}
+            {
+              "name": "def_name",
+              "type": "text"
+            },
+            {
+              "name": "def_description",
+              "type": "text"
+            }
           ],
           "copy_empty": [
-            {"target": "name",        "source": "def_name",        "coalesce": false},
-            {"target": "description", "source": "def_description", "coalesce": true}
+            {
+              "target": "name",
+              "source": "def_name",
+              "coalesce": false
+            },
+            {
+              "target": "description",
+              "source": "def_description",
+              "coalesce": true
+            }
           ]
         }
       ]
     },
-
     "indexes": [
       {
         "name": "definition",
@@ -152,23 +163,35 @@
         "current_only": true
       }
     ],
-
     "repository": {
       "entity_singular_short": "instance",
       "entity_plural_short": "instances",
       "entity_singular_words": "report instance",
       "entity_plural_words": "report instances"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<cstdint>", "<optional>", "<string>", "<boost/uuid/uuid.hpp>"],
-        "entity": ["<cstdint>", "<optional>", "<string>", "\"sqlgen/Timestamp.hpp\"", "<boost/uuid/uuid.hpp>"],
-        "generator": ["\"faker-cxx/Word.h\"", "\"faker-cxx/Lorem.h\""]
+        "domain": [
+          "<chrono>",
+          "<cstdint>",
+          "<optional>",
+          "<string>",
+          "<boost/uuid/uuid.hpp>"
+        ],
+        "entity": [
+          "<cstdint>",
+          "<optional>",
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\"",
+          "<boost/uuid/uuid.hpp>"
+        ],
+        "generator": [
+          "\"faker-cxx/Word.h\"",
+          "\"faker-cxx/Lorem.h\""
+        ]
       },
       "iterator_var": "ri"
     },
-
     "qt": {
       "domain_include": "ores.reporting/domain/report_instance.hpp",
       "domain_class": "reporting::domain::report_instance",
@@ -178,7 +201,6 @@
       "key_field": "name",
       "key_widget": "nameEdit",
       "has_uuid_primary_key": true,
-
       "get_request_class": "reporting::messaging::get_report_instances_request",
       "get_response_class": "reporting::messaging::get_report_instances_response",
       "get_message_type": "get_report_instances_request",
@@ -191,27 +213,89 @@
       "history_request_class": "reporting::messaging::get_report_instance_history_request",
       "history_response_class": "reporting::messaging::get_report_instance_history_response",
       "history_message_type": "get_report_instance_history_request",
-
       "detail_fields": [
-        {"field": "name",           "label": "Name",          "widget": "nameEdit",        "type": "line_edit",
-         "is_key": true, "is_required": true, "placeholder": "Report instance name"},
-        {"field": "description",    "label": "Description",   "widget": "descriptionEdit", "type": "text_edit",
-         "placeholder": "Description"},
-        {"field": "output_message", "label": "Output",        "widget": "outputEdit",      "type": "text_edit",
-         "placeholder": "Execution log or error message"}
+        {
+          "field": "name",
+          "label": "Name",
+          "widget": "nameEdit",
+          "type": "line_edit",
+          "is_key": true,
+          "is_required": true,
+          "placeholder": "Report instance name"
+        },
+        {
+          "field": "description",
+          "label": "Description",
+          "widget": "descriptionEdit",
+          "type": "text_edit",
+          "placeholder": "Description"
+        },
+        {
+          "field": "output_message",
+          "label": "Output",
+          "widget": "outputEdit",
+          "type": "text_edit",
+          "placeholder": "Execution log or error message"
+        }
       ],
-
       "columns": [
-        {"enum_name": "Name",         "field": "name",          "header": "Name",       "is_string": true,    "width": 200},
-        {"enum_name": "DefinitionId", "field": "definition_id", "header": "Definition", "is_uuid": true,      "width": 200},
-        {"enum_name": "TriggerRunId", "field": "trigger_run_id","header": "Trigger Run","is_int": true,       "width": 100},
-        {"enum_name": "OutputMessage","field": "output_message", "header": "Output",    "is_string": true,    "width": 250},
-        {"enum_name": "StartedAt",    "field": "started_at",    "header": "Started At", "is_timestamp": true, "width": 150},
-        {"enum_name": "CompletedAt",  "field": "completed_at",  "header": "Completed",  "is_timestamp": true, "width": 150},
-        {"enum_name": "Version",      "field": "version",       "header": "Version",    "is_int": true,       "width": 60},
-        {"enum_name": "ModifiedBy",   "field": "modified_by",   "header": "Modified By","is_string": true,    "width": 120}
+        {
+          "enum_name": "Name",
+          "field": "name",
+          "header": "Name",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "DefinitionId",
+          "field": "definition_id",
+          "header": "Definition",
+          "is_uuid": true,
+          "width": 200
+        },
+        {
+          "enum_name": "TriggerRunId",
+          "field": "trigger_run_id",
+          "header": "Trigger Run",
+          "is_int": true,
+          "width": 100
+        },
+        {
+          "enum_name": "OutputMessage",
+          "field": "output_message",
+          "header": "Output",
+          "is_string": true,
+          "width": 250
+        },
+        {
+          "enum_name": "StartedAt",
+          "field": "started_at",
+          "header": "Started At",
+          "is_timestamp": true,
+          "width": 150
+        },
+        {
+          "enum_name": "CompletedAt",
+          "field": "completed_at",
+          "header": "Completed",
+          "is_timestamp": true,
+          "width": 150
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 60
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        }
       ],
-
       "settings_group": "ReportInstanceListWindow",
       "window_title": "Report Instances",
       "icon": "Record"

--- a/projects/ores.codegen/models/reporting/report_type_domain_entity.json
+++ b/projects/ores.codegen/models/reporting/report_type_domain_entity.json
@@ -3,13 +3,14 @@
     "schema": "public",
     "product": "ores",
     "component": "reporting",
+    "component_include": "reporting.api",
+    "component_core": "reporting.core",
     "has_tenant_id": true,
     "entity_singular": "report_type",
     "entity_plural": "report_types",
     "entity_title": "Report Type",
     "brief": "Supported report category classifications.",
     "description": "Reference data table defining valid report type classifications.\nExamples: 'risk', 'grid'.\n\nReport types are managed by the system tenant and drive which\nconfiguration block is used when creating a report definition.",
-
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -17,7 +18,6 @@
       "description": "Unique report type code.",
       "detail": "Examples: 'risk', 'grid'."
     },
-
     "columns": [
       {
         "name": "name",
@@ -46,34 +46,54 @@
         "generator_expr": "faker::number::integer(1, 100)"
       }
     ],
-
     "sql": {
       "tablename": "ores_reporting_report_types_tbl"
     },
-
     "repository": {
       "entity_singular_short": "type",
       "entity_plural_short": "types",
       "entity_singular_words": "report type",
       "entity_plural_words": "report types"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"],
-        "entity": ["<string>", "\"sqlgen/Timestamp.hpp\""]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ],
+        "entity": [
+          "<string>",
+          "\"sqlgen/Timestamp.hpp\""
+        ]
       },
       "iterator_var": "rt",
       "table_display": [
-        {"column": "code", "header": "Code"},
-        {"column": "name", "header": "Name"},
-        {"column": "description", "header": "Description"},
-        {"column": "display_order", "header": "Order"},
-        {"column": "modified_by", "header": "Modified By"},
-        {"column": "version", "header": "Version"}
+        {
+          "column": "code",
+          "header": "Code"
+        },
+        {
+          "column": "name",
+          "header": "Name"
+        },
+        {
+          "column": "description",
+          "header": "Description"
+        },
+        {
+          "column": "display_order",
+          "header": "Order"
+        },
+        {
+          "column": "modified_by",
+          "header": "Modified By"
+        },
+        {
+          "column": "version",
+          "header": "Version"
+        }
       ]
     },
-
     "qt": {
       "domain_include": "ores.reporting/domain/report_type.hpp",
       "domain_class": "reporting::domain::report_type",
@@ -82,7 +102,6 @@
       "item_var": "type",
       "key_field": "code",
       "has_uuid_primary_key": false,
-
       "get_request_class": "reporting::messaging::get_report_types_request",
       "get_response_class": "reporting::messaging::get_report_types_response",
       "get_message_type": "get_report_types_request",
@@ -95,26 +114,83 @@
       "history_request_class": "reporting::messaging::get_report_type_history_request",
       "history_response_class": "reporting::messaging::get_report_type_history_response",
       "history_message_type": "get_report_type_history_request",
-
       "detail_fields": [
-        {"field": "code", "label": "Code", "widget": "codeEdit", "type": "line_edit",
-         "is_key": true, "is_required": true, "placeholder": "Enter report type code"},
-        {"field": "name", "label": "Name", "widget": "nameEdit", "type": "line_edit",
-         "is_required": true, "placeholder": "Enter display name"},
-        {"field": "description", "label": "Description", "widget": "descriptionEdit",
-         "type": "text_edit", "placeholder": "Enter a description"}
+        {
+          "field": "code",
+          "label": "Code",
+          "widget": "codeEdit",
+          "type": "line_edit",
+          "is_key": true,
+          "is_required": true,
+          "placeholder": "Enter report type code"
+        },
+        {
+          "field": "name",
+          "label": "Name",
+          "widget": "nameEdit",
+          "type": "line_edit",
+          "is_required": true,
+          "placeholder": "Enter display name"
+        },
+        {
+          "field": "description",
+          "label": "Description",
+          "widget": "descriptionEdit",
+          "type": "text_edit",
+          "placeholder": "Enter a description"
+        }
       ],
-
       "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 120},
-        {"enum_name": "Name", "field": "name", "header": "Name", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 300},
-        {"enum_name": "DisplayOrder", "field": "display_order", "header": "Order", "is_int": true, "width": 80},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Code",
+          "field": "code",
+          "header": "Code",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "Name",
+          "field": "name",
+          "header": "Name",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 300
+        },
+        {
+          "enum_name": "DisplayOrder",
+          "field": "display_order",
+          "header": "Order",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "ReportTypeListWindow",
       "window_title": "Report Types",
       "icon": "FileBarChart"

--- a/projects/ores.codegen/models/scheduler/job_definition_domain_entity.json
+++ b/projects/ores.codegen/models/scheduler/job_definition_domain_entity.json
@@ -3,6 +3,8 @@
     "schema": "public",
     "product": "ores",
     "component": "scheduler",
+    "component_include": "scheduler.api",
+    "component_core": "scheduler.core",
     "entity_singular": "job_definition",
     "entity_plural": "job_definitions",
     "entity_title": "Job Definition",
@@ -10,7 +12,6 @@
     "generator_facet_name": "generator",
     "brief": "Persistent plan for a pg_cron scheduled SQL job.",
     "description": "Metadata overlay for a pg_cron cron.job entry. Tracks the job name,\ncron expression, SQL command, target database, and active state.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
@@ -18,7 +19,6 @@
       "description": "UUID primary key for the job definition.",
       "uuid_check_fn": "ores_utility_nil_uuid_fn()"
     },
-
     "columns": [
       {
         "name": "party_id",
@@ -82,7 +82,6 @@
         "description": "1 = active, 0 = paused."
       }
     ],
-
     "sql": {
       "tablename": "ores_scheduler_job_definitions_tbl",
       "nullable_tenant_id": true,
@@ -102,7 +101,6 @@
         }
       ]
     },
-
     "indexes": [
       {
         "name": "name_tenant_uniq",
@@ -125,21 +123,20 @@
         "current_only": true
       }
     ],
-
     "repository": {
       "entity_singular_short": "definition",
       "entity_plural_short": "definitions",
       "entity_singular_words": "job definition",
       "entity_plural_words": "job definitions"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<string>"]
+        "domain": [
+          "<string>"
+        ]
       },
       "iterator_var": "jd"
     },
-
     "qt": {
       "domain_include": "ores.scheduler/domain/job_definition.hpp",
       "domain_class": "scheduler::domain::job_definition",
@@ -149,7 +146,6 @@
       "key_field": "job_name",
       "key_widget": "jobNameEdit",
       "has_uuid_primary_key": true,
-
       "get_request_class": "scheduler::messaging::get_job_definitions_request",
       "get_response_class": "scheduler::messaging::get_job_definitions_response",
       "get_message_type": "get_job_definitions_request",
@@ -162,7 +158,6 @@
       "history_request_class": "scheduler::messaging::get_job_history_request",
       "history_response_class": "scheduler::messaging::get_job_history_response",
       "history_message_type": "get_job_history_request",
-
       "detail_fields": [
         {
           "field": "job_name",
@@ -205,17 +200,57 @@
           "placeholder": "Target PostgreSQL database name"
         }
       ],
-
       "columns": [
-        {"enum_name": "JobName",      "field": "job_name",           "header": "Job Name",    "is_string": true,  "width": 200},
-        {"enum_name": "Description",  "field": "description",        "header": "Description", "is_string": true,  "width": 250},
-        {"enum_name": "Schedule",     "field": "schedule_expression","header": "Schedule",    "is_string": true,  "width": 150},
-        {"enum_name": "DatabaseName", "field": "database_name",      "header": "Database",    "is_string": true,  "width": 150},
-        {"enum_name": "Active",       "field": "is_active",          "header": "Active",      "is_bool": true,    "width": 80},
-        {"enum_name": "Version",      "field": "version",            "header": "Version",     "is_int": true,     "width": 60},
-        {"enum_name": "ModifiedBy",   "field": "modified_by",        "header": "Modified By", "is_string": true,  "width": 120}
+        {
+          "enum_name": "JobName",
+          "field": "job_name",
+          "header": "Job Name",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 250
+        },
+        {
+          "enum_name": "Schedule",
+          "field": "schedule_expression",
+          "header": "Schedule",
+          "is_string": true,
+          "width": 150
+        },
+        {
+          "enum_name": "DatabaseName",
+          "field": "database_name",
+          "header": "Database",
+          "is_string": true,
+          "width": 150
+        },
+        {
+          "enum_name": "Active",
+          "field": "is_active",
+          "header": "Active",
+          "is_bool": true,
+          "width": 80
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 60
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        }
       ],
-
       "settings_group": "JobDefinitionListWindow",
       "window_title": "Job Definitions",
       "icon": "CalendarClock"

--- a/projects/ores.codegen/models/trading/business_day_convention_type_domain_entity.json
+++ b/projects/ores.codegen/models/trading/business_day_convention_type_domain_entity.json
@@ -3,6 +3,8 @@
     "schema": "public",
     "product": "ores",
     "component": "trading",
+    "component_include": "trading.api",
+    "component_core": "trading.core",
     "entity_singular": "business_day_convention_type",
     "entity_plural": "business_day_convention_types",
     "entity_title": "Business Day Convention Type",
@@ -10,7 +12,6 @@
     "generator_facet_name": "generator",
     "brief": "ORE business day convention code (e.g. Following, ModifiedFollowing, Unadjusted).",
     "description": "Reference data table defining valid business day conventions used in\ninstrument leg definitions. Values are sourced from ORE ore_types.xsd.",
-
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -19,7 +20,6 @@
       "detail": "Examples: 'Following', 'ModifiedFollowing', 'Preceding', 'Unadjusted'.",
       "generator_expr": "std::string(faker::word::noun()) + \"_bdc_\" + std::to_string(++counter)"
     },
-
     "columns": [
       {
         "name": "description",
@@ -30,25 +30,24 @@
         "generator_expr": "std::string(faker::lorem::sentence())"
       }
     ],
-
     "sql": {
       "tablename": "ores_trading_business_day_convention_types_tbl"
     },
-
     "repository": {
       "entity_singular_short": "type",
       "entity_plural_short": "types",
       "entity_singular_words": "business day convention type",
       "entity_plural_words": "business day convention types"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ]
       },
       "iterator_var": "t"
     },
-
     "qt": {
       "domain_include": "ores.trading.api/domain/business_day_convention_type.hpp",
       "domain_class": "trading::domain::business_day_convention_type",
@@ -57,7 +56,6 @@
       "item_var": "type",
       "key_field": "code",
       "has_uuid_primary_key": false,
-
       "get_request_class": "trading::messaging::get_business_day_convention_types_request",
       "get_response_class": "trading::messaging::get_business_day_convention_types_response",
       "get_message_type": "get_business_day_convention_types_request",
@@ -70,15 +68,43 @@
       "history_request_class": "trading::messaging::get_business_day_convention_type_history_request",
       "history_response_class": "trading::messaging::get_business_day_convention_type_history_response",
       "history_message_type": "get_business_day_convention_type_history_request",
-
       "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 350},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Code",
+          "field": "code",
+          "header": "Code",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 350
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "BusinessDayConventionTypeListWindow",
       "window_title": "Business Day Convention Types",
       "icon": "Calendar"

--- a/projects/ores.codegen/models/trading/day_count_fraction_type_domain_entity.json
+++ b/projects/ores.codegen/models/trading/day_count_fraction_type_domain_entity.json
@@ -3,6 +3,8 @@
     "schema": "public",
     "product": "ores",
     "component": "trading",
+    "component_include": "trading.api",
+    "component_core": "trading.core",
     "entity_singular": "day_count_fraction_type",
     "entity_plural": "day_count_fraction_types",
     "entity_title": "Day Count Fraction Type",
@@ -10,7 +12,6 @@
     "generator_facet_name": "generator",
     "brief": "ORE day count fraction convention code (e.g. A360, A365F, ActAct(ISDA)).",
     "description": "Reference data table defining valid day count fraction conventions used in\ninstrument leg definitions. Values are sourced from ORE ore_types.xsd.",
-
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -19,7 +20,6 @@
       "detail": "Examples: 'A360', 'A365F', 'ActAct(ISDA)', '30/360', 'Business252'.",
       "generator_expr": "std::string(faker::word::noun()) + \"_dcf_\" + std::to_string(++counter)"
     },
-
     "columns": [
       {
         "name": "description",
@@ -30,25 +30,24 @@
         "generator_expr": "std::string(faker::lorem::sentence())"
       }
     ],
-
     "sql": {
       "tablename": "ores_trading_day_count_fraction_types_tbl"
     },
-
     "repository": {
       "entity_singular_short": "type",
       "entity_plural_short": "types",
       "entity_singular_words": "day count fraction type",
       "entity_plural_words": "day count fraction types"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ]
       },
       "iterator_var": "t"
     },
-
     "qt": {
       "domain_include": "ores.trading.api/domain/day_count_fraction_type.hpp",
       "domain_class": "trading::domain::day_count_fraction_type",
@@ -57,7 +56,6 @@
       "item_var": "type",
       "key_field": "code",
       "has_uuid_primary_key": false,
-
       "get_request_class": "trading::messaging::get_day_count_fraction_types_request",
       "get_response_class": "trading::messaging::get_day_count_fraction_types_response",
       "get_message_type": "get_day_count_fraction_types_request",
@@ -70,15 +68,43 @@
       "history_request_class": "trading::messaging::get_day_count_fraction_type_history_request",
       "history_response_class": "trading::messaging::get_day_count_fraction_type_history_response",
       "history_message_type": "get_day_count_fraction_type_history_request",
-
       "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 350},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Code",
+          "field": "code",
+          "header": "Code",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 350
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "DayCountFractionTypeListWindow",
       "window_title": "Day Count Fraction Types",
       "icon": "Calendar"

--- a/projects/ores.codegen/models/trading/floating_index_type_domain_entity.json
+++ b/projects/ores.codegen/models/trading/floating_index_type_domain_entity.json
@@ -3,6 +3,8 @@
     "schema": "public",
     "product": "ores",
     "component": "trading",
+    "component_include": "trading.api",
+    "component_core": "trading.core",
     "entity_singular": "floating_index_type",
     "entity_plural": "floating_index_types",
     "entity_title": "Floating Index Type",
@@ -10,7 +12,6 @@
     "generator_facet_name": "generator",
     "brief": "ORE floating rate index code (e.g. EUR-EURIBOR-6M, USD-SOFR, GBP-SONIA).",
     "description": "Reference data table defining valid floating rate indices used in\ninstrument floating leg definitions. Values are sourced from ORE ore_types.xsd.",
-
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -19,7 +20,6 @@
       "detail": "Examples: 'EUR-EURIBOR-6M', 'USD-SOFR', 'GBP-SONIA', 'JPY-TONAR'.",
       "generator_expr": "std::string(faker::word::noun()) + \"_idx_\" + std::to_string(++counter)"
     },
-
     "columns": [
       {
         "name": "description",
@@ -30,25 +30,24 @@
         "generator_expr": "std::string(faker::lorem::sentence())"
       }
     ],
-
     "sql": {
       "tablename": "ores_trading_floating_index_types_tbl"
     },
-
     "repository": {
       "entity_singular_short": "type",
       "entity_plural_short": "types",
       "entity_singular_words": "floating index type",
       "entity_plural_words": "floating index types"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ]
       },
       "iterator_var": "t"
     },
-
     "qt": {
       "domain_include": "ores.trading.api/domain/floating_index_type.hpp",
       "domain_class": "trading::domain::floating_index_type",
@@ -57,7 +56,6 @@
       "item_var": "type",
       "key_field": "code",
       "has_uuid_primary_key": false,
-
       "get_request_class": "trading::messaging::get_floating_index_types_request",
       "get_response_class": "trading::messaging::get_floating_index_types_response",
       "get_message_type": "get_floating_index_types_request",
@@ -70,15 +68,43 @@
       "history_request_class": "trading::messaging::get_floating_index_type_history_request",
       "history_response_class": "trading::messaging::get_floating_index_type_history_response",
       "history_message_type": "get_floating_index_type_history_request",
-
       "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 350},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Code",
+          "field": "code",
+          "header": "Code",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 350
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "FloatingIndexTypeListWindow",
       "window_title": "Floating Index Types",
       "icon": "Tag"

--- a/projects/ores.codegen/models/trading/leg_type_domain_entity.json
+++ b/projects/ores.codegen/models/trading/leg_type_domain_entity.json
@@ -3,6 +3,8 @@
     "schema": "public",
     "product": "ores",
     "component": "trading",
+    "component_include": "trading.api",
+    "component_core": "trading.core",
     "entity_singular": "leg_type",
     "entity_plural": "leg_types",
     "entity_title": "Leg Type",
@@ -10,7 +12,6 @@
     "generator_facet_name": "generator",
     "brief": "ORE leg type code (e.g. Fixed, Floating, OIS, CMS, CPI).",
     "description": "Reference data table defining valid leg types used in instrument leg definitions.\nValues are sourced from ORE ore_types.xsd LegType enumeration.",
-
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -19,7 +20,6 @@
       "detail": "Examples: 'Fixed', 'Floating', 'OIS', 'CMS', 'CMSSpread', 'CPI', 'YoY'.",
       "generator_expr": "std::string(faker::word::noun()) + \"_leg_\" + std::to_string(++counter)"
     },
-
     "columns": [
       {
         "name": "description",
@@ -30,25 +30,24 @@
         "generator_expr": "std::string(faker::lorem::sentence())"
       }
     ],
-
     "sql": {
       "tablename": "ores_trading_leg_types_tbl"
     },
-
     "repository": {
       "entity_singular_short": "type",
       "entity_plural_short": "types",
       "entity_singular_words": "leg type",
       "entity_plural_words": "leg types"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ]
       },
       "iterator_var": "t"
     },
-
     "qt": {
       "domain_include": "ores.trading.api/domain/leg_type.hpp",
       "domain_class": "trading::domain::leg_type",
@@ -57,7 +56,6 @@
       "item_var": "type",
       "key_field": "code",
       "has_uuid_primary_key": false,
-
       "get_request_class": "trading::messaging::get_leg_types_request",
       "get_response_class": "trading::messaging::get_leg_types_response",
       "get_message_type": "get_leg_types_request",
@@ -70,15 +68,43 @@
       "history_request_class": "trading::messaging::get_leg_type_history_request",
       "history_response_class": "trading::messaging::get_leg_type_history_response",
       "history_message_type": "get_leg_type_history_request",
-
       "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 350},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Code",
+          "field": "code",
+          "header": "Code",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 350
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "LegTypeListWindow",
       "window_title": "Leg Types",
       "icon": "Tag"

--- a/projects/ores.codegen/models/trading/party_role_type_domain_entity.json
+++ b/projects/ores.codegen/models/trading/party_role_type_domain_entity.json
@@ -2,6 +2,8 @@
   "domain_entity": {
     "schema": "public",
     "component": "trading",
+    "component_include": "trading.api",
+    "component_core": "trading.core",
     "entity_singular": "party_role_type",
     "entity_plural": "party_role_types",
     "entity_title": "Party Role Type",
@@ -9,7 +11,6 @@
     "generator_facet_name": "generator",
     "brief": "FpML-aligned party role code (e.g. Counterparty, CalculationAgent, ExecutingBroker).",
     "description": "Reference data table defining valid trade party role type codes.\nExamples: 'Counterparty', 'CalculationAgent', 'ExecutingBroker', 'NovationTransferee'.",
-
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -18,7 +19,6 @@
       "detail": "Examples: 'Counterparty', 'CalculationAgent', 'ExecutingBroker'.",
       "generator_expr": "std::string(faker::word::noun()) + \"_role_\" + std::to_string(++counter)"
     },
-
     "columns": [
       {
         "name": "description",
@@ -29,21 +29,21 @@
         "generator_expr": "std::string(faker::lorem::sentence())"
       }
     ],
-
     "sql": {
       "tablename": "ores_trading_party_role_types_tbl"
     },
-
     "repository": {
       "entity_singular_short": "role_type",
       "entity_plural_short": "role_types",
       "entity_singular_words": "party role type",
       "entity_plural_words": "party role types"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ]
       },
       "iterator_var": "prt"
     }

--- a/projects/ores.codegen/models/trading/payment_frequency_type_domain_entity.json
+++ b/projects/ores.codegen/models/trading/payment_frequency_type_domain_entity.json
@@ -3,6 +3,8 @@
     "schema": "public",
     "product": "ores",
     "component": "trading",
+    "component_include": "trading.api",
+    "component_core": "trading.core",
     "entity_singular": "payment_frequency_type",
     "entity_plural": "payment_frequency_types",
     "entity_title": "Payment Frequency Type",
@@ -10,7 +12,6 @@
     "generator_facet_name": "generator",
     "brief": "ORE payment frequency code (e.g. Annual, Semiannual, Quarterly, Monthly).",
     "description": "Reference data table defining valid payment frequency conventions used in\ninstrument leg definitions. Values are sourced from ORE ore_types.xsd.",
-
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -19,7 +20,6 @@
       "detail": "Examples: 'Annual', 'Semiannual', 'Quarterly', 'Monthly', 'Once'.",
       "generator_expr": "std::string(faker::word::noun()) + \"_freq_\" + std::to_string(++counter)"
     },
-
     "columns": [
       {
         "name": "description",
@@ -30,25 +30,24 @@
         "generator_expr": "std::string(faker::lorem::sentence())"
       }
     ],
-
     "sql": {
       "tablename": "ores_trading_payment_frequency_types_tbl"
     },
-
     "repository": {
       "entity_singular_short": "type",
       "entity_plural_short": "types",
       "entity_singular_words": "payment frequency type",
       "entity_plural_words": "payment frequency types"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ]
       },
       "iterator_var": "t"
     },
-
     "qt": {
       "domain_include": "ores.trading.api/domain/payment_frequency_type.hpp",
       "domain_class": "trading::domain::payment_frequency_type",
@@ -57,7 +56,6 @@
       "item_var": "type",
       "key_field": "code",
       "has_uuid_primary_key": false,
-
       "get_request_class": "trading::messaging::get_payment_frequency_types_request",
       "get_response_class": "trading::messaging::get_payment_frequency_types_response",
       "get_message_type": "get_payment_frequency_types_request",
@@ -70,15 +68,43 @@
       "history_request_class": "trading::messaging::get_payment_frequency_type_history_request",
       "history_response_class": "trading::messaging::get_payment_frequency_type_history_response",
       "history_message_type": "get_payment_frequency_type_history_request",
-
       "columns": [
-        {"enum_name": "Code", "field": "code", "header": "Code", "is_string": true, "width": 200},
-        {"enum_name": "Description", "field": "description", "header": "Description", "is_string": true, "width": 350},
-        {"enum_name": "Version", "field": "version", "header": "Version", "is_int": true, "width": 80},
-        {"enum_name": "ModifiedBy", "field": "modified_by", "header": "Modified By", "is_string": true, "width": 120},
-        {"enum_name": "RecordedAt", "field": "recorded_at", "header": "Recorded At", "is_timestamp": true, "width": 150}
+        {
+          "enum_name": "Code",
+          "field": "code",
+          "header": "Code",
+          "is_string": true,
+          "width": 200
+        },
+        {
+          "enum_name": "Description",
+          "field": "description",
+          "header": "Description",
+          "is_string": true,
+          "width": 350
+        },
+        {
+          "enum_name": "Version",
+          "field": "version",
+          "header": "Version",
+          "is_int": true,
+          "width": 80
+        },
+        {
+          "enum_name": "ModifiedBy",
+          "field": "modified_by",
+          "header": "Modified By",
+          "is_string": true,
+          "width": 120
+        },
+        {
+          "enum_name": "RecordedAt",
+          "field": "recorded_at",
+          "header": "Recorded At",
+          "is_timestamp": true,
+          "width": 150
+        }
       ],
-
       "settings_group": "PaymentFrequencyTypeListWindow",
       "window_title": "Payment Frequency Types",
       "icon": "Clock"

--- a/projects/ores.codegen/models/trading/trade_id_type_domain_entity.json
+++ b/projects/ores.codegen/models/trading/trade_id_type_domain_entity.json
@@ -2,6 +2,8 @@
   "domain_entity": {
     "schema": "public",
     "component": "trading",
+    "component_include": "trading.api",
+    "component_core": "trading.core",
     "entity_singular": "trade_id_type",
     "entity_plural": "trade_id_types",
     "entity_title": "Trade ID Type",
@@ -9,7 +11,6 @@
     "generator_facet_name": "generator",
     "brief": "Trade identifier type code (e.g. UTI, USI, Internal).",
     "description": "Reference data table defining valid trade identifier type codes.\nExamples: 'UTI', 'USI', 'Internal', 'CICI'.",
-
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -18,7 +19,6 @@
       "detail": "Examples: 'UTI', 'USI', 'Internal'.",
       "generator_expr": "std::string(faker::word::noun()) + \"_id_type_\" + std::to_string(++counter)"
     },
-
     "columns": [
       {
         "name": "description",
@@ -29,21 +29,21 @@
         "generator_expr": "std::string(faker::lorem::sentence())"
       }
     ],
-
     "sql": {
       "tablename": "ores_trading_trade_id_types_tbl"
     },
-
     "repository": {
       "entity_singular_short": "id_type",
       "entity_plural_short": "id_types",
       "entity_singular_words": "trade ID type",
       "entity_plural_words": "trade ID types"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ]
       },
       "iterator_var": "tit"
     }

--- a/projects/ores.codegen/models/trading/trade_party_role_domain_entity.json
+++ b/projects/ores.codegen/models/trading/trade_party_role_domain_entity.json
@@ -2,6 +2,8 @@
   "domain_entity": {
     "schema": "public",
     "component": "trading",
+    "component_include": "trading.api",
+    "component_core": "trading.core",
     "entity_singular": "trade_party_role",
     "entity_plural": "trade_party_roles",
     "entity_title": "Trade Party Role",
@@ -9,7 +11,6 @@
     "generator_facet_name": "generator",
     "brief": "Counterparty role assignment on a trade.",
     "description": "Associates a counterparty with a specific role on a trade.\nThe internal party (the house) is derived from book_id via books.party_id.\nSupports multiple counterparties per trade in different roles.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
@@ -17,7 +18,6 @@
       "description": "UUID uniquely identifying this party role assignment.",
       "detail": "Surrogate key for the trade party role record."
     },
-
     "columns": [
       {
         "name": "trade_id",
@@ -47,21 +47,22 @@
         "generator_expr": "std::string(\"Counterparty\")"
       }
     ],
-
     "sql": {
       "tablename": "ores_trading_party_roles_tbl"
     },
-
     "repository": {
       "entity_singular_short": "role",
       "entity_plural_short": "roles",
       "entity_singular_words": "trade party role",
       "entity_plural_words": "trade party roles"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>", "<boost/uuid/uuid.hpp>"]
+        "domain": [
+          "<chrono>",
+          "<string>",
+          "<boost/uuid/uuid.hpp>"
+        ]
       },
       "iterator_var": "pr"
     }

--- a/projects/ores.codegen/models/trading/trade_type_domain_entity.json
+++ b/projects/ores.codegen/models/trading/trade_type_domain_entity.json
@@ -2,6 +2,8 @@
   "domain_entity": {
     "schema": "public",
     "component": "trading",
+    "component_include": "trading.api",
+    "component_core": "trading.core",
     "entity_singular": "trade_type",
     "entity_plural": "trade_types",
     "entity_title": "Trade Type",
@@ -9,7 +11,6 @@
     "generator_facet_name": "generator",
     "brief": "ORE instrument type code (e.g. Swap, FxForward, CapFloor, Swaption).",
     "description": "Reference data table defining valid trade type classifications used to\ncategorise trades in the system.",
-
     "primary_key": {
       "column": "code",
       "type": "text",
@@ -18,7 +19,6 @@
       "detail": "Examples: 'Swap', 'FxForward', 'CapFloor', 'Swaption'.",
       "generator_expr": "std::string(faker::word::noun()) + \"_trade_\" + std::to_string(++counter)"
     },
-
     "columns": [
       {
         "name": "description",
@@ -56,21 +56,21 @@
         "generator_expr": "false"
       }
     ],
-
     "sql": {
       "tablename": "ores_trading_trade_types_tbl"
     },
-
     "repository": {
       "entity_singular_short": "type",
       "entity_plural_short": "types",
       "entity_singular_words": "trade type",
       "entity_plural_words": "trade types"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<string>"]
+        "domain": [
+          "<chrono>",
+          "<string>"
+        ]
       },
       "iterator_var": "tt"
     }

--- a/projects/ores.codegen/models/workflow/workflow_instance_domain_entity.json
+++ b/projects/ores.codegen/models/workflow/workflow_instance_domain_entity.json
@@ -2,6 +2,8 @@
   "domain_entity": {
     "schema": "public",
     "component": "workflow",
+    "component_include": "workflow.api",
+    "component_core": "workflow.core",
     "entity_singular": "workflow_instance",
     "entity_plural": "workflow_instances",
     "entity_singular_title": "Workflow Instance",
@@ -9,16 +11,13 @@
     "has_tenant_id": true,
     "brief": "A single execution of a named workflow.",
     "description": "Tracks the lifecycle of a workflow execution, including its type, status,\nthe serialised request that triggered it, and any result or error produced.\nInstances are append-mostly; status transitions are the primary mutation.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
       "cpp_type": "boost::uuids::uuid",
       "description": "UUID primary key for the workflow instance."
     },
-
     "natural_keys": [],
-
     "columns": [
       {
         "name": "tenant_id",
@@ -115,21 +114,23 @@
         "description": "Timestamp of the most recent step-completed event processed."
       }
     ],
-
     "sql": {
       "tablename": "ores_workflow_workflow_instances_tbl"
     },
-
     "repository": {
       "entity_singular_short": "instance",
       "entity_plural_short": "instances",
       "entity_singular_words": "workflow instance",
       "entity_plural_words": "workflow instances"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<optional>", "<string>", "<boost/uuid/uuid.hpp>"]
+        "domain": [
+          "<chrono>",
+          "<optional>",
+          "<string>",
+          "<boost/uuid/uuid.hpp>"
+        ]
       },
       "iterator_var": "wi"
     }

--- a/projects/ores.codegen/models/workflow/workflow_step_domain_entity.json
+++ b/projects/ores.codegen/models/workflow/workflow_step_domain_entity.json
@@ -2,6 +2,8 @@
   "domain_entity": {
     "schema": "public",
     "component": "workflow",
+    "component_include": "workflow.api",
+    "component_core": "workflow.core",
     "entity_singular": "workflow_step",
     "entity_plural": "workflow_steps",
     "entity_singular_title": "Workflow Step",
@@ -9,16 +11,13 @@
     "has_tenant_id": false,
     "brief": "A single step within a workflow instance.",
     "description": "Records the execution of one step in a saga workflow, including the step\nindex, name, status, request/response payloads, and timing. Steps reference\ntheir parent workflow instance via workflow_id.",
-
     "primary_key": {
       "column": "id",
       "type": "uuid",
       "cpp_type": "boost::uuids::uuid",
       "description": "UUID primary key for the workflow step."
     },
-
     "natural_keys": [],
-
     "columns": [
       {
         "name": "workflow_id",
@@ -131,21 +130,23 @@
         "description": "Timestamp when the step reached a terminal state."
       }
     ],
-
     "sql": {
       "tablename": "ores_workflow_workflow_steps_tbl"
     },
-
     "repository": {
       "entity_singular_short": "step",
       "entity_plural_short": "steps",
       "entity_singular_words": "workflow step",
       "entity_plural_words": "workflow steps"
     },
-
     "cpp": {
       "includes": {
-        "domain": ["<chrono>", "<optional>", "<string>", "<boost/uuid/uuid.hpp>"]
+        "domain": [
+          "<chrono>",
+          "<optional>",
+          "<string>",
+          "<boost/uuid/uuid.hpp>"
+        ]
       },
       "iterator_var": "ws"
     }

--- a/projects/ores.codegen/src/codegen/generate.py
+++ b/projects/ores.codegen/src/codegen/generate.py
@@ -139,7 +139,7 @@ def cmd_regenerate(args: Any, base_dir: Path) -> int:
 
         model_files = sorted(
             f for f in models_dir.glob(comp.entity_glob)
-            if not f.name.endswith(comp.exclude_suffix)
+            if comp.exclude_suffix is None or not f.name.endswith(comp.exclude_suffix)
         )
         if not model_files:
             log.warning(

--- a/projects/ores.codegen/src/codegen/manifest.py
+++ b/projects/ores.codegen/src/codegen/manifest.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 
 @dataclass
@@ -10,7 +10,7 @@ class Component:
     # *_entity.json also matches *_domain_entity.json; exclude the latter so
     # regenerate only processes pure schema models, not domain entity models.
     # None means no exclusion.
-    exclude_suffix: str = "_domain_entity.json"
+    exclude_suffix: Optional[str] = "_domain_entity.json"
 
 
 COMPONENTS: Dict[str, Component] = {

--- a/projects/ores.codegen/src/codegen/manifest.py
+++ b/projects/ores.codegen/src/codegen/manifest.py
@@ -9,10 +9,12 @@ class Component:
     entity_glob: str = "*_entity.json"
     # *_entity.json also matches *_domain_entity.json; exclude the latter so
     # regenerate only processes pure schema models, not domain entity models.
+    # None means no exclusion.
     exclude_suffix: str = "_domain_entity.json"
 
 
 COMPONENTS: Dict[str, Component] = {
+    # SQL schema components (--profile sql)
     "refdata": Component(
         name="refdata",
         models_dir="projects/ores.codegen/models/refdata",
@@ -30,6 +32,79 @@ COMPONENTS: Dict[str, Component] = {
     "iam": Component(
         name="iam",
         models_dir="projects/ores.codegen/models/iam",
+    ),
+    # C++ domain entity components (--profile all-cpp)
+    "analytics-cpp": Component(
+        name="analytics-cpp",
+        models_dir="projects/ores.codegen/models/analytics",
+        entity_glob="*_domain_entity.json",
+        exclude_suffix=None,
+    ),
+    "compute-cpp": Component(
+        name="compute-cpp",
+        models_dir="projects/ores.codegen/models/compute",
+        entity_glob="*_domain_entity.json",
+        exclude_suffix=None,
+    ),
+    "controller-cpp": Component(
+        name="controller-cpp",
+        models_dir="projects/ores.codegen/models/controller",
+        entity_glob="*_domain_entity.json",
+        exclude_suffix=None,
+    ),
+    "database-cpp": Component(
+        name="database-cpp",
+        models_dir="projects/ores.codegen/models/database",
+        entity_glob="*_domain_entity.json",
+        exclude_suffix=None,
+    ),
+    "dq-cpp": Component(
+        name="dq-cpp",
+        models_dir="projects/ores.codegen/models/dq",
+        entity_glob="*_domain_entity.json",
+        exclude_suffix=None,
+    ),
+    "iam-cpp": Component(
+        name="iam-cpp",
+        models_dir="projects/ores.codegen/models/iam",
+        entity_glob="*_domain_entity.json",
+        exclude_suffix=None,
+    ),
+    "refdata-cpp": Component(
+        name="refdata-cpp",
+        models_dir="projects/ores.codegen/models/refdata",
+        entity_glob="*_domain_entity.json",
+        exclude_suffix=None,
+    ),
+    "reporting-cpp": Component(
+        name="reporting-cpp",
+        models_dir="projects/ores.codegen/models/reporting",
+        entity_glob="*_domain_entity.json",
+        exclude_suffix=None,
+    ),
+    "scheduler-cpp": Component(
+        name="scheduler-cpp",
+        models_dir="projects/ores.codegen/models/scheduler",
+        entity_glob="*_domain_entity.json",
+        exclude_suffix=None,
+    ),
+    "trading-cpp": Component(
+        name="trading-cpp",
+        models_dir="projects/ores.codegen/models/trading",
+        entity_glob="*_domain_entity.json",
+        exclude_suffix=None,
+    ),
+    "workflow-cpp": Component(
+        name="workflow-cpp",
+        models_dir="projects/ores.codegen/models/workflow",
+        entity_glob="*_domain_entity.json",
+        exclude_suffix=None,
+    ),
+    "workspace-cpp": Component(
+        name="workspace-cpp",
+        models_dir="projects/ores.codegen/models/workspace",
+        entity_glob="*_domain_entity.json",
+        exclude_suffix=None,
     ),
 }
 


### PR DESCRIPTION
## Summary

- Adds `component_include` and `component_core` to all 42 path-error `_domain_entity.json` models so `codegen.py` writes to `ores.<component>.api/` and `ores.<component>.core/` (not the non-existent `ores.<component>/`).
- Registers 12 new `-cpp` component entries in `manifest.py` so `codegen.py regenerate --component X --profile all-cpp` works for all components.
- Fixes `exclude_suffix=None` handling in `generate.py` (`str.endswith("")` is always `True`, which was silently excluding every file).

`database_info` (flat component, `ores.database` has no api/core split) is intentionally excluded.

All 12 components verified: `regenerate --dry-run` finds correct model counts with zero errors.

## Test plan

- [ ] `codegen.py regenerate --component refdata-cpp --profile all-cpp --dry-run` lists 25 models with zero errors
- [ ] `codegen.py regenerate --component trading-cpp --profile all-cpp --dry-run` lists 21 models with zero errors
- [ ] Spot-check: `codegen.py generate --model models/compute/app_domain_entity.json --profile all-cpp --dry-run` outputs path under `ores.compute.api/`
- [ ] Existing SQL components (`refdata`, `trade`, `dq`, `iam`) still work with `--profile sql`
- [ ] Site builds cleanly

Story-ID: 3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E
Task-ID: D2E8F4A1-9B3C-4D7F-6A5B-8E1C7D3F9A2B

🤖 Generated with [Claude Code](https://claude.com/claude-code)