### PR TITLE
[ores.qt.api] Fix MSVC C1202 in parse_trade_instrument.cpp

### DIFF
--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_client_manager_add_tags_and_archiver_export.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_client_manager_add_tags_and_archiver_export.org
@@ -75,8 +75,9 @@ Three Windows/macOS CI failures after PR #969 (service parser exports):
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                                              | File                          | Decision | Notes                              |
+|---+------------------------------------------------------------------------------+-------------------------------+----------+------------------------------------|
+| 1 | Introduce try_parse_and_populate template to remove duplication (line 134)  | parse_trade_instrument.cpp    | Accept   | Fixed 0b0c8551f + 0b990a8d5        |
+| 2 | Use helper across all 10 leg-based cases (line 272)                          | parse_trade_instrument.cpp    | Accept   | Fixed 0b0c8551f                    |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_client_manager_add_tags_and_archiver_export.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_client_manager_add_tags_and_archiver_export.org
@@ -8,7 +8,7 @@
 #+filetags: :fix_rfl_complexity:sprint_19:v0:
 #+owner: marco
 #+branch: feature/fix-windows-macos-ci
-#+pr: 978
+#+pr: 978 982
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-06-01
@@ -46,9 +46,9 @@ Three Windows/macOS CI failures after PR #969 (service parser exports):
 |--------------+------------------------------------------------------------------|
 | State        | STARTED                                                          |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]]  |
-| Now          | Committed; PR open; awaiting CI.                                 |
-| Waiting on   | CI green + review.                                               |
-| Next         | Merge PR; mark DONE.                                             |
+| Now          | PR #982 open for parse_trade_instrument C1202 fix; awaiting CI.  |
+| Waiting on   | CI green + review on PR #982.                                     |
+| Next         | Merge PR #982; mark DONE.                                         |
 | Last touched | 2026-06-01                                                       |
 
 * Acceptance
