### PR TITLE
[ores.qt.admin,ores.sql] Display account type as badge in Qt accounts list

### DIFF
--- a/doc/agile/product_backlog/inbox/ab_notebook_curve_replication.org
+++ b/doc/agile/product_backlog/inbox/ab_notebook_curve_replication.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: ADA913CE-E719-4B5D-9D8C-5C0186B788A0
+:END:
+#+title: ab-notebook: reproducible interest rate curve bootstrapping
+#+description: Luigi Ballabio's Jupyter notebook replicating the Ametrano & Bianchetti (2013) curve bootstrapping paper — a case study in research reproducibility relevant to ORE Studio's curve infrastructure.
+#+type: capture
+#+level: cross
+#+filetags: :quantlib:curves:reproducibility:research:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+[[https://github.com/lballabio/ab-notebook][ab-notebook]] is a Jupyter notebook by Luigi Ballabio (QuantLib author)
+that fully replicates "Everything You Always Wanted to Know About
+Multiple Interest Rate Curve Bootstrapping but Were Afraid to Ask"
+(Ametrano & Bianchetti, 2013). It demonstrates a complete
+reproducibility workflow: pinned dependencies via Pipenv, DOI-based
+software version citations via Zenodo, and zero-install browser
+execution via mybinder.org. The companion article is [[https://implementingquantlib.substack.com/p/the-software-side-of-replication]["The Software Side
+of Replication"]] (Ballabio, Wilmott Magazine November 2025 / Substack),
+which generalises the methodology: Git + GitHub for version control,
+Jupyter for the notebook layer, Pipenv/Poetry for dependency
+management, Docker for environment isolation, and Binder for online
+execution.
+
+* Why
+
+ORE Studio's core domain is interest rate curve bootstrapping — the
+exact subject of the Ametrano & Bianchetti paper. The ab-notebook
+demonstrates the toolchain and reproducibility standards that the
+QuantLib community considers best practice for publishing computational
+finance research. Relevant angles:
+
+- *Reproducibility infrastructure* — Zenodo DOI citations + Pipenv
+  pinning + Binder is a proven, low-friction pattern. ORE Studio could
+  apply the same to its own example notebooks or published analyses.
+- *Curve bootstrapping reference* — the notebook itself is a
+  worked reference implementation of multi-curve bootstrapping (OIS
+  discounting, EONIA/EURIBOR, dual-curve framework). Useful as a
+  cross-check / test fixture for ORE Studio's own curve engine.
+- *QuantLib version pinning* — the repo shows how to pin a specific
+  QuantLib version for reproducibility, which is directly applicable
+  to ORE Studio's QuantLib dependency management.
+
+* References
+
+- [[https://github.com/lballabio/ab-notebook][lballabio/ab-notebook]] — GitHub repository (BSD-3-Clause, Jupyter/Python)
+- [[https://implementingquantlib.substack.com/p/the-software-side-of-replication][The Software Side of Replication]] — Luigi Ballabio, Wilmott Magazine Nov 2025 / Substack
+- Ametrano & Bianchetti (2013), "Everything You Always Wanted to Know About Multiple Interest Rate Curve Bootstrapping but Were Afraid to Ask"
+
+* See also
+
+- [[id:E808F432-2FDA-47E8-B003-1E8B908870FE][Interest Rate Curves]] — ORE Studio's knowledge doc on curve bootstrapping concepts.

--- a/doc/agile/product_backlog/inbox/badge_in_combo_box.org
+++ b/doc/agile/product_backlog/inbox/badge_in_combo_box.org
@@ -1,0 +1,28 @@
+:PROPERTIES:
+:ID: 0CD11BEF-1D04-4984-97C4-BB498B81579B
+:END:
+#+title: Badge rendering inside QComboBox selected state
+#+description: Account type combo in AccountDetailDialog shows plain text in closed state. Full badge rendering requires QComboBox subclass overriding paintEvent, or a coloured swatch QLabel next to the combo. Defer until the pattern is needed in more than one place.
+#+type: capture
+#+level: cross
+#+filetags: :qt:badge:ux:combo:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+(One paragraph: the idea.)
+
+* Why
+
+(Motivation, problem being solved, related context.)
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/product_backlog/inbox/use_badges_in_the_history_dialog.org
+++ b/doc/agile/product_backlog/inbox/use_badges_in_the_history_dialog.org
@@ -1,0 +1,38 @@
+:PROPERTIES:
+:ID:       AEE11EE6-6666-4D71-BC05-A2D16B6DC582
+:END:
+#+title: Use badges in the history dialog
+#+description: Make history dialog consistent with main window and details dialog for badges by using badges there too.
+#+type: capture
+#+version: 2
+#+level: cross
+#+filetags: :inbox:capture:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+At present we only have badges in the main window. We are adding them to
+details, but we do not have them in the history dialog. Claude:
+
+#+begin_quote
+One gap worth noting: the history dialog shows historical account rows but has
+no delegate wiring, so Status, Locked, and AccountType appear as plain text in
+history. That's consistent with every other entity's history dialog — badges
+aren't applied there anywhere — so it's not a regression, just a general
+limitation.
+#+end_quote
+
+* Why
+
+UX should be consistent across dialogs.
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_19/account_type_badge_qt/story.org
+++ b/doc/agile/versions/v0/sprint_19/account_type_badge_qt/story.org
@@ -45,7 +45,9 @@ produced so future badges can be added without archaeology.
   one badge definition and badge mapping per account type value.
 - A knowledge doc exists at =doc/knowledge/architecture/badge_system_wiring.org=
   covering the three-layer structure (=ores.dq=, =ores.sql=, =ores.qt.api=)
-  and a "how to add a new badge" section using =account_type= as the worked example.
+  with =account_type= as the worked example.
+- A thin recipe at =doc/recipes/qt/how_do_i_add_a_badge_in_qt.org=
+  checklists the four steps and links to the knowledge doc.
 - No regressions to the =Status= or =Locked= badge columns.
 
 * Tasks

--- a/doc/agile/versions/v0/sprint_19/account_type_badge_qt/story.org
+++ b/doc/agile/versions/v0/sprint_19/account_type_badge_qt/story.org
@@ -1,0 +1,63 @@
+:PROPERTIES:
+:ID: 814D4E79-8EB9-4B2B-8A87-DB72F145044D
+:END:
+#+title: Story: Display account type as badge in Qt accounts list
+#+description: Account type is plain text in the accounts MDI window; wire it as a DB-driven badge via BadgeCache/DelegatePaintUtils, plus a recipe for how to set up a badge in Qt.
+#+type: story
+#+level: s2
+#+filetags: :qt:iam:badge:accounts:sprint_19:v0:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+The =account_type= column in the Qt accounts MDI window renders as
+plain text ("user", "service", etc.). Wire it as a DB-driven pill
+badge — consistent with =login_status= and =account_locked= — so the
+account type is visually distinct and colour-coded without hardcoding
+any colours in C++.
+
+A recipe documenting the end-to-end badge setup process is also
+produced so future badges can be added without archaeology.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                                |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Start implementation task.             |
+| Last touched  | 2026-06-04                             |
+
+* Acceptance
+
+- The =Type= column in the accounts list renders as a pill badge
+  (coloured background, white text) for all known values: user,
+  service, algorithm, llm.
+- Colours are resolved via =BadgeCache= — no hardcoded hex values in
+  =AccountItemDelegate=.
+- SQL population script contains a =account_type= code domain with
+  one badge definition and badge mapping per account type value.
+- A recipe exists at =doc/recipes/qt/how_do_i_set_up_a_badge_in_qt.org=
+  covering the full process: SQL population, code domain, badge
+  definitions, badge mappings, delegate wiring, and =sizeHint=.
+- No regressions to the =Status= or =Locked= badge columns.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:5433FF26-FF0A-45A4-882A-4A9C41F51CB9][Implement account type badge in AccountItemDelegate]] | BACKLOG | | | Add account_type code domain + badge defs to SQL; wire Column::AccountType in delegate. |
+| [[id:36118737-9E05-48F0-889A-E800BA58825C][Write recipe: how to set up a badge in Qt]] | BACKLOG | | | Document end-to-end badge setup: SQL, code domain, definitions, mappings, delegate, sizeHint. |
+
+* Decisions
+
+* Out of scope
+
+- Wt badge rendering for account type (separate story).
+- Changing the badge system architecture.

--- a/doc/agile/versions/v0/sprint_19/account_type_badge_qt/story.org
+++ b/doc/agile/versions/v0/sprint_19/account_type_badge_qt/story.org
@@ -43,9 +43,9 @@ produced so future badges can be added without archaeology.
   =AccountItemDelegate=.
 - SQL population script contains a =account_type= code domain with
   one badge definition and badge mapping per account type value.
-- A recipe exists at =doc/recipes/qt/how_do_i_set_up_a_badge_in_qt.org=
-  covering the full process: SQL population, code domain, badge
-  definitions, badge mappings, delegate wiring, and =sizeHint=.
+- A knowledge doc exists at =doc/knowledge/architecture/badge_system_wiring.org=
+  covering the three-layer structure (=ores.dq=, =ores.sql=, =ores.qt.api=)
+  and a "how to add a new badge" section using =account_type= as the worked example.
 - No regressions to the =Status= or =Locked= badge columns.
 
 * Tasks
@@ -53,7 +53,7 @@ produced so future badges can be added without archaeology.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:5433FF26-FF0A-45A4-882A-4A9C41F51CB9][Implement account type badge in AccountItemDelegate]] | BACKLOG | | | Add account_type code domain + badge defs to SQL; wire Column::AccountType in delegate. |
-| [[id:36118737-9E05-48F0-889A-E800BA58825C][Write recipe: how to set up a badge in Qt]] | BACKLOG | | | Document end-to-end badge setup: SQL, code domain, definitions, mappings, delegate, sizeHint. |
+| [[id:36118737-9E05-48F0-889A-E800BA58825C][Write knowledge doc: badge system wiring]] | BACKLOG | | | Architectural knowledge doc covering ores.dq/ores.sql/ores.qt.api layers; account_type as worked example. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_document_badge_setup_in_qt.org
+++ b/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_document_badge_setup_in_qt.org
@@ -1,0 +1,67 @@
+:PROPERTIES:
+:ID: 36118737-9E05-48F0-889A-E800BA58825C
+:END:
+#+title: Task: Write recipe: how to set up a badge in Qt
+#+description: Document the end-to-end steps for wiring a new field as a DB-driven badge in Qt: SQL population, code domain, badge definitions, mappings, delegate wiring, and sizeHint.
+#+type: task
+#+level: s1
+#+filetags: :account_type_badge_qt:sprint_19:v0:
+#+owner: marco
+#+branch: feature/account-type-badge-qt
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:814D4E79-8EB9-4B2B-8A87-DB72F145044D][Display account type as badge in Qt accounts list]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Produce a recipe at =doc/recipes/qt/how_do_i_set_up_a_badge_in_qt.org=
+documenting the full end-to-end process for wiring a new field as a
+DB-driven badge in the Qt layer. Written after the implementation task
+is complete, so it describes the actual steps taken.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                                |
+| Parent story | [[id:814D4E79-8EB9-4B2B-8A87-DB72F145044D][Display account type as badge in Qt accounts list]] |
+| Now          | Not yet started.                       |
+| Waiting on   | [[id:5433FF26-FF0A-45A4-882A-4A9C41F51CB9][Implement account type badge]] (recipe written after impl). |
+| Next         | Implement badge task first.            |
+| Last touched | 2026-06-04                             |
+
+* Acceptance
+
+- Recipe file exists at =doc/recipes/qt/how_do_i_set_up_a_badge_in_qt.org=
+  and is indexed by compass.
+- Recipe covers all six steps: code domain SQL, badge definitions SQL,
+  badge mappings SQL, delegate paint branch, sizeHint, and fallback
+  colours.
+- Concrete =account_type= wiring is used as the worked example.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_document_badge_setup_in_qt.org
+++ b/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_document_badge_setup_in_qt.org
@@ -2,7 +2,7 @@
 :ID: 36118737-9E05-48F0-889A-E800BA58825C
 :END:
 #+title: Task: Write knowledge doc: badge system wiring
-#+description: Document how the DB-driven badge system is structured and extended — spanning ores.dq (domain), ores.sql (population), and ores.qt.api (BadgeCache/delegate) — as an architectural knowledge doc.
+#+description: Produce an architectural knowledge doc (badge_system_wiring.org) covering the three-layer badge structure, plus a thin recipe that checklists the steps and points to it.
 #+type: task
 #+level: s1
 #+filetags: :account_type_badge_qt:sprint_19:v0:
@@ -19,11 +19,14 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-Produce a knowledge doc at
-=doc/knowledge/architecture/badge_system_wiring.org= that describes
-how the DB-driven badge system is structured and how to extend it with
-a new badge. Written after the implementation task so it reflects the
-actual code, not aspirational design.
+Produce two linked documents, both written after the implementation
+task so they reflect actual code:
+
+1. A knowledge doc at =doc/knowledge/architecture/badge_system_wiring.org=
+   describing how the DB-driven badge system is structured and why.
+2. A thin recipe at =doc/recipes/qt/how_do_i_add_a_badge_in_qt.org=
+   that checklists the four implementation steps and links to the
+   knowledge doc for architecture and context.
 
 * Status
 
@@ -43,9 +46,12 @@ actual code, not aspirational design.
 - Doc covers the three-layer structure: =ores.dq= domain model,
   =ores.sql= population (code domain, badge definitions, badge mappings),
   and =ores.qt.api= runtime (=BadgeCache=, delegate, =sizeHint=).
-- "How to add a new badge" section uses the =account_type= wiring as
-  the worked example.
+- "How to add a new badge" section uses =account_type= wiring as the
+  worked example.
 - Linked from =ores.qt.api= component overview's =* See also= section.
+- Recipe exists at =doc/recipes/qt/how_do_i_add_a_badge_in_qt.org=
+  (type: =recipe=) with four checklist steps pointing to the knowledge
+  doc for detail.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_document_badge_setup_in_qt.org
+++ b/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_document_badge_setup_in_qt.org
@@ -1,8 +1,8 @@
 :PROPERTIES:
 :ID: 36118737-9E05-48F0-889A-E800BA58825C
 :END:
-#+title: Task: Write recipe: how to set up a badge in Qt
-#+description: Document the end-to-end steps for wiring a new field as a DB-driven badge in Qt: SQL population, code domain, badge definitions, mappings, delegate wiring, and sizeHint.
+#+title: Task: Write knowledge doc: badge system wiring
+#+description: Document how the DB-driven badge system is structured and extended — spanning ores.dq (domain), ores.sql (population), and ores.qt.api (BadgeCache/delegate) — as an architectural knowledge doc.
 #+type: task
 #+level: s1
 #+filetags: :account_type_badge_qt:sprint_19:v0:
@@ -19,10 +19,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Goal
 
-Produce a recipe at =doc/recipes/qt/how_do_i_set_up_a_badge_in_qt.org=
-documenting the full end-to-end process for wiring a new field as a
-DB-driven badge in the Qt layer. Written after the implementation task
-is complete, so it describes the actual steps taken.
+Produce a knowledge doc at
+=doc/knowledge/architecture/badge_system_wiring.org= that describes
+how the DB-driven badge system is structured and how to extend it with
+a new badge. Written after the implementation task so it reflects the
+actual code, not aspirational design.
 
 * Status
 
@@ -37,12 +38,14 @@ is complete, so it describes the actual steps taken.
 
 * Acceptance
 
-- Recipe file exists at =doc/recipes/qt/how_do_i_set_up_a_badge_in_qt.org=
-  and is indexed by compass.
-- Recipe covers all six steps: code domain SQL, badge definitions SQL,
-  badge mappings SQL, delegate paint branch, sizeHint, and fallback
-  colours.
-- Concrete =account_type= wiring is used as the worked example.
+- Knowledge doc exists at =doc/knowledge/architecture/badge_system_wiring.org=
+  (type: =knowledge=, tags: =qt=, =architecture=, =badge=) and is indexed by compass.
+- Doc covers the three-layer structure: =ores.dq= domain model,
+  =ores.sql= population (code domain, badge definitions, badge mappings),
+  and =ores.qt.api= runtime (=BadgeCache=, delegate, =sizeHint=).
+- "How to add a new badge" section uses the =account_type= wiring as
+  the worked example.
+- Linked from =ores.qt.api= component overview's =* See also= section.
 
 * Plan
 

--- a/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_document_badge_setup_in_qt.org
+++ b/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_document_badge_setup_in_qt.org
@@ -32,11 +32,11 @@ task so they reflect actual code:
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                                |
+| State        | DONE                                   |
 | Parent story | [[id:814D4E79-8EB9-4B2B-8A87-DB72F145044D][Display account type as badge in Qt accounts list]] |
-| Now          | Not yet started.                       |
-| Waiting on   | [[id:5433FF26-FF0A-45A4-882A-4A9C41F51CB9][Implement account type badge]] (recipe written after impl). |
-| Next         | Implement badge task first.            |
+| Now          | Nothing.                               |
+| Waiting on   | Nothing.                               |
+| Next         | Nothing.                               |
 | Last touched | 2026-06-04                             |
 
 * Acceptance
@@ -74,3 +74,14 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+Produced two linked documents using =compass add=:
+
+- =doc/knowledge/architecture/badge_system_wiring.org= (=F7DE2705=)
+  — three-layer architecture (=ores.dq= entities, SQL population,
+  =BadgeCache=/delegate), full =paint()= template, worked example
+  using =account_type=. Wired into =knowledge.org= Architecture section
+  and =ores.qt.api= component overview.
+- =doc/recipes/qt/how_do_i_add_a_badge_in_qt.org= (=5C39026D=) —
+  four-step checklist (code domain, definitions, mappings, delegate)
+  pointing to the knowledge doc for detail.

--- a/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_implement_account_type_badge_qt.org
+++ b/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_implement_account_type_badge_qt.org
@@ -1,0 +1,77 @@
+:PROPERTIES:
+:ID: 5433FF26-FF0A-45A4-882A-4A9C41F51CB9
+:END:
+#+title: Task: Implement account type badge in AccountItemDelegate
+#+description: Add account_type code domain + badge definitions + mappings to SQL population; wire Column::AccountType in AccountItemDelegate to resolve via BadgeCache.
+#+type: task
+#+level: s1
+#+filetags: :account_type_badge_qt:sprint_19:v0:
+#+owner: marco
+#+branch: feature/account-type-badge-qt
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:814D4E79-8EB9-4B2B-8A87-DB72F145044D][Display account type as badge in Qt accounts list]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Wire the =Type= column in the accounts MDI list as a DB-driven pill
+badge. Currently =Column::AccountType= falls through to the default
+text renderer in =AccountItemDelegate=; it should resolve via
+=BadgeCache= (code domain =account_type=) exactly as =login_status=
+and =account_locked= do.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                                |
+| Parent story | [[id:814D4E79-8EB9-4B2B-8A87-DB72F145044D][Display account type as badge in Qt accounts list]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-04                             |
+
+* Acceptance
+
+- =dq_badge_system_populate.sql= contains an =account_type= code
+  domain, four badge definitions (user, service, algorithm, llm),
+  and four badge mappings.
+- =AccountItemDelegate::paint= handles =Column::AccountType= in the
+  badge branch; =sizeHint= covers it too.
+- No hardcoded hex colours in the delegate; all resolved via
+  =BadgeCache=.
+- Existing =Status= and =Locked= badge columns are unaffected.
+
+* Plan
+
+1. Add to =dq_badge_system_populate.sql=:
+   - Code domain: =account_type=, "Account Type", display_order next in sequence.
+   - Badge definitions: one per type value (user → primary/info, service → secondary,
+     algorithm → warning, llm → success — exact colours TBD).
+   - Badge mappings: map each =account_type= value to its definition.
+2. In =AccountItemDelegate.cpp=:
+   - Add =Column::AccountType= to the badge column guard in =paint()=.
+   - Resolve via =badgeCache_->resolve("account_type", text.toStdString())=.
+   - Fall back to default gray if cache miss (same pattern as existing badges).
+   - Add =Column::AccountType= to =sizeHint()= badge check.
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_implement_account_type_badge_qt.org
+++ b/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_implement_account_type_badge_qt.org
@@ -72,7 +72,8 @@ and =account_locked= do.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Sync partiesWidget_ when accountTypeCombo changes in create mode | AccountDetailDialog.cpp | Accepted | Second currentIndexChanged connection added; 4aafc41 |
+| 2 | Translate badge text in delegate (tr() for user/service/algorithm/llm) | AccountItemDelegate.cpp | Accepted | resolve() still uses raw code as key; 4aafc41 |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_implement_account_type_badge_qt.org
+++ b/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_implement_account_type_badge_qt.org
@@ -29,11 +29,11 @@ and =account_locked= do.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                                |
+| State        | DONE                                   |
 | Parent story | [[id:814D4E79-8EB9-4B2B-8A87-DB72F145044D][Display account type as badge in Qt accounts list]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing.                               |
 | Last touched | 2026-06-04                             |
 
 * Acceptance
@@ -75,3 +75,13 @@ and =account_locked= do.
 |   |                 |      |          |       |
 
 * Result
+
+Added =account_type= code domain (display_order 17), four badge
+definitions (=account_type_user=, =account_type_service=,
+=account_type_algorithm=, =account_type_llm=, display_orders 33–36),
+and four badge mappings to =dq_badge_system_populate.sql=.
+
+Wired =Column::AccountType= into =AccountItemDelegate::paint()= and
+=sizeHint()= using the same =BadgeCache::resolve("account_type", ...)=
+pattern as =login_status= and =account_locked=. Badge text is the raw
+type code as returned by the model; sizeHint minimum width set to 80px.

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -74,6 +74,7 @@ dedicated thread pool to prevent =QThreadPool= starvation.
 |-------+-------+-------+-----+-------------|
 | [[id:61F836E5-2277-4765-9038-AF7D0176C993][Make UI more responsive]] | DONE | 2026-06-01 | 2026-06-01 | Fix waitForFinished() in destructors; add spinners; pre-populate combos; dedicated I/O thread pool. |
 | [[id:F8E2AB1E-344B-4B04-BD0B-6EC96CDA5298][PnL tracking improvements]] | DONE | 2026-06-03 | 2026-06-03 | Capture: FX locking, timeframe-scoped PnL, dual charts, two-phase sell P&L, FIFO/WAVG. See [[id:42F22269-B875-489D-A3D7-7FEC456C69EA][Lightyear knowledge doc]]. |
+| [[id:814D4E79-8EB9-4B2B-8A87-DB72F145044D][Display account type as badge in Qt accounts list]] | BACKLOG | | | Wire account_type as DB-driven badge in AccountItemDelegate; SQL population; badge setup recipe. |
 
 ** Tooling
 

--- a/doc/knowledge/architecture/badge_system_wiring.org
+++ b/doc/knowledge/architecture/badge_system_wiring.org
@@ -1,0 +1,141 @@
+:PROPERTIES:
+:ID: F7DE2705-4D20-4878-A10C-A834F3283683
+:END:
+#+title: Badge system wiring
+#+description: How the DB-driven badge system is structured and how to extend it with a new badge — spanning ores.dq, ores.sql, and ores.qt.api.
+#+type: knowledge
+#+level: cross
+#+filetags: :qt:architecture:badge:knowledge:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+
+* Summary
+
+ORE Studio renders pill badges in Qt list views via a three-layer
+DB-driven system: =ores.dq= owns the four domain entities
+(=badge_severity=, =code_domain=, =badge_definition=,
+=badge_mapping=); =ores.sql= seeds them at install time; and
+=ores.qt.api='s =BadgeCache= loads them at login and resolves
+=(domain, entity_code)= pairs to colours at paint time. Adding a new
+badge requires no C++ changes to the resolution logic — only a SQL
+population entry and a one-line delegate call. Return to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
+
+* Detail
+
+** The four domain entities
+
+All four live in the =dq= schema and are managed by =ores.dq=.
+
+| Entity | Table | Purpose |
+|--------+-------+---------|
+| [[id:22798D61-7CF5-4FFC-8AC4-F3D469C47918][=badge_severity=]] | =ores_dq_badge_severities_tbl= | Named severity levels (secondary, info, success, warning, danger, primary). Codes align with Bootstrap 5 classes so Wt needs no translation. |
+| [[id:17FF90EF-64C4-4FF2-B30F-C0714A79FFD4][=code_domain=]] | =ores_dq_code_domains_tbl= | Named namespace that disambiguates codes across entity types (e.g. =account_type=, =login_status=). |
+| [[id:7BEB786A-A573-474E-9677-64C869A64E47][=badge_definition=]] | =ores_dq_badge_definitions_tbl= | One row per visual variant: label, background colour, text colour, severity, CSS class hint. |
+| [[id:BBB49AAA-E476-435B-88CF-CC252B76655C][=badge_mapping=]] | =ores_dq_badge_mappings_tbl= | Junction: maps =(code_domain, entity_code)= → =badge_definition=. |
+
+** SQL population
+
+All badge metadata lives in one idempotent script:
+
+#+begin_example
+projects/ores.sql/populate/dq/dq_badge_system_populate.sql
+#+end_example
+
+The script uses upsert functions so it is safe to re-run. The
+structure per new badge domain is always three blocks:
+
+1. *Code domain* — one =ores_dq_code_domains_upsert_fn= call naming
+   the domain and its =display_order=.
+2. *Badge definitions* — one =ores_dq_badge_definitions_upsert_fn=
+   call per distinct visual variant (label, hex colours, severity
+   code, CSS class, display_order).
+3. *Badge mappings* — one =ores_dq_badge_mappings_upsert_fn= call per
+   value, mapping =(domain, entity_code)= → =badge_definition_code=.
+
+The entity code in the mapping must match exactly what the Qt model
+returns for that column (see §Qt wiring below).
+
+** BadgeCache
+
+=BadgeCache= (=projects/ores.qt/api/include/ores.qt/BadgeCache.hpp=)
+is a session-scoped cache populated at login from the standard
+service/protocol/client pipeline. It exposes one method:
+
+#+begin_src cpp
+const badge_definition* resolve(
+    const std::string& domain,
+    const std::string& entity_code) const;
+#+end_src
+
+Returns =nullptr= on cache miss — callers must fall back to a default
+colour. The cache is injected into every =ItemDelegate= at
+construction via the =plugin_context= received in =on_login=.
+
+** Qt wiring — item delegate
+
+Each entity list view has an =ItemDelegate= subclass (e.g.
+=AccountItemDelegate=) that overrides =paint()= and =sizeHint()=.
+
+*paint():*
+
+#+begin_src cpp
+if (index.column() == Column::MyField /* || ... */) {
+    QStyle* style = QApplication::style();
+    style->drawPrimitive(QStyle::PE_PanelItemViewItem, &opt, painter);
+
+    static const QColor default_gray(107, 114, 128);
+    static const QColor white(255, 255, 255);
+    QColor bgColor = default_gray;
+    QColor textColor = white;
+
+    QString text = index.data(Qt::DisplayRole).toString();
+    QString badgeText = text; // or a translated label
+
+    if (badgeCache_) {
+        auto* def = badgeCache_->resolve("my_domain", text.toStdString());
+        if (def) {
+            bgColor = QColor(QString::fromStdString(def->background_colour));
+            textColor = QColor(QString::fromStdString(def->text_colour));
+        }
+    }
+
+    QFont badgeFont = opt.font;
+    badgeFont.setPointSize(qRound(badgeFont.pointSize() * 0.8));
+    badgeFont.setBold(true);
+    DelegatePaintUtils::draw_centered_badge(
+        painter, opt.rect, badgeText, bgColor, textColor, badgeFont);
+    return;
+}
+#+end_src
+
+*sizeHint():* add the same column guard and set a minimum height of 24
+and a minimum width appropriate for the longest label (typically
+50–90 px).
+
+The entity code passed to =resolve()= must exactly match the string
+the model returns for =Qt::DisplayRole= on that column. If the model
+returns a display name (=tr("Online")=), the badge mapping key must
+use that display name. If the model returns the raw DB code (="user"=),
+the mapping key must use the raw code.
+
+** Worked example — account_type
+
+=account_type= badge (added in sprint 19):
+
+- Code domain: =account_type=, display_order 17.
+- Four badge definitions: =account_type_user= (info/#3b82f6),
+  =account_type_service= (secondary/#6b7280),
+  =account_type_algorithm= (warning/#eab308),
+  =account_type_llm= (primary/#7c3aed).
+- Four mappings keyed on the raw DB codes: ='user'=, ='service'=,
+  ='algorithm'=, ='llm'= (because =ClientAccountModel= returns
+  =account.account_type= verbatim).
+- Delegate: =Column::AccountType= added to the badge guard in
+  =AccountItemDelegate::paint()= and =sizeHint()= (min width 80 px).
+
+* See also
+
+- [[id:30A3A7F4-E1A9-42FB-AF9D-FF36FA0F3D21][ores.qt.api]] — =BadgeCache=, =DelegatePaintUtils=, and the =plugin_context= that injects the cache.
+- [[id:5C39026D-0507-4544-ACF1-5A93EA3C3338][How do I add a badge to a Qt list view?]] — the four-step checklist.
+- [[id:E81C7FEA-33E4-400A-839A-9D1618BED211][Qt plugin architecture]] — how =plugin_context= (including =badge_cache=) is passed to plugins at login.
+- [[id:FC186D19-9421-45A2-BBCC-4355D66AA41F][Entity controller pattern]] — the delegate sits in the entity UI stack alongside the model and list window.

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -66,6 +66,8 @@ How the codebase is put together.
   lifecycle, the two-phase menu-building sequence.
 - [[id:2FDDC2F6-C510-4A86-8C50-D79C83EDDFFF][Qt entity patterns]] — ClientModel, list window, detail dialog,
   history dialog, and async-fetch patterns.
+- [[id:F7DE2705-4D20-4878-A10C-A834F3283683][Badge system wiring]] — DB-driven pill badges: =ores.dq= entities,
+  SQL population, =BadgeCache=, and delegate wiring.
 - [[id:E44891DC-234C-42DB-90E1-9421400ABD1A][Qt menu and toolbar patterns]] — plugin registration,
   =on_login()= menu wiring, and MDI window toolbar construction.
 - [[id:05891220-2503-48A0-ADF5-13EC95B605D7][CLI entity patterns]] — options structs, parser layout, and

--- a/doc/llm/skills/run-runbook/SKILL.org
+++ b/doc/llm/skills/run-runbook/SKILL.org
@@ -12,7 +12,7 @@
 
 #+begin_export markdown
 ---
-name: run_runbook
+name: run-runbook
 description: Find the runbook closest to the user's request in the runbooks catalogue and execute it end-to-end.
 license: Complete terms in LICENSE.txt
 ---

--- a/doc/recipes/qt/how_do_i_add_a_badge_in_qt.org
+++ b/doc/recipes/qt/how_do_i_add_a_badge_in_qt.org
@@ -1,0 +1,73 @@
+:PROPERTIES:
+:ID: 5C39026D-0507-4544-ACF1-5A93EA3C3338
+:END:
+#+title: How do I add a badge to a Qt list view?
+#+description: Checklist for wiring a new field as a DB-driven badge in Qt: SQL population, code domain, badge definitions, badge mappings, delegate paint, and sizeHint.
+#+type: recipe
+#+level: cross
+#+filetags: :qt:badge:recipe:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+
+The badge resolution architecture — how =BadgeCache=, =code_domain=,
+=badge_definition=, and =badge_mapping= fit together — is in
+[[id:F7DE2705-4D20-4878-A10C-A834F3283683][Badge system wiring]].
+
+* Question
+
+How do I render a new field as a DB-driven pill badge in a Qt list view?
+
+* Answer
+
+Four steps; all are required.
+
+*1. Add a code domain* to =dq_badge_system_populate.sql=:
+
+#+begin_src sql
+PERFORM ores_dq_code_domains_upsert_fn(ores_utility_system_tenant_id_fn(),
+    'my_domain', 'My Domain', 'Description of the domain.', <next_display_order>);
+#+end_src
+
+*2. Add badge definitions* — one per distinct visual variant:
+
+#+begin_src sql
+PERFORM ores_dq_badge_definitions_upsert_fn(ores_utility_system_tenant_id_fn(),
+    'my_def_code', 'Label', 'Tooltip description.',
+    '#rrggbb', '#ffffff', 'severity_code', 'badge bg-severity', <next_display_order>);
+#+end_src
+
+Severity codes: =secondary=, =info=, =success=, =warning=, =danger=, =primary=.
+
+*3. Add badge mappings* — one per entity code value:
+
+#+begin_src sql
+PERFORM ores_dq_badge_mappings_upsert_fn(ores_utility_system_tenant_id_fn(),
+    'my_domain', 'entity_code_value', 'my_def_code');
+#+end_src
+
+The entity code must match exactly what the Qt model returns for
+=Qt::DisplayRole= on that column (raw DB code or translated display string).
+
+*4. Wire the delegate* in the entity's =ItemDelegate=:
+
+- =paint()=: add =Column::MyField= to the badge column guard; call
+  =badgeCache_->resolve("my_domain", text.toStdString())= and apply
+  the returned colours; fall back to default gray on =nullptr=.
+- =sizeHint()=: add the same column guard; set minimum height 24 px
+  and a minimum width appropriate for the longest label.
+
+* Script
+
+No script — changes are to =dq_badge_system_populate.sql= and the
+entity's =ItemDelegate=. See [[id:F7DE2705-4D20-4878-A10C-A834F3283683][Badge system wiring]] for the full
+=paint()= code template.
+
+* Tested by
+
+Manual: re-run the population script against a dev database and open
+the entity list view to confirm badge colours appear.
+
+* See also
+
+- [[id:F7DE2705-4D20-4878-A10C-A834F3283683][Badge system wiring]] — architecture, =BadgeCache= API, and worked example.
+- [[id:FC186D19-9421-45A2-BBCC-4355D66AA41F][Entity controller pattern]] — the delegate's place in the entity UI stack.

--- a/projects/ores.qt/admin/src/AccountDetailDialog.cpp
+++ b/projects/ores.qt/admin/src/AccountDetailDialog.cpp
@@ -124,6 +124,12 @@ AccountDetailDialog::AccountDetailDialog(QWidget* parent)
     ui_->accountTypeCombo->addItem(tr("LLM"),       QString("llm"));
     connect(ui_->accountTypeCombo, &QComboBox::currentIndexChanged, this,
         &AccountDetailDialog::onFieldChanged);
+    connect(ui_->accountTypeCombo, &QComboBox::currentIndexChanged, this,
+        [this](int index) {
+            if (partiesWidget_)
+                partiesWidget_->setAccountType(
+                    ui_->accountTypeCombo->itemData(index).toString().toStdString());
+        });
 
     // Create roles widget and add it to the Roles tab layout
     rolesWidget_ = new AccountRolesWidget(this);

--- a/projects/ores.qt/admin/src/AccountDetailDialog.cpp
+++ b/projects/ores.qt/admin/src/AccountDetailDialog.cpp
@@ -113,8 +113,17 @@ AccountDetailDialog::AccountDetailDialog(QWidget* parent)
         ui_->confirmPasswordEdit->setEchoMode(mode);
     });
 
-    // Hide isAdminCheckBox - admin privileges are now managed via RBAC role assignments
+    // Admin row hidden — privileges managed via RBAC role assignments
     ui_->isAdminCheckBox->setVisible(false);
+    ui_->labelIsAdmin->setVisible(false);
+
+    // Populate account type combo
+    ui_->accountTypeCombo->addItem(tr("User"),      QString("user"));
+    ui_->accountTypeCombo->addItem(tr("Service"),   QString("service"));
+    ui_->accountTypeCombo->addItem(tr("Algorithm"), QString("algorithm"));
+    ui_->accountTypeCombo->addItem(tr("LLM"),       QString("llm"));
+    connect(ui_->accountTypeCombo, &QComboBox::currentIndexChanged, this,
+        &AccountDetailDialog::onFieldChanged);
 
     // Create roles widget and add it to the Roles tab layout
     rolesWidget_ = new AccountRolesWidget(this);
@@ -198,6 +207,10 @@ void AccountDetailDialog::setAccount(const iam::domain::account& account) {
     ui_->usernameEdit->setText(QString::fromStdString(account.username));
     ui_->emailEdit->setText(QString::fromStdString(account.email));
 
+    const QString typeCode = QString::fromStdString(account.account_type);
+    const int typeIdx = ui_->accountTypeCombo->findData(typeCode);
+    ui_->accountTypeCombo->setCurrentIndex(typeIdx >= 0 ? typeIdx : 0);
+
     populateProvenance(account.version, account.modified_by, account.performed_by,
         account.recorded_at, account.change_reason_code, account.change_commentary);
 
@@ -244,10 +257,16 @@ void AccountDetailDialog::setCreateMode(bool createMode) {
     if (partiesIdx >= 0) tw->setTabEnabled(partiesIdx, true);
     setProvenanceEnabled(!createMode);
 
-    if (createMode && partiesWidget_) {
-        partiesWidget_->setAccountType("user");
-        partiesWidget_->load();
+    // Account type: editable only on create; read-only display in edit mode
+    ui_->accountTypeCombo->setEnabled(createMode);
+    if (createMode) {
+        ui_->accountTypeCombo->setCurrentIndex(0); // default: user
+        if (partiesWidget_)
+            partiesWidget_->setAccountType("user");
     }
+
+    if (createMode && partiesWidget_)
+        partiesWidget_->load();
     if (createMode && rolesWidget_)
         rolesWidget_->load();
 }
@@ -256,6 +275,8 @@ iam::domain::account AccountDetailDialog::getAccount() const {
     iam::domain::account account = currentAccount_;
     account.username = ui_->usernameEdit->text().toStdString();
     account.email = ui_->emailEdit->text().toStdString();
+    account.account_type =
+        ui_->accountTypeCombo->currentData().toString().toStdString();
     account.modified_by = modifiedByUsername_.empty() ? "qt_user" : modifiedByUsername_;
 
     return account;
@@ -264,6 +285,7 @@ iam::domain::account AccountDetailDialog::getAccount() const {
 void AccountDetailDialog::clearDialog() {
     ui_->usernameEdit->clear();
     ui_->emailEdit->clear();
+    ui_->accountTypeCombo->setCurrentIndex(0);
     ui_->passwordEdit->clear();
     ui_->confirmPasswordEdit->clear();
 
@@ -425,9 +447,11 @@ void AccountDetailDialog::onSaveClicked() {
         const std::string username = ui_->usernameEdit->text().toStdString();
         const std::string password = ui_->passwordEdit->text().toStdString();
         const std::string email = ui_->emailEdit->text().toStdString();
+        const std::string account_type =
+            ui_->accountTypeCombo->currentData().toString().toStdString();
 
         QFuture<std::pair<bool, std::string>> future =
-            QtConcurrent::run([self, username, password, email,
+            QtConcurrent::run([self, username, password, email, account_type,
                                pendingPartyAdds, pendingRoleAdds]()
                 -> std::pair<bool, std::string> {
                 if (!self) return {false, ""};
@@ -439,6 +463,7 @@ void AccountDetailDialog::onSaveClicked() {
                 request.principal = username;
                 request.password = password;
                 request.email = email;
+                request.account_type = account_type;
                 request.totp_secret = "";
 
                 auto response_result =
@@ -848,7 +873,9 @@ void AccountDetailDialog::setReadOnly(bool readOnly, int versionNumber) {
 void AccountDetailDialog::setFieldsReadOnly(bool readOnly) {
     ui_->usernameEdit->setReadOnly(readOnly);
     ui_->emailEdit->setReadOnly(readOnly);
-    // Note: isAdminCheckBox is hidden - admin privileges managed via RBAC
+    // Account type only editable on create; keep disabled in all read-only paths
+    if (readOnly)
+        ui_->accountTypeCombo->setEnabled(false);
 }
 
 void AccountDetailDialog::updateSaveResetButtonState() {

--- a/projects/ores.qt/admin/src/AccountItemDelegate.cpp
+++ b/projects/ores.qt/admin/src/AccountItemDelegate.cpp
@@ -44,7 +44,8 @@ void AccountItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
 
     // Handle badge columns
     if (index.column() == Column::Status ||
-        index.column() == Column::Locked) {
+        index.column() == Column::Locked ||
+        index.column() == Column::AccountType) {
 
         QStyle* style = QApplication::style();
         style->drawPrimitive(QStyle::PE_PanelItemViewItem, &opt, painter);
@@ -73,6 +74,15 @@ void AccountItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
             badgeText = (text == "Locked") ? tr("Yes") : tr("No");
             if (badgeCache_) {
                 auto* def = badgeCache_->resolve("account_locked", text.toStdString());
+                if (def) {
+                    bgColor = QColor(QString::fromStdString(def->background_colour));
+                    textColor = QColor(QString::fromStdString(def->text_colour));
+                }
+            }
+        } else if (index.column() == Column::AccountType) {
+            badgeText = text;
+            if (badgeCache_) {
+                auto* def = badgeCache_->resolve("account_type", text.toStdString());
                 if (def) {
                     bgColor = QColor(QString::fromStdString(def->background_colour));
                     textColor = QColor(QString::fromStdString(def->text_colour));
@@ -123,10 +133,13 @@ QSize AccountItemDelegate::sizeHint(const QStyleOptionViewItem& option,
     QSize size = QStyledItemDelegate::sizeHint(option, index);
 
     if (index.column() == Column::Status ||
-        index.column() == Column::Locked) {
+        index.column() == Column::Locked ||
+        index.column() == Column::AccountType) {
         size.setHeight(qMax(size.height(), 24));
         if (index.column() == Column::Status) {
             size.setWidth(qMax(size.width(), 70));
+        } else if (index.column() == Column::AccountType) {
+            size.setWidth(qMax(size.width(), 80));
         } else {
             size.setWidth(qMax(size.width(), 50));
         }

--- a/projects/ores.qt/admin/src/AccountItemDelegate.cpp
+++ b/projects/ores.qt/admin/src/AccountItemDelegate.cpp
@@ -80,7 +80,11 @@ void AccountItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
                 }
             }
         } else if (index.column() == Column::AccountType) {
-            badgeText = text;
+            if (text == "user")           badgeText = tr("User");
+            else if (text == "service")   badgeText = tr("Service");
+            else if (text == "algorithm") badgeText = tr("Algorithm");
+            else if (text == "llm")       badgeText = tr("LLM");
+            else                          badgeText = text;
             if (badgeCache_) {
                 auto* def = badgeCache_->resolve("account_type", text.toStdString());
                 if (def) {

--- a/projects/ores.qt/admin/ui/AccountDetailDialog.ui
+++ b/projects/ores.qt/admin/ui/AccountDetailDialog.ui
@@ -67,16 +67,32 @@
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="labelIsAdmin">
+           <widget class="QLabel" name="labelAccountType">
             <property name="text">
-             <string>Admin:</string>
+             <string>Type:</string>
             </property>
            </widget>
           </item>
           <item row="2" column="1">
+           <widget class="QComboBox" name="accountTypeCombo"/>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelIsAdmin">
+            <property name="text">
+             <string>Admin:</string>
+            </property>
+            <property name="visible">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
            <widget class="QCheckBox" name="isAdminCheckBox">
             <property name="text">
              <string>Grant administrative privileges</string>
+            </property>
+            <property name="visible">
+             <bool>false</bool>
             </property>
            </widget>
           </item>

--- a/projects/ores.qt/api/modeling/component_overview.org
+++ b/projects/ores.qt/api/modeling/component_overview.org
@@ -67,4 +67,5 @@ used across all plugins.
 - [[id:25812E6F-7AD1-36E4-697B-EEC8015C4F1F][ores.qt]] — the application shell (MainWindow) that loads and drives plugins.
 - [[id:E81C7FEA-33E4-400A-839A-9D1618BED211][Qt Plugin Architecture]] — full plugin lifecycle and menu-building sequence.
 - [[id:FC186D19-9421-45A2-BBCC-4355D66AA41F][Entity Controller Pattern]] — detailed description of the base class pattern.
+- [[id:F7DE2705-4D20-4878-A10C-A834F3283683][Badge system wiring]] — how =BadgeCache= fits into the system and how to add new badges.
 - [[id:C9C24C99-F16C-45BE-A262-1C0F4502765E][ores.nats]] — NATS transport underlying ClientManager.

--- a/projects/ores.sql/populate/dq/dq_badge_system_populate.sql
+++ b/projects/ores.sql/populate/dq/dq_badge_system_populate.sql
@@ -294,6 +294,26 @@ BEGIN
         'tenant_bootstrapping', 'Bootstrapping', 'Tenant is awaiting initial provisioning wizard run.',
         '#0ea5e9', '#ffffff', 'info', 'badge bg-info', 32);
 
+    -- Account Type: User
+    PERFORM ores_dq_badge_definitions_upsert_fn(ores_utility_system_tenant_id_fn(),
+        'account_type_user', 'User', 'Human user account.',
+        '#3b82f6', '#ffffff', 'info', 'badge bg-info', 33);
+
+    -- Account Type: Service
+    PERFORM ores_dq_badge_definitions_upsert_fn(ores_utility_system_tenant_id_fn(),
+        'account_type_service', 'Service', 'Service account for non-human processes.',
+        '#6b7280', '#ffffff', 'secondary', 'badge bg-secondary', 34);
+
+    -- Account Type: Algorithm
+    PERFORM ores_dq_badge_definitions_upsert_fn(ores_utility_system_tenant_id_fn(),
+        'account_type_algorithm', 'Algorithm', 'Account for automated algorithms.',
+        '#eab308', '#ffffff', 'warning', 'badge bg-warning', 35);
+
+    -- Account Type: LLM
+    PERFORM ores_dq_badge_definitions_upsert_fn(ores_utility_system_tenant_id_fn(),
+        'account_type_llm', 'LLM', 'Account for Large Language Model agents.',
+        '#7c3aed', '#ffffff', 'primary', 'badge bg-primary', 36);
+
     -- =============================================================================
     -- Code Domains (workspace)
     -- =============================================================================
@@ -301,6 +321,10 @@ BEGIN
     PERFORM ores_dq_code_domains_upsert_fn(ores_utility_system_tenant_id_fn(),
         'workspace_status', 'Workspace Status',
         'Lifecycle status codes for workspace records.', 16);
+
+    PERFORM ores_dq_code_domains_upsert_fn(ores_utility_system_tenant_id_fn(),
+        'account_type', 'Account Type',
+        'Classification of account types (user, service, algorithm, llm).', 17);
 
     -- =============================================================================
     -- Badge Mappings
@@ -447,6 +471,16 @@ BEGIN
         'dq_treatment', 'Cleaned', 'treatment_cleaned');
     PERFORM ores_dq_badge_mappings_upsert_fn(ores_utility_system_tenant_id_fn(),
         'dq_treatment', 'Enriched', 'treatment_enriched');
+
+    -- account_type
+    PERFORM ores_dq_badge_mappings_upsert_fn(ores_utility_system_tenant_id_fn(),
+        'account_type', 'user', 'account_type_user');
+    PERFORM ores_dq_badge_mappings_upsert_fn(ores_utility_system_tenant_id_fn(),
+        'account_type', 'service', 'account_type_service');
+    PERFORM ores_dq_badge_mappings_upsert_fn(ores_utility_system_tenant_id_fn(),
+        'account_type', 'algorithm', 'account_type_algorithm');
+    PERFORM ores_dq_badge_mappings_upsert_fn(ores_utility_system_tenant_id_fn(),
+        'account_type', 'llm', 'account_type_llm');
 
     -- =============================================================================
     -- Summary


### PR DESCRIPTION
## Summary

- Add `account_type` DB-driven badge to the accounts list view: code domain, four badge definitions (user/info, service/secondary, algorithm/warning, llm/primary), and four mappings in `dq_badge_system_populate.sql`; `Column::AccountType` wired in `AccountItemDelegate::paint()` and `sizeHint()`
- Add `accountTypeCombo` to `AccountDetailDialog` General tab — editable on create (wired into `save_account_request.account_type`), read-only display in edit/view modes
- Fix orphaned `Admin:` label left visible when `isAdminCheckBox` was hidden for RBAC migration
- Add badge system wiring knowledge doc (`doc/knowledge/architecture/badge_system_wiring.org`) and thin recipe (`doc/recipes/qt/how_do_i_add_a_badge_in_qt.org`)
- Capture filed for badge rendering in history dialog and badge-in-combo closed state

## Test plan

- [ ] Accounts list shows coloured pill badges in the Type column for each account type value
- [ ] Existing Status and Locked badge columns unaffected
- [ ] Account detail dialog General tab shows Type combo; disabled in edit/view, enabled on create
- [ ] Creating a new account with a non-default type saves correctly
- [ ] Admin label no longer appears in the detail dialog
- [ ] `compass search badge` surfaces the new knowledge doc and recipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)