### PR TITLE
[codegen] Add entity_org doc-type for org-mode entity scaffolding

### DIFF
--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/story.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/story.org
@@ -6,7 +6,7 @@
 #+type: story
 #+level: s2
 #+filetags: :tooling:codegen:literate:sprint_19:v0:
-#+branch: feature/refactor-codegen-cpp
+#+branch: feature/codegen-org-migration
 #+created: 2026-06-01
 #+updated: 2026-06-01
 #+todo: BACKLOG STARTED | DONE ABANDONED
@@ -58,11 +58,11 @@ against an inadequate model format and migrating later.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                                |
+| State         | STARTED                                |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                              |
-| Now           | Story created from the POC results.    |
+| Now           | Task 1 (compass scaffold) in progress on =feature/codegen-org-migration=. |
 | Waiting on    | Nothing.                               |
-| Next          | Start Task 1 (compass scaffolding) and Task 2 (co-locate the pilot org file). |
+| Next          | Finish Task 1, then Task 2 (co-locate the pilot org file). |
 | Last touched  | 2026-06-01                             |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_compass_entity_org_scaffold.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_compass_entity_org_scaffold.org
@@ -37,6 +37,7 @@ migration task that follows in this story.
 | Waiting on   | Nothing.                               |
 | Next         | Test scaffold; raise PR.               |
 | Last touched | 2026-06-01                             |
+| Review       | PR #965 round 1: 4 comments, 2 accepted (fixed in =2bd0b00b1=), 2 declined (sections already present + convention preserved). |
 
 * Acceptance
 
@@ -135,6 +136,9 @@ One commit per logical unit:
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Task missing =* PRs= / =* Review= sections; suggest =\| # \| Link \| Status \| Notes \|= columns. | task_compass_entity_org_scaffold.org:127 | Declined | PR #965 round 1. Sections already present (lines 128, 134); suggested PR column shape differs from the repo convention (=\| PR \| Title \|=, e.g. task_org_codegen_extensions.org). |
+| 2 | Template hardcodes =#+title: ores.{{component}}.{{slug}}=; use standard =\{\{title\}\}=. | doc_entity_org.org.mustache:4 | Accepted | PR #965 round 1. Fixed in =2bd0b00b1=; doc_generate already computes the title when --title is omitted. |
+| 3 | Drop the stale "template ignores =\{\{title\}\}=" remark from doc_generate. | doc_generate.py:298 | Accepted | PR #965 round 1. Fixed in =2bd0b00b1= (follow-on to comment 2). |
+| 4 | Task missing =* Review= section. | task_compass_entity_org_scaffold.org:127 | Declined | PR #965 round 1. Section already present at line 134 with the standard columns. |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_compass_entity_org_scaffold.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_compass_entity_org_scaffold.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :codegen_org_model_migration:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/codegen-org-migration
 #+pr:
 #+blocked_on: none
 #+blocked_since:
@@ -19,28 +19,109 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Add =entity_org= as a first-class doc-type in =ores.codegen='s
+=doc_generate=, scaffold-able via =compass add entity_org=. A single
+command produces =projects/ores.<component>/modeling/ores.<component>.<entity>.org=
+with the correct frontmatter, all standard sections (Flags, Primary
+key, Natural keys, Columns, SQL, C++), and an inline =[[id:...]]=
+pointer to the [[id:BDE309BA-71DA-4A52-AA10-00F17AFDA476][org-entity meta-model]]. This unblocks every per-component
+migration task that follows in this story.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                                |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Not yet started.                       |
+| Now          | Implementing template + doc_generate wiring. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-01                               |
+| Next         | Test scaffold; raise PR.               |
+| Last touched | 2026-06-01                             |
 
 * Acceptance
 
