### PR TITLE
[compass] Fix env init venv activation path on Windows

### DIFF
--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/story.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/story.org
@@ -34,9 +34,9 @@ within this larger effort.
 |---------------+--------------------------------------------------|
 | State         | STARTED                                          |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                               |
-| Now           | compass test results, sprint charts, branch staleness, bearings all shipped. rat now generates XML for compass test results. |
+| Now           | compass test results, sprint charts, branch staleness, bearings all shipped. rat now generates XML for compass test results. Windows env init bug scaffolded. |
 | Waiting on    | Nothing.                                         |
-| Next          | Document the compass env commands; then db/nats/Operate/Build/Generate migrations. |
+| Next          | Fix Windows venv activation path; document the compass env commands; then db/nats/Operate/Build/Generate migrations. |
 | Last touched  | 2026-06-03                                       |
 
 * Background: script inventory (2026-06-02)
@@ -132,6 +132,7 @@ migrate; the single service registry's home (=projects/services.json=).
 | [[id:81DE1DC9-FB73-46DB-A8AB-E4BE8F78C591][Port sprint_metrics.py to compass sprint charts]] | BACKLOG | | | compass sprint charts; auto-detects current sprint; deletes standalone script; updates recipes. |
 | [[id:196FE762-F1A6-49BC-A2FF-60F3FC08114D][Port parse_test_results.py to compass test results]] | BACKLOG | | | New test pillar; auto-resolves preset from .env; recipe for test run overview; deletes standalone script. |
 | [[id:4CB61A14-83D7-44A6-A6E5-F0A553B93675][Fix: compass test results missing after make rat]] | DONE | 2026-06-03 | 2026-06-03 | Wire XML reporter into rat custom targets so compass test results has data after the standard dev workflow. |
+| [[id:813B6AB7-5B5A-461C-92AF-C9C60C710F66][Fix compass env init venv activation path on Windows]] | STARTED | 2026-06-03 | | compass.sh sources venv/bin/activate on all platforms; Windows Git Bash needs venv/Scripts/activate. Detected from CI failure on PR #1031. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_fix_compass_env_init_windows.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_fix_compass_env_init_windows.org
@@ -1,0 +1,71 @@
+:PROPERTIES:
+:ID: 813B6AB7-5B5A-461C-92AF-C9C60C710F66
+:END:
+#+title: Task: Fix compass env init venv activation path on Windows
+#+description: compass.sh env init creates the venv but sources venv/bin/activate (Unix path); on Windows Git Bash the activate script is at venv/Scripts/activate, causing CI to exit 1 with 'No such file or directory'.
+#+type: task
+#+level: s1
+#+filetags: :consolidate_scripts_into_compass:sprint_19:v0:
+#+owner: marco
+#+branch: feature/fix-compass-env-init-windows
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-03
+#+updated: 2026-06-03
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+=compass.sh env init= (and the =--no-deps= variant) sources =venv/bin/activate=
+after creating the virtual environment. On Windows (Git Bash / MSYS2) the activate
+script lives at =venv/Scripts/activate=, so the source step exits 1 with
+"No such file or directory" even though the venv was created successfully.
+
+Fix =compass.sh= to detect the platform and source the correct path so that
+=compass env init= works on Windows CI runners and developer machines.
+
+Discovered from the Windows CI failure on PR #1031 (fix-windows-macos-ci
+story), where the step "Run =./projects/ores.compass/compass.sh --no-deps env
+init -y=" exits 1.
+
+* Status
+
+| Field        | Value                                                              |
+|--------------+--------------------------------------------------------------------|
+| State        | STARTED                                                            |
+| Parent story | [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]]                        |
+| Now          | Scaffolded; root cause confirmed; fix not yet implemented.         |
+| Waiting on   | Nothing.                                                           |
+| Next         | Patch compass.sh activate path detection; verify on Linux + CI.   |
+| Last touched | 2026-06-03                                                         |
+
+* Acceptance
+
+- =compass env init= completes without error on Windows Git Bash (CI runner).
+- =compass env init= continues to work on Linux and macOS.
+- The =--no-deps= flag path is also covered (same activation step).
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_fix_compass_env_init_windows.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_fix_compass_env_init_windows.org
@@ -37,10 +37,10 @@ init -y=" exits 1.
 |--------------+--------------------------------------------------------------------|
 | State        | STARTED                                                            |
 | Parent story | [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]]                        |
