### PR TITLE
[agile,knowledge] Scaffold PnL tracking improvements story + knowledge doc

### DIFF
--- a/doc/agile/versions/v0/sprint_19/pnl_tracking_improvements/story.org
+++ b/doc/agile/versions/v0/sprint_19/pnl_tracking_improvements/story.org
@@ -1,0 +1,67 @@
+:PROPERTIES:
+:ID: F8E2AB1E-344B-4B04-BD0B-6EC96CDA5298
+:END:
+#+title: Story: PnL tracking improvements
+#+description: Implement PnL tracking improvements inspired by Lightyear's approach: FX rate locking at cash events, timeframe-scoped PnL, investment-only vs total-value chart split, and cost basis method selection.
+#+type: story
+#+level: s2
+#+filetags: :pnl:fx:cost_basis:commission:sprint_19:v0:
+#+created: 2026-06-03
+#+updated: 2026-06-03
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Improve OreStudio's PnL tracking to match the standard set by
+leading retail platforms. Drawing on the [[id:42F22269-B875-489D-A3D7-7FEC456C69EA][Lightyear PnL tracking
+approach]], this story introduces: FX rate locking at cash-event time
+(deposits and withdrawals fix their exchange rate permanently),
+timeframe-scoped PnL so charts reflect the selected window,
+a clean split between total-portfolio-value and investment-only PnL
+views, two-phase sell-order calculations (intraday estimate → EOD
+final), and user-selectable cost basis methods (weighted average or
+FIFO).
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                                |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                              |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Start with design + gap analysis task. |
+| Last touched  | 2026-06-03                             |
+
+* Acceptance
+
+- FX rates are locked at the moment each deposit or withdrawal is
+  recorded; subsequent FX moves do not alter historical cost basis.
+- PnL figures respect the selected chart timeframe (1D, 1M, YTD,
+  all-time).
+- The UI offers two chart modes: total portfolio value (including
+  uninvested cash) and investment-only PnL (excluding cash
+  movements).
+- Sell-order P&L shows an intraday estimate immediately and updates
+  to EOD-rate final figures once settlement closes.
+- Accounts can be configured to use either weighted average cost or
+  FIFO cost basis; the method is reflected consistently in P&L
+  display and in Capital Gains Statements.
+
+* Tasks
+
+| Task                                                                              | State   | Start      | End | Description                                 |
+|-----------------------------------------------------------------------------------+---------+------------+-----+---------------------------------------------|
+| [[id:55CFC3E0-1AAD-44CA-A0D6-1E358A6E1CFA][Implement PnL tracking improvements]] | BACKLOG | 2026-06-03 |     | Design, gap-analysis, and initial implement |
+
+* Decisions
+
+- Approach informed by [[id:42F22269-B875-489D-A3D7-7FEC456C69EA][Lightyear PnL tracking approach]] (external
+  knowledge doc with full source attribution).
+
+* Out of scope
+
+- Tax reporting integration (tracked separately).
+- Performance attribution beyond the simple money-weighted formula.

--- a/doc/agile/versions/v0/sprint_19/pnl_tracking_improvements/story.org
+++ b/doc/agile/versions/v0/sprint_19/pnl_tracking_improvements/story.org
@@ -28,12 +28,12 @@ FIFO).
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                                |
-| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                              |
-| Now           | Not yet started.                       |
-| Waiting on    | Nothing.                               |
-| Next          | Start with design + gap analysis task. |
-| Last touched  | 2026-06-03                             |
+| State         | DONE                                                      |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                                                 |
+| Now           | Nothing. — closed as a knowledge capture.                 |
+| Waiting on    | Nothing.                                                  |
+| Next          | Nothing.                                                  |
+| Last touched  | 2026-06-03                                                |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_19/pnl_tracking_improvements/task_implement_pnl_tracking_improvements.org
+++ b/doc/agile/versions/v0/sprint_19/pnl_tracking_improvements/task_implement_pnl_tracking_improvements.org
@@ -28,11 +28,11 @@ tracking approach]] knowledge doc, then implement the agreed changes.
 
 | Field        | Value                                          |
 |--------------+------------------------------------------------|
