### PR TITLE
[agile,llm,compass] Close badge story; add capture skill; misc doc improvements

### DIFF
--- a/doc/agile/product_backlog/inbox/unify_account_and_administration_menus.org
+++ b/doc/agile/product_backlog/inbox/unify_account_and_administration_menus.org
@@ -1,0 +1,40 @@
+:PROPERTIES:
+:ID: 74E3F0D0-CF33-44C4-84EC-A0078EE48541
+:END:
+#+title: Unify Account and Administration menus into a single menu
+#+description: The Account and Administration submenus under System are confusing; investigate how other systems name these and consolidate into one coherent menu.
+#+type: capture
+#+level: cross
+#+filetags: :qt:ux:menus:iam:admin:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+The Qt System menu currently has two separate submenus — =Account= and
+=Administration= — whose split is not intuitive. Account-related
+functionality is spread across both and it is not obvious to a user
+which submenu to reach for. The menus should be consolidated into a
+single, clearly named menu (e.g. =Accounts=, =Identity=, =Users=, or
+similar). Before deciding on the name and structure, investigate how
+comparable desktop applications (financial workstations, ERP systems,
+admin tooling) label and group this kind of functionality.
+
+* Why
+
+Users have found the dual-menu layout confusing. A single well-named
+menu reduces cognitive overhead and is consistent with how most
+applications handle account/user management. The rename and
+reorganisation should be driven by precedent from comparable systems,
+not guesswork.
+
+* References
+
+- =projects/ores.qt/admin/src/AdminPlugin.cpp= — where the Account
+  and Administration submenus are wired into the System menu.
+
+* See also
+
+- [[id:E81C7FEA-33E4-400A-839A-9D1618BED211][Qt plugin architecture]] — how plugins contribute to the System menu via =setup_menus= / =create_menus=.

--- a/doc/agile/product_backlog/inbox/warn_on_account_create_without_role.org
+++ b/doc/agile/product_backlog/inbox/warn_on_account_create_without_role.org
@@ -1,0 +1,41 @@
+:PROPERTIES:
+:ID: F5C813D4-49E7-48BC-B098-FE0BE2277BBC
+:END:
+#+title: Warn when creating account without a role assignment
+#+description: Creating a new account without assigning at least one role is most likely an error; show a warning message box as we already do for missing party assignments.
+#+type: capture
+#+level: cross
+#+filetags: :iam:accounts:ux:validation:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+When saving a new account in =AccountDetailDialog= (create mode),
+if no role has been assigned via the Roles tab, show a
+=MessageBoxHelper::question= warning — offering Yes/No to proceed
+anyway — mirroring the existing check for missing party assignments
+(=AccountDetailDialog::onSaveClicked=, ~line 423). The implementation
+is symmetric: check =rolesWidget_->hasPendingChanges()= and
+=rolesWidget_->hasAvailableRoles()= (or equivalent) before dispatching
+the async create request, and block or warn accordingly.
+
+* Why
+
+An account without a role cannot do anything useful in the system.
+The pattern already exists for parties: if no party is assigned, a
+question dialog is shown ("No Party Assigned — create the account
+without a party?"). The same reasoning applies to roles — an account
+with no role has no permissions and the omission is almost certainly
+a mistake. Consistent validation makes the two checks parallel and
+makes the create flow self-documenting.
+
+* References
+
+- =projects/ores.qt/admin/src/AccountDetailDialog.cpp= ~line 422 — existing party warning, the model to follow.
+
+* See also
+
+-

--- a/doc/agile/product_backlog/inbox/warn_on_account_create_without_role.org
+++ b/doc/agile/product_backlog/inbox/warn_on_account_create_without_role.org
@@ -36,6 +36,3 @@ makes the create flow self-documenting.
 
 - =projects/ores.qt/admin/src/AccountDetailDialog.cpp= ~line 422 — existing party warning, the model to follow.
 
-* See also
-
--

--- a/doc/agile/versions/v0/sprint_19/account_type_badge_qt/story.org
+++ b/doc/agile/versions/v0/sprint_19/account_type_badge_qt/story.org
@@ -27,7 +27,7 @@ produced so future badges can be added without archaeology.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                                |
+| State         | STARTED                                |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
 | Now           | Not yet started.                       |
 | Waiting on    | Nothing.                               |
@@ -54,8 +54,8 @@ produced so future badges can be added without archaeology.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:5433FF26-FF0A-45A4-882A-4A9C41F51CB9][Implement account type badge in AccountItemDelegate]] | BACKLOG | | | Add account_type code domain + badge defs to SQL; wire Column::AccountType in delegate. |
-| [[id:36118737-9E05-48F0-889A-E800BA58825C][Write knowledge doc: badge system wiring]] | BACKLOG | | | Architectural knowledge doc covering ores.dq/ores.sql/ores.qt.api layers; account_type as worked example. |
+| [[id:5433FF26-FF0A-45A4-882A-4A9C41F51CB9][Implement account type badge in AccountItemDelegate]] | DONE | 2026-06-04 | 2026-06-04 | Add account_type code domain + badge defs to SQL; wire Column::AccountType in delegate. |
+| [[id:36118737-9E05-48F0-889A-E800BA58825C][Write knowledge doc: badge system wiring]] | DONE | 2026-06-04 | 2026-06-04 | Architectural knowledge doc covering ores.dq/ores.sql/ores.qt.api layers; account_type as worked example. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/account_type_badge_qt/story.org
+++ b/doc/agile/versions/v0/sprint_19/account_type_badge_qt/story.org
@@ -27,11 +27,11 @@ produced so future badges can be added without archaeology.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                                |
+| State         | DONE                                   |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | Not yet started.                       |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                               |
-| Next          | Start implementation task.             |
+| Next          | Nothing.                               |
 | Last touched  | 2026-06-04                             |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_document_badge_setup_in_qt.org
