### PR TITLE
[ores.compute.wrapper,ores.qt.api] Fix remaining Windows/macOS CI failures

### DIFF
--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
@@ -33,10 +33,10 @@ the variant from the Qt UI boundary as well, since the variant serves no purpose
 |---------------+-----------------------------------------------------------------------------------------------|
 | State         | STARTED                                                                                       |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                                       |
-| Now           | Task 5: deleting ClientManagerTradeDetail.cpp to fix remaining macOS/Windows CI failures.     |
-| Waiting on    | —                                                                                             |
-| Next          | PR for Task 5; verify macOS and Windows CI green; close story.                                |
-| Last touched  | 2026-05-31                                                                                    |
+| Now           | Task 7: PR open for ClientManager AddTagsToVariants + archiver export; awaiting CI.           |
+| Waiting on    | CI green + review on task 7 PR.                                                               |
+| Next          | Merge task 7 PR; verify all CI green; close story.                                            |
+| Last touched  | 2026-06-01                                                                                    |
 
 * Acceptance
 
@@ -60,7 +60,8 @@ the variant from the Qt UI boundary as well, since the variant serves no purpose
 | [[id:F9E5967D-77E7-49E3-9806-74AF22D26191][Write round-trip tests for instrument parse dispatch]]                      | DONE    | 2026-05-30 | 2026-05-31 | One test per instrument family; serialize server-side, verify client dispatch.  |
 | [[id:5C955A5E-0130-40D7-B77F-B41F4F526B79][Refactor IInstrumentForm to type-specific populate methods]]                | DONE    | 2026-05-30 | 2026-05-31 | Remove trade_instrument variant from the Qt UI boundary; typed populate per form.|
 | [[id:2991CE7B-48F3-489F-9792-1BCB529E85BB][Delete leftover get_trade_detail code and fix remaining AddTagsToVariants use]] | DONE    | 2026-05-31 | 2026-05-31 | Delete ClientManagerTradeDetail.cpp; remove getTradeDetail API; restore macOS/Windows CI.    |