-| Now          | Scaffolded; root cause confirmed; fix not yet implemented.         |
-| Waiting on   | Nothing.                                                           |
-| Next         | Patch compass.sh activate path detection; verify on Linux + CI.   |
-| Last touched | 2026-06-03                                                         |
+| Now          | Fix implemented in compass.sh; Linux smoke-test passes; awaiting CI. |
+| Waiting on   | Windows CI green on PR #1032.                                        |
+| Next         | Merge once CI is green.                                              |
+| Last touched | 2026-06-03                                                           |
 
 * Acceptance
 

--- a/projects/ores.compass/compass.sh
+++ b/projects/ores.compass/compass.sh
@@ -10,6 +10,13 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV_PATH="$SCRIPT_DIR/venv"
 
+# On Windows (Git Bash / MSYS2) the venv layout uses Scripts/ not bin/.
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+    VENV_BIN="$VENV_PATH/Scripts"
+else
+    VENV_BIN="$VENV_PATH/bin"
+fi
+
 # --- Optional leading flag: --no-deps ---
 # Bootstrap the venv but skip the pip install. The only dependency
 # (pystache) is needed solely by the `add`/scaffold command; the stdlib-only
@@ -38,15 +45,15 @@ if [ ! -d "$VENV_PATH" ]; then
         echo "ℹ️  --no-deps: skipping dependency install (stdlib-only use)."
     elif [ -f "$SCRIPT_DIR/requirements.txt" ]; then
         echo "📦 Installing dependencies from requirements.txt..."
-        "$VENV_PATH/bin/pip" install --upgrade pip -q
-        "$VENV_PATH/bin/pip" install -r "$SCRIPT_DIR/requirements.txt" -q
+        "$VENV_BIN/pip" install --upgrade pip -q
+        "$VENV_BIN/pip" install -r "$SCRIPT_DIR/requirements.txt" -q
     else
         echo "ℹ️  No requirements.txt found. Using standard library only."
     fi
     echo "✅ Virtual environment ready."
 fi
 
-source "$VENV_PATH/bin/activate"
+source "$VENV_BIN/activate"
 
 # Change to the repository root so that relative paths (e.g. --parent-dir
 # doc/agile/...) resolve correctly. Use git rev-parse for robustness;


### PR DESCRIPTION
## Summary

`compass.sh env init` creates the virtual environment correctly but then sources
`venv/bin/activate` unconditionally. On Windows (Git Bash / MSYS2), the activate
script lives at `venv/Scripts/activate`, so the source step exits 1 with
\"No such file or directory\" — even though the venv was created successfully.

Detected from the Windows CI failure on PR #1031 (`fix-windows-macos-ci` story),
step \"Run `./projects/ores.compass/compass.sh --no-deps env init -y`\".

This PR scaffolds the task. The fix — detecting the platform in `compass.sh` and
sourcing the correct activation path — follows in the next commit on this branch.

## Changes

- `task_fix_compass_env_init_windows.org` — new task doc, STARTED, with goal, acceptance, and root-cause notes
- `story.org` — task wired into the Consolidate-scripts story Tasks table; Status updated

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Consolidate standalone scripts into compass](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/story.html) | 6695E245-E789-40EC-8AC6-EB10276CA241 |
| Task | [Fix compass env init venv activation path on Windows](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_fix_compass_env_init_windows.html) | 813B6AB7-5B5A-461C-92AF-C9C60C710F66 |