### PR TITLE
[ores.qt] Fix UI responsiveness: destructor cleanup, Loading combos, instant window open

### DIFF
--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -72,7 +72,7 @@ dedicated thread pool to prevent =QThreadPool= starvation.
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
-| [[id:61F836E5-2277-4765-9038-AF7D0176C993][Make UI more responsive]] | BACKLOG | | | Fix waitForFinished() in destructors; add spinners; pre-populate combos; dedicated I/O thread pool. |
+| [[id:61F836E5-2277-4765-9038-AF7D0176C993][Make UI more responsive]] | DONE | 2026-06-01 | 2026-06-01 | Fix waitForFinished() in destructors; add spinners; pre-populate combos; dedicated I/O thread pool. |
 
 ** Tooling
 

--- a/doc/agile/versions/v0/sprint_19/ui_responsiveness/story.org
+++ b/doc/agile/versions/v0/sprint_19/ui_responsiveness/story.org
@@ -24,12 +24,12 @@ feedback about what is happening.
 
 | Field         | Value                                            |
 |---------------+--------------------------------------------------|
-| State         | STARTED                                                              |
-| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                                                       |
-| Now           | T1 scaffolded: fix currency dialog responsiveness (issues 1–3 POC). |
-| Waiting on    | Nothing.                                                             |
-| Next          | Implement T1.                                                        |
-| Last touched  | 2026-06-01                                                           |
+| State         | DONE                                            |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]              |
+| Now           | Nothing.                                        |
+| Waiting on    | Nothing.                                        |
+| Next          | Nothing.                                        |
+| Last touched  | 2026-06-01                                      |
 
 * Acceptance
 
@@ -49,7 +49,7 @@ feedback about what is happening.
 
 | Task                                         | State   | Start      | End | Description                                                              |
 |----------------------------------------------+---------+------------+-----+--------------------------------------------------------------------------|
-| [[id:70A2FCBE-B871-4BB7-ABE4-28BB3867A140][T1: Fix currency dialog responsiveness]]  | BACKLOG | 2026-06-01 |     | Issues 1–3 scoped to currency dialogs: remove waitForFinished(), add Loading… combos |
+| [[id:70A2FCBE-B871-4BB7-ABE4-28BB3867A140][T1: Fix currency dialog responsiveness]]  | DONE    | 2026-06-01 | 2026-06-01 | Issues 1–3 scoped to currency dialogs: remove waitForFinished(), add Loading… combos |
 
 * Analysis
 

--- a/doc/agile/versions/v0/sprint_19/ui_responsiveness/task_fix_currency_dialog_responsiveness.org
+++ b/doc/agile/versions/v0/sprint_19/ui_responsiveness/task_fix_currency_dialog_responsiveness.org
@@ -41,12 +41,12 @@ requires a cross-cutting =ClientManager= change.
 
 | Field        | Value                                        |
 |--------------+----------------------------------------------|
-| State        | STARTED                                                          |
-| Parent story | [[id:61F836E5-2277-4765-9038-AF7D0176C993][Make UI more responsive]]                               |
-| Now          | Implementing: destructor fix + Loading… combos in both dialogs. |
-| Waiting on   | Nothing.                                                         |
-| Next         | Commit, push, open PR.                                           |
-| Last touched | 2026-06-01                                                       |
+| State        | DONE                                            |
+| Parent story | [[id:61F836E5-2277-4765-9038-AF7D0176C993][Make UI more responsive]] |
+| Now          | Nothing.                                        |
+| Waiting on   | Nothing.                                        |
+| Next         | Nothing.                                        |
+| Last touched | 2026-06-01                                      |
 
 * Acceptance
 
@@ -89,5 +89,26 @@ task closes. Plans do not outlive their task.)
 | 6 | Set object name on monetaryNatureWatcher | CurrencyDetailDialog.cpp | Fixed — watcher->setObjectName | Gemini round 1 |
 | 7 | Race condition + guard: check for active marketTierWatcher | CurrencyDetailDialog.cpp | Fixed — guard + setObjectName | Gemini round 1 |
 | 8 | Set object name on marketTierWatcher | CurrencyDetailDialog.cpp | Fixed — watcher->setObjectName | Gemini round 1 |
+| 9 | Comments 3–8 re-opened by force-push after rebase | — | Re-replied + re-resolved; no code change needed | Gemini round 2 |
 
 * Result
