### PR TITLE
[agile] Introduce milestone concept; clarify versioning strategy

### DIFF
--- a/doc/agile/agile.org
+++ b/doc/agile/agile.org
@@ -18,8 +18,10 @@ sprints that compose a [[id:CA4D4BDE-2EAB-4F0A-BC8B-7C0BCB17BC82][version]]. The
   sprints, sizing tasks, cross-sprint continuations.
 - [[id:A064D838-F127-4DD6-BB42-9A7902039AEE][Sprint themes]] — definitions of the six themes and the epic convention used
   to group stories in sprint backlogs.
-- [[id:37C10313-E6E9-4D42-B82D-B6758D0A3AD9][Versions]] — every version of the product, the sprints inside each, and the
+- [[id:37C10313-E6E9-4D42-B82D-B6758D0A3AD9][Versions]] — every version series of the product, the sprints inside each, and the
   stories and tasks that compose those sprints.
+- [[id:C540506E-7129-4CF2-AE3E-6C8BB9C9417F][Milestones]] — the named major release targets each version series works towards;
+  owns identity, theme, mission, and definition of done.
 - [[id:D4219199-7B17-4A89-B4BC-6019738642DA][Product backlog]] — pre-sprint ideas split into [[id:9A17E8DF-7E94-4F55-8A14-BCB7D9A16D6B][next]] (next-version candidates)
   and [[id:C1BF2C4F-2DB3-49C1-94E9-7D2B3E4F1AB8][deferred]] (longer-term wishlist).
 
@@ -32,9 +34,10 @@ state transitions generically — it is not agile-specific. Agile is the loop
 
 | Field           | Value     |
 |-----------------+-----------|
-| Current Version | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][v0]]        |
-| Current Sprint  | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Next sprint     | Sprint 20 |
+| Current Version  | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][v0]]                            |
+| Current Sprint   | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                     |
+| Next sprint      | Sprint 20                     |
+| Target milestone | [[id:DDA02748-7054-463B-9238-CC196601403D][v1.0 — Static World]]           |
 
 * See also
 

--- a/doc/agile/milestones/milestones.org
+++ b/doc/agile/milestones/milestones.org
@@ -1,0 +1,45 @@
+:PROPERTIES:
+:ID: C540506E-7129-4CF2-AE3E-6C8BB9C9417F
+:END:
+#+title: Milestones
+#+description: Catalogue of all ORE Studio milestones — the major release targets that bound each version series.
+#+type: knowledge
+#+level: cross
+#+filetags: :milestones:index:agile:
+#+created: 2026-06-02
+#+updated: 2026-06-02
+
+* Summary
+
+A [[id:65B2F1A0-3C4D-4E7A-9B8D-1F2A3C4D5E6F][milestone]] is the named major release target that a [[id:CA4D4BDE-2EAB-4F0A-BC8B-7C0BCB17BC82][version]] series works towards — the
+major release that closes one series and opens the next. Milestones own
+the /what and why/: identity, theme, mission, and definition of done.
+Versions own the /how and when/: the release series, sprints, and
+in-progress builds. The two are distinct documents so neither
+duplicates the other.
+
+* Milestones vs versions
+
+#+ATTR_HTML: :class hug-leading
+| Concept   | Owns                                          | Example                    |
+|-----------+-----------------------------------------------+----------------------------|
+| Version   | Release series, sprints, in-progress builds   | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]] (0.0.x builds) |
+| Milestone | Identity, theme, mission, DoD, time horizon   | [[id:DDA02748-7054-463B-9238-CC196601403D][Milestone v1.0]]             |
+
+A version does not carry a mission statement of its own; it points to
+its target milestone instead. When the milestone's definition of done
+is met, the version closes and the software cuts the milestone release
+(e.g. 1.0.0). Work then moves to the next version series.
+
+* Catalogue
+
+#+ATTR_HTML: :class hug-leading
+| Milestone                                           | Theme          | Version series     | Time horizon | Status      |
+|-----------------------------------------------------+----------------+--------------------+--------------+-------------|
+| [[id:DDA02748-7054-463B-9238-CC196601403D][v1.0 — Static World]]  | Static world   | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]] (0.x.x)  | ~6 months    | IN PROGRESS |
+| [[id:1651993D-F3E8-4A73-861C-0A0B03F12CF0][v2.0 — Dynamic World]] | Dynamic world  | Version 1 (1.x.x)  | ~18 months   | PLANNED     |
+
+* See also
+
+- [[id:37C10313-E6E9-4D42-B82D-B6758D0A3AD9][Versions]] — the version series that do the work.
+- [[id:E5635EAC-CCE9-C0A4-A00B-C1780FF4A88E][Agile]] — entry point to the agile information architecture.

