### PR TITLE
[agile] Scaffold compass_cli_ux_redesign story in sprint 19

### DIFF
--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/story.org
@@ -1,0 +1,131 @@
+:PROPERTIES:
+:ID: A596D1E7-6A74-4E55-996D-6F1F2E48F261
+:END:
+#+title: Story: Compass CLI UX redesign
+#+description: Design and implement a noun-based command taxonomy for compass (sprint/story/task namespaces); fix tool description; organise --help by pillar; add sprint and story status report commands.
+#+type: story
+#+level: s2
+#+filetags: :tooling:compass:ux:cli:sprint_19:v0:
+#+created: 2026-05-31
+#+updated: 2026-05-31
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+=ores.compass= started as an orientation tool but has grown into a full
+developer toolkit — scaffolding, capture, journal, backlog, and fleet
+management alongside the original orientation commands. Two problems have
+emerged:
+
+1. *Misleading description.* The tool still calls itself "a repository
+   orientation tool" in its docstring and =--help= output. New contributors
+   (and LLMs) underestimate its scope.
+
+2. *Inconsistent UX.* Commands are named by verb (=goto=, =add=, =where=,
+   =fleet=) or by noun (=journal=, =capture=, =inbox=). Adding =compass sprint=
+   or =compass story= commands without a taxonomy creates a third naming
+   convention and paints future development into a corner.
+
+3. *Missing orient commands.* There is no way to get a status snapshot of the
+   current sprint (all stories by state) or of a story (all tasks by state).
+   =compass where= only shows STARTED items.
+
+This story:
+- defines the full noun-based command taxonomy through a System 2 UX analysis
+- fixes the tool description and organises =--help= by pillar
+- implements =compass sprint status= and =compass story status=
+- writes a recipe for the new orient commands
+- establishes backward-compatibility rules (aliases, deprecation warnings) so
+  existing scripts and skills are not silently broken
+
+** Proposed taxonomy (to be validated in Task 1)
+
+#+begin_example
+compass orient           # pillar header (existing commands keep their names)
+  where                  # current version/sprint/in-flight (existing)
+  fleet                  # worktree status via journal (existing)
+
+compass sprint           # sprint-level operations
+  status                 # all stories in current sprint, grouped by state (NEW)
+  new                    # open a new sprint (currently: how_do_i_open_a_new_sprint recipe)
+  close                  # close a sprint
+
+compass story            # story-level operations
+  status <id>            # all tasks in story, grouped by state (NEW)
+  new                    # create a story (currently: compass goto --slug)
+  start <id>             # mark story STARTED
+  close <id>             # mark story DONE
+
+compass task             # task-level operations
+  new                    # create a task (currently: compass goto --story)
+  start <id>             # mark task STARTED
+  close <id>             # mark task DONE
+
+compass journal          # session journal (existing)
+  update / where / log
+
+compass capture          # file a capture (existing)
+compass backlog          # backlog buckets (existing)
+compass search           # full-text search (existing)
+compass list             # doc listing (existing)
+compass show             # single doc detail (existing)
+#+end_example
+
+The Task 1 analysis will determine which verbs (=goto=, =add=) become aliases
+and whether backward-incompatible renames need a deprecation period.
+
+* Status
+
+| Field         | Value                                       |
+|---------------+---------------------------------------------|
+| State         | STARTED                                     |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                                   |
+| Now           | Task 1 in progress: UX analysis.            |
+| Waiting on    | Nothing.                                    |
+| Next          | Complete Task 1; proceed to implementation. |
+| Last touched  | 2026-05-31                                  |
+
+* Acceptance
+
+- A UX analysis document records the full command taxonomy, backward-compat
+  decisions, and pillar organisation.
+- =compass --help= describes the tool as a "developer toolkit" (not "orientation
+  tool") and lists subcommands grouped by pillar.
+- =compass sprint status= prints all stories in the current sprint grouped by
+  state (DONE / STARTED / BACKLOG) with task counts.
+- =compass story status <id>= prints all tasks in a story grouped by state,
+  with branch and PR per task.
+- A recipe documents =compass sprint status= and =compass story status=,
+  linked from the agile recipe index.
+- Existing commands (=goto=, =add=, =where=, =fleet=, =capture=, =journal=,
+  =backlog=, =search=, =list=, =show=) continue to work unchanged (aliases or
+  retained names per taxonomy decision).
+- All compass references in =doc/recipes/=, =doc/llm/skills/=, and
+  =doc/llm/runbooks/= are consistent with the new taxonomy and description.
+  No recipe or skill refers to a renamed command without also documenting the alias.
+- CI passes. Site builds cleanly.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:ACBF9164-1806-4472-8C96-C57821AD5F29][Compass CLI UX analysis and taxonomy]] | STARTED | 2026-05-31 | | System 2 analysis: full command taxonomy, pillar organisation, backward-compat rules, description fix. |
+| Task: Fix compass description and organise --help by pillar | BACKLOG | | | Update module docstring; group argparse subcommands by pillar in --help output. |
+| Task: Implement compass sprint status | BACKLOG | | | All stories in current sprint grouped by state (DONE/STARTED/BACKLOG) with task counts. |
+| Task: Implement compass story status | BACKLOG | | | All tasks in a story grouped by state, with branch and PR per task. |
+| Task: Write recipe for new orient commands | BACKLOG | | | Recipe documenting compass sprint status and compass story status; link from agile recipe index. |
+| Task: Audit and update compass recipes, skills, and runbooks | BACKLOG | | | Review all compass references in doc/recipes, doc/llm/skills, doc/llm/runbooks; update any inconsistencies with the new taxonomy and description. |
+
+* Decisions
+
+- /Task 1 gates all implementation./ No code changes until the taxonomy
+  and backward-compat decisions are recorded and agreed.
+
+* Out of scope
+
+- Implementing =compass sprint new/close= or =compass story new/start/close=
+  in this story — those are follow-on stories once the taxonomy is agreed.
+- Renaming the =ores.compass= project or Python package.
+- Removing any existing command names — aliases only, no hard breakage.

