### PR TITLE
[agile] Close open sprint 19 story

### DIFF
--- a/doc/agile/versions/v0/sprint_19/open_sprint_19/story.org
+++ b/doc/agile/versions/v0/sprint_19/open_sprint_19/story.org
@@ -20,12 +20,12 @@ Sprint 19 is open: sprint.org scaffolded with mission and Previous wired to spri
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | DONE                                   |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | Scaffolding sprint 19 and wiring into version manifest. |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                               |
-| Next          | Open PR.                               |
-| Last touched  | 2026-05-29                               |
+| Next          | Nothing.                               |
+| Last touched  | 2026-06-03                             |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_19/open_sprint_19/task_reorganise_sprint_backlog_into_epics.org
+++ b/doc/agile/versions/v0/sprint_19/open_sprint_19/task_reorganise_sprint_backlog_into_epics.org
@@ -8,7 +8,7 @@
 #+filetags: :open_sprint_19:sprint_19:v0:
 #+owner: marco
 #+branch: feature/reorganise-sprint-backlog-into-epics
-#+pr:
+#+pr: https://github.com/OreStudio/OreStudio/pull/1028
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-03
@@ -60,7 +60,7 @@ Split the single 17-row Tooling table into:
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1028][#1028]] | Reorganise sprint 19 Tooling section into named epics |
 
 * Review
 


### PR DESCRIPTION
## Summary

- Mark *Open sprint 19* story as DONE
- Wire PR #1028 into the reorganise-epics task (PR reference + `#+pr:` header)

## Test plan

- [ ] `story.org` status table shows `DONE`
- [ ] Task file `#+pr:` header and PRs table reference #1028
- [ ] Site builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)