### PR TITLE
[cmake] Wire XML reporter into rat targets so compass test results works

### DIFF
--- a/doc/agile/product_backlog/inbox/refactor_the_65_per_component_test_cmakelists_into.org
+++ b/doc/agile/product_backlog/inbox/refactor_the_65_per_component_test_cmakelists_into.org
@@ -1,0 +1,28 @@
+:PROPERTIES:
+:ID: E9A4AA97-C515-4D6E-A28B-AC85B0AB40BB
+:END:
+#+title: Centralise test target boilerplate into a shared CMake macro
+#+description: Refactor the 65 per-component test CMakeLists into a shared ores_add_test_target() CMake macro in projects/CMakeLists.txt — eliminates the add_custom_target + add_test duplication that has to be updated every time the test runner pattern changes.
+#+type: capture
+#+level: cross
+#+filetags: :capture:
+#+created: 2026-06-03
+#+updated: 2026-06-03
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+(One paragraph: the idea.)
+
+* Why
+
+(Motivation, problem being solved, related context.)
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/story.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/story.org
@@ -34,10 +34,10 @@ within this larger effort.
 |---------------+--------------------------------------------------|
 | State         | STARTED                                          |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                               |
-| Now           | Provision pillar live: compass env init/diff/list/version; scripts deleted, CI + dashboard cut over. env-init task shipped in PR. |
+| Now           | compass test results, sprint charts, branch staleness, bearings all shipped. rat now generates XML for compass test results. |
 | Waiting on    | Nothing.                                         |
 | Next          | Document the compass env commands; then db/nats/Operate/Build/Generate migrations. |
-| Last touched  | 2026-06-02                                       |
+| Last touched  | 2026-06-03                                       |
 
 * Background: script inventory (2026-06-02)
 

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/story.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/story.org
@@ -131,6 +131,7 @@ migrate; the single service registry's home (=projects/services.json=).
 | [[id:E65F42A6-0762-4F75-866F-25A428B3973F][Surface branch staleness vs main in compass Orient]] | STARTED | 2026-06-02 | | Compact ↑ahead/↓behind-origin/main indicator (no fetch) on where/status/fleet, escalating to a warning when too stale. |
 | [[id:81DE1DC9-FB73-46DB-A8AB-E4BE8F78C591][Port sprint_metrics.py to compass sprint charts]] | BACKLOG | | | compass sprint charts; auto-detects current sprint; deletes standalone script; updates recipes. |
 | [[id:196FE762-F1A6-49BC-A2FF-60F3FC08114D][Port parse_test_results.py to compass test results]] | BACKLOG | | | New test pillar; auto-resolves preset from .env; recipe for test run overview; deletes standalone script. |
+| [[id:4CB61A14-83D7-44A6-A6E5-F0A553B93675][Fix: compass test results missing after make rat]] | DONE | 2026-06-03 | 2026-06-03 | Wire XML reporter into rat custom targets so compass test results has data after the standard dev workflow. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_fix_test_results_not_generated_by_rat.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_fix_test_results_not_generated_by_rat.org
@@ -8,7 +8,7 @@
 #+filetags: :consolidate_scripts_into_compass:sprint_19:v0:
 #+owner: marco
 #+branch: feature/fix-test-results-not-generated-by-rat
-#+pr:
+#+pr: 1026
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-03
@@ -88,9 +88,9 @@ flag.
 
 * PRs
 
-| PR | Title |
-|----+-------|
-|    |       |
+| PR   | Title                                                              |
+|------+--------------------------------------------------------------------|
+| 1026 | [cmake] Wire XML reporter into rat targets so compass test results works |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_fix_test_results_not_generated_by_rat.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_fix_test_results_not_generated_by_rat.org
@@ -94,9 +94,11 @@ flag.
 
 * Review
 
