### PR TITLE
Surface branch staleness in compass Orient (where/fleet)

### DIFF
--- a/compass.sh
+++ b/compass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Compass — ORE Studio developer toolkit.
+# This root-level entry point forwards to the real script so compass is
+# discoverable from the repo root without knowing the project layout.
+exec "$(dirname "${BASH_SOURCE[0]}")/projects/ores.compass/compass.sh" "$@"

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/story.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/story.org
@@ -128,7 +128,7 @@ migrate; the single service registry's home (=projects/services.json=).
 | [[id:333104A0-FFFE-4C20-9390-FA2ED732C2D5][Migrate the Operate pillar (services, client, logs)]] | BACKLOG | | | compass services {start,stop,status,clear-logs} + --delete-logs, compass client. |
 | [[id:D38238C9-702F-47AC-BE64-91D84A8EE716][Migrate the Build pillar (build, site)]] | BACKLOG | | | compass build, compass site serve. |
 | [[id:32DB538C-E2A6-493C-8CBA-6C73A7A10EC4][Add the Generate pillar (delegating gen verbs)]] | BACKLOG | | | compass gen verbs delegating to ores.codegen (keeps its own CLI). |
-| [[id:E65F42A6-0762-4F75-866F-25A428B3973F][Surface branch staleness vs main in compass Orient]] | BACKLOG | | | Compact ↑ahead/↓behind-origin/main indicator (no fetch) on where/status/fleet, escalating to a warning when too stale. |
+| [[id:E65F42A6-0762-4F75-866F-25A428B3973F][Surface branch staleness vs main in compass Orient]] | STARTED | 2026-06-02 | | Compact ↑ahead/↓behind-origin/main indicator (no fetch) on where/status/fleet, escalating to a warning when too stale. |
 | [[id:81DE1DC9-FB73-46DB-A8AB-E4BE8F78C591][Port sprint_metrics.py to compass sprint charts]] | BACKLOG | | | compass sprint charts; auto-detects current sprint; deletes standalone script; updates recipes. |
 | [[id:196FE762-F1A6-49BC-A2FF-60F3FC08114D][Port parse_test_results.py to compass test results]] | BACKLOG | | | New test pillar; auto-resolves preset from .env; recipe for test run overview; deletes standalone script. |
 

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_surface_branch_staleness_vs_main.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_surface_branch_staleness_vs_main.org
@@ -119,8 +119,11 @@ and in a detached HEAD it degrades without error.
 
 * Review
 
+** Round 1 (gemini-code-assist bot)
+
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| C1 | Combine two =rev-list= calls into one =--left-right --count= | =compass.py:644= | Accepted | Fewer subprocesses per worktree, especially for fleet |
+| C1 | Resolve =.git= dir directly instead of =git rev-parse --git-dir= | =compass.py:644= | Accepted | Eliminates one subprocess; direct file read is simpler |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_surface_branch_staleness_vs_main.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_surface_branch_staleness_vs_main.org
@@ -8,7 +8,7 @@
 #+filetags: :consolidate_scripts_into_compass:sprint_19:v0:
 #+owner: marco
 #+branch: feature/surface-branch-staleness-orient
-#+pr:
+#+pr: 1021
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-02
@@ -113,9 +113,9 @@ and in a detached HEAD it degrades without error.
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR   | Title                                                      |
+|------+------------------------------------------------------------|
+| 1021 | Surface branch staleness in compass Orient (where/fleet)   |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_surface_branch_staleness_vs_main.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_surface_branch_staleness_vs_main.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :consolidate_scripts_into_compass:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/surface-branch-staleness-orient
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -35,12 +35,12 @@ fresh as the last =git fetch= — is made visible rather than hidden.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
-| Parent story | [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]] |
-| Now          | Not yet started.                       |
-| Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-02                               |
+| State        | STARTED                                              |
+| Parent story | [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]]         |
+| Now          | Implement =branch_staleness()= helper + chip renderer. |
+| Waiting on   | Nothing.                                             |
+| Next         | Wire chip into =where=, =status=, =fleet=.           |
+| Last touched | 2026-06-02                                           |
 
 * Acceptance
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -623,9 +623,12 @@ def branch_staleness(root):
         info["error"] = "no-remote"
         return info
 
