### PR TITLE
[codegen] Fix include guard regression in C++ header templates (Task 3)

### DIFF
--- a/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_fix_template_bugs.org
+++ b/doc/agile/versions/v0/sprint_19/refactor_codegen_cpp/task_fix_template_bugs.org
@@ -48,11 +48,11 @@ regenerating with a buggy template would corrupt production include guards.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                                |
+| State        | DONE                                   |
 | Parent story | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] |
-| Now          | Not yet started.                       |
-| Waiting on   | [[id:A4C9D7F2-3E5B-4A1C-8F6D-9B2E7A4C1D8F][Audit C++ template drift]] (for any additional bugs). |
-| Next         | Start once drift audit is complete.    |
+| Now          | Nothing.                               |
+| Waiting on   | Nothing.                               |
+| Next         | Task 4: Resolve breaking API drift.    |
 | Last touched | 2026-05-30                             |
 
 * Acceptance
@@ -81,4 +81,44 @@ regenerating with a buggy template would corrupt production include guards.
 
 * Result
 
-(Populated when task is complete.)
+** Include guard fix
+
+14 header templates updated to use =component_include_upper= (api files) and
+=component_core_upper= (core files) in their =#ifndef= / =#define= include guards,
+replacing the incorrect =component_upper= (which dropped the =.api= / =.core=
+segment).
+
+Templates fixed with =component_include_upper=:
+
+| Template | Guard segment |
+|----------+---------------|
+| =cpp_domain_type_class.hpp= | =ORES_{{component_include_upper}}_DOMAIN_...= |
+| =cpp_domain_type_class_non_temporal.hpp= | =ORES_{{component_include_upper}}_DOMAIN_...= |
+| =cpp_domain_type_json_io.hpp= | =ORES_{{component_include_upper}}_DOMAIN_..._JSON_IO_...= |
+| =cpp_domain_type_table.hpp= | =ORES_{{component_include_upper}}_DOMAIN_..._TABLE_...= |
+| =cpp_domain_type_table_io.hpp= | =ORES_{{component_include_upper}}_DOMAIN_..._TABLE_IO_...= |
+| =cpp_domain_type_generator.hpp= | =ORES_{{component_include_upper}}_..._GENERATOR_...= |
+| =cpp_protocol.hpp= (both =domain_entity= and =entity= sections) | =ORES_{{component_include_upper}}_MESSAGING_..._PROTOCOL_...= |
+
+Templates fixed with =component_core_upper=:
+
+| Template | Guard segment |
+|----------+---------------|
+| =cpp_domain_type_entity.hpp= | =ORES_{{component_core_upper}}_REPOSITORY_..._ENTITY_...= |
+| =cpp_domain_type_entity_non_temporal.hpp= | =ORES_{{component_core_upper}}_REPOSITORY_..._ENTITY_...= |
+| =cpp_domain_type_mapper.hpp= | =ORES_{{component_core_upper}}_REPOSITORY_..._MAPPER_...= |
+| =cpp_domain_type_mapper_non_temporal.hpp= | =ORES_{{component_core_upper}}_REPOSITORY_..._MAPPER_...= |
+| =cpp_domain_type_repository.hpp= | =ORES_{{component_core_upper}}_REPOSITORY_..._REPOSITORY_...= |
+| =cpp_domain_type_repository_non_temporal.hpp= | =ORES_{{component_core_upper}}_REPOSITORY_..._REPOSITORY_...= |
+| =cpp_service.hpp= | =ORES_{{component_core_upper}}_SERVICE_..._SERVICE_...= |
+
+Backward compatibility: for models without =component_include= / =component_core=
+set, both variables default to =component=, so guard format is unchanged.
+
+Spot-checked against =rounding_type= (all 18 files manually corrected in a prior
+sprint — template now matches production exactly). Also verified =iam/tenant=.
+
+All 12 C++ components dry-run clean (zero errors, zero warnings):
+=analytics-cpp=, =compute-cpp=, =controller-cpp=, =database-cpp=, =dq-cpp=,
+=iam-cpp=, =refdata-cpp=, =reporting-cpp=, =scheduler-cpp=, =trading-cpp=,
+=workflow-cpp=, =workspace-cpp=.

