### PR TITLE
[compass] Task 4: implement compass story status

### DIFF
--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/story.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/story.org
@@ -114,7 +114,8 @@ and whether backward-incompatible renames need a deprecation period.
 | [[id:ACBF9164-1806-4472-8C96-C57821AD5F29][Compass CLI UX analysis and taxonomy]] | DONE | 2026-05-31 | 2026-06-01 | System 2 analysis: full command taxonomy, pillar organisation, backward-compat rules, description fix. |
 | [[id:EE9BBBBF-73E3-4AB9-81E6-9B047BF9D2D4][Fix compass description and organise --help by pillar]] | DONE | 2026-06-01 | 2026-06-01 | Update module docstring; add pillar epilog to --help output. |
 | [[id:A5B4156C-B75A-42D9-9E08-2AB8F5504A8D][Implement compass sprint status]] | DONE | 2026-06-01 | 2026-06-01 | All stories in current sprint grouped by state with task counts; reads story.org directly. |
-| [[id:1048B3EE-34B8-42DD-9CF0-7A61CCB147F7][Implement compass story status]] | BACKLOG | | | All tasks in a story grouped by state, with branch and PR per task. |
+| [[id:1048B3EE-34B8-42DD-9CF0-7A61CCB147F7][Implement compass story status]] | DONE | 2026-06-01 | 2026-06-01 | All tasks in a story grouped by state, with branch and PR per task. |
+| [[id:CCFF58E1-CC1E-4887-AFD7-0A5AB8BF68E4][Load SSH_AUTH_SOCK from .env in compass.sh]] | BACKLOG | | | Add SSH_AUTH_SOCK to .env; update compass.sh to source .env so git operations work without manual export. |
 | [[id:5B8C56E9-A128-4EFE-913B-E2116788F7EF][Write recipe for new orient commands]] | BACKLOG | | | Recipe for compass sprint status and compass story status; wire into agile recipe index. |
 | [[id:C3114FD0-A03B-4BD9-AB8C-6BF73D1265C3][Audit and update compass recipes, skills, and runbooks]] | BACKLOG | | | Review all 34 compass references; update for new taxonomy and description. |
 | [[id:E3F0F75F-59C8-4CF1-BD15-A937FED1FC72][Show blocked story dependency tree in compass where]] | BACKLOG | | | Extend compass where to display blocked story chains as a tree in the Orient pillar. |

--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_story_status.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_story_status.org
@@ -8,7 +8,7 @@
 #+filetags: :compass_cli_ux_redesign:sprint_19:v0:
 #+owner: marco
 #+branch: feature/implement-story-status
-#+pr:
+#+pr: 972
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-06-01
@@ -73,7 +73,7 @@ From [[id:ACBF9164-1806-4472-8C96-C57821AD5F29][UX analysis]]:
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/972][#972]] | [compass] Task 4: implement compass story status |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_story_status.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_story_status.org
@@ -77,6 +77,9 @@ From [[id:ACBF9164-1806-4472-8C96-C57821AD5F29][UX analysis]]:
 
 * Review
 
+** Round 1 — 2026-06-01
+
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Unknown states (DISCOVERED/ABANDONED) all sort to bucket 9 and interleave | compass.py | Fixed: add state as second sort key so unknown states group correctly; also applied to cmd_sprint | Gemini review |
+| 2 | CRLF line endings leave =\r= before =$=; =[ \t]*= doesn't match it | compass.py | Fixed: use =[ \t\r]*= in =_BRANCH_FIELD_RE2= and =_PR_FIELD_RE= | Gemini review |

--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_story_status.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_story_status.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :compass_cli_ux_redesign:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/implement-story-status
 #+pr:
 #+blocked_on: none
 #+blocked_since:
@@ -28,11 +28,11 @@ story without opening files manually.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                                     |
+| State        | DONE                                        |
 | Parent story | [[id:A596D1E7-6A74-4E55-996D-6F1F2E48F261][Compass CLI UX redesign]]                    |
-| Now          | Not yet started.                            |
-| Waiting on   | [[id:ACBF9164-1806-4472-8C96-C57821AD5F29][Task 1: UX analysis]] (DONE — unblocked).   |
-| Next         | Implement =cmd_story()= in =compass.py=.    |
+| Now          | Nothing.                                    |
+| Waiting on   | Nothing.                                    |
+| Next         | Done. T5: write recipe for orient commands. |
 | Last touched | 2026-06-01                                  |
 
 * Acceptance
@@ -45,6 +45,17 @@ story without opening files manually.
 - Story is resolved by UUID prefix or folder slug (same logic as
   =resolve_story()= already in compass).
 - CI passes.
+
+* Result
+
+- =compass story status <id>= implemented: tasks grouped by DONE/STARTED/BLOCKED/BACKLOG.
+- Branch and PR shown per task; =--uuids= shows full task UUID.
+- Reuses =_STATE_RE=, =_TITLE_RE2=, =_ORG_ID_RE= from T3.
+- New helpers: =_BRANCH_FIELD_RE2=, =_PR_FIELD_RE= with =[ \t]*= to avoid
+  multiline bleed when frontmatter field has no value.
+- =_read_task_detail()= extracts title, state, uuid, branch, pr from task files.
+- =story status= wired as sub-subcommand of =compass story=.
+- Epilog updated: story status now live.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_load_ssh_from_env.org
+++ b/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_load_ssh_from_env.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: CCFF58E1-CC1E-4887-AFD7-0A5AB8BF68E4
+:END:
+#+title: Task: Load SSH_AUTH_SOCK from .env in compass.sh
+#+description: Add SSH_AUTH_SOCK to the project .env file; update compass.sh to source .env like other scripts so git push/fetch via compass work without manual env var export.
+#+type: task
+#+level: s1
+#+filetags: :compass_cli_ux_redesign:sprint_19:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-06-01
+#+updated: 2026-06-01
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:A596D1E7-6A74-4E55-996D-6F1F2E48F261][Compass CLI UX redesign]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:A596D1E7-6A74-4E55-996D-6F1F2E48F261][Compass CLI UX redesign]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-01                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -879,6 +879,27 @@ def _journal_last_entry(worktree_path):
 _STATE_RE  = re.compile(r"^\| State[^|]*\|\s*([A-Z]+)", re.MULTILINE)
 _TITLE_RE2 = re.compile(r"^#\+title:\s*(?:Story:\s*)?(.+?)\s*$", re.MULTILINE | re.IGNORECASE)
 
