### PR TITLE
[compass] Wire compass goto to auto-update the session journal

### DIFF
--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/story.org
@@ -134,7 +134,7 @@ worktrees.
 |------+-------+-------+-----+-------------|
 | [[id:07F68E53-A2A6-4F1F-B699-44B9896EA7DD][Design journal format and gitignore setup]] | DONE | 2026-05-31 | 2026-05-31 | Specify .journal.org entry schema; add to .gitignore; write format as a recipe. |
 | [[id:A8FCCECE-9B64-49A9-8C24-2AE3A1EC7E08][Implement compass journal subcommand]] | DONE | 2026-05-31 | 2026-05-31 | Add compass journal update, where, and log subcommands to compass.py. |
-| Task: Wire compass goto to auto-update the journal | BACKLOG | | | Call compass journal update at the end of compass goto (new-story and existing-story modes). |
+| [[id:6AF5890B-8409-4652-AA68-929CBC45C69B][Wire compass goto to auto-update the journal]] | DONE | 2026-05-31 | 2026-05-31 | Call compass journal update at the end of compass goto (new-story and existing-story modes). |
 | Task: Refactor compass fleet to use journal | BACKLOG | | | Read .journal.org from each worktree in compass fleet; show story+task+state; graceful fallback. |
 | Task: Write recipe and update semi-autonomous developer skill | BACKLOG | | | Document journal use in a recipe; update the semi-autonomous developer skill to check/update the journal at task pickup. |
 

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/task_wire_goto_journal_update.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/task_wire_goto_journal_update.org
@@ -66,6 +66,15 @@ Three additions to =compass.py=:
 |----+-------|
 | [[https://github.com/OreStudio/OreStudio/pull/954][#954]] | [compass] Wire compass goto to auto-update the session journal |
 
+* Review
+
+** Round 1 — 2026-05-31
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+| 1 | =_ORG_ID_RE= doesn't match indented =:ID:= properties | compass.py | Fixed: allow =^[ \t]*= leading whitespace | Gemini review |
+| 2 | Ad-hoc inner class =_JournalArgs= non-idiomatic | compass.py | Fixed: use =argparse.Namespace= | Gemini review |
+
 * Result
 
 - =_read_org_id()= implemented and verified (returns correct UUIDs from

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/task_wire_goto_journal_update.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/task_wire_goto_journal_update.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_session_journal:sprint_19:v0:
 #+owner: marco
 #+branch: feature/wire-goto-journal-update
-#+pr:
+#+pr: 954
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-31
@@ -64,7 +64,7 @@ Three additions to =compass.py=:
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/954][#954]] | [compass] Wire compass goto to auto-update the session journal |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/task_wire_goto_journal_update.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/task_wire_goto_journal_update.org
@@ -1,0 +1,74 @@
+:PROPERTIES:
+:ID: 6AF5890B-8409-4652-AA68-929CBC45C69B
+:END:
+#+title: Task: Wire compass goto to auto-update the journal
+#+description: Call compass journal update at the end of compass goto (both new-story and existing-story modes) so the journal is updated automatically whenever a task is picked up.
+#+type: task
+#+level: s1
+#+filetags: :compass_session_journal:sprint_19:v0:
+#+owner: marco
+#+branch: feature/wire-goto-journal-update
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-31
+#+updated: 2026-05-31
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+After =compass goto= creates a branch and scaffolds a task, automatically
+append a journal entry to =.journal.org= so Claude does not need to call
+=compass journal update= manually. This makes journal tracking invisible
+and reliable — it happens as part of the existing workflow.
+
+* Status
+
+| Field        | Value                                          |
+|--------------+------------------------------------------------|
+| State        | DONE                                           |
+| Parent story | [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]]                       |
+| Now          | Nothing.                                       |
+| Waiting on   | Nothing.                                       |
+| Next         | Done. Task 4: refactor compass fleet to use journal. |
+| Last touched | 2026-05-31                                     |
+
+* Acceptance
+
+- After =compass goto= completes, =.journal.org= contains a new entry
+  with the correct story UUID, task UUID, branch, and =State :: STARTED=.
+- The update is best-effort: if it fails (index unavailable, disk error),
+  =compass goto= still succeeds and prints a normal result.
+- Both new-story mode and existing-story mode update the journal.
+- UUIDs are read from the scaffolded =story.org= and =task_<slug>.org=
+  files via =_read_org_id()=, not from CLI args.
+
+* Notes
+
+** Implementation
+
+Three additions to =compass.py=:
+
+1. =_ORG_ID_RE= — compiled regex for =^:ID:\s+(\S+)= to extract UUID
+   from an org properties drawer.
+2. =_read_org_id(path)= — reads the =:ID:= value from an org file;
+   returns =None= if absent or unreadable.
+3. Step 4 in =cmd_goto= — reads story and task UUIDs via =_read_org_id=
+   after scaffolding, builds a =_JournalArgs= namespace, calls
+   =_journal_update()=. Wrapped in =try/except Exception: pass= so a
+   journal failure never blocks =goto=.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Result
+
+- =_read_org_id()= implemented and verified (returns correct UUIDs from
+  story and task org files).
+- =cmd_goto= auto-updates =.journal.org= at the end of both modes.
+- =compass journal where= shows the correct entry after =compass goto= runs.

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -1233,7 +1233,7 @@ def _set_frontmatter_branch(path, branch):
     if new != text:                      # avoid a redundant write
         Path(path).write_text(new, encoding="utf-8")
 
-_ORG_ID_RE = re.compile(r"^:ID:\s+(\S+)\s*$", re.MULTILINE)
+_ORG_ID_RE = re.compile(r"^[ \t]*:ID:\s+(\S+)\s*$", re.MULTILINE)
 
 def _read_org_id(path):
     """Return the :ID: value from an org file, or None if absent/unreadable."""
@@ -1381,13 +1381,9 @@ def cmd_goto(argv):
         story_uuid = _read_org_id(story_file)
         task_uuid  = _read_org_id(task_path)
         if story_uuid and task_uuid:
-            class _JournalArgs:
-                story  = story_uuid
-                task   = task_uuid
-                branch = branch
-                state  = "STARTED"
-                pr     = "none"
-            _journal_update(_JournalArgs())
+            _journal_update(argparse.Namespace(
+                story=story_uuid, task=task_uuid, branch=branch,
+                state="STARTED", pr="none"))
     except Exception:
         pass  # journal update is informational; never block goto on failure
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -1233,6 +1233,17 @@ def _set_frontmatter_branch(path, branch):
     if new != text:                      # avoid a redundant write
         Path(path).write_text(new, encoding="utf-8")
 
+_ORG_ID_RE = re.compile(r"^:ID:\s+(\S+)\s*$", re.MULTILINE)
+
+def _read_org_id(path):
+    """Return the :ID: value from an org file, or None if absent/unreadable."""
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+        m = _ORG_ID_RE.search(text)
+        return m.group(1) if m else None
+    except (OSError, UnicodeDecodeError):
+        return None
+
 def resolve_story(ident):
     """Resolve a story identifier to (story_dir, title), or (None, None).
 
@@ -1364,7 +1375,23 @@ def cmd_goto(argv):
     # 3. record the branch on the task so fleet/where can map this worktree
     _set_frontmatter_branch(task_path, branch)
 
-    # 4. next steps (deliberately manual — needs judgement)
+    # 4. update the session journal — best-effort, never fails the goto
+    try:
+        story_file = Path(PROJECT_ROOT) / story_dir / "story.org"
+        story_uuid = _read_org_id(story_file)
+        task_uuid  = _read_org_id(task_path)
+        if story_uuid and task_uuid:
+            class _JournalArgs:
+                story  = story_uuid
+                task   = task_uuid
+                branch = branch
+                state  = "STARTED"
+                pr     = "none"
+            _journal_update(_JournalArgs())
+    except Exception:
+        pass  # journal update is informational; never block goto on failure
+
+    # 5. next steps (deliberately manual — needs judgement)
     print("\nNext steps:")
     if new_story:
         print(f"  - wire the story into {sprint_dir}/sprint.org (* Stories table)")


### PR DESCRIPTION
## Summary

After `compass goto` creates a branch and scaffolds a task, it now automatically appends a journal entry to `.journal.org` with the story UUID, task UUID, branch name, and `State :: STARTED`. No manual `compass journal update` call is needed.

The update is best-effort — wrapped in `try/except` so a journal failure (index unavailable, disk error) never blocks `goto`.

## Changes

- `compass.py` — `_ORG_ID_RE` and `_read_org_id(path)` helper to extract `:ID:` from org files; step 4 added to `cmd_goto` to read UUIDs and call `_journal_update()` automatically
- `task_wire_goto_journal_update.org` — Task 3 scaffolded and marked DONE
- `story.org` — Task 3 row updated to DONE with org-roam link

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Compass session journal](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_session_journal/story.html) | 20AC8397-1ACD-4B1A-B0FE-6FAB74477592 |
| Task | [Wire compass goto to auto-update the journal](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_session_journal/task_wire_goto_journal_update.html) | 6AF5890B-8409-4652-AA68-929CBC45C69B |