### PR TITLE
[multi,compass] Timestamp unification mop-up; compass test logging toggle

### DIFF
--- a/doc/agile/inbox/timestamp-sentinel-constants.org
+++ b/doc/agile/inbox/timestamp-sentinel-constants.org
@@ -1,0 +1,53 @@
+:PROPERTIES:
+:ID: 0E3B7794-95A0-4C9E-9D9D-42D770F841F7
+:END:
+#+title: Replace hardcoded timestamp sentinels with MAX/MIN_TIMESTAMP constexprs
+#+description: 137 entity headers and the codegen template hardcode '9999-12-31 23:59:59' as the valid_from/valid_to default. Move MAX_TIMESTAMP from helpers.hpp to db_types.hpp, add a MIN_TIMESTAMP counterpart, and switch the template plus all entities to use them.
+#+type: capture
+#+level: cross
+#+filetags: :database:codegen:time:cleanup:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+Introduce named sentinel constants for the bitemporal timestamp range and use
+them everywhere the literals appear today:
+
+- Move =MAX_TIMESTAMP= (="9999-12-31 23:59:59"=) from
+  =ores.database/repository/helpers.hpp= to =db_types.hpp=, next to
+  =db_timestamp= itself. =helpers.hpp= already includes =db_types.hpp= so all
+  existing users keep working.
+- Add a =MIN_TIMESTAMP= counterpart for the start-of-time sentinel.
+- Switch the codegen template
+  (=cpp_domain_type_entity.hpp.mustache=) and all ~137 entity headers from the
+  hardcoded literal to =db_timestamp valid_from = MAX_TIMESTAMP;=.
+- While in the template, also fix the pre-unification drift: lines 56-57 still
+  emit the =optional<sqlgen::Timestamp>= variant that the timestamp
+  unification story eliminated.
+
+* Why
+
+The literal ="9999-12-31 23:59:59"= is hardcoded in 137 entity headers, the
+codegen template, and =CurrencyDetailDialog.hpp= — yet =MAX_TIMESTAMP= already
+exists as a constexpr in =helpers.hpp=. Entities cannot include =helpers.hpp=
+cheaply (it drags in boost exception diagnostics, =sqlgen/postgres.hpp= and
+logging), which is why the duplication arose. A magic string repeated 280+
+times is a single-point-of-change hazard; the constant belongs in the same
+lightweight header as the type it parameterises.
+
+Surfaced during review of PR #1036 (timestamp unification mop-up), where
+badge_mapping_entity copied the hardcoded-literal idiom from its 136 siblings.
+
+* References
+
+- =projects/ores.database/include/ores.database/repository/helpers.hpp:40= — existing =MAX_TIMESTAMP=.
+- =projects/ores.codegen/library/templates/cpp_domain_type_entity.hpp.mustache:56-57,98-99= — template hardcoding (and optional<> drift).
+- =projects/ores.qt/refdata/include/ores.qt/CurrencyDetailDialog.hpp:181= — duplicate local constant.
+- PR #1036 review thread on =badge_mapping_entity.hpp=.
+
+* See also
+
+- [[id:71116F94-09A7-43FD-BD56-4B5B25BEAC80][Story: Unify entity timestamp handling]] — the story this fell out of.

--- a/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/story.org
+++ b/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/story.org
@@ -7,7 +7,7 @@
 #+level: s2
 #+filetags: :sprint_19:v0:time:
 #+created: 2026-06-03