@@ -71,6 +71,7 @@ Three Windows/macOS CI failures after PR #969 (service parser exports):
 | PR | Title |
 |----+-------|
 | [[https://github.com/OreStudio/OreStudio/pull/978][#978]] | [ores.compute.wrapper,ores.qt.api] Fix remaining Windows/macOS CI failures |
+| [[https://github.com/OreStudio/OreStudio/pull/982][#982]] | [ores.qt.api] Fix MSVC C1202 in parse_trade_instrument.cpp |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_client_manager_add_tags_and_archiver_export.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_client_manager_add_tags_and_archiver_export.org
@@ -19,7 +19,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-Two remaining Windows/macOS CI failures after PR #969 (service parser exports):
+Three Windows/macOS CI failures after PR #969 (service parser exports):
 
 1. *macOS Clang + Windows MSVC*: =ClientManager.hpp= applied =rfl::AddTagsToVariants= to all
    four =rfl::json::read= call sites. =export_portfolio_response= contains
@@ -31,6 +31,14 @@ Two remaining Windows/macOS CI failures after PR #969 (service parser exports):
 2. *Windows Clang (linker)*: =ores::compute::wrapper::filesystem::archiver= was missing
    =ORES_COMPUTE_WRAPPER_EXPORT=, so =pack= and =extract= static methods were not exported
    from the DLL.
+
+3. *Windows MSVC C1202 in parse_trade_instrument.cpp*: reflecting a combined
+   ={concrete_instrument; vector<swap_leg>}= struct in a single =rfl::json::read= call creates
+   a Literal over the union of all unique field names from both types (~29 for
+   =swaption_instrument= + =swap_leg=). MSVC's =no_duplicate_field_names= recursive template
+   check triggers C1202. Fix: split every leg-based type read into two separate
+   =rfl::json::read= calls — one for the instrument sub-object, one for the legs. Applied
+   uniformly to all 9 swap types and composite.
 
 * Status
 
@@ -46,7 +54,7 @@ Two remaining Windows/macOS CI failures after PR #969 (service parser exports):
 * Acceptance
 
 - macOS CI: no fold-expression nesting limit error from =ClientManager.hpp= reads.
-- Windows MSVC CI: no =C1202= recursive type error from =ClientManager.hpp= reads.
+- Windows MSVC CI: no =C1202= in =ClientManager.hpp= or =parse_trade_instrument.cpp=.
 - Windows Clang CI: =archiver::pack= and =archiver::extract= link without undefined symbol errors.
 - No regression on Linux CI.
 

--- a/projects/ores.qt.api/src/parse_trade_instrument.cpp
+++ b/projects/ores.qt.api/src/parse_trade_instrument.cpp
@@ -139,6 +139,21 @@ struct eq_digital_wrapper   { td::equity_digital_option_instrument  instrument; 
 struct eq_accum_wrapper     { td::equity_accumulator_instrument     instrument; };
 struct eq_position_wrapper  { td::equity_position_instrument        instrument; };
 
+// Two-pass helper for leg-based types: parse instrument, short-circuit on failure,
+// then parse legs, then call the matching populate overload.
+template<typename InstrOuter, typename LegsOuter>
+static bool try_parse_and_populate(const std::string& raw,
+    IInstrumentFormPopulator& populator)
+{
+    auto r_instr = try_parse<InstrOuter>(raw);
+    if (!r_instr) return false;
+    auto r_legs = try_parse<LegsOuter>(raw);
+    if (!r_legs) return false;
+    populator.populate(r_instr->instrument.instrument,
+                       std::move(r_legs->instrument.legs));
+    return true;
+}
+
 } // namespace
 
 namespace ores::qt {
@@ -198,77 +213,47 @@ parse_trade_instrument(const std::string& raw, IInstrumentFormPopulator& populat
     }
     case product_type::composite: {
         BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading composite_instrument";
-        auto r_instr = try_parse<composite_instr_outer>(raw);
-        auto r_legs  = try_parse<composite_legs_outer>(raw);
-        if (!r_instr || !r_legs) return std::nullopt;
-        populator.populate(r_instr->instrument.instrument,
-                           std::move(r_legs->instrument.legs));
+        if (!try_parse_and_populate<composite_instr_outer, composite_legs_outer>(raw, populator))
+            return std::nullopt;
         break;
     }
     case product_type::swap: {
         if (ttc == "ForwardRateAgreement") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading fra_instrument";
-            auto r_instr = try_parse<fra_instr_outer>(raw);
-            auto r_legs  = try_parse<swap_legs_outer>(raw);
-            if (!r_instr || !r_legs) return std::nullopt;
-            populator.populate(r_instr->instrument.instrument,
-                               std::move(r_legs->instrument.legs));
+            if (!try_parse_and_populate<fra_instr_outer, swap_legs_outer>(raw, populator))
+                return std::nullopt;
         } else if (ttc == "Swap" || ttc == "CrossCurrencySwap" || ttc == "FlexiSwap") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading vanilla_swap_instrument";
-            auto r_instr = try_parse<vanilla_swap_instr_outer>(raw);
-            auto r_legs  = try_parse<swap_legs_outer>(raw);
-            if (!r_instr || !r_legs) return std::nullopt;
-            populator.populate(r_instr->instrument.instrument,
-                               std::move(r_legs->instrument.legs));
+            if (!try_parse_and_populate<vanilla_swap_instr_outer, swap_legs_outer>(raw, populator))
+                return std::nullopt;
         } else if (ttc == "CapFloor") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading cap_floor_instrument";
-            auto r_instr = try_parse<cap_floor_instr_outer>(raw);
-            auto r_legs  = try_parse<swap_legs_outer>(raw);
-            if (!r_instr || !r_legs) return std::nullopt;
-            populator.populate(r_instr->instrument.instrument,
-                               std::move(r_legs->instrument.legs));
+            if (!try_parse_and_populate<cap_floor_instr_outer, swap_legs_outer>(raw, populator))
+                return std::nullopt;
         } else if (ttc == "Swaption") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading swaption_instrument";
-            auto r_instr = try_parse<swaption_instr_outer>(raw);
-            auto r_legs  = try_parse<swap_legs_outer>(raw);
-            if (!r_instr || !r_legs) return std::nullopt;
-            populator.populate(r_instr->instrument.instrument,
-                               std::move(r_legs->instrument.legs));
+            if (!try_parse_and_populate<swaption_instr_outer, swap_legs_outer>(raw, populator))
+                return std::nullopt;
         } else if (ttc == "BalanceGuaranteedSwap") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading balance_guaranteed_swap_instrument";
-            auto r_instr = try_parse<bgs_instr_outer>(raw);
-            auto r_legs  = try_parse<swap_legs_outer>(raw);
-            if (!r_instr || !r_legs) return std::nullopt;
-            populator.populate(r_instr->instrument.instrument,
-                               std::move(r_legs->instrument.legs));
+            if (!try_parse_and_populate<bgs_instr_outer, swap_legs_outer>(raw, populator))
+                return std::nullopt;
         } else if (ttc == "CallableSwap") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading callable_swap_instrument";
-            auto r_instr = try_parse<callable_swap_instr_outer>(raw);
-            auto r_legs  = try_parse<swap_legs_outer>(raw);
-            if (!r_instr || !r_legs) return std::nullopt;
-            populator.populate(r_instr->instrument.instrument,
-                               std::move(r_legs->instrument.legs));
+            if (!try_parse_and_populate<callable_swap_instr_outer, swap_legs_outer>(raw, populator))
+                return std::nullopt;
         } else if (ttc == "KnockOutSwap") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading knock_out_swap_instrument";