--- a/doc/agile/milestones/v1.org
+++ b/doc/agile/milestones/v1.org
@@ -1,0 +1,60 @@
+:PROPERTIES:
+:ID: DDA02748-7054-463B-9238-CC196601403D
+:END:
+#+title: Milestone v1.0 — Static World
+#+description: Every ORE sample loads, executes, and round-trips with zero diff. Marks graduation from the 0.x.x series to 1.0.0.
+#+type: knowledge
+#+level: cross
+#+filetags: :milestone:v1_0:
+#+created: 2026-06-02
+#+updated: 2026-06-02
+
+* Identity
+
+Milestone v1.0 is the /static world/ release. Time stands still: market
+data does not tick, trades do not change state, and no live feeds are
+required. The world is a snapshot, and the goal is to reproduce it
+perfectly. ORE Studio can ingest any ORE sample, persist every input
+and output, execute the pipeline end-to-end, and produce results that
+are bit-for-bit identical to the ground-truth reference outputs. Every
+sample is green; nothing is deferred.
+
+* Theme
+
+Static world: zero diffs, full round-trips, complete ORE sample
+coverage. The correctness bar is the ORE reference implementation
+itself.
+
+* Mission
+
+- Model all ORE XML input types and make them importable.
+- Persist every ORE output type in the database.
+- Execute the full ORE pipeline end-to-end inside ORE Studio.
+- Achieve zero-diff round-trips for every ORE sample.
+- Provide GUI coverage for every data operation.
+- Establish the main architectural tiers (database, services, UI).
+
+* Definition of done
+
+Every ORE sample in the reference suite loads, executes, and
+round-trips with a zero diff against the ground-truth outputs. No
+sample is deferred or partially supported.
+
+* Time horizon
+
+~6 months from current sprint.
+
+* Status
+
+| Field           | Value                                              |
+|-----------------+----------------------------------------------------|
+| State           | IN PROGRESS                                        |
+| Worked towards  | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]] (0.x.x release series)                |
+| Unlocks         | Version 1 (1.x.x release series)                  |
+| Last touched    | 2026-06-02                                         |
+
+* See also
+
+- [[id:C540506E-7129-4CF2-AE3E-6C8BB9C9417F][Milestones]] — catalogue of all milestones.
+- [[id:2F71292F-CDB0-4E2E-B50F-4F02E10597C4][Product vision]] — the durable statement of what ORE Studio is.
+- [[id:1651993D-F3E8-4A73-861C-0A0B03F12CF0][Milestone v2.0]] — the next milestone after this one.

--- a/doc/agile/milestones/v2.org
+++ b/doc/agile/milestones/v2.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID: 1651993D-F3E8-4A73-861C-0A0B03F12CF0
+:END:
+#+title: Milestone v2.0 — Dynamic World
+#+description: Market data ticks, trades change state, curve bootstrapping runs live. Marks graduation from the 1.x.x series to 2.0.0.
+#+type: knowledge
+#+level: cross
+#+filetags: :milestone:v2_0:
+#+created: 2026-06-02
+#+updated: 2026-06-02
+
+* Identity
+
+Milestone v2.0 is the /dynamic world/ release. Time moves: market data
+ticks in real time, trades transition through their lifecycle states,
+and the system responds. ORE Studio supports live curve bootstrapping,
+pricing screens that update as data arrives, and trade change
+workflows. Where v1.0 proved correctness against a static snapshot,
+v2.0 proves correctness in a live environment.
+
+* Theme
+
+Dynamic world: ticking data, live pricing, trade lifecycle, curve
+bootstrapping.
+
+* Mission
+
+- Introduce real-time market data feeds.
+- Support trade state transitions and change workflows.
+- Implement live curve bootstrapping from market data.
+- Provide pricing screens that update on data change.
+- Extend the GUI to cover dynamic data operations.
+
+* Definition of done
+
+Market data ticks, trades change state, curves bootstrap from live
+data, and pricing screens reflect current valuations — all inside ORE
+Studio without manual intervention.
+
+* Time horizon
+
+~18 months after v1.0 is achieved.
+
+* Status
+
+| Field           | Value                                              |
+|-----------------+----------------------------------------------------|
+| State           | PLANNED                                            |
+| Worked towards  | Version 1 (1.x.x release series)                  |
+| Unlocks         | Version 2 (2.x.x release series)                  |
+| Last touched    | 2026-06-02                                         |
+
+* See also
+
+- [[id:C540506E-7129-4CF2-AE3E-6C8BB9C9417F][Milestones]] — catalogue of all milestones.
+- [[id:DDA02748-7054-463B-9238-CC196601403D][Milestone v1.0]] — the preceding milestone.
+- [[id:2F71292F-CDB0-4E2E-B50F-4F02E10597C4][Product vision]] — the durable statement of what ORE Studio is.

--- a/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/story.org
+++ b/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/story.org
@@ -2,7 +2,7 @@
 :ID: EC20475A-E7B4-4DFB-8E55-4B8DA6B36202
 :END:
 #+title: Story: Clarify versioning strategy
-#+description: Rename v0→v1 and introduce v2; rewrite version identities to match the static/dynamic product arc.
+#+description: Introduce milestones as a first-class agile concept; separate version identity from the release series.
 #+type: story
 #+level: s2
 #+filetags: :agile:versions:docs:sprint_19:v0:
@@ -14,31 +14,47 @@ This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id
 
 * Goal
 
