### PR TITLE
[compass] Add task start; fix journal resume gap; document journal commands

### DIFF
--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/task_fix_journal_not_updated_on_resume.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/task_fix_journal_not_updated_on_resume.org
@@ -1,0 +1,81 @@
+:PROPERTIES:
+:ID: F088A0A7-2442-47BD-A73D-C431B14D88CA
+:END:
+#+title: Task: Fix journal not updated on session resume
+#+description: Journal is only written on compass story/task new. Resuming an existing task after restart never stamps the journal — the main recovery use case is unhandled.
+#+type: task
+#+level: s1
+#+filetags: :compass_session_journal:sprint_19:v0:
+#+owner: marco
+#+branch: feature/fix-journal-not-updated-on-resume
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-02
+#+updated: 2026-06-02
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Fix two gaps in journal reliability:
+
+1. *Resume gap* — =compass story new= and =compass task new= auto-stamp
+   the journal, but there is no trigger for resuming an existing task
+   after a restart. Environments that only work on existing branches
+   (the common case) never get a journal entry. Add a =compass story
+   resume= command (or wire =compass journal update= into the
+   semi-autonomous developer skill's startup flow) so a journal entry
+   is written whenever a Claude session picks up any task, new or
+   existing.
+
+2. *Silent failure* — the journal update call is wrapped in
+   =except Exception: pass=, swallowing errors invisibly. Replace with
+   =except Exception as e: print(f"⚠️  journal update failed: {e}")= so
+   failures are visible. (Already done as a quick fix in this task.)
+
+* Status
+
+| Field        | Value                                          |
+|--------------+------------------------------------------------|
+| State        | STARTED                                        |
+| Parent story | [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]]                        |
+| Now          | Silent-catch fix committed; resume gap pending.|
+| Waiting on   | Nothing.                                       |
+| Next         | Implement resume trigger in compass or skill.  |
+| Last touched | 2026-06-02                                     |
+
+* Acceptance
+
+- =compass journal where= returns a meaningful entry after a fresh
+  session picks up an *existing* task (not just a newly-created one).
+- All four local environments have a =.journal.org= after their next
+  session startup.
+- Journal update failures print a visible =⚠️= warning to stderr
+  instead of disappearing silently.
+
+* Plan
+
+1. Silent-catch fix: =except Exception as e: print(f"⚠️ ...")= — done.
+2. Add =compass story resume --story <slug-or-uuid>= (or extend
+   =compass story status= to optionally stamp the journal).
+3. Update the semi-autonomous developer skill to call
+   =compass journal update= at the top of every session, not just
+   when creating new tasks.
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/task_fix_journal_not_updated_on_resume.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/task_fix_journal_not_updated_on_resume.org
@@ -19,50 +19,61 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-Fix two gaps in journal reliability:
+Redesign the journal trigger model and fix a silent failure. Three use
+cases need coverage:
 
-1. *Resume gap* — =compass story new= and =compass task new= auto-stamp
-   the journal, but there is no trigger for resuming an existing task
-   after a restart. Environments that only work on existing branches
-   (the common case) never get a journal entry. Add a =compass story
-   resume= command (or wire =compass journal update= into the
-   semi-autonomous developer skill's startup flow) so a journal entry
-   is written whenever a Claude session picks up any task, new or
-   existing.
+1. *New story, new task* — =compass story new= scaffolds artefacts and
+   branch. The developer then calls =compass task start= to clock on.
+2. *Existing story, new task* — =compass task new= scaffolds the task
+   and branch. The developer then calls =compass task start= to clock on.
+3. *Existing story, existing task* — the common restart / resume case.
+   =compass task start= switches to the branch, flips state to STARTED
+   if BACKLOG, and stamps the journal.
 
-2. *Silent failure* — the journal update call is wrapped in
-   =except Exception: pass=, swallowing errors invisibly. Replace with
-   =except Exception as e: print(f"⚠️  journal update failed: {e}")= so
-   failures are visible. (Already done as a quick fix in this task.)
+The key design decision: *remove the implicit journal stamp from
+=story new= and =task new=*. Creation ≠ starting work. The journal
+should record intent, not scaffolding noise. =compass task start= is
+the explicit "I am now working on this" signal and is a required step
+in the new-story and new-task runbooks.
+
+=compass task start <slug-or-uuid>= must:
+- Locate the task file (by slug, UUID, or branch name).
+- =git switch <branch>= (creates off =origin/main= if it does not exist yet).
+- Flip state from BACKLOG → STARTED if not already STARTED.
+- Stamp the journal with story UUID, task UUID, branch, and state.
+
+Also fix the *silent failure* introduced by the earlier =except
+Exception: pass= (already replaced with a visible =⚠️= warning).
 
 * Status
 
-| Field        | Value                                          |
-|--------------+------------------------------------------------|
-| State        | STARTED                                        |
-| Parent story | [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]]                        |
-| Now          | Silent-catch fix committed; resume gap pending.|
-| Waiting on   | Nothing.                                       |
-| Next         | Implement resume trigger in compass or skill.  |
-| Last touched | 2026-06-02                                     |
+| Field        | Value                                               |
+|--------------+-----------------------------------------------------|
+| State        | STARTED                                             |
+| Parent story | [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]]                             |
+| Now          | Silent-catch fixed; implementing task start + removing auto-stamp. |
+| Waiting on   | Nothing.                                            |
+| Next         | Implement, update runbooks, PR.                     |
+| Last touched | 2026-06-02                                          |
 
 * Acceptance
 