-            auto r_instr = try_parse<knock_out_swap_instr_outer>(raw);
-            auto r_legs  = try_parse<swap_legs_outer>(raw);
-            if (!r_instr || !r_legs) return std::nullopt;
-            populator.populate(r_instr->instrument.instrument,
-                               std::move(r_legs->instrument.legs));
+            if (!try_parse_and_populate<knock_out_swap_instr_outer, swap_legs_outer>(raw, populator))
+                return std::nullopt;
         } else if (ttc == "InflationSwap") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading inflation_swap_instrument";
-            auto r_instr = try_parse<inflation_swap_instr_outer>(raw);
-            auto r_legs  = try_parse<swap_legs_outer>(raw);
-            if (!r_instr || !r_legs) return std::nullopt;
-            populator.populate(r_instr->instrument.instrument,
-                               std::move(r_legs->instrument.legs));
+            if (!try_parse_and_populate<inflation_swap_instr_outer, swap_legs_outer>(raw, populator))
+                return std::nullopt;
         } else if (ttc == "RiskParticipationAgreement") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading rpa_instrument";
-            auto r_instr = try_parse<rpa_instr_outer>(raw);
-            auto r_legs  = try_parse<swap_legs_outer>(raw);
-            if (!r_instr || !r_legs) return std::nullopt;
-            populator.populate(r_instr->instrument.instrument,
-                               std::move(r_legs->instrument.legs));
+            if (!try_parse_and_populate<rpa_instr_outer, swap_legs_outer>(raw, populator))
+                return std::nullopt;
         } else {
             BOOST_LOG_SEV(lg(), warn)
                 << "getTradeInstrument: unknown (product_type, trade_type) — ("

--- a/projects/ores.qt.api/src/parse_trade_instrument.cpp
+++ b/projects/ores.qt.api/src/parse_trade_instrument.cpp
@@ -143,7 +143,7 @@ struct eq_position_wrapper  { td::equity_position_instrument        instrument; 
 // then parse legs, then call the matching populate overload.
 template<typename InstrOuter, typename LegsOuter>
 static bool try_parse_and_populate(const std::string& raw,
-    IInstrumentFormPopulator& populator)
+    ores::qt::IInstrumentFormPopulator& populator)
 {
     auto r_instr = try_parse<InstrOuter>(raw);
     if (!r_instr) return false;

--- a/projects/ores.qt.api/src/parse_trade_instrument.cpp
+++ b/projects/ores.qt.api/src/parse_trade_instrument.cpp
@@ -54,62 +54,71 @@ struct response_envelope {
 };
 
 // Phase 2: one named wrapper per concrete leaf type.
-// Named wrappers are required because C++ does not permit struct definitions
-// inside template argument lists (e.g. rfl::json::read<struct{...}> is ill-formed).
 //
 // Flat types (bond, credit, commodity, scripted, fx_*, equity_*):
-//   trade_instrument holds the concrete type directly (or within a sub-variant).
-//   The "instrument" key in the response JSON maps directly to the leaf struct's fields.
-//   Structure: response["instrument"] = {concrete_instrument_fields}
+//   response["instrument"] = {concrete_instrument_fields}
 //
-// with_legs types (swap, composite):
-//   trade_instrument holds swap_instrument_data or composite_instrument_data, both of
-//   which are with_legs<VariantOrStruct, Leg> = {T instrument; vector<Leg> legs;}.
-//   The "instrument" key in the response JSON maps to the with_legs struct, which itself
-//   has an "instrument" field containing the concrete type.
-//   Structure: response["instrument"] = {"instrument": {concrete_fields}, "legs": [...]}
-//   The *_data intermediate struct captures this inner nesting.
+// with_legs types (composite, swap):
+//   response["instrument"] = {"instrument": {concrete_fields}, "legs": [...]}
+//
+// MSVC C1202 note: reflecting a combined {concrete_instrument; vector<*_leg>} struct in
+// a single rfl::json::read call creates a Literal over the union of all unique field
+// names from both types (~24-29 combined). This exceeds MSVC's recursive template
+// dependency limit. Fix: split into two reads — one for "instrument.instrument",
+// one for "instrument.legs". Each read sees at most ~19 fields, well within the limit.
 
-// Flat types
+// --- Flat types ---
+
 struct bond_wrapper      { td::bond_instrument      instrument; };
 struct credit_wrapper    { td::credit_instrument    instrument; };
 struct commodity_wrapper { td::commodity_instrument instrument; };
 struct scripted_wrapper  { td::scripted_instrument  instrument; };
 
-// Composite (with composite legs) — two-level wrapper: outer captures with_legs structure,
-// inner captures the concrete composite_instrument.
-struct composite_data    { td::composite_instrument instrument; std::vector<td::composite_leg> legs; };
-struct composite_wrapper { composite_data instrument; };
+// --- Composite (composite_instrument + composite legs): split reads ---
 
-// Rates / swap types (with swap legs) — same two-level pattern as composite.
-struct fra_data          { td::fra_instrument               instrument; std::vector<td::swap_leg> legs; };
-struct fra_wrapper       { fra_data instrument; };
+struct composite_instr_inner { td::composite_instrument            instrument; };
+struct composite_instr_outer { composite_instr_inner               instrument; };
 
-struct vanilla_swap_data    { td::vanilla_swap_instrument   instrument; std::vector<td::swap_leg> legs; };
-struct vanilla_swap_wrapper { vanilla_swap_data instrument; };
+struct composite_legs_inner  { std::vector<td::composite_leg>      legs; };
+struct composite_legs_outer  { composite_legs_inner                instrument; };
 
-struct cap_floor_data    { td::cap_floor_instrument         instrument; std::vector<td::swap_leg> legs; };
-struct cap_floor_wrapper { cap_floor_data instrument; };
+// --- Rates/swap types (swap_leg shared): split reads ---
+//
+// Instrument-only wrappers: read response["instrument"]["instrument"].
 
-struct swaption_data     { td::swaption_instrument          instrument; std::vector<td::swap_leg> legs; };
-struct swaption_wrapper  { swaption_data instrument; };
+struct fra_instr_inner          { td::fra_instrument                    instrument; };
+struct fra_instr_outer          { fra_instr_inner                       instrument; };
 
-struct bgs_data          { td::balance_guaranteed_swap_instrument instrument; std::vector<td::swap_leg> legs; };
-struct bgs_wrapper       { bgs_data instrument; };
+struct vanilla_swap_instr_inner { td::vanilla_swap_instrument           instrument; };
+struct vanilla_swap_instr_outer { vanilla_swap_instr_inner              instrument; };
 
-struct callable_swap_data    { td::callable_swap_instrument instrument; std::vector<td::swap_leg> legs; };
-struct callable_swap_wrapper { callable_swap_data instrument; };
+struct cap_floor_instr_inner    { td::cap_floor_instrument              instrument; };
+struct cap_floor_instr_outer    { cap_floor_instr_inner                 instrument; };
 
-struct knock_out_swap_data    { td::knock_out_swap_instrument instrument; std::vector<td::swap_leg> legs; };
-struct knock_out_swap_wrapper { knock_out_swap_data instrument; };
+struct swaption_instr_inner     { td::swaption_instrument               instrument; };
+struct swaption_instr_outer     { swaption_instr_inner                  instrument; };
 
-struct inflation_swap_data    { td::inflation_swap_instrument instrument; std::vector<td::swap_leg> legs; };
-struct inflation_swap_wrapper { inflation_swap_data instrument; };
+struct bgs_instr_inner          { td::balance_guaranteed_swap_instrument instrument; };
+struct bgs_instr_outer          { bgs_instr_inner                       instrument; };
 
-struct rpa_data    { td::rpa_instrument instrument; std::vector<td::swap_leg> legs; };
-struct rpa_wrapper { rpa_data instrument; };
+struct callable_swap_instr_inner { td::callable_swap_instrument         instrument; };
+struct callable_swap_instr_outer { callable_swap_instr_inner            instrument; };
 
-// FX types (direct alternatives in fx_instrument_variant — no extra nesting)
+struct knock_out_swap_instr_inner { td::knock_out_swap_instrument       instrument; };
+struct knock_out_swap_instr_outer { knock_out_swap_instr_inner          instrument; };
+
+struct inflation_swap_instr_inner { td::inflation_swap_instrument       instrument; };
+struct inflation_swap_instr_outer { inflation_swap_instr_inner          instrument; };
+
+struct rpa_instr_inner          { td::rpa_instrument                    instrument; };
+struct rpa_instr_outer          { rpa_instr_inner                       instrument; };
+
+// Legs-only wrapper: shared across all swap types.
+struct swap_legs_inner { std::vector<td::swap_leg> legs; };
+struct swap_legs_outer { swap_legs_inner instrument; };
+
+// --- FX types ---
+
 struct fx_forward_wrapper        { td::fx_forward_instrument        instrument; };
 struct fx_vanilla_option_wrapper { td::fx_vanilla_option_instrument instrument; };
 struct fx_barrier_option_wrapper { td::fx_barrier_option_instrument instrument; };
@@ -118,7 +127,8 @@ struct fx_asian_forward_wrapper  { td::fx_asian_forward_instrument  instrument; 
 struct fx_accumulator_wrapper    { td::fx_accumulator_instrument    instrument; };
 struct fx_variance_swap_wrapper  { td::fx_variance_swap_instrument  instrument; };
 
-// Equity types (direct alternatives in equity_instrument_variant — no extra nesting)
+// --- Equity types ---
+
 struct eq_option_wrapper    { td::equity_option_instrument          instrument; };
 struct eq_forward_wrapper   { td::equity_forward_instrument         instrument; };
 struct eq_swap_wrapper      { td::equity_swap_instrument            instrument; };
@@ -188,57 +198,77 @@ parse_trade_instrument(const std::string& raw, IInstrumentFormPopulator& populat
     }
     case product_type::composite: {
         BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading composite_instrument";
-        auto r = try_parse<composite_wrapper>(raw);
-        if (!r) return std::nullopt;
-        populator.populate(r->instrument.instrument, std::move(r->instrument.legs));
+        auto r_instr = try_parse<composite_instr_outer>(raw);
+        auto r_legs  = try_parse<composite_legs_outer>(raw);
+        if (!r_instr || !r_legs) return std::nullopt;
+        populator.populate(r_instr->instrument.instrument,
+                           std::move(r_legs->instrument.legs));
         break;
     }
     case product_type::swap: {
         if (ttc == "ForwardRateAgreement") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading fra_instrument";
-            auto r = try_parse<fra_wrapper>(raw);
-            if (!r) return std::nullopt;
-            populator.populate(r->instrument.instrument, std::move(r->instrument.legs));
+            auto r_instr = try_parse<fra_instr_outer>(raw);
+            auto r_legs  = try_parse<swap_legs_outer>(raw);
+            if (!r_instr || !r_legs) return std::nullopt;
+            populator.populate(r_instr->instrument.instrument,
+                               std::move(r_legs->instrument.legs));
         } else if (ttc == "Swap" || ttc == "CrossCurrencySwap" || ttc == "FlexiSwap") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading vanilla_swap_instrument";
-            auto r = try_parse<vanilla_swap_wrapper>(raw);
-            if (!r) return std::nullopt;
-            populator.populate(r->instrument.instrument, std::move(r->instrument.legs));
+            auto r_instr = try_parse<vanilla_swap_instr_outer>(raw);
+            auto r_legs  = try_parse<swap_legs_outer>(raw);
+            if (!r_instr || !r_legs) return std::nullopt;
+            populator.populate(r_instr->instrument.instrument,
+                               std::move(r_legs->instrument.legs));
         } else if (ttc == "CapFloor") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading cap_floor_instrument";
-            auto r = try_parse<cap_floor_wrapper>(raw);
-            if (!r) return std::nullopt;
-            populator.populate(r->instrument.instrument, std::move(r->instrument.legs));
+            auto r_instr = try_parse<cap_floor_instr_outer>(raw);
+            auto r_legs  = try_parse<swap_legs_outer>(raw);
+            if (!r_instr || !r_legs) return std::nullopt;
+            populator.populate(r_instr->instrument.instrument,
+                               std::move(r_legs->instrument.legs));
         } else if (ttc == "Swaption") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading swaption_instrument";
-            auto r = try_parse<swaption_wrapper>(raw);
-            if (!r) return std::nullopt;
-            populator.populate(r->instrument.instrument, std::move(r->instrument.legs));
+            auto r_instr = try_parse<swaption_instr_outer>(raw);
+            auto r_legs  = try_parse<swap_legs_outer>(raw);
+            if (!r_instr || !r_legs) return std::nullopt;
+            populator.populate(r_instr->instrument.instrument,
+                               std::move(r_legs->instrument.legs));
         } else if (ttc == "BalanceGuaranteedSwap") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading balance_guaranteed_swap_instrument";
