### PR TITLE
[compass] Implement compass journal subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ compile_commands.json
 # org-roam
 .org-roam.db
 
+# per-worktree Claude session journal (machine-local, not shared)
+.journal.org
+
 .cache
 
 # vcpkg

--- a/doc/agile/product_backlog/inbox/rename_compass_to_something_like_swiss_knife.org
+++ b/doc/agile/product_backlog/inbox/rename_compass_to_something_like_swiss_knife.org
@@ -1,0 +1,32 @@
+:PROPERTIES:
+:ID:       67DA3C48-9D9D-4315-8AB6-684D548B6917
+:END:
+#+title: Rename compass to something like swiss knife
+#+description: Compass is a misleading name, it does much more than that.
+#+type: capture
+#+version: 2
+#+level: cross
+#+filetags: :inbox:capture:
+#+created: 2026-05-31
+#+updated: 2026-05-31
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+Compass started as an orientation tool but we want it to be much more, to start
+coalescing the repetitive parts of runbooks. We need to rename the tool to
+something else like swiss knife and make the orientation parts the compass
+command, e.g.: swiss_knife.sh compass.
+
+* Why
+
+The command has a misleading name. We need the name compass to be used for orientation.
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/product_backlog/inbox/ssh_variable_needs_to_be_in_env.org
+++ b/doc/agile/product_backlog/inbox/ssh_variable_needs_to_be_in_env.org
@@ -1,0 +1,31 @@
+:PROPERTIES:
+:ID:       7EF13B9E-F3D5-4ED7-875E-1EA3369EB2F8
+:END:
+#+title: SSH variable needs to be in .env
+#+description: SSH variable permissions are still an issue due to source command
+#+type: capture
+#+version: 2
+#+level: cross
+#+filetags: :inbox:capture:
+#+created: 2026-05-31
+#+updated: 2026-05-31
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+We need to move the SSH script so it is called within .env
+
+* Why
+
+At present we are asked for permissions for every command with source. We will
+move the gh and git commands into compass soon. We will need SSH variable to be
+in .env then.
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/story.org
@@ -104,11 +104,11 @@ worktrees.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                                |
+| State         | STARTED                                |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                              |
-| Now           | Not yet started.                       |
+| Now           | Task 1 in progress: design journal format. |
 | Waiting on    | Nothing.                               |
-| Next          | Start Task 1: design journal format.   |
+| Next          | Complete Task 1; open PR.              |
 | Last touched  | 2026-05-31                             |
 
 * Acceptance
@@ -132,7 +132,7 @@ worktrees.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:07F68E53-A2A6-4F1F-B699-44B9896EA7DD][Design journal format and gitignore setup]] | BACKLOG | | | Specify .journal.org entry schema; add to .gitignore; write format as a recipe. |
+| [[id:07F68E53-A2A6-4F1F-B699-44B9896EA7DD][Design journal format and gitignore setup]] | DONE | 2026-05-31 | 2026-05-31 | Specify .journal.org entry schema; add to .gitignore; write format as a recipe. |
 | Task: Implement compass journal subcommand | BACKLOG | | | Add compass journal update, where, and log subcommands to compass.py. |
 | Task: Wire compass goto to auto-update the journal | BACKLOG | | | Call compass journal update at the end of compass goto (new-story and existing-story modes). |
 | Task: Refactor compass fleet to use journal | BACKLOG | | | Read .journal.org from each worktree in compass fleet; show story+task+state; graceful fallback. |

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/story.org
@@ -133,7 +133,7 @@ worktrees.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:07F68E53-A2A6-4F1F-B699-44B9896EA7DD][Design journal format and gitignore setup]] | DONE | 2026-05-31 | 2026-05-31 | Specify .journal.org entry schema; add to .gitignore; write format as a recipe. |
-| Task: Implement compass journal subcommand | BACKLOG | | | Add compass journal update, where, and log subcommands to compass.py. |
+| [[id:A8FCCECE-9B64-49A9-8C24-2AE3A1EC7E08][Implement compass journal subcommand]] | DONE | 2026-05-31 | 2026-05-31 | Add compass journal update, where, and log subcommands to compass.py. |
 | Task: Wire compass goto to auto-update the journal | BACKLOG | | | Call compass journal update at the end of compass goto (new-story and existing-story modes). |
 | Task: Refactor compass fleet to use journal | BACKLOG | | | Read .journal.org from each worktree in compass fleet; show story+task+state; graceful fallback. |
 | Task: Write recipe and update semi-autonomous developer skill | BACKLOG | | | Document journal use in a recipe; update the semi-autonomous developer skill to check/update the journal at task pickup. |

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/task_implement_compass_journal.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/task_implement_compass_journal.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_session_journal:sprint_19:v0:
 #+owner: marco
 #+branch: feature/implement-compass-journal
