### PR TITLE
[agile] Split sprint 19 Tooling into Compass/Codegen/C++ Components epics

### DIFF
--- a/doc/agile/versions/v0/sprint_19/open_sprint_19/story.org
+++ b/doc/agile/versions/v0/sprint_19/open_sprint_19/story.org
@@ -42,6 +42,7 @@ Sprint 19 is open: sprint.org scaffolded with mission and Previous wired to spri
 |------+-------+-------+-----+-------------|
 | [[id:5F388610-0F72-4A03-A8D9-67ADD371924A][Open new sprint]] | DONE | 2026-05-29 | 2026-05-29 | Follow the [[id:47032D2E-4922-4A43-B594-AD76F0213E10][Open a new sprint]] runbook. |
 | [[id:D397393C-2836-430E-88F7-8C220C6CCBC6][Add compass goto sprint support]] | BACKLOG | | | Extend goto with sprint/story/task modes; update runbook. |
+| [[id:6A6EF96D-0709-4512-914B-774C9E38AF6E][Reorganise sprint 19 Tooling section into named epics]] | DONE | 2026-06-03 | 2026-06-03 | Split 17-story flat Tooling table into Compass / Codegen / C++ Components epic sub-sections. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/open_sprint_19/task_reorganise_sprint_backlog_into_epics.org
+++ b/doc/agile/versions/v0/sprint_19/open_sprint_19/task_reorganise_sprint_backlog_into_epics.org
@@ -1,0 +1,84 @@
+:PROPERTIES:
+:ID: 6A6EF96D-0709-4512-914B-774C9E38AF6E
+:END:
+#+title: Task: Reorganise sprint 19 Tooling section into named epics
+#+description: The Tooling section in sprint.org has 17+ stories in a flat table. Group them under named sub-epics (Compass, Codegen, etc.) so the sprint backlog is readable at a glance.
+#+type: task
+#+level: s1
+#+filetags: :open_sprint_19:sprint_19:v0:
+#+owner: marco
+#+branch: feature/reorganise-sprint-backlog-into-epics
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-03
+#+updated: 2026-06-03
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:A48DEC19-E769-4C71-AC0B-434B551DC801][Open sprint 19]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Make =sprint.org= scannable at a glance by introducing =*** Epic:=
+sub-headings inside =** Tooling=, matching the structure the =** Product=
+section already uses. The 17-story flat Tooling table is unreadable;
+grouping by theme (Compass, Codegen, C++ Components) lets reviewers find
+relevant stories without scrolling through unrelated entries.
+
+* Status
+
+| Field        | Value                                                      |
+|--------------+------------------------------------------------------------|
+| State        | DONE                                                       |
+| Parent story | [[id:A48DEC19-E769-4C71-AC0B-434B551DC801][Open sprint 19]]                                             |
+| Now          | Nothing.                                                   |
+| Waiting on   | Nothing.                                                   |
+| Next         | Nothing.                                                   |
+| Last touched | 2026-06-03                                                 |
+
+* Acceptance
+
+- =** Tooling= contains three =*** Epic:= sub-sections, each with its
+  own story table: Compass, Codegen, C++ Components.
+- No stories are added, removed, or have their state changed.
+- The resulting structure mirrors =** Product= (which already uses
+  =*** Epic:= sub-headings).
+
+* Plan
+
+Split the single 17-row Tooling table into:
+
+| Epic | Stories |
+|------+---------|
+| Compass | session journal, CLI UX redesign, consolidate scripts, bearings |
+| Codegen | SQL refactor, C++ refactor, org-mode migration, seeder, MASD doc, decommission scripts, safety guardrails, Phase 1/2/3, CI zero-diff |
+| C++ Components | regroup, move trade-instrument parsing |
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result
+
+Split the 17-story flat =** Tooling= table in =sprint.org= into three
+=*** Epic:= sub-sections matching the =** Product= structure:
+
+- =*** Epic: Compass= (4 stories) — session journal, CLI UX redesign,
+  consolidate scripts, bearings
+- =*** Epic: Codegen= (11 stories) — SQL refactor, MASD doc, org-mode
+  migration, seeder, C++ refactor (BLOCKED), decommission scripts,
+  safety guardrails, Phase 1/2/3, CI zero-diff
+- =*** Epic: C++ Components= (2 stories) — regroup, move trade-instrument
+  parsing
+
+No story states changed; no stories added or removed.

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -76,26 +76,46 @@ dedicated thread pool to prevent =QThreadPool= starvation.
 
 ** Tooling
 
