### PR TITLE
[agile] Component migration: brainstorm + cross-linking follow-on task

### DIFF
--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/story.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/story.org
@@ -110,6 +110,7 @@ against an inadequate model format and migrating later.
 | [[id:ADBD1D70-F62F-468E-A4FB-26DF28FBA527][Migrate component JSON models to org-mode]] | BACKLOG | | | 32 files. Per-package CMake / C++ component metadata. Biggest kind. |
 | [[id:3B4C2C1F-2174-4A41-A838-991C6D5631B8][Migrate slovaris reference-data JSONs to org-mode]] | BACKLOG | | | 6 files. Reference-data taxonomy read as sibling data via =load_data=; needs a loader extension. |
 | [[id:EE3A7822-C95F-48C8-8474-862209C446FE][Retire plantuml_er_model.json from models/]] | BACKLOG | | | Generated artefact — move to a build path + gitignore. |
+| [[id:95031F88-44AB-4705-BA99-05A874800EC5][Cross-link entity / component overview / schema org docs]] | BACKLOG | | | Wire the four load-bearing edges: group overview → sub-components, group overview → entities, entity → group, entity → schema (lookup tables). Includes creating 11 missing top-level group overviews. |
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_cross_link_entity_component_schema.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_cross_link_entity_component_schema.org
@@ -1,0 +1,145 @@
+:PROPERTIES:
+:ID: 95031F88-44AB-4705-BA99-05A874800EC5
+:END:
+#+title: Task: Cross-link entity / component overview / schema org docs
+#+description: Existing entity org files (ores.<component>.<entity>.org) have zero org-roam links to other docs in the model graph. Once the component-model migration (ADBD1D70) lands the component identity inside each component_overview.org, three links become natural and load-bearing for navigation: 1) component overview → list of every entity org under its modeling/ dir; 2) entity → owning component overview (back-link); 3) entity → the schema document for any column that references a lookup table (e.g. party.party_type → ores.refdata.party_type.org), once the table-kind migration (92AEBBDA) lands. This task sweeps the cross-links into every already-migrated entity and each affected overview.
+#+type: task
+#+level: s1
+#+filetags: :codegen_org_model_migration:sprint_19:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-01
+#+updated: 2026-06-01
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The model graph today is a set of disconnected leaves. Entity org
+files don't reference each other, don't reference the component
+that owns them, don't reference the schema document for the lookup
+tables they depend on, and the top-level group =modeling/= folders
+have no overview at all (except =ores.database/=). This task wires
+every load-bearing edge so a reader landing on any one doc can
+navigate to all the others.
+
+Four edges to land:
+
+1. *Group overview → sub-component overviews.* For each of the 11
+   top-level groups that has no =component_overview.org= today
+   (refdata, trading, iam, dq, analytics, reporting, scheduler,
+   workflow, controller, workspace, compute), create one at
+   =projects/ores.<group>/modeling/component_overview.org=, with
+   id-links to each sub-component overview (api / core / service /
+   qt). For =database= the overview already exists; just add the
+   missing links.
+2. *Group overview → entity models.* The group overview gains an
+   =* Entities= section listing every =ores.<group>.<entity>.org=
+   under the same =modeling/=, as id-links.
+3. *Entity → owning group + sub-component back-link.* Each entity
+   org gains links back to its group overview and (where it makes
+   sense) the sub-component overview it pairs with.
+4. *Entity → schema document.* For columns referencing a lookup
+   table (e.g. =party.party_type= → =ores.refdata.party_type=), the
+   entity org links to the matching table-kind org file. Requires
+   the table-kind migration ([[id:92AEBBDA-1FDD-4501-9C66-E893EF448CE6][refdata table migration]]) and the
+   lookup-entity migration ([[id:F88B35A5-0BE4-4274-99FC-2F08AAE5F80B][lookup-entity migration]]) to have
+   landed.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                                |
+| Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
+| Now          | Not yet started.                       |
+| Waiting on   | [[id:ADBD1D70-F62F-468E-A4FB-26DF28FBA527][component migration]] for the overview shape; [[id:92AEBBDA-1FDD-4501-9C66-E893EF448CE6][table-kind]] + [[id:F88B35A5-0BE4-4274-99FC-2F08AAE5F80B][lookup-entity]] migrations for edge 4. |
+| Next         | Settle the link conventions; sweep.    |
+| Last touched | 2026-06-01                             |
+
+* Acceptance
+
+- 11 new =projects/ores.<group>/modeling/component_overview.org=
+  files, plus the existing =ores.database/= one, each:
+  - carrying an id-link to every existing sub-component overview
+    (api / core / service / qt), and
+  - listing every entity org under the same =modeling/= dir in an
+    =* Entities= section, as id-links.
+- Every entity org under each group's =modeling/= carries a link
+  back to its group overview.
+- Every entity column that references a lookup table carries an
+  id-link to the lookup's org file (entity-kind or table-kind, per
+  the corresponding migration's decision).
+- Sub-component overviews link up to the group overview (the
+  reverse of edge 1).
+- =compass list --type component= surfaces the new group overviews.
+
+* Plan
+
+** 1. Settle conventions
+
+- How does a doc express "owning component"? Property drawer
+  (=:component:= id) vs section (=* See also: component=)? Match
+  whatever the [[id:ADBD1D70-F62F-468E-A4FB-26DF28FBA527][component migration]] settled on.
+- For "entity → schema": a per-column =:schema:= property in the
+  column drawer, or a =* See also= section listing the cross-refs?
+
+** 2. Group overviews (11 new)
+
+Scaffold via compass (=add component= type) or hand-write from the
+existing =ores.database= shape. Each one carries:
+- Frontmatter (=#+title= = full group name, =#+type: component=).
+- =* Summary= prose introducing the group.
+- =* Sub-components= section: id-links to every sub-component
+  overview that exists for the group.
+- =* Entities= section: id-links to every entity org under the same
+  =modeling/=.
+
+** 3. Sub-component → group back-link sweep
+
+Add a =* Group= section (or property) to each existing
+sub-component overview pointing at its group overview.
+
+** 4. Entity → group back-link sweep
+
+Touch every =ores.<group>.<entity>.org= already in the tree to add
+the back-link.
+
+** 5. Entity → schema link sweep
+
+After edges 1-4 ship, walk every entity column that references a
+lookup table and add an id-link. Driven by a small script that
+parses the entity's =* Columns= sub-headings and matches column
+names against the lookup catalogue.
+
+** 6. Commit + raise PR
+
+Likely two PRs:
+- Edges 1-3 (overview infrastructure) — depends on [[id:ADBD1D70-F62F-468E-A4FB-26DF28FBA527][component migration]].
+- Edges 4-5 (entity → schema) — depends on the table-kind and
+  lookup-entity migrations as well.
+
+* Notes
+
+The component migration task ([[id:ADBD1D70-F62F-468E-A4FB-26DF28FBA527][ADBD1D70]]) holds the design
+brainstorm for whether codegen reads the group overview as a model
+or only the sub-components. Settle that there first; this task
+follows its lead.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_component_models_to_org.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_component_models_to_org.org
@@ -19,28 +19,200 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Move the 32 =ores_*_component.json= files into org-mode and have
+codegen read the component identity from there. Do this *without*
+creating a second per-component document — the project already has
+=component_overview.org= files in each component's =modeling/=
+directory (86 of them across the tree). The component identity that
+codegen needs (name, full_name, brief, description) is a thin
+property layer; the literate overview is the home for it. The
+migration target is *one* org file per component, not two.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | BACKLOG                                |
 | Parent story | [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-01                               |
+| Now          | Design brainstorm captured below; needs sign-off before implementation. |
+| Waiting on   | Decision on the design questions in =* Design — brainstorm=. |
+| Next         | Settle the shape; implement. |
+| Last touched | 2026-06-01                             |
+
+* Design — brainstorm
+
+** The overlap
+
+=projects/ores.codegen/models/<package>/ores_<package>_component.json=
+is tiny — exactly:
+
+#+begin_src json
+{
+  "component": {
+    "name": "<short>",
+    "full_name": "ores.<package>",
+    "brief": "<one line>",
+    "description": "<paragraph>"
+  }
+}
+#+end_src
+
+=projects/ores.<package>/modeling/component_overview.org= already
+exists (86 instances), already carries =#+type: component=, already
+holds =#+title= (≈ full_name), =#+description= (≈ description) and a
+=* Summary= section that subsumes =description=. The =brief=
+attribute has no analogue today.
+
+So we have *two ways* to describe a component, and the JSON's content
+is a strict subset of what the overview already says. The user's
+question on the migration story:
+
+#+begin_quote
+Do we really need two completely separate documents to model aspects
+of the component? We already have the notion of component overview.
+#+end_quote
+
+The answer this task assumes is *no*. =component_overview.org= is
+the home; the codegen drawer hangs off it.
+
+** Proposed shape (option A — recommended)
+
+One org file per component: the existing
+=projects/ores.<package>/modeling/component_overview.org=, with a
+property drawer added so codegen can read the identity:
+
+#+begin_example
+,:PROPERTIES:
+,:ID: <existing org-roam id>
+,:name:      refdata.service
+,:full_name: ores.refdata.service
+,:brief:     Reference data service
+,:END:
+,#+title: ores.refdata.service
+,#+description: Standalone NATS microservice ...
+,#+type: component
+,#+codegen_role: component_model     ; the discovery hint codegen uses
+,#+filetags: :refdata:service:component:
+#+end_example
+
+The overview's =* Summary= section already covers what the JSON
+calls =description=, so we don't duplicate.
+
+org_loader gains a =load_component_model= that reads the drawer +
+=#+title= + =#+description= and returns the same dict shape the
+JSON path produced. =manifest.py= / =generate.py= dispatch on
+=#+codegen_role:= when discovering files in =modeling/=.
+
+** Alternative (option B — explicitly rejected)
+
+A separate =ores.<package>.component.org= sitting alongside the
+overview. This is what the inventory task initially assumed and is
+what the simple "JSON → org" pattern would produce. Rejected because
+it duplicates identity and creates an extra file for humans to
+maintain.
+
+** Cross-linking work this surfaces
+
+Once the component model lives in the overview, three forward/back
+links become natural and load-bearing for navigation:
+
+1. *Component overview → entity models* — the overview gains a
+   =* Entities= section that lists every =ores.<package>.<entity>.org=
+   under the same =modeling/= dir, as id-links.
+2. *Entity model → owning component* — each entity org gains a
+   =#+component_overview: <id>= keyword or a =* Component= section
+   with an id-link back to the overview.
+3. *Entity model → schema document* — for columns referencing a
+   lookup table, the entity org links to the matching table-kind
+   org file (lands after [[id:92AEBBDA-1FDD-4501-9C66-E893EF448CE6][refdata table migration]] / per-entity
+   lookups). Lookup column =party_type= → table doc
+   =ores.refdata.party_type.org=.
+
+Items 1 and 2 affect already-migrated entity orgs and need a separate
+sweep — captured as [[id:95031F88-44AB-4705-BA99-05A874800EC5][Cross-link entity / component overview / schema
+org docs]]. Item 3 has to wait for the table-kind migrations to land.
+
+** Two-level component hierarchy (group + sub-components)
+
+The migration story also introduced top-level component folders
+(=projects/ores.refdata/=, =projects/ores.trading/=, ...) which
+today only hold entity models under =modeling/=. Those *groups*
+will have their own component models too, sitting *above* the
+existing sub-component overviews:
+
+#+begin_example
+projects/ores.refdata/modeling/component_overview.org      ← GROUP
+projects/ores.refdata.api/modeling/component_overview.org   ← sub
+projects/ores.refdata.core/modeling/component_overview.org  ← sub
+projects/ores.refdata.service/modeling/component_overview.org
+projects/ores.qt.refdata/modeling/component_overview.org    ← sub
+#+end_example
+
+The group overview is the index for the family. It links to each
+sub-component overview, and the sub-components link back.
+
+Concrete state today (12 groups in scope):
+
+| Group     | =modeling/= dir | Group overview exists? |
+|-----------+-----------------+------------------------|
+| database  | ✓               | ✓ (already present)    |
+| All other 11 (refdata, trading, iam, dq, analytics, reporting, scheduler, workflow, controller, workspace, compute) | ✓ | ✗ — to be created |
+
+The 32 JSON component models map onto a *mix* of groups and
+sub-components. JSON covers groups =compute=, =controller=,
+=reporting=, =trading=, =workflow= plus utility groups (=nats=,
+=service=, =storage=, =ore.*=). JSON has *no* group model for
+=refdata=, =analytics=, =dq=, =iam=, =scheduler=, =workspace=,
+=database= — for those, the group overview is brand new.
+
+So the work here is broader than "translate 32 JSON files":
+
+- Migrate every JSON into the matching existing overview (or, where
+  the overview is missing, create one as part of this task).
+- Create the missing group overviews for the 7 groups JSON doesn't
+  cover, so every group has an index doc.
+- Decide whether the group overview is itself a codegen-readable
+  "component model" or whether codegen continues to read only the
+  sub-component models. Suggest: codegen keeps reading
+  sub-components; the group overview is *navigation-only*.
+
+** Open questions for sign-off
+
+- Confirm option A (merge into overview) vs option B (parallel doc).
+- Name of the codegen discovery keyword (=#+codegen_role:= vs
+  =#+type:=). The existing overview already uses =#+type: component=;
+  we may not need a new keyword at all and instead extend codegen to
+  treat every =#+type: component= file as a component model.
+- Should =brief= live in the drawer or as a new =#+brief:= keyword
+  (matching the entity convention)?
+- Confirm: the *group* overview is navigation-only (humans + Emacs);
+  codegen continues to read the *sub-component* overviews as
+  component models.
 
 * Acceptance
 
--
+(Filled in once the brainstorm decisions land. The shape below is
+the option-A target.)
+
+- Each =projects/ores.<package>/modeling/component_overview.org= has
+  a property drawer carrying =name=, =full_name=, =brief= (or
+  =#+brief:=) so codegen can read the identity without a sibling
+  JSON.
+- =org_loader= gains a component reader; =manifest.py= and
+  =generate.py= discover component models under each component's
+  =modeling/= dir via the same dispatch path the entity migration
+  established.
+- All 32 =ores_*_component.json= files removed. =projects/ores.codegen/models/=
+  shrinks by 32.
+- Regenerating any consumer that pulls component identity produces
+  output unchanged from the JSON-driven path.
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+(Filled in after sign-off. High-level shape: settle the keyword
+question, write the loader, hand-edit the 32 overview drawers, run
+regen, delete JSON. Cross-linking work runs as a follow-on task,
+not here.)
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_component_models_to_org.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_component_models_to_org.org
@@ -226,6 +226,6 @@ not here.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Task missing =* PRs= / =* Review= sections (false-positive). | task_migrate_component_models_to_org.org:218 | Declined | PR #992 (brainstorm) round 1. Both sections already present at lines 219 / 225. |
 
 * Result


### PR DESCRIPTION
## Summary

No code change — agile-docs only. Captures two related design moves on the org-codegen migration story before implementation starts on the component-model migration.

### Brainstorm on the component-migration task (`ADBD1D70`)

Discovered by inspection that `*_component.json` (32 files, each just `{name, full_name, brief, description}`) describes the same thing as the existing `component_overview.org` files (86 instances, already `#+type: component`). Recommendation: merge codegen identity into the overview via a property drawer; don't create a parallel per-component doc.

The brainstorm also captures the two-level hierarchy the regroup-components effort exposed:

- *Group* — `projects/ores.<group>/modeling/component_overview.org` (only `ores.database/` has one today; 11 missing).
- *Sub-components* — `ores.<group>.api/`, `ores.<group>.core/`, `ores.<group>.service/`, `ores.qt.<group>/` — each already has its own overview.

The 32 JSONs cover a *mix* of groups and sub-components, and don't cover every group. The migration target is broader than translation: it also creates the missing group overviews.

Open questions left for sign-off:

- Merge into overview vs parallel doc.
- Codegen discovery keyword (`#+codegen_role:` vs reusing `#+type: component`).
- `brief` as drawer property vs `#+brief:` keyword.
- Whether the *group* overview is codegen-readable or navigation-only.

### New follow-on task (`95031F88`)

Cross-link entity / component overview / schema org docs. Four edges to land:

1. Group overview → sub-component overviews (11 new group overviews).
2. Group overview → entity models (the entities already under each `modeling/`).
3. Entity → owning group back-link.
4. Entity → schema document for lookup columns (e.g. `party.party_type` → `ores.refdata.party_type.org`).

Edge 4 depends on the table-kind (`92AEBBDA`) and lookup-entity (`F88B35A5`) migrations to have landed.

## Changes

- `task_migrate_component_models_to_org.org` (ADBD1D70) — Goal rewritten around the no-parallel-doc principle. New `* Design — brainstorm` section: overlap, options A/B (recommended/rejected), two-level hierarchy (group + sub), open questions. Status field gates implementation on sign-off.
- `task_cross_link_entity_component_schema.org` (95031F88) — new task scaffolded with full goal / acceptance / plan covering all four edges. Status field gates it on the component task + table-kind / lookup-entity migrations.
- Story task table picks up the new task row.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Codegen unified model — org-mode migration](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/story.html) | D85E2B30-8C64-46DF-819D-B50D2E70B73C |
| Task | [Migrate component JSON models to org-mode](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_migrate_component_models_to_org.html) | ADBD1D70-F62F-468E-A4FB-26DF28FBA527 |
| Task | [Cross-link entity / component overview / schema org docs](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_cross_link_entity_component_schema.html) | 95031F88-44AB-4705-BA99-05A874800EC5 |