-(Describe the user-visible outcome this story delivers.)
+Resolve the naming confusion between a version series (v0, v1 — the
+0.x.x / 1.x.x release containers) and a major release target (v1.0,
+v2.0 — what closes the series). Introduce [[id:65B2F1A0-3C4D-4E7A-9B8D-1F2A3C4D5E6F][milestone]] as the first-class
+concept that owns identity, theme, mission, and DoD. Versions become
+lean containers: release series, sprints, and a pointer to their target
+milestone.
 
 * Status
 
-| Field         | Value                                  |
-|---------------+----------------------------------------|
-| State         | BACKLOG                              |
-| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | Not yet started.                       |
-| Waiting on    | Nothing.                               |
-| Next          | Break the story into tasks.            |
-| Last touched  | 2026-06-02                               |
+| Field         | Value                                                      |
+|---------------+------------------------------------------------------------|
+| State         | DONE                                                       |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                                                  |
+| Now           | Nothing.                                                   |
+| Waiting on    | Nothing.                                                   |
+| Next          | Merge PR #1000.                                            |
+| Last touched  | 2026-06-02                                                 |
 
 * Acceptance
 
--
+- =doc/agile/milestones/= exists with =milestones.org=, =v1.org=, =v2.org=.
+- =milestones.org= explains the milestone/version distinction with a comparison table.
+- =v0/version.org= is lean: no identity/mission/DoD; points to Milestone v1.0.
+- =agile.org= and =versions.org= link to milestones.
+- Glossary has a =Milestone= entry; =Version= entry corrected.
 
 * Tasks
 
-| Task | State | Start | End | Description |
-|------+-------+-------+-----+-------------|
-|      |       |       |     |             |
+#+ATTR_HTML: :class hug-leading
+| Task                                                            | State | Start      | End        | Description                                              |
+|-----------------------------------------------------------------+-------+------------+------------+----------------------------------------------------------|
+| [[id:450D52AB-8BD9-459E-9F77-6C0BD652FFAB][Create milestones infrastructure]]  | DONE  | 2026-06-02 | 2026-06-02 | Scaffold milestones dir, catalogue, v1.org, v2.org; update glossary. |
+| [[id:1109067A-5BD1-4B8F-8B6D-DF671D9EE3BF][Slim v0/version.org]]               | DONE  | 2026-06-02 | 2026-06-02 | Strip identity/mission/DoD; add milestone pointer.       |
+| [[id:EDAE4567-CA33-45A0-8FBF-6A8D062E3DC0][Wire milestones into index docs]]   | DONE  | 2026-06-02 | 2026-06-02 | Link from agile.org and versions.org; At a glance row.   |
 
 * Decisions
 
+- Milestone docs use =#+type: knowledge= for now; a dedicated =milestone= compass type is a future improvement.
+- Version 1 row in milestones catalogue is plain text (no org-roam link) until =v1/version.org= is created.
+
 * Out of scope
 
--
+- Renaming the =v0/= directory — the directory name correctly matches the 0.x.x release series.
+- Creating =v1/version.org= — deferred until v1 work begins.

--- a/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/story.org
+++ b/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/story.org
@@ -1,0 +1,44 @@
+:PROPERTIES:
+:ID: EC20475A-E7B4-4DFB-8E55-4B8DA6B36202
+:END:
+#+title: Story: Clarify versioning strategy
+#+description: Rename v0→v1 and introduce v2; rewrite version identities to match the static/dynamic product arc.
+#+type: story
+#+level: s2
+#+filetags: :agile:versions:docs:sprint_19:v0:
+#+created: 2026-06-02
+#+updated: 2026-06-02
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+(Describe the user-visible outcome this story delivers.)
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-06-02                               |
+
+* Acceptance
+
+-
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+|      |       |       |     |             |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/task_implement_clarify_versioning_strategy.org
+++ b/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/task_implement_clarify_versioning_strategy.org
@@ -61,8 +61,11 @@ release target.
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                    | File                   | Decision | Notes                                        |
+|---+----------------------------------------------------+------------------------+----------+----------------------------------------------|
+| 1 | Story and task files committed in draft state      | story.org, task_*.org  | Fixed    | Filled goal, DONE state, PR refs             |
+| 2 | Sprint.org story description stale (old plan)      | sprint.org             | Fixed    | Updated to reflect actual work done          |
+| 3 | Branch fields on tasks 2+3 wrong; #+pr: empty      | task_rewrite_*.org     | Fixed    | Corrected to clarify-versioning-strategy     |
+| 4 | versions.org dropped MINOR=sprint CMake note       | versions.org           | Fixed    | Restored with updated phrasing               |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/task_implement_clarify_versioning_strategy.org
+++ b/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/task_implement_clarify_versioning_strategy.org
@@ -8,7 +8,7 @@
 #+filetags: :clarify_versioning_strategy:sprint_19:v0:
 #+owner: marco
 #+branch: feature/clarify-versioning-strategy
-#+pr:
+#+pr: 1000
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-02
@@ -31,11 +31,11 @@ release target.
 
 | Field        | Value                                      |
 |--------------+--------------------------------------------|
-| State        | STARTED                                    |
+| State        | DONE                                       |
 | Parent story | [[id:EC20475A-E7B4-4DFB-8E55-4B8DA6B36202][Clarify versioning strategy]]   |
