### PR TITLE
[doc] Add MASD and code generation principles document

### DIFF
--- a/doc/agile/versions/v0/sprint_19/document_masd_codegen_principles/task_implement_document_masd_codegen_principles.org
+++ b/doc/agile/versions/v0/sprint_19/document_masd_codegen_principles/task_implement_document_masd_codegen_principles.org
@@ -133,3 +133,4 @@ rather than an idealised design.
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
 | 1 | Remove empty =* Result= placeholder | task_implement_document_masd_codegen_principles.org | Fixed — removed | Gemini round 1 |
+| 2 | "all eight profiles" inconsistent — table has 7 | masd_and_codegen_principles.org | Fixed — "all seven profiles" | Gemini round 2 |

--- a/doc/agile/versions/v0/sprint_19/document_masd_codegen_principles/task_implement_document_masd_codegen_principles.org
+++ b/doc/agile/versions/v0/sprint_19/document_masd_codegen_principles/task_implement_document_masd_codegen_principles.org
@@ -126,6 +126,7 @@ rather than an idealised design.
 | PR | Title |
 |----+-------|
 | [[https://github.com/OreStudio/OreStudio/pull/988][#988]] | [agile] Scaffold MASD and code generation principles story |
+| [[https://github.com/OreStudio/OreStudio/pull/991][#991]] | [doc] Add MASD and code generation principles document |
 
 * Review
 

--- a/doc/compass.org
+++ b/doc/compass.org
@@ -123,6 +123,19 @@ Short, tested, executable how-tos grouped by topic
 Shell commands inside =#+begin_src sh :results verbatim= blocks so they run in place via
 =C-c C-c=.
 
+** Engineering principles
+
+Core documents that explain /why/ the project is built the way it is —
+the theory behind the architecture, the methodology behind the tools.
+
+- [[id:2A585483-DFF5-429C-ACD3-396342E31117][MASD and code generation principles]] — the theoretical and practical
+  foundations of code generation: MASD concepts (logical/physical space,
+  products, components, facets, transformations), the reference-implementation
+  backout strategy, and where ORE Studio sits on the automation spectrum.
+- [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][Model Assisted Software Development]] — the practical ORE Studio guide:
+  how logical/physical space and the facet catalogue are applied in practice.
+- [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] — the four-layer architecture and component inventory.
+
 ** =knowledge/=: durable reference
 
 See [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] for the full index; external reference docs are under

--- a/doc/knowledge/masd_and_codegen_principles.org
+++ b/doc/knowledge/masd_and_codegen_principles.org
@@ -266,7 +266,7 @@ The automation spectrum (P-6 above) provides a useful frame for honest assessmen
 | 3     | Full entity generated with no human editing     | Partial (SQL + domain + protocol) |
 | 4     | Product-line generation: new entity = new model | Not yet reached           |
 
-The immediate goal is to reach Level 3 for the complete entity stack (all eight
+The immediate goal is to reach Level 3 for the complete entity stack (all seven
 profiles) using the =currency= reference implementation as the fitness function.
 Level 4, where a new =country= or =party= entity requires only a model file, is the
 long-term target.

--- a/doc/knowledge/masd_and_codegen_principles.org
+++ b/doc/knowledge/masd_and_codegen_principles.org
@@ -1,0 +1,288 @@
+:PROPERTIES:
+:ID: 2A585483-DFF5-429C-ACD3-396342E31117
+:END:
+#+title: MASD and code generation principles
+#+description: The theoretical and practical foundations of code generation in ORE Studio: how MASD concepts — logical/physical space, products, components, facets, and transformations — map onto the development process, and the reference-implementation backout strategy for building the generator incrementally from a proven hand-written entity.
+#+type: knowledge
+#+level: cross
+#+filetags: :masd:mde:codegen:methodology:principles:knowledge:
+#+created: 2026-06-01
+#+updated: 2026-06-01
+
+* Summary
+
+ORE Studio treats code generation not as an optional productivity tool but as a
+first-class engineering principle rooted in Model-Driven Engineering (MDE) and,
+more specifically, in the Model Assisted Software Development (MASD) methodology.
+Under MASD, a software project is understood as a collection of physical artefacts
+— files and directories — that are projections from a higher-dimension /logical
+space/ populated by typed entities with well-defined /facets/. Rather than
+designing an abstract generator first and deriving code from it, ORE Studio follows
+MASD's /reference-implementation backout/ strategy: a single entity is commissioned
+fully by hand, its recurring patterns are extracted into templates, and the
+generator is then used to produce all subsequent entities. This document explains
+the theory, the terminology, and how both apply to day-to-day development.
+
+* The MASD conceptual model
+
+MASD is a Software Development Methodology (SDM) concerned specifically with the
+engineering of /infrastructure code/ — the schematic, repetitive layers of a
+software system that are necessary but contain little domain-specific logic. It was
+developed as part of a PhD programme (see [[https://uhra.herts.ac.uk/id/eprint/17031/][Model Assisted Software Development]]) and
+implemented in the code generator Dogen, which served as its reference
+implementation for over a decade.
+
+ORE Studio does not use Dogen. However, the conceptual model underlying MASD
+remains deeply relevant and is the lens through which the project's architecture
+and development process should be read.
+
+** Logical and physical space
+
+MASD begins with a distinction adapted from Lakos's /Large Scale C++ Software
+Design/:
+
+#+begin_quote
+/Logical design/ addresses all the type-related aspects of design — classes and
+their relationships. /Physical design/ addresses the placement of logical entities,
+such as classes and functions, into physical ones, such as files and libraries.
+All design has a physical aspect.
+#+end_quote
+
+MASD formalises this intuition into two spaces:
+
+- The /physical space/ is the world of files and directories — what lives on disk
+  and in the repository. Every C++ header, SQL script, org-mode document, and
+  Mustache template is a physical artefact.
+- The /logical space/ is the higher-dimension space of /entities/ with /properties/
+  — the abstract description of what a domain element is, independent of how it
+  is realised in any particular file or language.
+
+Physical artefacts are /projections/ of logical entities. The same logical entity
+projects into many physical artefacts across many components: a C++ struct in an
+=.api= component, a repository in a =.core= component, a NATS message type in a
+messaging header, a SQL table in a create script, a Qt MDI window in a UI plugin.
+Each projection is a distinct expression of the same underlying logical truth.
+
+This projection relationship is the foundation on which all of ORE Studio's code
+generation is built.
+
+* Taxonomic analysis: products, components, and product families
+
+MASD provides a precise vocabulary for classifying the artefacts in a software
+project. Understanding this taxonomy is essential for knowing where generated code
+should live and how the project is decomposed.
+
+** Product
+
+A /product/ is the overall container for physical artefacts — a complete software
+system composed of executables and libraries. In MASD terms, ORE Studio itself is a
+product. It follows all of MASD's conventions, including the component directory
+structure and the profile-based generation model. The GitHub repository is the
+canonical boundary of the product.
+
+** Component
+
+A /component/ is a library or executable that is part of a larger product. Each
+component follows MASD's component directory structure layout; it may also be a
+self-contained sub-product used as a dependency by other components. In ORE Studio,
+every =ores.*= CMake target is a component:
+
+- =ores.refdata.api= — domain types and NATS protocol for reference data
+- =ores.refdata.core= — repository, mapper, service layer
+- =ores.qt.refdata= — Qt MDI windows and dialogs for reference data
+- =ores.codegen= — the generator itself
+
+Each component is the /native home/ for exactly one layer of the logical entity's
+projection. The component structure directly encodes the facet catalogue (see below).
+
+** Product family
+
+A /product family/ is a collection of related products unified by a shared
+methodology and reference implementation. MASD itself is a product family: Dogen
+(the generator) plus a set of reference products, one per supported target language.
+ORE Studio is a single product at present but is designed to be extensible along the
+same axis — the generator, the reference implementation (=currency=), and the entity
+evaluation checklist together constitute the embryonic product family machinery.
+
+** SRPP: the unit of extraction
+
+MASD defines a /Schematic and Repetitive Pattern in the Physical space/ (SRPP) as
+the class of patterns found in infrastructure code that vary predictably across
+entities but are otherwise mechanically identical. An SRPP is what a Mustache
+template encodes. Identifying an SRPP is the analytical step that precedes writing
+a template — and the act of commissioning the first entity by hand is precisely the
+process of surfacing the SRPPs that the generator will later exploit.
+
+In ORE Studio, the commissioning of the =currency= entity produced the canonical
+set of SRPPs for reference-data entities: the C++ domain struct, the rfl-based JSON
+I/O, the repository entity and mapper, the service class, the NATS protocol types,
+the SQL DDL and trigger scripts, and the full Qt UI (12 files: MDI window,
+controller, detail dialog, history dialog, client model, and their headers).
+
+* Facets and the facet catalogue
+
+Within each component, a logical entity is expressed through one or more /facets/.
+A facet is a well-defined concern in the entity's lifecycle — the type definition,
+the test data generator, the repository layer, the service layer, and so on. Each
+facet has a canonical form that is consistent across all entities of the same kind.
+
+The facets of a domain entity in ORE Studio are generated by [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] profiles.
+Each profile corresponds to one or more facets:
+
+| Facet                                   | Codegen profile       |
+|-----------------------------------------+-----------------------|
+| Type definition (struct, JSON I/O, table I/O) | =--profile domain=  |
+| Test data generator                     | =--profile generator= |
+| Repository entity and mapper            | =--profile repository= |
+| Repository CRUD operations              | =--profile repository= |
+| Service layer                           | =--profile service=   |
+| NATS messaging protocol                 | =--profile protocol=  |
+| SQL schema, triggers, drop scripts      | =--profile sql=       |
+| Qt UI (12 files: window, dialog, model) | =--profile qt=        |
+
+See [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] for the full profile descriptions and the Mustache templates each
+profile invokes.
+
+* Model transformations
+
+MDE distinguishes three categories of /model transformation/ (following Czarnecki
+and Helsen):
+
+- *Model-to-Model (M2M)* — transforms one model into another at the same or a
+  different abstraction level. Refactoring a meta-model or translating between
+  modeling notations are examples.
+- *Model-to-Text (M2T)* — produces a string representation (source code,
+  documentation, configuration) from a model. This is the category that code
+  generators occupy.
+- *Text-to-Text (T2T)* — converts one textual representation into another without
+  an intermediate model step.
+
+=ores.codegen= is a /Model-to-Text/ transformer: it takes JSON model files (the
+source models), applies Mustache templates parameterised by a profile, and produces
+physical artefacts (C++ headers, SQL scripts, org documents). The JSON schema is
+the implicit meta-model; the profile catalogue is the transformation configuration;
+the Mustache templates are the transformation rules.
+
+In a strict MDE architecture the transformation chain would be explicit and
+formally specified. ORE Studio takes a pragmatic position: the meta-model is
+implicit in the JSON schema and in the skill recipes that LLMs use to author model
+files, rather than in a formal meta-meta-model such as MOF or Ecore. This is
+consistent with MASD's philosophy of using NLP and LLMs in place of rigid
+formalism — the underlying concepts are encoded in skills and recipes that an LLM
+can understand and apply, rather than in a metamodelling tower that a human must
+navigate.
+
+* The six MASD principles
+
+MASD articulates six core principles that govern its design decisions. Each applies
+directly to how ORE Studio approaches code generation:
+
+1. *Focus Narrowly (P-1)* — MASD targets infrastructure code only, not business
+   logic. ORE Studio's generator produces the mechanical layers (C++ plumbing, SQL
+   DDL, Qt boilerplate) but never touches the domain logic inside a service class.
+   The generator knows nothing about financial instruments; it knows a great deal
+   about how to wire a NATS handler.
+
+2. *Integrate Pervasively (P-2)* — the generator must fit the existing toolchain
+   without disruption. =ores.codegen= is invoked via =compass=, produces files
+   that slot into CMake targets and the existing directory layout, and carries the
+   standard licence header and editor modeline on every output file.
+
+3. *Evolve Gradually (P-3)* — coverage grows incrementally, driven by concrete
+   practice. The generator is not designed to handle all entities speculatively;
+   each new profile is added when a second real entity needs it. The commissioning
+   process surfaces new SRPPs; those SRPPs become templates; templates become
+   profiles. This is the theoretical backing for the backout strategy described
+   below.
+
+4. *Govern Openly (P-4)* — all templates, models, and profiles are in the open
+   repository and subject to the same review process as production code.
+
+5. *Standardise Judiciously (P-5)* — de facto standards (Mustache, JSON, Python)
+   at the core for agility; the physical artefacts conform to the project's own
+   conventions (C++ style, SQL naming, org frontmatter contract).
+
+6. *Assist and Guide (P-6)* — the automation spectrum runs from Level 0 (stub
+   generation: scaffold a file, human writes the rest) to Level 4 (full product
+   line generation: the generator owns everything). ORE Studio currently operates
+   between Level 2 (most infrastructure layers generated for a well-modelled entity)
+   and Level 3 (the generator can produce a working system for a new entity without
+   human editing of generated files). Closing this gap is the long-term generative
+   objective.
+
+* The reference-implementation backout strategy
+
+The most distinctive aspect of ORE Studio's approach to code generation is the
+/backout strategy/ — the deliberate choice to extract the generator from a proven
+hand-written implementation rather than to design it top-down.
+
+The workflow is as follows:
+
+1. *Commission the reference entity by hand.* The =currency= entity is the
+   reference implementation. Every layer — domain type, JSON I/O, table I/O,
+   repository, mapper, service, NATS protocol, SQL schema, and full Qt UI — was
+   written by hand without any generator involvement. The result is a working,
+   tested, reviewed system that serves as the ground truth.
+
+2. *Identify the SRPPs.* After commissioning, the recurring patterns are made
+   explicit. The [[id:897A7156-504D-4581-AD4C-026D643C0838][entity evaluation checklist]] formalises what "fully commissioned"
+   means at each layer; the patterns that appear identically across all checklist
+   items are candidates for extraction.
+
+3. *Encode patterns as Mustache templates.* Each SRPP becomes a =.mustache= file
+   parameterised by the entity model. The model (a JSON file or, increasingly, a
+   literate org-mode file) provides the variable data — entity name, field list,
+   namespace, component path.
+
+4. *Add a profile entry.* The template set is registered in
+   =projects/ores.codegen/library/profiles.json=, giving it a stable name that
+   callers can invoke with =--profile=.
+
+5. *Verify zero drift.* The generator is run against the =currency= model and its
+   output is diffed against the hand-written files. A zero diff confirms the
+   template faithfully encodes the SRPP. The hand-written files are then replaced
+   by the generated output; from that point, only the model and the template are
+   edited.
+
+6. *Extend to new entities.* With a verified template, commissioning a new entity
+   reduces to authoring its model file and running the generator. The [[id:897A7156-504D-4581-AD4C-026D643C0838][entity
+   evaluation checklist]] confirms coverage.
+
+This strategy avoids the central failure mode of top-down code generation: a
+generator that produces code which nobody has ever actually used. By grounding every
+template in a proven implementation, ORE Studio ensures that generated code is
+correct from the first entity onward. The cost — one fully hand-written reference
+entity — is paid once. All subsequent entities amortise it.
+
+* Where ORE Studio sits on the automation spectrum today
+
+The automation spectrum (P-6 above) provides a useful frame for honest assessment:
+
+| Level | Description                                     | ORE Studio status         |
+|-------+-------------------------------------------------+---------------------------|
+| 0     | Stub generation only; human writes all content  | Exceeded                  |
+| 1     | One layer generated (e.g. SQL only)             | Exceeded                  |
+| 2     | Multiple layers generated; some human editing   | Achieved for SQL, domain  |
+| 3     | Full entity generated with no human editing     | Partial (SQL + domain + protocol) |
+| 4     | Product-line generation: new entity = new model | Not yet reached           |
+
+The immediate goal is to reach Level 3 for the complete entity stack (all eight
+profiles) using the =currency= reference implementation as the fitness function.
+Level 4, where a new =country= or =party= entity requires only a model file, is the
+long-term target.
+
+* See also
+
+- [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][MASD]] — the ORE Studio implementation guide: how logical/physical space and the
+  facet catalogue are applied in practice. The present document is the theoretical
+  companion; that document is the practical reference.
+- [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] — the code generator that implements the facet transformations:
+  inputs, templates, profiles, and operational recipes.
+- [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] — internal structure, template system, model-template
+  mapping.
+- [[id:897A7156-504D-4581-AD4C-026D643C0838][ores.refdata entity evaluation checklist]] — the canonical definition of what
+  "fully commissioned" means at each layer; the fitness function for backout
+  verification.
+- [[id:429AE3F5-A825-8834-0353-9B98F235AE84][Type definition facet]] — the primary facet: the domain struct and its I/O.
+- [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] — the four-layer architecture; shows how components map to layers
+  and how facets distribute across components.

--- a/projects/ores.codegen/modeling/component_overview.org
+++ b/projects/ores.codegen/modeling/component_overview.org
@@ -164,9 +164,11 @@ harness.  See [[id:F27E5DF7-6223-4B6F-80A5-CEFBEB1BC756][Component architecture]
 
 * See also
 
-- [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][Model Assisted Software Development]] — the conceptual model (logical
-  entities, facets, transformations) that the profile catalogue
-  implements.
+- [[id:2A585483-DFF5-429C-ACD3-396342E31117][MASD and code generation principles]] — the theoretical and practical
+  foundations: why code generation exists in ORE Studio, how MASD
+  concepts map onto the development process, and the backout strategy.
+- [[id:BA0E3273-DC4B-7CD4-447B-06227B7D09A8][Model Assisted Software Development]] — the practical implementation
+  guide: logical/physical space, facet catalogue, applied to ORE Studio.
 - [[id:FE693595-6693-459B-AD9B-EB7E3ABBBC88][ores.codegen architecture]] — directory layout, internal modules,
   template system, model-template mapping, modeline configuration,
   features.

--- a/projects/ores.lisp/src/ores-build-site.el
+++ b/projects/ores.lisp/src/ores-build-site.el
@@ -130,6 +130,7 @@
     <a href='/OreStudio/doc/llm/llm.html'>LLMs</a>
     <a href='/OreStudio/doc/manual/manuals.html'>Manuals</a>
     <a href='/OreStudio/doc/downloads.html'>Downloads</a>
+    <a href='/OreStudio/doc/knowledge/masd_and_codegen_principles.html'>Code Gen</a>
     <a href='/OreStudio/doc/agile/agile.html'>Agile</a>
     <a href='/OreStudio/doc/developer.html'>Developer</a>
     <a href='/OreStudio/doc/agile/versions/versions.html'>Roadmap</a>


### PR DESCRIPTION
## Summary

Adds a permanent technical knowledge document establishing code generation
as a first-class engineering principle of ORE Studio, and wires it into
the site navigation.

The document weaves MASD theory (Model Assisted Software Development) with
ORE Studio's development process — it is intentionally philosophical and
theoretical, not an implementation reference. Implementation details
remain in `ores.codegen`.

## Changes

**`doc/knowledge/masd_and_codegen_principles.org`** — new document covering:
- The MASD conceptual model: logical/physical space, projections (Lakos)
- Taxonomic analysis: Product → Component → Product Family → SRPP, mapped to ORE Studio
- Model transformation taxonomy: M2M, M2T, T2T — and where `ores.codegen` sits
- Facet catalogue (reused from `projects/modeling/masd.org`)
- The six MASD principles with ORE Studio commentary
- The reference-implementation backout strategy: hand-write `currency` → identify SRPPs → encode as Mustache → zero-diff verify → extend to new entities
- Automation spectrum table (Level 0–4) and ORE Studio's current position

**`projects/ores.lisp/src/ores-build-site.el`** — "Code Gen" navbar entry between Architecture and Agile, linking directly to the document

**`doc/compass.org`** — new "Engineering principles" section above the knowledge folder entry

**`projects/ores.codegen/modeling/component_overview.org`** — "See also" updated to distinguish the new theoretical doc from the existing MASD practical reference

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Document MASD and code generation principles](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/document_masd_codegen_principles/story.html) | EE6A643D-6C6C-41B8-88FD-2EA9351414CD |
| Task | [Write the MASD and code generation principles document](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/document_masd_codegen_principles/task_implement_document_masd_codegen_principles.html) | 9C7C4C36-76AD-48C0-B217-D6E82F831C03 |