+++ b/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_document_badge_setup_in_qt.org
@@ -8,7 +8,7 @@
 #+filetags: :account_type_badge_qt:sprint_19:v0:
 #+owner: marco
 #+branch: feature/account-type-badge-qt
-#+pr:
+#+pr: https://github.com/OreStudio/OreStudio/pull/1038
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-04
@@ -65,7 +65,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1038][#1038]] | Display account type as badge in Qt accounts list |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_implement_account_type_badge_qt.org
+++ b/doc/agile/versions/v0/sprint_19/account_type_badge_qt/task_implement_account_type_badge_qt.org
@@ -8,7 +8,7 @@
 #+filetags: :account_type_badge_qt:sprint_19:v0:
 #+owner: marco
 #+branch: feature/account-type-badge-qt
-#+pr:
+#+pr: https://github.com/OreStudio/OreStudio/pull/1038
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-04
@@ -66,7 +66,7 @@ and =account_locked= do.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1038][#1038]] | Display account type as badge in Qt accounts list |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -74,7 +74,7 @@ dedicated thread pool to prevent =QThreadPool= starvation.
 |-------+-------+-------+-----+-------------|
 | [[id:61F836E5-2277-4765-9038-AF7D0176C993][Make UI more responsive]] | DONE | 2026-06-01 | 2026-06-01 | Fix waitForFinished() in destructors; add spinners; pre-populate combos; dedicated I/O thread pool. |
 | [[id:F8E2AB1E-344B-4B04-BD0B-6EC96CDA5298][PnL tracking improvements]] | DONE | 2026-06-03 | 2026-06-03 | Capture: FX locking, timeframe-scoped PnL, dual charts, two-phase sell P&L, FIFO/WAVG. See [[id:42F22269-B875-489D-A3D7-7FEC456C69EA][Lightyear knowledge doc]]. |
-| [[id:814D4E79-8EB9-4B2B-8A87-DB72F145044D][Display account type as badge in Qt accounts list]] | BACKLOG | | | Wire account_type as DB-driven badge in AccountItemDelegate; SQL population; badge setup recipe. |
+| [[id:814D4E79-8EB9-4B2B-8A87-DB72F145044D][Display account type as badge in Qt accounts list]] | DONE | 2026-06-04 | 2026-06-04 | Wire account_type as DB-driven badge in AccountItemDelegate; SQL population; badge setup recipe. PR [[https://github.com/OreStudio/OreStudio/pull/1038][#1038]]. |
 
 ** Tooling
 

--- a/doc/llm/skills/capture/SKILL.org
+++ b/doc/llm/skills/capture/SKILL.org
@@ -1,0 +1,94 @@
+:PROPERTIES:
+:ID: E767A313-2E08-4682-8586-39138529385C
+:END:
+#+title: Capture
+#+author: Marco Craveiro
+#+options: <:nil c:nil todo:nil ^:nil d:nil date:nil author:nil toc:t
+#+startup: inlineimages
+#+export_exclude_tags: noexport
+#+filetags: :agile:capture:backlog:compass:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+
+#+begin_export markdown
+---
+name: capture
+description: File a single idea or observation into the product backlog inbox as a well-structured capture.
+license: Complete terms in LICENSE.txt
+---
+#+end_export
+
+* When to use this skill
+
+When the user describes an idea, observation, bug, or feature request
+and asks to "capture" it or file it in the inbox — a single,
+well-defined item rather than a block of freeform notes. For bulk
+decomposition of unstructured text, use
+[[id:7072D39C-9607-48F9-8EE6-50E8647DB8ED][How do I capture ideas from freeform text?]] instead.
+
+* How to use this skill
+
+1. /Derive the capture fields/ from the user's message:
+   - *slug* — snake_case, 3–6 words, noun phrase (e.g.
+     =warn_on_create_without_role=).
+   - *title* — 5–10 words, imperative or noun phrase.
+   - *description* — one sentence: what it is.
+   - *tags* — 2–4 relevant tags (component, topic, area).
+
+2. /Scaffold the file/ via =compass add capture=:
+
+   #+begin_src sh :results verbatim
+   ./compass.sh add capture \
+     --slug <slug> \
+     --parent-dir doc/agile/product_backlog/inbox \
+     --title "<title>" \
+     --description "<description>" \
+     --tags "<tag1>,<tag2>"
+   #+end_src
+
+3. /Fill in the body/:
+   - =* What= — one paragraph: the idea, with enough detail to act
+     on it later. Include any file paths, line numbers, or links
+     the implementer will need.
+   - =* Why= — motivation: the problem being solved, inconsistency
+     being fixed, or user need being met.
+   - =* References= — any links, file paths, or related captures.
+   - =* See also= — id-links to related knowledge docs or stories.
+
+4. /Commit and push/:
+
+   #+begin_src sh :results verbatim
+   git add <file> && git commit -m "[agile] Capture: <title>" && git push
+   #+end_src
+
+* Recipes
+
+- [[id:7072D39C-9607-48F9-8EE6-50E8647DB8ED][How do I capture ideas from freeform text?]] — bulk variant:
+  decompose unstructured notes into multiple captures.
+
+* Reference
+
+- [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][Product backlog]] — bucket structure (inbox / next / deferred /
+  discarded) and triage lifecycle.
+- [[id:8B29A8D8-E004-4E87-B81D-ABEAF68F2B98][Document types]]§=capture= — required frontmatter and sections.
+
+* Artefacts                                                        :noexport:
+
+** Licence
+
+#+BEGIN_SRC fundamental :tangle LICENCE.txt
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+#+END_SRC

--- a/doc/llm/skills/claude_code_skills.org
+++ b/doc/llm/skills/claude_code_skills.org
@@ -29,6 +29,8 @@ See [[id:654D4A70-E63D-4C18-B5A5-886066E36314][CMake Runner]] for the deployment
 
 - [[id:2DF8ADAF-20C9-4757-9399-798EEC6DF828][Agile Product Owner]] — manage the team through story creation,
   prioritisation, sprint planning.
+- [[id:E767A313-2E08-4682-8586-39138529385C][Capture]] — file a single idea or observation into the product
+  backlog inbox as a well-structured capture.
 - [[id:00F85A2F-547A-4F11-99EB-A46A7DE5AB1C][Manual Updater]] — update the user manual when UI features are
   added or changed: find the chapter, edit prose, add screenshot
   placeholders, rebuild the PDF.

--- a/doc/recipes/codegen/how_do_i_create_a_new_doc.org
+++ b/doc/recipes/codegen/how_do_i_create_a_new_doc.org
@@ -222,6 +222,13 @@ folder name and the =name:= field in the skill's markdown frontmatter.
 
 Output: =doc/llm/skills/my_new_skill/SKILL.org=.
 
+After filling in the skill body, rebuild the shipped bundle so Claude
+Code picks up the change — see [[id:B5F231A9-5403-482C-8F2A-12D6917C58CD][How do I deploy the skills?]]:
+
+#+begin_src sh :results verbatim
+cmake --build --preset linux-clang-debug-make --target deploy_skills
+#+end_src
+
 ** New product identity
 :PROPERTIES:
 :ID: F1311596-B8ED-43AD-8C46-76C58C0194C7

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -1771,6 +1771,11 @@ def cmd_add(argv):
     if rc in (None, 0):
         print("ℹ️  Remember to wire the new artefact into its parent "
               "(e.g. the sprint's * Stories table) where needed.", file=sys.stderr)
+        if doc_type == "skill":
+            print("⚠️  Rebuild the skills bundle after filling in the skill body:",
+                  file=sys.stderr)
+            print(f"   {_ycmd('compass show B5F231A9-5403-482C-8F2A-12D6917C58CD')}",
+                  file=sys.stderr)
         if doc_type == "manual":
             print("⚠️  Manual link rule: [[id:UUID]] links to documents outside"
                   " doc/manual/ will break the PDF export.", file=sys.stderr)


### PR DESCRIPTION
## Summary

- Close *Display account type as badge* story (PR #1038 merged); both tasks marked DONE, PR wired into task docs and sprint table
- Add `capture` skill — single-item inbox capture playbook (`/capture`)
- `compass add skill` now prints a deploy-skills reminder with `compass show` for the recipe
- Add deploy-skills reminder to the "New Claude Code skill" recipe section
- Rename skill `run_runbook` → `run-runbook` (kebab-case convention)
- Two inbox captures: warn on account create without role; unify Account/Administration menus

## Test plan

- [ ] `compass journal where` shows story DONE and PR #1038
- [ ] `/capture` skill available and invocable
- [ ] `compass add skill --slug test ...` prints the deploy-skills reminder
- [ ] `run-runbook` skill listed in skill selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)