### PR TITLE
[ores.trading.core] Fix macOS/Windows CI: use reply_no_variant_tags for instrument response

### DIFF
--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
@@ -31,11 +31,11 @@ the variant from the Qt UI boundary as well, since the variant serves no purpose
 
 | Field         | Value                                                                                         |
 |---------------+-----------------------------------------------------------------------------------------------|
-| State         | DONE                                                                                          |
+| State         | STARTED                                                                                       |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                                       |
-| Now           | Nothing.                                                                                      |
+| Now           | Task 5: deleting ClientManagerTradeDetail.cpp to fix remaining macOS/Windows CI failures.     |
 | Waiting on    | —                                                                                             |
-| Next          | Merge Task 4 PR; story complete.                                                              |
+| Next          | PR for Task 5; verify macOS and Windows CI green; close story.                                |
 | Last touched  | 2026-05-31                                                                                    |
 
 * Acceptance
@@ -59,6 +59,7 @@ the variant from the Qt UI boundary as well, since the variant serves no purpose
 | [[id:06C98C06-F950-483A-997B-89AED70D1238][Rename get_trade_detail → get_trade_instrument and rewrite parse path]]    | DONE    | 2026-05-29 | 2026-05-30 | Rename protocol types, delete workarounds, rewrite client TU with dispatch.     |
 | [[id:F9E5967D-77E7-49E3-9806-74AF22D26191][Write round-trip tests for instrument parse dispatch]]                      | DONE    | 2026-05-30 | 2026-05-31 | One test per instrument family; serialize server-side, verify client dispatch.  |
 | [[id:5C955A5E-0130-40D7-B77F-B41F4F526B79][Refactor IInstrumentForm to type-specific populate methods]]                | DONE    | 2026-05-30 | 2026-05-31 | Remove trade_instrument variant from the Qt UI boundary; typed populate per form.|
+| [[id:2991CE7B-48F3-489F-9792-1BCB529E85BB][Delete leftover get_trade_detail code and fix remaining AddTagsToVariants use]] | STARTED | 2026-05-31 |            | Delete ClientManagerTradeDetail.cpp; remove getTradeDetail API; restore macOS/Windows CI.    |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_delete_get_trade_detail.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_delete_get_trade_detail.org
@@ -1,0 +1,74 @@
+:PROPERTIES:
+:ID: 2991CE7B-48F3-489F-9792-1BCB529E85BB
+:END:
+#+title: Task: Delete leftover get_trade_detail code and fix remaining AddTagsToVariants use
+#+description: Remove ClientManagerTradeDetail.cpp, delete the getTradeDetail API, and clean up any remaining code that still instantiates AddTagsToVariants on trade_instrument, restoring macOS and Windows CI.
+#+type: task
+#+level: s1
+#+filetags: :fix_rfl_complexity:sprint_19:v0:
+#+owner: marco
+#+branch: feature/delete-get-trade-detail
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-31
+#+updated: 2026-05-31
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Remove the leftover Sprint-18 =getTradeDetail= implementation that was
+supposed to be deleted in Task 2 but was not. =ClientManagerTradeDetail.cpp=
+still compiles =rfl::AddTagsToVariants= on =trade_instrument= (the
+502-alternative variant), which is the root cause of the continuing
+macOS fold-expression and Windows MSVC C1202 CI failures. Also remove
+the =getTradeDetail= declaration from =ClientManager.hpp= and audit any
+other remaining instantiation sites.
+
+* Status
+
+| Field        | Value                                                                               |
+|--------------+-------------------------------------------------------------------------------------|
+| State        | STARTED                                                                             |
+| Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
+| Now          | Deleting ClientManagerTradeDetail.cpp and removing the getTradeDetail API.          |
+| Waiting on   | —                                                                                   |
+| Next         | Open PR; verify macOS and Windows CI green.                                         |
+| Last touched | 2026-05-31                                                                          |
+
+* Acceptance
+
+- =ClientManagerTradeDetail.cpp= is deleted from =ores.qt.api/src/=.
+- =ClientManager.hpp= has no =getTradeDetail= declaration.
+- No translation unit in =ores.qt.api= or =ores.qt.trading= includes
+  =rfl/AddTagsToVariants.hpp= and instantiates it on =trade_instrument=,
+  =fx_instrument_variant=, =equity_instrument_variant=, or
+  =rates_instrument_variant=.
+- macOS CI: no fold-expression nesting limit error in =rfl/internal/StringLiteral.hpp=.
+- Windows MSVC CI: no C1202 recursive type error in =rfl/internal/no_duplicate_field_names.hpp=.
+- Linux CI remains green.
+- No call site in =ores.qt.trading= still references =getTradeDetail=.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_delete_get_trade_detail.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_delete_get_trade_detail.org
@@ -81,8 +81,9 @@ Files changed:
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                                 | File                  | Decision | Notes                                        |
+|---+-----------------------------------------------------------------+-----------------------+----------+----------------------------------------------|
+| 1 | Comment says "30+ alternatives"; should say "9 with sub-variants" | handler_helpers.hpp | Accept   | Fixed in 4f58bd687                          |
+| 2 | Same inaccuracy in trade_handler.hpp comment                    | trade_handler.hpp     | Accept   | Fixed in 4f58bd687                          |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_delete_get_trade_detail.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_delete_get_trade_detail.org
@@ -8,7 +8,7 @@
 #+filetags: :fix_rfl_complexity:sprint_19:v0:
 #+owner: marco
 #+branch: feature/delete-get-trade-detail
