### PR TITLE
[doc,cmake,cpp] Literate clang-format config: org source, tangle target, recipe, developer links

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,12 @@
 # -*- mode: yaml; yaml-tab-width: 4; indent-tabs-mode: nil -*-
+# Generated from doc/knowledge/architecture/clang_format_config.org.
+# Do not edit directly — run: cmake --build --preset <preset> --target tangle_clang_format
 ---
 Language: Cpp
-Standard: c++23
+# "Latest" means the most recent C++ standard the installed clang-format
+# understands — effectively c++23 on current toolchains.
+# The string "c++23" is not yet a valid enum value in clang-format 21.
+Standard: Latest
 
 # ORE Studio clang-format configuration.
 # Tuned to match the project's actual code conventions.
@@ -77,15 +82,19 @@ AllowShortLoopsOnASingleLine: false
 #   4. All other angle-bracket headers (std, rfl, openssl, ...)
 
 SortIncludes: CaseSensitive
-IncludeBlocks: Regroup
+IncludeBlocks: Merge
 IncludeCategories:
-  - Regex: '^"'
-    Priority: 1
-  - Regex: '^<Q[A-Z]'
-    Priority: 2
-  - Regex: '^<boost/'
-    Priority: 3
+  # Standard library and other angle-bracket headers first
   - Regex: '^<'
+    Priority: 1
+  # Boost headers
+  - Regex: '^<boost/'
+    Priority: 2
+  # Qt headers
+  - Regex: '^<Q[A-Z]'
+    Priority: 3
+  # Local project headers (quoted: ores.*, ui_*, etc.)
+  - Regex: '^"'
     Priority: 4
 
 # ── Misc ──────────────────────────────────────────────────────────────────────

--- a/.clang-format
+++ b/.clang-format
@@ -84,17 +84,20 @@ AllowShortLoopsOnASingleLine: false
 SortIncludes: CaseSensitive
 IncludeBlocks: Merge
 IncludeCategories:
-  # Standard library and other angle-bracket headers first
-  - Regex: '^<'
+  # Local project headers first (quoted: ores.*, ui_*, etc.)
+  # Rationale: including local headers first ensures each header is
+  # self-sufficient — missing transitive includes are caught immediately
+  # rather than being silently satisfied by a preceding std/Boost header.
+  - Regex: '^"'
     Priority: 1
-  # Boost headers
-  - Regex: '^<boost/'
-    Priority: 2
   # Qt headers
   - Regex: '^<Q[A-Z]'
+    Priority: 2
+  # Boost headers
+  - Regex: '^<boost/'
     Priority: 3