+*** Epic: Compass
+
+Developer toolkit consolidation: fold operational scripts into compass, extend Orient with staleness and bearings, redesign CLI taxonomy.
+
 #+ATTR_HTML: :class hug-leading
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:20AC8397-1ACD-4B1A-B0FE-6FAB74477592][Compass session journal]] | DONE | 2026-05-31 | 2026-05-31 | Per-machine .journal.org (gitignored) recording each Claude environment's story/task journey; compass journal commands; compass fleet refactor. |
 | [[id:A596D1E7-6A74-4E55-996D-6F1F2E48F261][Compass CLI UX redesign]] | DONE | 2026-05-31 | 2026-06-01 | Noun-based command taxonomy; fix tool description; --help by pillar; compass sprint/story status commands; audit recipes and skills. |
-| [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]] | DONE | 2026-05-29 | 2026-05-30 | Unified SQL template + model format + codegen.py CLI replacing all generate_*_schema.sh scripts. |
-| [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] | BLOCKED | | | Audit and resolve all drift between C++ templates and production files. Blocked on [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][org-mode migration story]] — the pilot exposed that the JSON model format cannot express custom methods cleanly. |
-| [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] | STARTED | 2026-06-01 | | Migrate every entity model from JSON to a literate org-mode file per entity, co-located with the component. Supersedes the unified-JSON Phase 2 story. |
-| [[id:5104ADAF-390D-4ADB-B005-CE726B553123][Introduce ores.seeder component for database test-data generation]] | STARTED | 2026-06-02 | | New tooling component owning SQL INSERT populate scripts. Slovaris is its first dataset; closes out the codegen org-mode migration story. |
-| [[id:FF9397CF-E6F6-44C3-9641-882EEA21C58D][Regroup C++ components under product-group parent directories]] | DONE | 2026-06-01 | 2026-06-02 | Move each =projects/ores.<group>.<role>/= (api, core, service) and =projects/ores.qt.<group>/= under a single =projects/ores.<group>/= parent so the group owns its modeling/ dir, root CMakeLists, and child layout. Blocks per-group org-migration tasks beyond refdata. |
-| [[id:FE9BB4DA-FC98-4C08-B784-104DCF3A6687][Move trade-instrument parsing out of ores.qt.api]] | BACKLOG | | | Extract the Qt-free parse logic into ores.trading.api so the dispatch test links a real target instead of hand-listing source files. Removes the stop-gap from the regroup story. |
 | [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]] | STARTED | 2026-06-02 | | Inventory the ~61 operational scripts; design operational compass pillars; fold scripts into documented compass subcommands. Absorbs the service-registry consolidation. |
 | [[id:2E5F5DB5-7417-45B8-8D0B-C71650127D32][Add compass bearings command for LLM on-boarding]] | BACKLOG | | | Single-command LLM orientation (compass bearings): where, last session, memory pointer, and command cheat-sheet. |
-| [[id:1C659EB3-5227-46B6-8B5C-68E9F98C10D1][Decommission legacy ores.codegen bash scripts]] | BACKLOG | | | Replace all direct bash script invocations of ores.codegen with ores.compass or codegen.py; remove legacy scripts starting with generate_doc.sh. |
+
+*** Epic: Codegen
+
+Unify the code generation model: migrate entity models from JSON to literate org-mode, refactor SQL and C++ generators, add safety guardrails and CI invariant.
+
+#+ATTR_HTML: :class hug-leading
+| Story | State | Start | End | Description |
+|-------+-------+-------+-----+-------------|
+| [[id:C4A7B1E2-5D3F-4A6B-8C9D-2E1F0A3B4C5D][Refactor ores.codegen SQL generation]] | DONE | 2026-05-29 | 2026-05-30 | Unified SQL template + model format + codegen.py CLI replacing all generate_*_schema.sh scripts. |
 | [[id:EE6A643D-6C6C-41B8-88FD-2EA9351414CD][Document MASD and code generation principles]] | DONE | 2026-06-01 | 2026-06-01 | Technical knowledge document weaving MDE/MASD theory with ores.codegen practice and the reference-implementation backout strategy. |