-#+pr:
+#+pr: 952
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-31
@@ -65,7 +65,7 @@ All code added to =projects/ores.compass/src/compass.py=:
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/952][#952]] | [compass] Implement compass journal subcommand |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/task_implement_compass_journal.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/task_implement_compass_journal.org
@@ -69,9 +69,12 @@ All code added to =projects/ores.compass/src/compass.py=:
 
 * Review
 
+** Round 1 — 2026-05-31
+
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | PR prefix bug: =##123= when caller passes =#123= | compass.py | Fixed: strip =#= before digit check | Gemini review |
+| 2 | Atomic write: open("w") risks corruption on interrupted write | compass.py | Fixed: tmp file + Path.replace() | Gemini review |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/task_implement_compass_journal.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/task_implement_compass_journal.org
@@ -1,0 +1,81 @@
+:PROPERTIES:
+:ID: A8FCCECE-9B64-49A9-8C24-2AE3A1EC7E08
+:END:
+#+title: Task: Implement compass journal subcommand
+#+description: Add compass journal update, where, and log subcommands to compass.py; wire journal into main() and argparse help.
+#+type: task
+#+level: s1
+#+filetags: :compass_session_journal:sprint_19:v0:
+#+owner: marco
+#+branch: feature/implement-compass-journal
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-31
+#+updated: 2026-05-31
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Add =compass journal= as a new compass subcommand with three sub-subcommands:
+=update= (append entry), =where= (last entry), =log= (full history). This
+makes the =.journal.org= format spec from Task 1 machine-readable and
+queryable from the CLI.
+
+* Status
+
+| Field        | Value                                       |
+|--------------+---------------------------------------------|
+| State        | DONE                                        |
+| Parent story | [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]]                    |
+| Now          | Nothing.                                    |
+| Waiting on   | Nothing.                                    |
+| Next         | Done. Task 3: wire compass goto auto-update. |
+| Last touched | 2026-05-31                                  |
+
+* Acceptance
+
+- =compass journal --help= shows =update=, =where=, =log= subcommands.
+- =compass journal update --story <UUID> --task <UUID> --branch <name> [--state STARTED] [--pr none]=
+  appends a timestamped entry with org-roam links to =.journal.org=.
+  Titles are resolved from the compass index; UUIDs are used as fallback.
+- =compass journal where= prints the last entry (timestamp, story, task,
+  state, branch, PR) in the standard fleet-style format.
+- =compass journal log= prints all entries newest-last with a count header.
+- =compass journal= is registered in =--help= output of the top-level parser.
+
+* Notes
+
+** Implementation location
+
+All code added to =projects/ores.compass/src/compass.py=:
+
+- =JOURNAL_FILE= constant (=PROJECT_ROOT / ".journal.org"=)
+- =_ORG_LINK_RE= — parses org-roam =[[id:UUID][Title]]= links
+- =_lookup_title(uuid)= — resolves UUID → title via =doc_index.load_all()=
+- =_journal_entries(text)= — splits =.journal.org= text into entry dicts
+- =_print_entry(entry)= — formats one entry in fleet-style output
+- =_journal_update(args)= / =_journal_where()= / =_journal_log()= — handlers
+- =cmd_journal(argv)= — top-level dispatcher with argparse sub-subcommands
+- Wired into =main()= short-circuit (line ~1270) and argparse registry
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+- =compass journal update=, =where=, =log= implemented and tested.
+- Title resolution via =doc_index.load_all()= (dict keyed by lowercase UUID).
+- =compass journal where= output verified against live =.journal.org=.
+- =compass journal log= shows multi-entry history with count header.

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/task_implement_compass_session_journal.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/task_implement_compass_session_journal.org
@@ -7,8 +7,8 @@
 #+level: s1
 #+filetags: :compass_session_journal:sprint_19:v0:
 #+owner: marco