-| [[id:D9E63BBA-82CE-4FD3-9354-47A0A12ED108][Fix missing Windows DLL export macros on service parser classes]]              | STARTED | 2026-06-01 |            | Add ORES_*_SERVICE_EXPORT to 16 service parser.hpp files; restore Windows CI linker.          |
+| [[id:D9E63BBA-82CE-4FD3-9354-47A0A12ED108][Fix missing Windows DLL export macros on service parser classes]]              | DONE    | 2026-06-01 | 2026-06-01 | Add ORES_*_SERVICE_EXPORT to 16 service parser.hpp files; restore Windows CI linker.          |
+| [[id:4BF920B2-CA2B-40EF-B463-DDC13D0C2516][Fix ClientManager AddTagsToVariants and archiver DLL export]]                  | STARTED | 2026-06-01 |            | Remove AddTagsToVariants from ClientManager reads; add ORES_COMPUTE_WRAPPER_EXPORT to archiver. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_client_manager_add_tags_and_archiver_export.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_client_manager_add_tags_and_archiver_export.org
@@ -1,0 +1,73 @@
+:PROPERTIES:
+:ID: 4BF920B2-CA2B-40EF-B463-DDC13D0C2516
+:END:
+#+title: Task: Fix ClientManager AddTagsToVariants and archiver DLL export
+#+description: Remove rfl::AddTagsToVariants from all ClientManager json::read calls; add ORES_COMPUTE_WRAPPER_EXPORT to archiver to restore Windows Clang link.
+#+type: task
+#+level: s1
+#+filetags: :fix_rfl_complexity:sprint_19:v0:
+#+owner: marco
+#+branch: feature/fix-windows-macos-ci
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-06-01
+#+updated: 2026-06-01
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Two remaining Windows/macOS CI failures after PR #969 (service parser exports):
+
+1. *macOS Clang + Windows MSVC*: =ClientManager.hpp= applied =rfl::AddTagsToVariants= to all
+   four =rfl::json::read= call sites. =export_portfolio_response= contains
+   =with_legs<std::variant<...>>= whose fully-qualified type name is 502 chars, exceeding
+   Clang's fold-expression nesting limit of 256 and MSVC's equivalent in
+   =no_duplicate_field_names.hpp=. The server already dropped =AddTagsToVariants= in commit
+   =f6f767439=; the client reads must match.
+
+2. *Windows Clang (linker)*: =ores::compute::wrapper::filesystem::archiver= was missing
+   =ORES_COMPUTE_WRAPPER_EXPORT=, so =pack= and =extract= static methods were not exported
+   from the DLL.
+
+* Status
+
+| Field        | Value                                                            |
+|--------------+------------------------------------------------------------------|
+| State        | STARTED                                                          |
+| Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]]  |
+| Now          | Committed; PR open; awaiting CI.                                 |
+| Waiting on   | CI green + review.                                               |
+| Next         | Merge PR; mark DONE.                                             |
+| Last touched | 2026-06-01                                                       |
+
+* Acceptance
+
+- macOS CI: no fold-expression nesting limit error from =ClientManager.hpp= reads.
+- Windows MSVC CI: no =C1202= recursive type error from =ClientManager.hpp= reads.
+- Windows Clang CI: =archiver::pack= and =archiver::extract= link without undefined symbol errors.
+- No regression on Linux CI.
+
+* Notes
+
+- The =AddTagsToVariants= removal from =ClientManager.hpp= resolves the "export_portfolio
+  latent issue" documented in the story's =* Decisions= section. It was not Linux-only: it
+  also fired on macOS and Windows once those CIs ran far enough into the build.
+- The =archiver= export omission is the same pattern as task 6 (service parsers) but in
+  =ores.compute.wrapper= rather than a service project.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_client_manager_add_tags_and_archiver_export.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_client_manager_add_tags_and_archiver_export.org
@@ -8,7 +8,7 @@
 #+filetags: :fix_rfl_complexity:sprint_19:v0:
 #+owner: marco
 #+branch: feature/fix-windows-macos-ci
