### PR TITLE
[doc] UX Language: colour semantics, badge catalogue, entity window anatomy

### DIFF
--- a/doc/agile/versions/v0/sprint_19/badge-colour-semantics/story.org
+++ b/doc/agile/versions/v0/sprint_19/badge-colour-semantics/story.org
@@ -29,11 +29,11 @@ records these rules alongside icons and entity window anatomy.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | STARTED                              |
+| State         | DONE                                 |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | Implementation DONE and merged via PR #1044. |
+| Now           | Nothing.                               |
 | Waiting on    | Nothing.                               |
-| Next          | UX language documentation task.        |
+| Next          | Nothing — story closed.                |
 | Last touched  | 2026-06-04                               |
 
 * Acceptance
@@ -57,7 +57,7 @@ records these rules alongside icons and entity window anatomy.
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
 | [[id:2209A56A-3CBB-43E2-AD4A-188E8098AB81][Fix gray badge misuses; orange fallback; detail dialog badges]] | DONE | 2026-06-04 | 2026-06-04 | Recolour service/unlocked/done; orange fallback in all badge resolvers; BadgeLabelUtils; account detail dialog badges. PR #1044. |
-| [[id:81566322-DDC7-46D5-8A36-DEE1557DBF6D][Start the UX language documentation: colours, icons, entity window anatomy]] | BACKLOG | | | doc/knowledge/ui/ux_language.org: colour semantics, badge catalogue, icon link, entity window anatomy, links incl. Developer Links. |
+| [[id:81566322-DDC7-46D5-8A36-DEE1557DBF6D][Start the UX language documentation: colours, icons, entity window anatomy]] | DONE | 2026-06-04 | 2026-06-04 | doc/knowledge/ui/ux_language.org: colour semantics, badge catalogue, icon link, entity window anatomy, links incl. Developer Links. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/badge-colour-semantics/task_ux-language-doc.org
+++ b/doc/agile/versions/v0/sprint_19/badge-colour-semantics/task_ux-language-doc.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :ux:documentation:knowledge:badge-colour-semantics:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/ux-language-doc
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -22,7 +22,7 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 Start the project's UX language documentation: a single umbrella doc that
 states the visual-language rules (colours, icons, window anatomy) and links
 to the existing per-aspect documents. Today the icon inventory lives in
-[[id:2A167638-8B5A-4691-90CB-4A6B55785108][Icon Guidelines]] and badge mechanics in the badge-system design plan, but
+[[id:6EF42145-CEE7-4035-806A-A4200A3E003A][Icon Guidelines]] and badge mechanics in the badge-system design plan, but
 there is no place that documents the /language/: what colours mean, what a
 typical entity window looks like, and how the pieces relate.
 
@@ -40,7 +40,7 @@ typical entity window looks like, and how the pieces relate.
    - A catalogue table of all badge definitions with hex colours and
      semantics, mirroring =dq_badge_system_populate.sql= (note the populate
      script is the source of truth; the table documents intent).
-3. /Iconography section./ Link to [[id:2A167638-8B5A-4691-90CB-4A6B55785108][Icon Guidelines]] (which carries the icon
+3. /Iconography section./ Link to [[id:6EF42145-CEE7-4035-806A-A4200A3E003A][Icon Guidelines]] (which carries the icon
    inventory); summarise the semantic rules only.
 4. /Entity window anatomy section./ Using the existing screenshots
    (=tmp/= and =doc/assets/images/=), document the standard windows of a
@@ -68,11 +68,11 @@ typical entity window looks like, and how the pieces relate.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | DONE                                 |
 | Parent story | [[id:72E7A7D0-A268-410F-B137-942DC5F16934][Badge colour semantics: reserve gray for inactive states]] |
-| Now          | Not yet started.                       |
+| Now          | Nothing.                               |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing — task closed.                 |
 | Last touched | 2026-06-04                               |
 
 * Plan
@@ -96,3 +96,14 @@ task closes. Plans do not outlive their task.)
 |   |                 |      |          |       |
 
 * Result
