### PR TITLE
[agile] Scaffold API/core split investigation story

### DIFF
--- a/doc/agile/versions/v0/sprint_19/investigate_api_core_split/story.org
+++ b/doc/agile/versions/v0/sprint_19/investigate_api_core_split/story.org
@@ -1,0 +1,79 @@
+:PROPERTIES:
+:ID: BD519FC9-6B29-4055-877F-861E46043A06
+:END:
+#+title: Story: Investigate the API/core split in components
+#+description: The api sub-component was meant to be lightweight — standard types consumable by NATS clients without pulling in database or other heavy dependencies — but ores.dq.api links ores.database.lib. Inventory what every split component keeps in api vs core, understand the coupling, and define the refactor so api is just standard types (or at worst other apis).
+#+type: story
+#+level: s2
+#+filetags: :architecture:components:cpp:investigation:sprint_19:v0:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+The api/core split exists so that consumers who only need a
+component's /types/ — typically NATS clients that serialise and
+deserialise its messages — can link the =api= sub-component without
+pulling in the database layer, repositories, or any other heavy
+machinery. That contract appears to have eroded: =ores.dq.api= links
+=ores.database.lib= directly
+(=projects/ores.dq/api/src/CMakeLists.txt=), which defeats the entire
+point of the split. Seventeen components currently carry an api+core
+split; if DQ's coupling pattern holds elsewhere, the erosion is
+systemic.
+
+This story does two things, in order:
+
+1. /Inventory/ — catalogue what every split component keeps in =api=
+   versus =core= (facets, headers, link dependencies), starting with
+   DQ, and flag every api that pulls in heavy dependencies.
+2. /Understand and decide/ — for each flagged api, determine whether
+   the coupling has a real reason. Ideally there is none, and the
+   refactor target is: *an api contains pretty much just standard
+   types — or at worst depends on other apis*.
+
+Refactor tasks are expected to be discovered out of the
+investigation; if the pattern holds across components, follow-up
+stories will extend the cleanup to all of them.
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
+| Now           | Scaffolded; investigation not yet started. |
+| Waiting on    | Nothing.                               |
+| Next          | Run the inventory task, starting with ores.dq. |
+| Last touched  | 2026-06-04                               |
+
+* Acceptance
+
+- An investigation report exists covering all 17 api+core split
+  components: what each keeps in =api= vs =core=, and the full link
+  dependency list of each =api=.
+- Every api with heavy dependencies (database or similar) is flagged,
+  with the coupling characterised: which headers/facets cause it and
+  whether any genuine reason for it exists.
+- A refactor direction is decided and recorded: what moves out of
+  each offending =api= (and to where) so that apis are standard types
+  only, or at worst depend on other apis.
+- Follow-up refactor tasks (or stories, if the pattern is systemic)
+  are filed for the offending components, DQ first.
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+| [[id:681BBF6B-4DD8-411A-9B19-76AA5E14C1FC][Inventory api/core contents across split components]] | BACKLOG | | | Catalogue api vs core contents + link deps for all 17 split components, DQ first; flag heavy apis; investigation report. |
+
+* Decisions
+
+* Out of scope
+
+- The refactor itself — this story decides and files it; execution is
+  follow-up work scoped by the findings.
+- Components without an api/core split.

