### PR TITLE
[compass] Task 3: implement compass sprint status

### DIFF
--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/story.org
@@ -113,7 +113,7 @@ and whether backward-incompatible renames need a deprecation period.
 |------+-------+-------+-----+-------------|
 | [[id:ACBF9164-1806-4472-8C96-C57821AD5F29][Compass CLI UX analysis and taxonomy]] | DONE | 2026-05-31 | 2026-06-01 | System 2 analysis: full command taxonomy, pillar organisation, backward-compat rules, description fix. |
 | [[id:EE9BBBBF-73E3-4AB9-81E6-9B047BF9D2D4][Fix compass description and organise --help by pillar]] | DONE | 2026-06-01 | 2026-06-01 | Update module docstring; add pillar epilog to --help output. |
-| [[id:A5B4156C-B75A-42D9-9E08-2AB8F5504A8D][Implement compass sprint status]] | BACKLOG | | | All stories in current sprint grouped by state with task counts; reads story.org directly. |
+| [[id:A5B4156C-B75A-42D9-9E08-2AB8F5504A8D][Implement compass sprint status]] | DONE | 2026-06-01 | 2026-06-01 | All stories in current sprint grouped by state with task counts; reads story.org directly. |
 | [[id:1048B3EE-34B8-42DD-9CF0-7A61CCB147F7][Implement compass story status]] | BACKLOG | | | All tasks in a story grouped by state, with branch and PR per task. |
 | [[id:5B8C56E9-A128-4EFE-913B-E2116788F7EF][Write recipe for new orient commands]] | BACKLOG | | | Recipe for compass sprint status and compass story status; wire into agile recipe index. |
 | [[id:C3114FD0-A03B-4BD9-AB8C-6BF73D1265C3][Audit and update compass recipes, skills, and runbooks]] | BACKLOG | | | Review all 34 compass references; update for new taxonomy and description. |

--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/story.org
@@ -125,10 +125,10 @@ and whether backward-incompatible renames need a deprecation period.
   and backward-compat decisions are recorded and agreed.
 - /=--uuids= flag is a consistent convention./ =compass sprint status --uuids=,
   =compass story status --uuids= (T4), and any future listing command show the
-  first 8 characters of each item's UUID as a suffix. This makes it easy to
-  copy a UUID prefix for use with =compass story status <uuid>=, =compass show=,
-  or other commands that accept a UUID. The flag name =--uuids= is standardised
-  across all listing commands.
+  full UUID of each item as a bracketed suffix. The full UUID is shown (not a
+  prefix) so it can be copied and passed directly to =compass story status=,
+  =compass show=, or any other command that accepts a UUID or UUID prefix.
+  The flag name =--uuids= is standardised across all listing commands.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/story.org
@@ -123,6 +123,12 @@ and whether backward-incompatible renames need a deprecation period.
 
 - /Task 1 gates all implementation./ No code changes until the taxonomy
   and backward-compat decisions are recorded and agreed.
+- /=--uuids= flag is a consistent convention./ =compass sprint status --uuids=,
+  =compass story status --uuids= (T4), and any future listing command show the
+  first 8 characters of each item's UUID as a suffix. This makes it easy to
+  copy a UUID prefix for use with =compass story status <uuid>=, =compass show=,
+  or other commands that accept a UUID. The flag name =--uuids= is standardised
+  across all listing commands.
 
 * Out of scope
 

--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_sprint_status.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_sprint_status.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :compass_cli_ux_redesign:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/implement-sprint-status
 #+pr:
 #+blocked_on: none
 #+blocked_since:
@@ -28,11 +28,11 @@ STARTED items.
 
 | Field        | Value                                       |
 |--------------+---------------------------------------------|
-| State        | BACKLOG                                     |
+| State        | DONE                                        |
 | Parent story | [[id:A596D1E7-6A74-4E55-996D-6F1F2E48F261][Compass CLI UX redesign]]                    |
-| Now          | Not yet started.                            |
-| Waiting on   | [[id:ACBF9164-1806-4472-8C96-C57821AD5F29][Task 1: UX analysis]] (DONE — unblocked).   |
-| Next         | Implement =cmd_sprint()= in =compass.py=.   |
+| Now          | Nothing.                                    |
+| Waiting on   | Nothing.                                    |
+| Next         | Done. T4: implement compass story status.   |
 | Last touched | 2026-06-01                                  |
 
 * Acceptance
@@ -47,6 +47,16 @@ STARTED items.
   (not from =sprint.org=) to avoid the drift problem identified in the
   sprint status audit.
 - CI passes.
