### PR TITLE
[agile] Task 5: update session journal recipe and semi-autonomous developer skill

### DIFF
--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/story.org
@@ -104,11 +104,11 @@ worktrees.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                                |
+| State         | DONE                                   |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                              |
-| Now           | Task 1 in progress: design journal format. |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                               |
-| Next          | Complete Task 1; open PR.              |
+| Next          | Done. All 5 tasks complete.            |
 | Last touched  | 2026-05-31                             |
 
 * Acceptance
@@ -136,7 +136,7 @@ worktrees.
 | [[id:A8FCCECE-9B64-49A9-8C24-2AE3A1EC7E08][Implement compass journal subcommand]] | DONE | 2026-05-31 | 2026-05-31 | Add compass journal update, where, and log subcommands to compass.py. |
 | [[id:6AF5890B-8409-4652-AA68-929CBC45C69B][Wire compass goto to auto-update the journal]] | DONE | 2026-05-31 | 2026-05-31 | Call compass journal update at the end of compass goto (new-story and existing-story modes). |
 | [[id:6F0272A9-6059-45FD-819C-0CE7A5555A69][Refactor compass fleet to use journal]] | DONE | 2026-05-31 | 2026-05-31 | Read .journal.org from each worktree in compass fleet; show story+task+state; graceful fallback. |
-| Task: Write recipe and update semi-autonomous developer skill | BACKLOG | | | Document journal use in a recipe; update the semi-autonomous developer skill to check/update the journal at task pickup. |
+| [[id:63AAE181-4D5B-464E-9938-368AA190623E][Write recipe and update semi-autonomous developer skill]] | DONE | 2026-05-31 | 2026-05-31 | Document journal use in a recipe; update the semi-autonomous developer skill to check/update the journal at task pickup. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/task_update_semi_autonomous_skill.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/task_update_semi_autonomous_skill.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_session_journal:sprint_19:v0:
 #+owner: marco
 #+branch: feature/update-semi-autonomous-skill
