### PR TITLE
[ores.service,services] Fix macOS and Windows CI failures

### DIFF
--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
@@ -59,7 +59,8 @@ the variant from the Qt UI boundary as well, since the variant serves no purpose
 | [[id:06C98C06-F950-483A-997B-89AED70D1238][Rename get_trade_detail → get_trade_instrument and rewrite parse path]]    | DONE    | 2026-05-29 | 2026-05-30 | Rename protocol types, delete workarounds, rewrite client TU with dispatch.     |
 | [[id:F9E5967D-77E7-49E3-9806-74AF22D26191][Write round-trip tests for instrument parse dispatch]]                      | DONE    | 2026-05-30 | 2026-05-31 | One test per instrument family; serialize server-side, verify client dispatch.  |
 | [[id:5C955A5E-0130-40D7-B77F-B41F4F526B79][Refactor IInstrumentForm to type-specific populate methods]]                | DONE    | 2026-05-30 | 2026-05-31 | Remove trade_instrument variant from the Qt UI boundary; typed populate per form.|
-| [[id:2991CE7B-48F3-489F-9792-1BCB529E85BB][Delete leftover get_trade_detail code and fix remaining AddTagsToVariants use]] | STARTED | 2026-05-31 |            | Delete ClientManagerTradeDetail.cpp; remove getTradeDetail API; restore macOS/Windows CI.    |
+| [[id:2991CE7B-48F3-489F-9792-1BCB529E85BB][Delete leftover get_trade_detail code and fix remaining AddTagsToVariants use]] | DONE    | 2026-05-31 | 2026-05-31 | Delete ClientManagerTradeDetail.cpp; remove getTradeDetail API; restore macOS/Windows CI.    |
+| [[id:D9E63BBA-82CE-4FD3-9354-47A0A12ED108][Fix missing Windows DLL export macros on service parser classes]]              | STARTED | 2026-06-01 |            | Add ORES_*_SERVICE_EXPORT to 11 service parser.hpp files; restore Windows CI linker.          |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
@@ -60,7 +60,7 @@ the variant from the Qt UI boundary as well, since the variant serves no purpose
 | [[id:F9E5967D-77E7-49E3-9806-74AF22D26191][Write round-trip tests for instrument parse dispatch]]                      | DONE    | 2026-05-30 | 2026-05-31 | One test per instrument family; serialize server-side, verify client dispatch.  |
 | [[id:5C955A5E-0130-40D7-B77F-B41F4F526B79][Refactor IInstrumentForm to type-specific populate methods]]                | DONE    | 2026-05-30 | 2026-05-31 | Remove trade_instrument variant from the Qt UI boundary; typed populate per form.|
 | [[id:2991CE7B-48F3-489F-9792-1BCB529E85BB][Delete leftover get_trade_detail code and fix remaining AddTagsToVariants use]] | DONE    | 2026-05-31 | 2026-05-31 | Delete ClientManagerTradeDetail.cpp; remove getTradeDetail API; restore macOS/Windows CI.    |
-| [[id:D9E63BBA-82CE-4FD3-9354-47A0A12ED108][Fix missing Windows DLL export macros on service parser classes]]              | STARTED | 2026-06-01 |            | Add ORES_*_SERVICE_EXPORT to 11 service parser.hpp files; restore Windows CI linker.          |
+| [[id:D9E63BBA-82CE-4FD3-9354-47A0A12ED108][Fix missing Windows DLL export macros on service parser classes]]              | STARTED | 2026-06-01 |            | Add ORES_*_SERVICE_EXPORT to 16 service parser.hpp files; restore Windows CI linker.          |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_delete_get_trade_detail.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_delete_get_trade_detail.org
@@ -31,12 +31,12 @@ other remaining instantiation sites.
 
 | Field        | Value                                                                               |
 |--------------+-------------------------------------------------------------------------------------|