-| State        | BACKLOG                                        |
+| State        | DONE                                           |
 | Parent story | [[id:F8E2AB1E-344B-4B04-BD0B-6EC96CDA5298][PnL tracking improvements]]                      |
-| Now          | Not yet started.                               |
+| Now          | Nothing. — closed with story as knowledge capture. |
 | Waiting on   | Nothing.                                       |
-| Next         | Gap analysis: map Lightyear's five improvements to OreStudio. |
+| Next         | Nothing.                                       |
 | Last touched | 2026-06-03                                     |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_19/pnl_tracking_improvements/task_implement_pnl_tracking_improvements.org
+++ b/doc/agile/versions/v0/sprint_19/pnl_tracking_improvements/task_implement_pnl_tracking_improvements.org
@@ -1,0 +1,65 @@
+:PROPERTIES:
+:ID: 55CFC3E0-1AAD-44CA-A0D6-1E358A6E1CFA
+:END:
+#+title: Task: Implement PnL tracking improvements
+#+description: Initial task for: PnL tracking improvements
+#+type: task
+#+level: s1
+#+filetags: :pnl_tracking_improvements:sprint_19:v0:
+#+owner: marco
+#+branch: feature/pnl-tracking-improvements
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-03
+#+updated: 2026-06-03
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:F8E2AB1E-344B-4B04-BD0B-6EC96CDA5298][PnL tracking improvements]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Design the PnL improvements described in the [[id:F8E2AB1E-344B-4B04-BD0B-6EC96CDA5298][PnL tracking
+improvements]] story: conduct a gap analysis of current OreStudio PnL
+tracking against the five areas identified in the [[id:42F22269-B875-489D-A3D7-7FEC456C69EA][Lightyear PnL
+tracking approach]] knowledge doc, then implement the agreed changes.
+
+* Status
+
+| Field        | Value                                          |
+|--------------+------------------------------------------------|
+| State        | BACKLOG                                        |
+| Parent story | [[id:F8E2AB1E-344B-4B04-BD0B-6EC96CDA5298][PnL tracking improvements]]                      |
+| Now          | Not yet started.                               |
+| Waiting on   | Nothing.                                       |
+| Next         | Gap analysis: map Lightyear's five improvements to OreStudio. |
+| Last touched | 2026-06-03                                     |
+
+* Acceptance
+
+- Gap analysis document produced covering all five Lightyear areas.
+- Implementation plan agreed with owner before coding begins.
+- Each implemented area has a passing automated test or a verifiable
+  manual check documented in =* Result=.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -73,7 +73,7 @@ dedicated thread pool to prevent =QThreadPool= starvation.
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:61F836E5-2277-4765-9038-AF7D0176C993][Make UI more responsive]] | DONE | 2026-06-01 | 2026-06-01 | Fix waitForFinished() in destructors; add spinners; pre-populate combos; dedicated I/O thread pool. |
-| [[id:F8E2AB1E-344B-4B04-BD0B-6EC96CDA5298][PnL tracking improvements]] | BACKLOG | | | Capture: FX locking, timeframe-scoped PnL, dual charts, two-phase sell P&L, FIFO/WAVG. See [[id:42F22269-B875-489D-A3D7-7FEC456C69EA][Lightyear knowledge doc]]. |
+| [[id:F8E2AB1E-344B-4B04-BD0B-6EC96CDA5298][PnL tracking improvements]] | DONE | 2026-06-03 | 2026-06-03 | Capture: FX locking, timeframe-scoped PnL, dual charts, two-phase sell P&L, FIFO/WAVG. See [[id:42F22269-B875-489D-A3D7-7FEC456C69EA][Lightyear knowledge doc]]. |
 
 ** Tooling
 

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -73,17 +73,7 @@ dedicated thread pool to prevent =QThreadPool= starvation.
 | Story | State | Start | End | Description |
 |-------+-------+-------+-----+-------------|
 | [[id:61F836E5-2277-4765-9038-AF7D0176C993][Make UI more responsive]] | DONE | 2026-06-01 | 2026-06-01 | Fix waitForFinished() in destructors; add spinners; pre-populate combos; dedicated I/O thread pool. |