--
+- New mustache template at
+  =projects/ores.codegen/library/templates/doc_entity_org.org.mustache=
+  with the standard frontmatter (=#+type: ores.codegen.entity=, etc.)
+  and skeleton sections in the order the meta-model documents.
+- =doc_generate.py= recognises =--type entity_org= and a new
+  =--component= flag; the layout case writes to
+  =projects/ores.<component>/modeling/ores.<component>.<slug>.org=.
+- =compass add entity_org --slug party --component refdata= creates the
+  file at the right path with no further flags required.
+- The scaffolded file contains a single =[[id:BDE309BA-71DA-4A52-AA10-00F17AFDA476][Codegen org-entity meta-model]]=
+  link in its prose body so authors land on the spec.
+- A round-trip smoke test passes:
+  =compass add entity_org --slug smoke --component refdata --description "..."=
+  produces a parseable file (=load_org_model= returns without raising),
+  and the file is then deleted as part of the test.
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+** 1. Template
+
+Write =doc_entity_org.org.mustache= mirroring the meta-model spec.
+Frontmatter:
+
+#+begin_example
+,:PROPERTIES:
+,:ID: {{id}}
+,:END:
+,#+title: ores.{{component}}.{{slug}}
+,#+description: {{description}}
+,#+type: ores.codegen.entity
+,#+component: {{component}}
+,#+filetags: {{filetags}}
+,#+created: {{date}}
+,#+updated: {{date}}
+#+end_example
+
+Body: one paragraph describing the modelled entity (placeholder for the
+author), then the =See [[id:BDE309BA-...][meta-model]]= pointer, then
+empty section headings.
+
+** 2. doc_generate wiring
+
+In =projects/ores.codegen/src/doc_generate.py=:
+- Add =entity_org= to =TYPE_TO_TEMPLATE=, =PARENTLESS_TYPES=,
+  and =DEFAULT_INITIAL_STATE= (empty).
+- Add =--component= as a new argparse argument.
+- Layout: when =args.type == "entity_org"=, default =parent_dir= to
+  =projects/ores.<component>/modeling= if not given, and write to
+  =parent_dir / f"ores.{component}.{slug}.org"=.
+- Add =component= to the template variables dict.
+
+** 3. compass plumbing
+
+Compass already forwards unknown flags to doc_generate, so =--component=
+flows through automatically. The only compass change is updating the
+=usage= banner in =cmd_add= to list =entity_org= alongside the existing
+types.
+
+** 4. Validation
+
+Round-trip smoke test:
+
+#+begin_src sh
+projects/ores.compass/compass.sh add entity_org \
+  --slug smoke --component refdata \
+  --title "ores.refdata.smoke" \
+  --description "Smoke test entity"
+python3 -c "
+import sys, pathlib
+sys.path.insert(0, 'projects/ores.codegen/src/codegen')
+from org_loader import load_org_model
+load_org_model(pathlib.Path('projects/ores.refdata/modeling/ores.refdata.smoke.org'))
+print('OK')"
+rm projects/ores.refdata/modeling/ores.refdata.smoke.org
+#+end_src
+
+** 5. Commit + PR
+
+One commit per logical unit:
+- Template.
+- doc_generate wiring + compass banner update.
+- Task doc updates.
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_compass_entity_org_scaffold.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_compass_entity_org_scaffold.org
@@ -8,7 +8,7 @@
 #+filetags: :codegen_org_model_migration:sprint_19:v0:
 #+owner: marco
 #+branch: feature/codegen-org-migration
-#+pr:
+#+pr: 965
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-06-01
@@ -127,9 +127,9 @@ One commit per logical unit:
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR   | Title |
+|------+-------|
+| #965 | [codegen] Add entity_org doc-type for org-mode entity scaffolding |
 
 * Review
 

--- a/projects/ores.codegen/library/templates/doc_entity_org.org.mustache
+++ b/projects/ores.codegen/library/templates/doc_entity_org.org.mustache
@@ -1,0 +1,97 @@
+:PROPERTIES:
+:ID: {{id}}
+:END:
+#+title: ores.{{component}}.{{slug}}
+#+description: {{description}}
+#+type: ores.codegen.entity
+#+component: {{component}}
+#+filetags: {{filetags}}
+#+entity_singular: {{slug}}
+#+entity_plural:
+#+entity_title:
+#+brief:
+#+created: {{date}}
+#+updated: {{date}}
+
+(One or two paragraphs describing the modelled entity itself — what it
+represents in the domain, its key relationships, and any defining
+invariants.)
+
+See [[id:BDE309BA-71DA-4A52-AA10-00F17AFDA476][Codegen org-entity meta-model]] for the shape this file follows.
+
+* Flags
+:PROPERTIES:
+:schema:    public
+:product:   ores
+:component: {{component}}
+:END:
+
+* Primary key
+:PROPERTIES:
+:column:   id
+:type:     uuid
+:cpp_type: boost::uuids::uuid
+:END:
+
+(Description of the primary key.)
+
+* Natural keys
+
+* Columns
+
+* SQL
+
+** Flags
+:PROPERTIES:
+:tablename:
+:END:
+
+* C++
+
+** Flags
+:PROPERTIES:
+:END:
+
+** Repository
+:PROPERTIES:
+:entity_singular_short:
+:entity_plural_short:
+:entity_singular_words:
+:entity_plural_words:
+:END:
+
+** Domain includes
+
+#+begin_src cpp :name includes
+#+end_src
+
+** Entity includes
+
+#+begin_src cpp :name includes
+#+end_src
+
+** Conventions
+:PROPERTIES:
+:iterator_var:
+:END:
+
+** Table display
+
+| Column | Header |
+|--------+--------|
+
+** Qt
+:PROPERTIES:
+:END:
+
+*** Detail fields
+
+| Field | Label |
+|-------+-------|
+
+*** Columns (Qt model)
+
+| Column | Header |
+|--------+--------|
+
+** Custom repository methods

--- a/projects/ores.codegen/library/templates/doc_entity_org.org.mustache
+++ b/projects/ores.codegen/library/templates/doc_entity_org.org.mustache
@@ -1,7 +1,7 @@
 :PROPERTIES:
 :ID: {{id}}
 :END:
-#+title: ores.{{component}}.{{slug}}
+#+title: {{title}}
 #+description: {{description}}
 #+type: ores.codegen.entity
 #+component: {{component}}

--- a/projects/ores.codegen/src/doc_generate.py
+++ b/projects/ores.codegen/src/doc_generate.py
@@ -46,6 +46,7 @@ TYPE_TO_TEMPLATE = {
     "release_notes": "doc_release_notes.org.mustache",
     "investigation": "doc_investigation.org.mustache",
     "runbook": "doc_runbook.org.mustache",
+    "entity_org": "doc_entity_org.org.mustache",
 }
 
 DEFAULT_INITIAL_STATE = {
@@ -63,6 +64,7 @@ DEFAULT_INITIAL_STATE = {
     "memory": "",
     "investigation": "",
     "runbook": "",
+    "entity_org": "",
 }
 
 # Composition: each type's direct parent type.
@@ -78,6 +80,7 @@ PARENT_OF_TYPE = {
 PARENTLESS_TYPES = {
     "version", "component", "recipe", "knowledge", "skill", "product_identity",
     "capture", "memory", "release_notes", "investigation", "runbook",
+    "entity_org",
 }
 
 
@@ -240,6 +243,11 @@ def parse_args(argv=None):
                         choices=["feedback", "user", "project", "reference"],
                         help="For --type memory: subtype of memory being stored. "
                              "Default feedback. Ignored for other types.")
+    parser.add_argument("--component", default="",
+                        help="For --type entity_org: short component name "
+                             "(refdata, trading, ...). Drives the output path "
+                             "(projects/ores.<component>/modeling/) and the "
+                             "ores.<component>.<slug> title.")
     parser.add_argument("--force", action="store_true",
                         help="Overwrite the output file if it already exists.")
     return parser.parse_args(argv)
@@ -253,6 +261,15 @@ def main(argv=None):
                               prompt_label="Type",
                               choices=list(TYPE_TO_TEMPLATE))
     args.slug = fill_required("slug", args.slug, prompt_label="Slug (snake_case)")
+
+    # entity_org derives its parent dir from the component if not given.
+    if args.type == "entity_org":
+        args.component = fill_required(
+            "component", args.component,
+            prompt_label="Component (refdata, trading, ...)")
+        if not args.parent_dir:
+            args.parent_dir = f"projects/ores.{args.component}/modeling"
+
     args.parent_dir = fill_required("parent-dir", args.parent_dir,
                                     prompt_label="Parent directory")
     parent_dir = Path(args.parent_dir)
@@ -275,7 +292,10 @@ def main(argv=None):
         args.parent_title = fill_required("parent-title", args.parent_title,
                                           prompt_label=f"Parent {parent_type} title")
 
-    # Required content fields.
+    # Required content fields. entity_org derives its title from
+    # component + slug; the template ignores {{title}}.
+    if args.type == "entity_org" and not args.title:
+        args.title = f"ores.{args.component}.{args.slug}"
     args.title = fill_required("title", args.title, prompt_label="Title")
     args.description = fill_required("description", args.description,
                                      prompt_label="Description (one-liner)")
@@ -346,6 +366,7 @@ def main(argv=None):
         "predecessor_title": args.predecessor_title or "",
         "bucket": bucket,
         "memory_subtype": memory_subtype,
+        "component": args.component,
     }
 
     template_path = TEMPLATE_DIR / TYPE_TO_TEMPLATE[args.type]