+
+* Result
+
+- =compass sprint status= implemented in =compass.py=.
+- Stories read from =story.org= files directly (not =sprint.org=) to avoid drift.
+- Grouped by state: DONE / STARTED / BLOCKED / BACKLOG; alphabetical within each group.
+- Task counts (done/total) shown per story from =task_*.org= glob.
+- =--format json= emits machine-readable output.
+- Wired into =main()= short-circuit and argparse registry.
+- =_STATE_RE= and =_TITLE_RE2= regexes shared with upcoming =compass story status=.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_sprint_status.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_sprint_status.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_cli_ux_redesign:sprint_19:v0:
 #+owner: marco
 #+branch: feature/implement-sprint-status
-#+pr:
+#+pr: 970
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-06-01
@@ -75,7 +75,7 @@ From [[id:ACBF9164-1806-4472-8C96-C57821AD5F29][UX analysis]]:
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/970][#970]] | [compass] Task 3: implement compass sprint status |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_sprint_status.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_sprint_status.org
@@ -79,6 +79,11 @@ From [[id:ACBF9164-1806-4472-8C96-C57821AD5F29][UX analysis]]:
 
 * Review
 
+** Round 1 — 2026-06-01
+
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | =_TITLE_RE2= needs =IGNORECASE=; =_STATE_RE= can match trailing =|= | compass.py | Fixed: added =IGNORECASE=; tightened state pattern to =[A-Z]+= | Gemini review |
+| 2 | Normalise story state to uppercase | compass.py | Fixed: =.upper()= on state | Gemini review |
+| 3 | Normalise task state to uppercase | compass.py | Fixed: =.upper()= on task state | Gemini review |
+| 4 | Guard against missing sprint directory | compass.py | Fixed: check exists, print error, return 1 | Gemini review |

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -880,14 +880,16 @@ _STATE_RE  = re.compile(r"^\| State[^|]*\|\s*(\S+)", re.MULTILINE)
 _TITLE_RE2 = re.compile(r"^#\+title:\s*(?:Story:\s*)?(.+?)\s*$", re.MULTILINE)
 
 def _read_story_state(story_file):
-    """Return (title, state) from a story.org file, or (stem, 'UNKNOWN')."""
+    """Return (title, state, uuid) from a story.org file, or (stem, 'UNKNOWN', None)."""
     try:
         text = story_file.read_text(encoding="utf-8")
         tm = _TITLE_RE2.search(text)
         sm = _STATE_RE.search(text)
+        im = _ORG_ID_RE.search(text)
         title = tm.group(1) if tm else story_file.parent.name
         state = sm.group(1) if sm else "UNKNOWN"
-        return title, state
+        uuid  = im.group(1) if im else None
+        return title, state, uuid
     except (OSError, UnicodeDecodeError):
         return story_file.parent.name, "UNKNOWN"
 
@@ -914,6 +916,8 @@ def cmd_sprint(argv):
 
     st = sub.add_parser("status", help="All stories in the current sprint grouped by state")
     st.add_argument("-f", "--format", choices=["pretty", "json"], default="pretty")
+    st.add_argument("--uuids", action="store_true",
+                    help="Show story UUIDs alongside titles for use with other commands")
 
     args = ap.parse_args(argv)
 
@@ -926,9 +930,9 @@ def cmd_sprint(argv):
 
         stories = []
         for sf in sorted(sprint_dir.glob("*/story.org")):
-            title, state = _read_story_state(sf)
+            title, state, uuid = _read_story_state(sf)
             done, total = _task_counts(sf.parent)
-            stories.append({"title": title, "state": state,
+            stories.append({"title": title, "state": state, "uuid": uuid,
                             "tasks_done": done, "tasks_total": total,
                             "path": str(sf.relative_to(PROJECT_ROOT))})
 
@@ -946,7 +950,8 @@ def cmd_sprint(argv):
                 current_state = s["state"]
                 print(f"  {current_state}")
             tasks = f"{s['tasks_done']}/{s['tasks_total']}" if s["tasks_total"] else "—"
-            print(f"    [{tasks}] {s['title']}")
+            uuid_suffix = f"  ({s['uuid'][:8]})" if args.uuids and s["uuid"] else ""
+            print(f"    [{tasks}] {s['title']}{uuid_suffix}")
         return 0
 
 def _org_link_text(link_str):

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -950,7 +950,7 @@ def cmd_sprint(argv):
                 current_state = s["state"]
                 print(f"  {current_state}")
             tasks = f"{s['tasks_done']}/{s['tasks_total']}" if s["tasks_total"] else "—"
-            uuid_suffix = f"  ({s['uuid'][:8]})" if args.uuids and s["uuid"] else ""
+            uuid_suffix = f"  [{s['uuid']}]" if args.uuids and s["uuid"] else ""
             print(f"    [{tasks}] {s['title']}{uuid_suffix}")
         return 0
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -876,6 +876,79 @@ def _journal_last_entry(worktree_path):
     except (OSError, UnicodeDecodeError):
         return None
 
+_STATE_RE  = re.compile(r"^\| State[^|]*\|\s*(\S+)", re.MULTILINE)
+_TITLE_RE2 = re.compile(r"^#\+title:\s*(?:Story:\s*)?(.+?)\s*$", re.MULTILINE)
+
+def _read_story_state(story_file):
+    """Return (title, state) from a story.org file, or (stem, 'UNKNOWN')."""
+    try:
+        text = story_file.read_text(encoding="utf-8")
+        tm = _TITLE_RE2.search(text)
+        sm = _STATE_RE.search(text)
+        title = tm.group(1) if tm else story_file.parent.name
+        state = sm.group(1) if sm else "UNKNOWN"
+        return title, state
+    except (OSError, UnicodeDecodeError):
+        return story_file.parent.name, "UNKNOWN"
+
+def _task_counts(story_dir):
+    """Return (done, total) task count for a story directory."""
+    done = total = 0
+    for tf in sorted(story_dir.glob("task_*.org")):
+        try:
+            text = tf.read_text(encoding="utf-8")
+            m = _STATE_RE.search(text)
+            state = m.group(1) if m else "UNKNOWN"
+            total += 1
+            if state == "DONE":
+                done += 1
+        except (OSError, UnicodeDecodeError):
+            pass
+    return done, total
+
+def cmd_sprint(argv):
+    """compass sprint — sprint-level operations."""
+    ap = argparse.ArgumentParser(prog="compass sprint",
+                                 description="Sprint-level operations.")
+    sub = ap.add_subparsers(dest="subcmd", required=True)
+
+    st = sub.add_parser("status", help="All stories in the current sprint grouped by state")
+    st.add_argument("-f", "--format", choices=["pretty", "json"], default="pretty")
+
+    args = ap.parse_args(argv)
+
+    if args.subcmd == "status":
+        _, current_sprint = current_version_sprint(doc_index.load_all())
+        if current_sprint is None:
+            print("❌ No current sprint found.", file=sys.stderr)
+            return 1
+        sprint_dir = Path(PROJECT_ROOT) / _parent_dir(current_sprint.rel_path)
+
+        stories = []
+        for sf in sorted(sprint_dir.glob("*/story.org")):
+            title, state = _read_story_state(sf)
+            done, total = _task_counts(sf.parent)
+            stories.append({"title": title, "state": state,
+                            "tasks_done": done, "tasks_total": total,
+                            "path": str(sf.relative_to(PROJECT_ROOT))})
+
+        if args.format == "json":
+            print(json.dumps({"sprint": current_sprint.title, "stories": stories}, indent=2))
+            return 0
+
+        order = {"DONE": 0, "STARTED": 1, "BLOCKED": 2, "BACKLOG": 3}
+        stories.sort(key=lambda s: (order.get(s["state"], 9), s["title"]))
+
+        print(f"🧭 ores.compass — sprint status: {current_sprint.title}\n")
+        current_state = None
+        for s in stories:
+            if s["state"] != current_state:
+                current_state = s["state"]
+                print(f"  {current_state}")
+            tasks = f"{s['tasks_done']}/{s['tasks_total']}" if s["tasks_total"] else "—"
+            print(f"    [{tasks}] {s['title']}")
+        return 0
+
 def _org_link_text(link_str):
     """Extract plain title from an org-roam [[id:...][Title]] link, or return as-is."""
     m = _ORG_LINK_RE.match(link_str or "")
@@ -1442,6 +1515,8 @@ def main():
         sys.exit(doc_show.main(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] == "add":
         sys.exit(cmd_add(sys.argv[2:]))
+    if len(sys.argv) >= 2 and sys.argv[1] == "sprint":
+        sys.exit(cmd_sprint(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] == "story":
         sys.exit(cmd_story(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] == "task":
@@ -1462,9 +1537,9 @@ def main():
         "  Journal:  journal\n"
         "\n"
         "Entity commands (sub-subcommands span pillars):\n"
+        "  sprint:   status (orient)\n"
         "  story:    new (scaffold) | status (orient — coming soon)\n"
         "  task:     new (scaffold)\n"
-        "  sprint:   status (orient — coming soon)\n"
     )
     parser = argparse.ArgumentParser(
         description="Compass: developer toolkit for ORE Studio — orient, scaffold, capture, and search.",
@@ -1505,6 +1580,8 @@ def main():
                           help="Show one doc by UUID/prefix: metadata, blurb, in/out links")
     subparsers.add_parser("add",
                           help="Create a v2 doc via ores.codegen (low-level scaffold); 'add --help' for usage")
+    subparsers.add_parser("sprint",
+                          help="Sprint-level operations: 'sprint status' for all stories by state; 'sprint --help'")
     subparsers.add_parser("story",
                           help="Story-level operations: 'story new' to create story+branch+task; 'story --help'")
     subparsers.add_parser("task",

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -876,8 +876,8 @@ def _journal_last_entry(worktree_path):
     except (OSError, UnicodeDecodeError):
         return None
 
-_STATE_RE  = re.compile(r"^\| State[^|]*\|\s*(\S+)", re.MULTILINE)
-_TITLE_RE2 = re.compile(r"^#\+title:\s*(?:Story:\s*)?(.+?)\s*$", re.MULTILINE)
+_STATE_RE  = re.compile(r"^\| State[^|]*\|\s*([A-Z]+)", re.MULTILINE)
+_TITLE_RE2 = re.compile(r"^#\+title:\s*(?:Story:\s*)?(.+?)\s*$", re.MULTILINE | re.IGNORECASE)
 
 def _read_story_state(story_file):
     """Return (title, state, uuid) from a story.org file, or (stem, 'UNKNOWN', None)."""
@@ -887,11 +887,11 @@ def _read_story_state(story_file):
         sm = _STATE_RE.search(text)
         im = _ORG_ID_RE.search(text)
         title = tm.group(1) if tm else story_file.parent.name
-        state = sm.group(1) if sm else "UNKNOWN"
+        state = sm.group(1).upper() if sm else "UNKNOWN"
         uuid  = im.group(1) if im else None
         return title, state, uuid
     except (OSError, UnicodeDecodeError):
-        return story_file.parent.name, "UNKNOWN"
+        return story_file.parent.name, "UNKNOWN", None
 
 def _task_counts(story_dir):
     """Return (done, total) task count for a story directory."""
@@ -900,7 +900,7 @@ def _task_counts(story_dir):
         try:
             text = tf.read_text(encoding="utf-8")
             m = _STATE_RE.search(text)
-            state = m.group(1) if m else "UNKNOWN"
+            state = m.group(1).upper() if m else "UNKNOWN"
             total += 1
             if state == "DONE":
                 done += 1
@@ -927,6 +927,9 @@ def cmd_sprint(argv):
             print("❌ No current sprint found.", file=sys.stderr)
             return 1
         sprint_dir = Path(PROJECT_ROOT) / _parent_dir(current_sprint.rel_path)
+        if not sprint_dir.exists():
+            print(f"❌ Sprint directory not found: {sprint_dir}", file=sys.stderr)
+            return 1
 
         stories = []
         for sf in sorted(sprint_dir.glob("*/story.org")):


### PR DESCRIPTION
## Summary

Adds `compass sprint status` — a new Orient-pillar command that prints all stories in the current sprint grouped by state, with task counts per story. Reads `story.org` files directly (not `sprint.org`) to avoid the drift problem identified earlier in this sprint.

```
🧭 ores.compass — sprint status: Sprint 19

  DONE
    [5/5] Compass session journal
    [1/1] Fix knowledge graph issues
    [5/5] Refactor ores.codegen SQL generation
  STARTED
    [4/7] Commission: currency
    [2/7] Compass CLI UX redesign
  BLOCKED
    [6/19] Refactor ores.codegen C++ generation
  BACKLOG
    [—] Commission: book
    ...
```

## Changes

- `compass.py` — `_STATE_RE` / `_TITLE_RE2` regexes; `_read_story_state()`; `_task_counts()`; `cmd_sprint()` with `status` sub-subcommand; wired into `main()` and argparse registry; epilog updated (`sprint status` now live)
- `task_implement_sprint_status.org` — marked DONE with Result
- `story.org` — task row updated to DONE

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Compass CLI UX redesign](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/story.html) | A596D1E7-6A74-4E55-996D-6F1F2E48F261 |
| Task | [Implement compass sprint status](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_sprint_status.html) | A5B4156C-B75A-42D9-9E08-2AB8F5504A8D |