### PR TITLE
[ores.shell] Fix mTLS, stale NATS subjects, and currencies bugs

### DIFF
--- a/build/scripts/init-environment.sh
+++ b/build/scripts/init-environment.sh
@@ -48,8 +48,9 @@ ENV_FILE="${CHECKOUT_ROOT}/.env"
 #   3  Added ORES_WORKSPACE_SERVICE_DB_* for new workspace service.
 #   4  Added ORES_SITE_PORT for the local documentation site server.
 #   5  Added org-roam knowledge graph integration to site build.
+#   6  Added ORES_SHELL_NATS_* for ores.shell mTLS auto-connect support.
 # ---------------------------------------------------------------------------
-ENV_VERSION=5
+ENV_VERSION=6
 
 # ---------------------------------------------------------------------------
 # Argument parsing
@@ -509,6 +510,15 @@ EOF
     echo "ORES_SHELL_DB_USER=${ORES_DB_SHELL_USER}"
     echo "ORES_SHELL_DB_PASSWORD=${ORES_DB_SHELL_PASSWORD}"
     echo "ORES_SHELL_DB_DATABASE=${DB_NAME}"
+    echo ""
+    echo "# ---------------------------------------------------------------------------"
+    echo "# Shell NATS credentials (read by C++ make_mapper(\"SHELL\"))"
+    echo "# ---------------------------------------------------------------------------"
+    echo "ORES_SHELL_NATS_URL=${NATS_URL}"
+    echo "ORES_SHELL_NATS_SUBJECT_PREFIX=${NATS_PREFIX}"
+    echo "ORES_SHELL_NATS_TLS_CA=${NATS_TLS_CA}"
+    echo "ORES_SHELL_NATS_TLS_CERT=${NATS_TLS_CERT}"
+    echo "ORES_SHELL_NATS_TLS_KEY=${NATS_TLS_KEY}"
     echo ""
     echo "# ---------------------------------------------------------------------------"
     echo "# HTTP server DB credentials (read by C++ make_mapper(\"HTTP_SERVER\"))"