-#+updated: 2026-06-03
+#+updated: 2026-06-04
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -39,10 +39,10 @@ Architecture reference: [[id:4AAD3581-CFA7-4B44-A2DD-0236784E939F][Time and Time
 |---------------+----------------------------------------------------------------|
 | State         | STARTED                                                        |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                                                      |
-| Now           | Architecture documented; plan written; ready to implement.     |
+| Now           | Tasks 1 and 2 DONE: bulk in PR #1033, stragglers + timepoint_to_timestamp deletion on mop-up branch. |
 | Waiting on    | Nothing.                                                       |
-| Next          | Start task 1: fix optional<db_timestamp> across all entities.  |
-| Last touched  | 2026-06-03                                                     |
+| Next          | Run full test suite (task 4); verify no epoch timestamps in history dialogs — unblocks currency Qt verification. |
+| Last touched  | 2026-06-04                                                     |
 
 * Acceptance
 
@@ -58,8 +58,8 @@ Architecture reference: [[id:4AAD3581-CFA7-4B44-A2DD-0236784E939F][Time and Time
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:D24905FA-DF57-4758-AD03-019BC3FB5C01][Fix optional<db_timestamp> → db_timestamp for all NOT NULL entity fields]] | STARTED | 2026-06-03 | | ~100 entity files: every valid_from/valid_to and other NOT NULL ts fields. |
-| [[id:CBD64E21-D0BC-4EB1-BC65-FEEC8D8E1C78][Replace timepoint_to_timestamp with datetime::to_db_string on write side]] | BACKLOG | | | ~50 mapper write sites; delete timepoint_to_timestamp from mapper_helpers. |
+| [[id:D24905FA-DF57-4758-AD03-019BC3FB5C01][Fix optional<db_timestamp> → db_timestamp for all NOT NULL entity fields]] | DONE | 2026-06-03 | 2026-06-04 | ~100 entity files: every valid_from/valid_to and other NOT NULL ts fields. |
+| [[id:CBD64E21-D0BC-4EB1-BC65-FEEC8D8E1C78][Replace timepoint_to_timestamp with datetime::to_db_string on write side]] | DONE | 2026-06-03 | 2026-06-04 | Call sites migrated in PR #1033; function deleted from mapper_helpers in mop-up. |
 | [[id:35473DF9-42DD-4163-9912-05A4523DC8F3][Investigate direct time_point entity fields (stretch)]] | BACKLOG | | | Confirm sqlgen handles time_point via custom rfl parser; prototype one entity. |
 | [[id:A573F0D0-C163-40A4-87FB-DE1A7C049FC0][Verify full build and tests green]] | BACKLOG | | | Full build + test run; confirm no epoch timestamps in history dialogs. |
 

--- a/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-helpers.org
+++ b/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-helpers.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :unify-entity-timestamps:sprint_19:v0:
 #+owner: marco
-#+branch: feature/unify-entity-timestamps
+#+branch: feature/unify-entity-timestamps-mopup
 #+pr:
 #+blocked_on:
 #+blocked_since:

--- a/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-helpers.org
+++ b/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-helpers.org
@@ -12,7 +12,7 @@
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-03
-#+updated: 2026-06-03
+#+updated: 2026-06-04
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:71116F94-09A7-43FD-BD56-4B5B25BEAC80][Unify entity timestamp handling]] story.
@@ -31,12 +31,12 @@ Nullable columns (=completed_at=, =last_event_at=, etc.) must stay as
 
 | Field        | Value                                                        |
 |--------------+--------------------------------------------------------------|
-| State        | STARTED                                                      |
+| State        | DONE                                                         |
 | Parent story | [[id:71116F94-09A7-43FD-BD56-4B5B25BEAC80][Unify entity timestamp handling]] |
-| Now          | Plan written. Ready to implement.                            |
+| Now          | Complete. Bulk landed in PR #1033; stragglers mopped up on follow-up branch. |
 | Waiting on   | Nothing.                                                     |
-| Next         | Run transformation script on all entity files.               |
-| Last touched | 2026-06-03                                                   |
+| Next         | Nothing — task closed.                                       |
+| Last touched | 2026-06-04                                                   |
 
 * Acceptance
 
@@ -111,3 +111,25 @@ grep -rn "optional<db_timestamp>" projects/ --include="*_entity.hpp" | grep -v b
 |   |                 |      |          |       |
 
 * Result
+
+Bulk conversion (~100 entity files) landed in PR #1033 on branch
+=feature/unify-entity-timestamps=. The mop-up on
+=feature/unify-entity-timestamps-mopup= fixed the 7 remaining
+=optional<db_timestamp>= fields whose DDL columns are =NOT NULL=:
+
+- =badge_mapping_entity.hpp= — =valid_from=/=valid_to= (with the
+  standard =9999-12-31 23:59:59= defaults, currency pattern).
+- =database_info_entity.hpp=, =workflow_step_entity.hpp=,
+  =workflow_instance_entity.hpp=, =workflow_batch_link_entity.hpp=,
+  =report_input_bundle_entity.hpp= — =created_at= (service_instance
+  pattern, no struct default).
+
+Read-side mappers dropped their null-guard + dereference
+(=database_info_mapper=, =workflow_step_mapper=,
+=workflow_instance_mapper=). Two write sites that relied on
+=nullopt= → DB =current_timestamp= default now set the timestamp
+explicitly via =datetime::to_db_string(now())=
+(=report_execution_handler=, =report_submit_handler=).
+
+The 11 remaining =optional<db_timestamp>= fields were verified
+nullable in DDL — correctly optional. Full build green.

--- a/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-helpers.org
+++ b/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-helpers.org
@@ -108,7 +108,8 @@ grep -rn "optional<db_timestamp>" projects/ --include="*_entity.hpp" | grep -v b
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | valid_from should default to early epoch, not 9999 | badge_mapping_entity.hpp | Declined | Matches currency/badge_definition/host pattern; DB trigger owns the fields on insert. |
+| 2 | Now field should be 'Nothing.' on DONE tasks | task_fix-mapper-helpers.org | Fixed in c54d298b1 | |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-helpers.org
+++ b/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-helpers.org
@@ -8,7 +8,7 @@
 #+filetags: :unify-entity-timestamps:sprint_19:v0:
 #+owner: marco
 #+branch: feature/unify-entity-timestamps-mopup