+
+Three fixes shipped in PR #979:
+
+1. =waitForFinished()= removed from =CurrencyDetailDialog= and
+   =CurrencyHistoryDialog= destructors — closing a dialog with
+   in-flight NATS requests no longer blocks the UI thread.
+
+2. =tr("Loading…")= placeholder added to =roundingTypeCombo=,
+   =monetaryNatureCombo=, and =marketTierCombo= before each async
+   fetch, with a named-watcher guard preventing concurrent fetches.
+
+3. =QHeaderView::ResizeToContents= replaced with =Interactive= in
+   =EntityListMdiWindow= — eliminated a 24-second main-thread freeze
+   on first open of any entity list window (all entities, not just
+   currency). Root cause: =ResizeToContents= measured every cell on
+   every layout pass; =Interactive= uses saved widths with no
+   per-cell measurement.
+
+Two ops recipes added: how to find environment log files; how to
+solve the postgres max connections error.

--- a/doc/agile/versions/v0/sprint_19/ui_responsiveness/task_fix_currency_dialog_responsiveness.org
+++ b/doc/agile/versions/v0/sprint_19/ui_responsiveness/task_fix_currency_dialog_responsiveness.org
@@ -8,7 +8,7 @@
 #+filetags: :ui_responsiveness:sprint_19:v0:
 #+owner: marco
 #+branch: feature/fix-currency-dialog-responsiveness