-| Now          | Creating milestone docs and updating glossary. |
+| Now          | Nothing.                                   |
 | Waiting on   | Nothing.                                   |
-| Next         | Commit and open PR.                        |
+| Next         | Merge PR #1000.                            |
 | Last touched | 2026-06-02                                 |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/task_implement_clarify_versioning_strategy.org
+++ b/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/task_implement_clarify_versioning_strategy.org
@@ -1,0 +1,68 @@
+:PROPERTIES:
+:ID: 450D52AB-8BD9-459E-9F77-6C0BD652FFAB
+:END:
+#+title: Task: Create milestones infrastructure
+#+description: Scaffold doc/agile/milestones/ with milestones.org catalogue, v1.org, and v2.org stub; add Milestone entry to glossary; update Version entry.
+#+type: task
+#+level: s1
+#+filetags: :clarify_versioning_strategy:sprint_19:v0:
+#+owner: marco
+#+branch: feature/clarify-versioning-strategy
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-02
+#+updated: 2026-06-02
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:EC20475A-E7B4-4DFB-8E55-4B8DA6B36202][Clarify versioning strategy]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Create the =doc/agile/milestones/= infrastructure. This introduces the
+milestone concept as a first-class agile artefact: a =milestones.org=
+catalogue explaining milestones vs versions, plus individual docs
+=v1.org= (static world → v1.0) and =v2.org= (dynamic world → v2.0).
+Also add a =Milestone= entry to the glossary and correct the =Version=
+entry, which currently conflates the development series with the major
+release target.
+
+* Status
+
+| Field        | Value                                      |
+|--------------+--------------------------------------------|
+| State        | STARTED                                    |
+| Parent story | [[id:EC20475A-E7B4-4DFB-8E55-4B8DA6B36202][Clarify versioning strategy]]   |
+| Now          | Creating milestone docs and updating glossary. |
+| Waiting on   | Nothing.                                   |
+| Next         | Commit and open PR.                        |
+| Last touched | 2026-06-02                                 |
+
+* Acceptance
+
+- =doc/agile/milestones/= exists with =milestones.org=, =v1.org=, =v2.org=.
+- =milestones.org= has a catalogue table and explains the milestone/version distinction.
+- Each milestone doc carries: identity, theme, mission, DoD, time horizon, worked-towards-by, unlocks.
+- Glossary has a =Milestone= entry with org-roam links; =Version= entry updated.
+
+* Plan
+
+1. =compass add knowledge= for =milestones.org= (catalogue + explanation).
+2. =compass add knowledge= for =v1.org= and =v2.org= (individual milestone docs).
+3. Update glossary: add =Milestone=, correct =Version=, update =Version identity=.
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/task_rewrite_version_1_identity.org
+++ b/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/task_rewrite_version_1_identity.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 1109067A-5BD1-4B8F-8B6D-DF671D9EE3BF
+:END:
+#+title: Task: Slim v0/version.org
+#+description: Remove identity/mission/DoD from v0/version.org; add pointer to the v1 milestone; keep only series metadata (0.x.x releases, sprints, status).
+#+type: task
+#+level: s1
+#+filetags: :clarify_versioning_strategy:sprint_19:v0:
+#+owner: marco
+#+branch: feature/rewrite-version-1-identity
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-02
+#+updated: 2026-06-02
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:EC20475A-E7B4-4DFB-8E55-4B8DA6B36202][Clarify versioning strategy]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:EC20475A-E7B4-4DFB-8E55-4B8DA6B36202][Clarify versioning strategy]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-02                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/task_rewrite_version_1_identity.org
+++ b/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/task_rewrite_version_1_identity.org
@@ -7,8 +7,8 @@
 #+level: s1
 #+filetags: :clarify_versioning_strategy:sprint_19:v0:
 #+owner: marco
-#+branch: feature/rewrite-version-1-identity
-#+pr:
+#+branch: feature/clarify-versioning-strategy
+#+pr: 1000
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-02
@@ -19,36 +19,33 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Strip =Identity=, =Mission=, =Definition of done=, and =Release scope=
+sections from =doc/agile/versions/v0/version.org=. Those now live in
+[[id:DDA02748-7054-463B-9238-CC196601403D][Milestone v1.0 — Static World]]. Add a =Target milestone= row to the
+Status table and update the opening paragraph to point there.
 
 * Status
 