+
+Created =doc/knowledge/ui/ux_language.org= ([[id:166B2D77-6D04-47D5-A651-5431E1F2E082][UX Language]]) with the four
+sections: colour semantics (the gray and orange rules plus a ten-colour
+vocabulary table), the badge colour catalogue (all 36 definitions, with
+the populate script noted as source of truth), iconography (linking the
+Icon Guidelines inventory), and entity window anatomy (MDI list window
+with toolbar/badges/paging, detail dialog with provenance and
+change-reason flow, history dialog — illustrated with four screenshots).
+Inbound links added from ui_design_principles, icon_guidelines, the
+badge system design plan (note box) and a new Design and UX section on
+the Developer Links page. Site build green locally.

--- a/doc/agile/versions/v0/sprint_19/badge-colour-semantics/task_ux-language-doc.org
+++ b/doc/agile/versions/v0/sprint_19/badge-colour-semantics/task_ux-language-doc.org
@@ -8,7 +8,7 @@
 #+filetags: :ux:documentation:knowledge:badge-colour-semantics:sprint_19:v0:
 #+owner: marco
 #+branch: feature/ux-language-doc
-#+pr:
+#+pr: https://github.com/OreStudio/OreStudio/pull/1051
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-04
@@ -87,7 +87,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1051][#1051]] | [doc] UX Language: colour semantics, badge catalogue, entity window anatomy |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/badge-colour-semantics/task_ux-language-doc.org
+++ b/doc/agile/versions/v0/sprint_19/badge-colour-semantics/task_ux-language-doc.org
@@ -93,7 +93,7 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1-4 | Image paths should be ../../ not ../../../ | ux_language.org | Declined | Images live in assets/images/ at repo root; doc/assets does not exist. Verified on disk + green site build. |
 
 * Result
 

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -77,7 +77,7 @@ while dogfooding the product.
 | [[id:61F836E5-2277-4765-9038-AF7D0176C993][Make UI more responsive]] | DONE | 2026-06-01 | 2026-06-01 | Fix waitForFinished() in destructors; add spinners; pre-populate combos; dedicated I/O thread pool. |
 | [[id:F8E2AB1E-344B-4B04-BD0B-6EC96CDA5298][PnL tracking improvements]] | DONE | 2026-06-03 | 2026-06-03 | Capture: FX locking, timeframe-scoped PnL, dual charts, two-phase sell P&L, FIFO/WAVG. See [[id:42F22269-B875-489D-A3D7-7FEC456C69EA][Lightyear knowledge doc]]. |
 | [[id:814D4E79-8EB9-4B2B-8A87-DB72F145044D][Account type badge in Qt]] | DONE | 2026-06-04 | 2026-06-04 | Wire account_type as DB-driven badge in AccountItemDelegate; SQL population; badge setup recipe. PR [[https://github.com/OreStudio/OreStudio/pull/1038][#1038]]. |
-| [[id:72E7A7D0-A268-410F-B137-942DC5F16934][Badge colour semantics]] | STARTED | 2026-06-04 | | Gray = inactive only; recolour service/unlocked/done; orange missing-definition fallback; detail dialog badges; UX language doc. |
+| [[id:72E7A7D0-A268-410F-B137-942DC5F16934][Badge colour semantics]] | DONE | 2026-06-04 | 2026-06-04 | Gray = inactive only; recolour service/unlocked/done; orange missing-definition fallback; detail dialog badges; UX language doc. PR [[https://github.com/OreStudio/OreStudio/pull/1044][#1044]]. |
 
 ** Tooling
 

--- a/doc/developer.org
+++ b/doc/developer.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :developer:
 #+created: 2026-05-25
-#+updated: 2026-05-25
+#+updated: 2026-06-04
 
 Quick-reference index of the external services and dashboards used in the ORE
 Studio developer workflow. Covers source hosting, API documentation, community
@@ -47,6 +47,14 @@ share onboarding links with a new contributor or LLM agent.
 |----------+------|
 | C++ clang-format config | [[id:2BE1DCB1-6F10-4568-9945-E1AFA079FC7B][C++ code style: clang-format configuration]] — literate source, all settings documented. |
 | Format recipe | [[id:4CEC17FA-CB28-4B21-B139-AD8F30E02C43][How do I format C++ sources with clang-format?]] |
+
+** Design and UX
+
+| Resource | Link |
+|----------+------|
+| UX Language | [[id:166B2D77-6D04-47D5-A651-5431E1F2E082][UX Language]] — colour semantics, badge catalogue, entity window anatomy. |
+| UI design principles | [[id:6743F6E3-578C-4E4B-9DD6-D5A0DF6734C8][UI design principles]] — typography, colour, spacing, motion. |
+| Icon guidelines | [[id:6EF42145-CEE7-4035-806A-A4200A3E003A][Icon guidelines]] — icon inventory and semantic usage. |
 
 ** Releases
 

--- a/doc/knowledge/ui/icon_guidelines.org
+++ b/doc/knowledge/ui/icon_guidelines.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :knowledge:ui:icons:design:
 #+created: 2026-05-21
-#+updated: 2026-05-21
+#+updated: 2026-06-04
 
 ORE Studio's icon catalogue lives here as a single visual-language
 reference. Pick an icon by its semantic category, then match the
@@ -908,3 +908,5 @@ Update this skill document:
 
 - [[id:2A167638-8B5A-4691-90CB-4A6B55785108][icon-guidelines skill]] — the task-shaped entry point.
 - [[id:6743F6E3-578C-4E4B-9DD6-D5A0DF6734C8][UI design principles]] — broader design language.
+- [[id:166B2D77-6D04-47D5-A651-5431E1F2E082][UX Language]] — the umbrella visual-language reference linking
+  icons, colour semantics and entity window anatomy.

--- a/doc/knowledge/ui/ui_design_principles.org
+++ b/doc/knowledge/ui/ui_design_principles.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :knowledge:ui:design:
 #+created: 2026-05-21
-#+updated: 2026-05-21
+#+updated: 2026-06-04
 
 The design system the ORE Studio UI is built against — Jony
 Ive-level precision with intentional personality. Use this to set
@@ -319,6 +319,8 @@ context-driven execution.
 * See also
 
 - [[id:89935F29-7C6C-1E84-EAD3-EC4BD20421F5][design-principles skill]] — the task-shaped entry point.
+- [[id:166B2D77-6D04-47D5-A651-5431E1F2E082][UX Language]] — the visual-language semantics: colour meanings,
+  badge catalogue, entity window anatomy.
 - [[id:6EF42145-CEE7-4035-806A-A4200A3E003A][Icon guidelines]] — the icon vocabulary.
 - [[id:E81C7FEA-33E4-400A-839A-9D1618BED211][Qt plugin architecture]] — where these principles meet the
   Qt-side technical contract.

--- a/doc/knowledge/ui/ux_language.org
+++ b/doc/knowledge/ui/ux_language.org
@@ -1,0 +1,190 @@
+:PROPERTIES:
+:ID: 166B2D77-6D04-47D5-A651-5431E1F2E082
+:END:
+#+title: UX Language
+#+description: The umbrella visual-language reference for ORE Studio: colour semantics (gray means inactive, orange means missing badge definition), the badge colour catalogue, iconography rules, and the anatomy of a typical entity's windows.
+#+type: knowledge
+#+level: cross
+#+filetags: :knowledge:ui:ux:design:badges:icons:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+#+startup: inlineimages
+
+* Summary
+
+ORE Studio's UI speaks one visual language across every window: colours
+carry fixed meanings (gray always reads "inactive", orange always reads
+"missing badge definition"), icons follow the semantic rules of the
+[[id:6EF42145-CEE7-4035-806A-A4200A3E003A][Icon Guidelines]], and every entity presents the same three windows — an
+MDI list window, a detail dialog, and a history dialog — with identical
+toolbars, badges and paging behaviour. This document is the umbrella
+reference for that language; the per-aspect documents it links to carry
+the inventories. The aesthetic rules (typography, spacing, motion) live
+in [[id:6743F6E3-578C-4E4B-9DD6-D5A0DF6734C8][UI design principles]]; this document covers /semantics/: what the
+visual vocabulary means.
+
+* Detail
+
+** Colour semantics
+
+Badge and indicator colours are drawn from the Tailwind palette and
+carry fixed, application-wide meanings. The two load-bearing rules:
+
+1. /Gray (=#6b7280=) is reserved for inactive states./ Gray exclusively
+   means inactive, off, "no", never-used, or otherwise negative/dormant:
+   =Inactive=, =Never= (logged in), =Draft=, =Raw= (unprocessed), the
+   "No" half of boolean badges, =Pending=/=Unsent= result states. No
+   positive, completed or neutral-active state may be gray — "Unlocked"
+   is green, "Done" is green, "Service" is teal.
+
+2. /Orange (=#f97316=) means "badge definition missing"./ When a badge
+   resolver finds no definition for a code-domain value (or the
+   definition carries an unparseable colour), the badge renders in
+   orange — =color_constants::badge_fallback=. Orange is never a
+   semantic state colour: an orange badge in the UI is a gap in the
+   badge seed data to be fixed, deliberately visible rather than
+   camouflaged as "inactive".
+
+The full colour vocabulary:
+
+| Colour | Hex       | Meaning                                            |
+|--------+-----------+----------------------------------------------------|
+| Green  | =#22c55e= | Positive/healthy: active, online, success, done, unlocked, actual |
+| Red    | =#ef4444= | Negative/destructive: locked, failed, fail policy, archived |
+| Amber  | =#eab308= | Caution: frozen, old login, no-reply, skip policy, suspended, estimated |
+| Blue   | =#3b82f6= | Informational/neutral: pending, recent, queue, primary origin, user account |
+| Sky    | =#0ea5e9= | In-progress/transitional: running, cleaned, bootstrapping |
+| Teal   | =#14b8a6= | Service account type                               |
+| Violet | =#7c3aed= / =#8b5cf6= / =#a855f7= | Classifications: virtual type, derived origin, enriched treatment, LLM account |
+| Pink   | =#ec4899= | Simulated nature                                   |
+| Gray   | =#6b7280= | *Inactive only*: inactive, never, draft, raw, "No" |
+| Orange | =#f97316= | *Missing badge definition* (fallback, never semantic) |
+
+*** Badge colour catalogue
+
+Badges are database-driven: severities, code domains, definitions and
+mappings live in the =dq= schema, seeded by
+=projects/ores.sql/populate/dq/dq_badge_system_populate.sql= — *the
+populate script is the source of truth*; this table documents intent.
+The mechanism (schema, BadgeCache, delegate resolution) is described in
+the [[id:7E4B1C93-2F8A-4D56-B3E7-9A0C5F812D6E][badge system design]].
+
+| Badge                  | Colour | Semantics                          |
+|------------------------+--------+------------------------------------|
+| =active=               | Green  | Record is active and operational   |
+| =inactive=             | Gray   | Record is inactive (rule 1)        |
+| =frozen=               | Amber  | No changes permitted               |
+| =pending=              | Blue   | Awaiting processing or approval    |
+| =type_virtual=         | Violet | Virtual construct                  |
+| =type_physical=        | Blue   | Physical construct                 |
+| =login_online=         | Green  | User currently logged in           |
+| =login_recent=         | Blue   | Logged in recently                 |
+| =login_old=            | Amber  | Not logged in for a long time      |
+| =login_never=          | Gray   | Never logged in (rule 1)           |
+| =account_locked=       | Red    | Account locked                     |
+| =account_unlocked=     | Green  | Account accessible (positive)      |
+| =account_type_user=    | Blue   | Human user account                 |
+| =account_type_service= | Teal   | Service account                    |
+| =account_type_algorithm= | Amber | Algorithm account                 |
+| =account_type_llm=     | Violet | LLM agent account                  |
+| =outcome_success=      | Green  | Task completed successfully        |
+| =outcome_failed=       | Red    | Task failed                        |
+| =outcome_no_reply=     | Amber  | No reply from worker               |
+| =state_running=        | Sky    | Task executing                     |
+| =state_done=           | Green  | Task completed (positive)          |
+| =policy_skip=          | Amber  | Skip overlapping executions        |
+| =policy_queue=         | Blue   | Queue overlapping executions       |
+| =policy_fail=          | Red    | Fail on overlapping executions     |
+| =fsm_draft=            | Gray   | Draft, not yet active (rule 1)     |
+| =fsm_suspended=        | Amber  | Suspended                          |
+| =archived=             | Red    | Archived, no longer active         |
+| =origin_primary=       | Blue   | Primary data source                |
+| =origin_derived=       | Violet | Derived from another source        |
+| =nature_actual=        | Green  | Real-world data                    |
+| =nature_estimated=     | Amber  | Estimated data                     |
+| =nature_simulated=     | Pink   | Simulated data                     |
+| =treatment_raw=        | Gray   | Unprocessed (rule 1)               |
+| =treatment_cleaned=    | Sky    | Cleaned                            |
+| =treatment_enriched=   | Violet | Enriched                           |
+| =tenant_bootstrapping= | Sky    | Awaiting provisioning wizard       |
+
+Badges render through two code paths, both resolving via =BadgeCache=:
+=DelegatePaintUtils::draw_centered_badge= in table delegates, and
+=BadgeLabelUtils::apply= for labels in detail dialogs. Both fall back
+to orange per rule 2.
+
+** Iconography
+
+The icon vocabulary — inventory, variants, sizes and semantic usage
+rules — lives in the [[id:6EF42145-CEE7-4035-806A-A4200A3E003A][Icon Guidelines]]. The semantic core: each action
+has exactly one icon application-wide (Reload, Add, Edit, Delete,
+History never vary between windows), entity types carry their own
+identifying icon in window titles and menus, and icon colour follows
+the same rules as badges — the standard toolbar tint is
+=color_constants::icon_color=, with gray reserved for disabled actions.
+
+** Entity window anatomy
+
+Every persisted entity presents the same three windows, so a user who
+has learned one entity has learned them all. The screenshots below use
+currencies and accounts; the anatomy is identical for any entity.
+
+*** MDI list window
+
+[[../../../assets/images/currencies_main_window.png]]
+
+The list window is an MDI child inside the main window:
+
+- /Toolbar/ — =Reload=, =Add=, =Edit=, =Delete=, =History= in fixed
+  order with fixed icons. Actions that need a selection (=Edit=,
+  =Delete=, =History=) are disabled — grayed, per the colour rule —
+  until a row is selected.
+- /Table/ — one row per latest record version. Status-like columns
+  render as badges (see the colour catalogue); =Version= is monospace;
+  =Recorded At= shows relative time ("4 minutes ago").
+- /Footer/ — "Showing all records (N)" plus the pagination controls:
+  =First= / =Previous= / =Next= / =Last=, a =Load All= action, and a
+  page-size combo (25/50/100/200/500, default 100). Windows whose
+  record count fits one page show the controls disabled.
+- /Eventing/ — changes made in another session arrive via NATS and
+  refresh the view without manual reload; the reload button carries a
+  stale indicator when unseen changes are pending.
+
+*** Detail dialog
+
+[[../../../assets/images/account_details.png]]
+
+Opened by =Add= or =Edit= (or double-click). One dialog serves create,
+edit and read-only historical modes:
+
+- /Form/ — the entity's editable fields; combo boxes are populated
+  from reference data and show a loading state while fetching.
+- /Tabs/ — related aspects beyond the core form (e.g. an account's
+  Parties and Roles tabs); read-only status groups render values as
+  badges via =BadgeLabelUtils= (e.g. Online/Locked).
+- /Provenance/ — who changed the record, when, and why (version,
+  modified by, performed by, change reason, commentary).
+
+[[../../../assets/images/account_details_provenance.png]]
+
+- /Change reason flow/ — saving a modification prompts for a change
+  reason (category-filtered) and optional commentary, which feed the
+  provenance of the new version.
+
+*** History dialog
+
+[[../../../assets/images/currency_history_dialog.png]]
+
+Opened by =History= on a selected row. Shows every version of the
+record, newest first, with the same badge and provenance vocabulary as
+the detail dialog. Selecting a version opens it read-only in the
+detail dialog. Deleting a record preserves its history.
+
+* See also
+
+- [[id:6743F6E3-578C-4E4B-9DD6-D5A0DF6734C8][UI design principles]] — the aesthetic rules: typography, colour
+  values, spacing, motion.
+- [[id:6EF42145-CEE7-4035-806A-A4200A3E003A][Icon Guidelines]] — the icon inventory and semantic usage rules.
+- [[id:7E4B1C93-2F8A-4D56-B3E7-9A0C5F812D6E][Database-Driven Badge System Design]] — the badge mechanism: schema,
+  caching, delegate resolution.
+- [[id:5B271351-399A-4BD7-A096-E5DF1EDAD8F5][Developer Links]] — developer-facing index, including this document.

--- a/doc/llm/skills/claude_code_skills.org
+++ b/doc/llm/skills/claude_code_skills.org
@@ -7,13 +7,23 @@
 #+level: cross
 #+filetags: :skills:claude_code:catalogue:index:knowledge:
 #+created: 2024-06-15
-#+updated: 2026-05-21
+#+updated: 2026-06-04
 
 Every Claude Code [[id:4F6384FE-CDE9-40F6-B13D-8A84B6CD77F7][skill]] used with ORE Studio lives at
 =doc/llm/skills/<slug>/SKILL.org= and is listed below, grouped by area. Skills are
 /task-shaped/: each one is the playbook an LLM session loads to perform a
 specific unit of work end-to-end. Compare with [[id:66F2A9E8-0385-4D56-B4B1-0957208990DC][function]], which is /role-shaped/.
 See [[id:654D4A70-E63D-4C18-B5A5-886066E36314][CMake Runner]] for the deployment workflow or return to [[id:7474935C-95D1-3034-B833-83DCD9FB3A09][Knowledge]].
+
+#+begin_note
+*Skill naming.* Skill slugs use kebab-case (dashes, not underscores):
+=run-runbook=, =cmake-runner=, =skill-manager=. The slug is both the
+directory name under =doc/llm/skills/= and the =name:= field in the
+skill's frontmatter — keep them identical. Note that deployment
+(=deploy_skills=) does not remove stale directories from
+=.claude/skills/=, so after renaming a skill delete the old deployed
+directory by hand.
+#+end_note
 
 * Meta-skills
 

--- a/doc/plans/2026-03-28-badge-system-design.org
+++ b/doc/plans/2026-03-28-badge-system-design.org
@@ -8,6 +8,12 @@
 
 * Overview
 
+#+begin_note
+The colour semantics that badge definitions must follow — gray reserved
+for inactive/negative states, orange as the missing-definition fallback
+— along with the full badge colour catalogue live in [[id:166B2D77-6D04-47D5-A651-5431E1F2E082][UX Language]].
+#+end_note
+
 Badge rendering in ORE Studio is currently fully hardcoded in C++. Colours live
 in =ColorConstants.hpp=, resolver functions live in =BadgeColors.hpp=, and some
 delegates (e.g. =AccountItemDelegate=) hardcode colours inline. There is no


### PR DESCRIPTION
## Summary

Creates `doc/knowledge/ui/ux_language.org` — the umbrella visual-language reference for ORE Studio — completing the badge colour semantics story. Where `ui_design_principles` covers aesthetics and `icon_guidelines` the icon inventory, UX Language covers *semantics*: what the visual vocabulary means, application-wide.

## Changes

- **New knowledge doc** `doc/knowledge/ui/ux_language.org` with four sections:
  - *Colour semantics* — the two load-bearing rules (gray exclusively means inactive/off/no/negative; orange exclusively means "badge definition missing") plus a ten-colour vocabulary table.
  - *Badge colour catalogue* — all 36 badge definitions with colours and semantics; `dq_badge_system_populate.sql` noted as source of truth.
  - *Iconography* — links the Icon Guidelines inventory; summarises the semantic rules.
  - *Entity window anatomy* — the three standard windows (MDI list with toolbar/badge columns/paging footer, detail dialog with tabs/provenance/change-reason flow, history dialog), illustrated with four screenshots.
- **Inbound links**: `ui_design_principles` and `icon_guidelines` See-also sections, a note box in the badge system design plan, and a new *Design and UX* section on the Developer Links page.
- **Task link fix**: the task's Icon Guidelines references pointed at the skill instead of the knowledge doc.
- **Agile**: documentation task DONE; badge colour semantics story DONE (both tasks complete); sprint table updated.

## Notes / Decisions

- Site build verified green locally before pushing (all id links resolve).

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Badge colour semantics: reserve gray for inactive states](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/badge-colour-semantics/story.html) | 72E7A7D0-A268-410F-B137-942DC5F16934 |
| Task | [Start the UX language documentation](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/badge-colour-semantics/task_ux-language-doc.html) | 81566322-DDC7-46D5-8A36-DEE1557DBF6D |

🤖 Generated with [Claude Code](https://claude.com/claude-code)