-- =compass journal where= returns a meaningful entry after a fresh
-  session picks up an *existing* task (not just a newly-created one).
-- All four local environments have a =.journal.org= after their next
-  session startup.
-- Journal update failures print a visible =⚠️= warning to stderr
-  instead of disappearing silently.
+- =compass task start <slug>= exists and stamps the journal for all
+  three use cases (new task, resume BACKLOG, resume STARTED).
+- =compass story new= and =compass task new= no longer auto-stamp
+  the journal — creation is decoupled from starting work.
+- The start-new-story and work-task-to-merged-PR runbooks include
+  =compass task start= as an explicit step.
+- =compass journal where= returns a meaningful entry after resuming
+  any existing task.
+- Journal failures print a visible =⚠️= warning rather than silently
+  disappearing.
 
 * Plan
 
-1. Silent-catch fix: =except Exception as e: print(f"⚠️ ...")= — done.
-2. Add =compass story resume --story <slug-or-uuid>= (or extend
-   =compass story status= to optionally stamp the journal).
-3. Update the semi-autonomous developer skill to call
-   =compass journal update= at the top of every session, not just
-   when creating new tasks.
+1. Remove =_journal_update= call from =story new= / =task new=.
+2. Implement =compass task start <slug-or-uuid>= subcommand.
+3. Update runbooks: =start_new_story= and =work_task_to_merged_pr=.
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_19/compass_session_journal/task_fix_journal_not_updated_on_resume.org
+++ b/doc/agile/versions/v0/sprint_19/compass_session_journal/task_fix_journal_not_updated_on_resume.org
@@ -79,14 +79,16 @@ Exception: pass= (already replaced with a visible =⚠️= warning).
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR   | Title                                                                          |
+|------+--------------------------------------------------------------------------------|
+| 1013 | [compass] Add task start; fix journal resume gap; document journal commands     |
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                    | File        | Decision | Notes                                   |
+|---+----------------------------------------------------+-------------+----------+-----------------------------------------|
+| 1 | d.id may be None, causes AttributeError on .lower()| compass.py  | Fixed    | Added d.id and guard (ec204c103)        |
+| 2 | Deduplicate candidates by rel_path not d.id        | compass.py  | Fixed    | Changed {d.id:d} to {d.rel_path:d}     |
+| 3 | Exact-string state match fragile to table spacing  | compass.py  | Fixed    | Replaced with re.subn pattern           |
 
 * Result

--- a/doc/llm/runbooks/start_new_story/runbook.org
+++ b/doc/llm/runbooks/start_new_story/runbook.org
@@ -46,15 +46,26 @@ In execution order:
 
 2a. /Read all generated files before writing anything./ Immediately after scaffold, read every file compass created and note the =:ID:= property of each. Do this before writing any content to =story.org= or the task file. Failure to read first causes placeholder UUIDs to be written and then silently corrected — an error-prone pattern that breaks org-roam links.
 