-| Field        | Value                                  |
-|--------------+----------------------------------------|
-| State        | BACKLOG                              |
-| Parent story | [[id:EC20475A-E7B4-4DFB-8E55-4B8DA6B36202][Clarify versioning strategy]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-02                               |
+| Field        | Value                               |
+|--------------+-------------------------------------|
+| State        | DONE                                |
+| Parent story | [[id:EC20475A-E7B4-4DFB-8E55-4B8DA6B36202][Clarify versioning strategy]]        |
+| Now          | Nothing.                            |
+| Waiting on   | Nothing.                            |
+| Next         | Merge PR #1000.                     |
+| Last touched | 2026-06-02                          |
 
 * Acceptance
 
--
-
-* Plan
-
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
-
-* Notes
+- =v0/version.org= has no =Identity=, =Mission=, =DoD=, or =Release scope= sections.
+- Status table has a =Target milestone= row linking to =[[id:DDA02748-7054-463B-9238-CC196601403D][Milestone v1.0]]=.
+- Opening paragraph redirects the reader to the milestone for identity.
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR   | Title                                              |
+|------+----------------------------------------------------|
+| 1000 | [agile] Introduce milestone concept; clarify versioning strategy |
 
 * Review
 
@@ -57,3 +54,6 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+=v0/version.org= reduced from 93 to ~35 lines. Identity content now
+lives exclusively in =doc/agile/milestones/v1.org=.

--- a/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/task_scaffold_version_2_doc.org
+++ b/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/task_scaffold_version_2_doc.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: EDAE4567-CA33-45A0-8FBF-6A8D062E3DC0
+:END:
+#+title: Task: Wire milestones into agile index docs
+#+description: Link milestones.org from agile.org and versions.org; add Next Milestone row to agile.org At a glance table; update version.org glossary entry example.
+#+type: task
+#+level: s1
+#+filetags: :clarify_versioning_strategy:sprint_19:v0:
+#+owner: marco
+#+branch: feature/scaffold-version-2-doc
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-02
+#+updated: 2026-06-02
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:EC20475A-E7B4-4DFB-8E55-4B8DA6B36202][Clarify versioning strategy]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:EC20475A-E7B4-4DFB-8E55-4B8DA6B36202][Clarify versioning strategy]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-02                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/task_scaffold_version_2_doc.org
+++ b/doc/agile/versions/v0/sprint_19/clarify_versioning_strategy/task_scaffold_version_2_doc.org
@@ -7,8 +7,8 @@
 #+level: s1
 #+filetags: :clarify_versioning_strategy:sprint_19:v0:
 #+owner: marco
-#+branch: feature/scaffold-version-2-doc
-#+pr:
+#+branch: feature/clarify-versioning-strategy
+#+pr: 1000
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-02
@@ -19,36 +19,34 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Wire the new [[id:C540506E-7129-4CF2-AE3E-6C8BB9C9417F][Milestones]] index into the agile information architecture.
+Add a Milestones bullet to =agile.org=, a =Target milestone= row to the
+=At a glance= table, and update =versions.org= to describe version
+series rather than missions, with a =See also= link to milestones.
 
 * Status
 
-| Field        | Value                                  |
-|--------------+----------------------------------------|
-| State        | BACKLOG                              |
-| Parent story | [[id:EC20475A-E7B4-4DFB-8E55-4B8DA6B36202][Clarify versioning strategy]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-02                               |
+| Field        | Value                               |
+|--------------+-------------------------------------|
+| State        | DONE                                |
+| Parent story | [[id:EC20475A-E7B4-4DFB-8E55-4B8DA6B36202][Clarify versioning strategy]]        |
+| Now          | Nothing.                            |
+| Waiting on   | Nothing.                            |
+| Next         | Merge PR #1000.                     |
+| Last touched | 2026-06-02                          |
 
 * Acceptance
 
--
-
-* Plan
-
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
-
-* Notes
+- =agile.org= index list includes a Milestones bullet with org-roam link.
+- =agile.org= At a glance table has a =Target milestone= row.
+- =versions.org= opening describes version as release series; links to milestones.
+- =versions.org= table has =Series= and =Target milestone= columns.
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR   | Title                                              |
+|------+----------------------------------------------------|
+| 1000 | [agile] Introduce milestone concept; clarify versioning strategy |
 
 * Review
 
@@ -57,3 +55,6 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+=agile.org= and =versions.org= now link into =doc/agile/milestones/=.
+The agile entry point is complete.

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -100,7 +100,7 @@ dedicated thread pool to prevent =QThreadPool= starvation.
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:A48DEC19-E769-4C71-AC0B-434B551DC801][Open sprint 19]] | STARTED | 2026-05-29 | | Scaffold sprint 19, wire version manifest, bump version, PR. |
-| [[id:EC20475A-E7B4-4DFB-8E55-4B8DA6B36202][Clarify versioning strategy]] | STARTED | 2026-06-02 | | Rename v0→v1, rewrite version 1 identity (static/roundtrips/zero-diffs), scaffold version 2 doc (dynamic/time). |
+| [[id:EC20475A-E7B4-4DFB-8E55-4B8DA6B36202][Clarify versioning strategy]] | DONE | 2026-06-02 | 2026-06-02 | Introduce milestone concept; separate version identity from release series; scaffold v1.0 and v2.0 milestone docs. |
 | [[id:2A6F5FE2-8C50-494F-948F-6BA519075FA9][Sprint planning]] | DONE | 2026-05-29 | 2026-05-29 | Select stories from backlog, size tasks, confirm mission. |
 | [[id:73D162FD-92D6-4567-8D94-4368C97F96E4][Sprint health review — System 2 analysis]] | STARTED | 2026-05-31 | | Periodic System 2 health checks: goal alignment, load, PR velocity, story/task balance, focus, verdict. |
 

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -100,6 +100,7 @@ dedicated thread pool to prevent =QThreadPool= starvation.
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:A48DEC19-E769-4C71-AC0B-434B551DC801][Open sprint 19]] | STARTED | 2026-05-29 | | Scaffold sprint 19, wire version manifest, bump version, PR. |
+| [[id:EC20475A-E7B4-4DFB-8E55-4B8DA6B36202][Clarify versioning strategy]] | STARTED | 2026-06-02 | | Rename v0→v1, rewrite version 1 identity (static/roundtrips/zero-diffs), scaffold version 2 doc (dynamic/time). |
 | [[id:2A6F5FE2-8C50-494F-948F-6BA519075FA9][Sprint planning]] | DONE | 2026-05-29 | 2026-05-29 | Select stories from backlog, size tasks, confirm mission. |
 | [[id:73D162FD-92D6-4567-8D94-4368C97F96E4][Sprint health review — System 2 analysis]] | STARTED | 2026-05-31 | | Periodic System 2 health checks: goal alignment, load, PR velocity, story/task balance, focus, verdict. |
 

