### PR TITLE
[agile] Scaffold documentation review follow-ups story

### DIFF
--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/story.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/story.org
@@ -74,8 +74,6 @@ and inventory that links them, and the smaller additions woven in.
 | [[id:FAFFCE73-0AD3-4801-A613-4E6C9BDEF1D5][Split document types into one page per type]] | BACKLOG | | | One document_type_<type>.org per type; document_types.org becomes the index. |
 | [[id:3DA4EDB1-F6E2-42D1-A029-0E8422A05E7A][Link product identity to the user manual]] | BACKLOG | | | "If you are looking for instructions on how to use the product see..." |
 
-* Decisions
-
 * Out of scope
 
 - Changing the agile process itself beyond the additions above — this

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/story.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/story.org
@@ -1,0 +1,83 @@
+:PROPERTIES:
+:ID: 305E3A3B-8A72-49D3-9972-FAF06FEB4552
+:END:
+#+title: Story: Documentation review follow-ups
+#+description: Assorted improvements from a documentation review: split document types into per-type pages, add a definition-of-done doc, add outreach and demo steps to the agile process, restructure the agile process into per-concept pages (story, task, sprint phases), and link product identity to the user manual.
+#+type: story
+#+level: s2
+#+filetags: :documentation:agile:meta:sprint_19:v0:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+A documentation review of the agile and meta docs surfaced a batch of
+structural gaps. The biggest: the agile process page jumbles together
+concepts that deserve their own pages — what a story is (and epics,
+and sizing), what a task is, and the three sprint phases — leaving
+readers no single place to learn each concept and recipes nothing
+precise to link to. Around that sit smaller gaps: document_types.org
+is one long page rather than a page per type; there is no document
+explaining what a definition of done is and why task/story/sprint/
+version carry one; the process has no outreach step and no demo step
+at sprint closure; and the product identity page does not point
+readers at the user manual.
+
+This story delivers the restructure: per-concept pages with
+agile-domain overviews, the agile process page reduced to an overview
+and inventory that links them, and the smaller additions woven in.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
+| Now           | Not yet started; tasks scaffolded.     |
+| Waiting on    | Nothing.                               |
+| Next          | Pick up the restructure task first — it shapes where the smaller additions land. |
+| Last touched  | 2026-06-04                               |
+
+* Acceptance
+
+- =document_types.org= is split into one page per document type
+  (=document_type_<type>.org=), with the original page remaining as
+  the index linking them.
+- A definition-of-done document exists explaining the concept and why
+  task, story, sprint, and version documents must carry one; those
+  documents org-roam-link to it.
+- The agile process includes an outreach step (LinkedIn post,
+  Twitter/X post, Discord announcement).
+- Sprint closure includes creation of the sprint demo as its last
+  step.
+- Dedicated pages exist for: story (what a story is, what an epic is,
+  how stories are sized), task, sprint planning, sprint execution,
+  and sprint closure — each opening with an agile-domain overview and
+  then carrying the detail currently in the process page.
+- The agile process page is an overview/inventory linking the
+  per-concept pages; story and task pages are linked from the
+  glossary; recipes link directly to the relevant phase page.
+- The product identity document links to the user manual for readers
+  looking for usage instructions.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:CD257D0D-31A9-4950-9568-97CFBC2DC7EF][Restructure agile process into per-concept pages]] | BACKLOG | | | Story/task/sprint-phase pages with domain overviews; process page becomes overview + inventory; glossary and recipe links. |
+| [[id:C94B52D2-D14E-4819-887A-E0BBC5EC54BC][Add demo creation to sprint closure]] | BACKLOG | | | Demo as the last step of sprint closure, if not already present. |
+| [[id:3E8C142C-EFE3-432B-88F5-12CAFFCBDDD4][Add outreach step to the agile process]] | BACKLOG | | | LinkedIn post, Twitter/X post, Discord announcement. |
+| [[id:ACBB8643-CA16-4523-885C-E87943164378][Add a definition-of-done document]] | BACKLOG | | | What a DoD is, why task/story/sprint/version must have one; org-roam links from those docs. |
+| [[id:FAFFCE73-0AD3-4801-A613-4E6C9BDEF1D5][Split document types into one page per type]] | BACKLOG | | | One document_type_<type>.org per type; document_types.org becomes the index. |
+| [[id:3DA4EDB1-F6E2-42D1-A029-0E8422A05E7A][Link product identity to the user manual]] | BACKLOG | | | "If you are looking for instructions on how to use the product see..." |
+
+* Decisions
+
+* Out of scope
+
+- Changing the agile process itself beyond the additions above — this
+  is a documentation restructure, not a process redesign.
+- Restructuring recipes or runbooks (only their links are updated).

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_definition_of_done_doc.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_definition_of_done_doc.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: ACBB8643-CA16-4523-885C-E87943164378
+:END:
+#+title: Task: Add a definition-of-done document
+#+description: New doc explaining what a definition of done is and why certain document types (task, story, sprint, version) must carry one; org-roam links from those documents to it.
+#+type: task
+#+level: s1
+#+filetags: :documentation:agile:documentation_review_followups:sprint_19:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-04                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_definition_of_done_doc.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_definition_of_done_doc.org
@@ -32,11 +32,6 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 | Next         | Begin implementation.                  |
 | Last touched | 2026-06-04                               |
 