--- a/projects/ores.codegen/library/templates/cpp_domain_type_class.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_class.hpp.mustache
@@ -1,7 +1,7 @@
 {{{cpp_license}}}
 {{#domain_entity}}
-#ifndef ORES_{{component_upper}}_DOMAIN_{{entity_singular_upper}}_HPP
-#define ORES_{{component_upper}}_DOMAIN_{{entity_singular_upper}}_HPP
+#ifndef ORES_{{component_include_upper}}_DOMAIN_{{entity_singular_upper}}_HPP
+#define ORES_{{component_include_upper}}_DOMAIN_{{entity_singular_upper}}_HPP
 
 {{#cpp.includes.domain}}
 #include {{{.}}}

--- a/projects/ores.codegen/library/templates/cpp_domain_type_class_non_temporal.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_class_non_temporal.hpp.mustache
@@ -1,7 +1,7 @@
 {{{cpp_license}}}
 {{#domain_entity}}
-#ifndef ORES_{{component_upper}}_DOMAIN_{{entity_singular_upper}}_HPP
-#define ORES_{{component_upper}}_DOMAIN_{{entity_singular_upper}}_HPP
+#ifndef ORES_{{component_include_upper}}_DOMAIN_{{entity_singular_upper}}_HPP
+#define ORES_{{component_include_upper}}_DOMAIN_{{entity_singular_upper}}_HPP
 
 {{#cpp.includes.domain}}
 #include {{{.}}}

--- a/projects/ores.codegen/library/templates/cpp_domain_type_entity.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_entity.hpp.mustache
@@ -1,7 +1,7 @@
 {{{cpp_license}}}
 {{#domain_entity}}
-#ifndef ORES_{{component_upper}}_REPOSITORY_{{entity_singular_upper}}_ENTITY_HPP
-#define ORES_{{component_upper}}_REPOSITORY_{{entity_singular_upper}}_ENTITY_HPP
+#ifndef ORES_{{component_core_upper}}_REPOSITORY_{{entity_singular_upper}}_ENTITY_HPP
+#define ORES_{{component_core_upper}}_REPOSITORY_{{entity_singular_upper}}_ENTITY_HPP
 
 #include <string>
 #include <optional>

--- a/projects/ores.codegen/library/templates/cpp_domain_type_entity_non_temporal.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_entity_non_temporal.hpp.mustache
@@ -1,7 +1,7 @@
 {{{cpp_license}}}
 {{#domain_entity}}
-#ifndef ORES_{{component_upper}}_REPOSITORY_{{entity_singular_upper}}_ENTITY_HPP
-#define ORES_{{component_upper}}_REPOSITORY_{{entity_singular_upper}}_ENTITY_HPP
+#ifndef ORES_{{component_core_upper}}_REPOSITORY_{{entity_singular_upper}}_ENTITY_HPP
+#define ORES_{{component_core_upper}}_REPOSITORY_{{entity_singular_upper}}_ENTITY_HPP
 
 #include <string>
 #include <optional>

--- a/projects/ores.codegen/library/templates/cpp_domain_type_generator.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_generator.hpp.mustache
@@ -1,7 +1,7 @@
 {{{cpp_license}}}
 {{#domain_entity}}
-#ifndef ORES_{{component_upper}}_{{generator_facet_name_upper}}_{{entity_singular_upper}}_GENERATOR_HPP
-#define ORES_{{component_upper}}_{{generator_facet_name_upper}}_{{entity_singular_upper}}_GENERATOR_HPP
+#ifndef ORES_{{component_include_upper}}_{{generator_facet_name_upper}}_{{entity_singular_upper}}_GENERATOR_HPP
+#define ORES_{{component_include_upper}}_{{generator_facet_name_upper}}_{{entity_singular_upper}}_GENERATOR_HPP
 
 #include <vector>
 #include "ores.{{component_include}}/export.hpp"

--- a/projects/ores.codegen/library/templates/cpp_domain_type_json_io.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_json_io.hpp.mustache
@@ -1,7 +1,7 @@
 {{{cpp_license}}}
 {{#domain_entity}}
-#ifndef ORES_{{component_upper}}_DOMAIN_{{entity_singular_upper}}_JSON_IO_HPP
-#define ORES_{{component_upper}}_DOMAIN_{{entity_singular_upper}}_JSON_IO_HPP
+#ifndef ORES_{{component_include_upper}}_DOMAIN_{{entity_singular_upper}}_JSON_IO_HPP
+#define ORES_{{component_include_upper}}_DOMAIN_{{entity_singular_upper}}_JSON_IO_HPP
 
 #include <iosfwd>
 #include "ores.{{component_include}}/domain/{{entity_singular}}.hpp"

--- a/projects/ores.codegen/library/templates/cpp_domain_type_mapper.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_mapper.hpp.mustache
@@ -1,7 +1,7 @@
 {{{cpp_license}}}
 {{#domain_entity}}
-#ifndef ORES_{{component_upper}}_REPOSITORY_{{entity_singular_upper}}_MAPPER_HPP
-#define ORES_{{component_upper}}_REPOSITORY_{{entity_singular_upper}}_MAPPER_HPP
+#ifndef ORES_{{component_core_upper}}_REPOSITORY_{{entity_singular_upper}}_MAPPER_HPP
+#define ORES_{{component_core_upper}}_REPOSITORY_{{entity_singular_upper}}_MAPPER_HPP
 
 #include "ores.{{component_include}}/domain/{{entity_singular}}.hpp"
 #include "ores.{{component_core}}/repository/{{entity_singular}}_entity.hpp"

--- a/projects/ores.codegen/library/templates/cpp_domain_type_mapper_non_temporal.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_mapper_non_temporal.hpp.mustache
@@ -1,7 +1,7 @@
 {{{cpp_license}}}
 {{#domain_entity}}
-#ifndef ORES_{{component_upper}}_REPOSITORY_{{entity_singular_upper}}_MAPPER_HPP
-#define ORES_{{component_upper}}_REPOSITORY_{{entity_singular_upper}}_MAPPER_HPP
+#ifndef ORES_{{component_core_upper}}_REPOSITORY_{{entity_singular_upper}}_MAPPER_HPP
+#define ORES_{{component_core_upper}}_REPOSITORY_{{entity_singular_upper}}_MAPPER_HPP
 
 #include "ores.{{component_include}}/domain/{{entity_singular}}.hpp"
 #include "ores.{{component_core}}/repository/{{entity_singular}}_entity.hpp"

--- a/projects/ores.codegen/library/templates/cpp_domain_type_repository.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_repository.hpp.mustache
@@ -1,7 +1,7 @@
 {{{cpp_license}}}
 {{#domain_entity}}
-#ifndef ORES_{{component_upper}}_REPOSITORY_{{entity_singular_upper}}_REPOSITORY_HPP
-#define ORES_{{component_upper}}_REPOSITORY_{{entity_singular_upper}}_REPOSITORY_HPP
+#ifndef ORES_{{component_core_upper}}_REPOSITORY_{{entity_singular_upper}}_REPOSITORY_HPP
+#define ORES_{{component_core_upper}}_REPOSITORY_{{entity_singular_upper}}_REPOSITORY_HPP
 
 #include <string>
 #include <vector>

--- a/projects/ores.codegen/library/templates/cpp_domain_type_repository_non_temporal.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_repository_non_temporal.hpp.mustache
@@ -1,7 +1,7 @@
 {{{cpp_license}}}
 {{#domain_entity}}
-#ifndef ORES_{{component_upper}}_REPOSITORY_{{entity_singular_upper}}_REPOSITORY_HPP
-#define ORES_{{component_upper}}_REPOSITORY_{{entity_singular_upper}}_REPOSITORY_HPP
+#ifndef ORES_{{component_core_upper}}_REPOSITORY_{{entity_singular_upper}}_REPOSITORY_HPP
+#define ORES_{{component_core_upper}}_REPOSITORY_{{entity_singular_upper}}_REPOSITORY_HPP
 
 #include <vector>
 #include <sqlgen/postgres.hpp>

--- a/projects/ores.codegen/library/templates/cpp_domain_type_table.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_table.hpp.mustache
@@ -1,7 +1,7 @@
 {{{cpp_license}}}
 {{#domain_entity}}
-#ifndef ORES_{{component_upper}}_DOMAIN_{{entity_singular_upper}}_TABLE_HPP
-#define ORES_{{component_upper}}_DOMAIN_{{entity_singular_upper}}_TABLE_HPP
+#ifndef ORES_{{component_include_upper}}_DOMAIN_{{entity_singular_upper}}_TABLE_HPP
+#define ORES_{{component_include_upper}}_DOMAIN_{{entity_singular_upper}}_TABLE_HPP
 
 #include <string>
 #include <vector>

--- a/projects/ores.codegen/library/templates/cpp_domain_type_table_io.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_domain_type_table_io.hpp.mustache
@@ -1,7 +1,7 @@
 {{{cpp_license}}}
 {{#domain_entity}}
-#ifndef ORES_{{component_upper}}_DOMAIN_{{entity_singular_upper}}_TABLE_IO_HPP
-#define ORES_{{component_upper}}_DOMAIN_{{entity_singular_upper}}_TABLE_IO_HPP
+#ifndef ORES_{{component_include_upper}}_DOMAIN_{{entity_singular_upper}}_TABLE_IO_HPP
+#define ORES_{{component_include_upper}}_DOMAIN_{{entity_singular_upper}}_TABLE_IO_HPP
 
 #include <iosfwd>
 #include <vector>

--- a/projects/ores.codegen/library/templates/cpp_protocol.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_protocol.hpp.mustache
@@ -1,7 +1,7 @@
 {{{cpp_license}}}
 {{#domain_entity}}
-#ifndef ORES_{{component_upper}}_MESSAGING_{{entity_singular_upper}}_PROTOCOL_HPP
-#define ORES_{{component_upper}}_MESSAGING_{{entity_singular_upper}}_PROTOCOL_HPP
+#ifndef ORES_{{component_include_upper}}_MESSAGING_{{entity_singular_upper}}_PROTOCOL_HPP
+#define ORES_{{component_include_upper}}_MESSAGING_{{entity_singular_upper}}_PROTOCOL_HPP
 
 #include <string>
 #include <vector>
@@ -92,8 +92,8 @@ struct get_{{entity_plural}}_{{name_suffix}}_response {
 #endif
 {{/domain_entity}}
 {{#entity}}
-#ifndef ORES_{{component_upper}}_MESSAGING_{{entity_singular_upper}}_PROTOCOL_HPP
-#define ORES_{{component_upper}}_MESSAGING_{{entity_singular_upper}}_PROTOCOL_HPP
+#ifndef ORES_{{component_include_upper}}_MESSAGING_{{entity_singular_upper}}_PROTOCOL_HPP
+#define ORES_{{component_include_upper}}_MESSAGING_{{entity_singular_upper}}_PROTOCOL_HPP
 
 #include <string>
 #include <vector>

--- a/projects/ores.codegen/library/templates/cpp_service.hpp.mustache
+++ b/projects/ores.codegen/library/templates/cpp_service.hpp.mustache
@@ -1,7 +1,7 @@
 {{{cpp_license}}}
 {{#domain_entity}}
-#ifndef ORES_{{component_upper}}_SERVICE_{{entity_singular_upper}}_SERVICE_HPP
-#define ORES_{{component_upper}}_SERVICE_{{entity_singular_upper}}_SERVICE_HPP
+#ifndef ORES_{{component_core_upper}}_SERVICE_{{entity_singular_upper}}_SERVICE_HPP
+#define ORES_{{component_core_upper}}_SERVICE_{{entity_singular_upper}}_SERVICE_HPP
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
## Summary

- Fixed include guard regression in 14 C++ header templates used by `--profile all-cpp`
- api-side templates (`domain/`, `messaging/`, `generators/`) now use `{{component_include_upper}}` (e.g. `ORES_REFDATA_API_DOMAIN_…`)
- core-side templates (`repository/`, `service/`) now use `{{component_core_upper}}` (e.g. `ORES_REFDATA_CORE_REPOSITORY_…`)
- Previously all guards used `{{component_upper}}`, dropping the `.api`/`.core` segment

## Test plan

- [ ] Spot-check `rounding_type` (production guard `ORES_REFDATA_API_DOMAIN_ROUNDING_TYPE_HPP` — template now matches)
- [ ] Dry-run all 12 C++ components: zero errors, zero warnings
- [ ] Verify backward compatibility: models without `component_include`/`component_core` produce unchanged guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)