--- a/doc/agile/versions/v0/version.org
+++ b/doc/agile/versions/v0/version.org
@@ -2,51 +2,30 @@
 :ID: E6FD30ED-963E-4705-B414-91BF471C23D0
 :END:
 #+title: Version 0
-#+description: The pre-1.0 alpha version. Establishes architecture, models all ORE inputs/outputs, and adds GUI for all data operations.
+#+description: The 0.x.x release series. Works towards Milestone v1.0 (Static World).
 #+type: version
 #+level: s4
-#+filetags: :v0:alpha:
+#+filetags: :v0:
 #+created: 2024-06-15
-#+updated: 2026-05-29
+#+updated: 2026-06-02
 #+todo: STARTED | RELEASED
 
-This page documents *v0* — the pre-1.0 alpha [[id:CA4D4BDE-2EAB-4F0A-BC8B-7C0BCB17BC82][version]] of ORE Studio. It
-captures v0's identity, mission, definition of done, current status,
-and the sprints that compose it. For the durable, version-independent
+This page documents *v0* — the 0.x.x [[id:CA4D4BDE-2EAB-4F0A-BC8B-7C0BCB17BC82][version]] series of ORE Studio. It
+captures the series status and the sprints that compose it. The
+identity, mission, and definition of done live in the target
+[[id:DDA02748-7054-463B-9238-CC196601403D][Milestone v1.0 — Static World]]. For the durable, version-independent
 statement of what ORE Studio is, see the [[id:2F71292F-CDB0-4E2E-B50F-4F02E10597C4][product vision]].
-
-* Identity
-
-Version 0 is the alpha line — the pre-1.0 effort that lays down the
-architectural foundations and brings every ORE input and output into a
-persistent, GUI-driven environment. It is not feature-complete; it is the
-version where the shape of ORE Studio is settled.
-
-What makes v0 distinct from v1.0: v0 is allowed to be incomplete and to
-break compatibility freely. The product identity (what we are building)
-is durable; the implementation in v0 is not — for the durable statement
-see [[id:2F71292F-CDB0-4E2E-B50F-4F02E10597C4][ORE Studio product vision]].
-
-* Mission
-
-- Establish the main architectural tiers (database, services, UI).
-- Model all ORE XML inputs and outputs.
-- Add GUI support for every data operation.
-
-* Definition of done
-
-V0 closes when a user can load any ORE sample, execute it, and view the
-results graphically inside ORE Studio.
 
 * Status
 
-| Field        | Value                                                       |
-|--------------+-------------------------------------------------------------|
-| State        | STARTED                                                     |
-| Now          | Sprint 19 open; entity health review and CI fix stories lined up. |
-| Waiting on   | Nothing.                                                    |
-| Next         | Work sprint 19 stories.                                     |
-| Last touched | 2026-05-29                                                  |
+| Field            | Value                                                             |
+|------------------+-------------------------------------------------------------------|
+| State            | STARTED                                                           |
+| Target milestone | [[id:DDA02748-7054-463B-9238-CC196601403D][Milestone v1.0 — Static World]]                                     |
+| Now              | Sprint 19 open; entity health review and CI fix stories lined up. |
+| Waiting on       | Nothing.                                                          |
+| Next             | Work sprint 19 stories.                                           |
+| Last touched     | 2026-06-02                                                        |
 
 * Sprints
 
@@ -75,18 +54,3 @@ the current sprint; the rest are closed.
 | [[id:A2B8A670-3B02-11F1-BCE2-4B06F4BBA5D7][Sprint 17]] | 2026-04-18 |            | Windows/MSVC portability, symbol visibility, ORE conventions, workspace, DQ publish, service isolation, SQL codegen, Qt UI, v2 docs. |
 | [[id:1737C00C-699A-475A-BC94-743C6CDA1001][Sprint 18]] | 2026-05-22 | 2026-05-29 | Compass CLI, LLM-first docs, agile artefact improvements; ORE pipeline deferred. |
 | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] | 2026-05-29 |            | Entity health review post-NATS; manual docs; evaluation tooling; CI fixes.       |