-#+pr:
+#+pr: 978
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-06-01
@@ -62,7 +62,7 @@ Two remaining Windows/macOS CI failures after PR #969 (service parser exports):
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/978][#978]] | [ores.compute.wrapper,ores.qt.api] Fix remaining Windows/macOS CI failures |
 
 * Review
 

--- a/projects/ores.compute.wrapper/include/ores.compute.wrapper/filesystem/archiver.hpp
+++ b/projects/ores.compute.wrapper/include/ores.compute.wrapper/filesystem/archiver.hpp
@@ -21,6 +21,7 @@
 #define ORES_COMPUTE_WRAPPER_FILESYSTEM_ARCHIVER_HPP
 
 #include <filesystem>
+#include "ores.compute.wrapper/export.hpp"
 
 namespace ores::compute::wrapper::filesystem {
 
@@ -32,7 +33,7 @@ namespace ores::compute::wrapper::filesystem {
  * wchar_t*, so the wide-character libarchive variants must be used.
  * On POSIX, the standard char* variants are used.
  */
-class archiver final {
+class ORES_COMPUTE_WRAPPER_EXPORT archiver final {
 public:
     /**
      * @brief Pack a directory tree into a .tar.gz archive.

--- a/projects/ores.qt.api/include/ores.qt/ClientManager.hpp
+++ b/projects/ores.qt.api/include/ores.qt/ClientManager.hpp
@@ -33,7 +33,6 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/random_generator.hpp>
 #include <rfl/json.hpp>
-#include <rfl/AddTagsToVariants.hpp>
 #include <QObject>
 #include <QTimer>
 #include "ores.utility/rfl/reflectors.hpp"
@@ -353,7 +352,7 @@ public:
             const std::string_view data(
                 reinterpret_cast<const char*>(msg.data.data()),
                 msg.data.size());
-            auto result = rfl::json::read<ResponseType, rfl::AddTagsToVariants>(data);
+            auto result = rfl::json::read<ResponseType>(data);
             if (!result) {
                 return std::unexpected(
                     std::string("Failed to deserialize response: ") +
@@ -385,7 +384,7 @@ public:
         try {
             const auto raw = send_authenticated_request(
                 RequestType::nats_subject, rfl::json::write(request), timeout);
-            auto result = rfl::json::read<ResponseType, rfl::AddTagsToVariants>(raw);
+            auto result = rfl::json::read<ResponseType>(raw);
             if (!result) {
                 return std::unexpected(
                     std::string("Failed to deserialize response: ") +
@@ -515,7 +514,7 @@ public:
             const auto raw = send_authenticated_request_with_workspace(
                 RequestType::nats_subject, rfl::json::write(request),
                 workspace_id_override, timeout);
-            auto result = rfl::json::read<ResponseType, rfl::AddTagsToVariants>(raw);
+            auto result = rfl::json::read<ResponseType>(raw);
             if (!result) {
                 return std::unexpected(
                     std::string("Failed to deserialize response: ") +
@@ -554,7 +553,7 @@ public:
             const auto raw = send_authenticated_request_with_workspace_ctx(
                 RequestType::nats_subject, rfl::json::write(request),
                 workspace_ctx.id.toStdString(), std::move(chain), timeout);
-            auto result = rfl::json::read<ResponseType, rfl::AddTagsToVariants>(raw);
+            auto result = rfl::json::read<ResponseType>(raw);
             if (!result) {
                 return std::unexpected(
                     std::string("Failed to deserialize response: ") +


### PR DESCRIPTION
## Summary

- **macOS Clang + Windows MSVC**: `ClientManager.hpp` was passing `rfl::AddTagsToVariants` to all four `rfl::json::read` call sites. `export_portfolio_response` contains `with_legs<std::variant<fra_instrument,...>>` whose fully-qualified type name is 502 chars — exceeding Clang's fold-expression nesting limit of 256 and MSVC's equivalent in `no_duplicate_field_names.hpp`. The server already dropped `AddTagsToVariants` in commit `f6f767439`; the client reads now match.
- **Windows Clang (linker)**: `ores::compute::wrapper::filesystem::archiver` was missing `ORES_COMPUTE_WRAPPER_EXPORT`, so `pack` and `extract` static methods were not exported from the DLL — same pattern as task 6 (service parsers, PR #969) but in `ores.compute.wrapper`.

## Changes

| File | Change |
|------|--------|
| `projects/ores.qt.api/include/ores.qt/ClientManager.hpp` | Remove `#include <rfl/AddTagsToVariants.hpp>`; strip `rfl::AddTagsToVariants` from all 4 `json::read` call sites |
| `projects/ores.compute.wrapper/include/ores.compute.wrapper/filesystem/archiver.hpp` | Add `#include "ores.compute.wrapper/export.hpp"`; annotate class with `ORES_COMPUTE_WRAPPER_EXPORT` |

## Story / Task

- Story: [Fix rfl complexity failure (Windows + macOS CI)](../blob/main/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org) — `7763D0EE-A500-4497-9B2D-973C02ADC739`
- Task 7: [Fix ClientManager AddTagsToVariants and archiver DLL export](../blob/main/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_client_manager_add_tags_and_archiver_export.org) — `4BF920B2-CA2B-40EF-B463-DDC13D0C2516`

## Test plan

- [ ] macOS CI (debug + release): no fold-expression nesting limit error from `ClientManager.hpp` reads
- [ ] Windows MSVC CI (debug + release): no `C1202` recursive type error from `ClientManager.hpp` reads
- [ ] Windows Clang CI (debug + release): `archiver::pack` / `archiver::extract` link without undefined symbol errors
- [ ] Linux CI: unaffected (still green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)