--- a/doc/agile/versions/v0/sprint_19/commission_currency/task_verify_shell.org
+++ b/doc/agile/versions/v0/sprint_19/commission_currency/task_verify_shell.org
@@ -28,12 +28,12 @@ mutations trigger NATS events. Fix any regressions found.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                                |
 | Parent story | [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Start service; run shell commands.     |
-| Last touched | 2026-05-29                               |
+| Now          | PR #959 open; awaiting CI and review.  |
+| Waiting on   | CI green + review.                     |
+| Next         | Merge PR; mark DONE.                   |
+| Last touched | 2026-05-31                             |
 
 * Acceptance
 
@@ -50,7 +50,7 @@ mutations trigger NATS events. Fix any regressions found.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/959][#959]] | [ores.shell] Fix mTLS, stale NATS subjects, and currencies bugs |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/commission_currency/task_verify_shell.org
+++ b/doc/agile/versions/v0/sprint_19/commission_currency/task_verify_shell.org
@@ -54,8 +54,10 @@ mutations trigger NATS events. Fix any regressions found.
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                                    | File                    | Decision | Notes          |
+|---+--------------------------------------------------------------------+-------------------------+----------+----------------|
+| 1 | Unnecessary =std::string()= wrap on =bootstrap_status= subject     | application.cpp         | Accept   | Fixed 29ab304f |
+| 2 | Unnecessary =std::string()= wrap on =create_initial_admin= subject | accounts_commands.cpp   | Accept   | Fixed 29ab304f |
+| 3 | Unnecessary =std::string()= wrap on =bootstrap_status= subject     | connection_commands.cpp | Accept   | Fixed 29ab304f |
 
 * Result

--- a/doc/llm/memory/memory.org
+++ b/doc/llm/memory/memory.org
@@ -83,6 +83,9 @@ of these exclusions, push back: the right home is somewhere else.
   always =#+version: 2= for docs; never increment it when editing content.
 - [[id:68829E75-34A4-4A7F-915D-AED6285FFD9B][PR review runbook does not include merging]] — runbook ends at resolve
   threads; never call =gh pr merge= after review steps; user merges.
+- [[id:426D228A-CCA8-4AC7-AE78-942E03A06497][Never cross worktree boundaries]] — all work stays in the active
+  checkout; if a branch is taken by another worktree, flag it to the
+  user rather than crossing environments.
 
 ** User
 

--- a/doc/llm/memory/never_cross_worktree_boundaries.org
+++ b/doc/llm/memory/never_cross_worktree_boundaries.org
@@ -1,0 +1,25 @@
+:PROPERTIES:
+:ID: 426D228A-CCA8-4AC7-AE78-942E03A06497
+:END:
+#+title: Never cross worktree boundaries
+#+description: All work must stay within the active OreStudio checkout; never cd or git -C into another worktree.
+#+type: memory
+#+memory_subtype: feedback
+#+level: cross
+#+filetags: :memory:feedback:
+#+created: 2026-05-31
+#+updated: 2026-05-31
+
+All work in a session must stay within the current working directory's
+OreStudio checkout (e.g. =local4=). Never =cd= into or use =git -C= to
+operate on another checkout (=local1=, =local2=, =local3=, =remote=).
+
+*Why:* Crossing into =local2= during sprint 19 caused a commit to land on
+=feature/delete-get-trade-detail= (an unrelated in-flight branch) instead of
+=feature/commission-currency=, silently corrupting someone else's work in
+progress.
+
+*How to apply:* If a branch is already checked out in another worktree (git
+refuses with "already used by worktree at …"), do NOT go to that worktree.
+Instead: (1) flag the conflict to the user, (2) offer to pick a different
+task or create a fresh branch from =origin/main= within the current checkout.

--- a/doc/recipes/cmake/how_do_i_start_services.org
+++ b/doc/recipes/cmake/how_do_i_start_services.org
@@ -1,0 +1,83 @@
+:PROPERTIES:
+:ID: D8663EF2-5626-462E-AADC-AB2717F49C0D
+:END:
+#+title: How do I start the ORE Studio services?
+#+description: Start NATS and all backend services for a local checkout using start-services.sh; stop and check status with companion scripts.
+#+type: recipe
+#+level: cross
+#+filetags: :cmake:build:services:nats:controller:recipe:
+#+created: 2026-05-31
+#+updated: 2026-05-31
+
+Requires =.env= and built binaries (see [[id:49F7DA81-ADB7-44ED-BE7E-06DBFBB32A84][How do I set up a development environment?]]).
+Start order: NATS server → controller; the controller spawns all other
+services (IAM, domain services, HTTP, Wt, compute wrappers) in dependency order.
+
+* Question
+
+How do I start all ORE Studio backend services for a local checkout?
+
+* Answer
+
+1. /Ensure the environment is initialised/ and the project is built (see
+   [[id:1794B513-877B-4B93-A818-53F080C55E47][How do I initialise the checkout environment?]] and [[id:F176FCA1-68D5-420D-B076-75A65FEE5EBB][How do I build the system?]]).
+
+2. /Start services/:
+
+   #+begin_src sh :results verbatim
+   ./build/scripts/start-services.sh
+   #+end_src
+
+   The preset defaults to =ORES_PRESET= from =.env=. Override with =--preset=:
+
+   #+begin_src sh :results verbatim
+   ./build/scripts/start-services.sh --preset linux-clang-debug-make
+   #+end_src
+
+   Change log verbosity with =--log-level= (default: =trace=):
+
+   #+begin_src sh :results verbatim
+   ./build/scripts/start-services.sh --log-level info
+   #+end_src
+
+   The script blocks until the controller logs =All services started=, then exits.
+
+** Check status
+
+   #+begin_src sh :results verbatim
+   ./build/scripts/status-services.sh
+   #+end_src
+
+** Stop all services
+
+   #+begin_src sh :results verbatim
+   ./build/scripts/stop-services.sh
+   #+end_src
+
+** Logs
+
+Logs land in =build/output/<preset>/publish/log/=. Each service writes its own
+=<name>.log= file; the NATS server writes =nats-server.log=.
+
+** Prerequisites checklist
+
+- =.env= exists (run =init-environment.sh= if not — see [[id:1794B513-877B-4B93-A818-53F080C55E47][How do I initialise the checkout environment?]]).
+- Database initialised (=./projects/ores.sql/recreate_database.sh -y=).
+- Project built (=cmake --build --preset <preset>=).
+- =nats-server= on =PATH= or in =/usr/sbin=.
+
+* Script
+
+=build/scripts/start-services.sh= — starts NATS then the controller; blocks until all services are up.
+=build/scripts/stop-services.sh= — stops all services cleanly.
+=build/scripts/status-services.sh= — shows running/stopped state per service.
+
+* Tested by
+
+Manual, each development session. No CI path — CI uses pre-configured runners.
+
+* See also
+
+- [[id:1794B513-877B-4B93-A818-53F080C55E47][How do I initialise the checkout environment?]] — generate =.env= and NATS certs first.
+- [[id:49F7DA81-ADB7-44ED-BE7E-06DBFBB32A84][How do I set up a development environment?]] — full bootstrap including packages and DB.
+- [[id:F176FCA1-68D5-420D-B076-75A65FEE5EBB][How do I build the system?]] — build binaries before starting services.

--- a/projects/ores.shell/src/app/application.cpp
+++ b/projects/ores.shell/src/app/application.cpp
@@ -64,7 +64,7 @@ bool auto_connect(ores::nats::service::nats_client& session, std::ostream& out,
 
 void check_bootstrap_status(ores::nats::service::nats_client& session, std::ostream& out) {
     try {
-        auto reply = session.request("iam.v1.auth.bootstrap-status",
+        auto reply = session.request(std::string(iam::messaging::bootstrap_status_request::nats_subject),
             rfl::json::write(iam::messaging::bootstrap_status_request{}));
         auto data_str = std::string(
             reinterpret_cast<const char*>(reply.data.data()), reply.data.size());

--- a/projects/ores.shell/src/app/application.cpp
+++ b/projects/ores.shell/src/app/application.cpp
@@ -64,7 +64,7 @@ bool auto_connect(ores::nats::service::nats_client& session, std::ostream& out,
 
 void check_bootstrap_status(ores::nats::service::nats_client& session, std::ostream& out) {
     try {
-        auto reply = session.request(std::string(iam::messaging::bootstrap_status_request::nats_subject),
+        auto reply = session.request(iam::messaging::bootstrap_status_request::nats_subject,
             rfl::json::write(iam::messaging::bootstrap_status_request{}));
         auto data_str = std::string(
             reinterpret_cast<const char*>(reply.data.data()), reply.data.size());

--- a/projects/ores.shell/src/app/commands/accounts_commands.cpp
+++ b/projects/ores.shell/src/app/commands/accounts_commands.cpp
@@ -77,7 +77,7 @@ std::string format_duration(std::chrono::seconds dur) {
 
 template<typename Response>
 std::optional<Response> do_request(std::ostream& out, nats_client& session,
-    const std::string& subject, const std::string& body) {
+    std::string_view subject, const std::string& body) {
     try {
         auto reply = session.request(subject, body);
         auto data_str = std::string(
@@ -96,7 +96,7 @@ std::optional<Response> do_request(std::ostream& out, nats_client& session,
 
 template<typename Response>
 std::optional<Response> do_auth_request(std::ostream& out, nats_client& session,
-    const std::string& subject, const std::string& body) {
+    std::string_view subject, const std::string& body) {
     try {
         auto reply = session.authenticated_request(subject, body);
         auto data_str = std::string(
@@ -467,7 +467,7 @@ process_bootstrap(std::ostream& out, nats_client& session,
     req.email = std::move(email);
 
     auto result = do_request<iam::messaging::create_initial_admin_response>(
-        out, session, std::string(iam::messaging::create_initial_admin_request::nats_subject), rfl::json::write(req));
+        out, session, iam::messaging::create_initial_admin_request::nats_subject, rfl::json::write(req));
     if (!result) return;
 
     if (result->success) {

--- a/projects/ores.shell/src/app/commands/accounts_commands.cpp
+++ b/projects/ores.shell/src/app/commands/accounts_commands.cpp
@@ -467,7 +467,7 @@ process_bootstrap(std::ostream& out, nats_client& session,
     req.email = std::move(email);
 
     auto result = do_request<iam::messaging::create_initial_admin_response>(
-        out, session, "iam.v1.auth.bootstrap", rfl::json::write(req));
+        out, session, std::string(iam::messaging::create_initial_admin_request::nats_subject), rfl::json::write(req));
     if (!result) return;
 
     if (result->success) {

--- a/projects/ores.shell/src/app/commands/connection_commands.cpp
+++ b/projects/ores.shell/src/app/commands/connection_commands.cpp
@@ -44,7 +44,7 @@ auto& anon_lg() {
 
 void check_bootstrap_status(nats_client& session, std::ostream& out) {
     try {
-        auto reply = session.request(std::string(iam::messaging::bootstrap_status_request::nats_subject),
+        auto reply = session.request(iam::messaging::bootstrap_status_request::nats_subject,
             rfl::json::write(iam::messaging::bootstrap_status_request{}));
         auto data_str = std::string(
             reinterpret_cast<const char*>(reply.data.data()), reply.data.size());

--- a/projects/ores.shell/src/app/commands/connection_commands.cpp
+++ b/projects/ores.shell/src/app/commands/connection_commands.cpp
@@ -44,7 +44,7 @@ auto& anon_lg() {
 
 void check_bootstrap_status(nats_client& session, std::ostream& out) {
     try {
-        auto reply = session.request("iam.v1.auth.bootstrap-status",
+        auto reply = session.request(std::string(iam::messaging::bootstrap_status_request::nats_subject),
             rfl::json::write(iam::messaging::bootstrap_status_request{}));
         auto data_str = std::string(
             reinterpret_cast<const char*>(reply.data.data()), reply.data.size());

--- a/projects/ores.shell/src/app/commands/currencies_commands.cpp
+++ b/projects/ores.shell/src/app/commands/currencies_commands.cpp
@@ -38,7 +38,7 @@ namespace {
 
 template<typename Response>
 std::optional<Response> do_request(std::ostream& out, nats_client& session,
-    const std::string& subject, const std::string& body) {
+    std::string_view subject, const std::string& body) {
     try {
         auto reply = session.request(subject, body);
         auto data_str = std::string(
@@ -57,7 +57,7 @@ std::optional<Response> do_request(std::ostream& out, nats_client& session,
 
 template<typename Response>
 std::optional<Response> do_auth_request(std::ostream& out, nats_client& session,
-    const std::string& subject, const std::string& body) {
+    std::string_view subject, const std::string& body) {
     try {
         auto reply = session.authenticated_request(subject, body);
         auto data_str = std::string(

--- a/projects/ores.shell/src/app/commands/currencies_commands.cpp
+++ b/projects/ores.shell/src/app/commands/currencies_commands.cpp
@@ -131,7 +131,7 @@ process_get_currencies(std::ostream& out, nats_client& session,
     req.offset = state.current_offset;
     req.limit = pagination.page_size();
 
-    auto result = do_request<refdata::messaging::get_currencies_response>(
+    auto result = do_auth_request<refdata::messaging::get_currencies_response>(
         out, session, "refdata.v1.currencies.list", rfl::json::write(req));
     if (!result) return;
 
@@ -189,7 +189,7 @@ process_add_currency(std::ostream& out, nats_client& session,
             .symbol = std::move(symbol),
             .fraction_symbol = "",
             .fractions_per_unit = fractions,
-            .rounding_type = "Nearest",
+            .rounding_type = "Closest",
             .rounding_precision = 2,
             .format = "",
             .monetary_nature = "fiat",

--- a/projects/ores.shell/src/config/parser.cpp
+++ b/projects/ores.shell/src/config/parser.cpp
@@ -23,6 +23,7 @@
 #include <boost/program_options.hpp>
 #include <boost/throw_exception.hpp>
 #include "ores.shell/config/parser_exception.hpp"
+#include "ores.nats/config/nats_configuration.hpp"
 #include "ores.nats/config/nats_options.hpp"
 #include "ores.utility/version/version.hpp"
 #include "ores.logging/logging_configuration.hpp"
@@ -38,9 +39,6 @@ const std::string usage_error_msg("Usage error: ");
 
 const std::string help_arg("help");
 const std::string version_arg("version");
-
-const std::string nats_url_arg("nats-url");
-const std::string nats_subject_prefix_arg("nats-subject-prefix");
 const std::string login_username_arg("login-username");
 const std::string login_password_arg("login-password");
 
@@ -48,6 +46,7 @@ using boost::program_options::value;
 using boost::program_options::variables_map;
 using boost::program_options::options_description;
 
+using ores::nats::config::nats_configuration;
 using ores::nats::config::nats_options;
 using ores::shell::config::options;
 using ores::shell::config::login_options;
@@ -71,13 +70,7 @@ options_description make_options_description() {
     const auto tod(telemetry_configuration::make_options_description(
             "ores-shell", ORES_VERSION));
 
-    options_description cod("Connection");
-    cod.add_options()
-        (nats_url_arg.c_str(), value<std::string>(),
-            "NATS server URL (e.g., nats://localhost:4222)")
-        (nats_subject_prefix_arg.c_str(), value<std::string>(),
-            "Subject prefix prepended to every NATS subject "
-            "(format: ores.{tier}.{instance}, e.g. ores.dev.local1)");
+    const auto cod(nats_configuration::make_options_description());
 
     options_description lod2("Login");
     lod2.add_options()
@@ -125,18 +118,16 @@ void version(std::ostream& info) {
 
 /**
  * @brief Reads the connection configuration from the variables map.
+ *
+ * Returns empty if subject_prefix is not set — the shell should not
+ * auto-connect unless a complete configuration is provided.
  */
 std::optional<nats_options>
 read_connection_configuration(const variables_map& vm) {
-    if (vm.count(nats_url_arg) == 0 && vm.count(nats_subject_prefix_arg) == 0)
+    auto opts = nats_configuration::read_options(vm);
+    if (opts.subject_prefix.empty())
         return {};
-
-    nats_options r;
-    if (vm.count(nats_url_arg) != 0)
-        r.url = vm[nats_url_arg].as<std::string>();
-    if (vm.count(nats_subject_prefix_arg) != 0)
-        r.subject_prefix = vm[nats_subject_prefix_arg].as<std::string>();
-    return r;
+    return opts;
 }
 
 /**

--- a/projects/ores.sql/utility/validate_env_version.sh
+++ b/projects/ores.sql/utility/validate_env_version.sh
@@ -18,7 +18,7 @@
 
 set -euo pipefail
 
-REQUIRED_ENV_VERSION=5
+REQUIRED_ENV_VERSION=6
 
 # Changelog:
 #   1: Initial env versioning; renamed ORES_COMPUTE_WRAPPER_USER -> ORES_DB_COMPUTE_WRAPPER_USER
@@ -26,6 +26,7 @@ REQUIRED_ENV_VERSION=5
 #   3: Added ORES_WORKSPACE_SERVICE_DB_* for new workspace service
 #   4: Added ORES_SITE_PORT for the local documentation site server
 #   5: Added org-roam knowledge graph integration to site build
+#   6: Added ORES_SHELL_NATS_* for ores.shell mTLS auto-connect support
 
 CURRENT_VERSION="${ORES_ENV_VERSION:-0}"
 


### PR DESCRIPTION
## Summary

Fixes four bugs discovered during currency shell verification, plus adds
mTLS support to `ores.shell` and the supporting environment infrastructure.
All changes use existing shared implementations — no new shell-specific
code was introduced.

## Changes

**mTLS support (`parser.cpp`, `init-environment.sh`, `validate_env_version.sh`)**
- Replace the hand-rolled `Connection` options block in `parser.cpp` with
  `nats_configuration::make_options_description()` from `ores.nats`, which
  already covers `--nats-tls-ca/cert/key`. `read_connection_configuration`
  now delegates to `nats_configuration::read_options()`.
- Add `ORES_SHELL_NATS_URL/SUBJECT_PREFIX/TLS_CA/CERT/KEY` to
  `init-environment.sh` so the shell auto-connects with mTLS on startup
  using the qt.client certs. `ENV_VERSION` → 6; `REQUIRED_ENV_VERSION` → 6.

**Stale NATS subjects (`application.cpp`, `connection_commands.cpp`, `accounts_commands.cpp`)**
- Replace hardcoded `"iam.v1.auth.bootstrap-status"` and `"iam.v1.auth.bootstrap"`
  with the protocol constants from `bootstrap_protocol.hpp`
  (`bootstrap_status_request::nats_subject`, `create_initial_admin_request::nats_subject`).
  These were out of sync with the IAM service's actual subscriptions.

**Currency bugs (`currencies_commands.cpp`)**
- `currencies get`: use `do_auth_request` — the endpoint requires authentication.
- `currencies add`: rounding_type default `"Nearest"` → `"Closest"` to match
  the DB check constraint.

**Documentation**
- New recipe: `doc/recipes/cmake/how_do_i_start_services.org` — documents
  `start-services.sh`, `stop-services.sh`, and `status-services.sh`.
- New memory: `doc/llm/memory/never_cross_worktree_boundaries.org` — captures
  the rule that all session work must stay within the active checkout.

## Notes / Decisions

- The shell uses the qt.client NATS certs rather than a dedicated shell cert.
  A dedicated `ores.shell` cert can be added to `generate_nats_certs.sh` as
  a follow-up if needed.
- `rounding_type = "Closest"` is the correct default for a general-purpose
  currency entry; the DB constraint accepts `Up`, `Down`, `Closest`,
  `Floor`, `Ceiling`.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Commission: currency](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/commission_currency/story.html) | 7F9C0F29-4268-4B62-A1BB-2153ECF0A858 |
| Task | [Verify currency shell commands and NATS integration](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/commission_currency/task_verify_shell.html) | 3D394DE4-7101-4E4B-A774-DD583BC5F0B0 |