-            auto r = try_parse<bgs_wrapper>(raw);
-            if (!r) return std::nullopt;
-            populator.populate(r->instrument.instrument, std::move(r->instrument.legs));
+            auto r_instr = try_parse<bgs_instr_outer>(raw);
+            auto r_legs  = try_parse<swap_legs_outer>(raw);
+            if (!r_instr || !r_legs) return std::nullopt;
+            populator.populate(r_instr->instrument.instrument,
+                               std::move(r_legs->instrument.legs));
         } else if (ttc == "CallableSwap") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading callable_swap_instrument";
-            auto r = try_parse<callable_swap_wrapper>(raw);
-            if (!r) return std::nullopt;
-            populator.populate(r->instrument.instrument, std::move(r->instrument.legs));
+            auto r_instr = try_parse<callable_swap_instr_outer>(raw);
+            auto r_legs  = try_parse<swap_legs_outer>(raw);
+            if (!r_instr || !r_legs) return std::nullopt;
+            populator.populate(r_instr->instrument.instrument,
+                               std::move(r_legs->instrument.legs));
         } else if (ttc == "KnockOutSwap") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading knock_out_swap_instrument";
-            auto r = try_parse<knock_out_swap_wrapper>(raw);
-            if (!r) return std::nullopt;
-            populator.populate(r->instrument.instrument, std::move(r->instrument.legs));
+            auto r_instr = try_parse<knock_out_swap_instr_outer>(raw);
+            auto r_legs  = try_parse<swap_legs_outer>(raw);
+            if (!r_instr || !r_legs) return std::nullopt;
+            populator.populate(r_instr->instrument.instrument,
+                               std::move(r_legs->instrument.legs));
         } else if (ttc == "InflationSwap") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading inflation_swap_instrument";
