### PR TITLE
[agile] Fix 4 duplicate org-roam IDs in sprint_18/ore_samples_support

### DIFF
--- a/doc/agile/versions/v0/sprint_18/ore_samples_support/task_fix_portfolios_and_books_not_visible_in_workspace_context.org
+++ b/doc/agile/versions/v0/sprint_18/ore_samples_support/task_fix_portfolios_and_books_not_visible_in_workspace_context.org
@@ -1,5 +1,5 @@
 :PROPERTIES:
-:ID: 1BFBA7F6-59BF-4814-BECE-C2AB75F78C41
+:ID: BEAD6EE5-BE2D-4CEA-BBE8-170E5DD65114
 :END:
 #+title: Task: Fix: portfolios and books not visible in workspace context
 #+description: Fix the bug where portfolios and books are not visible when a workspace is active.

--- a/doc/agile/versions/v0/sprint_18/ore_samples_support/task_workspace_full_entity_cpp_core.org
+++ b/doc/agile/versions/v0/sprint_18/ore_samples_support/task_workspace_full_entity_cpp_core.org
@@ -1,5 +1,5 @@
 :PROPERTIES:
-:ID: 71EB9DB0-1F5C-48D0-AA2E-E47A9F487B86
+:ID: C8FD97CA-F4B5-47D5-BD0D-565739DFFDDE
 :END:
 #+title: Task: Workspace full entity: C++ core
 #+description: Implement the C++ core for workspace as a full standard entity: repository, service, and history support generated from the model.

--- a/doc/agile/versions/v0/sprint_18/ore_samples_support/task_workspace_full_entity_model_and_api.org
+++ b/doc/agile/versions/v0/sprint_18/ore_samples_support/task_workspace_full_entity_model_and_api.org
@@ -1,5 +1,5 @@
 :PROPERTIES:
-:ID: C10117BF-4054-4B31-AF2F-158EE8ABE88A
+:ID: 86E8D4E2-AE8A-4022-90D1-5AF0C3D9E0F7
 :END:
 #+title: Task: Workspace full entity: model and API
 #+description: Promote workspace to a full standard entity at the model and API layer: history table, generated detail dialog metadata, and API surface.

--- a/doc/agile/versions/v0/sprint_18/ore_samples_support/task_workspace_full_entity_qt_ui.org
+++ b/doc/agile/versions/v0/sprint_18/ore_samples_support/task_workspace_full_entity_qt_ui.org
@@ -1,5 +1,5 @@
 :PROPERTIES:
-:ID: FF7AAAB1-9C6D-4304-A74C-62FA45188D45
+:ID: 21E7855C-832B-4672-B94A-C41B7563B369
 :END:
 #+title: Task: Workspace full entity: Qt UI
 #+description: Wire the generated workspace detail dialog and history view into the Qt client.

--- a/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_validate_codegen_after_subcomponent_regroup.org
+++ b/doc/agile/versions/v0/sprint_19/codegen_org_model_migration/task_validate_codegen_after_subcomponent_regroup.org
@@ -19,7 +19,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-PR #997 ([[id:164255805][Regroup C++ components under product-group parent
+PR #997 ([[id:FF9397CF-E6F6-44C3-9641-882EEA21C58D][Regroup C++ components under product-group parent
 directories]]) moved every per-facet subcomponent from a top-level
 =projects/ores.qt.refdata/= shape into the parent
 =projects/ores.qt/refdata/= shape (and the same for =ores.cli=,


### PR DESCRIPTION
## Summary

- Fixes 4 duplicate `:ID:` entries found during site build (org-roam warned: "4 duplicate IDs found")
- All duplicates were in `doc/agile/versions/v0/sprint_18/ore_samples_support/`
- Each was a pair of original scaffold + phase replacement that shared a UUID
- The phase files (which have PR numbers and are the live versions) keep their IDs
- The unused scaffold originals receive fresh UUIDs

## Pairs fixed

| Original (gets new UUID) | Live version (keeps UUID) |
|---|---|
| `task_fix_portfolios_and_books_not_visible_in_workspace_context.org` (BACKLOG) | `task_fix_workspace_portfolio_book_visibility.org` (DONE) |
| `task_workspace_full_entity_cpp_core.org` (BACKLOG) | `task_workspace_full_entity_phase2.org` (DONE, PR #856) |
| `task_workspace_full_entity_model_and_api.org` (no PR) | `task_workspace_full_entity_phase1.org` (DONE, PR #856) |
| `task_workspace_full_entity_qt_ui.org` (no PR) | `task_workspace_full_entity_phase3.org` (DONE, PR #858) |

No external org-roam links were affected (none of the duplicate IDs were referenced outside their own directory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)