-#+pr:
+#+pr: https://github.com/OreStudio/OreStudio/pull/1036
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-03
@@ -102,7 +102,7 @@ grep -rn "optional<db_timestamp>" projects/ --include="*_entity.hpp" | grep -v b
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1036][#1036]] | [multi,compass] Timestamp unification mop-up; compass test logging toggle |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-helpers.org
+++ b/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-helpers.org
@@ -33,7 +33,7 @@ Nullable columns (=completed_at=, =last_event_at=, etc.) must stay as
 |--------------+--------------------------------------------------------------|
 | State        | DONE                                                         |
 | Parent story | [[id:71116F94-09A7-43FD-BD56-4B5B25BEAC80][Unify entity timestamp handling]] |
-| Now          | Complete. Bulk landed in PR #1033; stragglers mopped up on follow-up branch. |
+| Now          | Nothing.                                                     |
 | Waiting on   | Nothing.                                                     |
 | Next         | Nothing — task closed.                                       |
 | Last touched | 2026-06-04                                                   |

--- a/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-write-sites.org
+++ b/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-write-sites.org
@@ -60,7 +60,7 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Now field should be 'Nothing.' on DONE tasks | task_fix-mapper-write-sites.org | Fixed in c54d298b1 | |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-write-sites.org
+++ b/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-write-sites.org
@@ -8,7 +8,7 @@
 #+filetags: :unify-entity-timestamps:sprint_19:v0:
 #+owner: marco
 #+branch: feature/unify-entity-timestamps-mopup
-#+pr:
+#+pr: https://github.com/OreStudio/OreStudio/pull/1036
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-03
@@ -54,7 +54,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1036][#1036]] | [multi,compass] Timestamp unification mop-up; compass test logging toggle |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-write-sites.org
+++ b/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-write-sites.org
@@ -30,7 +30,7 @@ timestamp.
 |--------------+----------------------------------------|
 | State        | DONE                                 |
 | Parent story | [[id:71116F94-09A7-43FD-BD56-4B5B25BEAC80][Unify entity timestamp fields: replace optional<db_timestamp> with std::string]] |
-| Now          | Complete. Call sites migrated in PR #1033; function deleted in mop-up. |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
 | Next         | Nothing — task closed.                 |
 | Last touched | 2026-06-04                               |

--- a/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-write-sites.org
+++ b/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-write-sites.org
@@ -7,34 +7,40 @@
 #+level: s1
 #+filetags: :unify-entity-timestamps:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/unify-entity-timestamps-mopup
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-03
-#+updated: 2026-06-03
+#+updated: 2026-06-04
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:71116F94-09A7-43FD-BD56-4B5B25BEAC80][Unify entity timestamp fields: replace optional<db_timestamp> with std::string]] story. It captures the goal, current status, acceptance, and any notes or results.
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Eliminate =timepoint_to_timestamp= (silent-failure write-side
+conversion) in favour of =datetime::to_db_string=, which cannot fail
+for valid time_points and throws rather than returning an empty
+timestamp.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                                 |
 | Parent story | [[id:71116F94-09A7-43FD-BD56-4B5B25BEAC80][Unify entity timestamp fields: replace optional<db_timestamp> with std::string]] |
-| Now          | Not yet started.                       |
+| Now          | Complete. Call sites migrated in PR #1033; function deleted in mop-up. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-03                               |
+| Next         | Nothing — task closed.                 |
+| Last touched | 2026-06-04                               |
 
 * Acceptance
 
--
+- No call sites of =timepoint_to_timestamp= remain.
+- =timepoint_to_timestamp= is deleted from =mapper_helpers.hpp=.
+- Both throwing overloads of =timestamp_to_timepoint= remain.
+- Build green.
 
 * Plan
 
@@ -57,3 +63,10 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+All write-site call sites had already been migrated to
+=datetime::to_db_string= as part of PR #1033 — a grep on the mop-up
+branch found zero remaining callers. This task therefore reduced to
+deleting the =timepoint_to_timestamp= function and its doc block from
+=mapper_helpers.hpp=. Both throwing =timestamp_to_timepoint= overloads
+remain. Full build green.

--- a/doc/knowledge/architecture/cmake_setup.org
+++ b/doc/knowledge/architecture/cmake_setup.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :cmake:build:architecture:knowledge:
 #+created: 2026-05-18
-#+updated: 2026-05-26
+#+updated: 2026-06-04
 
 ORE Studio uses CMake with CMakePresets to drive its build across
 Linux, macOS, and Windows. Presets fix the compiler, build type, and