-3. /Fill in the story content./ Open =story.org= and complete the =* Goal=, =* Acceptance=, =* Tasks=, and =* Out of scope= sections. Use the actual UUIDs from step 2a for any =[[id:UUID]]= references to compass-generated tasks. Use [[id:F9AD7932-8E11-433C-A812-B57DBC9BF5D8][LLM instructions]] as the entry-point skill. Every internal-doc reference uses an =[[id:UUID]]= link, never a relative path.
+3. /Clock on./ Run =compass task start= with the first task's slug to switch
+   branch, mark the task STARTED, and stamp the session journal:
 
-4. /Mark the story STARTED./ Update the =* Status= table: state → =STARTED=, fill =Now= and =Next=, set =#+owner:=, refresh =#+updated:=. Follow [[id:DA003A23-1604-43E7-A98F-A305148FBCF4][How do I start work on a story?]] step 3.
+   #+begin_src sh :results verbatim
+   ./projects/ores.compass/compass.sh task start <first-task-slug>
+   #+end_src
 
-5. /Wire into the sprint./ Add a row to the parent sprint's =* Stories= table. Each row: =| [[id:UUID][Title]] | STARTED | date | | Theme |=.
+   This is the explicit "I am now working on this" signal. The journal entry
+   records the story, task, branch, and state so =compass where= and
+   =compass fleet= show context after a restart.
 
-6. /Commit the status change./ Use [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][ORE Studio commit conventions]]: =[agile] Mark <story> STARTED= with a =Co-Authored-By:= trailer.
+4. /Fill in the story content./ Open =story.org= and complete the =* Goal=, =* Acceptance=, =* Tasks=, and =* Out of scope= sections. Use the actual UUIDs from step 2a for any =[[id:UUID]]= references to compass-generated tasks. Use [[id:F9AD7932-8E11-433C-A812-B57DBC9BF5D8][LLM instructions]] as the entry-point skill. Every internal-doc reference uses an =[[id:UUID]]= link, never a relative path.
 
-7. /Push and open a PR./ Push with =git push -u origin <branch>=, then follow [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][How do I create a PR?]] — title format =[COMPONENT] Description=, body sections Summary / Changes / Traceability (Markdown table with Artefact, Link, full UUID). Record the PR number in the task's =* PRs= table.
+5. /Mark the story STARTED./ Update the =* Status= table: state → =STARTED=, fill =Now= and =Next=, set =#+owner:=, refresh =#+updated:=. Follow [[id:DA003A23-1604-43E7-A98F-A305148FBCF4][How do I start work on a story?]] step 3.
+
+6. /Wire into the sprint./ Add a row to the parent sprint's =* Stories= table. Each row: =| [[id:UUID][Title]] | STARTED | date | | Theme |=.
+
+7. /Commit the status change./ Use [[id:F4B1A670-3B02-11F1-BCE2-4B06F4BBA5D9][ORE Studio commit conventions]]: =[agile] Mark <story> STARTED= with a =Co-Authored-By:= trailer.
+
+8. /Push and open a PR./ Push with =git push -u origin <branch>=, then follow [[id:CC928252-E0C5-4C3C-A7A8-D613593E4E37][How do I create a PR?]] — title format =[COMPONENT] Description=, body sections Summary / Changes / Traceability (Markdown table with Artefact, Link, full UUID). Record the PR number in the task's =* PRs= table.
 
 * Postconditions
 

--- a/doc/llm/runbooks/work_task_to_merged_pr/runbook.org
+++ b/doc/llm/runbooks/work_task_to_merged_pr/runbook.org
@@ -26,7 +26,17 @@ Take an existing task from =BACKLOG= through implementation, PR creation, review
 
 In execution order:
 
-1. /Pick up the task./ Read =task_<slug>.org=: understand the =* Goal=, =* Acceptance= criteria, and =* Notes=. Mark the task =STARTED= and set =#+branch:=, =#+pr:= (if known), and =#+owner:=.
+1. /Clock on./ Run =compass task start= with the task's slug to switch branch,
+   mark the task =STARTED=, and stamp the session journal:
+
+   #+begin_src sh :results verbatim
+   ./projects/ores.compass/compass.sh task start <task-slug>
+   #+end_src
+
+   This covers all three cases: new task on an existing story, resuming a
+   BACKLOG task, and restarting an already-STARTED task after a session reset.
+   Read =task_<slug>.org= after clocking on: understand the =* Goal=,
+   =* Acceptance= criteria, and =* Notes=. Set =#+owner:= and =#+pr:= once known.
 
 2. /Sync with main./ Fetch and rebase onto =origin/main=:
    #+begin_src sh