-| State        | STARTED                                                                             |
+| State        | DONE                                                                                |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
-| Now          | Deleting ClientManagerTradeDetail.cpp and removing the getTradeDetail API.          |
-| Waiting on   | —                                                                                   |
-| Next         | Open PR; verify macOS and Windows CI green.                                         |
-| Last touched | 2026-05-31                                                                          |
+| Now          | Nothing.                                                                            |
+| Waiting on   | Nothing.                                                                            |
+| Next         | N/A.                                                                                |
+| Last touched | 2026-06-01                                                                          |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_windows_service_parser_exports.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_windows_service_parser_exports.org
@@ -1,0 +1,71 @@
+:PROPERTIES:
+:ID: D9E63BBA-82CE-4FD3-9354-47A0A12ED108
+:END:
+#+title: Task: Fix missing Windows DLL export macros on service parser classes
+#+description: Add ORES_*_SERVICE_EXPORT to all service config/parser.hpp files missing it so ores.*.service.tests.exe links on Windows.
+#+type: task
+#+level: s1
+#+filetags: :fix_rfl_complexity:sprint_19:v0:
+#+owner: marco
+#+branch: feature/fix-windows-macos-ci
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-06-01
+#+updated: 2026-06-01
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+11 service =config/parser.hpp= files lack the =ORES_*_SERVICE_EXPORT= macro
+on their =parser= class. On Windows (shared library build), this means the
+=parse= member function is not exported from the DLL, so test binaries that
+call it fail to link. Add the include and export macro to every affected
+service parser header.
+
+* Status
+
+| Field        | Value                                                            |
+|--------------+------------------------------------------------------------------|
+| State        | STARTED                                                          |
+| Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]]  |
+| Now          | Implementing fix across all 11 affected service parsers.         |
+| Waiting on   | Nothing.                                                         |
+| Next         | Open PR; verify Windows CI green.                                |
+| Last touched | 2026-06-01                                                       |
+
+* Acceptance
+
+- All service =config/parser.hpp= files include their =export.hpp= and
+  annotate the =parser= class with =ORES_*_SERVICE_EXPORT=.
+- =ores.assets.service.tests.exe= links on Windows (no undefined symbol).
+- Windows CI green; no regressions on Linux or macOS.
+
+* Plan
+
+Affected services (11): =ores.wt.service=, =ores.analytics.service=,
+=ores.scheduler.service=, =ores.controller.service=, =ores.synthetic.service=,
+=ores.iam.service=, =ores.reporting.service=, =ores.workspace.service=,
+=ores.marketdata.service=, =ores.compute.service=, =ores.assets.service=.
+
+Pattern (from working example in =ores.trading.service=):
+1. Add =#include "ores.<name>.service/export.hpp"= to =config/parser.hpp=.
+2. Annotate the class: =class ORES_<NAME>_SERVICE_EXPORT parser final {=.
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_windows_service_parser_exports.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_windows_service_parser_exports.org
@@ -19,7 +19,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-11 service =config/parser.hpp= files lack the =ORES_*_SERVICE_EXPORT= macro
+16 service =config/parser.hpp= files lack the =ORES_*_SERVICE_EXPORT= macro
 on their =parser= class. On Windows (shared library build), this means the
 =parse= member function is not exported from the DLL, so test binaries that
 call it fail to link. Add the include and export macro to every affected
@@ -45,10 +45,12 @@ service parser header.
 
 * Plan
 
-Affected services (11): =ores.wt.service=, =ores.analytics.service=,
-=ores.scheduler.service=, =ores.controller.service=, =ores.synthetic.service=,
-=ores.iam.service=, =ores.reporting.service=, =ores.workspace.service=,
-=ores.marketdata.service=, =ores.compute.service=, =ores.assets.service=.
+Affected services (16): =ores.analytics.service=, =ores.assets.service=,
+=ores.compute.service=, =ores.controller.service=, =ores.dq.service=,
+=ores.iam.service=, =ores.marketdata.service=, =ores.ore.service=,
+=ores.reporting.service=, =ores.scheduler.service=, =ores.synthetic.service=,
+=ores.telemetry.service=, =ores.variability.service=, =ores.workflow.service=,
+=ores.workspace.service=, =ores.wt.service=.
 
 Pattern (from working example in =ores.trading.service=):
 1. Add =#include "ores.<name>.service/export.hpp"= to =config/parser.hpp=.

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_windows_service_parser_exports.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_windows_service_parser_exports.org
@@ -8,7 +8,7 @@
 #+filetags: :fix_rfl_complexity:sprint_19:v0:
 #+owner: marco
 #+branch: feature/fix-windows-macos-ci
-#+pr:
+#+pr: 969
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-06-01
@@ -31,9 +31,9 @@ service parser header.
 |--------------+------------------------------------------------------------------|
 | State        | STARTED                                                          |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]]  |
-| Now          | Implementing fix across all 11 affected service parsers.         |
-| Waiting on   | Nothing.                                                         |
-| Next         | Open PR; verify Windows CI green.                                |
+| Now          | PR #969 open; awaiting CI and review.                            |
+| Waiting on   | CI green + review.                                               |
+| Next         | Merge PR; mark DONE.                                             |
 | Last touched | 2026-06-01                                                       |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_windows_service_parser_exports.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_windows_service_parser_exports.org