-#+pr:
+#+pr: 956
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-31
@@ -75,9 +75,9 @@ Files changed:
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR  | Title                                                                                                       |
+|-----+-------------------------------------------------------------------------------------------------------------|
+| 956 | [ores.trading.core] Fix macOS/Windows CI: use reply_no_variant_tags for instrument response                 |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_delete_get_trade_detail.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_delete_get_trade_detail.org
@@ -53,9 +53,23 @@ other remaining instantiation sites.
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+Root cause: =registrar_trades.cpp= includes =trade_handler.hpp=, which calls
+=reply(nats_, msg, resp)= where =resp= is =get_trade_instrument_response=.
+=reply()= uses =rfl::json::write<rfl::AddTagsToVariants>= generically on all
+response types. Applied to =get_trade_instrument_response= (which contains
+=trade_instrument=, a 9-alternative variant whose sub-variants bring the
+total field-name union to 502), this triggers =rfl::Literal<f1,…,f502>=
+at compile time, exceeding the macOS fold-expression nesting limit (256) and
+the Windows MSVC recursive-type limit (C1202).
+
+Fix: Add =reply_no_variant_tags= to =handler_helpers.hpp= and use it in
+=trade_handler.hpp::instrument()=. The new client reads concrete leaf types
+via product_type/trade_type dispatch (=parse_trade_instrument=) and does not
+need =AddTagsToVariants= type-name tags in the wire format.
+
+Files changed:
+- =ores.service/include/ores.service/messaging/handler_helpers.hpp= — new =reply_no_variant_tags= helper
+- =ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp= — use it in =instrument()=; add =using= declaration
 
 * Notes
 