--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_compass_cli_ux_redesign.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_compass_cli_ux_redesign.org
@@ -1,0 +1,101 @@
+:PROPERTIES:
+:ID: ACBF9164-1806-4472-8C96-C57821AD5F29
+:END:
+#+title: Task: Compass CLI UX analysis and taxonomy
+#+description: System 2 analysis of compass CLI UX: define full noun-based command taxonomy, pillar organisation, backward-compatibility rules, and description fix. Produces the design document that gates all implementation tasks.
+#+type: task
+#+level: s1
+#+filetags: :compass_cli_ux_redesign:sprint_19:v0:
+#+owner: marco
+#+branch: feature/compass-cli-ux-redesign
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-05-31
+#+updated: 2026-05-31
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:A596D1E7-6A74-4E55-996D-6F1F2E48F261][Compass CLI UX redesign]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Conduct a System 2 analysis of the =ores.compass= CLI UX and produce a
+design document that all implementation tasks can build from. The analysis
+must answer:
+
+1. What is the correct noun-based command taxonomy?
+2. Which existing verb commands become aliases vs. retain their names?
+3. What backward-compatibility guarantees apply (aliases, deprecation
+   warnings, hard renames)?
+4. How are subcommands grouped in =--help= output (pillar organisation)?
+5. What is the correct one-line tool description?
+6. Which existing recipes, skills, and runbooks reference compass commands
+   and will need updating?
+
+* Status
+
+| Field        | Value                                         |
+|--------------+-----------------------------------------------|
+| State        | STARTED                                       |
+| Parent story | [[id:A596D1E7-6A74-4E55-996D-6F1F2E48F261][Compass CLI UX redesign]]                      |
+| Now          | Writing taxonomy and design document.         |
+| Waiting on   | Nothing.                                      |
+| Next         | Complete design doc; gate implementation tasks. |
+| Last touched | 2026-05-31                                    |
+
+* Acceptance
+
+- A design document at =doc/plans/YYYY-MM-DD-compass-cli-ux-taxonomy.org=
+  records the full command taxonomy, pillar groupings, and
+  backward-compatibility decisions.
+- The document includes a table mapping every current command to its
+  taxonomy position and backward-compat treatment.
+- All implementation tasks in the story can proceed from the document
+  without further design discussion.
+
+* Notes
+
+** Commands to inventory
+
+Current compass commands (as of sprint 19):
+
+| Command | Current pillar | Notes |
+|---------+----------------+-------|
+| =index= | Search | Internal; keep |
+| =search= / =find= | Search | Keep |
+| =debug= | Search | Internal; keep |
+| =where= / =status= | Orient | Keep; =status= is alias |
+| =fleet= | Orient | Keep |
+| =list= | Navigate | Keep |
+| =show= | Navigate | Keep |
+| =add= | Scaffold | Becomes alias for =story new= / =task new=? |
+| =goto= | Scaffold | Becomes alias for =story new= + branch? |
+| =capture= | Capture | Keep |
+| =inbox= / =next= / =deferred= / =discarded= | Backlog | Keep |
+| =backlog= | Backlog | Keep |
+| =journal= | Journal | Keep (already noun-based) |
+
+** Key design questions for the analysis
+
+1. Does =compass goto= become =compass task new= or does it stay as =goto=
+   (since it does more: fetch, branch, scaffold, journal update)?
+2. Does =compass add= become =compass story new= / =compass task new= or
+   does =add= remain as a low-level scaffold primitive?
+3. Should =compass sprint= and =compass story= be flat subcommands or
+   subcommand groups with sub-subcommands (like =journal=)?
+4. What is the scope of this sprint? Only =status= commands and description
+   fix, or also start wiring =compass sprint new= / =compass story new=?
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_compass_cli_ux_redesign.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_compass_cli_ux_redesign.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_cli_ux_redesign:sprint_19:v0:
 #+owner: marco
 #+branch: feature/compass-cli-ux-redesign
