### PR TITLE
[ores.qt.api] Split swap-type rfl parsing into dedicated TU to fix MSVC C1202

### DIFF
--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_client_manager_add_tags_and_archiver_export.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_client_manager_add_tags_and_archiver_export.org
@@ -8,7 +8,7 @@
 #+filetags: :fix_rfl_complexity:sprint_19:v0:
 #+owner: marco
 #+branch: feature/fix-windows-macos-ci
-#+pr: 978 982
+#+pr: 978 982 985
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-06-01
@@ -46,9 +46,9 @@ Three Windows/macOS CI failures after PR #969 (service parser exports):
 |--------------+------------------------------------------------------------------|
 | State        | STARTED                                                          |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]]  |
-| Now          | PR #982 open for parse_trade_instrument C1202 fix; awaiting CI.  |
-| Waiting on   | CI green + review on PR #982.                                     |
-| Next         | Merge PR #982; mark DONE.                                         |
+| Now          | PR #985 open (TU split for swap types); review round 1 addressed. |
+| Waiting on   | CI green + merge on PR #985.                                       |
+| Next         | Merge PR #985; verify Windows CI green; mark DONE.                 |
 | Last touched | 2026-06-01                                                       |
 
 * Acceptance
@@ -72,6 +72,7 @@ Three Windows/macOS CI failures after PR #969 (service parser exports):
 |----+-------|
 | [[https://github.com/OreStudio/OreStudio/pull/978][#978]] | [ores.compute.wrapper,ores.qt.api] Fix remaining Windows/macOS CI failures |
 | [[https://github.com/OreStudio/OreStudio/pull/982][#982]] | [ores.qt.api] Fix MSVC C1202 in parse_trade_instrument.cpp |
+| [[https://github.com/OreStudio/OreStudio/pull/985][#985]] | [ores.qt.api] Split swap-type rfl parsing into dedicated TU to fix MSVC C1202 |
 
 * Review
 
@@ -79,5 +80,7 @@ Three Windows/macOS CI failures after PR #969 (service parser exports):
 |---+------------------------------------------------------------------------------+-------------------------------+----------+------------------------------------|
 | 1 | Introduce try_parse_and_populate template to remove duplication (line 134)  | parse_trade_instrument.cpp    | Accept   | Fixed 0b0c8551f + 0b990a8d5        |
 | 2 | Use helper across all 10 leg-based cases (line 272)                          | parse_trade_instrument.cpp    | Accept   | Fixed 0b0c8551f                    |
+| 3 | Add explicit <optional> and <vector> includes (PR #985 line 34)              | parse_swap_instruments.cpp    | Accept   | Fixed 7c28c434f                    |
+| 4 | Forward-declare IInstrumentFormPopulator instead of full include (PR #985)   | parse_swap_impl.hpp           | Accept   | Fixed 7c28c434f                    |
 
 * Result

--- a/projects/ores.qt.api/src/parse_swap_impl.hpp
+++ b/projects/ores.qt.api/src/parse_swap_impl.hpp
@@ -1,0 +1,41 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#ifndef ORES_QT_PARSE_SWAP_IMPL_HPP
+#define ORES_QT_PARSE_SWAP_IMPL_HPP
+
+// Internal header: declares the swap-instrument parse entry point implemented
+// in parse_swap_instruments.cpp. Kept separate so that the rfl::json::read
+// instantiations for all 9 swap types live in a single fresh translation unit,
+// avoiding MSVC C1202 (template dependency graph too complex) which fires when
+// those instantiations share a TU with the flat/FX/equity instrument types.
+
+#include <string>
+#include "ores.qt/IInstrumentFormPopulator.hpp"
+
+namespace ores::qt::internal {
+
+// Dispatch on ttc ("ForwardRateAgreement", "Swap", "Swaption", …).
+// Returns false and logs on parse failure or unknown ttc.
+bool parse_swap_instrument(const std::string& raw, const std::string& ttc,
+    ores::qt::IInstrumentFormPopulator& pop);
+
+}
+
+#endif

--- a/projects/ores.qt.api/src/parse_swap_impl.hpp
+++ b/projects/ores.qt.api/src/parse_swap_impl.hpp
@@ -27,7 +27,8 @@
 // those instantiations share a TU with the flat/FX/equity instrument types.
 
 #include <string>
-#include "ores.qt/IInstrumentFormPopulator.hpp"
+
+namespace ores::qt { struct IInstrumentFormPopulator; }
 
 namespace ores::qt::internal {
 

--- a/projects/ores.qt.api/src/parse_swap_instruments.cpp
+++ b/projects/ores.qt.api/src/parse_swap_instruments.cpp
@@ -1,0 +1,146 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+// This translation unit is intentionally isolated from parse_trade_instrument.cpp.
+//
+// MSVC C1202 ("recursive type or function dependency context too complex") fires
+// when rfl::json::read<> is instantiated for too many types in the same TU: the
+// accumulated rfl::StringLiteral<N> field-name types fill MSVC's internal template
+// dependency graph.  Splitting all 9 swap-instrument types into this dedicated TU
+// gives MSVC a clean slate; the flat/FX/equity types in parse_trade_instrument.cpp
+// never enter this compilation context.
+
+#include <rfl/json.hpp>
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+#include "ores.logging/make_logger.hpp"
+#include "ores.qt/IInstrumentFormPopulator.hpp"
+#include "parse_swap_impl.hpp"
+
+namespace {
+
+using namespace ores::logging;
+namespace td = ores::trading::domain;
+
+inline std::string_view logger_name = "ores.qt.parse_swap_instruments";
+[[nodiscard]] static auto& lg() {
+    static auto instance = make_logger(logger_name);
+    return instance;
+}
+
+template<typename T>
+static std::optional<T> try_parse(const std::string& raw) {
+    auto r = rfl::json::read<T>(raw);
+    if (!r) {
+        BOOST_LOG_SEV(lg(), error)
+            << "parse_swap_instrument: deserialise failed: " << r.error().what();
+        return std::nullopt;
+    }
+    return std::move(*r);
+}
+
+// Shared legs wrapper: swap_leg is the same for all 9 swap types.
+struct swap_legs_inner { std::vector<td::swap_leg> legs; };
+struct swap_legs_outer { swap_legs_inner instrument; };
+
+// Per-type instrument wrappers: read response["instrument"]["instrument"].
+struct fra_instr_inner          { td::fra_instrument                    instrument; };
+struct fra_instr_outer          { fra_instr_inner                       instrument; };
+
+struct vanilla_swap_instr_inner { td::vanilla_swap_instrument           instrument; };
+struct vanilla_swap_instr_outer { vanilla_swap_instr_inner              instrument; };
+
+struct cap_floor_instr_inner    { td::cap_floor_instrument              instrument; };
+struct cap_floor_instr_outer    { cap_floor_instr_inner                 instrument; };
+
+struct swaption_instr_inner     { td::swaption_instrument               instrument; };
+struct swaption_instr_outer     { swaption_instr_inner                  instrument; };
+
+struct bgs_instr_inner          { td::balance_guaranteed_swap_instrument instrument; };
+struct bgs_instr_outer          { bgs_instr_inner                       instrument; };
+
+struct callable_swap_instr_inner { td::callable_swap_instrument         instrument; };
+struct callable_swap_instr_outer { callable_swap_instr_inner            instrument; };
+
+struct knock_out_swap_instr_inner { td::knock_out_swap_instrument       instrument; };
+struct knock_out_swap_instr_outer { knock_out_swap_instr_inner          instrument; };
+
+struct inflation_swap_instr_inner { td::inflation_swap_instrument       instrument; };
+struct inflation_swap_instr_outer { inflation_swap_instr_inner          instrument; };
+
+struct rpa_instr_inner          { td::rpa_instrument                    instrument; };
+struct rpa_instr_outer          { rpa_instr_inner                       instrument; };
+
+template<typename InstrOuter, typename LegsOuter>
+static bool try_parse_and_populate(const std::string& raw,
+    ores::qt::IInstrumentFormPopulator& populator)
+{
+    auto r_instr = try_parse<InstrOuter>(raw);
+    if (!r_instr) return false;
+    auto r_legs = try_parse<LegsOuter>(raw);
+    if (!r_legs) return false;
+    populator.populate(r_instr->instrument.instrument,
+                       std::move(r_legs->instrument.legs));
+    return true;
+}
+
+} // namespace
+
+namespace ores::qt::internal {
+
+bool parse_swap_instrument(const std::string& raw, const std::string& ttc,
+    ores::qt::IInstrumentFormPopulator& pop)
+{
+    using namespace ores::logging;
+
+    if (ttc == "ForwardRateAgreement") {
+        BOOST_LOG_SEV(lg(), debug) << "parse_swap_instrument: reading fra_instrument";
+        return try_parse_and_populate<fra_instr_outer, swap_legs_outer>(raw, pop);
+    } else if (ttc == "Swap" || ttc == "CrossCurrencySwap" || ttc == "FlexiSwap") {
+        BOOST_LOG_SEV(lg(), debug) << "parse_swap_instrument: reading vanilla_swap_instrument";
+        return try_parse_and_populate<vanilla_swap_instr_outer, swap_legs_outer>(raw, pop);
+    } else if (ttc == "CapFloor") {
+        BOOST_LOG_SEV(lg(), debug) << "parse_swap_instrument: reading cap_floor_instrument";
+        return try_parse_and_populate<cap_floor_instr_outer, swap_legs_outer>(raw, pop);
+    } else if (ttc == "Swaption") {
+        BOOST_LOG_SEV(lg(), debug) << "parse_swap_instrument: reading swaption_instrument";
+        return try_parse_and_populate<swaption_instr_outer, swap_legs_outer>(raw, pop);
+    } else if (ttc == "BalanceGuaranteedSwap") {
+        BOOST_LOG_SEV(lg(), debug) << "parse_swap_instrument: reading balance_guaranteed_swap_instrument";
+        return try_parse_and_populate<bgs_instr_outer, swap_legs_outer>(raw, pop);
+    } else if (ttc == "CallableSwap") {
+        BOOST_LOG_SEV(lg(), debug) << "parse_swap_instrument: reading callable_swap_instrument";
+        return try_parse_and_populate<callable_swap_instr_outer, swap_legs_outer>(raw, pop);
+    } else if (ttc == "KnockOutSwap") {
+        BOOST_LOG_SEV(lg(), debug) << "parse_swap_instrument: reading knock_out_swap_instrument";
+        return try_parse_and_populate<knock_out_swap_instr_outer, swap_legs_outer>(raw, pop);
+    } else if (ttc == "InflationSwap") {
+        BOOST_LOG_SEV(lg(), debug) << "parse_swap_instrument: reading inflation_swap_instrument";
+        return try_parse_and_populate<inflation_swap_instr_outer, swap_legs_outer>(raw, pop);
+    } else if (ttc == "RiskParticipationAgreement") {
+        BOOST_LOG_SEV(lg(), debug) << "parse_swap_instrument: reading rpa_instrument";
+        return try_parse_and_populate<rpa_instr_outer, swap_legs_outer>(raw, pop);
+    }
+
+    BOOST_LOG_SEV(lg(), warn)
+        << "parse_swap_instrument: unknown trade_type: " << ttc;
+    return false;
+}
+
+} // namespace ores::qt::internal

--- a/projects/ores.qt.api/src/parse_swap_instruments.cpp
+++ b/projects/ores.qt.api/src/parse_swap_instruments.cpp
@@ -27,6 +27,8 @@
 // gives MSVC a clean slate; the flat/FX/equity types in parse_trade_instrument.cpp
 // never enter this compilation context.
 
+#include <optional>
+#include <vector>
 #include <rfl/json.hpp>
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include "ores.logging/make_logger.hpp"

--- a/projects/ores.qt.api/src/parse_trade_instrument.cpp
+++ b/projects/ores.qt.api/src/parse_trade_instrument.cpp
@@ -22,6 +22,12 @@
 #include "ores.qt/parse_trade_instrument.hpp"
 #include "ores.qt/IInstrumentFormPopulator.hpp"
 #include "ores.logging/make_logger.hpp"
+#include "parse_swap_impl.hpp"
+
+// Swap-type rfl instantiations live in parse_swap_instruments.cpp (separate TU)
+// to avoid MSVC C1202: the accumulated rfl::StringLiteral field-name types from
+// flat/FX/equity types fill MSVC's template dependency graph; swap types need a
+// clean slate.
 
 namespace {
 
@@ -34,7 +40,6 @@ inline std::string_view logger_name = "ores.qt.parse_trade_instrument";
     return instance;
 }
 
-// Attempt to parse the raw response JSON as T. Returns nullopt and logs on failure.
 template<typename T>
 static std::optional<T> try_parse(const std::string& raw) {
     auto r = rfl::json::read<T>(raw);
@@ -53,21 +58,7 @@ struct response_envelope {
     td::trade trade;
 };
 
-// Phase 2: one named wrapper per concrete leaf type.
-//
-// Flat types (bond, credit, commodity, scripted, fx_*, equity_*):
-//   response["instrument"] = {concrete_instrument_fields}
-//
-// with_legs types (composite, swap):
-//   response["instrument"] = {"instrument": {concrete_fields}, "legs": [...]}
-//
-// MSVC C1202 note: reflecting a combined {concrete_instrument; vector<*_leg>} struct in
-// a single rfl::json::read call creates a Literal over the union of all unique field
-// names from both types (~24-29 combined). This exceeds MSVC's recursive template
-// dependency limit. Fix: split into two reads — one for "instrument.instrument",
-// one for "instrument.legs". Each read sees at most ~19 fields, well within the limit.
-
-// --- Flat types ---
+// --- Flat types (no legs) ---
 
 struct bond_wrapper      { td::bond_instrument      instrument; };
 struct credit_wrapper    { td::credit_instrument    instrument; };
@@ -82,40 +73,18 @@ struct composite_instr_outer { composite_instr_inner               instrument; }
 struct composite_legs_inner  { std::vector<td::composite_leg>      legs; };
 struct composite_legs_outer  { composite_legs_inner                instrument; };
 
-// --- Rates/swap types (swap_leg shared): split reads ---
-//
-// Instrument-only wrappers: read response["instrument"]["instrument"].
-
-struct fra_instr_inner          { td::fra_instrument                    instrument; };
-struct fra_instr_outer          { fra_instr_inner                       instrument; };
-
-struct vanilla_swap_instr_inner { td::vanilla_swap_instrument           instrument; };
-struct vanilla_swap_instr_outer { vanilla_swap_instr_inner              instrument; };
-
-struct cap_floor_instr_inner    { td::cap_floor_instrument              instrument; };
-struct cap_floor_instr_outer    { cap_floor_instr_inner                 instrument; };
-
-struct swaption_instr_inner     { td::swaption_instrument               instrument; };
-struct swaption_instr_outer     { swaption_instr_inner                  instrument; };
-
-struct bgs_instr_inner          { td::balance_guaranteed_swap_instrument instrument; };
-struct bgs_instr_outer          { bgs_instr_inner                       instrument; };
-
-struct callable_swap_instr_inner { td::callable_swap_instrument         instrument; };
-struct callable_swap_instr_outer { callable_swap_instr_inner            instrument; };
-
-struct knock_out_swap_instr_inner { td::knock_out_swap_instrument       instrument; };
-struct knock_out_swap_instr_outer { knock_out_swap_instr_inner          instrument; };
-
-struct inflation_swap_instr_inner { td::inflation_swap_instrument       instrument; };
-struct inflation_swap_instr_outer { inflation_swap_instr_inner          instrument; };
-
-struct rpa_instr_inner          { td::rpa_instrument                    instrument; };
-struct rpa_instr_outer          { rpa_instr_inner                       instrument; };
-
-// Legs-only wrapper: shared across all swap types.
-struct swap_legs_inner { std::vector<td::swap_leg> legs; };
-struct swap_legs_outer { swap_legs_inner instrument; };
+template<typename InstrOuter, typename LegsOuter>
+static bool try_parse_and_populate(const std::string& raw,
+    ores::qt::IInstrumentFormPopulator& populator)
+{
+    auto r_instr = try_parse<InstrOuter>(raw);
+    if (!r_instr) return false;
+    auto r_legs = try_parse<LegsOuter>(raw);
+    if (!r_legs) return false;
+    populator.populate(r_instr->instrument.instrument,
+                       std::move(r_legs->instrument.legs));
+    return true;
+}
 
 // --- FX types ---
 
@@ -138,21 +107,6 @@ struct eq_asian_wrapper     { td::equity_asian_option_instrument    instrument; 
 struct eq_digital_wrapper   { td::equity_digital_option_instrument  instrument; };
 struct eq_accum_wrapper     { td::equity_accumulator_instrument     instrument; };
 struct eq_position_wrapper  { td::equity_position_instrument        instrument; };
-
-// Two-pass helper for leg-based types: parse instrument, short-circuit on failure,
-// then parse legs, then call the matching populate overload.
-template<typename InstrOuter, typename LegsOuter>
-static bool try_parse_and_populate(const std::string& raw,
-    ores::qt::IInstrumentFormPopulator& populator)
-{
-    auto r_instr = try_parse<InstrOuter>(raw);
-    if (!r_instr) return false;
-    auto r_legs = try_parse<LegsOuter>(raw);
-    if (!r_legs) return false;
-    populator.populate(r_instr->instrument.instrument,
-                       std::move(r_legs->instrument.legs));
-    return true;
-}
 
 } // namespace
 
@@ -178,8 +132,6 @@ parse_trade_instrument(const std::string& raw, IInstrumentFormPopulator& populat
         << "getTradeInstrument: product_type=" << td::to_string(pt)
         << " trade_type=" << ttc;
 
-    // Phase 2: dispatch on (product_type, trade_type) — read concrete leaf
-    // struct directly, no AddTagsToVariants, no trade_instrument variant.
     using ores::trading::domain::product_type;
 
     switch (pt) {
@@ -218,48 +170,9 @@ parse_trade_instrument(const std::string& raw, IInstrumentFormPopulator& populat
         break;
     }
     case product_type::swap: {
-        if (ttc == "ForwardRateAgreement") {
-            BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading fra_instrument";
-            if (!try_parse_and_populate<fra_instr_outer, swap_legs_outer>(raw, populator))
-                return std::nullopt;
-        } else if (ttc == "Swap" || ttc == "CrossCurrencySwap" || ttc == "FlexiSwap") {
-            BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading vanilla_swap_instrument";
-            if (!try_parse_and_populate<vanilla_swap_instr_outer, swap_legs_outer>(raw, populator))
-                return std::nullopt;
-        } else if (ttc == "CapFloor") {
-            BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading cap_floor_instrument";
-            if (!try_parse_and_populate<cap_floor_instr_outer, swap_legs_outer>(raw, populator))
-                return std::nullopt;
-        } else if (ttc == "Swaption") {
-            BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading swaption_instrument";
-            if (!try_parse_and_populate<swaption_instr_outer, swap_legs_outer>(raw, populator))
-                return std::nullopt;
-        } else if (ttc == "BalanceGuaranteedSwap") {
-            BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading balance_guaranteed_swap_instrument";
-            if (!try_parse_and_populate<bgs_instr_outer, swap_legs_outer>(raw, populator))
-                return std::nullopt;
-        } else if (ttc == "CallableSwap") {
-            BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading callable_swap_instrument";
-            if (!try_parse_and_populate<callable_swap_instr_outer, swap_legs_outer>(raw, populator))
-                return std::nullopt;
-        } else if (ttc == "KnockOutSwap") {
-            BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading knock_out_swap_instrument";
-            if (!try_parse_and_populate<knock_out_swap_instr_outer, swap_legs_outer>(raw, populator))
-                return std::nullopt;
-        } else if (ttc == "InflationSwap") {
-            BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading inflation_swap_instrument";
-            if (!try_parse_and_populate<inflation_swap_instr_outer, swap_legs_outer>(raw, populator))
-                return std::nullopt;
-        } else if (ttc == "RiskParticipationAgreement") {
-            BOOST_LOG_SEV(lg(), debug) << "getTradeInstrument: reading rpa_instrument";
-            if (!try_parse_and_populate<rpa_instr_outer, swap_legs_outer>(raw, populator))
-                return std::nullopt;
-        } else {
-            BOOST_LOG_SEV(lg(), warn)
-                << "getTradeInstrument: unknown (product_type, trade_type) — ("
-                << td::to_string(pt) << ", " << ttc << "); returning monostate";
+        // Swap-type rfl instantiations are in parse_swap_instruments.cpp (separate TU).
+        if (!internal::parse_swap_instrument(raw, ttc, populator))
             return std::nullopt;
-        }
         break;
     }
     case product_type::fx: {


### PR DESCRIPTION
## Summary

MSVC C1202 ("recursive type or function dependency context too complex") still fired in `parse_trade_instrument.cpp` after the per-field-count split (PR #982), because the issue is **accumulated context across the whole TU**, not just per-type field count. By the time MSVC reaches `swaption_instr_outer` (~11th type in the file), the `rfl::StringLiteral<N>` types from all preceding flat/FX/equity instrument types have filled MSVC's internal template dependency graph.

Fix: move all 9 swap-instrument types into a new dedicated TU (`parse_swap_instruments.cpp`). MSVC starts with a clean dependency graph for that file. `parse_trade_instrument.cpp` dispatches to `internal::parse_swap_instrument()` — an ordinary non-template function call.

## Changes

| File | Change |
|------|--------|
| `projects/ores.qt.api/src/parse_swap_instruments.cpp` | **New** — all 9 swap types + `swap_legs_outer` + `try_parse_and_populate`; implements `internal::parse_swap_instrument()` |
| `projects/ores.qt.api/src/parse_swap_impl.hpp` | **New** — internal header declaring `internal::parse_swap_instrument()` |
| `projects/ores.qt.api/src/parse_trade_instrument.cpp` | Remove swap-type structs and rfl instantiations; include `parse_swap_impl.hpp`; dispatch via function call |

The `src/CMakeLists.txt` glob picks up the new `.cpp` automatically.

## Story / Task

- Story: [Fix rfl complexity failure (Windows + macOS CI)](../blob/main/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org) — `7763D0EE-A500-4497-9B2D-973C02ADC739`
- Task 7: [Fix ClientManager AddTagsToVariants and archiver DLL export](../blob/main/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_client_manager_add_tags_and_archiver_export.org) — `4BF920B2-CA2B-40EF-B463-DDC13D0C2516`

## Test plan

- [ ] Windows MSVC CI (debug + release): no C1202 in `parse_trade_instrument.cpp` or `parse_swap_instruments.cpp`
- [ ] Windows Clang CI: passes
- [ ] macOS CI: no fold-expression nesting limit errors
- [ ] Linux CI: unaffected
- [ ] Instrument parse dispatch tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)