--- a/projects/ores.service/include/ores.service/messaging/handler_helpers.hpp
+++ b/projects/ores.service/include/ores.service/messaging/handler_helpers.hpp
@@ -163,7 +163,7 @@ void reply(ores::nats::service::client& nats,
 
 // Like reply() but writes WITHOUT AddTagsToVariants.
 // Use this when the response contains a large std::variant (e.g. trade_instrument
-// with 30+ alternatives) whose field-name union would exceed the macOS/Windows
+// with nested sub-variants) whose field-name union would exceed the macOS/Windows
 // fold-expression nesting limit. Safe when the client dispatches on a separate
 // discriminator (e.g. product_type/trade_type) rather than relying on type tags.
 template<typename Resp>

--- a/projects/ores.service/include/ores.service/messaging/handler_helpers.hpp
+++ b/projects/ores.service/include/ores.service/messaging/handler_helpers.hpp
@@ -161,6 +161,21 @@ void reply(ores::nats::service::client& nats,
     nats.publish(msg.reply_subject, std::span<const std::byte>(p, json.size()));
 }
 
+// Like reply() but writes WITHOUT AddTagsToVariants.
+// Use this when the response contains a large std::variant (e.g. trade_instrument
+// with 30+ alternatives) whose field-name union would exceed the macOS/Windows
+// fold-expression nesting limit. Safe when the client dispatches on a separate
+// discriminator (e.g. product_type/trade_type) rather than relying on type tags.
+template<typename Resp>
+void reply_no_variant_tags(ores::nats::service::client& nats,
+    const ores::nats::message& msg,
+    const Resp& resp) {
+    if (msg.reply_subject.empty()) return;
+    const auto json = rfl::json::write(resp);
+    const auto* p = reinterpret_cast<const std::byte*>(json.data());
+    nats.publish(msg.reply_subject, std::span<const std::byte>(p, json.size()));
+}
+
 /**
  * @brief Checks whether the request context carries a required permission.
  *

--- a/projects/ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp
@@ -583,7 +583,8 @@ public:
         }
         BOOST_LOG_SEV(trade_handler_lg(), debug)
             << "Completed " << msg.subject;
-        // trade_instrument is a 30+-alternative variant; reply() would apply
+        // trade_instrument is a 9-alternative variant with nested sub-variants
+        // (bringing the total field-name union to 502 names); reply() would apply
         // AddTagsToVariants and exceed the macOS/Windows fold-expression nesting
         // limit. The client dispatches on product_type/trade_type and reads
         // concrete leaf types directly, so type-name tags are not needed.

--- a/projects/ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp
@@ -85,6 +85,7 @@ inline auto& trade_handler_lg() {
 } // namespace
 
 using ores::service::messaging::reply;
+using ores::service::messaging::reply_no_variant_tags;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
@@ -582,7 +583,11 @@ public:
         }
         BOOST_LOG_SEV(trade_handler_lg(), debug)
             << "Completed " << msg.subject;
-        reply(nats_, msg, resp);
+        // trade_instrument is a 30+-alternative variant; reply() would apply
+        // AddTagsToVariants and exceed the macOS/Windows fold-expression nesting
+        // limit. The client dispatches on product_type/trade_type and reads
+        // concrete leaf types directly, so type-name tags are not needed.
+        reply_no_variant_tags(nats_, msg, resp);
     }
 
     void export_portfolio(ores::nats::message msg) {


### PR DESCRIPTION
## Summary

- Add `reply_no_variant_tags()` to `handler_helpers.hpp` — same as `reply()` but writes without `rfl::AddTagsToVariants`.
- Use it in `trade_handler.hpp::instrument()` to break the 502-field compile-time computation that was failing macOS and Windows CI.

## Root cause

`trade_handler.hpp::instrument()` called the generic `reply()` which applies `rfl::json::write<rfl::AddTagsToVariants>` to `get_trade_instrument_response`. That response contains `trade_instrument` — a 9-alternative variant whose sub-variants bring the total field-name union to 502 names. `rfl` instantiates `rfl::Literal<f1,…,f502>` at compile time:

- **macOS Clang**: fold expression with 502 arguments exceeded nesting limit of 256 (`rfl/internal/StringLiteral.hpp`)
- **Windows MSVC**: C1202 recursive type or function dependency too complex (`rfl/internal/no_duplicate_field_names.hpp`)

## Why removing AddTagsToVariants is safe

The new client (`parse_trade_instrument`) dispatches on `product_type`/`trade_type` and reads concrete leaf types directly (e.g. `bond_wrapper{bond_instrument instrument}`). It never reconstructs `trade_instrument` and does not consume type-name tags. Omitting `AddTagsToVariants` from the write side is a compatible wire-format change.

## Traceability

- Story: [Fix rfl complexity failure (Windows + macOS CI)](doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org) — `7763D0EE-A500-4497-9B2D-973C02ADC739`
- Task: [Delete leftover get_trade_detail code and fix remaining AddTagsToVariants use](doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_delete_get_trade_detail.org) — `2991CE7B-48F3-489F-9792-1BCB529E85BB`

🤖 Generated with [Claude Code](https://claude.com/claude-code)