@@ -112,16 +112,19 @@ CI workflows set these automatically via =$(nproc)=.
 
 ** Test logging
 
-Test logging is disabled by default for performance. Two switches:
+Test logging is disabled by default for performance. It is controlled
+by three variables in =.env=: =ORES_TEST_LOG_ENABLED=,
+=ORES_TEST_LOG_LEVEL= (=trace=, =debug=, =info=, =warn=, =error=) and
+=ORES_TEST_LOG_CONSOLE=. The root =CMakeLists.txt= forwards every
+=.env= variable verbatim to test processes via =ORES_TEST_ENV_CMD=,
+and =.env= is registered as a =CMAKE_CONFIGURE_DEPENDS= so changes
+trigger an automatic re-configure on the next build.
 
-- =-DORES_TEST_LOG_LEVEL=<level>= at configure time. Levels: =OFF=
-  (default), =trace=, =debug=, =info=, =warn=, =error=.
-- =-DORES_TEST_LOG_CONSOLE=ON= to mirror logs to stdout (default
-  =OFF=).
-
-Environment-variable equivalents (override the configure-time
-defaults at run time): =ORES_TEST_LOG_ENABLED=,
-=ORES_TEST_LOG_LEVEL=, =ORES_TEST_LOG_CONSOLE=.
+Toggle with =compass test logging on [level]= / =off= / =status=
+(aliases: =compass env init --enable-logging= / =--disable-logging=).
+The variables can also be set directly in the process environment for
+a one-off run; the runtime listener in =ores.testing= reads them at
+test startup.
 
 See [[id:4BF2516D-F37E-4E31-AD7B-124F2639B9AB][How do I enable test logging?]] for the operational steps;
 [[id:20D2CB34-4E2F-45D3-8FA2-F1C5B4C7B22F][How do I run the tests?]] is the surrounding test-run recipe.

--- a/doc/recipes/cmake/how_do_i_enable_test_logging.org
+++ b/doc/recipes/cmake/how_do_i_enable_test_logging.org
@@ -2,12 +2,12 @@
 :ID: 4BF2516D-F37E-4E31-AD7B-124F2639B9AB
 :END:
 #+title: How do I enable test logging?
-#+description: Turn on test-suite logging — configure-time flags (ORES_TEST_LOG_LEVEL, ORES_TEST_LOG_CONSOLE) and equivalent runtime environment variables.
+#+description: Turn on test-suite logging with compass test logging on/off/status — the ORES_TEST_LOG_* variables in .env, forwarded to test processes by CMake.
 #+type: recipe
 #+level: cross
 #+filetags: :cmake:build:tests:logging:recipe:
 #+created: 2026-05-21
-#+updated: 2026-05-21
+#+updated: 2026-06-04
 
 Test logging is /off/ by default for performance. The conceptual
 description lives in [[id:5AAE6900-8488-4E22-9F31-A1B9D5320EFB][CMake setup]]§"Test logging"; this recipe is