--- a/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_inventory_api_core_contents.org
+++ b/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_inventory_api_core_contents.org
@@ -70,7 +70,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1045][#1045]] | [agile] Scaffold API/core split investigation story |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_inventory_api_core_contents.org
+++ b/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_inventory_api_core_contents.org
@@ -1,0 +1,81 @@
+:PROPERTIES:
+:ID: 681BBF6B-4DD8-411A-9B19-76AA5E14C1FC
+:END:
+#+title: Task: Inventory api/core contents across split components
+#+description: For all 17 api+core split components, catalogue what lives in each sub-component (facets, headers, link dependencies), flag every api that pulls in heavy dependencies (database, etc.), and characterise the coupling — starting with ores.dq. Produce an investigation report grounding the refactor decision.
+#+type: task
+#+level: s1
+#+filetags: :architecture:components:cpp:investigate_api_core_split:sprint_19:v0:
+#+owner: marco
+#+branch: feature/investigate-api-core-split
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:BD519FC9-6B29-4055-877F-861E46043A06][Investigate the API/core split in components]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+Produce the investigation report that grounds the api/core refactor
+decision:
+
+1. For each of the 17 api+core split components, catalogue what lives
+   in =api= and what lives in =core=: facets (domain, messaging,
+   eventing, generators, repository, service, ...), notable headers,
+   and the full =target_link_libraries= list of each sub-component.
+2. Flag every =api= that links heavy dependencies — =ores.database=
+   and similar — starting from the known offender, =ores.dq.api=
+   (=projects/ores.dq/api/src/CMakeLists.txt= links
+   =ores.database.lib=).
+3. For each flagged api, characterise the coupling: which headers or
+   facets drag the dependency in, and whether any genuine reason for
+   it exists.
+4. Recommend the refactor: what moves where so each api is standard
+   types only — or at worst depends on other apis. File the
+   follow-up refactor tasks/stories, DQ first.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:BD519FC9-6B29-4055-877F-861E46043A06][Investigate the API/core split in components]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-04                               |
+
+* Acceptance
+
+- Investigation report covering all 17 split components: api vs core
+  contents and full api link-dependency lists.
+- Every heavy-dependency api flagged, with the coupling traced to the
+  responsible headers/facets and its rationale (or lack of one)
+  recorded.
+- Refactor recommendation written into the parent story's
+  =* Decisions=; follow-up tasks/stories filed.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -119,6 +119,7 @@ Regroup and refactor the C++ component layout to align with the product-group mo
 |-------+-------+-------+-----+-------------|
 | [[id:FF9397CF-E6F6-44C3-9641-882EEA21C58D][Regroup C++ components under product-group parent directories]] | DONE | 2026-06-01 | 2026-06-02 | Move each =projects/ores.<group>.<role>/= (api, core, service) and =projects/ores.qt.<group>/= under a single =projects/ores.<group>/= parent so the group owns its modeling/ dir, root CMakeLists, and child layout. Blocks per-group org-migration tasks beyond refdata. |
 | [[id:FE9BB4DA-FC98-4C08-B784-104DCF3A6687][Move trade-instrument parsing out of ores.qt.api]] | BACKLOG | | | Extract the Qt-free parse logic into ores.trading.api so the dispatch test links a real target instead of hand-listing source files. Removes the stop-gap from the regroup story. |
+| [[id:BD519FC9-6B29-4055-877F-861E46043A06][Investigate the API/core split in components]] | BACKLOG | | | Inventory api vs core across all 17 split components; flag heavy apis (ores.dq.api links ores.database.lib); decide refactor so apis are standard types or other apis only. |
 
 ** Agile
 


### PR DESCRIPTION
## Summary

Scaffolds the *Investigate the API/core split in components* story
under sprint 19 (Tooling → C++ Components epic). The `api`
sub-component exists so NATS-type consumers can link a component's
types without pulling in the database layer — but `ores.dq.api` links
`ores.database.lib` directly, and 17 components carry the api+core
split, so the erosion may be systemic. Agile bookkeeping only.

## Changes

- New story `investigate_api_core_split`: goal (inventory →
  understand coupling → decide refactor; target is apis as standard
  types or at-worst other apis), acceptance, out-of-scope.
- One investigation task: inventory api/core contents and api link
  dependencies across all 17 split components, DQ first; flag heavy
  apis; file follow-up refactor work from the findings.
- Story wired into the sprint 19 C++ Components epic table (BACKLOG).

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Investigate the API/core split in components](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/investigate_api_core_split/story.html) | BD519FC9-6B29-4055-877F-861E46043A06 |
| Task | [Inventory api/core contents across split components](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_inventory_api_core_contents.html) | 681BBF6B-4DD8-411A-9B19-76AA5E14C1FC |