-#+pr:
+#+pr: 958
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-31
@@ -70,7 +70,7 @@ pickup.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/958][#958]] | [agile] Task 5: update session journal recipe and semi-autonomous developer skill |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/task_update_semi_autonomous_skill.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/task_update_semi_autonomous_skill.org
@@ -72,6 +72,14 @@ pickup.
 |----+-------|
 | [[https://github.com/OreStudio/OreStudio/pull/958][#958]] | [agile] Task 5: update session journal recipe and semi-autonomous developer skill |
 
+* Review
+
+** Round 1 — 2026-05-31
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+| 1 | Missing =* Review= section in task doc | task file | Fixed: added; declined suggested =* Reviews= name and table format (wrong convention) | Gemini review |
+
 * Result
 
 - Recipe updated: provisional hedging removed; auto-update noted; manual

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/task_update_semi_autonomous_skill.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/task_update_semi_autonomous_skill.org
@@ -1,0 +1,80 @@
+:PROPERTIES:
+:ID: 63AAE181-4D5B-464E-9938-368AA190623E
+:END:
+#+title: Task: Write recipe and update semi-autonomous developer skill
+#+description: Update the session journal recipe to remove provisional hedges now that compass journal is live; add overlap-check step and journal auto-update note to the semi-autonomous developer skill.
+#+type: task
+#+level: s1
+#+filetags: :compass_session_journal:sprint_19:v0:
+#+owner: marco
+#+branch: feature/update-semi-autonomous-skill
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-31
+#+updated: 2026-05-31
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The session journal recipe was written before =compass journal= was
+implemented and contains provisional hedging ("once implemented", "until
+available"). Now that all journal commands are live, clean up the recipe
+and teach the semi-autonomous developer skill to use the journal at task
+pickup.
+
+* Status
+
+| Field        | Value                                      |
+|--------------+--------------------------------------------|
+| State        | DONE                                       |
+| Parent story | [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]]                   |
+| Now          | Nothing.                                   |
+| Waiting on   | Nothing.                                   |
+| Next         | Done. Story complete — all 5 tasks DONE.   |
+| Last touched | 2026-05-31                                 |
+
+* Acceptance
+
+- =how_do_i_use_the_session_journal.org= has no provisional hedging;
+  all =compass journal= commands are presented as available.
+- Recipe notes that =compass goto= auto-updates the journal.
+- Recipe documents when manual =compass journal update= is still needed
+  (task completion, mid-session switch).
+- Semi-autonomous developer skill Step 2 includes a =compass fleet=
+  overlap check before branching.
+- Skill Step 2 notes that =compass goto= writes the journal entry automatically.
+- Skill =* Reference= section links to the session journal recipe.
+
+* Notes
+
+** Recipe changes
+
+- Removed "once =compass journal= is implemented" hedge in Querying section.
+- Removed "until =compass journal= is available" manual-write section.
+- Added note that =compass goto= auto-updates the journal.
+- Clarified when manual =compass journal update= is still needed (DONE
+  entry at task completion).
+- Fixed =compass fleet --story <UUID>= reference (flag not implemented;
+  replaced with plain =compass fleet=).
+
+** Skill changes
+
+- Step 2 expanded: run =compass fleet= before branching; link to journal
+  recipe; note =compass goto= auto-update.
+- =* Reference= section: added link to session journal recipe.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Result
+
+- Recipe updated: provisional hedging removed; auto-update noted; manual
+  update guidance added for DONE entries.
+- Skill updated: =compass fleet= overlap check added to Step 2; journal
+  recipe linked from Reference.

--- a/doc/llm/skills/semi-autonomous-developer/SKILL.org
+++ b/doc/llm/skills/semi-autonomous-developer/SKILL.org
@@ -31,12 +31,23 @@ Locate the current sprint (highest-numbered directory under
 =doc/agile/versions/v0/=).  Read the story file and its tasks.  If
 no tasks exist yet, create them with =TaskCreate= before coding.
 
-** Step 2 — Create a feature branch and mark STARTED
+** Step 2 — Check for overlap, then branch and mark STARTED
 
-Follow [[id:DA003A23-1604-43E7-A98F-A305148FBCF4][How do I start work on a story?]] — branch from =main= using
-=feature/concise-lowercase-description=, mark the story =STARTED=,
-and commit the status change.  The full state machine is in
-[[id:8810E0F9-C5B9-4CFA-A710-774AD6C771DD][Lifecycle]]; the execution-phase context is in [[id:227958A5-0F78-4CC6-A116-B83988592B68][Sprint execution]].
+Before branching, run =compass fleet= to see what every other worktree is
+currently working on. If another environment is already working on the same
+story or a story that touches the same area of the codebase, coordinate
+before proceeding. See [[id:B4C7D2E1-9F3A-4A6B-8E5D-3C1F7B2A9D4E][How do I use the session journal?]] for overlap
+detection guidance.
+
+#+begin_src sh
+compass fleet
+#+end_src
+
+Then branch using =compass goto= per [[id:DA003A23-1604-43E7-A98F-A305148FBCF4][How do I start work on a story?]],
+mark the story =STARTED=, and commit the status change. =compass goto=
+automatically appends a =STARTED= entry to =.journal.org= — no manual
+journal update needed. The full state machine is in [[id:8810E0F9-C5B9-4CFA-A710-774AD6C771DD][Lifecycle]]; the
+execution-phase context is in [[id:227958A5-0F78-4CC6-A116-B83988592B68][Sprint execution]].
 
 ** Step 3 — Implement incrementally
 
@@ -75,6 +86,7 @@ table.
 - [[id:654D4A70-E63D-4C18-B5A5-886066E36314][cmake-runner]] — build and test commands.
 - [[id:545D6B43-17FC-0234-FF2B-AB6565695616][pr-manager]] — PR creation, monitoring, and merge lifecycle.
 - [[id:2DF8ADAF-20C9-4757-9399-798EEC6DF828][agile-product-owner]] — sprint and story management conventions.
+- [[id:B4C7D2E1-9F3A-4A6B-8E5D-3C1F7B2A9D4E][How do I use the session journal?]] — overlap detection and restart recovery.
 
 * Artefacts                                                        :noexport:
 

--- a/doc/recipes/agile/how_do_i_use_the_session_journal.org
+++ b/doc/recipes/agile/how_do_i_use_the_session_journal.org
@@ -18,8 +18,9 @@ before picking up a new story?
 * Answer
 
 Each worktree has a =.journal.org= file in its root directory. The file is
-gitignored (machine-local, never committed). Every time Claude picks up a
-new task, it appends an entry to =.journal.org=.
+gitignored (machine-local, never committed). =compass goto= appends an entry
+automatically whenever a task is picked up, so no manual update is normally
+needed.
 
 ** Entry format
 
@@ -42,52 +43,43 @@ Fields:
 | =Branch ::= | Current git branch name |
 | =PR ::= | GitHub PR number (=#NNN=) or =none= |
 
-** When to update the journal
-
-Update =.journal.org= whenever you:
-
-1. *Pick up a new task* — append an entry with =State :: STARTED= before
-   doing any other work.
-2. *Complete a task* — append a closing entry with =State :: DONE= and
-   the PR number if one was opened.
-3. *Switch tasks mid-session* — append a new entry for the incoming task.
-
 ** Querying the journal
 
-Once =compass journal= is implemented (Task 2 of
-[[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]]):
-
 #+begin_src sh
-# Where was I? (last entry in this worktree)
+# Where was I? (last entry in this worktree — restart recovery)
 compass journal where
 
 # Full journey of this worktree
 compass journal log
 
-# Which worktree last worked on a given story?
-compass fleet --story <UUID>
+# What is every worktree currently working on? (overlap detection)
+compass fleet
 #+end_src
 
-Until =compass journal= is available, read =.journal.org= directly or
-use =compass fleet= (which shows branch names per worktree).
+** When to update the journal manually
+
+=compass goto= writes the initial =State :: STARTED= entry automatically.
+Manual updates are needed when:
+
+1. *Completing a task* — append a closing entry with =State :: DONE= and
+   the PR number:
+   #+begin_src sh
+   compass journal update --story <UUID> --task <UUID> \
+     --branch <branch> --state DONE --pr <N>
+   #+end_src
+2. *Switching tasks mid-session* — run =compass goto= for the new task;
+   it will append a new =STARTED= entry automatically.
 
 ** Overlap detection before picking up a story
 
-Before running =compass goto= to start a new story, check what the other
-worktrees are currently working on:
+Before running =compass goto=, check what every other worktree is working on:
 
 #+begin_src sh
 compass fleet
 #+end_src
 
 If another worktree's journal shows the same story or a story touching the
-same files, coordinate before proceeding.
-
-** Writing the entry manually (before compass journal is available)
-
-Open =.journal.org= in the project root and append a heading block
-following the format above. The file does not need to be created — create
-it if absent.
+same area of the codebase, coordinate before proceeding.
 
 * Conventions
 
@@ -102,5 +94,5 @@ it if absent.
 
 * See also
 
-- [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]] — the story implementing this feature.
-- [[id:1F41F21C-8D2A-46DA-8C6A-571564DF2C0E][How do I work a task?]] — task lifecycle; update the journal at task pickup.
+- [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]] — the story that implemented this feature.
+- [[id:1F41F21C-8D2A-46DA-8C6A-571564DF2C0E][How do I work a task?]] — task lifecycle.


### PR DESCRIPTION
## Summary

Closes out the **Compass session journal** story (all 5 tasks now DONE) by updating the recipe and the semi-autonomous developer skill to reflect that `compass journal` and `compass goto` auto-update are live.

## Changes

**`how_do_i_use_the_session_journal.org`**
- Remove provisional "once implemented" / "until available" hedges — `compass journal` is live
- Note that `compass goto` auto-updates the journal; clarify when manual `compass journal update` is still needed (DONE entry at task completion)
- Fix `compass fleet --story <UUID>` reference (flag not implemented; use plain `compass fleet`)

**`semi-autonomous-developer/SKILL.org`**
- Step 2: add `compass fleet` overlap check before branching with link to journal recipe
- Step 2: note `compass goto` auto-updates `.journal.org` — no manual call needed
- Reference section: link to session journal recipe

**Agile docs**
- Task 5 scaffolded and marked DONE
- Story marked DONE (all 5 tasks complete)

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Compass session journal](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_session_journal/story.html) | 20AC8397-1ACD-4B1A-B0FE-6FAB74477592 |
| Task | [Write recipe and update semi-autonomous developer skill](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_session_journal/task_update_semi_autonomous_skill.html) | 63AAE181-4D5B-464E-9938-368AA190623E |