@@ -16,52 +16,61 @@ logging is configured, see [[id:20D2CB34-4E2F-45D3-8FA2-F1C5B4C7B22F][How do I r
 
 * Question
 
-How do I enable test logging — choose a level, optionally mirror it
-to stdout — at configure time and at run time?
+How do I enable test logging — choose a level — and turn it back off
+when I'm done?
 
 * Answer
 
-There are two switches, each set at /configure/ time and overridable
-at /run/ time via environment variables.
+Test logging is controlled by three =ORES_TEST_LOG_*= variables in
+=.env=. The root =CMakeLists.txt= forwards every =.env= variable
+verbatim to test processes, and =.env= is a CMake configure
+dependency, so any change is picked up automatically on the next
+build or test run — no manual re-configure needed.
 
-1. /Pick the level/ at configure time. Levels: =OFF= (default),
-   =trace=, =debug=, =info=, =warn=, =error=.
+The compass test pillar provides the toggle:
+
+1. /Enable/ — defaults to =debug=; pass a level (=trace=, =debug=,
+   =info=, =warn=, =error=) to override:
 
    #+begin_src sh :results verbatim
-   cmake --preset linux-clang-debug-ninja -DORES_TEST_LOG_LEVEL=debug
+   ./compass.sh test logging on
+   ./compass.sh test logging on trace
    #+end_src
 
-2. /Mirror logs to stdout/ as well as the log file (default =OFF=):
+   This appends a =# Test logging= block to =.env= setting
+   =ORES_TEST_LOG_ENABLED=true=, =ORES_TEST_LOG_LEVEL=<level>= and
+   =ORES_TEST_LOG_CONSOLE=true=.
+
+2. /Disable/ — strips the block; absence means disabled:
 
    #+begin_src sh :results verbatim
-   cmake --preset linux-clang-debug-ninja \
-         -DORES_TEST_LOG_LEVEL=debug \
-         -DORES_TEST_LOG_CONSOLE=ON
+   ./compass.sh test logging off
    #+end_src
 
-3. /Override at run time/ — the env vars override the configure-time
-   defaults without re-running CMake. Useful for a single test run
-   when you don't want to disturb the cached configuration:
+3. /Inspect/ — show the current settings:
 
    #+begin_src sh :results verbatim
-   ORES_TEST_LOG_ENABLED=1 \
+   ./compass.sh test logging status
+   #+end_src
+
+4. /One-off override/ — the same variables can be set in the process
+   environment for a single run without touching =.env= (the runtime
+   listener in =ores.testing= reads them directly):
+
+   #+begin_src sh :results verbatim
+   ORES_TEST_LOG_ENABLED=true \
    ORES_TEST_LOG_LEVEL=trace \
-   ORES_TEST_LOG_CONSOLE=1 \
+   ORES_TEST_LOG_CONSOLE=true \
        ctest --preset linux-clang-debug-ninja
    #+end_src
 
-4. /Turn it back off/ — set the level to =OFF= (or =unset= the env
-   var):
-
-   #+begin_src sh :results verbatim
-   cmake --preset linux-clang-debug-ninja -DORES_TEST_LOG_LEVEL=OFF
-   #+end_src
+=compass env init --enable-logging [level]= and =--disable-logging=
+remain as aliases for the same operation.
 
 * Script
 
-No wrapper — these are bare CMake/CTest invocations. The presets are
-listed by =./build/scripts/build.sh --list-presets= (see
-[[id:AADBEF95-AFD8-4DC0-A4EC-505E47B07F86][How do I list available presets?]]).
+=compass test logging= in =projects/ores.compass/src/compass.py=,
+delegating to =_logging_only= in =env_init.py=.
 
 * Tested by
 

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -2309,10 +2309,56 @@ def cmd_test(argv):
     rp.add_argument("--preset", default="",
                     help="CMake preset name (default: read ORES_PRESET from .env)")
 
+    lp = sub.add_parser("logging",
+                        help="Toggle test logging: 'logging on [level]', "
+                             "'logging off', 'logging status'")
+    lp.add_argument("action", choices=["on", "off", "status"],
+                    help="on: enable test logging; off: disable; "
+                         "status: show current .env settings")
+    lp.add_argument("level", nargs="?", default="debug",
+                    help="Log level for 'on' (trace, debug, info, warn, error; "
+                         "default: debug)")
+
     args = ap.parse_args(argv)
 
     if args.subcmd == "results":
         return _cmd_test_results(args)
+    if args.subcmd == "logging":
+        return _cmd_test_logging(args)
+
+
+def _cmd_test_logging(args):
+    """compass test logging on|off|status — toggle test logging in .env.
+
+    Delegates to env_init._logging_only: the three ORES_TEST_LOG_* vars in
+    .env are forwarded verbatim to test processes by the root CMakeLists,
+    and .env is a CMAKE_CONFIGURE_DEPENDS so the next build re-configures
+    automatically.
+    """
+    env_file = PROJECT_ROOT / ".env"
+    if args.action == "status":
+        if not env_file.is_file():
+            print("❌ No .env found. Run 'compass env init' first.",
+                  file=sys.stderr)
+            return 1
+        vals = {}
+        for line in env_file.read_text(encoding="utf-8").splitlines():
+            key, _, val = line.partition("=")
+            if key.strip().startswith("ORES_TEST_LOG_"):
+                vals[key.strip()] = val.strip()
+        if not vals:
+            print("Test logging: disabled (no ORES_TEST_LOG_* vars in .env)")
+            print("  Enable with: compass test logging on [level]")
+        else:
+            enabled = vals.get("ORES_TEST_LOG_ENABLED", "false") == "true"
+            print(f"Test logging: {'enabled' if enabled else 'disabled'}")
+            for k in sorted(vals):
+                print(f"  {k}={vals[k]}")
+        return 0
+
+    import env_init
+    return env_init._logging_only(
+        env_file, "enable" if args.action == "on" else "disable", args.level)
 
 
 def _cmd_test_results(args):
@@ -2352,11 +2398,13 @@ def _cmd_test_results(args):
 
     print(f"🧭 ores.compass — test results: preset={preset}\n")
     print(f"Found {len(xml_files)} test-results file(s)  |  "
-          f"Logs: {log_dir or 'none (run with -DORES_TEST_LOG_LEVEL=debug to enable)'}\n")
+          f"Logs: {log_dir or 'none'}\n")
 
     if log_dir is None:
-        print("⚠️  No log directory found. To enable logging, reconfigure CMake:")
-        print(f"   cmake --preset {preset} -DORES_TEST_LOG_LEVEL=debug\n")
+        print("⚠️  No log directory found. To enable test logging:")
+        print("   compass test logging on [trace|debug|info|warn|error]")
+        print("   The change is picked up automatically on the next test run")
+        print("   (.env is a CMake configure dependency). Then re-run the tests.\n")
 
     total_stats = {"total": 0, "passed": 0, "failed": 0,
                    "skipped": 0, "duration": 0.0}
@@ -2705,7 +2753,8 @@ def main():
     subparsers.add_parser("env",
                           help="Provision: 'env init' generates .env + certs + IAM key; 'env diff'; 'env --help'")
     subparsers.add_parser("test",
-                          help="Test: 'test results' parses Catch2 XML and shows an overview; 'test --help'")
+                          help="Test: 'test results' shows last run overview; "
+                               "'test logging on|off|status' toggles test logging; 'test --help'")
     subparsers.add_parser("bearings",
                           help="Cold-start orientation: identity, where, last session, recipes, memories")
     subparsers.add_parser("orient",

--- a/projects/ores.compass/src/doc_show.py
+++ b/projects/ores.compass/src/doc_show.py
@@ -31,9 +31,10 @@ from doc_index import (
     resolve_id, resolve_anchor, find_ambiguous,
 )
 
-_C_BOLD  = "\033[1m"
-_C_CYAN  = "\033[36m"
-_C_RESET = "\033[0m"
+_C_BOLD   = "\033[1m"
+_C_CYAN   = "\033[36m"
+_C_YELLOW = "\033[33m"
+_C_RESET  = "\033[0m"
 
 def _h(text):
     """Wrap text in bold cyan for section headings."""

--- a/projects/ores.compass/src/env_init.py
+++ b/projects/ores.compass/src/env_init.py
@@ -137,7 +137,8 @@ def _logging_only(env_file: Path, op: str, level: str) -> int:
         print("Test logging disabled.")
     env_file.write_text(out)
     env_file.chmod(0o600)
-    print("Re-run 'cmake --preset <preset>' to pick up the change.")
+    print("Picked up automatically on the next build/test run "
+          "(.env is a CMake configure dependency).")
     return 0
 
 

--- a/projects/ores.compute/core/include/ores.compute.core/repository/workflow_batch_link_entity.hpp
+++ b/projects/ores.compute/core/include/ores.compute.core/repository/workflow_batch_link_entity.hpp
@@ -44,7 +44,7 @@ struct workflow_batch_link_entity {
     std::string tenant_id;
     std::string workflow_step_id;
     std::string workflow_instance_id;
-    std::optional<db_timestamp> created_at;
+    db_timestamp created_at;
 };
 
 }