+_BRANCH_FIELD_RE2 = re.compile(r"^#\+branch:[ \t]*(\S+)[ \t]*$", re.MULTILINE)
+_PR_FIELD_RE      = re.compile(r"^#\+pr:[ \t]*(\S+)[ \t]*$", re.MULTILINE)
+
+def _read_task_detail(task_file):
+    """Return (title, state, uuid, branch, pr) from a task.org file."""
+    try:
+        text = task_file.read_text(encoding="utf-8")
+        tm = _TITLE_RE2.search(text)
+        sm = _STATE_RE.search(text)
+        im = _ORG_ID_RE.search(text)
+        bm = _BRANCH_FIELD_RE2.search(text)
+        pm = _PR_FIELD_RE.search(text)
+        title  = _strip_type_prefix(tm.group(1)) if tm else task_file.stem
+        state  = sm.group(1).upper() if sm else "UNKNOWN"
+        uuid   = im.group(1) if im else None
+        branch = bm.group(1) if bm else None
+        pr     = pm.group(1) if pm else None
+        return title, state, uuid, branch, pr
+    except (OSError, UnicodeDecodeError):
+        return task_file.stem, "UNKNOWN", None, None, None
+
 def _read_story_state(story_file):
     """Return (title, state, uuid) from a story.org file, or (stem, 'UNKNOWN', None)."""
     try:
@@ -1459,6 +1480,12 @@ def cmd_story(argv):
     new_p.add_argument("--kind",        default="feature", choices=["feature", "hotfix"])
     new_p.add_argument("--dry-run",     action="store_true")
 
+    st = sub.add_parser("status", help="All tasks in a story grouped by state with branch and PR")
+    st.add_argument("story", help="Story UUID/prefix or folder slug")
+    st.add_argument("-f", "--format", choices=["pretty", "json"], default="pretty")
+    st.add_argument("--uuids", action="store_true",
+                    help="Show task UUIDs alongside titles")
+
     args = ap.parse_args(argv)
 
     if args.subcmd == "new":
@@ -1476,6 +1503,42 @@ def cmd_story(argv):
             (args.slug, args.title, args.description, args.tags),
             task_slug, task_title, f"Initial task for: {args.title}",
             branch, args.base, args.dry_run, current_sprint)
+
+    if args.subcmd == "status":
+        story_dir, story_title = resolve_story(args.story)
+        if story_dir is None:
+            print(f"❌ Could not resolve story '{args.story}'.", file=sys.stderr)
+            return 1
+        story_path = Path(PROJECT_ROOT) / story_dir
+        if not story_path.exists():
+            print(f"❌ Story directory not found: {story_path}", file=sys.stderr)
+            return 1
+
+        tasks = []
+        for tf in sorted(story_path.glob("task_*.org")):
+            title, state, uuid, branch, pr = _read_task_detail(tf)
+            tasks.append({"title": title, "state": state, "uuid": uuid,
+                          "branch": branch, "pr": pr,
+                          "path": str(tf.relative_to(PROJECT_ROOT))})
+
+        if args.format == "json":
+            print(json.dumps({"story": story_title, "tasks": tasks}, indent=2))
+            return 0
+
+        order = {"DONE": 0, "STARTED": 1, "BLOCKED": 2, "BACKLOG": 3}
+        tasks.sort(key=lambda t: (order.get(t["state"], 9), t["title"]))
+
+        print(f"🧭 ores.compass — story status: {story_title}\n")
+        current_state = None
+        for t in tasks:
+            if t["state"] != current_state:
+                current_state = t["state"]
+                print(f"  {current_state}")
+            uuid_suffix   = f"  [{t['uuid']}]" if args.uuids and t["uuid"] else ""
+            branch_info   = f"  {t['branch']}" if t["branch"] else ""
+            pr_info       = f"  PR:{t['pr']}" if t["pr"] and t["pr"] != "none" else ""
+            print(f"    {t['title']}{uuid_suffix}{branch_info}{pr_info}")
+        return 0
 
 
 def cmd_task(argv):
