### PR TITLE
[doc] Add site and manual dev docs; v0.0.18 downloads; org-roam links

### DIFF
--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
@@ -153,4 +153,5 @@ practice today) but is a known latent issue for a future story.
 - [[id:D75F4921-B431-4E78-99AB-62A47F761D1D][Investigation: MSVC C1202 and rfl complexity]] — root-cause analysis; O(N²) check, triple-isolation recommendation.
 - [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D8][Resolve RFL complexity issues]] — sprint 18 predecessor; same structural-isolation pattern.
 - [[id:D2E4921B-B431-4E78-99AB-62A47F761D1D][Implement triple isolation for RFL complexity]] — the sprint 18 MSVC C1202 workaround (TU split + two-phase parse + =-fbracket-depth=) that this story supersedes.
+- [[id:FE82780A-789D-4C41-BADF-827B0CD9A540][ORE Studio Sprint 18 – Release Notes]] — sprint 18 release covering the triple-isolation workaround context.
 - [[https://github.com/getml/reflect-cpp/issues/350][reflect-cpp issue #350]] — upstream tracking.

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
@@ -152,4 +152,5 @@ practice today) but is a known latent issue for a future story.
 - [[id:367D0D5F-24BB-4AA1-B784-D79E95C15A16][Fix rfl complexity failure in ClientManagerTradeDetail (capture)]] — exact MSVC C1202 and Clang error messages.
 - [[id:D75F4921-B431-4E78-99AB-62A47F761D1D][Investigation: MSVC C1202 and rfl complexity]] — root-cause analysis; O(N²) check, triple-isolation recommendation.
 - [[id:D8B1A670-3B02-11F1-BCE2-4B06F4BBA5D8][Resolve RFL complexity issues]] — sprint 18 predecessor; same structural-isolation pattern.
+- [[id:D2E4921B-B431-4E78-99AB-62A47F761D1D][Implement triple isolation for RFL complexity]] — the sprint 18 MSVC C1202 workaround (TU split + two-phase parse + =-fbracket-depth=) that this story supersedes.
 - [[https://github.com/getml/reflect-cpp/issues/350][reflect-cpp issue #350]] — upstream tracking.

--- a/doc/downloads.org
+++ b/doc/downloads.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :downloads:
 #+created: 2026-05-25
-#+updated: 2026-05-25
+#+updated: 2026-05-31
 
 ORE Studio is in early active development (version 0.x). Releases are published
 on [[https://github.com/OreStudio/OreStudio/releases][GitHub]] and are provided for evaluation and learning purposes only. Many
@@ -26,6 +26,7 @@ next sprint.
 #+ATTR_HTML: :class hug-leading
 | Version | Code Name             | Source   | Linux | macOS | Windows | Comments                          |
 |---------+-----------------------+----------+-------+-------+---------+-----------------------------------|
+| [[https://github.com/OreStudio/OreStudio/releases/tag/v0.0.18][v0.0.18]] | Jose Sobral           | [[https://github.com/OreStudio/OreStudio/archive/refs/tags/v0.0.18.zip][ZIP]], [[https://github.com/OreStudio/OreStudio/archive/refs/tags/v0.0.18.tar.gz][TGZ]] | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.18/linux-gcc-release-ninja-v0.0.18.zip][DEB]]   | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.18/macos-clang-release-ninja-v0.0.18.zip][DMG]]   | —       | No Windows build in this release. |
 | [[https://github.com/OreStudio/OreStudio/releases/tag/v0.0.17][v0.0.17]] | Mutumieque            | [[https://github.com/OreStudio/OreStudio/archive/refs/tags/v0.0.17.zip][ZIP]], [[https://github.com/OreStudio/OreStudio/archive/refs/tags/v0.0.17.tar.gz][TGZ]] | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.17/linux-gcc-release-ninja-v0.0.17.zip][DEB]]   | [[https://github.com/OreStudio/OreStudio/releases/download/v0.0.17/macos-clang-release-ninja-v0.0.17.zip][DMG]]   | —       | No Windows build in this release. |
 | [[https://github.com/OreStudio/OreStudio/releases/tag/v0.0.16][v0.0.16]] | Oncocua               | [[https://github.com/OreStudio/OreStudio/archive/refs/tags/v0.0.16.zip][ZIP]], [[https://github.com/OreStudio/OreStudio/archive/refs/tags/v0.0.16.tar.gz][TGZ]] | —     | —     | —       | No builds available.              |
 | [[https://github.com/OreStudio/OreStudio/releases/tag/v0.0.15][v0.0.15]] | Isaias                | [[https://github.com/OreStudio/OreStudio/archive/refs/tags/v0.0.15.zip][ZIP]], [[https://github.com/OreStudio/OreStudio/archive/refs/tags/v0.0.15.tar.gz][TGZ]] | —     | —     | —       | No builds available.              |

--- a/doc/manual/manuals.org
+++ b/doc/manual/manuals.org
@@ -32,3 +32,4 @@ via the project issue tracker so they can be corrected.
 
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the full documentation graph.
 - [[id:1A5E0079-5771-4213-B624-62FA9AC947B4][Functions]] — component and service documentation.
+- [[id:E71704D9-60D4-4898-AF25-B6B07101DB90][ORE Studio Manual (developer)]] — for details on how the manual is built: the =ox-latex= pipeline, Tufte layout, margin figures, version stamping, and the =deploy_manual= CMake target.

--- a/doc/manual/manuals.org
+++ b/doc/manual/manuals.org
@@ -33,3 +33,4 @@ via the project issue tracker so they can be corrected.
 - [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the full documentation graph.
 - [[id:1A5E0079-5771-4213-B624-62FA9AC947B4][Functions]] — component and service documentation.
 - [[id:E71704D9-60D4-4898-AF25-B6B07101DB90][ORE Studio Manual (developer)]] — for details on how the manual is built: the =ox-latex= pipeline, Tufte layout, margin figures, version stamping, and the =deploy_manual= CMake target.
+- [[id:E19E9FDE-4743-4B2E-8724-6369B3E43131][ORE Studio Site]] — for details on how the site is built and deployed; manual PDFs are published as static assets alongside the HTML pages via the =deploy_site= target.

--- a/projects/ores.lisp/modeling/component_overview.org
+++ b/projects/ores.lisp/modeling/component_overview.org
@@ -114,6 +114,7 @@ actions under a short heading and maps them to single-keystroke bindings.
 
 * See also
 
+- [[id:E19E9FDE-4743-4B2E-8724-6369B3E43131][ORE Studio Site]] — how the site is built, the menu bar definition, the 404 page, and the org-roam graph injection.
 - [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]] — editor overview and the build targets (=deploy_site=, =deploy_manual=, etc.) that =ores.lisp= scripts drive.
 - [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]] — the knowledge graph layer that =ores-org-roam-export.el= exports.
 - [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] — architectural context.

--- a/projects/ores.lisp/modeling/component_overview.org
+++ b/projects/ores.lisp/modeling/component_overview.org
@@ -115,6 +115,7 @@ actions under a short heading and maps them to single-keystroke bindings.
 * See also
 
 - [[id:E19E9FDE-4743-4B2E-8724-6369B3E43131][ORE Studio Site]] — how the site is built, the menu bar definition, the 404 page, and the org-roam graph injection.
+- [[id:E71704D9-60D4-4898-AF25-B6B07101DB90][ORE Studio Manual]] — how the PDF user manual is built via ox-latex, Tufte layout, margin figures, and version stamping.
 - [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]] — editor overview and the build targets (=deploy_site=, =deploy_manual=, etc.) that =ores.lisp= scripts drive.
 - [[id:C53486A1-54A3-4FD3-BC5F-15F4CE6BC4ED][org-roam]] — the knowledge graph layer that =ores-org-roam-export.el= exports.
 - [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] — architectural context.

--- a/projects/ores.lisp/modeling/manual.org
+++ b/projects/ores.lisp/modeling/manual.org
@@ -84,5 +84,6 @@ centred title, author, version, and the login-screen screenshot
 
 * See also
 
+- [[id:914738C6-7C77-41CD-A949-55DBBE0B6908][ORE Studio Manuals]] — the user-facing manuals index; for the available manuals and their PDF downloads, start here.
 - [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]] — component overview; lists =ores-build-manual.el= under Source files.
 - [[id:E19E9FDE-4743-4B2E-8724-6369B3E43131][ORE Studio Site]] — the companion page covering HTML site build and menu bar.

--- a/projects/ores.lisp/modeling/manual.org
+++ b/projects/ores.lisp/modeling/manual.org
@@ -1,0 +1,88 @@
+:PROPERTIES:
+:ID: E71704D9-60D4-4898-AF25-B6B07101DB90
+:END:
+#+title: ORE Studio Manual
+#+description: How the ORE Studio user manual is built — org-latex export, Tufte layout, margin figures, version stamping, and the deploy_manual CMake target.
+#+type: knowledge
+#+level: cross
+#+filetags: :manual:lisp:emacs:latex:
+#+created: 2026-05-31
+#+updated: 2026-05-31
+
+* Summary
+
+The ORE Studio user manual is a PDF produced by Emacs =ox-latex=
+(=org-latex-export-to-pdf=), driven by =ores-build-manual.el= in
+[[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]]. The source is
+=doc/manual/user_guide/user_manual.org=; output lands alongside it as
+=user_manual.pdf=. The layout uses the =tufte-book= LaTeX class for
+wide-margin typography. The =deploy_manual= CMake target runs the
+full pipeline in one step via =emacs -Q --script .build-manual.el=.
+
+* Detail
+
+** Build pipeline
+
+#+begin_src sh
+cmake --build --preset linux-clang-debug-ninja --target deploy_manual
+#+end_src
+
+This invokes =emacs -Q --script .build-manual.el=, which loads
+=ores-build-manual.el= and calls =org-latex-export-to-pdf= on
+=doc/manual/user_guide/user_manual.org=. LaTeX is run twice
+(=pdflatex= × 2) so that cross-references and the table of contents
+are fully resolved.
+
+** LaTeX classes
+
+Two custom classes are registered in =ores-build-manual.el=:
+
+- =ores-manual= — a plain =book= class (=a4paper, 11pt=). Heading
+  hierarchy: =*= → =\chapter=, =**= → =\section=, etc. Used as a
+  fallback.
+- =ores-tufte= — the primary class, based on =tufte-book=
+  (=a4paper, justified=). Provides the wide-margin aesthetic:
+  sidenotes, margin figures, and full-bleed headings. =tufte-book=
+  manages its own geometry, fonts, and hyperref; =user_manual.org=
+  keeps only a minimal preamble.
+
+** Margin figures
+
+Small figures (width ≤ 510 px AND height ≤ 320 px) are automatically
+promoted to LaTeX =marginfigure= environments by the
+=ores/figures-to-margin= filter, registered via
+=org-export-filter-final-output-functions=. Larger screenshots stay
+in the text column. This transform is LaTeX-only; the HTML site is
+unaffected.
+
+The filter inspects each =\begin{figure}…\end{figure}= block,
+reads the PNG header of the referenced image to get pixel dimensions,
+and rewrites the block to =\begin{marginfigure}= when both thresholds
+are met.
+
+** Image width
+
+=org-latex-image-default-width= is set to =\\maxwidth=, a custom
+LaTeX macro defined in =user_manual.org= that yields the image's
+natural pixel width when it is smaller than =0.6\linewidth=, and
+=0.6\linewidth= otherwise. This prevents large dialog screenshots
+from overflowing the text column while letting small crops render at
+their natural size.
+
+** Version stamping
+
+The cover page version number is read at export time from
+=CMakeLists.txt= by =ores/cmake-version=, which greps for the
+=project(OreStudio VERSION …)= line. This keeps the PDF cover in
+sync with the single source of truth without any manual update step.
+
+** Title page
+
+A custom =org-latex-title-command= generates the cover page:
+centred title, author, version, and the login-screen screenshot
+(=assets/images/login_screen.png=) scaled to 60% of the text width.
+
+* See also
+
+- [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]] — component overview; lists =ores-build-manual.el= under Source files.
+- [[id:E19E9FDE-4743-4B2E-8724-6369B3E43131][ORE Studio Site]] — the companion page covering HTML site build and menu bar.

--- a/projects/ores.lisp/modeling/site.org
+++ b/projects/ores.lisp/modeling/site.org
@@ -99,4 +99,5 @@ makes in-page id-link navigation work correctly in the browser.
 
 - [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]] — component overview; lists all source files including =ores-build-site.el=.
 - [[id:4D3C2B1A-9E8F-4A7B-6C5D-3E2F1A0B9C8D][Page Not Found]] — the 404 page served by GitHub Pages.
+- [[id:E71704D9-60D4-4898-AF25-B6B07101DB90][ORE Studio Manual]] — the companion page covering the PDF manual build via ox-latex.
 - [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]] — editor overview covering the =deploy_site= build target.

--- a/projects/ores.lisp/modeling/site.org
+++ b/projects/ores.lisp/modeling/site.org
@@ -1,0 +1,102 @@
+:PROPERTIES:
+:ID: E19E9FDE-4743-4B2E-8724-6369B3E43131
+:END:
+#+title: ORE Studio Site
+#+description: How the ORE Studio documentation site is built, published, and structured — org-publish pipeline, menu bar, 404 page, and graph export.
+#+type: knowledge
+#+level: cross
+#+filetags: :site:lisp:emacs:
+#+created: 2026-05-31
+#+updated: 2026-05-31
+
+* Summary
+
+The ORE Studio documentation site is generated from the repository's
+=.org= files via Emacs =org-publish=, driven by =ores-build-site.el=
+in [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]]. Every =.org= file (excluding =vcpkg/=, =build/=, and
+=.packages/=) is exported to HTML and published to
+=build/output/site/OreStudio/=, which maps to
+=https://orestudio.github.io/OreStudio/=. The knowledge graph
+(=org-roam-ui=) is exported separately and injected at =/graph/=. The
+=deploy_site= CMake target runs the full pipeline in one step.
+
+* Detail
+
+** Build pipeline
+
+The site is built by invoking Emacs in batch mode:
+
+#+begin_src sh
+cmake --build --preset linux-clang-debug-ninja --target deploy_site
+#+end_src
+
+This calls =emacs -Q --script .build-site.el=, which loads
+=ores-build-site.el= and runs =org-publish-all=. The publishing
+project is defined in =org-publish-project-alist= inside that file
+and has two components:
+
+- =site:pages= — exports all =.org= files to HTML recursively from
+  the repo root, skipping =vcpkg/=, =build/=, =tmp/=, and
+  =external/org-roam-ui=.
+- The =org-roam-ui= graph — built separately and injected at =/graph/=
+  by =ores-inject-site-nav=.
+
+** Menu bar
+
+The navigation bar is defined as a Lisp string variable
+=site-html-preamble= in =ores-build-site.el= and injected into every
+page via the =:html-preamble= key of the =site:pages= project:
+
+#+begin_src elisp
+(defvar site-html-preamble "<header id='site-header'>
+  <nav id='site-nav'>
+    <a href='/OreStudio/readme.html'>Home</a>
+    <a href='/OreStudio/doc/orientation.html'>Orientation</a>
+    <a href='/OreStudio/doc/identity/product_identity.html'>Product</a>
+    <a href='/OreStudio/projects/modeling/system_model.html'>Architecture</a>
+    <a href='/OreStudio/doc/llm/llm.html'>LLMs</a>
+    <a href='/OreStudio/doc/manual/manuals.html'>Manuals</a>
+    <a href='/OreStudio/doc/downloads.html'>Downloads</a>
+    <a href='/OreStudio/doc/agile/agile.html'>Agile</a>
+    <a href='/OreStudio/doc/developer.html'>Developer</a>
+    <a href='/OreStudio/doc/agile/versions/versions.html'>Roadmap</a>
+    <a href='/OreStudio/graph/index.html'>Knowledge Graph</a>
+    <a href='https://github.com/OreStudio/OreStudio' ...><i class='fab fa-github'></i></a>
+  </nav>
+</header>")
+#+end_src
+
+All href values use the absolute =/OreStudio/= prefix to match the
+GitHub Pages base URL. To add or rename a menu item, edit
+=site-html-preamble= in =ores-build-site.el= and redeploy.
+
+The same preamble is injected into the graph page (=graph/index.html=)
+by =ores-inject-site-nav=, with a small CSS override to fix the
+floating header over the graph canvas.
+
+** Styling and assets
+
+- =assets/style.css= — main stylesheet, referenced via =html-header=.
+- =assets/images/modern-icon.png= — favicon.
+- =highlight.js= (CDN) — source-block syntax highlighting.
+- =font-awesome= (CDN) — icon glyphs (GitHub logo in the nav bar).
+
+** 404 page
+
+The [[id:4D3C2B1A-9E8F-4A7B-6C5D-3E2F1A0B9C8D][Page Not Found]] page is at =404.org= in the repo root. GitHub
+Pages serves it automatically for any URL that does not resolve to a
+published file.
+
+** Headline ID anchors
+
+=org-publish= does not stamp an =id= attribute matching =[[id:UUID]]=
+links onto headings. =ores-build-site.el= works around this by
+advising =org-html-headline= to prepend an empty =<a id="ID-UUID"/>=
+anchor before every heading that carries an =:ID:= property. This
+makes in-page id-link navigation work correctly in the browser.
+
+* See also
+
+- [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]] — component overview; lists all source files including =ores-build-site.el=.
+- [[id:4D3C2B1A-9E8F-4A7B-6C5D-3E2F1A0B9C8D][Page Not Found]] — the 404 page served by GitHub Pages.
+- [[id:DF6F1D17-2199-472C-868E-1E50D0887AAD][Emacs]] — editor overview covering the =deploy_site= build target.


### PR DESCRIPTION
## Summary

- Add `v0.0.18` (Jose Sobral) Linux and macOS download links to `doc/downloads.org`.
- Add `projects/ores.lisp/modeling/site.org` — knowledge doc covering the org-publish pipeline, `site-html-preamble` menu bar, 404 page, headline ID anchor advice, and graph injection. Includes org-roam link to the [[Page Not Found]] 404 page.
- Add `projects/ores.lisp/modeling/manual.org` — knowledge doc covering the `ox-latex` pipeline, `tufte-book` class, margin-figure promotion, `\maxwidth` image macro, version stamping from `CMakeLists.txt`, and the custom title page.
- Wire both new docs into `component_overview.org` and cross-link them with each other, with `doc/manual/manuals.org` (user-facing ↔ dev-oriented), and with the [[ORE Studio Site]] build doc.
- Add org-roam links in the `fix_rfl_complexity` story to the Sprint 18 triple-isolation workaround task and Sprint 18 release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)