### PR TITLE
[modeling] Add tooling layer to system model

### DIFF
--- a/doc/agile/versions/v0/sprint_19/add_tooling_layer_to_system_model/story.org
+++ b/doc/agile/versions/v0/sprint_19/add_tooling_layer_to_system_model/story.org
@@ -1,0 +1,75 @@
+:PROPERTIES:
+:ID: D90A3E68-D331-4473-AFAB-C1CBC94BA0CD
+:END:
+#+title: Story: Add tooling layer to system model
+#+description: Create system_model_tooling.org sub-page; add tooling layer blurb to system_model.org; link foundation layer docs back to tooling layer via org-roam.
+#+type: story
+#+level: s2
+#+filetags: :modeling:architecture:tooling:system_model:documentation:sprint_19:v0:
+#+created: 2026-06-02
+#+updated: 2026-06-02
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+The [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] describes four runtime layers (Foundation, Infrastructure,
+Domain, Application) but does not document the Tooling layer — the
+developer tools that support the build, test, and documentation workflows.
+[[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] already has a =* Tooling= section listing =ores.compass=,
+=ores.codegen=, =ores.lisp=, and =ores.sql=, but the system model itself
+has no parallel entry point.
+
+This story adds that entry point:
+1. A new =system_model_tooling.org= sub-page following the same format as
+   the four existing per-layer pages.
+2. A Tooling entry in =system_model.org= with a short blurb and an org-roam
+   id-link to the sub-page.
+3. Id-links from =system_model_foundation.org= back to the Tooling page
+   where tooling components (compass, codegen, lisp, sql) are mentioned.
+
+* Status
+
+| Field         | Value                                                            |
+|---------------+------------------------------------------------------------------|
+| State         | STARTED                                                          |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                                                        |
+| Now           | Task 1 in progress.                                              |
+| Waiting on    | —                                                                |
+| Next          | Implement task; PR; merge.                                       |
+| Last touched  | 2026-06-02                                                       |
+
+* Acceptance
+
+- =projects/modeling/system_model_tooling.org= exists with a component
+  inventory for all four tooling components.
+- =projects/modeling/system_model.org= has a =* Tooling Layer= bullet with
+  an id-link to =system_model_tooling.org=.
+- =projects/modeling/system_model_foundation.org= links back to
+  =system_model_tooling.org= via org-roam id-links where tooling
+  components are cross-referenced.
+- Site builds clean.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:7F7456F7-DC80-4596-B375-CE026905E036][Create system_model_tooling.org and update system model links]] | DONE | 2026-06-02 | 2026-06-02 | Create system_model_tooling.org; add tooling blurb to system_model.org; add back-links from foundation layer. |
+
+* Decisions
+
+- /Tooling is not a fifth runtime layer./ The four runtime layers describe
+  the dependency order of components that run in production. Tooling
+  components (compass, codegen, lisp, sql) are not part of that stack —
+  they support development. The system model entry is a sibling section,
+  not a fifth layer in the diagram.
+- /Existing tooling docs are not updated here./ The component overviews for
+  ores.compass, ores.codegen, ores.lisp, and ores.sql were written in
+  sprint 18 (Tooling documentation story). This story only wires them into
+  the system model index.
+
+* Out of scope
+
+- Updating the architecture PlantUML diagram to show a tooling tier.
+- Updating individual tooling component overviews.