-#+pr:
+#+pr: 960
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-05-31
@@ -90,7 +90,7 @@ Current compass commands (as of sprint 19):
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/960][#960]] | [agile] Scaffold compass_cli_ux_redesign story in sprint 19 |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_compass_cli_ux_redesign.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_compass_cli_ux_redesign.org
@@ -94,8 +94,8 @@ Current compass commands (as of sprint 19):
 
 * Review
 
+** Round 1 — 2026-05-31
+
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
-
-* Result
+| 1 | Empty =* Result= section should be omitted | task file | Fixed: removed | Gemini review |

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -84,7 +84,7 @@ and file backlog captures for Wt and HTTP gaps. One story per entity.
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:A48DEC19-E769-4C71-AC0B-434B551DC801][Open sprint 19]] | STARTED | 2026-05-29 | | Scaffold sprint 19, wire version manifest, bump version, PR. |
-| [[id:2A6F5FE2-8C50-494F-948F-6BA519075FA9][Sprint planning]] | STARTED | 2026-05-29 | | Select stories from backlog, size tasks, confirm mission. |
+| [[id:2A6F5FE2-8C50-494F-948F-6BA519075FA9][Sprint planning]] | DONE | 2026-05-29 | 2026-05-29 | Select stories from backlog, size tasks, confirm mission. |
 | [[id:73D162FD-92D6-4567-8D94-4368C97F96E4][Sprint health review — System 2 analysis]] | STARTED | 2026-05-31 | | Periodic System 2 health checks: goal alignment, load, PR velocity, story/task balance, focus, verdict. |
 
 ** LLMs