+** Round 1 (gemini-code-assist bot)
+
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| C1 | Refactor =add_custom_target= into a shared CMake macro across 65 files | =analytics/tests/CMakeLists.txt:46= | Declined | Pre-existing duplication; this PR is a one-line bug fix; macro refactor is a separate story |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_fix_test_results_not_generated_by_rat.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_fix_test_results_not_generated_by_rat.org
@@ -1,0 +1,113 @@
+:PROPERTIES:
+:ID: 4CB61A14-83D7-44A6-A6E5-F0A553B93675
+:END:
+#+title: Task: Fix: compass test results missing after make rat
+#+description: make rat does not generate test-results*.xml because the custom test targets use only -r compact; compass test results always errors. Wire XML reporter into the rat targets.
+#+type: task
+#+level: s1
+#+filetags: :consolidate_scripts_into_compass:sprint_19:v0:
+#+owner: marco
+#+branch: feature/fix-test-results-not-generated-by-rat
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-03
+#+updated: 2026-06-03
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Make =make rat= produce =test-results*.xml= files so that =compass test
+results= has data to parse after the standard developer test workflow.
+Today, the custom =test_<name>= targets (wired into =run_all_tests= →
+=rat=) run tests with =-r compact= only; the XML reporter is only
+invoked by =ctest=, which most developers do not run directly.
+
+* Status
+
+| Field        | Value                                                                  |
+|--------------+------------------------------------------------------------------------|
+| State        | DONE                                                                   |
+| Parent story | [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]]                            |
+| Now          | Nothing.                                                               |
+| Waiting on   | Nothing.                                                               |
+| Next         | Nothing.                                                               |
+| Last touched | 2026-06-03                                                             |
+
+* Acceptance
+
+- =cmake --build --preset <P> --target rat= produces =test-results*.xml=
+  files alongside the compact output in =build/output/<P>/publish/bin/=.
+- =compass test results= (with no =ctest= invocation) displays the
+  results table immediately after a =rat= run.
+- No existing CTest behaviour is broken; XML is also still written on
+  =ctest= runs.
+
+* Plan
+
+Each component's =tests/CMakeLists.txt= has:
+
+#+begin_example
+add_custom_target(test_${tests_target_name}
+    COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+    ...)
+#+end_example
+
+=ORES_CATCH2_ARGS= contains =-r compact= but not the XML reporter.
+Catch2 supports multiple =-r= flags simultaneously. The fix is to append
+=-r xml::out=<path>= to the COMMAND in every =add_custom_target(test_...)=,
+matching the path already used by =add_test=:
+
+#+begin_example
+${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
+#+end_example
+
+Rather than editing every test CMakeLists individually, the cleaner fix
+is to extend =ORES_CATCH2_ARGS= in =projects/CMakeLists.txt= to include
+the XML reporter — but that would hard-code a path that isn't available
+at that scope. Instead, add a second COMMAND line to the custom target
+that re-runs the binary with the XML reporter only (silent, no compact
+output), or add the XML flag inline.
+
+Simplest approach: in each =add_custom_target(test_${tests_target_name})=,
+change COMMAND to run Catch2 with both reporters:
+
+#+begin_example
+COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}>
+        ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
+#+end_example
+
+This is a mechanical change across all test CMakeLists; verify with a
+grep after applying that no =add_custom_target(test_= is missing the XML
+flag.
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Root cause: =add_custom_target(test_${tests_target_name})= in every
+component's =tests/CMakeLists.txt= ran tests with =ORES_CATCH2_ARGS=
+(=-r compact= only). The XML reporter was only invoked by =add_test=
+definitions consumed by =ctest=; =make rat= never called =ctest=.
+
+Fix: appended =-r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml=
+to the =COMMAND= line in all 65 =add_custom_target(test_...)= blocks.
+Catch2 supports multiple =-r= flags simultaneously; compact output to
+terminal is unchanged; XML is now also written on every =rat= run.
+=compass test results= will find the XML files after =make rat= without
+any =ctest= invocation.

--- a/projects/ores.analytics/api/tests/CMakeLists.txt
+++ b/projects/ores.analytics/api/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.analytics/core/tests/CMakeLists.txt
+++ b/projects/ores.analytics/core/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.analytics/service/tests/CMakeLists.txt
+++ b/projects/ores.analytics/service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.assets/api/tests/CMakeLists.txt
+++ b/projects/ores.assets/api/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.assets/core/tests/CMakeLists.txt
+++ b/projects/ores.assets/core/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.assets/service/tests/CMakeLists.txt
+++ b/projects/ores.assets/service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.cli/tests/CMakeLists.txt
+++ b/projects/ores.cli/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.compute/api/tests/CMakeLists.txt
+++ b/projects/ores.compute/api/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.compute/core/tests/CMakeLists.txt
+++ b/projects/ores.compute/core/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.compute/service/tests/CMakeLists.txt
+++ b/projects/ores.compute/service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.compute/wrapper/tests/CMakeLists.txt
+++ b/projects/ores.compute/wrapper/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.connections/tests/CMakeLists.txt
+++ b/projects/ores.connections/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.controller/api/tests/CMakeLists.txt
+++ b/projects/ores.controller/api/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.controller/core/tests/CMakeLists.txt
+++ b/projects/ores.controller/core/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.controller/service/tests/CMakeLists.txt
+++ b/projects/ores.controller/service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.database/tests/CMakeLists.txt
+++ b/projects/ores.database/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.dq/api/tests/CMakeLists.txt
+++ b/projects/ores.dq/api/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.dq/core/tests/CMakeLists.txt
+++ b/projects/ores.dq/core/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.dq/service/tests/CMakeLists.txt
+++ b/projects/ores.dq/service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.eventing/tests/CMakeLists.txt
+++ b/projects/ores.eventing/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.fpml/tests/CMakeLists.txt
+++ b/projects/ores.fpml/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.geo/tests/CMakeLists.txt
+++ b/projects/ores.geo/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.http/api/tests/CMakeLists.txt
+++ b/projects/ores.http/api/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.iam/api/tests/CMakeLists.txt
+++ b/projects/ores.iam/api/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.iam/core/tests/CMakeLists.txt
+++ b/projects/ores.iam/core/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.iam/service/tests/CMakeLists.txt
+++ b/projects/ores.iam/service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.marketdata/api/tests/CMakeLists.txt
+++ b/projects/ores.marketdata/api/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.marketdata/core/tests/CMakeLists.txt
+++ b/projects/ores.marketdata/core/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.marketdata/service/tests/CMakeLists.txt
+++ b/projects/ores.marketdata/service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.nats/tests/CMakeLists.txt
+++ b/projects/ores.nats/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.ore/api/tests/CMakeLists.txt
+++ b/projects/ores.ore/api/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.ore/core/tests/CMakeLists.txt
+++ b/projects/ores.ore/core/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.ore/service/tests/CMakeLists.txt
+++ b/projects/ores.ore/service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.platform/tests/CMakeLists.txt
+++ b/projects/ores.platform/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.qt/api/tests/CMakeLists.txt
+++ b/projects/ores.qt/api/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.qt/application/tests/CMakeLists.txt
+++ b/projects/ores.qt/application/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.refdata/api/tests/CMakeLists.txt
+++ b/projects/ores.refdata/api/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.refdata/core/tests/CMakeLists.txt
+++ b/projects/ores.refdata/core/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Running ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 add_dependencies(run_all_tests test_${tests_target_name})

--- a/projects/ores.refdata/service/tests/CMakeLists.txt
+++ b/projects/ores.refdata/service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.reporting/api/tests/CMakeLists.txt
+++ b/projects/ores.reporting/api/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.reporting/core/tests/CMakeLists.txt
+++ b/projects/ores.reporting/core/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.reporting/service/tests/CMakeLists.txt
+++ b/projects/ores.reporting/service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.scheduler/api/tests/CMakeLists.txt
+++ b/projects/ores.scheduler/api/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.scheduler/core/tests/CMakeLists.txt
+++ b/projects/ores.scheduler/core/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.scheduler/service/tests/CMakeLists.txt
+++ b/projects/ores.scheduler/service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.security/tests/CMakeLists.txt
+++ b/projects/ores.security/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.service/tests/CMakeLists.txt
+++ b/projects/ores.service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.storage/tests/CMakeLists.txt
+++ b/projects/ores.storage/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.synthetic/api/tests/CMakeLists.txt
+++ b/projects/ores.synthetic/api/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.synthetic/core/tests/CMakeLists.txt
+++ b/projects/ores.synthetic/core/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.synthetic/service/tests/CMakeLists.txt
+++ b/projects/ores.synthetic/service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.telemetry/core/tests/CMakeLists.txt
+++ b/projects/ores.telemetry/core/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.telemetry/database/tests/CMakeLists.txt
+++ b/projects/ores.telemetry/database/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.telemetry/service/tests/CMakeLists.txt
+++ b/projects/ores.telemetry/service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.trading/api/tests/CMakeLists.txt
+++ b/projects/ores.trading/api/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.trading/core/tests/CMakeLists.txt
+++ b/projects/ores.trading/core/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.trading/service/tests/CMakeLists.txt
+++ b/projects/ores.trading/service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.utility/tests/CMakeLists.txt
+++ b/projects/ores.utility/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.variability/api/tests/CMakeLists.txt
+++ b/projects/ores.variability/api/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.variability/core/tests/CMakeLists.txt
+++ b/projects/ores.variability/core/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.variability/service/tests/CMakeLists.txt
+++ b/projects/ores.variability/service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.workflow/api/tests/CMakeLists.txt
+++ b/projects/ores.workflow/api/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.workflow/core/tests/CMakeLists.txt
+++ b/projects/ores.workflow/core/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.workflow/service/tests/CMakeLists.txt
+++ b/projects/ores.workflow/service/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 

--- a/projects/ores.wt.service/tests/CMakeLists.txt
+++ b/projects/ores.wt.service/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(${tests_target_name}
 add_custom_target(test_${tests_target_name}
     COMMENT "Testing ${tests_target_name}" VERBATIM
     COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
+        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     DEPENDS ${tests_target_name})
 


### PR DESCRIPTION
## Summary

- `make rat` was not generating `test-results*.xml` because the custom `test_<name>` targets only used `-r compact`; XML output was only produced by `ctest` (which developers rarely run directly)
- `compass test results` always errored with "No test-results*.xml files found" after a `rat` run
- Fix: appended `-r xml::out=...` to the `COMMAND` line in all 65 `add_custom_target(test_...)` blocks across every component's `tests/CMakeLists.txt`
- Catch2 supports multiple `-r` flags simultaneously; compact terminal output is unchanged

## Root cause

```cmake
# Before — compact only, no XML written:
add_custom_target(test_${tests_target_name}
    COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
    ...)

# After — compact + XML:
add_custom_target(test_${tests_target_name}
    COMMAND ${ORES_TEST_ENV_CMD} $<TARGET_FILE:${tests_binary_name}> ${ORES_CATCH2_ARGS}
        -r xml::out=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test-results-${tests_target_name}.xml
    ...)
```

## Test plan

- [ ] `cmake --build --preset linux-gcc-debug-ninja --target rat` produces `test-results*.xml` in `build/output/<preset>/publish/bin/`
- [ ] `./compass.sh test results` displays the results table after a `rat` run (no `ctest` needed)
- [ ] CI green (existing `add_test` XML generation unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)