--- a/doc/recipes/agile/how_do_i_know_what_i_was_working_on.org
+++ b/doc/recipes/agile/how_do_i_know_what_i_was_working_on.org
@@ -1,0 +1,76 @@
+:PROPERTIES:
+:ID: F3373CC1-C2B3-4371-A63F-FBEC54297265
+:END:
+#+title: How do I know what I was working on?
+#+description: Use compass journal where and compass task start to recover session context after a restart.
+#+type: recipe
+#+level: cross
+#+filetags: :agile:compass:llm:recipe:journal:restart:
+#+created: 2026-06-02
+#+updated: 2026-06-02
+
+* Question
+
+After restarting a Claude session (or starting a fresh one in an existing
+worktree), how do I find out what this environment was last working on and
+get back to it quickly?
+
+* Answer
+
+Two commands: =compass journal where= to read the last recorded context,
+then =compass task start= to clock back on.
+
+** Step 1 — read the last journal entry
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh journal where
+#+end_src
+
+Example output:
+
+#+begin_example
+📓 ores.compass — last entry (2026-06-02 09:39)
+
+Story:  Clarify versioning strategy  [EC20475A-E7B4-4DFB-8E55-4B8DA6B36202]
+Task:   Scaffold version 2 doc       [EDAE4567-CA33-45A0-8FBF-6A8D062E3DC0]
+State:  STARTED
+Branch: feature/scaffold-version-2-doc
+PR:     none
+#+end_example
+
+If no journal exists yet:
+
+#+begin_example
+No .journal.org found. Run 'compass task start <slug>' when you pick up a task.
+#+end_example
+
+Use =compass where= to see what is in-flight in the sprint and pick up a task.
+
+** Step 2 — clock back on
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh task start <task-slug>
+#+end_src
+
+This switches to the task's branch, ensures state is STARTED, and appends
+a fresh journal entry so context is recorded for the next restart.
+
+** Checking all environments (overlap detection)
+
+Before picking up new work, check whether another worktree is already on
+the same story:
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh fleet
+#+end_src
+
+* Tested by
+
+Manual smoke test: run =compass journal where= in a worktree that has
+previously called =compass task start=.
+
+* See also
+
+- [[id:B4C7D2E1-9F3A-4A6B-8E5D-3C1F7B2A9D4E][How do I use the session journal?]] — full journal reference (all commands).
+- [[id:2EA7FF1B-CC23-4275-9ADA-8C43103E3103][Work a task through to merged PR]] — task lifecycle runbook.
+- [[id:41E5F9A8-1C2B-4ECA-8EA0-1ABBAB0B6A31][How do I see where we are?]] — sprint/story/task overview.

--- a/doc/recipes/agile/how_do_i_use_the_session_journal.org
+++ b/doc/recipes/agile/how_do_i_use_the_session_journal.org
@@ -2,12 +2,12 @@
 :ID: B4C7D2E1-9F3A-4A6B-8E5D-3C1F7B2A9D4E
 :END:
 #+title: How do I use the session journal?
-#+description: Read and update .journal.org to record what story/task each Claude environment is working on; use compass journal commands for restart recovery and overlap detection.
+#+description: Use compass task start to clock on to work; use compass journal where/log for restart recovery and compass fleet for overlap detection.
 #+type: recipe
 #+level: cross
 #+filetags: :agile:compass:llm:recipe:journal:
 #+created: 2026-05-31
-#+updated: 2026-05-31
+#+updated: 2026-06-02
 
 * Question
 
@@ -17,82 +17,95 @@ before picking up a new story?
 
 * Answer
 