--- a/doc/agile/versions/v0/sprint_19/add_tooling_layer_to_system_model/task_add_tooling_layer_docs.org
+++ b/doc/agile/versions/v0/sprint_19/add_tooling_layer_to_system_model/task_add_tooling_layer_docs.org
@@ -1,0 +1,84 @@
+:PROPERTIES:
+:ID: 7F7456F7-DC80-4596-B375-CE026905E036
+:END:
+#+title: Task: Create system_model_tooling.org and update system model links
+#+description: Create system_model_tooling.org; add tooling blurb to system_model.org; add back-links from system_model_foundation.org to tooling page.
+#+type: task
+#+level: s1
+#+filetags: :add_tooling_layer_to_system_model:sprint_19:v0:
+#+owner: marco
+#+branch: feature/fix-windows-macos-ci
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-02
+#+updated: 2026-06-02
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:D90A3E68-D331-4473-AFAB-C1CBC94BA0CD][Add tooling layer to system model]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Wire the tooling components into the system model so they are discoverable
+from the architecture documentation:
+
+1. Create =projects/modeling/system_model_tooling.org= with a component
+   inventory for the four tooling components (compass, codegen, lisp, sql).
+2. Add a Tooling bullet to =projects/modeling/system_model.org= with an
+   id-link to the new sub-page.
+3. Add back-links from =projects/modeling/system_model_foundation.org= to
+   the Tooling page at the =ores.sql= and =ores.codegen= sections and in
+   =* See also=.
+
+All links are org-roam id-links.
+
+* Status
+
+| Field        | Value                                                            |
+|--------------+------------------------------------------------------------------|
+| State        | DONE                                                             |
+| Parent story | [[id:D90A3E68-D331-4473-AFAB-C1CBC94BA0CD][Add tooling layer to system model]]                |
+| Now          | Implemented; PR pending.                                         |
+| Waiting on   | PR.                                                              |
+| Next         | Raise PR; merge; close story.                                    |
+| Last touched | 2026-06-02                                                       |
+
+* Acceptance
+
+- =projects/modeling/system_model_tooling.org= exists with component tables
+  for compass, codegen, lisp, and sql; links back to the system model index
+  and knowledge.org.
+- =projects/modeling/system_model.org= has a Tooling Layer bullet with
+  id-link to the new page, clearly noted as not a runtime layer.
+- =projects/modeling/system_model_foundation.org= has id-links to the Tooling
+  Layer page at the =ores.sql= section, the =ores.codegen= section, and in
+  =* See also=.
+- All links are org-roam =[[id:...][Title]]= links.
+
+* Notes
+
+- Existing tooling component overviews (compass, codegen, lisp, sql) are not
+  modified — this task only creates the system model index page and wires
+  back-links from the foundation layer.
+- =ores.sql= and =ores.codegen= appear in =system_model_foundation.org= for
+  historical reasons (they were listed there before the Tooling layer concept
+  was formalised). The back-links added here make it clear they also belong
+  in the Tooling layer documentation.
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+- =projects/modeling/system_model_tooling.org= created with four component sections.
+- =system_model.org= Tooling Layer bullet added.
+- =system_model_foundation.org= back-links added at ores.sql, ores.codegen, and See also.

--- a/doc/agile/versions/v0/sprint_19/add_tooling_layer_to_system_model/task_add_tooling_layer_docs.org
+++ b/doc/agile/versions/v0/sprint_19/add_tooling_layer_to_system_model/task_add_tooling_layer_docs.org
@@ -38,7 +38,7 @@ All links are org-roam id-links.
 |--------------+------------------------------------------------------------------|
 | State        | DONE                                                             |
 | Parent story | [[id:D90A3E68-D331-4473-AFAB-C1CBC94BA0CD][Add tooling layer to system model]]                |
-| Now          | Implemented; PR pending.                                         |
+| Now          | Nothing.                                                         |
 | Waiting on   | PR.                                                              |
 | Next         | Raise PR; merge; close story.                                    |
 | Last touched | 2026-06-02                                                       |

--- a/doc/agile/versions/v0/sprint_19/add_tooling_layer_to_system_model/task_add_tooling_layer_docs.org
+++ b/doc/agile/versions/v0/sprint_19/add_tooling_layer_to_system_model/task_add_tooling_layer_docs.org
@@ -8,7 +8,7 @@
 #+filetags: :add_tooling_layer_to_system_model:sprint_19:v0:
 #+owner: marco
 #+branch: feature/fix-windows-macos-ci