-
-* Release scope
-
-In scope for v0:
-
-- All ORE XML input types modelled and importable.
-- All ORE output types displayable in the GUI.
-- Persistent storage for every data operation.
-- A working Qt UI that exercises the end-to-end pipeline.
-
-Deferred to later versions:
-
-- Performance optimisation beyond "fast enough to demo".
-- Multi-user / multi-tenant features beyond the minimum scaffolding.
-- Cloud deployment.

--- a/doc/agile/versions/versions.org
+++ b/doc/agile/versions/versions.org
@@ -12,8 +12,9 @@
 This is the index of ORE Studio /versions/. A [[id:CA4D4BDE-2EAB-4F0A-BC8B-7C0BCB17BC82][version]] is a release
 series — a coherent group of [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprints]] producing incremental builds
 (0.x.x, 1.x.x, …) as it works towards a target [[id:65B2F1A0-3C4D-4E7A-9B8D-1F2A3C4D5E6F][milestone]]. The version
-name matches CMake's =MAJOR= component; the milestone is what closes
-the version and cuts the major release. See [[id:C540506E-7129-4CF2-AE3E-6C8BB9C9417F][Milestones]] for the targets.
+name matches CMake's =MAJOR= component; =MINOR= is the sprint number
+inside the version. The milestone is what closes the version and cuts
+the major release. See [[id:C540506E-7129-4CF2-AE3E-6C8BB9C9417F][Milestones]] for the targets.
 
 * Versions
 

--- a/doc/agile/versions/versions.org
+++ b/doc/agile/versions/versions.org
@@ -2,29 +2,18 @@
 :ID: 37C10313-E6E9-4D42-B82D-B6758D0A3AD9
 :END:
 #+title: Versions
-#+description: Index of every ORE Studio version — what each is for, when it ran, and which sprints compose it.
+#+description: Index of every ORE Studio version series — which release series each is, and which milestone it targets.
 #+type: knowledge
 #+level: cross
 #+filetags: :versions:index:knowledge:
 #+created: 2026-05-21
-#+updated: 2026-05-21
+#+updated: 2026-06-02
 
-This is the index of ORE Studio /versions/. A [[id:CA4D4BDE-2EAB-4F0A-BC8B-7C0BCB17BC82][version]] is a coherent
-group of [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprints]] aligned to a single version mission — what that
-release of the product is /for/. Versions are the outermost unit of
-planning under the [[id:2F71292F-CDB0-4E2E-B50F-4F02E10597C4][product vision]], and CMake's =MAJOR.MINOR.PATCH=
-encodes them: =MAJOR= is the version, =MINOR= is the sprint inside it.
-
-* What a version is for
-
-A version is the surface on which we agree what "shipping" means for a
-period of months. Its [[id:8B29A8D8-E004-4E87-B81D-ABEAF68F2B98][Definition of done]] is the contract: when this
-list of capabilities is met, the version can be released.
-
-Sprints are the work; the version is the destination. A version
-closes when its DoD is met; until then, every sprint inside it
-contributes to that DoD. The [[id:46DFE47F-967B-4C24-95BF-3E21F97CFD20][agile process]] describes how the loop
-runs at the sprint level.
+This is the index of ORE Studio /versions/. A [[id:CA4D4BDE-2EAB-4F0A-BC8B-7C0BCB17BC82][version]] is a release
+series — a coherent group of [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprints]] producing incremental builds
+(0.x.x, 1.x.x, …) as it works towards a target [[id:65B2F1A0-3C4D-4E7A-9B8D-1F2A3C4D5E6F][milestone]]. The version
+name matches CMake's =MAJOR= component; the milestone is what closes
+the version and cuts the major release. See [[id:C540506E-7129-4CF2-AE3E-6C8BB9C9417F][Milestones]] for the targets.
 
 * Versions
 
@@ -32,6 +21,11 @@ In lexicographic order. The lexicographically highest folder is the
 active version; the rest are released.
 
 #+ATTR_HTML: :class hug-leading
-| Version                                                         | Start      | End | State    | Mission                                                                            |
-|-----------------------------------------------------------------+------------+-----+----------+------------------------------------------------------------------------------------|
-| [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]] | 2024-06-15 |     | STARTED  | Establish architecture, model all ORE inputs/outputs, add GUI for every operation. |
+| Version                                       | Series | Start      | End | State   | Target milestone                                      |
+|-----------------------------------------------+--------+------------+-----+---------+-------------------------------------------------------|
+| [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]] | 0.x.x  | 2024-06-15 |     | STARTED | [[id:DDA02748-7054-463B-9238-CC196601403D][Milestone v1.0 — Static World]]   |
+
+* See also
+
+- [[id:C540506E-7129-4CF2-AE3E-6C8BB9C9417F][Milestones]] — the named release targets each version series works towards.
+- [[id:E5635EAC-CCE9-C0A4-A00B-C1780FF4A88E][Agile]] — entry point to the agile information architecture.

--- a/doc/meta/glossary.org
+++ b/doc/meta/glossary.org
@@ -93,34 +93,52 @@ with [[id:6CA8B181-BD81-4EF4-AF27-64F5491D62F0][System 4]].
 | How to generate | See [[id:7D72A9DA-984F-4130-BFF6-97B66B233907][Sprint closure]] in the agile process — release notes,        |
 |                 | release cut, post-mortem are steps 2–4 of the closure sequence. |
 