-Each worktree has a =.journal.org= file in its root directory. The file is
-gitignored (machine-local, never committed). =compass story new= or =compass task new= appends an entry
-automatically whenever a task is picked up, so no manual update is normally
-needed.
+Each worktree has a =.journal.org= file in its root directory — machine-local,
+gitignored, never committed. Use =compass task start= to clock on whenever
+you pick up a task (new or existing). The journal then answers two questions:
+=compass journal where= ("where was I?") and =compass fleet= ("what is every
+worktree doing?").
+
+** Clocking on to a task
+
+#+begin_src sh :results verbatim
+# New task or resuming an existing task — all three cases:
+./projects/ores.compass/compass.sh task start <task-slug>
+#+end_src
+
+This switches to the task's branch, flips the state from BACKLOG to STARTED
+if needed, and appends a timestamped entry to =.journal.org=. It is the
+required first step in both [[id:4F01E2FF-69AB-4839-88D1-4D8C21D99D3C][Start work on a new story]] and
+[[id:2EA7FF1B-CC23-4275-9ADA-8C43103E3103][Work a task through to merged PR]].
+
+** Restart recovery
+
+#+begin_src sh :results verbatim
+# What was I working on? (last entry in this worktree)
+./projects/ores.compass/compass.sh journal where
+#+end_src
+
+Then clock back on:
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh task start <slug-from-where-output>
+#+end_src
+
+** Viewing the full session history
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh journal log
+#+end_src
+
+** Overlap detection before picking up a story
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh fleet
+#+end_src
+
+Shows every worktree's current story, task, branch, and PR. Check this before
+starting new work to avoid touching the same area as another environment.
+
+** Updating the journal manually
+
+For cases not covered by =compass task start= (e.g. recording a PR number
+or a DONE state):
+
+#+begin_src sh :results verbatim
+./projects/ores.compass/compass.sh journal update \
+  --story <UUID> --task <UUID> \
+  --branch <branch> --state DONE --pr <N>
+#+end_src
 
 ** Entry format
 
 #+begin_example
-* 2026-05-31 09:15 — [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]]
-  - Task :: [[id:07F68E53-A2A6-4F1F-B699-44B9896EA7DD][Design journal format and gitignore setup]]
+* 2026-06-02 09:34 — [[id:EC20475A-E7B4-4DFB-8E55-4B8DA6B36202][Clarify versioning strategy]]
+  - Task :: [[id:450D52AB-8BD9-459E-9F77-6C0BD652FFAB][Create milestones infrastructure]]
   - State :: STARTED
-  - Branch :: feature/design-journal-format
+  - Branch :: feature/clarify-versioning-strategy
   - PR :: none
 #+end_example
 
-Fields:
-
 | Field | Description |
 |-------+-------------|
-| Heading timestamp | ISO date + time of the entry (when work was picked up) |
+| Heading timestamp | ISO date + time of clock-on |
 | Story link | org-roam =[[id:UUID][Title]]= of the parent story |
 | =Task ::= | org-roam =[[id:UUID][Title]]= of the specific task |
-| =State ::= | Task state at pickup: =STARTED=, =DONE=, =BLOCKED=, etc. |
-| =Branch ::= | Current git branch name |
-| =PR ::= | GitHub PR number (=#NNN=) or =none= |
-
-** Querying the journal
-
-#+begin_src sh
-# Where was I? (last entry in this worktree — restart recovery)
-compass journal where
-
-# Full journey of this worktree
-compass journal log
-
-# What is every worktree currently working on? (overlap detection)
-compass fleet
-#+end_src
-
-** When to update the journal manually
-
-=compass story new= or =compass task new= writes the initial =State :: STARTED= entry automatically.
-Manual updates are needed when:
-
-1. *Completing a task* — append a closing entry with =State :: DONE= and
-   the PR number:
-   #+begin_src sh
-   compass journal update --story <UUID> --task <UUID> \
-     --branch <branch> --state DONE --pr <N>
-   #+end_src
-2. *Switching tasks mid-session* — run =compass story new= or =compass task new= for the new task;
-   it will append a new =STARTED= entry automatically.
-
-** Overlap detection before picking up a story
-
-Before running =compass story new= or =compass task new=, check what every other worktree is working on:
-
-#+begin_src sh
-compass fleet
-#+end_src
-
-If another worktree's journal shows the same story or a story touching the
-same area of the codebase, coordinate before proceeding.
+| =State ::= | =STARTED=, =DONE=, =BLOCKED=, etc. |
+| =Branch ::= | Current git branch |
+| =PR ::= | GitHub PR number or =none= |
 
 * Conventions
 
-- One entry per task pickup, not per commit. The entry records intent, not
-  every action taken.
-- Org-roam links (=[[id:UUID][Title]]=) are preferred over plain text so
-  entries are navigable from Emacs and stable when titles change.
-- The file grows indefinitely; do not prune it. Old entries are the journey
-  log and may be queried with =compass journal log=.
-- =.journal.org= is *never* committed to git. If it appears in =git status=,
-  check that =.gitignore= contains the entry.
+- Clock on with =compass task start= at the start of every task pickup,
+  including after restarts. Do not rely on creation commands to do it.
+- One entry per task pickup, not per commit.
+- Org-roam links are preferred — entries are navigable from Emacs and stable
+  when titles change.
+- The file grows indefinitely; do not prune it.
+- =.journal.org= is *never* committed to git.
 
 * See also
 
+- [[id:F3373CC1-C2B3-4371-A63F-FBEC54297265][How do I know what I was working on?]] — the restart recovery recipe.
+- [[id:4F01E2FF-69AB-4839-88D1-4D8C21D99D3C][Start work on a new story]] — full new-story runbook.
+- [[id:2EA7FF1B-CC23-4275-9ADA-8C43103E3103][Work a task through to merged PR]] — full task-to-merge runbook.
 - [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]] — the story that implemented this feature.