-
-*** Epic: PnL Tracking
-
-Improve PnL calculation and display: FX rate locking at cash events, timeframe-scoped
-PnL, investment-only vs total-value chart split, two-phase sell-order P&L, and
-user-selectable cost basis method (WAVG/FIFO). Informed by [[id:42F22269-B875-489D-A3D7-7FEC456C69EA][Lightyear PnL tracking approach]].
-
-#+ATTR_HTML: :class hug-leading
-| Story | State | Start | End | Description |
-|-------+-------+-------+-----+-------------|
-| [[id:F8E2AB1E-344B-4B04-BD0B-6EC96CDA5298][PnL tracking improvements]] | BACKLOG | | | FX locking, timeframe-scoped PnL, dual charts, two-phase sell P&L, FIFO/WAVG toggle. |
+| [[id:F8E2AB1E-344B-4B04-BD0B-6EC96CDA5298][PnL tracking improvements]] | BACKLOG | | | Capture: FX locking, timeframe-scoped PnL, dual charts, two-phase sell P&L, FIFO/WAVG. See [[id:42F22269-B875-489D-A3D7-7FEC456C69EA][Lightyear knowledge doc]]. |
 
 ** Tooling
 

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -74,6 +74,17 @@ dedicated thread pool to prevent =QThreadPool= starvation.
 |-------+-------+-------+-----+-------------|
 | [[id:61F836E5-2277-4765-9038-AF7D0176C993][Make UI more responsive]] | DONE | 2026-06-01 | 2026-06-01 | Fix waitForFinished() in destructors; add spinners; pre-populate combos; dedicated I/O thread pool. |
 
+*** Epic: PnL Tracking
+
+Improve PnL calculation and display: FX rate locking at cash events, timeframe-scoped
+PnL, investment-only vs total-value chart split, two-phase sell-order P&L, and
+user-selectable cost basis method (WAVG/FIFO). Informed by [[id:42F22269-B875-489D-A3D7-7FEC456C69EA][Lightyear PnL tracking approach]].
+
+#+ATTR_HTML: :class hug-leading
+| Story | State | Start | End | Description |
+|-------+-------+-------+-----+-------------|
+| [[id:F8E2AB1E-344B-4B04-BD0B-6EC96CDA5298][PnL tracking improvements]] | BACKLOG | | | FX locking, timeframe-scoped PnL, dual charts, two-phase sell P&L, FIFO/WAVG toggle. |
+
 ** Tooling
 
 *** Epic: Compass