--- a/projects/ores.compute/core/src/messaging/report_submit_handler.cpp
+++ b/projects/ores.compute/core/src/messaging/report_submit_handler.cpp
@@ -19,10 +19,12 @@
  */
 #include "ores.compute.core/messaging/report_submit_handler.hpp"
 
+#include <chrono>
 #include <format>
 #include <rfl/json.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/uuid_generators.hpp>
+#include "ores.platform/time/datetime.hpp"
 #include "ores.database/service/tenant_context.hpp"
 #include "ores.service/messaging/workflow_helpers.hpp"
 #include "ores.service/messaging/handler_helpers.hpp"
@@ -138,6 +140,8 @@ void report_submit_handler::submit(ores::nats::message msg) {
         link.tenant_id            = req.tenant_id;
         link.workflow_step_id     = wf->step_id;
         link.workflow_instance_id = wf->instance_id;
+        link.created_at           = ores::platform::time::datetime::to_db_string(
+            std::chrono::system_clock::now());
 
         repository::workflow_batch_link_repository link_repo;
         link_repo.create(tenant_ctx, link);

--- a/projects/ores.database/include/ores.database/repository/database_info_entity.hpp
+++ b/projects/ores.database/include/ores.database/repository/database_info_entity.hpp
@@ -43,7 +43,7 @@ struct database_info_entity {
     std::string build_environment;
     std::string git_commit;
     std::string git_date;
-    std::optional<db_timestamp> created_at;
+    db_timestamp created_at;
 };
 
 ORES_DATABASE_EXPORT std::ostream& operator<<(std::ostream& s, const database_info_entity& v);

--- a/projects/ores.database/include/ores.database/repository/mapper_helpers.hpp
+++ b/projects/ores.database/include/ores.database/repository/mapper_helpers.hpp
@@ -118,35 +118,6 @@ timestamp_to_timepoint(const db_timestamp& ts) {
     return platform::time::datetime::from_iso8601_utc(ts.str() + "+00");
 }
 
-/**
- * @brief Converts a std::chrono::system_clock::time_point to a db_timestamp.
- *
- * Formats the time_point as an ISO 8601 UTC string with Z suffix. PostgreSQL
- * TIMESTAMPTZ columns accept the Z suffix correctly and store the UTC instant.
- *
- * @param tp The time_point to convert
- * @param lg The logger to use for logging
- * @return A db_timestamp, or an empty db_timestamp if conversion fails
- *
- * @example
- * entity.last_login = timepoint_to_timestamp(std::chrono::system_clock::now(), lg);
- */
-inline db_timestamp
-timepoint_to_timestamp(const std::chrono::system_clock::time_point& tp,
-    logging::logger_t& lg) {
-    using namespace ores::logging;
-
-    const auto s = platform::time::datetime::to_iso8601_utc(tp);
-    // Strip the Z suffix — db_timestamp::from_string expects no timezone designator
-    const auto bare = s.substr(0, s.size() - 1);
-    const auto r = db_timestamp::from_string(bare);
-    if (!r) {
-        BOOST_LOG_SEV(lg, error) << "Error converting timepoint to timestamp";
-        return {};
-    }
-    return r.value();
-}
-
 }
 
 #endif