-#+pr:
+#+pr: 1015
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-02
@@ -69,13 +69,13 @@ All links are org-roam id-links.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1015][#1015]] | [modeling] Add tooling layer to system model |
 
 * Review
 
-| # | Comment summary | File | Decision | Notes |
-|---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| # | Comment summary                                             | File                             | Decision | Notes           |
+|---+-------------------------------------------------------------+----------------------------------+----------+-----------------|
+| 1 | Now field must be Nothing. when task state is DONE          | task_add_tooling_layer_docs.org  | Accept   | Fixed aa09bd532 |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -119,6 +119,7 @@ dedicated thread pool to prevent =QThreadPool= starvation.
 |-------+-------+-------+-----+-------------|
 | [[id:40B50055-EB09-4B5B-B26C-24F0F9CD1C5B][Entity manual: add shell documentation per chapter]] | BACKLOG | | | Each entity chapter in the manual covers Qt UI and shell usage side by side.             |
 | [[id:F3CB848E-72C1-4F81-AAE4-1265F41D47C1][Fix knowledge graph issues]]                         | DONE    | 2026-05-30 | 2026-05-31 | Fix knowledge graph: images not displaying and left-panel controls missing. |
+| [[id:D90A3E68-D331-4473-AFAB-C1CBC94BA0CD][Add tooling layer to system model]]                  | STARTED | 2026-06-02 | | Add system_model_tooling.org; tooling blurb in system_model.org; foundation layer back-links. |
 
 ** Infrastructure
 

--- a/projects/modeling/system_model.org
+++ b/projects/modeling/system_model.org
@@ -47,6 +47,9 @@ the system belongs to exactly one of these layers:
 - [[id:C9AD7DA5-D00E-4CA9-A978-E74F776E0F17][Application Layer]]: the surfaces. Depends on every layer below. Qt desktop, CLI,
   HTTP servers, Wt web frontend, and the compute engine. If a user touches it,
   it lives here.
+- [[id:A3F8B2C1-9D4E-4F7A-B6C5-2E8D1A0F3B9C][Tooling Layer]]: the instruments contributors reach for to build, test, and
+  document the system. Not a runtime layer — these components carry no production
+  dependency. [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]], [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]], [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]], and [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]] live here.
 
 * See Also
 

--- a/projects/modeling/system_model_foundation.org
+++ b/projects/modeling/system_model_foundation.org
@@ -115,6 +115,7 @@ Related documents:
   cross-service access is controlled.
 - [[id:496DC90B-8951-42A6-A63E-B1762DF496C6][PlantUML ER diagram conventions]] — conventions used to diagram the database
   schema.
+- [[id:A3F8B2C1-9D4E-4F7A-B6C5-2E8D1A0F3B9C][Tooling Layer]] — =ores.sql= in its developer-tooling context.
 
 ** ores.security
 
@@ -137,8 +138,11 @@ scaffolding. Also the engine behind the =compass= CLI tool.
 |---------------+------------------------------------------+--------------|
 | [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]]  | Stencil-driven C++ and org-mode code gen | [[id:00E33570-F7BE-7F94-FD83-2FDC9CB04463][ores.utility]] |
 
+- [[id:A3F8B2C1-9D4E-4F7A-B6C5-2E8D1A0F3B9C][Tooling Layer]] — =ores.codegen= and =ores.compass= in their developer-tooling context.
+
 * See also
 
 - [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] — the index page with the four-layer architecture overview.
+- [[id:A3F8B2C1-9D4E-4F7A-B6C5-2E8D1A0F3B9C][Tooling Layer]] — full tooling component inventory (compass, codegen, lisp, sql).
 - [[id:6FF02DD3-0F3B-4BCB-87CA-3224030D00E8][System Model: Infrastructure Layer]] — the next layer up.
 - [[id:A1C3E5F7-92B4-4D6A-B8C2-3F1D7E9A0B5C][Shared Library Symbol Visibility]] — how symbols are exported across Foundation shared libraries.