+* Milestone
+:PROPERTIES:
+:ID: 65B2F1A0-3C4D-4E7A-9B8D-1F2A3C4D5E6F
+:END:
+
+The named major release target that a [[id:CA4D4BDE-2EAB-4F0A-BC8B-7C0BCB17BC82][version]] series works towards. A
+milestone owns the /what and why/: identity, theme, mission, definition
+of done, and time horizon. It does not contain sprints — that is the
+version's job. When the milestone's definition of done is met, the
+current version series closes and the software cuts the milestone
+release (e.g. 1.0.0). The next version series then begins.
+
+#+ATTR_HTML: :class hug-leading
+| Field           | Value                                          |
+|-----------------+------------------------------------------------|
+| Owner           | [[id:6CA8B181-BD81-4EF4-AF27-64F5491D62F0][System 4]]                                       |
+| Example         | [[id:DDA02748-7054-463B-9238-CC196601403D][Milestone v1.0 — Static World]]                  |
+| Inventory       | [[id:C540506E-7129-4CF2-AE3E-6C8BB9C9417F][Milestones]]                                     |
+
 * Version
 :PROPERTIES:
 :ID: CA4D4BDE-2EAB-4F0A-BC8B-7C0BCB17BC82
 :END:
 
-A major release target (e.g. 1.0). A coherent set of sprints.
+A release series — a coherent set of [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprints]] producing incremental
+builds (e.g. 0.0.x, 1.0.x) as it works towards a target [[id:65B2F1A0-3C4D-4E7A-9B8D-1F2A3C4D5E6F][milestone]]. The
+version name matches the CMake =MAJOR= component: =v0= produces 0.x.x
+builds; =v1= produces 1.x.x builds. A version does not carry a mission
+statement of its own — that lives in its target milestone.
 
 #+ATTR_HTML: :class hug-leading
-| Field           | Value                            |
-|-----------------+----------------------------------|
-| Owner           | [[id:6CA8B181-BD81-4EF4-AF27-64F5491D62F0][System 4]]                         |
-| How to generate | [[id:8FC15EA1-AB30-47BE-993F-ED624A57F761][New version]] in the codegen recipe |
-| Example         | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]]                        |
-| Inventory       | [[id:37C10313-E6E9-4D42-B82D-B6758D0A3AD9][Versions]]                         |
+| Field           | Value                              |
+|-----------------+------------------------------------|
+| Owner           | [[id:6CA8B181-BD81-4EF4-AF27-64F5491D62F0][System 4]]                           |
+| How to generate | [[id:8FC15EA1-AB30-47BE-993F-ED624A57F761][New version]] in the codegen recipe   |
+| Example         | [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]] (targets [[id:DDA02748-7054-463B-9238-CC196601403D][Milestone v1.0]])   |
+| Inventory       | [[id:37C10313-E6E9-4D42-B82D-B6758D0A3AD9][Versions]]                           |
 
 * Version identity
 :PROPERTIES:
 :ID: 83BC06E5-77DD-4ABA-87CB-48A10EC0208A
 :END:
 
-The mini-mission of a version: what it exists to deliver, what makes it
-distinct.
-
-#+ATTR_HTML: :class hug-leading
-| Field   | Value                                 |
-|---------+---------------------------------------|
-| Owner   | [[id:6CA8B181-BD81-4EF4-AF27-64F5491D62F0][System 4]]                              |
-| Example | the =* Identity= section of [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]] |
+Deprecated. Identity now lives in the target [[id:65B2F1A0-3C4D-4E7A-9B8D-1F2A3C4D5E6F][milestone]] document, not
+in the version. See the =* Identity= section of [[id:DDA02748-7054-463B-9238-CC196601403D][Milestone v1.0]] for the
+current example.
 
 * Product identity
 :PROPERTIES:


### PR DESCRIPTION
## Summary

- Introduces `doc/agile/milestones/` as a first-class agile artefact, separating version identity from the release series
- Versions now own the release series, sprints, and status; milestones own identity, theme, mission, DoD, and time horizon
- Adds `milestones.org` catalogue, `v1.org` (Static World), and `v2.org` (Dynamic World stub)
- Slims `v0/version.org` to series metadata only, pointing to Milestone v1.0
- Updates glossary with new `Milestone` entry and corrected `Version` definition
- Wires milestones into `agile.org` and `versions.org`

## Changes

- `doc/agile/milestones/milestones.org` — catalogue explaining milestone vs version distinction
- `doc/agile/milestones/v1.org` — Static World: end-to-end ORE samples, roundtrips, zero diffs, ~6 month horizon
- `doc/agile/milestones/v2.org` — Dynamic World: ticking market data, trade changes, curve bootstrapping, ~18 month horizon
- `doc/agile/versions/v0/version.org` — stripped to release series + sprints table + milestone link
- `doc/agile/versions/versions.org` — updated to describe version series not missions; links to milestones
- `doc/agile/agile.org` — milestones bullet added; At a glance gains Target milestone row
- `doc/meta/glossary.org` — new Milestone entry; Version entry corrected; Version identity deprecated

🤖 Generated with [Claude Code](https://claude.com/claude-code)