### PR TITLE
[compass] Refactor compass fleet to use session journal

### DIFF
--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/story.org
@@ -135,7 +135,7 @@ worktrees.
 | [[id:07F68E53-A2A6-4F1F-B699-44B9896EA7DD][Design journal format and gitignore setup]] | DONE | 2026-05-31 | 2026-05-31 | Specify .journal.org entry schema; add to .gitignore; write format as a recipe. |
 | [[id:A8FCCECE-9B64-49A9-8C24-2AE3A1EC7E08][Implement compass journal subcommand]] | DONE | 2026-05-31 | 2026-05-31 | Add compass journal update, where, and log subcommands to compass.py. |
 | [[id:6AF5890B-8409-4652-AA68-929CBC45C69B][Wire compass goto to auto-update the journal]] | DONE | 2026-05-31 | 2026-05-31 | Call compass journal update at the end of compass goto (new-story and existing-story modes). |
-| Task: Refactor compass fleet to use journal | BACKLOG | | | Read .journal.org from each worktree in compass fleet; show story+task+state; graceful fallback. |
+| [[id:6F0272A9-6059-45FD-819C-0CE7A5555A69][Refactor compass fleet to use journal]] | DONE | 2026-05-31 | 2026-05-31 | Read .journal.org from each worktree in compass fleet; show story+task+state; graceful fallback. |
 | Task: Write recipe and update semi-autonomous developer skill | BACKLOG | | | Document journal use in a recipe; update the semi-autonomous developer skill to check/update the journal at task pickup. |
 
 * Decisions

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/task_refactor_fleet_journal.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/task_refactor_fleet_journal.org
@@ -1,0 +1,77 @@
+:PROPERTIES:
+:ID: 6F0272A9-6059-45FD-819C-0CE7A5555A69
+:END:
+#+title: Task: Refactor compass fleet to use journal
+#+description: Read .journal.org from each worktree in compass fleet; show story+task+state from journal; fall back to branch-based lookup when no journal present.
+#+type: task
+#+level: s1
+#+filetags: :compass_session_journal:sprint_19:v0:
+#+owner: marco
+#+branch: feature/refactor-fleet-journal
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-31
+#+updated: 2026-05-31
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Refactor =compass fleet= to read =.journal.org= from each worktree so
+the fleet view shows story, task, and state from the journal rather than
+inferring context by scanning task org files for =#+branch:= matches.
+Worktrees without a journal fall back to the existing branch-based lookup.
+
+* Status
+
+| Field        | Value                                          |
+|--------------+------------------------------------------------|
+| State        | DONE                                           |
+| Parent story | [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]]                       |
+| Now          | Nothing.                                       |
+| Waiting on   | Nothing.                                       |
+| Next         | Done. Task 5: recipe + semi-autonomous developer skill. |
+| Last touched | 2026-05-31                                     |
+
+* Acceptance
+
+- =compass fleet= reads =<worktree>/.journal.org= for each worktree and
+  uses the last entry's story, task, and state in preference to the
+  branch-based =task_for_branch= lookup.
+- Worktrees without a =.journal.org= fall back to the existing branch
+  scan and display =(from branch)= to signal the data source.
+- Journal-sourced rows show =[STATE]= after the task title.
+- The =--format json= output includes =journal= (bool), =task_state=,
+  and =journal_branch= fields.
+- =compass fleet= still works correctly when no worktree has a journal.
+
+* Notes
+
+** Implementation
+
+Two helpers added to =compass.py=:
+
+- =_journal_last_entry(worktree_path)= — reads =<path>/.journal.org=,
+  parses with =_journal_entries()=, returns the last entry dict or =None=.
+- =_org_link_text(link_str)= — extracts the plain title from an org-roam
+  =[[id:...][Title]]= link; returns the string as-is if not an org link.
+
+=cmd_fleet= updated: for each worktree, try =_journal_last_entry= first;
+if it returns an entry, use =story_link= and =task= fields for titles and
+=state= for the state badge. Fall back to =task_for_branch= only if no
+journal is available.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Result
+
+- =compass fleet= tested across 5 worktrees: journal worktree shows
+  =[STARTED]= badge; others show =(from branch)= fallback.
+- Graceful fallback confirmed — worktrees without =.journal.org= still
+  display correctly.

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/task_refactor_fleet_journal.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/task_refactor_fleet_journal.org
@@ -69,6 +69,14 @@ journal is available.
 |----+-------|
 | [[https://github.com/OreStudio/OreStudio/pull/955][#955]] | [compass] Refactor compass fleet to use session journal |
 
+* Review
+
+** Round 1 — 2026-05-31
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+| 1 | =_org_link_text= returns ="—"= polluting data layer / JSON | compass.py | Fixed: return =link_str= unchanged; display layer applies ="—"= | Gemini review |
+
 * Result
 
 - =compass fleet= tested across 5 worktrees: journal worktree shows

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/task_refactor_fleet_journal.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/task_refactor_fleet_journal.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_session_journal:sprint_19:v0:
 #+owner: marco
 #+branch: feature/refactor-fleet-journal
-#+pr:
+#+pr: 955
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-31
@@ -67,7 +67,7 @@ journal is available.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/955][#955]] | [compass] Refactor compass fleet to use session journal |
 
 * Result
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -871,6 +871,22 @@ def task_for_branch(worktree_path, branch):
         return task_title, story_title
     return None, None
 
+def _journal_last_entry(worktree_path):
+    """Return the last entry dict from a worktree's .journal.org, or None."""
+    jf = Path(worktree_path) / ".journal.org"
+    try:
+        if not jf.exists() or not jf.stat().st_size:
+            return None
+        entries = _journal_entries(jf.read_text(encoding="utf-8"))
+        return entries[-1] if entries else None
+    except (OSError, UnicodeDecodeError):
+        return None
+
+def _org_link_text(link_str):
+    """Extract plain title from an org-roam [[id:...][Title]] link, or return as-is."""
+    m = _ORG_LINK_RE.match(link_str or "")
+    return m.group(2) if m else (link_str or "—")
+
 def cmd_fleet(args):
     worktrees = list_worktrees()
     if not worktrees:
@@ -881,9 +897,17 @@ def cmd_fleet(args):
 
     rows = []
     for path, branch in worktrees:
-        task_title = story_title = None
-        if branch:
-            task_title, story_title = task_for_branch(path, branch)
+        journal = _journal_last_entry(path)
+        if journal:
+            story_title = _org_link_text(journal.get("story_link"))
+            task_title  = _org_link_text(journal.get("task"))
+            task_state  = journal.get("state")
+            journal_branch = journal.get("branch")
+        else:
+            task_title = story_title = task_state = journal_branch = None
+            if branch:
+                task_title, story_title = task_for_branch(path, branch)
+
         pr = pr_map.get(branch) if branch else None
         rows.append({
             "worktree": Path(path).name,
@@ -892,6 +916,9 @@ def cmd_fleet(args):
             "branch": branch,
             "story": story_title,
             "task": task_title,
+            "task_state": task_state,
+            "journal_branch": journal_branch,
+            "journal": bool(journal),
             "pr": ({"number": pr["number"], "state": pr["state"], "url": pr["url"]}
                    if pr else None),
         })
@@ -906,10 +933,12 @@ def cmd_fleet(args):
         branch = r["branch"] or "(detached)"
         print(f"{mark} {r['worktree']}   {branch}")
         if r["task"] or r["story"]:
-            print(f"      story: {r['story'] or '—'}")
-            print(f"      task:  {r['task'] or '—'}")
+            state_suffix = f" [{r['task_state']}]" if r["task_state"] else ""
+            source = "" if r["journal"] else " (from branch)"
+            print(f"      story: {r['story'] or '—'}{source}")
+            print(f"      task:  {r['task'] or '—'}{state_suffix}")
         elif r["branch"] and r["branch"] != "main":
-            print("      (no task records this branch)")
+            print("      (no journal or task records this branch)")
         if r["pr"]:
             print(f"      PR:    #{r['pr']['number']} [{r['pr']['state']}]  {r['pr']['url']}")
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -885,7 +885,7 @@ def _journal_last_entry(worktree_path):
 def _org_link_text(link_str):
     """Extract plain title from an org-roam [[id:...][Title]] link, or return as-is."""
     m = _ORG_LINK_RE.match(link_str or "")
-    return m.group(2) if m else (link_str or "—")
+    return m.group(2) if m else link_str
 
 def cmd_fleet(args):
     worktrees = list_worktrees()


### PR DESCRIPTION
## Summary

Refactors `compass fleet` to read `.journal.org` from each worktree and use its last entry (story, task, state) in preference to the existing branch-based `task_for_branch()` scan. Worktrees without a journal fall back gracefully with a `(from branch)` annotation.

**Before:** fleet inferred context by globbing all `task_*.org` files and matching `#+branch:` — slow, and showed no task state.

**After:** fleet reads `.journal.org` directly — fast, shows `[STATE]` badge from journal; falls back to branch scan only when no journal exists.

## Changes

- `compass.py` — `_journal_last_entry(worktree_path)` reads the last journal entry from any worktree; `_org_link_text()` extracts plain titles from org-roam links; `cmd_fleet` prefers journal data with `[STATE]` badge, falls back with `(from branch)` annotation; JSON output gains `journal`, `task_state`, `journal_branch` fields
- `task_refactor_fleet_journal.org` — Task 4 scaffolded and marked DONE
- `story.org` — Task 4 row updated to DONE with org-roam link

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Compass session journal](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_session_journal/story.html) | 20AC8397-1ACD-4B1A-B0FE-6FAB74477592 |
| Task | [Refactor compass fleet to use journal](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_session_journal/task_refactor_fleet_journal.html) | 6F0272A9-6059-45FD-819C-0CE7A5555A69 |