--- a/projects/ores.database/src/repository/database_info_mapper.cpp
+++ b/projects/ores.database/src/repository/database_info_mapper.cpp
@@ -39,9 +39,7 @@ database_info_mapper::map(const database_info_entity& v) {
     r.build_environment = v.build_environment;
     r.git_commit = v.git_commit;
     r.git_date = v.git_date;
-    if (!v.created_at)
-        throw std::logic_error("Cannot map entity with null created_at to domain object.");
-    r.created_at = timestamp_to_timepoint(*v.created_at);
+    r.created_at = timestamp_to_timepoint(v.created_at);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;

--- a/projects/ores.dq/core/include/ores.dq.core/repository/badge_mapping_entity.hpp
+++ b/projects/ores.dq/core/include/ores.dq.core/repository/badge_mapping_entity.hpp
@@ -43,8 +43,8 @@ struct badge_mapping_entity {
     std::string tenant_id;
     std::string entity_code;
     std::string badge_code;
-    std::optional<db_timestamp> valid_from;
-    std::optional<db_timestamp> valid_to;
+    db_timestamp valid_from = "9999-12-31 23:59:59";
+    db_timestamp valid_to = "9999-12-31 23:59:59";
 };
 
 std::ostream& operator<<(std::ostream& s, const badge_mapping_entity& v);

--- a/projects/ores.reporting/core/include/ores.reporting.core/repository/report_input_bundle_entity.hpp
+++ b/projects/ores.reporting/core/include/ores.reporting.core/repository/report_input_bundle_entity.hpp
@@ -48,7 +48,7 @@ struct report_input_bundle_entity {
     std::string market_data_storage_key;
     int trade_count = 0;
     int series_count = 0;
-    std::optional<db_timestamp> created_at;
+    db_timestamp created_at;
 };
 
 }

--- a/projects/ores.reporting/core/src/messaging/report_execution_handler.cpp
+++ b/projects/ores.reporting/core/src/messaging/report_execution_handler.cpp
@@ -25,6 +25,7 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include "ores.utility/rfl/reflectors.hpp"
+#include "ores.platform/time/datetime.hpp"
 #include "ores.database/service/tenant_context.hpp"
 #include "ores.service/messaging/workflow_helpers.hpp"
 #include "ores.reporting.api/messaging/report_execution_protocol.hpp"