-            auto r = try_parse<inflation_swap_wrapper>(raw);
-            if (!r) return std::nullopt;
-            populator.populate(r->instrument.instrument, std::move(r->instrument.legs));
+            auto r_instr = try_parse<inflation_swap_instr_outer>(raw);
+            auto r_legs  = try_parse<swap_legs_outer>(raw);
+            if (!r_instr || !r_legs) return std::nullopt;
+            populator.populate(r_instr->instrument.instrument,
+                               std::move(r_legs->instrument.legs));
         } else if (ttc == "RiskParticipationAgreement") {
             BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading rpa_instrument";
-            auto r = try_parse<rpa_wrapper>(raw);
-            if (!r) return std::nullopt;
-            populator.populate(r->instrument.instrument, std::move(r->instrument.legs));
+            auto r_instr = try_parse<rpa_instr_outer>(raw);
+            auto r_legs  = try_parse<swap_legs_outer>(raw);
+            if (!r_instr || !r_legs) return std::nullopt;
+            populator.populate(r_instr->instrument.instrument,
+                               std::move(r_legs->instrument.legs));
         } else {
             BOOST_LOG_SEV(lg(), warn)
                 << "getTradeInstrument: unknown (product_type, trade_type) — ("


### PR DESCRIPTION
## Summary

- `parse_trade_instrument.cpp` reflected combined `{concrete_instrument; vector<swap_leg>}` structs in a single `rfl::json::read` call. The union of unique field names from `swaption_instrument` (18 fields) + `swap_leg` (19 fields, ~11 unique overlap) = ~29 total triggered MSVC's `no_duplicate_field_names` recursive template dependency check with C1202 ("recursive type or function dependency context too complex") — the same hard limit documented in the story's decisions.
- Fix: split every leg-based read into two separate `rfl::json::read` calls — one for `instrument.instrument`, one for `instrument.legs`. Each read sees ≤19 fields. Applied uniformly to all 9 swap types (`fra`, `vanilla_swap`, `cap_floor`, `swaption`, `bgs`, `callable_swap`, `knock_out_swap`, `inflation_swap`, `rpa`) and `composite`.
- A shared `swap_legs_outer`/`composite_legs_outer` wrapper is reused across all types in each family; only the instrument-side wrapper differs per type.

## Changes

| File | Change |
|------|--------|
| `projects/ores.qt.api/src/parse_trade_instrument.cpp` | Replace 9 combined `*_data` + `*_wrapper` structs with per-type `*_instr_inner`/`*_instr_outer` + shared `swap_legs_outer`/`composite_legs_outer`; inline two-pass reads at each dispatch site |

## Story / Task

- Story: [Fix rfl complexity failure (Windows + macOS CI)](../blob/main/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org) — `7763D0EE-A500-4497-9B2D-973C02ADC739`
- Task 7: [Fix ClientManager AddTagsToVariants and archiver DLL export](../blob/main/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_client_manager_add_tags_and_archiver_export.org) — `4BF920B2-CA2B-40EF-B463-DDC13D0C2516`

## Test plan

- [ ] Windows MSVC CI (debug + release): no C1202 in `parse_trade_instrument.cpp`
- [ ] Windows Clang CI: passes (linker fix already in PR #978)
- [ ] macOS CI: no fold-expression nesting limit errors
- [ ] Linux CI: unaffected (still green)
- [ ] Instrument parse dispatch tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)