-  # Local project headers (quoted: ores.*, ui_*, etc.)
-  - Regex: '^"'
+  # Standard library and other angle-bracket headers last
+  - Regex: '^<'
     Priority: 4
 
 # ── Misc ──────────────────────────────────────────────────────────────────────

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,11 @@ add_custom_target(deploy_manual
     COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-manual.el
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+add_custom_target(tangle_clang_format
+    COMMENT "Tangling .clang-format from doc/knowledge/architecture/clang_format_config.org" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-clang-format.el 2>&1
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
 set(ORES_SKILLS_DIRECTORY ".claude/skills")
 add_custom_target(deploy_skills
     COMMENT "Deploying ORE Studio Claude Code Skills to ${ORES_SIRE_DIRECTORY}" VERBATIM

--- a/doc/agile/versions/v0/sprint_19/clang_format_setup/task_add_cmake_format_targets.org
+++ b/doc/agile/versions/v0/sprint_19/clang_format_setup/task_add_cmake_format_targets.org
@@ -69,4 +69,5 @@ they work with any installed version.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Use find -exec instead of find|xargs (space-safety + empty-match hang) | CMakeLists.txt | Accepted | 141772bc |
+| 2 | Missing PRs and Review tables | task_add_cmake_format_targets.org | Accepted | 141772bc |

--- a/doc/agile/versions/v0/sprint_19/clang_format_setup/task_nightly_format_workflow_and_initial_pass.org
+++ b/doc/agile/versions/v0/sprint_19/clang_format_setup/task_nightly_format_workflow_and_initial_pass.org
@@ -76,4 +76,5 @@ in CI. Filed as a capture: [[id:A16A6F10-1362-4009-9BFB-44402D7A9403][Set up cla
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Missing PRs and Review tables | task_nightly_format_workflow_and_initial_pass.org | Accepted | 141772bc |
+| 2 | Broken id link (already fixed prior commit) | same | Accepted | 7aa507ab |

--- a/doc/developer.org
+++ b/doc/developer.org
@@ -32,13 +32,21 @@ share onboarding links with a new contributor or LLM agent.
 
 ** Build and Quality
 
-| Resource           | Link                                                                                                      |
-|--------------------+-----------------------------------------------------------------------------------------------------------|
-| CDash Dashboard    | [[https://my.cdash.org/index.php?project=OreStudio][my.cdash.org — OreStudio]]                          |
-| CI — Linux         | [[https://github.com/OreStudio/OreStudio/actions/workflows/continuous-linux.yml][continuous-linux.yml]]   |
-| CI — Windows       | [[https://github.com/OreStudio/OreStudio/actions/workflows/continuous-windows.yml][continuous-windows.yml]] |
-| CI — macOS         | [[https://github.com/OreStudio/OreStudio/actions/workflows/continuous-macos.yml][continuous-macos.yml]]   |
-| CI — Nightly Linux | [[https://github.com/OreStudio/OreStudio/actions/workflows/nightly-linux.yml][nightly-linux.yml]]       |
+| Resource              | Link                                                                                                            |
+|-----------------------+-----------------------------------------------------------------------------------------------------------------|
+| CDash Dashboard       | [[https://my.cdash.org/index.php?project=OreStudio][my.cdash.org — OreStudio]]                                |
+| CI — Linux            | [[https://github.com/OreStudio/OreStudio/actions/workflows/continuous-linux.yml][continuous-linux.yml]]       |
+| CI — Windows          | [[https://github.com/OreStudio/OreStudio/actions/workflows/continuous-windows.yml][continuous-windows.yml]]   |
+| CI — macOS            | [[https://github.com/OreStudio/OreStudio/actions/workflows/continuous-macos.yml][continuous-macos.yml]]     |
+| CI — Nightly Linux    | [[https://github.com/OreStudio/OreStudio/actions/workflows/nightly-linux.yml][nightly-linux.yml]]           |
+| CI — Nightly Format   | [[https://github.com/OreStudio/OreStudio/actions/workflows/nightly-format.yml][nightly-format.yml]]         |
+
+** Code Style
+
+| Resource | Link |
+|----------+------|
+| C++ clang-format config | [[id:2BE1DCB1-6F10-4568-9945-E1AFA079FC7B][C++ code style: clang-format configuration]] — literate source, all settings documented. |
+| Format recipe | [[id:4CEC17FA-CB28-4B21-B139-AD8F30E02C43][How do I format C++ sources with clang-format?]] |
 
 ** Releases
 

--- a/doc/knowledge/architecture/clang_format_config.org
+++ b/doc/knowledge/architecture/clang_format_config.org
@@ -252,14 +252,17 @@ AllowShortLoopsOnASingleLine: false
 ** Include ordering
 
 Includes are merged into a single sorted block (no blank lines
-between groups) and ordered from most stable to least stable:
-standard library first, then Boost, then Qt, then local project
-headers. Within each group, headers are sorted case-sensitively.
+between groups) and ordered local-first: project headers, then Qt,
+then Boost, then the standard library. Within each group, headers
+are sorted case-sensitively.
 
-The ordering rationale: reading from the most stable dependency to
-the least stable mirrors the dependency graph and helps reviewers
-understand which external libraries a file draws on before seeing
-its internal dependencies.
+The ordering rationale: including local headers first is the
+Google and LLVM convention for a reason — it surfaces missing
+transitive includes immediately. If =account.hpp= forgets to include
+=<string>= but the =#include "account.hpp"= line comes after a
+=<string>= include, the bug is hidden. Local-first catches it
+because nothing has yet satisfied =<string>= when the header is
+parsed.
 
 *Before* (unsorted, mixed):
 #+begin_example
@@ -269,30 +272,32 @@ its internal dependencies.
 #include <chrono>
 #+end_example
 
-*After* (std → Boost → Qt → local):
+*After* (local → Qt → Boost → std):
 #+begin_example
+#include "ores.utility/uuid/tenant_id.hpp"
+#include <boost/uuid/uuid.hpp>
 #include <chrono>
 #include <string>
-#include <boost/uuid/uuid.hpp>
-#include "ores.utility/uuid/tenant_id.hpp"
 #+end_example
 
 #+begin_src yaml
 
 # ── Includes ──────────────────────────────────────────────────────────────────
 # Sorted into one merged block (no blank line separators), ordered:
-#   std / other angle-bracket → Boost → Qt → local "ores.*" / "ui_*"
+#   local "ores.*" / "ui_*" → Qt → Boost → std / other angle-bracket
+# Local-first ensures each header is self-sufficient: a missing transitive
+# include cannot be silently satisfied by a preceding std/Boost header.
 SortIncludes: CaseSensitive
 IncludeBlocks: Merge
 IncludeCategories:
-  - Regex: '^<boost/'
-    Priority: 2
-  - Regex: '^<Q[A-Z]'
-    Priority: 3
   - Regex: '^"'
-    Priority: 4
-  - Regex: '^<'
     Priority: 1
+  - Regex: '^<Q[A-Z]'
+    Priority: 2
+  - Regex: '^<boost/'
+    Priority: 3
+  - Regex: '^<'
+    Priority: 4
 #+end_src
 
 ** Miscellaneous

--- a/doc/knowledge/architecture/clang_format_config.org
+++ b/doc/knowledge/architecture/clang_format_config.org
@@ -1,0 +1,372 @@
+:PROPERTIES:
+:ID: 2BE1DCB1-6F10-4568-9945-E1AFA079FC7B
+:END:
+#+title: C++ code style: clang-format configuration
+#+description: Literate source for .clang-format — every setting documented with rationale and examples, tangled to the repo root via the tangle_clang_format CMake target.
+#+type: knowledge
+#+level: cross
+#+filetags: :cpp:formatting:build:architecture:knowledge:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+
+* Summary
+
+This file is the single authoritative source for =.clang-format= at
+the repository root. Every setting is accompanied by the reasoning
+behind its choice and a before/after example. Do not edit
+=.clang-format= directly — regenerate it with the
+=tangle_clang_format= CMake target instead. The style is based on
+LLVM, tuned to match the conventions already in the codebase:
+4-space indent, no namespace indentation, leading-comma constructor
+initialisers, and =std → Boost → local= include ordering. Return
+to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
+
+* How to regenerate
+
+Tangle the literate source to =.clang-format= and commit the result:
+
+#+begin_src sh :results verbatim
+cmake --build --preset linux-clang-debug-make --target tangle_clang_format
+#+end_src
+
+The target runs =projects/ores.lisp/src/ores-build-clang-format.el=
+in Emacs batch mode, which calls =org-babel-tangle-file= on this
+document and writes the output to =.clang-format= at the repo root.
+
+* Literate source
+
+The canonical =.clang-format= is assembled from the sections below.
+Each section documents one group of settings and contains the
+corresponding YAML fragment. The Emacs tangle script collects all
+=#+begin_src yaml= blocks and concatenates them into the output file.
+
+** File header
+
+#+begin_src yaml
+# -*- mode: yaml; yaml-tab-width: 4; indent-tabs-mode: nil -*-
+# This file is generated from doc/knowledge/architecture/clang_format_config.org.
+# Do not edit directly — run: cmake --build --preset <preset> --target tangle_clang_format
+---
+Language: Cpp
+# "Latest" means the most recent C++ standard the installed clang-format
+# understands — effectively c++23 on current toolchains.
+# The string "c++23" is not yet a valid enum value in clang-format 21.
+Standard: Latest
+#+end_src
+
+** Baseline style
+
+LLVM style provides a well-documented, widely-used baseline. The
+sections below override specific settings to match the ORE Studio
+codebase conventions instead of LLVM's defaults.
+
+#+begin_src yaml
+
+# ── Baseline ─────────────────────────────────────────────────────────────────
+BasedOnStyle: LLVM
+#+end_src
+
+** Indentation
+
+The project uses 4-space indentation throughout. Key deviations from
+LLVM defaults:
+
+- =NamespaceIndentation: None= — namespace body is not indented.
+  LLVM defaults to =None= too, but we make it explicit.
+  *Before:* =namespace ores { class Foo {};= indented by 2 (LLVM default indent)
+  *After:* namespace body at column 0.
+
+- =AccessModifierOffset: -4= — =public:= / =private:= / =protected:=
+  appear at the class indentation level, not further indented.
+  *Before:* (LLVM default, =-2= with 2-space indent) =  public:=
+  *After:* =public:= at column 0 relative to class.
+
+- =IndentCaseLabels: true= — =case X:= is indented relative to =switch=.
+  *Before:* =switch (x) { case 1: ...= at same level as =switch=
+  *After:* =case 1:= indented 4 spaces inside =switch=.
+
+- =IndentPPDirectives: AfterHash= — preprocessor directives are indented
+  after the =#=, keeping nested =#if/#endif= readable.
+  *Before:* =#ifdef FOO\n#define BAR= — all at column 0
+  *After:* =#ifdef FOO\n#  define BAR= — nested defines indented
+
+#+begin_src yaml
+
+# ── Indentation ───────────────────────────────────────────────────────────────
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+NamespaceIndentation: None
+AccessModifierOffset: -4
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+#+end_src
+
+** Line length
+
+100 characters. Long enough for deeply namespaced C++ and Qt signal
+connections without excessive wrapping; short enough to allow
+side-by-side diffs at reasonable terminal widths.
+
+#+begin_src yaml
+
+# ── Line length ───────────────────────────────────────────────────────────────
+ColumnLimit: 100
+#+end_src
+
+** Pointer and reference alignment
+
+Pointer and reference qualifiers are attached to the type, not the
+variable name: =T* x= and =T& x=, not =T *x= and =T &x=. This is
+consistent throughout the codebase and matches Qt's own convention.
+
+*Before:* =void foo(const std::string &s, int *p)=
+*After:*  =void foo(const std::string& s, int* p)=
+
+=DerivePointerAlignment: false= prevents clang-format from inferring
+the alignment from the existing code (which would be inconsistent
+during the transition period).
+
+#+begin_src yaml
+
+# ── Pointer / reference alignment ────────────────────────────────────────────
+DerivePointerAlignment: false
+PointerAlignment: Left
+ReferenceAlignment: Left
+#+end_src
+
+** Constructor initialiser lists
+
+Initialisers use the leading-comma style: the colon and each comma
+appear at the start of a new line, indented 4 spaces. One initialiser
+per line, always (=PackConstructorInitializers: Never=).
+
+*Before* (packed, trailing-comma):
+#+begin_example
+Foo::Foo(int a, int b) : a_(a), b_(b), c_(0) {
+#+end_example
+
+*After* (one-per-line, leading-comma):
+#+begin_example
+Foo::Foo(int a, int b)
+    : a_(a)
+    , b_(b)
+    , c_(0) {
+#+end_example
+
+This style is already used consistently in the nats, http, and
+database components; the format pass extends it everywhere.
+
+#+begin_src yaml
+
+# ── Constructor initialiser lists ─────────────────────────────────────────────
+BreakConstructorInitializers: BeforeComma
+ConstructorInitializerIndentWidth: 4
+PackConstructorInitializers: Never
+#+end_src
+
+** Function parameters and arguments
+
+Parameters and arguments are never bin-packed — they either all fit
+on one line or each goes on its own line, aligned to the opening
+parenthesis.
+
+*Before* (bin-packed, fits whatever):
+#+begin_example
+void foo(TypeA a, TypeB b,
+         TypeC c, TypeD d) {
+#+end_example
+
+*After* (one per line when wrapping):
+#+begin_example
+void foo(TypeA a,
+         TypeB b,
+         TypeC c,
+         TypeD d) {
+#+end_example
+
+#+begin_src yaml
+
+# ── Function parameters / arguments ──────────────────────────────────────────
+BinPackParameters: false
+BinPackArguments: false
+#+end_src
+
+** Template declarations
+
+The =template<...>= line is always on its own line, separate from
+the function or class declaration that follows. This improves
+readability for the long template parameter lists common in this
+codebase (repository patterns, codegen helpers, etc.).
+
+*Before:*
+#+begin_example
+template<typename T> void foo(T x) {
+#+end_example
+
+*After:*
+#+begin_example
+template<typename T>
+void foo(T x) {
+#+end_example
+
+#+begin_src yaml
+
+# ── Templates ─────────────────────────────────────────────────────────────────
+AlwaysBreakTemplateDeclarations: Yes
+#+end_src
+
+** Short constructs
+
+Only empty function bodies are allowed on a single line (e.g.
+=Foo() {}=). All other functions, including trivial one-liners, are
+expanded to multiple lines. Short lambdas may remain inline when they
+are the sole argument to a function call.
+
+=AllowShortIfStatementsOnASingleLine: Never= and
+=AllowShortLoopsOnASingleLine: false= ensure that control flow is
+always on its own line, even for single-statement bodies — this makes
+diffs cleaner and reduces the chance of off-by-one errors when adding
+a second statement.
+
+*Before:*
+#+begin_example
+if (!joined.empty()) joined += ',';
+#+end_example
+
+*After:*
+#+begin_example
+if (!joined.empty())
+    joined += ',';
+#+end_example
+
+#+begin_src yaml
+
+# ── Short constructs ──────────────────────────────────────────────────────────
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+#+end_src
+
+** Include ordering
+
+Includes are merged into a single sorted block (no blank lines
+between groups) and ordered from most stable to least stable:
+standard library first, then Boost, then Qt, then local project
+headers. Within each group, headers are sorted case-sensitively.
+
+The ordering rationale: reading from the most stable dependency to
+the least stable mirrors the dependency graph and helps reviewers
+understand which external libraries a file draws on before seeing
+its internal dependencies.
+
+*Before* (unsorted, mixed):
+#+begin_example
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+#include <chrono>
+#+end_example
+
+*After* (std → Boost → Qt → local):
+#+begin_example
+#include <chrono>
+#include <string>
+#include <boost/uuid/uuid.hpp>
+#include "ores.utility/uuid/tenant_id.hpp"
+#+end_example
+
+#+begin_src yaml
+
+# ── Includes ──────────────────────────────────────────────────────────────────
+# Sorted into one merged block (no blank line separators), ordered:
+#   std / other angle-bracket → Boost → Qt → local "ores.*" / "ui_*"
+SortIncludes: CaseSensitive
+IncludeBlocks: Merge
+IncludeCategories:
+  - Regex: '^<boost/'
+    Priority: 2
+  - Regex: '^<Q[A-Z]'
+    Priority: 3
+  - Regex: '^"'
+    Priority: 4
+  - Regex: '^<'
+    Priority: 1
+#+end_src
+
+** Miscellaneous
+
+- =MaxEmptyLinesToKeep: 2= — prevents formatting passes from collapsing
+  intentional visual groupings while still removing excessive blank lines.
+- =FixNamespaceComments: false= — the codebase uses bare =}= to close
+  namespaces; adding trailing comments would be noisy.
+- =SortUsingDeclarations: false= — =using= declarations are grouped
+  intentionally; resorting them could change meaning for shadowing cases.
+- =AlignEscapedNewlines: Left= — backslash-escaped newlines in macros
+  are left-aligned (column 0) rather than right-aligned to the column
+  limit, keeping macro definitions compact.
+- =BreakBeforeTernaryOperators: false= — the ternary =?= / =:= stays
+  at the end of the line, not the start of the continuation, matching
+  the existing style.
+
+#+begin_src yaml
+
+# ── Miscellaneous ─────────────────────────────────────────────────────────────
+MaxEmptyLinesToKeep: 2
+FixNamespaceComments: false
+SortUsingDeclarations: false
+AlignEscapedNewlines: Left
+BreakBeforeTernaryOperators: false
+#+end_src
+
+* How to use
+
+** Format sources in-place
+
+Reformats all =.cpp=, =.hpp=, and =.h= files under =projects/= using the
+canonical =.clang-format= config. Run before opening a PR or after
+pulling changes that modify the config.
+
+See [[id:4CEC17FA-CB28-4B21-B139-AD8F30E02C43][How do I format C++ sources with clang-format?]] for the full recipe.
+
+#+begin_src sh
+cmake --build --preset linux-clang-debug-make --target format
+#+end_src
+
+** Check for drift (dry run)
+
+Reports files that differ from the canonical style without modifying
+them. Exits non-zero if any file would change — use this locally to
+verify a branch is clean before pushing.
+
+#+begin_src sh
+cmake --build --preset linux-clang-debug-make --target check-format
+#+end_src
+
+** Nightly CI workflow
+
+The [[https://github.com/OreStudio/OreStudio/actions/workflows/nightly-format.yml][nightly-format]] GitHub Actions workflow runs at 02:00 UTC every night.
+It installs =clang-format-18= on Ubuntu 24.04, reformats all sources
+in-place, and — if any file changed — raises a PR titled
+=[format] Nightly clang-format run= against =main=. When the PR is
+empty (no files changed) no action is taken.
+
+To trigger it manually: *Actions → Nightly Format → Run workflow*.
+
+** Updating the style
+
+To change a setting:
+
+1. Edit the relevant =#+begin_src yaml= block in this document.
+2. Update the documentation prose and example above the block.
+3. Run =tangle_clang_format= to regenerate =.clang-format=.
+4. Run =check-format= to see what changes; review the diff.
+5. Commit both this document and the regenerated =.clang-format=.
+
+* See also
+
+- [[id:4CEC17FA-CB28-4B21-B139-AD8F30E02C43][How do I format C++ sources with clang-format?]] — the format and check-format recipe.
+- [[id:5B271351-399A-4BD7-A096-E5DF1EDAD8F5][Developer Links]] — nightly-format CI workflow and other build dashboards.
+- [[id:5AAE6900-8488-4E22-9F31-A1B9D5320EFB][CMake setup]] — preset names and build directory layout.
+- [[id:2D83251F-0E24-4B97-B736-08F710316634][Claude Code Settings]] — the analogous literate source for =.claude/settings.json=.

--- a/doc/knowledge/knowledge.org
+++ b/doc/knowledge/knowledge.org
@@ -68,6 +68,8 @@ How the codebase is put together.
   history dialog, and async-fetch patterns.
 - [[id:F7DE2705-4D20-4878-A10C-A834F3283683][Badge system wiring]] — DB-driven pill badges: =ores.dq= entities,
   SQL population, =BadgeCache=, and delegate wiring.
+- [[id:2BE1DCB1-6F10-4568-9945-E1AFA079FC7B][C++ code style: clang-format configuration]] — literate source for
+  =.clang-format=; every setting documented with rationale and examples.
 - [[id:E44891DC-234C-42DB-90E1-9421400ABD1A][Qt menu and toolbar patterns]] — plugin registration,
   =on_login()= menu wiring, and MDI window toolbar construction.
 - [[id:05891220-2503-48A0-ADF5-13EC95B605D7][CLI entity patterns]] — options structs, parser layout, and

--- a/doc/recipes/cmake/cmake.org
+++ b/doc/recipes/cmake/cmake.org
@@ -27,3 +27,4 @@ a single how-do-I question with executable steps.
 - [[id:4BF2516D-F37E-4E31-AD7B-124F2639B9AB][How do I enable test logging?]]
 - [[id:E1A68ED5-20CB-426C-91C6-97984A692505][How do I investigate a test failure?]]
 - [[id:E9F98DA1-CF33-4B53-BC4D-A034C652F3B0][How do I bump the project version?]]
+- [[id:4CEC17FA-CB28-4B21-B139-AD8F30E02C43][How do I format C++ sources with clang-format?]]

--- a/doc/recipes/cmake/how_do_i_format_cpp_sources.org
+++ b/doc/recipes/cmake/how_do_i_format_cpp_sources.org
@@ -1,0 +1,70 @@
+:PROPERTIES:
+:ID: 4CEC17FA-CB28-4B21-B139-AD8F30E02C43
+:END:
+#+title: How do I format C++ sources with clang-format?
+#+description: Run the format or check-format CMake target to reformat or verify all C++ sources under projects/ against the canonical .clang-format style.
+#+type: recipe
+#+level: cross
+#+filetags: :cmake:cpp:formatting:clang-format:recipe:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+
+Style settings, rationale, and examples are in
+[[id:2BE1DCB1-6F10-4568-9945-E1AFA079FC7B][C++ code style: clang-format configuration]].
+
+* Question
+
+How do I reformat C++ source files, or check whether they are already
+correctly formatted?
+
+* Answer
+
+** Reformat in-place
+
+Runs =clang-format -i= on all =.cpp=, =.hpp=, and =.h= files under
+=projects/=. Use before opening a PR or after pulling a config change.
+
+#+begin_src sh :results verbatim
+cmake --build --preset linux-clang-debug-make --target format
+#+end_src
+
+** Check for drift (dry run)
+
+Reports files that differ from the canonical style and exits non-zero
+if any file would change. Does not modify files.
+
+#+begin_src sh :results verbatim
+cmake --build --preset linux-clang-debug-make --target check-format
+#+end_src
+
+** Run clang-format directly on one file
+
+Useful for inspecting what the formatter would do to a single file
+before committing to a full pass:
+
+#+begin_src sh :results verbatim
+clang-format --dry-run --Werror projects/ores.iam/api/include/ores.iam.api/domain/account.hpp
+#+end_src
+
+Replace =--dry-run --Werror= with =-i= to reformat in-place.
+
+* Script
+
+Both =format= and =check-format= are CMake custom targets defined in
+the top-level =CMakeLists.txt= inside the =if (CLANG_FORMAT_FOUND)=
+block. They use =find -exec {} += to collect files and pass them to
+=CLANG_FORMAT_BIN= (resolved by =FindClangTools.cmake=, which searches
+versions 20 down to 5.0). If clang-format is not installed, both
+targets are absent and CMake prints a warning at configure time.
+
+* Tested by
+
+The nightly [[https://github.com/OreStudio/OreStudio/actions/workflows/nightly-format.yml][nightly-format]] GitHub Actions workflow runs
+=clang-format-18= on Ubuntu 24.04 every night at 02:00 UTC and raises
+a PR if any file drifts. A clean nightly pass (no PR raised) confirms
+the tree is in sync.
+
+* See also
+
+- [[id:2BE1DCB1-6F10-4568-9945-E1AFA079FC7B][C++ code style: clang-format configuration]] — every setting with rationale and examples.
+- [[id:5720A0FB-E510-4F25-99CB-410D42062799][CMake recipes]] — full list of CMake targets.

--- a/projects/ores.lisp/src/ores-build-clang-format.el
+++ b/projects/ores.lisp/src/ores-build-clang-format.el
@@ -1,0 +1,64 @@
+;;; ores-build-clang-format.el --- -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026  Marco Craveiro
+
+;; Author: Marco Craveiro <marco.craveiro@gmail.com>
+;; Keywords: publish
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Tangles doc/knowledge/architecture/clang_format_config.org to .clang-format.
+;; All #+begin_src yaml blocks in the document are concatenated in order and
+;; written to .clang-format at the project root.
+
+;;; Code:
+(require 'org)
+(require 'ob-core)
+(require 'project)
+
+(setq debug-on-error nil)
+(setq debug-on-quit nil)
+
+(setq org-id-locations-file (expand-file-name "./.org-id-locations-file"))
+(setq package-user-dir (expand-file-name "./.packages"))
+
+;; Load the ORE Studio babel environment for ores/repo-root.
+(load-file (expand-file-name "projects/ores.lisp/src/ores-babel.el"))
+
+;; Resolve the project root.
+(defvar ores/--clang-format-root
+  (or (ores/repo-root)
+      (file-name-as-directory (expand-file-name ".")))
+  "Absolute path to the project root for this tangle run.")
+
+;; Inject the tangle target into org-babel's yaml defaults so the src blocks
+;; in clang_format_config.org need no explicit :tangle directive.
+(setq org-babel-default-header-args:yaml
+      `((:tangle . ,(expand-file-name ".clang-format"
+                                      ores/--clang-format-root))))
+
+(condition-case err
+    (progn
+      (org-babel-tangle-file
+       (expand-file-name "doc/knowledge/architecture/clang_format_config.org"
+                         ores/--clang-format-root))
+      (message "Tangled .clang-format to %s"
+               (expand-file-name ".clang-format" ores/--clang-format-root)))
+  (error
+   (message "clang-format tangle failed: %s" (error-message-string err))))
+
+(provide 'ores-build-clang-format)
+;;; ores-build-clang-format.el ends here


### PR DESCRIPTION
## Summary

- **`doc/knowledge/architecture/clang_format_config.org`** — literate source for `.clang-format`; every setting documented with rationale, before/after examples, usage instructions, and nightly CI workflow description. Scaffolded via `compass add knowledge`.
- **`projects/ores.lisp/src/ores-build-clang-format.el`** — Emacs tangle script mirroring `ores-build-settings.el`; called by the new `tangle_clang_format` CMake target.
- **`CMakeLists.txt`** — `tangle_clang_format` target added alongside the existing `deploy_*` targets.
- **`doc/recipes/cmake/how_do_i_format_cpp_sources.org`** — recipe covering `format`, `check-format`, and direct clang-format invocation on a single file.
- **`doc/developer.org`** — new *Code Style* section with links to the config doc and format recipe; nightly-format CI link added to the Build and Quality table.
- **`doc/knowledge/knowledge.org`** and **`doc/recipes/cmake/cmake.org`** — both updated to index the new documents.
- **`.clang-format`** — header updated to say "generated — do not edit directly"; `Standard: c++23` → `Latest` (valid in clang-format 21); local-first include ordering restored with self-sufficiency rationale in inline comments.

## To regenerate `.clang-format` from the org source

```sh
cmake --build --preset linux-clang-debug-make --target tangle_clang_format
```

## Test plan

- [ ] Site builds cleanly (org links resolve)
- [ ] `tangle_clang_format` runs without error (requires Emacs on PATH)
- [ ] Tangled `.clang-format` matches the committed file
- [ ] `developer.org` Code Style section renders correctly on the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)