### PR TITLE
[ores.qt.api,ores.qt.trading] Fix MSVC C1202 in BookMdiWindow via exportPortfolio()

### DIFF
--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
@@ -143,18 +143,93 @@ All parse branches must log at the correct level:
 - =error= on any deserialise failure, including the raw JSON fragment and the full rfl
   error message.
 
-** export_portfolio latent issue
+** The template instantiation leak pattern (root cause of repeated C1202)
 
-=export_portfolio_response= contains =vector<trade_export_item>= where each item has
-=trade_instrument instrument=. The generic =process_authenticated_request= template reads
-it with =AddTagsToVariants=. This path is not fixed by this story (it is Linux-only in
-practice today) but is a known latent issue for a future story.
+This is the underlying design issue that drove the recurring C1202 cascade. Understanding
+it is essential for preventing future occurrences.
 
-*Update (2026-06-02):* The =AddTagsToVariants= was removed in task 7 (PR #978), but the
-underlying issue surfaced on MSVC in =BookMdiWindow.cpp=: =process_authenticated_request=
-is a template that instantiates =rfl::json::read<ResponseType>= in the CALLER's TU.
-=BookMdiWindow.cpp= (step 4651/4936) already has a saturated template context; adding
-=swap_leg='s 19-field Literal triggers C1202. Task 8 addresses this systematically.
+*** What the pattern is
+
+=ClientManager.hpp= defines =process_authenticated_request<T>= as a *function template*:
+
+#+begin_src cpp
+template <nats_request RequestType>
+auto process_authenticated_request(RequestType request, ...)
+    -> std::expected<typename RequestType::response_type, std::string> {
+    using ResponseType = typename RequestType::response_type;
+    // ...
+    auto result = rfl::json::read<ResponseType>(raw);  // <-- instantiated in CALLER'S TU
+    // ...
+}
+#+end_src
+
+Because the body is in the header, every =.cpp= that calls this template compiles
+=rfl::json::read<ResponseType>= into its own translation unit. MSVC tracks a "template
+dependency graph" per TU: all =rfl::StringLiteral<N>= field-name types from every
+=rfl::json::read<X>= instantiation accumulate in that graph.
+
+*** When it triggers C1202
+
+C1202 fires when *two conditions coincide*:
+
+1. *The caller TU already has a saturated dependency graph.* A file compiled late in the
+   build (e.g. =BookMdiWindow.cpp= at step 4651/4936) includes many headers. Each header's
+   templates — not just rfl — add nodes to MSVC's dependency graph. By the time compilation
+   reaches the =process_authenticated_request= call, the graph is already large.
+
+2. *The ResponseType contains =trade_instrument= (or another type whose rfl reflection
+   chain reaches =swap_leg= or another struct with 15+ fields).* Adding even 19 new
+   =StringLiteral<N>= nodes (one per =swap_leg= field) is enough to push the graph over
+   MSVC's internal limit.
+
+Neither condition alone is sufficient. The pattern is invisible on Linux (GCC has more
+permissive limits) and only surfaces on MSVC for callers that are large enough.
+
+*** Proactive audit: how to find at-risk call sites
+
+The rule: a call site is at risk if =RequestType::response_type= contains
+=trade_instrument= (directly or via =trade_export_item=) and the calling file is large
+enough to saturate MSVC's dependency graph.
+
+*Step 1* — find all response types containing =trade_instrument= or =trade_export_item=:
+
+#+begin_src sh
+grep -rn "trade_instrument\|trade_export_item" \
+    projects --include="*.hpp" | \
+    grep "struct\|vector\|instrument " | \
+    grep -v "build\|vcpkg\|//\|domain/"
+#+end_src
+
+*Step 2* — from those types, identify which are =response_type= aliases of a request type
+that is passed to =process_authenticated_request=:
+
+#+begin_src sh
+grep -rn "process_authenticated_request\|process_request" \
+    projects --include="*.cpp" | grep -v "build\|vcpkg\|test"
+#+end_src
+
+Then cross-reference the inferred request type at each call site with the request type's
+=response_type=.
+
+*Current audit result (2026-06-02):*
+
+| Call site | Request type | response_type | Contains trade_instrument? | Risk |
+|-----------+--------------+---------------+----------------------------+------|
+| =BookMdiWindow.cpp:476= | =export_portfolio_request= | =export_portfolio_response= → =trade_export_item= → =trade_instrument= | Yes | HIGH — fix in task 8 |
+| All other call sites | various (save, get, delete, list) | simple domain structs | No | Safe |
+
+Only =export_portfolio_request= is at risk. =get_trade_instrument_request= also carries
+=trade_instrument= in its =response_type=, but it is handled by =parse_trade_instrument()=
+directly and is never passed through =process_authenticated_request=.
+
+*** The fix rule
+
+For any =process_authenticated_request<T>= call site where =T::response_type= contains
+=trade_instrument=: replace it with a *concrete (non-template) method* on =ClientManager=,
+implemented in a dedicated =.cpp= file. This isolates the =rfl::json::read<ResponseType>=
+instantiation to a fresh TU where MSVC's dependency graph starts clean.
+
+Pattern used in this story: =parse_swap_instruments.cpp=, =ClientManagerExportPortfolio.cpp=.
 
 ** Linear trace of C1202 errors and fixes
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org
@@ -33,10 +33,10 @@ the variant from the Qt UI boundary as well, since the variant serves no purpose
 |---------------+-----------------------------------------------------------------------------------------------|
 | State         | STARTED                                                                                       |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                                       |
-| Now           | Task 7: PR open for ClientManager AddTagsToVariants + archiver export; awaiting CI.           |
-| Waiting on    | CI green + review on task 7 PR.                                                               |
-| Next          | Merge task 7 PR; verify all CI green; close story.                                            |
-| Last touched  | 2026-06-01                                                                                    |
+| Now           | Task 8: investigating ClientManager template C1202 in BookMdiWindow.cpp.                      |
+| Waiting on    | Task 8 PR + CI green.                                                                         |
+| Next          | Merge task 8 PR; verify Windows CI fully green; close story.                                  |
+| Last touched  | 2026-06-02                                                                                    |
 
 * Acceptance
 
@@ -62,6 +62,7 @@ the variant from the Qt UI boundary as well, since the variant serves no purpose
 | [[id:2991CE7B-48F3-489F-9792-1BCB529E85BB][Delete leftover get_trade_detail code and fix remaining AddTagsToVariants use]] | DONE    | 2026-05-31 | 2026-05-31 | Delete ClientManagerTradeDetail.cpp; remove getTradeDetail API; restore macOS/Windows CI.    |
 | [[id:D9E63BBA-82CE-4FD3-9354-47A0A12ED108][Fix missing Windows DLL export macros on service parser classes]]              | DONE    | 2026-06-01 | 2026-06-01 | Add ORES_*_SERVICE_EXPORT to 16 service parser.hpp files; restore Windows CI linker.          |
 | [[id:4BF920B2-CA2B-40EF-B463-DDC13D0C2516][Fix ClientManager AddTagsToVariants and archiver DLL export]]                  | STARTED | 2026-06-01 |            | Remove AddTagsToVariants from ClientManager reads; add ORES_COMPUTE_WRAPPER_EXPORT to archiver. |
+| [[id:A10ACBA5-BABD-4B60-8CF3-79108BA9DA92][Investigate and fix ClientManager template C1202 for complex response types]]  | STARTED | 2026-06-02 |            | process_authenticated_request<T> injects rfl in caller's TU; fix by concrete method for export_portfolio. |
 
 * Decisions
 
@@ -148,6 +149,26 @@ All parse branches must log at the correct level:
 =trade_instrument instrument=. The generic =process_authenticated_request= template reads
 it with =AddTagsToVariants=. This path is not fixed by this story (it is Linux-only in
 practice today) but is a known latent issue for a future story.
+
+*Update (2026-06-02):* The =AddTagsToVariants= was removed in task 7 (PR #978), but the
+underlying issue surfaced on MSVC in =BookMdiWindow.cpp=: =process_authenticated_request=
+is a template that instantiates =rfl::json::read<ResponseType>= in the CALLER's TU.
+=BookMdiWindow.cpp= (step 4651/4936) already has a saturated template context; adding
+=swap_leg='s 19-field Literal triggers C1202. Task 8 addresses this systematically.
+
+** Linear trace of C1202 errors and fixes
+
+This story produced a sequence of progressively deeper C1202 fixes, each exposing the
+next layer. The full sequence:
+
+| # | Error location | Fields / cause | Fix | PR |
+|---+----------------+----------------+-----+----|
+| 1 | =ClientManagerTradeDetail.cpp= | =trade_instrument= variant 502-field =rfl::Literal= via =AddTagsToVariants= | Delete file; rewrite as two-phase dispatch (tasks 2–5) | multiple |
+| 2 | =ClientManager.hpp= (=process_authenticated_request=) | =export_portfolio_response= → 502-field =AddTagsToVariants= Literal on Clang/MSVC | Remove =AddTagsToVariants= from all 4 =json::read= call sites | PR #978 |
+| 3 | =ores.compute.wrapper/filesystem/archiver.hpp= | Missing =ORES_COMPUTE_WRAPPER_EXPORT= on Windows Clang | Add export macro | PR #978 |
+| 4 | =parse_trade_instrument.cpp= | Combined =swaption_instrument= (18) + =swap_leg= (19) = 29-field Literal: two types in one =rfl::json::read= | Split each leg-based read into two passes (instrument + legs separately) | PR #982 |
+| 5 | =parse_trade_instrument.cpp= | Accumulated TU context: flat/FX/equity types fill MSVC's graph before swap types start; =swaption_instr_outer= (19 fields) pushes it over | Move all 9 swap types to =parse_swap_instruments.cpp= (fresh TU) | PR #985 |
+| 6 | =BookMdiWindow.cpp= | =process_authenticated_request<export_portfolio_request>= is a template → instantiates =rfl::json::read<export_portfolio_response>= in BookMdiWindow's already-saturated context; =swap_leg= (19 fields) triggers C1202 | Concrete =ClientManager::exportPortfolio()= in a dedicated TU | task 8 |
 
 * See also
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_investigate_and_fix_clientmanager_template_c1202.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_investigate_and_fix_clientmanager_template_c1202.org
@@ -9,7 +9,7 @@
 #+owner: marco
 #+branch: feature/fix-windows-macos-ci
 #+pr: 1010
-#+blocked_on: none
+#+blocked_on:
 #+blocked_since:
 #+created: 2026-06-02
 #+updated: 2026-06-02

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_investigate_and_fix_clientmanager_template_c1202.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_investigate_and_fix_clientmanager_template_c1202.org
@@ -8,7 +8,7 @@
 #+filetags: :fix_rfl_complexity:sprint_19:v0:
 #+owner: marco
 #+branch: feature/fix-windows-macos-ci
-#+pr:
+#+pr: 1010
 #+blocked_on: none
 #+blocked_since:
 #+created: 2026-06-02
@@ -144,7 +144,7 @@ in future, the same pattern applies.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1010][#1010]] | [ores.qt.api,ores.qt.trading] Fix MSVC C1202 in BookMdiWindow via exportPortfolio() |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_investigate_and_fix_clientmanager_template_c1202.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_investigate_and_fix_clientmanager_template_c1202.org
@@ -148,8 +148,9 @@ in future, the same pattern applies.
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                                         | File                                       | Decision | Notes          |
+|---+-------------------------------------------------------------------------+--------------------------------------------+----------+----------------|
+| 1 | Leave #+blocked_on: empty rather than using placeholder 'none'          | task_investigate_and_fix_*.org             | Accept   | Fixed 326a5206d |
+| 2 | Use type-safe &ClientManager::sessionExpired overload of invokeMethod   | ClientManagerExportPortfolio.cpp           | Accept   | Fixed 326a5206d |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_investigate_and_fix_clientmanager_template_c1202.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_investigate_and_fix_clientmanager_template_c1202.org
@@ -1,0 +1,155 @@
+:PROPERTIES:
+:ID: A10ACBA5-BABD-4B60-8CF3-79108BA9DA92
+:END:
+#+title: Task: Investigate and fix ClientManager template C1202 for complex response types
+#+description: process_authenticated_request<T> instantiates rfl::json::read<ResponseType> in the caller's TU; for ResponseTypes containing trade_instrument the accumulated MSVC context triggers C1202. Systematic fix needed.
+#+type: task
+#+level: s1
+#+filetags: :fix_rfl_complexity:sprint_19:v0:
+#+owner: marco
+#+branch: feature/fix-windows-macos-ci
+#+pr:
+#+blocked_on: none
+#+blocked_since:
+#+created: 2026-06-02
+#+updated: 2026-06-02
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Understand why C1202 continues to appear after the swap-TU split (PR #985), and fix it
+systematically so no further MSVC C1202 errors appear in the Windows CI build.
+
+* Status
+
+| Field        | Value                                                            |
+|--------------+------------------------------------------------------------------|
+| State        | STARTED                                                          |
+| Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]]  |
+| Now          | Investigation complete; fix in progress.                          |
+| Waiting on   | PR.                                                              |
+| Next         | Raise PR; verify CI green.                                       |
+| Last touched | 2026-06-02                                                       |
+
+* Acceptance
+
+- No MSVC C1202 in any file in =ores.qt.trading= or =ores.qt.api=.
+- Windows CI (MSVC debug + release) green.
+- Linux CI unaffected.
+
+* Investigation
+
+** Symptom
+
+After the swap-TU split (PR #985 in task 7), C1202 still fires in
+=BookMdiWindow.cpp= at step [4651/4936]:
+
+#+begin_example
+BookMdiWindow.cpp(476): see reference to function template instantiation
+  'std::expected<export_portfolio_response,std::string>
+   ores::qt::ClientManager::process_authenticated_request
+     <export_portfolio_request>(RequestType, std::chrono::milliseconds)'
+ClientManager.hpp(387): see reference to
+  'rfl::Result<export_portfolio_response>
+   rfl::json::read<ResponseType,>(const std::string_view, ...)'
+#+end_example
+
+** Root cause: template instantiation in the caller's TU
+
+=ClientManager.hpp= defines =process_authenticated_request<T>= as a function
+template. The body contains:
+
+#+begin_src cpp
+auto result = rfl::json::read<ResponseType>(raw);
+#+end_src
+
+Being a template, this instantiation happens in the CALLER's translation unit,
+not in =ClientManager.cpp=. So every =.cpp= file that calls
+=process_authenticated_request<export_portfolio_request>= injects
+=rfl::json::read<export_portfolio_response>= into its own template context.
+
+** Why export_portfolio_response is uniquely problematic
+
+=export_portfolio_response= contains =vector<trade_export_item>= where:
+- =trade_export_item.instrument= is =trade_instrument=
+- =trade_instrument= is =std::variant<9 alternatives>=, several of which are
+  =with_legs<..., swap_leg>= types
+- =swap_leg= has 19 fields
+
+Without =AddTagsToVariants=, rfl processes each variant alternative
+independently. The rfl =Literal= for =swap_leg= (19 fields) is created in the
+caller's TU. =BookMdiWindow.cpp= already has a saturated template dependency
+graph (step 4651/4936, large set of includes), so 19 more =StringLiteral<N>=
+types push it over MSVC's C1202 threshold.
+
+** Why this did not appear earlier
+
+- The original C1202 fix (PR #978) removed =AddTagsToVariants= from
+  =ClientManager.hpp=, which eliminated the 502-field combined =rfl::Literal=.
+- The remaining sub-problem — that rfl still processes =trade_instrument= variant
+  alternatives (including =swap_leg=) in the caller's TU — was not visible on
+  Linux (GCC has more permissive limits) and only surfaced on MSVC in
+  =BookMdiWindow.cpp= once the rest of CI noise was cleared.
+
+** Affected call sites
+
+The only call site known to trigger C1202 is:
+- =ores.qt.trading/src/BookMdiWindow.cpp:476= —
+  =process_authenticated_request<export_portfolio_request>=
+
+Other request/response types used in =process_authenticated_request= contain
+simpler domain structs (no =trade_instrument= variant) and do not trigger C1202.
+
+** Fix: concrete method in a dedicated TU
+
+The fix follows the same isolation pattern as =parse_swap_instruments.cpp=:
+
+1. Add a concrete (non-template) =ClientManager::exportPortfolio()= method to
+   =ClientManager.hpp= (declared, not defined inline).
+2. Implement it in a new =ClientManagerExportPortfolio.cpp= — a fresh TU where
+   =rfl::json::read<export_portfolio_response>= is the ONLY complex rfl
+   instantiation, so MSVC's dependency graph is clean.
+3. Update =BookMdiWindow.cpp:476= to call =exportPortfolio()= instead of the
+   template.
+
+** Broader pattern: when to use concrete methods
+
+Any =process_authenticated_request<T>= call where =T::response_type= contains
+=trade_instrument= (directly or via =trade_export_item=) must be moved to a
+concrete method in a dedicated TU. Currently only =export_portfolio_request=
+meets this criterion. If new request types with complex response types are added
+in future, the same pattern applies.
+
+* Plan
+
+1. Add =exportPortfolio()= declaration to =ClientManager.hpp= (following the
+   same signature as =process_authenticated_request= but concrete, not a
+   template).
+2. Create =projects/ores.qt.api/src/ClientManagerExportPortfolio.cpp= with the
+   implementation (=rfl::json::read<export_portfolio_response>= in isolation).
+3. Update =BookMdiWindow.cpp= to call =exportPortfolio()= at line 476.
+4. Commit, push, PR, review, merge.
+
+* Notes
+
+- The glob in =ores.qt.api/src/CMakeLists.txt= picks up new =*.cpp= files
+  automatically — no build system change needed.
+- The =ores.qt.trading= project does NOT have a glob; if a new file were needed
+  there, =CMakeLists.txt= would need updating. For this fix, all changes are in
+  =ores.qt.api= and =ores.qt.trading= (just =BookMdiWindow.cpp=).
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/projects/ores.qt/api/include/ores.qt/ClientManager.hpp
+++ b/projects/ores.qt/api/include/ores.qt/ClientManager.hpp
@@ -404,6 +404,20 @@ public:
     }
 
     /**
+     * @brief Export all trades and instruments under a taxonomy node.
+     *
+     * Concrete (non-template) wrapper around process_authenticated_request for
+     * export_portfolio_request. Implemented in ClientManagerExportPortfolio.cpp
+     * so that rfl::json::read<export_portfolio_response> is instantiated in a
+     * dedicated translation unit — avoiding MSVC C1202 in large callers such as
+     * BookMdiWindow.cpp whose accumulated template context would otherwise be
+     * pushed over the limit by trade_instrument's rfl field-name Literals.
+     */
+    std::expected<trading::messaging::export_portfolio_response, std::string>
+    exportPortfolio(trading::messaging::export_portfolio_request request,
+        std::chrono::milliseconds timeout = std::chrono::seconds(30));
+
+    /**
      * @brief List sessions for an account.
      */
     std::optional<SessionListResult> listSessions(

--- a/projects/ores.qt/api/src/ClientManagerExportPortfolio.cpp
+++ b/projects/ores.qt/api/src/ClientManagerExportPortfolio.cpp
@@ -56,7 +56,7 @@ ClientManager::exportPortfolio(trading::messaging::export_portfolio_request requ
     } catch (const ores::nats::service::nats_connect_error&) {
         throw;
     } catch (const ores::nats::service::session_expired_error& e) {
-        QMetaObject::invokeMethod(this, "sessionExpired", Qt::QueuedConnection);
+        QMetaObject::invokeMethod(this, &ClientManager::sessionExpired, Qt::QueuedConnection);
         return std::unexpected(std::string(e.what()));
     } catch (const std::exception& e) {
         return std::unexpected(std::string(e.what()));

--- a/projects/ores.qt/api/src/ClientManagerExportPortfolio.cpp
+++ b/projects/ores.qt/api/src/ClientManagerExportPortfolio.cpp
@@ -1,0 +1,66 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * Copyright (C) 2026 Marco Craveiro <marco.craveiro@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+// Isolated TU for ClientManager::exportPortfolio().
+//
+// export_portfolio_response carries vector<trade_export_item> where each item
+// contains trade_instrument — a std::variant with 9 alternatives including
+// with_legs<..., swap_leg> types. rfl::json::read<export_portfolio_response>
+// instantiates rfl::StringLiteral<N> types for swap_leg's 19 fields.
+//
+// Because process_authenticated_request<T> is a header template, calling it
+// with export_portfolio_request in a large TU (BookMdiWindow.cpp, step 4651/4936)
+// injects those Literals into an already-saturated MSVC dependency graph, triggering
+// C1202. This concrete method keeps the instantiation in a dedicated, fresh TU.
+
+#include "ores.qt/ClientManager.hpp"
+#include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
+
+namespace ores::qt {
+
+std::expected<trading::messaging::export_portfolio_response, std::string>
+ClientManager::exportPortfolio(trading::messaging::export_portfolio_request request,
+    std::chrono::milliseconds timeout)
+{
+    using ResponseType = trading::messaging::export_portfolio_response;
+    using namespace trading::messaging;
+    try {
+        const auto raw = send_authenticated_request(
+            export_portfolio_request::nats_subject,
+            rfl::json::write(request),
+            timeout);
+        auto result = rfl::json::read<ResponseType>(raw);
+        if (!result) {
+            return std::unexpected(
+                std::string("Failed to deserialize response: ") +
+                result.error().what());
+        }
+        return std::move(*result);
+    } catch (const ores::nats::service::nats_connect_error&) {
+        throw;
+    } catch (const ores::nats::service::session_expired_error& e) {
+        QMetaObject::invokeMethod(this, "sessionExpired", Qt::QueuedConnection);
+        return std::unexpected(std::string(e.what()));
+    } catch (const std::exception& e) {
+        return std::unexpected(std::string(e.what()));
+    }
+}
+
+} // namespace ores::qt

--- a/projects/ores.qt/trading/src/BookMdiWindow.cpp
+++ b/projects/ores.qt/trading/src/BookMdiWindow.cpp
@@ -473,8 +473,7 @@ void BookMdiWindow::exportToXml() {
         trading::messaging::export_portfolio_request req;
         req.node_id = book_id;
 
-        auto r = self->clientManager_->process_authenticated_request(
-            std::move(req));
+        auto r = self->clientManager_->exportPortfolio(std::move(req));
         if (!r) {
             result.error = "Failed to communicate with server";
             return result;


### PR DESCRIPTION
## Summary

`BookMdiWindow.cpp` (step 4651/4936) called `process_authenticated_request<export_portfolio_request>()`, which — being a header template — instantiated `rfl::json::read<export_portfolio_response>` directly in BookMdiWindow's already-saturated MSVC template dependency graph. `export_portfolio_response` → `trade_export_item` → `trade_instrument` → `with_legs<..., swap_leg>` reaches swap_leg's 19 rfl StringLiteral field-name types, pushing the dependency graph over MSVC's C1202 limit.

This is the last identified at-risk call site (see story audit table): the only `process_authenticated_request<T>` call where `T::response_type` contains `trade_instrument`.

Fix: concrete `ClientManager::exportPortfolio()` method declared in `ClientManager.hpp` and implemented in the new `ClientManagerExportPortfolio.cpp` — a dedicated TU where `rfl::json::read<export_portfolio_response>` is the only complex rfl instantiation. `BookMdiWindow.cpp` calls `exportPortfolio()` directly.

## Changes

| File | Change |
|------|--------|
| `projects/ores.qt/api/include/ores.qt/ClientManager.hpp` | Add concrete `exportPortfolio()` declaration (non-template, with doc comment explaining the isolation rationale) |
| `projects/ores.qt/api/src/ClientManagerExportPortfolio.cpp` | **New** — implements `exportPortfolio()` in a fresh TU; same error-handling as the template |
| `projects/ores.qt/trading/src/BookMdiWindow.cpp` | Replace `process_authenticated_request(req)` at line 476 with `exportPortfolio(req)` |

## Story / Task

- Story: [Fix rfl complexity failure (Windows + macOS CI)](../blob/main/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/story.org) — `7763D0EE-A500-4497-9B2D-973C02ADC739`
- Task 8: [Investigate and fix ClientManager template C1202](../blob/main/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_investigate_and_fix_clientmanager_template_c1202.org) — `A10ACBA5-BABD-4B60-8CF3-79108BA9DA92`

## Test plan

- [ ] Windows MSVC CI (debug + release): no C1202 in `BookMdiWindow.cpp`
- [ ] Windows Clang CI: passes
- [ ] macOS CI: no fold-expression nesting limit errors
- [ ] Linux CI: unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)