@@ -361,6 +382,8 @@ def main(argv=None):
     #              "t" so they sort below story.org and stand apart from any
     #              future siblings in the story folder)
     # - skill:     <parent-dir>/<slug>/SKILL.org  (Claude Code skill folder)
+    # - entity_org: <parent-dir>/ores.<component>.<slug>.org  (codegen
+    #              entity model; filename matches the fully-qualified title)
     # - story / sprint / version: <parent-dir>/<slug>/<type>.org
     #   (these are composition nodes; they hold children)
     if args.type == "task":
@@ -368,6 +391,9 @@ def main(argv=None):
         leaf = args.slug if args.slug.startswith("task_") else f"task_{args.slug}"
         out_dir = parent_dir
         out_file = out_dir / f"{leaf}.org"
+    elif args.type == "entity_org":
+        out_dir = parent_dir
+        out_file = out_dir / f"ores.{args.component}.{args.slug}.org"
     elif args.type in ("component", "recipe", "knowledge", "product_identity",
                        "capture", "memory", "investigation"):
         # Captures live at agile/product_backlog/<bucket>/<slug>.org. The

--- a/projects/ores.codegen/src/doc_generate.py
+++ b/projects/ores.codegen/src/doc_generate.py
@@ -293,7 +293,7 @@ def main(argv=None):
                                           prompt_label=f"Parent {parent_type} title")
 
     # Required content fields. entity_org derives its title from
