### PR TITLE
[ci] Cap macOS build parallelism to 2 to prevent OOM kills

### DIFF
--- a/.github/workflows/continuous-macos.yml
+++ b/.github/workflows/continuous-macos.yml
@@ -139,8 +139,9 @@ jobs:
       - name: Run CTest workflow
         run: |
           brew install autoconf automake libtool autoconf-archive nats-server
-          export CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.logicalcpu)
+          export CMAKE_BUILD_PARALLEL_LEVEL=2
           export CTEST_PARALLEL_LEVEL=$(sysctl -n hw.logicalcpu)
+          export CTEST_MAX_PARALLELISM=2
           export VCPKG_DISABLE_SYSTEM_PACKAGE_CHECK=1
           export ORES_BUILD_PROVIDER="github"
           export ORES_BUILD_COMMIT="${GITHUB_SHA}"


### PR DESCRIPTION
## Summary

- macOS CI was failing mid-build with `Subprocess killed` at step ~438/2571 (inside `ores.trading.api`)
- Root cause: `macos-latest` runner has ~7 GB RAM; running `ninja -j 3` on ORE/QuantLib template-heavy TUs consumes >7 GB total, causing the OS to SIGKILL the build process
- Fix: cap `CMAKE_BUILD_PARALLEL_LEVEL` and `CTEST_MAX_PARALLELISM` to 2, giving each job ~3.5 GB headroom; test-run parallelism (`CTEST_PARALLEL_LEVEL`) is left at the full CPU count since tests are memory-light

## Test plan

- [ ] Continuous macOS CI passes on this PR (both debug and release variants)
- [ ] No regression on Linux or Windows CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)