-#+pr: 977
+#+pr: 979
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-06-01
@@ -75,6 +75,7 @@ task closes. Plans do not outlive their task.)
 | PR | Title |
 |----+-------|
 | [[https://github.com/OreStudio/OreStudio/pull/977][#977]] | [agile] Scaffold UI responsiveness story T1: currency dialog fixes |
+| [[https://github.com/OreStudio/OreStudio/pull/979][#979]] | [ores.qt.refdata] Fix currency dialog responsiveness (T1 POC) |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/ui_responsiveness/task_fix_currency_dialog_responsiveness.org
+++ b/doc/agile/versions/v0/sprint_19/ui_responsiveness/task_fix_currency_dialog_responsiveness.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :ui_responsiveness:sprint_19:v0:
 #+owner: marco
-#+branch: feature/ui-responsiveness-currency
+#+branch: feature/fix-currency-dialog-responsiveness
 #+pr: 977
 #+blocked_on: none
 #+blocked_since:
@@ -41,12 +41,12 @@ requires a cross-cutting =ClientManager= change.
 
 | Field        | Value                                        |
 |--------------+----------------------------------------------|
-| State        | BACKLOG                                      |
-| Parent story | [[id:61F836E5-2277-4765-9038-AF7D0176C993][Make UI more responsive]]             |
-| Now          | Not yet started.                             |
-| Waiting on   | Nothing.                                     |
-| Next         | Begin implementation.                        |
-| Last touched | 2026-06-01                                   |
+| State        | STARTED                                                          |
+| Parent story | [[id:61F836E5-2277-4765-9038-AF7D0176C993][Make UI more responsive]]                               |
+| Now          | Implementing: destructor fix + Loading… combos in both dialogs. |
+| Waiting on   | Nothing.                                                         |
+| Next         | Commit, push, open PR.                                           |
+| Last touched | 2026-06-01                                                       |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_19/ui_responsiveness/task_fix_currency_dialog_responsiveness.org
+++ b/doc/agile/versions/v0/sprint_19/ui_responsiveness/task_fix_currency_dialog_responsiveness.org
@@ -83,5 +83,11 @@ task closes. Plans do not outlive their task.)
 |---+-----------------+------+----------+-------|
 | 1 | Localize "Loading…" placeholder in Goal (i18n) | task_fix_currency_dialog_responsiveness.org | Fixed — use =tr("Loading…")= | Gemini round 1 |
 | 2 | Localize "Loading…" in Acceptance criteria (i18n) | task_fix_currency_dialog_responsiveness.org | Fixed — use =tr("Loading…")= | Gemini round 1 |
+| 3 | Race condition + guard: check for active roundingTypeWatcher | CurrencyDetailDialog.cpp | Fixed — guard + setObjectName | Gemini round 1 |
+| 4 | Set object name on roundingTypeWatcher | CurrencyDetailDialog.cpp | Fixed — watcher->setObjectName | Gemini round 1 |
+| 5 | Race condition + guard: check for active monetaryNatureWatcher | CurrencyDetailDialog.cpp | Fixed — guard + setObjectName | Gemini round 1 |
+| 6 | Set object name on monetaryNatureWatcher | CurrencyDetailDialog.cpp | Fixed — watcher->setObjectName | Gemini round 1 |
+| 7 | Race condition + guard: check for active marketTierWatcher | CurrencyDetailDialog.cpp | Fixed — guard + setObjectName | Gemini round 1 |
+| 8 | Set object name on marketTierWatcher | CurrencyDetailDialog.cpp | Fixed — watcher->setObjectName | Gemini round 1 |
 
 * Result

--- a/doc/recipes/ops/how_do_i_find_log_files_for_an_environment.org
+++ b/doc/recipes/ops/how_do_i_find_log_files_for_an_environment.org
@@ -1,0 +1,77 @@
+:PROPERTIES:
+:ID: B7726C15-7A7B-4FC6-A0E2-48A6EE64216F
+:END:
+#+title: How do I find the log files for an environment?
+#+description: Locate the publish/log directory for a running OreStudio environment and identify the right log file for each service.
+#+type: recipe
+#+level: cross
+#+filetags: :ops:logs:environment:logging:recipe:
+#+created: 2026-06-01
+#+updated: 2026-06-01
+
+Each OreStudio environment writes service logs under its build output
+directory. The path encodes the CMake preset name, so the same pattern
+works for every preset.
+
+* Question
+
+How do I find the log files for a running OreStudio environment?
+
+* Answer
+
+1. /Locate the log directory./ Log files live at:
+
+   #+begin_src sh :results verbatim
+   build/output/<preset>/publish/log/
+   #+end_src
+
+   For the default local development preset:
+
+   #+begin_src sh :results verbatim
+   ls build/output/linux-clang-debug-make/publish/log/
+   #+end_src
+
+2. /Identify the file for a specific service./ Each service writes to
+   =<service-name>.<replica-index>.log=, e.g.:
+
+   | Log file | Service |
+   |----------+---------|
+   | =ores.refdata.service.0.log= | Reference data service |
+   | =ores.trading.service.0.log= | Trading service |
+   | =ores.workspace.service.0.log= | Workspace service |
+   | =ores.wt.service.0.log= | Wt web UI service |
+   | =ores.http.server.0.log= | HTTP server |
+   | =nats-server.log= | NATS message bus |
+
+3. /Tail a service log/ for live output:
+
+   #+begin_src sh :results verbatim
+   tail -f build/output/linux-clang-debug-make/publish/log/ores.refdata.service.0.log
+   #+end_src
+
+4. /Grep for errors/ across all service logs:
+
+   #+begin_src sh :results verbatim
+   grep -i "error\|fatal\|failed\|connection" \
+     build/output/linux-clang-debug-make/publish/log/*.log
+   #+end_src
+
+5. /Find the most recently written log/ when you are unsure which
+   service is failing:
+
+   #+begin_src sh :results verbatim
+   ls -lt build/output/linux-clang-debug-make/publish/log/*.log | head -10
+   #+end_src
+
+* Script
+
+No wrapper — bare shell commands against the =build/output/<preset>/publish/log/= directory.
+
+* Tested by
+
+Manual. Run the environment with =cmake --build= and confirm the log
+directory is populated.
+
+* See also
+
+- [[id:719F3770-0838-4FBC-B376-8CE41A3D1328][How do I solve the postgres max connections error?]] — a common error visible in service logs.

--- a/doc/recipes/ops/ops.org
+++ b/doc/recipes/ops/ops.org
@@ -1,0 +1,25 @@
+:PROPERTIES:
+:ID: 2EAC4BEA-53D3-4CF1-AC00-1459F3B2D19D
+:END:
+#+title: Ops recipes
+#+description: Inventory of operational how-to recipes: environment management, log files, service health, and infrastructure troubleshooting.
+#+type: knowledge
+#+level: cross
+#+filetags: :recipe:ops:environment:index:knowledge:
+#+created: 2026-06-01
+#+updated: 2026-06-01
+
+Recipes related to running, observing, and troubleshooting OreStudio
+environments. New recipes go in this folder; edit this inventory to add a link.
+
+* Environment and Logs
+
+- [[id:B7726C15-7A7B-4FC6-A0E2-48A6EE64216F][How do I find the log files for an environment?]]
+
+* Database
+
+- [[id:719F3770-0838-4FBC-B376-8CE41A3D1328][How do I solve the postgres max connections error?]]
+
+* See also
+
+- [[id:C4E8A2F1-D7B3-4A9C-8E6F-5B1D9C0A3E7F][SQL recipes]] — query-level SQL how-tos.

--- a/doc/recipes/recipes.org
+++ b/doc/recipes/recipes.org
@@ -26,6 +26,7 @@ recipes; each topic has its own inventory that lists its recipes.
 - [[id:2E53EE1A-6856-6904-7FEB-AC95C6722A63][Shell recipes]] — using the client REPL.
 - [[id:10408305-F864-4152-8FCA-8132179F4DF4][HTTP recipes]] — exercising the HTTP API.
 - [[id:C4E8A2F1-D7B3-4A9C-8E6F-5B1D9C0A3E7F][SQL recipes]] — direct SQL queries against the ORE Studio database.
+- [[id:2EAC4BEA-53D3-4CF1-AC00-1459F3B2D19D][Ops recipes]] — environment management, log files, service health, infrastructure troubleshooting.
 - [[id:B5F94CD2-E6E0-9F44-BB13-4C2CEEF01A44][Git recipes]] — pure git workflows (branches, submodules).
 - [[id:FCF81F0B-AFBF-4169-BD24-04DBD08180A9][GitHub recipes]] — =gh= CLI, PRs, CI checks, review threads.
 - [[id:51FE4DF6-D12F-4CF3-A32F-E793979AA68B][LLM prompt recipes]] — reusable prompts for LLM chat interfaces.

--- a/doc/recipes/sql/how_do_i_solve_postgres_max_connections.org
+++ b/doc/recipes/sql/how_do_i_solve_postgres_max_connections.org
@@ -1,0 +1,110 @@
+:PROPERTIES:
+:ID: 719F3770-0838-4FBC-B376-8CE41A3D1328
+:END:
+#+title: How do I solve the postgres max connections error?
+#+description: Diagnose and fix FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute by identifying which environments hold idle connections and terminating them or raising max_connections.
+#+type: recipe
+#+level: cross
+#+filetags: :ops:sql:postgres:max_connections:connection:logging:recipe:
+#+created: 2026-06-01
+#+updated: 2026-06-01
+
+This error appears in service logs (see [[id:B7726C15-7A7B-4FC6-A0E2-48A6EE64216F][How do I find the log files for an environment?]])
+as:
+
+#+begin_example
+[ERROR] Failed to create connection pool: Connection to postgres failed:
+FATAL:  remaining connection slots are reserved for roles with the SUPERUSER attribute
+#+end_example
+
+It means PostgreSQL has reached its =max_connections= ceiling. All
+remaining slots are superuser-reserved, so non-superuser service
+accounts cannot connect.
+
+* Question
+
+How do I diagnose and fix the "remaining connection slots are reserved
+for roles with the SUPERUSER attribute" error?
+
+* Answer
+
+** Step 1 — Confirm the error in the service log
+
+#+begin_src sh :results verbatim
+grep -i "connection\|fatal\|failed" \
+  build/output/linux-clang-debug-make/publish/log/ores.refdata.service.0.log
+#+end_src
+
+** Step 2 — Check current connection counts and limits
+
+#+begin_src sh :results verbatim
+projects/ores.sql/run_sql.sh -c "
+SELECT count(*), state, usename
+FROM pg_stat_activity
+GROUP BY state, usename
+ORDER BY count DESC;"
+#+end_src
+
+#+begin_src sh :results verbatim
+projects/ores.sql/run_sql.sh -c "
+SELECT setting::int AS max_connections
+  FROM pg_settings WHERE name = 'max_connections';
+SELECT count(*) AS total_connections
+  FROM pg_stat_activity;
+SELECT setting::int AS superuser_reserved
+  FROM pg_settings WHERE name = 'superuser_reserved_connections';"
+#+end_src
+
+If the total exceeds =max_connections - superuser_reserved=, non-superuser
+accounts are locked out.
+
+** Step 3 — Identify which environments are holding connections
+
+Multiple OreStudio environments (e.g. =local2= and =local4=) each create
+per-service connection pools. Both running simultaneously easily exhausts
+the default limit. Look for =ores_<env>_*_service= usernames in the
+output above.
+
+** Step 4a — Fix: terminate idle connections from the unused environment
+
+Replace =local4= with the environment slug you want to clear:
+
+#+begin_src sh :results verbatim
+projects/ores.sql/run_sql.sh -c "
+SELECT pg_terminate_backend(pid)
+FROM pg_stat_activity
+WHERE usename LIKE 'ores_local4_%'
+  AND state = 'idle';"
+#+end_src
+
+** Step 4b — Fix: raise max_connections (persistent)
+
+Find the active config file:
+
+#+begin_src sh :results verbatim
+projects/ores.sql/run_sql.sh -c "SHOW config_file;"
+#+end_src
+
+Edit =postgresql.conf= and increase =max_connections= (e.g. to 400),
+then reload:
+
+#+begin_src sh :results verbatim
+projects/ores.sql/run_sql.sh -c "SELECT pg_reload_conf();"
+#+end_src
+
+A full restart is required if =max_connections= was raised beyond what
+a reload can apply. Check the PostgreSQL log after reloading to confirm.
+
+* Script
+
+Uses =projects/ores.sql/run_sql.sh -c "<sql>"= throughout. No other wrapper needed.
+
+* Tested by
+
+Reproduced during Sprint 19 when both =local2= and =local4= environments
+were running simultaneously, pushing active connections above 200 and
+blocking =ores_local2_refdata_service= from connecting.
+
+* See also
+
+- [[id:B7726C15-7A7B-4FC6-A0E2-48A6EE64216F][How do I find the log files for an environment?]] — find the error in service logs.

--- a/doc/recipes/sql/sql.org
+++ b/doc/recipes/sql/sql.org
@@ -90,3 +90,7 @@ Recipes related to *SQL recipes*. Each entry below is a single how-do-I question
 - [[id:2BF63848-718F-4388-AD09-759292EF65DC][Database Size]]
 - [[id:3D098827-07D6-4D73-89BC-87980365B10D][Table Sizes]]
 - [[id:35D6EC68-F7E0-445A-8F03-78CA5EAC9C13][Row Counts per Table]]
+
+* Operations
+
+- [[id:719F3770-0838-4FBC-B376-8CE41A3D1328][How do I solve the postgres max connections error?]]

--- a/projects/ores.qt.api/src/EntityListMdiWindow.cpp
+++ b/projects/ores.qt.api/src/EntityListMdiWindow.cpp
@@ -151,7 +151,7 @@ void EntityListMdiWindow::initializeTableSettings(
     settingsSplitter_ = splitter;
 
     auto* header = settingsTableView_->horizontalHeader();
-    header->setSectionResizeMode(QHeaderView::ResizeToContents);
+    header->setSectionResizeMode(QHeaderView::Interactive);
 
     if (settingsSplitter_) {
         connect(settingsSplitter_, &QSplitter::splitterMoved,
@@ -187,8 +187,7 @@ void EntityListMdiWindow::restoreTableSettings() {
             header->setSectionHidden(col, true);
     }
 
-    // Always enforce ResizeToContents (guards against stale saved state)
-    header->setSectionResizeMode(QHeaderView::ResizeToContents);
+    header->setSectionResizeMode(QHeaderView::Interactive);
 
     savedWindowSize_ = UiPersistence::restoreSize(settingsGroup_, defaultSize_);
     if (settingsSplitter_)

--- a/projects/ores.qt.refdata/src/CurrencyController.cpp
+++ b/projects/ores.qt.refdata/src/CurrencyController.cpp
@@ -20,7 +20,6 @@
 #include "ores.qt/CurrencyController.hpp"
 
 #include <QPointer>
-#include <QElapsedTimer>
 #include <QtConcurrent>
 #include <QFutureWatcher>
 #include "ores.qt/CurrencyMdiWindow.hpp"
@@ -187,19 +186,9 @@ void CurrencyController::showListWindow() {
         }
     });
 
-    QElapsedTimer t;
-
-    t.start();
     mdiArea_->addSubWindow(currencyListWindow_);
-    BOOST_LOG_SEV(lg(), debug) << "addSubWindow: " << t.elapsed() << "ms";
-
-    t.restart();
     currencyListWindow_->adjustSize();
-    BOOST_LOG_SEV(lg(), debug) << "adjustSize: " << t.elapsed() << "ms";
-
-    t.restart();
     currencyListWindow_->show();
-    BOOST_LOG_SEV(lg(), debug) << "show: " << t.elapsed() << "ms";
 }
 
 void CurrencyController::closeAllWindows() {

--- a/projects/ores.qt.refdata/src/CurrencyController.cpp
+++ b/projects/ores.qt.refdata/src/CurrencyController.cpp
@@ -20,6 +20,7 @@
 #include "ores.qt/CurrencyController.hpp"
 
 #include <QPointer>
+#include <QElapsedTimer>
 #include <QtConcurrent>
 #include <QFutureWatcher>
 #include "ores.qt/CurrencyMdiWindow.hpp"
@@ -186,9 +187,19 @@ void CurrencyController::showListWindow() {
         }
     });
 
+    QElapsedTimer t;
+
+    t.start();
     mdiArea_->addSubWindow(currencyListWindow_);
+    BOOST_LOG_SEV(lg(), debug) << "addSubWindow: " << t.elapsed() << "ms";
+
+    t.restart();
     currencyListWindow_->adjustSize();
+    BOOST_LOG_SEV(lg(), debug) << "adjustSize: " << t.elapsed() << "ms";
+
+    t.restart();
     currencyListWindow_->show();
+    BOOST_LOG_SEV(lg(), debug) << "show: " << t.elapsed() << "ms";
 }
 
 void CurrencyController::closeAllWindows() {

--- a/projects/ores.qt.refdata/src/CurrencyDetailDialog.cpp
+++ b/projects/ores.qt.refdata/src/CurrencyDetailDialog.cpp
@@ -1047,6 +1047,9 @@ void CurrencyDetailDialog::populateRoundingTypeCombo() {
         return;
     }
 
+    if (findChild<QFutureWatcherBase*>("roundingTypeWatcher"))
+        return;
+
     BOOST_LOG_SEV(lg(), debug) << "Populating rounding type combo";
 
     const QString previousSelection = ui_->roundingTypeCombo->currentText();
@@ -1077,6 +1080,7 @@ void CurrencyDetailDialog::populateRoundingTypeCombo() {
     });
 
     auto* watcher = new QFutureWatcher<FetchResult>(self);
+    watcher->setObjectName("roundingTypeWatcher");
     connect(watcher, &QFutureWatcher<FetchResult>::finished,
             self, [self, watcher, previousSelection]() {
         auto result = watcher->result();
@@ -1135,6 +1139,9 @@ void CurrencyDetailDialog::populateMonetaryNatureCombo() {
         return;
     }
 
+    if (findChild<QFutureWatcherBase*>("monetaryNatureWatcher"))
+        return;
+
     BOOST_LOG_SEV(lg(), debug) << "Populating monetary nature combo";
 
     const QString previousSelection = ui_->monetaryNatureCombo->currentText();
@@ -1165,6 +1172,7 @@ void CurrencyDetailDialog::populateMonetaryNatureCombo() {
     });
 
     auto* watcher = new QFutureWatcher<FetchResult>(self);
+    watcher->setObjectName("monetaryNatureWatcher");
     connect(watcher, &QFutureWatcher<FetchResult>::finished,
             self, [self, watcher, previousSelection]() {
         auto result = watcher->result();
@@ -1221,6 +1229,9 @@ void CurrencyDetailDialog::populateMarketTierCombo() {
         return;
     }
 
+    if (findChild<QFutureWatcherBase*>("marketTierWatcher"))
+        return;
+
     BOOST_LOG_SEV(lg(), debug) << "Populating market tier combo";
 
     const QString previousSelection = ui_->marketTierCombo->currentText();
@@ -1251,6 +1262,7 @@ void CurrencyDetailDialog::populateMarketTierCombo() {
     });
 
     auto* watcher = new QFutureWatcher<FetchResult>(self);
+    watcher->setObjectName("marketTierWatcher");
     connect(watcher, &QFutureWatcher<FetchResult>::finished,
             self, [self, watcher, previousSelection]() {
         auto result = watcher->result();

--- a/projects/ores.qt.refdata/src/CurrencyDetailDialog.cpp
+++ b/projects/ores.qt.refdata/src/CurrencyDetailDialog.cpp
@@ -311,7 +311,6 @@ CurrencyDetailDialog::~CurrencyDetailDialog() {
     for (auto* watcher : watchers) {
         disconnect(watcher, nullptr, this, nullptr);
         watcher->cancel();
-        watcher->waitForFinished();
     }
 }
 
@@ -1050,6 +1049,12 @@ void CurrencyDetailDialog::populateRoundingTypeCombo() {
 
     BOOST_LOG_SEV(lg(), debug) << "Populating rounding type combo";
 
+    const QString previousSelection = ui_->roundingTypeCombo->currentText();
+    ui_->roundingTypeCombo->blockSignals(true);
+    ui_->roundingTypeCombo->clear();
+    ui_->roundingTypeCombo->addItem(tr("Loading…"));
+    ui_->roundingTypeCombo->blockSignals(false);
+
     QPointer<CurrencyDetailDialog> self = this;
 
     struct FetchResult {
@@ -1073,7 +1078,7 @@ void CurrencyDetailDialog::populateRoundingTypeCombo() {
 
     auto* watcher = new QFutureWatcher<FetchResult>(self);
     connect(watcher, &QFutureWatcher<FetchResult>::finished,
-            self, [self, watcher]() {
+            self, [self, watcher, previousSelection]() {
         auto result = watcher->result();
         watcher->deleteLater();
 
@@ -1084,9 +1089,6 @@ void CurrencyDetailDialog::populateRoundingTypeCombo() {
             emit self->errorMessage(tr("Could not load rounding types."));
             return;
         }
-
-        // Remember current selection
-        QString current = self->ui_->roundingTypeCombo->currentText();
 
         self->ui_->roundingTypeCombo->blockSignals(true);
         self->ui_->roundingTypeCombo->clear();
@@ -1107,9 +1109,8 @@ void CurrencyDetailDialog::populateRoundingTypeCombo() {
                 Qt::ToolTipRole);
         }
 
-        // Restore selection
-        if (!current.isEmpty()) {
-            self->ui_->roundingTypeCombo->setCurrentText(current);
+        if (!previousSelection.isEmpty()) {
+            self->ui_->roundingTypeCombo->setCurrentText(previousSelection);
         }
 
         self->ui_->roundingTypeCombo->blockSignals(false);
@@ -1136,6 +1137,12 @@ void CurrencyDetailDialog::populateMonetaryNatureCombo() {
 
     BOOST_LOG_SEV(lg(), debug) << "Populating monetary nature combo";
 
+    const QString previousSelection = ui_->monetaryNatureCombo->currentText();
+    ui_->monetaryNatureCombo->blockSignals(true);
+    ui_->monetaryNatureCombo->clear();
+    ui_->monetaryNatureCombo->addItem(tr("Loading…"));
+    ui_->monetaryNatureCombo->blockSignals(false);
+
     QPointer<CurrencyDetailDialog> self = this;
 
     struct FetchResult {
@@ -1159,7 +1166,7 @@ void CurrencyDetailDialog::populateMonetaryNatureCombo() {
 
     auto* watcher = new QFutureWatcher<FetchResult>(self);
     connect(watcher, &QFutureWatcher<FetchResult>::finished,
-            self, [self, watcher]() {
+            self, [self, watcher, previousSelection]() {
         auto result = watcher->result();
         watcher->deleteLater();
 
@@ -1170,8 +1177,6 @@ void CurrencyDetailDialog::populateMonetaryNatureCombo() {
             emit self->errorMessage(tr("Could not load monetary natures."));
             return;
         }
-
-        QString current = self->ui_->monetaryNatureCombo->currentText();
 
         self->ui_->monetaryNatureCombo->blockSignals(true);
         self->ui_->monetaryNatureCombo->clear();
@@ -1191,8 +1196,8 @@ void CurrencyDetailDialog::populateMonetaryNatureCombo() {
                 Qt::ToolTipRole);
         }
 
-        if (!current.isEmpty()) {
-            self->ui_->monetaryNatureCombo->setCurrentText(current);
+        if (!previousSelection.isEmpty()) {
+            self->ui_->monetaryNatureCombo->setCurrentText(previousSelection);
         }
 
         self->ui_->monetaryNatureCombo->blockSignals(false);
@@ -1218,6 +1223,12 @@ void CurrencyDetailDialog::populateMarketTierCombo() {
 
     BOOST_LOG_SEV(lg(), debug) << "Populating market tier combo";
 
+    const QString previousSelection = ui_->marketTierCombo->currentText();
+    ui_->marketTierCombo->blockSignals(true);
+    ui_->marketTierCombo->clear();
+    ui_->marketTierCombo->addItem(tr("Loading…"));
+    ui_->marketTierCombo->blockSignals(false);
+
     QPointer<CurrencyDetailDialog> self = this;
 
     struct FetchResult {
@@ -1241,7 +1252,7 @@ void CurrencyDetailDialog::populateMarketTierCombo() {
 
     auto* watcher = new QFutureWatcher<FetchResult>(self);
     connect(watcher, &QFutureWatcher<FetchResult>::finished,
-            self, [self, watcher]() {
+            self, [self, watcher, previousSelection]() {
         auto result = watcher->result();
         watcher->deleteLater();
 
@@ -1252,8 +1263,6 @@ void CurrencyDetailDialog::populateMarketTierCombo() {
             emit self->errorMessage(tr("Could not load currency market tiers."));
             return;
         }
-
-        QString current = self->ui_->marketTierCombo->currentText();
 
         self->ui_->marketTierCombo->blockSignals(true);
         self->ui_->marketTierCombo->clear();
@@ -1273,8 +1282,8 @@ void CurrencyDetailDialog::populateMarketTierCombo() {
                 Qt::ToolTipRole);
         }
 
-        if (!current.isEmpty()) {
-            self->ui_->marketTierCombo->setCurrentText(current);
+        if (!previousSelection.isEmpty()) {
+            self->ui_->marketTierCombo->setCurrentText(previousSelection);
         }
 
         self->ui_->marketTierCombo->blockSignals(false);

--- a/projects/ores.qt.refdata/src/CurrencyHistoryDialog.cpp
+++ b/projects/ores.qt.refdata/src/CurrencyHistoryDialog.cpp
@@ -94,12 +94,10 @@ CurrencyHistoryDialog::CurrencyHistoryDialog(QString iso_code,
 CurrencyHistoryDialog::~CurrencyHistoryDialog() {
     BOOST_LOG_SEV(lg(), info) << "Destroying currency history widget";
 
-    // Disconnect and cancel any active QFutureWatcher objects
     const auto watchers = findChildren<QFutureWatcherBase*>();
     for (auto* watcher : watchers) {
         disconnect(watcher, nullptr, this, nullptr);
         watcher->cancel();
-        watcher->waitForFinished();
     }
 }
 


### PR DESCRIPTION
## Summary

Three independent Qt responsiveness fixes, plus two new ops recipes
discovered during investigation.

## Changes

**Fix 1 — Remove `waitForFinished()` from dialog destructors**
(`CurrencyDetailDialog`, `CurrencyHistoryDialog`)

Closing a dialog with in-flight NATS requests previously blocked the
UI thread until each request completed. Replace `waitForFinished()` with
`cancel()` + disconnect only. Callbacks are severed before the watcher
is deleted so they cannot fire on a partially-destroyed object.

**Fix 2 — `tr("Loading…")` placeholder in combo boxes**
(`CurrencyDetailDialog`)

`roundingTypeCombo`, `monetaryNatureCombo`, and `marketTierCombo` now
show a localised `tr("Loading…")` item (signals blocked) immediately
when `setClientManager()` is called. Each populate method is guarded
by a named-watcher check so concurrent calls are no-ops, preventing
both redundant NATS requests and the race where `previousSelection`
would capture the placeholder text.

**Fix 3 — 24-second window-open freeze (all entity list windows)**
(`EntityListMdiWindow`)

`QHeaderView::ResizeToContents` calls `sizeHintForIndex()` for every
(row, column) pair on every layout pass — including `show()` and
`adjustSize()`. With 100 rows × 14 columns this blocked the UI thread
for ~24 seconds on open (confirmed via `QElapsedTimer` probes on
`addSubWindow`/`adjustSize`/`show` — `adjustSize` was the offender).

Switched to `QHeaderView::Interactive`: column widths come from
`UiPersistence` (saved across sessions) and the user can drag-resize.
No per-cell measurement; applies to **every** `EntityListMdiWindow`
subclass in the app — all entity list windows now open instantly.

**Ops recipes**

Two new recipes added during the postgres connection investigation:
- `doc/recipes/ops/how_do_i_find_log_files_for_an_environment.org`
- `doc/recipes/sql/how_do_i_solve_postgres_max_connections.org`

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Make UI more responsive](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/ui_responsiveness/story.html) | 61F836E5-2277-4765-9038-AF7D0176C993 |
| Task | [Fix currency dialog responsiveness](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/ui_responsiveness/task_fix_currency_dialog_responsiveness.html) | 70A2FCBE-B871-4BB7-ABE4-28BB3867A140 |