-#+branch: feature/compass-session-journal
-#+pr: 948
+#+branch: feature/design-journal-format
+#+pr:
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-31
@@ -30,11 +30,11 @@ built until the format is specified and agreed.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                                |
+| State        | DONE                                   |
 | Parent story | [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]]               |
-| Now          | Not yet started.                       |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
-| Next         | Write format spec and update .gitignore. |
+| Next         | Done. Task 2: implement compass journal subcommand. |
 | Last touched | 2026-05-31                             |
 
 * Acceptance
@@ -79,6 +79,14 @@ from each worktree's =.journal.org= using the same parser.
 | PR | Title |
 |----+-------|
 | [[https://github.com/OreStudio/OreStudio/pull/948][#948]] | [agile] Scaffold compass_session_journal story in sprint 19 |
+
+* Result
+
+- =.journal.org= added to =.gitignore= with explanatory comment.
+- Recipe [[id:B4C7D2E1-9F3A-4A6B-8E5D-3C1F7B2A9D4E][How do I use the session journal?]] written under =doc/recipes/agile/=.
+- Recipe wired into =doc/recipes/agile/agile.org= index.
+- Entry format, field table, update rules, overlap-detection flow, and
+  manual-write instructions documented; all linked back to the story.
 
 * Review
 

--- a/doc/recipes/agile/agile.org
+++ b/doc/recipes/agile/agile.org
@@ -19,6 +19,10 @@ sprint /is/ — lives in [[id:46DFE47F-967B-4C24-95BF-3E21F97CFD20][Agile proces
 - [[id:1E666848-A785-437E-A463-3D5A0DA0765F][How do I open a new sprint?]]
 - [[id:9F274EE4-3CAB-47FD-BB6E-449D8B789D8C][How do I generate release notes?]]
 
+* Claude session coordination
+
+- [[id:B4C7D2E1-9F3A-4A6B-8E5D-3C1F7B2A9D4E][How do I use the session journal?]] — record task pickup in =.journal.org=; check fleet before starting a new story.
+
 * See also
 
 - [[id:46DFE47F-967B-4C24-95BF-3E21F97CFD20][Agile process]] — the four phases (planning, execution,

--- a/doc/recipes/agile/how_do_i_use_the_session_journal.org
+++ b/doc/recipes/agile/how_do_i_use_the_session_journal.org
@@ -1,0 +1,106 @@
+:PROPERTIES:
+:ID: B4C7D2E1-9F3A-4A6B-8E5D-3C1F7B2A9D4E
+:END:
+#+title: How do I use the session journal?
+#+description: Read and update .journal.org to record what story/task each Claude environment is working on; use compass journal commands for restart recovery and overlap detection.
+#+type: recipe
+#+level: cross
+#+filetags: :agile:compass:llm:recipe:journal:
+#+created: 2026-05-31
+#+updated: 2026-05-31
+
+* Question
+
+How do I record what I am working on so that after a restart I know
+where I left off, and so that other Claude instances can detect overlap
+before picking up a new story?
+
+* Answer
+
+Each worktree has a =.journal.org= file in its root directory. The file is
+gitignored (machine-local, never committed). Every time Claude picks up a
+new task, it appends an entry to =.journal.org=.
+
+** Entry format
+
+#+begin_example
+* 2026-05-31 09:15 — [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]]
+  - Task :: [[id:07F68E53-A2A6-4F1F-B699-44B9896EA7DD][Design journal format and gitignore setup]]
+  - State :: STARTED
+  - Branch :: feature/design-journal-format
+  - PR :: none
+#+end_example
+
+Fields:
+
+| Field | Description |
+|-------+-------------|
+| Heading timestamp | ISO date + time of the entry (when work was picked up) |
+| Story link | org-roam =[[id:UUID][Title]]= of the parent story |
+| =Task ::= | org-roam =[[id:UUID][Title]]= of the specific task |
+| =State ::= | Task state at pickup: =STARTED=, =DONE=, =BLOCKED=, etc. |
+| =Branch ::= | Current git branch name |
+| =PR ::= | GitHub PR number (=#NNN=) or =none= |
+
+** When to update the journal
+
+Update =.journal.org= whenever you:
+
+1. *Pick up a new task* — append an entry with =State :: STARTED= before
+   doing any other work.
+2. *Complete a task* — append a closing entry with =State :: DONE= and
+   the PR number if one was opened.
+3. *Switch tasks mid-session* — append a new entry for the incoming task.
+
+** Querying the journal
+
+Once =compass journal= is implemented (Task 2 of
+[[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]]):
+
+#+begin_src sh
+# Where was I? (last entry in this worktree)
+compass journal where
+
+# Full journey of this worktree
+compass journal log
+
+# Which worktree last worked on a given story?
+compass fleet --story <UUID>
+#+end_src
+
+Until =compass journal= is available, read =.journal.org= directly or
+use =compass fleet= (which shows branch names per worktree).
+
+** Overlap detection before picking up a story
+
+Before running =compass goto= to start a new story, check what the other
+worktrees are currently working on:
+
+#+begin_src sh
+compass fleet
+#+end_src
+
+If another worktree's journal shows the same story or a story touching the
+same files, coordinate before proceeding.
+
+** Writing the entry manually (before compass journal is available)
+
+Open =.journal.org= in the project root and append a heading block
+following the format above. The file does not need to be created — create
+it if absent.
+
+* Conventions
+
+- One entry per task pickup, not per commit. The entry records intent, not
+  every action taken.
+- Org-roam links (=[[id:UUID][Title]]=) are preferred over plain text so
+  entries are navigable from Emacs and stable when titles change.
+- The file grows indefinitely; do not prune it. Old entries are the journey
+  log and may be queried with =compass journal log=.
+- =.journal.org= is *never* committed to git. If it appears in =git status=,
+  check that =.gitignore= contains the entry.
+
+* See also
+
+- [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]] — the story implementing this feature.
+- [[id:1F41F21C-8D2A-46DA-8C6A-571564DF2C0E][How do I work a task?]] — task lifecycle; update the journal at task pickup.

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -739,7 +739,8 @@ def _journal_update(args):
     from datetime import datetime
     story_title = _lookup_title(args.story)
     task_title  = _lookup_title(args.task)
-    pr_val = f"#{args.pr}" if args.pr and args.pr.lstrip("#").isdigit() else (args.pr or "none")
+    clean_pr = args.pr.lstrip("#") if args.pr else ""
+    pr_val = f"#{clean_pr}" if clean_pr.isdigit() else (args.pr or "none")
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
     entry = (
         f"* {timestamp} — [[id:{args.story.upper()}][{story_title}]]\n"
@@ -749,8 +750,10 @@ def _journal_update(args):
         f"  - PR :: {pr_val}\n"
     )
     existing = JOURNAL_FILE.read_text(encoding="utf-8") if JOURNAL_FILE.exists() else ""
-    with open(JOURNAL_FILE, "w", encoding="utf-8") as f:
-        f.write((existing.rstrip("\n") + "\n\n" + entry) if existing.strip() else entry)
+    new_content = (existing.rstrip("\n") + "\n\n" + entry) if existing.strip() else entry
+    tmp = JOURNAL_FILE.with_suffix(".tmp")
+    tmp.write_text(new_content, encoding="utf-8")
+    tmp.replace(JOURNAL_FILE)
     print(f"📓 journal updated: {timestamp} — {story_title} / {task_title}")
     return 0
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -59,7 +59,8 @@ ORG_ROAM_DB = str(PROJECT_ROOT / "org-roam.db")
 if not os.path.exists(ORG_ROAM_DB):
     ORG_ROAM_DB = str(PROJECT_ROOT / ".org-roam.db")
 
-COMPASS_DB = str(PROJECT_ROOT / ".compass.db")
+COMPASS_DB   = str(PROJECT_ROOT / ".compass.db")
+JOURNAL_FILE = PROJECT_ROOT / ".journal.org"
 
 def strip_quotes(path):
     """Remove surrounding quotes from a path string."""
@@ -686,6 +687,123 @@ def cmd_where(args):
 _BRANCH_FIELD_RE = re.compile(r"^#\+branch:\s*(\S+)\s*$", re.MULTILINE)
 _TITLE_FIELD_RE  = re.compile(r"^#\+title:\s*(.+?)\s*$",   re.MULTILINE)
 
+# --- Journal pillar: per-worktree .journal.org ---
+
+_ORG_LINK_RE = re.compile(r"\[\[id:([A-F0-9-]+)\]\[([^\]]+)\]\]", re.IGNORECASE)
+
+def _lookup_title(uuid):
+    """Return the title for a UUID from the doc index, or the UUID itself if not found."""
+    try:
+        docs = doc_index.load_all()
+        doc = docs.get(uuid.lower()) or docs.get(uuid.upper())
+        if doc:
+            return _strip_type_prefix(doc.title)
+    except Exception:
+        pass
+    return uuid
+
+def _journal_entries(text):
+    """Parse .journal.org text into a list of entry dicts."""
+    entries = []
+    blocks = re.split(r"\n(?=\* \d{4}-)", "\n" + text)
+    for block in blocks:
+        block = block.strip()
+        if not block:
+            continue
+        m = re.match(r"^\* (\d{4}-\d{2}-\d{2} \d{2}:\d{2}) — (.+)$", block, re.MULTILINE)
+        if not m:
+            continue
+        entry = {"timestamp": m.group(1), "story_link": m.group(2).strip()}
+        for field in ("Task", "State", "Branch", "PR"):
+            fm = re.search(rf"^\s+- {field} ::\s+(.+)$", block, re.MULTILINE)
+            entry[field.lower()] = fm.group(1).strip() if fm else None
+        entries.append(entry)
+    return entries
+
+def _print_entry(entry):
+    """Print one journal entry in the standard fleet-style format."""
+    sl = entry["story_link"]
+    sm = _ORG_LINK_RE.match(sl)
+    story_display = f"{sm.group(2)} ({sm.group(1)[:8]})" if sm else sl
+
+    tl = entry.get("task") or ""
+    tm = _ORG_LINK_RE.match(tl)
+    task_display = f"{tm.group(2)} ({tm.group(1)[:8]})" if tm else (tl or "—")
+
+    print(f"  ● {entry['timestamp']} — {story_display}")
+    print(f"    Task:   {task_display} — {entry.get('state') or '?'}")
+    print(f"    Branch: {entry.get('branch') or '—'}")
+    print(f"    PR:     {entry.get('pr') or 'none'}")
+
+def _journal_update(args):
+    from datetime import datetime
+    story_title = _lookup_title(args.story)
+    task_title  = _lookup_title(args.task)
+    pr_val = f"#{args.pr}" if args.pr and args.pr.lstrip("#").isdigit() else (args.pr or "none")
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+    entry = (
+        f"* {timestamp} — [[id:{args.story.upper()}][{story_title}]]\n"
+        f"  - Task :: [[id:{args.task.upper()}][{task_title}]]\n"
+        f"  - State :: {args.state}\n"
+        f"  - Branch :: {args.branch}\n"
+        f"  - PR :: {pr_val}\n"
+    )
+    existing = JOURNAL_FILE.read_text(encoding="utf-8") if JOURNAL_FILE.exists() else ""
+    with open(JOURNAL_FILE, "w", encoding="utf-8") as f:
+        f.write((existing.rstrip("\n") + "\n\n" + entry) if existing.strip() else entry)
+    print(f"📓 journal updated: {timestamp} — {story_title} / {task_title}")
+    return 0
+
+def _journal_where():
+    if not JOURNAL_FILE.exists() or not JOURNAL_FILE.stat().st_size:
+        print("No .journal.org found. Run 'compass journal update' when you pick up a task.")
+        return 0
+    entries = _journal_entries(JOURNAL_FILE.read_text(encoding="utf-8"))
+    if not entries:
+        print("No entries in .journal.org.")
+        return 0
+    _print_entry(entries[-1])
+    return 0
+
+def _journal_log():
+    if not JOURNAL_FILE.exists() or not JOURNAL_FILE.stat().st_size:
+        print("No .journal.org found.")
+        return 0
+    entries = _journal_entries(JOURNAL_FILE.read_text(encoding="utf-8"))
+    if not entries:
+        print("No entries in .journal.org.")
+        return 0
+    print(f"📓 ores.compass — session journal ({len(entries)} {'entry' if len(entries) == 1 else 'entries'})\n")
+    for entry in entries:
+        _print_entry(entry)
+        print()
+    return 0
+
+def cmd_journal(argv):
+    """compass journal — read and write the per-worktree session journal (.journal.org)."""
+    ap = argparse.ArgumentParser(
+        prog="compass journal",
+        description="Read and write .journal.org — the per-worktree Claude session journal.")
+    sub = ap.add_subparsers(dest="subcmd", required=True)
+
+    up = sub.add_parser("update", help="Append a new entry to .journal.org")
+    up.add_argument("--story",  required=True, help="Story UUID")
+    up.add_argument("--task",   required=True, help="Task UUID")
+    up.add_argument("--branch", required=True, help="Current git branch name")
+    up.add_argument("--state",  default="STARTED", help="Task state (default: STARTED)")
+    up.add_argument("--pr",     default="none",    help="PR number or 'none' (default: none)")
+
+    sub.add_parser("where", help="Show the last journal entry (where was I?)")
+    sub.add_parser("log",   help="Show all journal entries in chronological order")
+
+    args = ap.parse_args(argv)
+    if args.subcmd == "update":
+        return _journal_update(args)
+    if args.subcmd == "where":
+        return _journal_where()
+    if args.subcmd == "log":
+        return _journal_log()
+
 def list_worktrees():
     """Return [(path, branch_or_None)] from `git worktree list --porcelain`."""
     try:
@@ -1266,6 +1384,8 @@ def main():
         sys.exit(cmd_goto(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] == "capture":
         sys.exit(cmd_capture(sys.argv[2:]))
+    if len(sys.argv) >= 2 and sys.argv[1] == "journal":
+        sys.exit(cmd_journal(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] in ALL_BUCKETS:
         sys.exit(cmd_backlog(sys.argv[1], sys.argv[2:]))
 
@@ -1306,6 +1426,8 @@ def main():
                           help="Create a v2 doc via ores.codegen (story/task/sprint/...); 'add --help' for usage")
     subparsers.add_parser("goto",
                           help="Start work: fetch main, branch, scaffold story+task, print next steps ('goto --help')")
+    subparsers.add_parser("journal",
+                          help="Read/write the per-worktree session journal; 'journal --help' for subcommands")
     subparsers.add_parser("inbox",     help="List captures in the product backlog inbox/")
     subparsers.add_parser("next",      help="List captures in the product backlog next/")
     subparsers.add_parser("deferred",  help="List captures in the product backlog deferred/")


### PR DESCRIPTION
## Summary

Adds `compass journal` — a new subcommand that reads and writes the per-worktree `.journal.org` session journal. This enables two workflows: restart recovery ("where was I?") and overlap detection across parallel Claude instances before picking up a new story.

## Changes

- `compass.py` — `compass journal update / where / log` implemented; `JOURNAL_FILE` constant; `_lookup_title()` (resolves UUID → title via doc index); `_journal_entries()` parser; `_print_entry()` formatter; wired into `main()` short-circuit and argparse registry
- `task_implement_compass_journal.org` — Task 2 scaffolded and marked DONE
- `story.org` — Task 2 row updated to DONE with org-roam link

Also carries forward from the Task 1 branch (cherry-picked):
- `.gitignore` — `.journal.org` entry added
- `how_do_i_use_the_session_journal.org` — recipe written
- `agile.org` — recipe wired into index
- Two inbox captures committed

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Compass session journal](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_session_journal/story.html) | 20AC8397-1ACD-4B1A-B0FE-6FAB74477592 |
| Task | [Implement compass journal subcommand](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_session_journal/task_implement_compass_journal.html) | A8FCCECE-9B64-49A9-8C24-2AE3A1EC7E08 |