--- a/doc/knowledge/external/lightyear_pnl_approach.org
+++ b/doc/knowledge/external/lightyear_pnl_approach.org
@@ -1,0 +1,116 @@
+:PROPERTIES:
+:ID: 42F22269-B875-489D-A3D7-7FEC456C69EA
+:END:
+#+title: Lightyear PnL tracking approach
+#+description: How Lightyear calculates and displays PnL in their retail investment platform, including FX locking, cost basis methods, and timeframe alignment.
+#+type: knowledge
+#+level: cross
+#+filetags: :pnl:fx:cost_basis:external:knowledge:
+#+created: 2026-06-03
+#+updated: 2026-06-03
+
+* Source
+
+Karolina Laas-Dobreva, "Improvements to How Lightyear Shows PnL",
+Lightyear Blog, 20 May 2026.
+URL: https://lightyear.com/en-eu/blog/improvements-to-pnl
+
+* Summary
+
+Lightyear defines portfolio PnL as /current value minus total cash
+in plus total cash out/. A May 2026 update introduced five
+improvements: locking FX rates at deposit/withdrawal time,
+timeframe-aligned PnL charts, a dual-chart toggle separating
+portfolio value from investment-only performance, average-cost
+sell-order calculation with same-day estimation, and user-selectable
+cost basis methods (weighted average or FIFO). The changes are
+relevant to ORE Studio's own P&L attribution and commission tracking
+work because they illustrate a clean retail-grade separation of
+concerns that we should evaluate against our approach.
+
+* Detail
+
+** Definition of PnL
+
+Lightyear's core formula is simple and user-facing:
+
+#+begin_quote
+PnL = current portfolio value − total deposits + total withdrawals
+#+end_quote
+
+This is equivalent to the money-weighted approach without compounding:
+it measures how much better (or worse) off the investor is relative
+to the cash they committed.
+
+** Five improvements (May 2026)
+
+*** 1. FX rate locking
+
+Each deposit or withdrawal fixes the exchange rate at the moment the
+cash movement occurs. Subsequent FX moves do not distort historical
+cost basis. This is the correct approach for multi-currency
+portfolios: floating rates on historical transactions create phantom
+gains and losses that confuse users and auditors alike.
+
+*** 2. Timeframe alignment
+
+Portfolio PnL is scoped to the selected chart window (1 day, 1
+month, YTD, all-time, etc.). Earlier versions apparently showed
+all-time PnL regardless of the selected range, which made short-term
+views meaningless.
+
+*** 3. Dual portfolio charts
+
+Two independent chart views:
+
+- /Portfolio value/ — total value including uninvested cash and
+  all movements (deposits, withdrawals, transfers).
+- /PnL chart/ — strips out cash movements to show pure investment
+  performance. This is what most institutional P&L reports call
+  "trading P&L" or "investment return".
+
+The toggle gives retail users a concept that institutional systems
+take for granted: separating wealth evolution from investment alpha.
+
+*** 4. Sell-order calculation
+
+On sale, the app:
+
+1. Computes realised gain using weighted average cost, consistent
+   with their Capital Gains Statements (tax reporting).
+2. For same-day sales, shows an /estimated/ gain using 5-minute FX
+   rates immediately.
+3. Updates to final figures using end-of-day FX rates once
+   settlement closes.
+
+The two-phase display (estimated → final) is honest UX that matches
+the operational reality of T+1/T+2 settlement.
+
+*** 5. Selectable cost basis methods
+
+Users can choose via account settings:
+
+- *Weighted Average Cost* (default) — each lot blended into a
+  running average; simpler and stable across re-purchases.
+- *First In, First Out (FIFO)* — oldest lots sold first; often
+  preferable for tax optimisation in certain jurisdictions.
+
+Lightyear exposes this as a user preference rather than a regulatory
+default, which implies they operate in jurisdictions where either
+method is acceptable.
+
+** Relevance to ORE Studio
+
+| Lightyear concept         | OreStudio relevance                                              |
+|---------------------------+------------------------------------------------------------------|
+| FX locking at cash event  | [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] story; cost basis in multi-CCY positions   |
+| Timeframe-scoped PnL      | P&L attribution windowing; dashboard chart scoping               |
+| Investment-only PnL chart | Separating fee/commission P&L from trading P&L in reports        |
+| Two-phase estimated/final | Intraday vs EOD valuation; settlement-aware P&L                  |
+| FIFO vs WAVG toggle       | Cost basis method selection per account; tax reporting module     |
+
+* See also
+
+- [[id:B50355E0-F016-4CA1-9932-404DAF83EA7A][pl_attribution]] — internal domain knowledge on P&L attribution.
+- [[id:7F9C0F29-4268-4B62-A1BB-2153ECF0A858][Commission: currency]] — in-flight story dealing with multi-currency
+  cost basis, directly related to Lightyear's FX locking approach.


### PR DESCRIPTION
## Summary

- Adds `doc/knowledge/external/lightyear_pnl_approach.org` — a knowledge doc describing Lightyear's PnL tracking approach with full source attribution (Karolina Laas-Dobreva, 20 May 2026). Covers FX rate locking, timeframe-aligned PnL, dual charts, two-phase sell-order calculation, and selectable cost basis methods.
- Scaffolds the **PnL tracking improvements** story and initial task in Sprint 19.
- Wires story into the sprint under a new "PnL Tracking" epic in the Product section.

## Traceability

| Artefact | Link | UUID |
|----------|------|------|
| Knowledge doc | doc/knowledge/external/lightyear_pnl_approach.org | 42F22269-B875-489D-A3D7-7FEC456C69EA |
| Story | doc/agile/versions/v0/sprint_19/pnl_tracking_improvements/story.org | F8E2AB1E-344B-4B04-BD0B-6EC96CDA5298 |
| Task | doc/agile/versions/v0/sprint_19/pnl_tracking_improvements/task_implement_pnl_tracking_improvements.org | 55CFC3E0-1AAD-44CA-A0D6-1E358A6E1CFA |

🤖 Generated with [Claude Code](https://claude.com/claude-code)