-* Acceptance
-
--
-
-* Plan
 
 (Transient implementation strategy. Written when work starts;
 distilled into the parent story's =* Decisions= and cleared when the

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_demo_step_to_sprint_closure.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_demo_step_to_sprint_closure.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: C94B52D2-D14E-4819-887A-E0BBC5EC54BC
+:END:
+#+title: Task: Add demo creation to sprint closure
+#+description: Add creation of the sprint demo as the last step of sprint closure in the agile process, if not already present.
+#+type: task
+#+level: s1
+#+filetags: :documentation:agile:documentation_review_followups:sprint_19:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-04                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_demo_step_to_sprint_closure.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_demo_step_to_sprint_closure.org
@@ -32,11 +32,6 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 | Next         | Begin implementation.                  |
 | Last touched | 2026-06-04                               |
 
-* Acceptance
-
--
-
-* Plan
 
 (Transient implementation strategy. Written when work starts;
 distilled into the parent story's =* Decisions= and cleared when the

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_outreach_step_to_process.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_outreach_step_to_process.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 3E8C142C-EFE3-432B-88F5-12CAFFCBDDD4
+:END:
+#+title: Task: Add outreach step to the agile process
+#+description: Add an outreach step to the agile process: LinkedIn post, Twitter/X post, and Discord announcement.
+#+type: task
+#+level: s1
+#+filetags: :documentation:agile:outreach:documentation_review_followups:sprint_19:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-04                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_outreach_step_to_process.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_add_outreach_step_to_process.org
@@ -32,11 +32,6 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 | Next         | Begin implementation.                  |
 | Last touched | 2026-06-04                               |
 
-* Acceptance
-
--
-
-* Plan
 
 (Transient implementation strategy. Written when work starts;
 distilled into the parent story's =* Decisions= and cleared when the

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_link_product_identity_to_manual.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_link_product_identity_to_manual.org
@@ -32,11 +32,6 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 | Next         | Begin implementation.                  |
 | Last touched | 2026-06-04                               |
 
-* Acceptance
-
--
-
-* Plan
 
 (Transient implementation strategy. Written when work starts;
 distilled into the parent story's =* Decisions= and cleared when the

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_link_product_identity_to_manual.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_link_product_identity_to_manual.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: 3DA4EDB1-F6E2-42D1-A029-0E8422A05E7A
+:END:
+#+title: Task: Link product identity to the user manual
+#+description: Add an org-roam link from the product identity document to the user manual, e.g. 'If you are looking for instructions on how to use the product see...'.
+#+type: task
+#+level: s1
+#+filetags: :documentation:meta:documentation_review_followups:sprint_19:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-04                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_restructure_agile_process_pages.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_restructure_agile_process_pages.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: CD257D0D-31A9-4950-9568-97CFBC2DC7EF
+:END:
+#+title: Task: Restructure agile process into per-concept pages
+#+description: Create dedicated pages for story (story, epic, sizing), task, sprint planning, sprint execution, and sprint closure — each opening with an agile-domain overview then the detail currently in the process page. Agile process becomes an overview/inventory page linking them; glossary and recipes link directly to the per-concept pages.
+#+type: task
+#+level: s1
+#+filetags: :documentation:agile:documentation_review_followups:sprint_19:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-04                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_restructure_agile_process_pages.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_restructure_agile_process_pages.org
@@ -32,11 +32,6 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 | Next         | Begin implementation.                  |
 | Last touched | 2026-06-04                               |
 
-* Acceptance
-
--
-
-* Plan
 
 (Transient implementation strategy. Written when work starts;
 distilled into the parent story's =* Decisions= and cleared when the

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_split_document_types_per_type.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_split_document_types_per_type.org
@@ -32,11 +32,6 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 | Next         | Begin implementation.                  |
 | Last touched | 2026-06-04                               |
 
-* Acceptance
-
--
-
-* Plan
 
 (Transient implementation strategy. Written when work starts;
 distilled into the parent story's =* Decisions= and cleared when the

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_split_document_types_per_type.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_split_document_types_per_type.org
@@ -1,0 +1,59 @@
+:PROPERTIES:
+:ID: FAFFCE73-0AD3-4801-A613-4E6C9BDEF1D5
+:END:
+#+title: Task: Split document types into one page per type
+#+description: Split doc/meta/document_types.org into one page per document type, named document_type_<type>.org (knowledge, task, story, recipe, ...), keeping document_types.org as the index that links them all.
+#+type: task
+#+level: s1
+#+filetags: :documentation:meta:documentation_review_followups:sprint_19:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+(Describe what user-visible-or-internal change this task produces.)
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-04                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -145,6 +145,7 @@ Regroup and refactor the C++ component layout to align with the product-group mo
 | [[id:F3CB848E-72C1-4F81-AAE4-1265F41D47C1][Fix knowledge graph issues]]                         | DONE    | 2026-05-30 | 2026-05-31 | Fix knowledge graph: images not displaying and left-panel controls missing. |
 | [[id:D90A3E68-D331-4473-AFAB-C1CBC94BA0CD][Add tooling layer to system model]]                  | DONE    | 2026-06-02 | 2026-06-03 | Add system_model_tooling.org; tooling blurb in system_model.org; foundation layer back-links. |
 | [[id:95429DF9-B645-4E41-8375-A2A5C84A8E5A][Document the sprint health charts]]                  | STARTED | 2026-06-04 | | Knowledge page for the four sprint charts; literate gnuplot sources tangled to scripts/; links from sprint template, process page, recipe, runbook. |
+| [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]]                    | BACKLOG | | | Per-concept agile pages (story, task, sprint phases); split document types; DoD doc; outreach + demo steps; product identity → manual link. |
 
 ** Infrastructure
 


### PR DESCRIPTION
## Summary

Scaffolds the *Documentation review follow-ups* story under sprint 19
(Documentation theme) with six BACKLOG tasks capturing the outcomes of
a documentation review of the agile and meta docs. Agile bookkeeping
only — no implementation in this PR.

## Changes

- New story `documentation_review_followups` with goal, acceptance,
  and out-of-scope; wired into the sprint 19 Stories table (BACKLOG).
- Six tasks, ordered with the structural one first:
  1. Restructure agile process into per-concept pages (story/epic/
     sizing, task, sprint planning, execution, closure); process page
     becomes overview + inventory; glossary/recipe links follow.
  2. Add demo creation as the last step of sprint closure.
  3. Add outreach step (LinkedIn, Twitter/X, Discord).
  4. Add a definition-of-done document, linked from task/story/
     sprint/version docs.
  5. Split document_types.org into one page per type.
  6. Link product identity to the user manual.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Documentation review follow-ups](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/documentation_review_followups/story.html) | 305E3A3B-8A72-49D3-9972-FAF06FEB4552 |