-- [[id:1F41F21C-8D2A-46DA-8C6A-571564DF2C0E][How do I work a task?]] — task lifecycle.

--- a/doc/recipes/compass/compass.org
+++ b/doc/recipes/compass/compass.org
@@ -34,6 +34,13 @@ Orient, Search, Scaffold, Capture, and Journal.
 - [[id:84C9177E-C737-428A-BDF9-E55FA6C9680C][How do I start a unit of work with compass?]] — fetch main, branch,
   scaffold a linked story+task (=story new= / =task new=).
 
+* Journal
+
+- [[id:F3373CC1-C2B3-4371-A63F-FBEC54297265][How do I know what I was working on?]] — restart recovery: read
+  the last entry and clock back on (=journal where= / =task start=).
+- [[id:B4C7D2E1-9F3A-4A6B-8E5D-3C1F7B2A9D4E][How do I use the session journal?]] — full journal reference:
+  clocking on, overlap detection, manual updates, entry format.
+
 * Captures
 
 - [[id:7072D39C-9607-48F9-8EE6-50E8647DB8ED][How do I capture ideas from freeform text?]] — paste unstructured

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -1623,7 +1623,22 @@ def cmd_task(argv):
     new_p.add_argument("--kind",      default="feature", choices=["feature", "hotfix"])
     new_p.add_argument("--dry-run",   action="store_true")
 