+| [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][Codegen unified model — org-mode migration]] | STARTED | 2026-06-01 | | Migrate every entity model from JSON to a literate org-mode file per entity, co-located with the component. Supersedes the unified-JSON Phase 2 story. |
+| [[id:5104ADAF-390D-4ADB-B005-CE726B553123][Introduce ores.seeder component for database test-data generation]] | STARTED | 2026-06-02 | | New tooling component owning SQL INSERT populate scripts. Slovaris is its first dataset; closes out the codegen org-mode migration story. |
+| [[id:3B8F2A1D-7C4E-4B6A-9E5D-2F1A8C3B7D9E][Refactor ores.codegen C++ generation]] | BLOCKED | | | Audit and resolve all drift between C++ templates and production files. Blocked on [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][org-mode migration story]] — the pilot exposed that the JSON model format cannot express custom methods cleanly. |
+| [[id:1C659EB3-5227-46B6-8B5C-68E9F98C10D1][Decommission legacy ores.codegen bash scripts]] | BACKLOG | | | Replace all direct bash script invocations of ores.codegen with ores.compass or codegen.py; remove legacy scripts starting with generate_doc.sh. |
 | [[id:C0075180-2306-42F9-B4F7-F34D801709B4][Codegen model safety guardrails]] | BACKLOG | | | Runtime guards for missing component fields; block dual-template SQL; document all-cpp limitations. Prerequisite for C++ audit. |
 | [[id:7AA5B5C3-F7DE-4A17-84A0-75FB3761D43E][Codegen unified model — Phase 1: Qt field derivation]] | BACKLOG | | | Derive Qt protocol class names from naming conventions; remove transcribed fields from all 75 models. |
 | [[id:88113E9B-DBD4-4E08-8CD9-49B8A709B871][Codegen unified model — Phase 2: single model file per entity]] | ABANDONED | | | Superseded by [[id:D85E2B30-8C64-46DF-819D-B50D2E70B73C][org-mode migration story]] which goes further than unified-JSON: literate org-mode with custom methods inline. |
 | [[id:AE89AD39-05D0-4A45-8BF4-FDC44BBB8A09][Codegen unified model — Phase 3: unify temporal/non-temporal templates]] | BACKLOG | | | Merge parallel temporal and non-temporal template families via is_temporal flag. |
 | [[id:73D7AFB0-F1D0-48D4-86CB-27E17798B674][Codegen CI zero-diff invariant]] | BACKLOG | | | CI job that regenerates all components and fails if any output differs from HEAD. |
+
+*** Epic: C++ Components
+
+Regroup and refactor the C++ component layout to align with the product-group model.
+
+#+ATTR_HTML: :class hug-leading
+| Story | State | Start | End | Description |
+|-------+-------+-------+-----+-------------|
+| [[id:FF9397CF-E6F6-44C3-9641-882EEA21C58D][Regroup C++ components under product-group parent directories]] | DONE | 2026-06-01 | 2026-06-02 | Move each =projects/ores.<group>.<role>/= (api, core, service) and =projects/ores.qt.<group>/= under a single =projects/ores.<group>/= parent so the group owns its modeling/ dir, root CMakeLists, and child layout. Blocks per-group org-migration tasks beyond refdata. |
+| [[id:FE9BB4DA-FC98-4C08-B784-104DCF3A6687][Move trade-instrument parsing out of ores.qt.api]] | BACKLOG | | | Extract the Qt-free parse logic into ores.trading.api so the dispatch test links a real target instead of hand-listing source files. Removes the stop-gap from the regroup story. |
 
 ** Agile
 


### PR DESCRIPTION
## Summary

- Splits the 17-story flat `** Tooling` table in `sprint.org` into three `*** Epic:` sub-sections, matching the structure `** Product` already uses
- No story states, start/end dates, or descriptions changed — purely structural

## Epics introduced

| Epic | Stories | States |
|------|---------|--------|
| Compass | 4 | 2 DONE, 1 STARTED, 1 BACKLOG |
| Codegen | 11 | 2 DONE, 2 STARTED, 1 BLOCKED, 1 ABANDONED, 5 BACKLOG |
| C++ Components | 2 | 1 DONE, 1 BACKLOG |

🤖 Generated with [Claude Code](https://claude.com/claude-code)