--- a/projects/modeling/system_model_tooling.org
+++ b/projects/modeling/system_model_tooling.org
@@ -1,0 +1,76 @@
+:PROPERTIES:
+:ID: A3F8B2C1-9D4E-4F7A-B6C5-2E8D1A0F3B9C
+:END:
+#+title: System Model: Tooling Layer
+#+description: Component inventory for the Tooling layer: the developer tools and automation that support building, testing, and documenting ORE Studio.
+#+type: knowledge
+#+level: cross
+#+filetags: :modeling:architecture:tooling:system_model:
+#+created: 2026-06-02
+#+updated: 2026-06-02
+
+This page is part of the [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]]. Tooling is not a runtime layer — these
+components do not run in production and carry no dependency on the four
+runtime layers. They exist to support the human and LLM contributors who
+build, test, and document ORE Studio: code generation, repository navigation,
+database lifecycle management, and Emacs developer ergonomics.
+
+See [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] → =* Tooling= for the entry-point index to all tooling docs.
+
+* Detail
+
+** ores.compass
+
+[[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] is the Python repository compass: the primary quality-of-life
+tool for both human contributors and LLM agents. It provides temporal
+orientation in the sprint (where are we, what is in flight), semantic search
+over the org-roam knowledge graph, agile scaffolding (story, task, capture,
+memory), and fleet management for parallel Claude environments.
+
+| Component    | Role                                                                    | Language |
+|--------------+-------------------------------------------------------------------------+----------|
+| [[id:6F7A122F-BC0F-4F3E-BA46-8B793FF15D10][ores.compass]] | Temporal orientation, doc search, agile scaffolding, fleet management   | Python   |
+
+** ores.codegen
+
+[[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] is the Python + Mustache code generator that produces SQL
+schemas, C++ domain types, and v2 org documents from per-entity model files.
+It embodies the MASD /back-out-from-reference-implementation/ strategy:
+entities are commissioned by hand first, the recurring pattern is extracted
+into a template, and every subsequent entity is generated. See
+[[id:EE6A643D-6C6C-41B8-88FD-2EA9351414CD][Document MASD and code generation principles]] for the design rationale.
+
+| Component    | Role                                                       | Language        |
+|--------------+------------------------------------------------------------+-----------------|
+| [[id:08FBD248-257A-A474-DD43-DB08949978F1][ores.codegen]] | SQL, C++, and org document generation from entity models   | Python, Mustache |
+
+** ores.lisp
+
+[[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]] is the Emacs Lisp developer tooling layer: dashboard, database
+browser, shell integration, and the org-roam export pipeline that converts
+the knowledge graph to the project site. It is the operational surface for
+contributors who work in Emacs.
+
+| Component  | Role                                                              | Language    |
+|------------+-------------------------------------------------------------------+-------------|
+| [[id:EAE593F5-B549-4705-A598-344405196574][ores.lisp]]  | Emacs dashboard, DB browser, shell integration, org-roam export   | Emacs Lisp  |
+
+** ores.sql
+
+[[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]] owns the PostgreSQL lifecycle: schema definitions, migration
+scripts, role provisioning, and database recreation. It is the authoritative
+source of the SQL schema and the scripts that set up a development or CI
+database from scratch. See the =* Scripts= section in the component overview
+for the full script inventory.
+
+| Component | Role                                                          | Language |
+|-----------+---------------------------------------------------------------+----------|
+| [[id:B7E9F3A1-C8D2-4E6B-A1F5-9D3C7E8B2A4F][ores.sql]]  | PostgreSQL schema, migrations, role provisioning, DB lifecycle | SQL, bash |
+
+* See Also
+
+- [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]] — the broader knowledge graph entry point, including the full
+  =* Tooling= section with narrative descriptions and recipe links.
+- [[id:BA6F2BF1-E16E-4E80-A3D0-CACC30FA04DB][Developer scripts]] — inventory of standalone scripts in =scripts/=,
+  grouped by purpose.
+- [[id:D773166D-0C91-8CB4-3323-42166BC07687][System Model]] — the top-level architecture index.


### PR DESCRIPTION
## Summary

- The System Model described four runtime layers (Foundation, Infrastructure, Domain, Application) but had no entry for the Tooling layer — the developer tools that support building, testing, and documenting ORE Studio
- `knowledge.org` already had a `* Tooling` section listing the four tools; the system model lacked a parallel entry point
- Creates `system_model_tooling.org` (new sub-page following the same format as the runtime-layer pages), adds a Tooling bullet to `system_model.org`, and back-links from `system_model_foundation.org` to the Tooling page

## Changes

| File | Change |
|------|--------|
| `projects/modeling/system_model_tooling.org` | **New** — component inventory for `ores.compass`, `ores.codegen`, `ores.lisp`, `ores.sql`; explicitly noted as not a runtime layer |
| `projects/modeling/system_model.org` | Add Tooling Layer bullet with `[[id:...][Tooling Layer]]` id-link |
| `projects/modeling/system_model_foundation.org` | Add `[[id:...][Tooling Layer]]` back-links at the `ores.sql` section, `ores.codegen` section, and `* See also` |

Existing tooling component overviews are not modified.

## Story / Task

- Story: [Add tooling layer to system model](../blob/main/doc/agile/versions/v0/sprint_19/add_tooling_layer_to_system_model/story.org) — `D90A3E68-D331-4473-AFAB-C1CBC94BA0CD`
- Task: [Create system_model_tooling.org and update system model links](../blob/main/doc/agile/versions/v0/sprint_19/add_tooling_layer_to_system_model/task_add_tooling_layer_docs.org) — `7F7456F7-DC80-4596-B375-CE026905E036`

## Test plan

- [ ] Site builds clean
- [ ] All org-roam id-links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)