@@ -322,7 +323,8 @@ void report_execution_handler::assemble_bundle(ores::nats::message msg) {
         bundle.market_data_storage_key = req.market_data_storage_key;
         bundle.trade_count = req.trade_count;
         bundle.series_count = req.series_count;
-        bundle.created_at = std::nullopt;  // DB default (current_timestamp)
+        bundle.created_at = ores::platform::time::datetime::to_db_string(
+            std::chrono::system_clock::now());
 
         repository::report_input_bundle_repository bundle_repo;
         bundle_repo.create(tenant_ctx, bundle);

--- a/projects/ores.workflow/core/include/ores.workflow.core/repository/workflow_instance_entity.hpp
+++ b/projects/ores.workflow/core/include/ores.workflow.core/repository/workflow_instance_entity.hpp
@@ -51,7 +51,7 @@ struct workflow_instance_entity {
     std::string materialised_steps_json;
     std::optional<db_timestamp> completed_at;
     std::optional<db_timestamp> last_event_at;
-    std::optional<db_timestamp> created_at;
+    db_timestamp created_at;
 };
 
 std::ostream& operator<<(std::ostream& s, const workflow_instance_entity& v);

--- a/projects/ores.workflow/core/include/ores.workflow.core/repository/workflow_step_entity.hpp
+++ b/projects/ores.workflow/core/include/ores.workflow.core/repository/workflow_step_entity.hpp
@@ -53,7 +53,7 @@ struct workflow_step_entity {
     std::string compensation_json;
     std::optional<db_timestamp> started_at;
     std::optional<db_timestamp> completed_at;
-    std::optional<db_timestamp> created_at;
+    db_timestamp created_at;
     std::optional<std::string> step_log_json;
 };
 

--- a/projects/ores.workflow/core/src/repository/workflow_instance_mapper.cpp
+++ b/projects/ores.workflow/core/src/repository/workflow_instance_mapper.cpp
@@ -51,9 +51,7 @@ workflow_instance_mapper::map(const workflow_instance_entity& v) {
         r.completed_at = timestamp_to_timepoint(*v.completed_at);
     if (v.last_event_at)
         r.last_event_at = timestamp_to_timepoint(*v.last_event_at);
-    if (!v.created_at)
-        throw std::logic_error("Cannot map entity with null created_at to domain object.");
-    r.created_at = timestamp_to_timepoint(*v.created_at);
+    r.created_at = timestamp_to_timepoint(v.created_at);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;

--- a/projects/ores.workflow/core/src/repository/workflow_step_mapper.cpp
+++ b/projects/ores.workflow/core/src/repository/workflow_step_mapper.cpp
@@ -54,9 +54,7 @@ workflow_step_mapper::map(const workflow_step_entity& v) {
         r.started_at = timestamp_to_timepoint(*v.started_at);
     if (v.completed_at)
         r.completed_at = timestamp_to_timepoint(*v.completed_at);
-    if (!v.created_at)
-        throw std::logic_error("Cannot map entity with null created_at to domain object.");
-    r.created_at = timestamp_to_timepoint(*v.created_at);
+    r.created_at = timestamp_to_timepoint(v.created_at);
     r.step_log_json = v.step_log_json.value_or("");
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;


### PR DESCRIPTION
## Summary

Closes out tasks 1 and 2 of the timestamp unification story: converts the 7 remaining `optional<db_timestamp>` fields whose DDL columns are `NOT NULL` to plain `db_timestamp`, and deletes the silent-failure `timepoint_to_timestamp` helper. Alongside, surfaces the test-logging toggle as `compass test logging on/off/status` and fixes two stale compass issues found en route.

## Changes

**Timestamp mop-up**
- `badge_mapping_entity` (dq): `valid_from`/`valid_to` → plain `db_timestamp` with standard defaults (currency pattern).
- `created_at` → plain `db_timestamp` in `database_info`, `workflow_step`, `workflow_instance`, `workflow_batch_link`, `report_input_bundle` (service_instance pattern).
- Read-side mappers drop the null-guard + dereference (`database_info_mapper`, `workflow_step_mapper`, `workflow_instance_mapper`).
- Two write sites that relied on `nullopt` → DB `current_timestamp` default now set the timestamp explicitly via `datetime::to_db_string(now())` (`report_execution_handler`, `report_submit_handler`).
- `timepoint_to_timestamp` deleted from `mapper_helpers.hpp`; all call sites were already migrated in #1033. Both throwing `timestamp_to_timepoint` overloads remain.
- Remaining 11 `optional<db_timestamp>` fields verified nullable in DDL — correctly optional.

**Compass**
- New `compass test logging on [level] / off / status` — delegates to the existing `.env` toggle in `env_init.py`; `env init --enable-logging/--disable-logging` remain as aliases.
- Fixed stale hint in `compass test results` pointing at the removed `-DORES_TEST_LOG_LEVEL` configure flag; fixed stale "re-run cmake" message (`.env` is a `CMAKE_CONFIGURE_DEPENDS`, auto-reconfigures).
- Fixed `NameError: _C_YELLOW` crash in `doc_show.py` link rendering.
- Rewrote the test-logging recipe and CMake setup §Test logging around the `.env` mechanism.

## Notes / Decisions

- The two handler write sites now stamp `created_at` app-side instead of leaning on the DB default — consistent with how all converted entities write timestamps.
- Full build green; 2211/2211 tests passed across 65 suites.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Unify entity timestamp handling](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/story.html) | 71116F94-09A7-43FD-BD56-4B5B25BEAC80 |
| Task | [Fix optional<db_timestamp> → db_timestamp for all NOT NULL entity fields](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-helpers.html) | D24905FA-DF57-4758-AD03-019BC3FB5C01 |
| Task | [Replace timepoint_to_timestamp with datetime::to_db_string on write side](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/unify-entity-timestamps/task_fix-mapper-write-sites.html) | CBD64E21-D0BC-4EB1-BC65-FEEC8D8E1C78 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)