-    for key, rev_range in (("ahead", "origin/main..HEAD"), ("behind", "HEAD..origin/main")):
-        val = _git_out("rev-list", "--count", rev_range, cwd=root)
-        info[key] = int(val) if val and val.isdigit() else 0
+    counts = _git_out("rev-list", "--left-right", "--count", "origin/main...HEAD", cwd=root)
+    if counts:
+        parts = counts.split()
+        if len(parts) == 2 and parts[0].isdigit() and parts[1].isdigit():
+            info["behind"] = int(parts[0])
+            info["ahead"]  = int(parts[1])
 
     base = _git_out("merge-base", "HEAD", "origin/main", cwd=root)
     if base:
@@ -633,12 +636,23 @@ def branch_staleness(root):
         if ts and ts.isdigit():
             info["base_age_s"] = time.time() - int(ts)
 
-    # FETCH_HEAD is written to the worktree-specific git dir (not the common
-    # dir) when git fetch is run from a secondary worktree, so use --git-dir.
-    gitdir = _git_out("rev-parse", "--git-dir", cwd=root)
+    # Resolve the worktree-specific git dir directly — avoids a subprocess.
+    # .git is a directory in the main checkout and a "gitdir: <path>" file in
+    # secondary worktrees; FETCH_HEAD lives in whichever dir git fetch writes to.
+    dot_git = Path(root) / ".git"
+    if dot_git.is_dir():
+        gitdir = dot_git
+    elif dot_git.is_file():
+        content = dot_git.read_text().strip()
+        if content.startswith("gitdir:"):
+            gp = Path(content.split(":", 1)[1].strip())
+            gitdir = gp if gp.is_absolute() else Path(root) / gp
+        else:
+            gitdir = None
+    else:
+        gitdir = None
     if gitdir:
-        fh = Path(gitdir) if Path(gitdir).is_absolute() else Path(root) / gitdir
-        fh = fh / "FETCH_HEAD"
+        fh = gitdir / "FETCH_HEAD"
         if fh.exists():
             info["fetch_age_s"] = time.time() - fh.stat().st_mtime
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -587,6 +587,127 @@ def current_version_sprint(docs):
     current_sprint = max(in_version or sprints, key=_seq_key)
     return current_version, current_sprint
 