@@ -107,7 +107,7 @@ and file backlog captures for Wt and HTTP gaps. One story per entity.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] | BACKLOG | | | Fix ClientManagerTradeDetail.cpp rfl::Literal 502-field compile failure; restore CI builds. |
+| [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] | STARTED | 2026-05-30 | | Fix ClientManagerTradeDetail.cpp rfl::Literal 502-field compile failure; restore CI builds. |
 
 ** Hotfixes
 

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -68,6 +68,7 @@ and file backlog captures for Wt and HTTP gaps. One story per entity.
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]] | BACKLOG | | | Per-machine .journal.org (gitignored) recording each Claude environment's story/task journey; compass journal commands; compass fleet refactor. |
+| [[id:A596D1E7-6A74-4E55-996D-6F1F2E48F261][Compass CLI UX redesign]] | STARTED | 2026-05-31 | | Noun-based command taxonomy; fix tool description; --help by pillar; compass sprint/story status commands; audit recipes and skills. |
 | [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]] | DONE | 2026-05-29 | 2026-05-30 | Unified SQL template + model format + codegen.py CLI replacing all generate_*_schema.sh scripts. |
 | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] | BACKLOG | | | Audit and resolve all drift between C++ templates and production files; fix template bugs; fix model consistency; zero-diff invariant. |
 | [[id:1C659EB3-5227-46B6-8B5C-68E9F98C10D1][Decommission legacy ores.codegen bash scripts]] | BACKLOG | | | Replace all direct bash script invocations of ores.codegen with ores.compass or codegen.py; remove legacy scripts starting with generate_doc.sh. |

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -67,7 +67,7 @@ and file backlog captures for Wt and HTTP gaps. One story per entity.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]] | BACKLOG | | | Per-machine .journal.org (gitignored) recording each Claude environment's story/task journey; compass journal commands; compass fleet refactor. |
+| [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]] | DONE | 2026-05-31 | 2026-05-31 | Per-machine .journal.org (gitignored) recording each Claude environment's story/task journey; compass journal commands; compass fleet refactor. |
 | [[id:A596D1E7-6A74-4E55-996D-6F1F2E48F261][Compass CLI UX redesign]] | STARTED | 2026-05-31 | | Noun-based command taxonomy; fix tool description; --help by pillar; compass sprint/story status commands; audit recipes and skills. |
 | [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]] | DONE | 2026-05-29 | 2026-05-30 | Unified SQL template + model format + codegen.py CLI replacing all generate_*_schema.sh scripts. |
 | [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] | BACKLOG | | | Audit and resolve all drift between C++ templates and production files; fix template bugs; fix model consistency; zero-diff invariant. |

--- a/doc/llm/runbooks/work_task_to_merged_pr/runbook.org
+++ b/doc/llm/runbooks/work_task_to_merged_pr/runbook.org
@@ -55,12 +55,20 @@ In execution order:
 
    After merge, update the task: state → =DONE=, fill =* Result=, distill any =* Plan= into the parent story's =* Decisions=.
 
+9. /Sync story and sprint state./ If this was the final task in the story, update both files in the same commit:
+
+   a. In the *story.org* =* Status= table: state → =DONE=, set =Now= to =Nothing.=, fill =End= date.
+   b. In the *sprint.org* =* Stories= table: update the story row to =DONE= and fill the =End= column.
+
+   Both files must stay in sync. A story marked =DONE= in =story.org= but =STARTED= or =BACKLOG= in =sprint.org= is a silent inconsistency that the sprint health review will not catch automatically.
+
 * Postconditions
 
 - Task is =DONE= with =* Result= filled.
 - PR is merged into =main=.
 - Review rounds are recorded in the task's =* Review= table.
 - Parent story reflects any decisions from the task's =* Plan=.
+- If the story is complete: =story.org= and =sprint.org= both show =DONE= with matching end dates.
 
 * See also
 


### PR DESCRIPTION
## Summary

Scaffolds the **Compass CLI UX redesign** story in Sprint 19. This story addresses the growing mismatch between compass's self-description ("orientation tool") and its actual scope, and designs a noun-based command taxonomy before any new commands are added.

This PR is scaffolding only — no implementation yet.

## Changes

- `compass_cli_ux_redesign/story.org` — full story with goal, 6-task breakdown, proposed taxonomy, acceptance criteria, decisions
- `compass_cli_ux_redesign/task_implement_compass_cli_ux_redesign.org` — Task 1: UX analysis and taxonomy (gates all implementation; includes command inventory and key design questions)
- `sprint.org` — story wired into Tooling section as STARTED

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Compass CLI UX redesign](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/story.html) | A596D1E7-6A74-4E55-996D-6F1F2E48F261 |
| Task | [Compass CLI UX analysis and taxonomy](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_compass_cli_ux_redesign.html) | ACBF9164-1806-4472-8C96-C57821AD5F29 |