@@ -62,12 +62,15 @@ Pattern (from working example in =ores.trading.service=):
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/969][#969]] | [ores.service,services] Fix macOS and Windows CI failures |
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                      | File                                        | Decision | Notes          |
+|---+------------------------------------------------------+---------------------------------------------+----------+----------------|
+| 1 | Service count says 11 in Goal (should be 16)         | task_fix_windows_service_parser_exports.org | Accept   | Fixed 71667d1c |
+| 2 | Service count says 11 in Now field (should be 16)    | task_fix_windows_service_parser_exports.org | Accept   | Fixed 71667d1c |
+| 3 | Affected list has 11 services (should be 16)         | task_fix_windows_service_parser_exports.org | Accept   | Fixed 71667d1c |
+| 4 | Story table says 11 service parsers (should be 16)   | story.org                                   | Accept   | Fixed 71667d1c |
 
 * Result

--- a/projects/ores.analytics.service/include/ores.analytics.service/config/parser.hpp
+++ b/projects/ores.analytics.service/include/ores.analytics.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.analytics.service/export.hpp"
 #include "ores.analytics.service/config/options.hpp"
 
 namespace ores::analytics::service::config {
@@ -34,7 +35,7 @@ namespace ores::analytics::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_ANALYTICS_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.assets.service/include/ores.assets.service/config/parser.hpp
+++ b/projects/ores.assets.service/include/ores.assets.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.assets.service/export.hpp"
 #include "ores.assets.service/config/options.hpp"
 
 namespace ores::assets::service::config {
@@ -34,7 +35,7 @@ namespace ores::assets::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_ASSETS_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.compute.service/include/ores.compute.service/config/parser.hpp
+++ b/projects/ores.compute.service/include/ores.compute.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.compute.service/export.hpp"
 #include "ores.compute.service/config/options.hpp"
 
 namespace ores::compute::service::config {
@@ -34,7 +35,7 @@ namespace ores::compute::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_COMPUTE_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.controller.service/include/ores.controller.service/config/parser.hpp
+++ b/projects/ores.controller.service/include/ores.controller.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.controller.service/export.hpp"
 #include "ores.controller.service/config/options.hpp"
 
 namespace ores::controller::service::config {
@@ -34,7 +35,7 @@ namespace ores::controller::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_CONTROLLER_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.dq.service/include/ores.dq.service/config/parser.hpp
+++ b/projects/ores.dq.service/include/ores.dq.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.dq.service/export.hpp"
 #include "ores.dq.service/config/options.hpp"
 
 namespace ores::dq::service::config {
@@ -34,7 +35,7 @@ namespace ores::dq::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_DQ_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.iam.service/include/ores.iam.service/config/parser.hpp
+++ b/projects/ores.iam.service/include/ores.iam.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.iam.service/export.hpp"
 #include "ores.iam.service/config/options.hpp"
 
 namespace ores::iam::service::config {
@@ -34,7 +35,7 @@ namespace ores::iam::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_IAM_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.marketdata.service/include/ores.marketdata.service/config/parser.hpp
+++ b/projects/ores.marketdata.service/include/ores.marketdata.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.marketdata.service/export.hpp"
 #include "ores.marketdata.service/config/options.hpp"
 
 namespace ores::marketdata::service::config {
@@ -34,7 +35,7 @@ namespace ores::marketdata::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_MARKETDATA_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.ore.service/include/ores.ore.service/config/parser.hpp
+++ b/projects/ores.ore.service/include/ores.ore.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.ore.service/export.hpp"
 #include "ores.ore.service/config/options.hpp"
 
 namespace ores::ore::service::config {
@@ -34,7 +35,7 @@ namespace ores::ore::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_ORE_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.reporting.service/include/ores.reporting.service/config/parser.hpp
+++ b/projects/ores.reporting.service/include/ores.reporting.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.reporting.service/export.hpp"
 #include "ores.reporting.service/config/options.hpp"
 
 namespace ores::reporting::service::config {
@@ -34,7 +35,7 @@ namespace ores::reporting::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_REPORTING_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.scheduler.service/include/ores.scheduler.service/config/parser.hpp
+++ b/projects/ores.scheduler.service/include/ores.scheduler.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.scheduler.service/export.hpp"
 #include "ores.scheduler.service/config/options.hpp"
 
 namespace ores::scheduler::service::config {
@@ -34,7 +35,7 @@ namespace ores::scheduler::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_SCHEDULER_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.service/include/ores.service/messaging/handler_helpers.hpp
+++ b/projects/ores.service/include/ores.service/messaging/handler_helpers.hpp
@@ -25,7 +25,6 @@
 #include <string_view>
 #include <boost/uuid/uuid.hpp>
 #include <rfl/json.hpp>
-#include <rfl/AddTagsToVariants.hpp>
 #include "ores.logging/make_logger.hpp"
 #include "ores.nats/domain/headers.hpp"
 #include "ores.nats/domain/message.hpp"
@@ -146,28 +145,8 @@ inline const std::string& delegated_actor(const ores::database::context& ctx) {
     return ctx.actor().empty() ? ctx.service_account() : ctx.actor();
 }
 
-// Serialise resp to JSON and publish to the message's reply subject.
-// AddTagsToVariants ensures each std::variant alternative carries a type-name
-// discriminant so the client can unambiguously select the right alternative.
-// Without it, std::monostate (zero required fields) always matches first.
-// No-op if the message has no reply subject.
 template<typename Resp>
 void reply(ores::nats::service::client& nats,
-    const ores::nats::message& msg,
-    const Resp& resp) {
-    if (msg.reply_subject.empty()) return;
-    const auto json = rfl::json::write<rfl::AddTagsToVariants>(resp);
-    const auto* p = reinterpret_cast<const std::byte*>(json.data());
-    nats.publish(msg.reply_subject, std::span<const std::byte>(p, json.size()));
-}
-
-// Like reply() but writes WITHOUT AddTagsToVariants.
-// Use this when the response contains a large std::variant (e.g. trade_instrument
-// with nested sub-variants) whose field-name union would exceed the macOS/Windows
-// fold-expression nesting limit. Safe when the client dispatches on a separate
-// discriminator (e.g. product_type/trade_type) rather than relying on type tags.
-template<typename Resp>
-void reply_no_variant_tags(ores::nats::service::client& nats,
     const ores::nats::message& msg,
     const Resp& resp) {
     if (msg.reply_subject.empty()) return;

--- a/projects/ores.synthetic.service/include/ores.synthetic.service/config/parser.hpp
+++ b/projects/ores.synthetic.service/include/ores.synthetic.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.synthetic.service/export.hpp"
 #include "ores.synthetic.service/config/options.hpp"
 
 namespace ores::synthetic::service::config {
@@ -34,7 +35,7 @@ namespace ores::synthetic::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_SYNTHETIC_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.telemetry.service/include/ores.telemetry.service/config/parser.hpp
+++ b/projects/ores.telemetry.service/include/ores.telemetry.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.telemetry.service/export.hpp"
 #include "ores.telemetry.service/config/options.hpp"
 
 namespace ores::telemetry::service::config {
@@ -34,7 +35,7 @@ namespace ores::telemetry::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_TELEMETRY_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp
+++ b/projects/ores.trading.core/include/ores.trading.core/messaging/trade_handler.hpp
@@ -85,7 +85,6 @@ inline auto& trade_handler_lg() {
 } // namespace
 
 using ores::service::messaging::reply;
-using ores::service::messaging::reply_no_variant_tags;
 using ores::service::messaging::decode;
 using ores::service::messaging::error_reply;
 using ores::service::messaging::has_permission;
@@ -583,12 +582,7 @@ public:
         }
         BOOST_LOG_SEV(trade_handler_lg(), debug)
             << "Completed " << msg.subject;
-        // trade_instrument is a 9-alternative variant with nested sub-variants
-        // (bringing the total field-name union to 502 names); reply() would apply
-        // AddTagsToVariants and exceed the macOS/Windows fold-expression nesting
-        // limit. The client dispatches on product_type/trade_type and reads
-        // concrete leaf types directly, so type-name tags are not needed.
-        reply_no_variant_tags(nats_, msg, resp);
+        reply(nats_, msg, resp);
     }
 
     void export_portfolio(ores::nats::message msg) {

--- a/projects/ores.variability.service/include/ores.variability.service/config/parser.hpp
+++ b/projects/ores.variability.service/include/ores.variability.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.variability.service/export.hpp"
 #include "ores.variability.service/config/options.hpp"
 
 namespace ores::variability::service::config {
@@ -34,7 +35,7 @@ namespace ores::variability::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_VARIABILITY_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.workflow.service/include/ores.workflow.service/config/parser.hpp
+++ b/projects/ores.workflow.service/include/ores.workflow.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.workflow.service/export.hpp"
 #include "ores.workflow.service/config/options.hpp"
 
 namespace ores::workflow::service::config {
@@ -34,7 +35,7 @@ namespace ores::workflow::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_WORKFLOW_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.workspace.service/include/ores.workspace.service/config/parser.hpp
+++ b/projects/ores.workspace.service/include/ores.workspace.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.workspace.service/export.hpp"
 #include "ores.workspace.service/config/options.hpp"
 
 namespace ores::workspace::service::config {
@@ -34,7 +35,7 @@ namespace ores::workspace::service::config {
  * Note on logging: logging is not available during parsing since the logger
  * is only initialised after options have been successfully parsed.
  */
-class parser final {
+class ORES_WORKSPACE_SERVICE_EXPORT parser final {
 public:
     std::optional<options>
     parse(const std::vector<std::string>& arguments, std::ostream& info,

--- a/projects/ores.wt.service/include/ores.wt.service/config/parser.hpp
+++ b/projects/ores.wt.service/include/ores.wt.service/config/parser.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include "ores.wt.service/export.hpp"
 #include "ores.wt.service/config/options.hpp"
 
 namespace ores::wt::service::config {
@@ -34,7 +35,7 @@ namespace ores::wt::service::config {
  * Parses database and logging options. Wt-specific options (--docroot,
  * --http-address, etc.) are passed through to the Wt framework.
  */
-class parser final {
+class ORES_WT_SERVICE_EXPORT parser final {
 public:
     struct parse_result {
         std::optional<options> opts;

--- a/projects/ores.wt.service/include/ores.wt.service/export.hpp
+++ b/projects/ores.wt.service/include/ores.wt.service/export.hpp
@@ -1,0 +1,25 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_WT_SERVICE_EXPORT_HPP
+#define ORES_WT_SERVICE_EXPORT_HPP
+
+// ores.wt.service is a static library; no DLL visibility decoration needed.
+#define ORES_WT_SERVICE_EXPORT
+
+#endif


### PR DESCRIPTION
## Summary

Fixes two independent CI failures that have been blocking macOS and
Windows builds on main.

**macOS** — `AddTagsToVariants` was being applied in the `reply()` NATS
helper to every response, including ones that contain `trade_instrument`
(a 9-alternative variant whose 502-field union exceeds Clang's
fold-expression nesting limit of 256). The architectural fix is to remove
`AddTagsToVariants` from `reply()` entirely: NATS request-reply clients
always have a discriminator (the type of request they made) and use
discriminator-based dispatch, not type-name tags, to deserialise variants.
`AddTagsToVariants` belongs only in file import/export paths where the
type is genuinely unknown. `reply_no_variant_tags` is deleted as it is
now identical to `reply`.

**Windows** — 16 service `config/parser.hpp` files were missing the
`ORES_*_SERVICE_EXPORT` annotation on the `parser` class. On Windows
shared-library builds, un-annotated member functions are not exported
from the DLL, so test binaries that call `parser::parse` directly fail
to link with an undefined symbol error. Each service already had
`target_compile_definitions(ORES_*_SERVICE_LIBRARY)` in its CMakeLists;
the header just needed the include and the class annotation.
`ores.wt.service` was also missing `export.hpp` entirely — added with a
no-op macro since it builds as a `STATIC` library.

## Changes

- **`ores.service/messaging/handler_helpers.hpp`** — `reply()` now uses
  plain `rfl::json::write`; `reply_no_variant_tags` deleted;
  `#include <rfl/AddTagsToVariants.hpp>` removed.
- **`ores.trading.core/messaging/trade_handler.hpp`** — `using
  reply_no_variant_tags` removed; two call sites reverted to `reply()`.
- **16 × `config/parser.hpp`** — `#include "ores.*.service/export.hpp"`
  and `ORES_*_SERVICE_EXPORT` added to `class parser`.
- **`ores.wt.service/export.hpp`** — new file; macro expands to nothing
  (static library).

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Fix rfl complexity failure (Windows + macOS CI)](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.html) | 7763D0EE-A500-4497-9B2D-973C02ADC739 |
| Task (macOS) | [Delete leftover get_trade_detail code and fix remaining AddTagsToVariants use](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_delete_get_trade_detail.html) | 2991CE7B-48F3-489F-9792-1BCB529E85BB |
| Task (Windows) | [Fix missing Windows DLL export macros on service parser classes](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_windows_service_parser_exports.html) | D9E63BBA-82CE-4FD3-9354-47A0A12ED108 |