@@ -1546,7 +1609,7 @@ def main():
         "\n"
         "Entity commands (sub-subcommands span pillars):\n"
         "  sprint:   status (orient)\n"
-        "  story:    new (scaffold) | status (orient — coming soon)\n"
+        "  story:    new (scaffold) | status (orient)\n"
         "  task:     new (scaffold)\n"
     )
     parser = argparse.ArgumentParser(

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -879,8 +879,8 @@ def _journal_last_entry(worktree_path):
 _STATE_RE  = re.compile(r"^\| State[^|]*\|\s*([A-Z]+)", re.MULTILINE)
 _TITLE_RE2 = re.compile(r"^#\+title:\s*(?:Story:\s*)?(.+?)\s*$", re.MULTILINE | re.IGNORECASE)
 
-_BRANCH_FIELD_RE2 = re.compile(r"^#\+branch:[ \t]*(\S+)[ \t]*$", re.MULTILINE)
-_PR_FIELD_RE      = re.compile(r"^#\+pr:[ \t]*(\S+)[ \t]*$", re.MULTILINE)
+_BRANCH_FIELD_RE2 = re.compile(r"^#\+branch:[ \t\r]*(\S+)[ \t\r]*$", re.MULTILINE)
+_PR_FIELD_RE      = re.compile(r"^#\+pr:[ \t\r]*(\S+)[ \t\r]*$", re.MULTILINE)
 
 def _read_task_detail(task_file):
     """Return (title, state, uuid, branch, pr) from a task.org file."""
@@ -965,7 +965,7 @@ def cmd_sprint(argv):
             return 0
 
         order = {"DONE": 0, "STARTED": 1, "BLOCKED": 2, "BACKLOG": 3}
-        stories.sort(key=lambda s: (order.get(s["state"], 9), s["title"]))
+        stories.sort(key=lambda s: (order.get(s["state"], 9), s["state"], s["title"]))
 
         print(f"🧭 ores.compass — sprint status: {current_sprint.title}\n")
         current_state = None
@@ -1526,7 +1526,7 @@ def cmd_story(argv):
             return 0
 
         order = {"DONE": 0, "STARTED": 1, "BLOCKED": 2, "BACKLOG": 3}
-        tasks.sort(key=lambda t: (order.get(t["state"], 9), t["title"]))
+        tasks.sort(key=lambda t: (order.get(t["state"], 9), t["state"], t["title"]))
 
         print(f"🧭 ores.compass — story status: {story_title}\n")
         current_state = None


### PR DESCRIPTION
## Summary

Adds `compass story status <id>` — all tasks in a story grouped by state (DONE/STARTED/BLOCKED/BACKLOG) with branch and PR per task. Accepts UUID, UUID prefix, or folder slug.

```
🧭 ores.compass — story status: Compass CLI UX redesign

  DONE
    Compass CLI UX analysis and taxonomy  feature/compass-ux-analysis  PR:964
    Fix compass description and organise --help by pillar  feature/fix-description-and-help  PR:966
    Implement compass sprint status  feature/implement-sprint-status  PR:970
  BACKLOG
    Implement compass story status  feature/implement-story-status
    Write recipe for new orient commands
    Audit and update compass recipes skills and runbooks
```

With `--uuids`:
```
    Compass CLI UX analysis and taxonomy  [ACBF9164-1806-4472-8C96-C57821AD5F29]  feature/compass-ux-analysis  PR:964
```

Also scaffolds the SSH `.env` task (load `SSH_AUTH_SOCK` from `.env` in `compass.sh`).

## Changes

- `compass.py` — `_BRANCH_FIELD_RE2`, `_PR_FIELD_RE` (use `[ \t]*` to prevent multiline bleed on empty fields); `_read_task_detail()`; `story status` sub-subcommand with `--uuids` and `--format json`; epilog updated
- `task_implement_story_status.org` — marked DONE with Result
- `task_load_ssh_from_env.org` — new task scaffolded
- `story.org` — task rows updated

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Compass CLI UX redesign](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/story.html) | A596D1E7-6A74-4E55-996D-6F1F2E48F261 |
| Task | [Implement compass story status](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/compass_cli_ux_redesign/task_implement_story_status.html) | 1048B3EE-34B8-42DD-9CF0-7A61CCB147F7 |