+# --- Branch staleness helpers (Orient pillar) ---
+
+def _git_out(*cmd, cwd):
+    """Run a git command; return stripped stdout or None on failure."""
+    try:
+        p = subprocess.run(["git"] + list(cmd), capture_output=True, text=True,
+                           cwd=str(cwd), timeout=5)
+        return p.stdout.strip() if p.returncode == 0 else None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+def branch_staleness(root):
+    """Compute how far the current branch has drifted from origin/main.
+
+    No network call — reads cached origin/main and .git/FETCH_HEAD only.
+    Returns a dict:
+      branch      - current branch name, or None (detached HEAD)
+      ahead       - commits ahead of origin/main
+      behind      - commits behind origin/main
+      base_age_s  - seconds since merge-base diverged (float), or None
+      fetch_age_s - seconds since last git fetch (float), or None
+      error       - None | "detached" | "no-remote"
+    """
+    info = {"branch": None, "ahead": 0, "behind": 0,
+            "base_age_s": None, "fetch_age_s": None, "error": None}
+
+    branch = _git_out("symbolic-ref", "--short", "HEAD", cwd=root)
+    if branch is None:
+        info["error"] = "detached"
+        return info
+    info["branch"] = branch
+
+    if _git_out("rev-parse", "--verify", "origin/main", cwd=root) is None:
+        info["error"] = "no-remote"
+        return info
+
+    for key, rev_range in (("ahead", "origin/main..HEAD"), ("behind", "HEAD..origin/main")):
+        val = _git_out("rev-list", "--count", rev_range, cwd=root)
+        info[key] = int(val) if val and val.isdigit() else 0
+
+    base = _git_out("merge-base", "HEAD", "origin/main", cwd=root)
+    if base:
+        ts = _git_out("log", "-1", "--format=%ct", base, cwd=root)
+        if ts and ts.isdigit():
+            info["base_age_s"] = time.time() - int(ts)
+
+    # FETCH_HEAD lives in the common git dir (shared by all worktrees)
+    common = _git_out("rev-parse", "--git-common-dir", cwd=root)
+    if common:
+        fh = Path(common) if Path(common).is_absolute() else Path(root) / common
+        fh = fh / "FETCH_HEAD"
+        if fh.exists():
+            info["fetch_age_s"] = time.time() - fh.stat().st_mtime
+
+    return info
+
+def _staleness_severity(info):
+    """Return 'ok', 'warn', or 'stale'."""
+    if info.get("error"):
+        return "ok"
+    behind     = info.get("behind", 0)
+    fetch_days = (info.get("fetch_age_s") or 0) / 86400
+    if behind >= 25 or fetch_days > 2:
+        return "stale"
+    if behind >= 10 or fetch_days > 1:
+        return "warn"
+    return "ok"
+
+def _age_human(seconds):
+    """Convert seconds to a compact label: 30m, 4h, 2d."""
+    if seconds is None:
+        return "?"
+    s = int(seconds)
+    if s < 3600:
+        return f"{s // 60}m"
+    if s < 86400:
+        return f"{s // 3600}h"
+    return f"{s // 86400}d"
+
+_C_GREEN  = "\033[32m"
+_C_YELLOW = "\033[33m"
+_C_RED    = "\033[31m"
+_C_RESET  = "\033[0m"
+_C_SEV    = {"ok": _C_GREEN, "warn": _C_YELLOW, "stale": _C_RED}
+
+def staleness_lines(info):
+    """Return (chip_line, warning_line_or_None) for a branch_staleness dict."""
+    error  = info.get("error")
+    branch = info.get("branch") or "(detached)"
+
+    if error == "detached":
+        return "⎇  (detached HEAD)", None
+    if error == "no-remote":
+        return f"⎇  {branch}  (no origin/main)", None
+
+    ahead      = info.get("ahead", 0)
+    behind     = info.get("behind", 0)
+    base_age   = _age_human(info.get("base_age_s"))
+    fetch_age  = _age_human(info.get("fetch_age_s"))
+    severity   = _staleness_severity(info)
+    col        = _C_SEV[severity]
+
+    if branch == "main":
+        if behind == 0:
+            chip = f"{col}⎇  main  (up to date, fetched {fetch_age} ago){_C_RESET}"
+        else:
+            chip = f"{col}⎇  main  ↓{behind}  (fetched {fetch_age} ago){_C_RESET}"
+        warning = (f"{_C_YELLOW}⚠  main is behind origin — run: git fetch{_C_RESET}"
+                   if behind > 0 else None)
+        return chip, warning
+
+    chip = (f"{col}⎇  {branch}  ↑{ahead} ↓{behind}"
+            f"  (diverged {base_age} ago, fetched {fetch_age} ago){_C_RESET}")
+    if severity == "stale":
+        warning = f"{_C_RED}⚠  Branch is stale — run: git fetch && git rebase origin/main{_C_RESET}"
+    elif severity == "warn":
+        warning = f"{_C_YELLOW}⚠  Branch is drifting — consider: git fetch && git rebase origin/main{_C_RESET}"
+    else:
+        warning = None
+    return chip, warning
+
 def cmd_where(args):
     docs = doc_index.load_all()
     current_version, current_sprint = current_version_sprint(docs)