-    # component + slug; the template ignores {{title}}.
+    # component + slug.
     if args.type == "entity_org" and not args.title:
         args.title = f"ores.{args.component}.{args.slug}"
     args.title = fill_required("title", args.title, prompt_label="Title")

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -1187,10 +1187,13 @@ def cmd_add(argv):
         print("usage: compass add <type> [generate_doc options]\n"
               "  types: story task sprint version recipe knowledge component\n"
               "         capture memory investigation product_identity skill\n"
-              "         diagram\n"
+              "         diagram entity_org\n"
               "  --parent-dir defaults to the current sprint (story) or\n"
               "  version (sprint), or doc/llm/skills (skill); required otherwise.\n"
               "  diagram: scaffolds a .puml file with the standard licence header.\n"
+              "  entity_org: scaffolds projects/ores.<component>/modeling/\n"
+              "    ores.<component>.<slug>.org; requires --component, --slug,\n"
+              "    --description.\n"
               "  remaining flags are passed through to ores.codegen "
               "(see 'How do I create a new v2 doc?').")
         return 0


### PR DESCRIPTION
## Summary

First task of the [Codegen unified model — org-mode migration](https://github.com/OreStudio/OreStudio/blob/main/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/story.org) story (D85E2B30-...). Adds a new `entity_org` doc-type to compass/codegen so per-component migrations can scaffold the standard skeleton with one command instead of hand-copying frontmatter and section headings.

- New mustache template `doc_entity_org.org.mustache` produces the six top-level sections (Flags, Primary key, Natural keys, Columns, SQL, C++) with their required property drawers and a single see-also link to the org-entity meta-model (BDE309BA-...) so authors land on the spec.
- `doc_generate` learns `--component`, defaults the parent dir to `projects/ores.<component>/modeling/` when not given, and writes to `ores.<component>.<slug>.org`.
- Compass's `add` help banner now lists `entity_org`; `--component` flows through unchanged because compass forwards unknown flags to `doc_generate`.

## Test plan

- [x] `compass add entity_org --slug smoke --component refdata --description ...` writes `projects/ores.refdata/modeling/ores.refdata.smoke.org` at the expected path.
- [x] The scaffolded file parses cleanly via `org_loader.parse_org` / `org_document_to_model` with all six sections detected.
- [x] Frontmatter includes `#+type: ores.codegen.entity`, `#+component: refdata`, and the meta-model see-also link.
- [ ] Sanity-check the scaffold by hand in Emacs (org property drawers render, see-also link resolves via org-roam id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)