-    start_p = sub.add_parser("start", help="Clock on to an existing task: switch branch, STARTED state, stamp journal")
+    start_p = sub.add_parser(
+        "start",
+        help="Clock on to a task: switch branch, flip to STARTED, stamp journal",
+        description=(
+            "Clock on to an existing task — covers all three use cases:\n"
+            "  1. new task just scaffolded (compass task new)\n"
+            "  2. BACKLOG task being picked up for the first time\n"
+            "  3. STARTED task being resumed after a restart\n\n"
+            "Switches to the task's branch, flips BACKLOG→STARTED if needed,\n"
+            "and appends a timestamped entry to .journal.org so 'compass journal\n"
+            "where' and 'compass fleet' show the current context.\n\n"
+            "This is the required first step in both the new-story and\n"
+            "work-task-to-merged-PR runbooks."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     start_p.add_argument("task", help="Task slug, UUID/prefix, or branch suffix")
 
     args = ap.parse_args(argv)

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -1537,11 +1537,11 @@ def _cmd_task_start(task_ident):
 
     # Resolve by UUID (exact or prefix), slug, or branch suffix.
     tasks = [d for d in docs.values() if d.doctype == "task"]
-    exact  = [d for d in tasks if d.id.lower() == il]
-    prefix = [d for d in tasks if d.id.lower().startswith(il)]
+    exact  = [d for d in tasks if d.id and d.id.lower() == il]
+    prefix = [d for d in tasks if d.id and d.id.lower().startswith(il)]
     slug   = [d for d in tasks if Path(d.rel_path).stem.lower() == f"task_{il}"
                                 or Path(d.rel_path).stem.lower() == il]
-    cands  = list({d.id: d for d in (exact or prefix) + slug}.values())
+    cands  = list({d.rel_path: d for d in (exact or prefix) + slug}.values())
 
     if not cands:
         print(f"❌ No task matching '{task_ident}'.", file=sys.stderr)
@@ -1581,9 +1581,9 @@ def _cmd_task_start(task_ident):
 
     # Flip BACKLOG → STARTED in the task file if needed.
     text = task_path.read_text(encoding="utf-8")
-    if "| State        | BACKLOG" in text:
-        text = text.replace("| State        | BACKLOG", "| State        | STARTED", 1)
-        task_path.write_text(text, encoding="utf-8")
+    new_text, n = re.subn(r'(\| State\s+\|) BACKLOG', r'\1 STARTED', text, count=1)
+    if n:
+        task_path.write_text(new_text, encoding="utf-8")
         print(f"📝 state: BACKLOG → STARTED")
 
     # Stamp the journal.

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -1444,7 +1444,7 @@ def _scaffold_and_branch(sprint_dir, story_dir, story_title, new_story,
     # 3. record branch on task so fleet/where can map this worktree
     _set_frontmatter_branch(task_path, branch)
 
-    # 4. update session journal — best-effort, never fails
+    # 4. update session journal
     try:
         story_uuid = _read_org_id(Path(PROJECT_ROOT) / story_dir / "story.org")
         task_uuid  = _read_org_id(task_path)
@@ -1452,8 +1452,8 @@ def _scaffold_and_branch(sprint_dir, story_dir, story_title, new_story,
             _journal_update(argparse.Namespace(
                 story=story_uuid, task=task_uuid, branch=branch,
                 state="STARTED", pr="none"))
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"⚠️  journal update failed: {e}", file=sys.stderr)
 
     # 5. next steps
     print("\nNext steps:")

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -1444,22 +1444,11 @@ def _scaffold_and_branch(sprint_dir, story_dir, story_title, new_story,
     # 3. record branch on task so fleet/where can map this worktree
     _set_frontmatter_branch(task_path, branch)
 
-    # 4. update session journal
-    try:
-        story_uuid = _read_org_id(Path(PROJECT_ROOT) / story_dir / "story.org")
-        task_uuid  = _read_org_id(task_path)
-        if story_uuid and task_uuid:
-            _journal_update(argparse.Namespace(
-                story=story_uuid, task=task_uuid, branch=branch,
-                state="STARTED", pr="none"))
-    except Exception as e:
-        print(f"⚠️  journal update failed: {e}", file=sys.stderr)
-
-    # 5. next steps
+    # 4. next steps
     print("\nNext steps:")
     if new_story:
         print(f"  - wire the story into {sprint_dir}/sprint.org (* Stories table)")
-    print(f"  - flip the {'story and task' if new_story else 'task'} State to STARTED when you begin")
+    print(f"  - compass task start {task_path.stem.removeprefix('task_')}   # clock on + stamp journal")
     print(f"  - git push -u origin {branch}   &&   open a PR")
     return 0
 
@@ -1541,6 +1530,84 @@ def cmd_story(argv):
         return 0
 
 
+def _cmd_task_start(task_ident):
+    """compass task start <slug-or-uuid> — clock on to an existing task."""
+    docs = doc_index.load_all()
+    il   = task_ident.lower()
+
+    # Resolve by UUID (exact or prefix), slug, or branch suffix.
+    tasks = [d for d in docs.values() if d.doctype == "task"]
+    exact  = [d for d in tasks if d.id.lower() == il]
+    prefix = [d for d in tasks if d.id.lower().startswith(il)]
+    slug   = [d for d in tasks if Path(d.rel_path).stem.lower() == f"task_{il}"
+                                or Path(d.rel_path).stem.lower() == il]
+    cands  = list({d.id: d for d in (exact or prefix) + slug}.values())
+
+    if not cands:
+        print(f"❌ No task matching '{task_ident}'.", file=sys.stderr)
+        return 1
+    if len(cands) > 1:
+        print(f"❌ Ambiguous — {len(cands)} tasks match '{task_ident}':", file=sys.stderr)
+        for c in cands:
+            print(f"   {c.id}  {c.rel_path}", file=sys.stderr)
+        return 1
+
+    task_doc  = cands[0]
+    task_path = Path(PROJECT_ROOT) / task_doc.rel_path
+
+    # Read branch from #+branch: frontmatter.
+    branch = _read_frontmatter_field(task_path, "branch")
+    if not branch:
+        print(f"❌ Task has no #+branch: set. Run 'compass task new' first.", file=sys.stderr)
+        return 1
+
+    # Find the parent story (one directory up, story.org).
+    story_path = task_path.parent / "story.org"
+    story_uuid = _read_org_id(story_path) if story_path.exists() else None
+
+    # Switch to the task branch (create off origin/main if absent).
+    result = subprocess.run(["git", "switch", branch], capture_output=True, text=True,
+                            cwd=PROJECT_ROOT)
+    if result.returncode != 0:
+        result2 = subprocess.run(
+            ["git", "switch", "-c", branch, "origin/main"],
+            capture_output=True, text=True, cwd=PROJECT_ROOT)
+        if result2.returncode != 0:
+            print(f"❌ git switch failed:\n{result2.stderr.strip()}", file=sys.stderr)
+            return 1
+        print(f"✅ created and switched to {branch} (off origin/main)")
+    else:
+        print(f"✅ switched to {branch}")
+
+    # Flip BACKLOG → STARTED in the task file if needed.
+    text = task_path.read_text(encoding="utf-8")
+    if "| State        | BACKLOG" in text:
+        text = text.replace("| State        | BACKLOG", "| State        | STARTED", 1)
+        task_path.write_text(text, encoding="utf-8")
+        print(f"📝 state: BACKLOG → STARTED")
+
+    # Stamp the journal.
+    try:
+        task_uuid = _read_org_id(task_path)
+        if story_uuid and task_uuid:
+            _journal_update(argparse.Namespace(
+                story=story_uuid, task=task_uuid, branch=branch,
+                state="STARTED", pr="none"))
+    except Exception as e:
+        print(f"⚠️  journal update failed: {e}", file=sys.stderr)
+
+    return 0
+
+
+def _read_frontmatter_field(path, field):
+    """Return the value of #+<field>: from an org file, or empty string."""
+    prefix = f"#+{field}:"
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.lower().startswith(prefix.lower()):
+            return line[len(prefix):].strip()
+    return ""
+
+
 def cmd_task(argv):
     """compass task — task-level operations."""
     ap = argparse.ArgumentParser(prog="compass task",
@@ -1555,6 +1622,9 @@ def cmd_task(argv):
     new_p.add_argument("--base",      default="origin/main")
     new_p.add_argument("--kind",      default="feature", choices=["feature", "hotfix"])
     new_p.add_argument("--dry-run",   action="store_true")
+
+    start_p = sub.add_parser("start", help="Clock on to an existing task: switch branch, STARTED state, stamp journal")
+    start_p.add_argument("task", help="Task slug, UUID/prefix, or branch suffix")
 
     args = ap.parse_args(argv)
 
@@ -1574,6 +1644,9 @@ def cmd_task(argv):
             sprint_dir, story_dir, story_title, None,
             args.task_slug, args.title, task_desc,
             branch, args.base, args.dry_run, current_sprint)
+
+    if args.subcmd == "start":
+        return _cmd_task_start(args.task)
 
 def main():
     # `list` and `show` pass every remaining argument straight through to the


### PR DESCRIPTION
## Summary

- Introduces \`compass task start <slug>\` as the explicit clock-on command covering all three use cases: new task, resume BACKLOG, and restart an in-progress task
- Decouples journal stamping from task/story creation — \`story new\` and \`task new\` no longer auto-stamp; creation ≠ starting work
- Fixes silent journal failure: \`except Exception: pass\` replaced with a visible \`⚠️\` warning to stderr
- Updates \`start_new_story\` and \`work_task_to_merged_pr\` runbooks to make \`compass task start\` a required first step
- Rewrites the session journal recipe to reflect the new model
- Adds restart-recovery recipe: *How do I know what I was working on?*
- Adds Journal section to \`compass.org\` index (was missing despite being one of the five pillars)
- Improves \`compass task start --help\` to document all three use cases inline

## Changes

- \`projects/ores.compass/src/compass.py\` — new \`compass task start\` subcommand; remove auto-stamp from scaffold path; visible journal failure warning; improved help text
- \`doc/llm/runbooks/start_new_story/runbook.org\` — step 3 is now \`compass task start\`
- \`doc/llm/runbooks/work_task_to_merged_pr/runbook.org\` — step 1 is now \`compass task start\`
- \`doc/recipes/agile/how_do_i_use_the_session_journal.org\` — rewritten for new model
- \`doc/recipes/agile/how_do_i_know_what_i_was_working_on.org\` — new restart-recovery recipe
- \`doc/recipes/compass/compass.org\` — new Journal section
- \`doc/agile/versions/v0/sprint_19/compass_session_journal/task_fix_journal_not_updated_on_resume.org\` — task doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)