@@ -647,6 +768,11 @@ def cmd_where(args):
         return
 
     print("🧭 ores.compass — where are we?\n")
+    chip, warning = staleness_lines(branch_staleness(PROJECT_ROOT))
+    print(chip)
+    if warning:
+        print(warning)
+    print()
     print(f"Version:  {current_version.title}  [{current_version.id.upper()}]")
     print(f"          {current_version.rel_path}")
     print(f"Sprint:   {current_sprint.title}  [{current_sprint.id.upper()}]")
@@ -1276,6 +1402,7 @@ def cmd_fleet(args):
             "journal": bool(journal),
             "pr": ({"number": pr["number"], "state": pr["state"], "url": pr["url"]}
                    if pr else None),
+            "staleness": branch_staleness(path),
         })
 
     if args.format == "json":
@@ -1286,7 +1413,11 @@ def cmd_fleet(args):
     for r in rows:
         mark = "→" if r["current"] else " "
         branch = r["branch"] or "(detached)"
+        chip, warning = staleness_lines(r["staleness"])
         print(f"{mark} {r['worktree']}   {branch}")
+        print(f"      {chip}")
+        if warning:
+            print(f"      {warning}")
         if r["task"] or r["story"]:
             state_suffix = f" [{r['task_state']}]" if r["task_state"] else ""
             source = "" if r["journal"] else " (from branch)"

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -633,10 +633,11 @@ def branch_staleness(root):
         if ts and ts.isdigit():
             info["base_age_s"] = time.time() - int(ts)
 
-    # FETCH_HEAD lives in the common git dir (shared by all worktrees)
-    common = _git_out("rev-parse", "--git-common-dir", cwd=root)
-    if common:
-        fh = Path(common) if Path(common).is_absolute() else Path(root) / common
+    # FETCH_HEAD is written to the worktree-specific git dir (not the common
+    # dir) when git fetch is run from a secondary worktree, so use --git-dir.
+    gitdir = _git_out("rev-parse", "--git-dir", cwd=root)
+    if gitdir:
+        fh = Path(gitdir) if Path(gitdir).is_absolute() else Path(root) / gitdir
         fh = fh / "FETCH_HEAD"
         if fh.exists():
             info["fetch_age_s"] = time.time() - fh.stat().st_mtime


### PR DESCRIPTION
## Summary

- Adds `branch_staleness(root)` helper — offline, reads cached `origin/main` and `FETCH_HEAD`; returns `ahead`, `behind`, `base_age_s`, `fetch_age_s`
- Adds `staleness_lines(info)` renderer — colour-coded chip (green/yellow/red) with optional warning line; handles detached HEAD, no-remote, and `main` as special cases
- Wires chip into `compass where`/`status` (printed at top, before Version/Sprint) and `compass fleet` (per-worktree row)
- Adds `./compass.sh` root-level forwarder so compass is discoverable without knowing the project layout
- Fixes `FETCH_HEAD` path: uses `--git-dir` (worktree-specific) not `--git-common-dir` (shared) — git fetch in a secondary worktree writes to the former

## Severity thresholds

| Level | Trigger |
|-------|---------|
| ok (green) | behind < 10 and fetch < 1 day |
| warn (yellow) | behind 10–24, or fetch 1–2 days |
| stale (red) | behind ≥ 25, or fetch > 2 days |

## Test plan

- [ ] `./compass.sh where` on a fresh branch — chip shows green, no warning
- [ ] `./compass.sh fleet` — chip appears per worktree; `main` worktree shows `↓N` variant
- [ ] `./compass.sh where -f json` — no chip in output (JSON unaffected)
- [ ] Simulate stale: manually backdate `FETCH_HEAD` mtime — chip turns red with remedy line
- [ ] Detached HEAD worktree — chip shows `⎇  (detached HEAD)`, no crash
- [ ] `./compass.sh where` from repo root via new forwarder — works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)