### PR TITLE
[dq,iam,qt,http,ore] Move change reason constants to ores.dq.api

### DIFF
--- a/doc/agile/product_backlog/inbox/add_compass_task_finish.org
+++ b/doc/agile/product_backlog/inbox/add_compass_task_finish.org
@@ -1,0 +1,28 @@
+:PROPERTIES:
+:ID: 7026F0C0-313B-4290-AD3E-9AED71FA46E6
+:END:
+#+title: Add compass task finish to clock off a task
+#+description: compass task start clocks on (branch, STARTED, journal) but there is no symmetric task finish: flip the task to DONE, stamp the End date in the story Tasks table, update Status rows, and append the clock-off to the journal. Closing a task is currently manual and error-prone.
+#+type: capture
+#+level: cross
+#+filetags: :compass:agile:journal:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+(One paragraph: the idea.)
+
+* Why
+
+(Motivation, problem being solved, related context.)
+
+* References
+
+-
+
+* See also
+
+-

--- a/doc/agile/versions/v0/sprint_19/investigate_api_core_split/story.org
+++ b/doc/agile/versions/v0/sprint_19/investigate_api_core_split/story.org
@@ -45,9 +45,9 @@ stories will extend the cleanup to all of them.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | Constants move implemented; full build verifying. |
+| Now           | Constants move in PR #1052; eventing split task filed. |
 | Waiting on    | Nothing.                               |
-| Next          | Land the constants-move PR; close the story. |
+| Next          | Land PR #1052, then the eventing api/core split. |
 | Last touched  | 2026-06-04                               |
 
 * Acceptance
@@ -70,6 +70,7 @@ stories will extend the cleanup to all of them.
 |------+-------+-------+-----+-------------|
 | [[id:681BBF6B-4DD8-411A-9B19-76AA5E14C1FC][Inventory api/core contents across split components]] | DONE | 2026-06-04 | 2026-06-04 | Catalogue api vs core contents + link deps for all 17 split components, DQ first; flag heavy apis; investigation report. PRs #1045, #1048 merged. |
 | [[id:9409F936-C45C-4BF8-9507-D796907D1E45][Move change reason constants from ores.database to ores.dq.api]] | STARTED | 2026-06-04 | | Constants are DQ-domain; ores.database has zero internal uses. Cycle-safe now dq.api is light. No aliases; fix all consumers. |
+| [[id:9800051F-8F04-4F2E-A143-4BFE2617816D][Split ores.eventing into api and core sub-components]] | BACKLOG | | | eventing links database PUBLIC and every api links eventing — the remaining transitive leak. api = domain + bus/registry; core = postgres_event_source. 18 consumers repointed. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/investigate_api_core_split/story.org
+++ b/doc/agile/versions/v0/sprint_19/investigate_api_core_split/story.org
@@ -45,9 +45,9 @@ stories will extend the cleanup to all of them.
 |---------------+----------------------------------------|
 | State         | STARTED                              |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | Inventory complete; DQ fix implemented, full build verifying. |
+| Now           | Constants move implemented; full build verifying. |
 | Waiting on    | Nothing.                               |
-| Next          | Land the DQ fix PR; then the constants-move follow-up task. |
+| Next          | Land the constants-move PR; close the story. |
 | Last touched  | 2026-06-04                               |
 
 * Acceptance
@@ -68,8 +68,8 @@ stories will extend the cleanup to all of them.
 
 | Task | State | Start | End | Description |
 |------+-------+-------+-----+-------------|
-| [[id:681BBF6B-4DD8-411A-9B19-76AA5E14C1FC][Inventory api/core contents across split components]] | STARTED | 2026-06-04 | | Catalogue api vs core contents + link deps for all 17 split components, DQ first; flag heavy apis; investigation report. |
-| [[id:9409F936-C45C-4BF8-9507-D796907D1E45][Move change reason constants from ores.database to ores.dq.api]] | BACKLOG | | | Constants are DQ-domain; ores.database has zero internal uses. Cycle-safe now dq.api is light. No aliases; fix all consumers. |
+| [[id:681BBF6B-4DD8-411A-9B19-76AA5E14C1FC][Inventory api/core contents across split components]] | DONE | 2026-06-04 | 2026-06-04 | Catalogue api vs core contents + link deps for all 17 split components, DQ first; flag heavy apis; investigation report. PRs #1045, #1048 merged. |
+| [[id:9409F936-C45C-4BF8-9507-D796907D1E45][Move change reason constants from ores.database to ores.dq.api]] | STARTED | 2026-06-04 | | Constants are DQ-domain; ores.database has zero internal uses. Cycle-safe now dq.api is light. No aliases; fix all consumers. |
 
 * Decisions
 

--- a/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_inventory_api_core_contents.org
+++ b/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_inventory_api_core_contents.org
@@ -41,11 +41,11 @@ decision:
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:BD519FC9-6B29-4055-877F-861E46043A06][Investigate the API/core split in components]] |
-| Now          | Inventory done; DQ fix implemented; full build verifying. |
+| Now          | Complete: PRs #1045 and #1048 merged.  |
 | Waiting on   | Nothing.                               |
-| Next         | Verify build, commit, update PR #1045. |
+| Next         | Nothing — see the constants-move follow-up task. |
 | Last touched | 2026-06-04                               |
 
 * Acceptance

--- a/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_move_change_reason_constants_to_dq.org
+++ b/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_move_change_reason_constants_to_dq.org
@@ -74,6 +74,6 @@ task closes. Plans do not outlive their task.)
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | qt.api must link ores.dq.api.lib PUBLIC after dropping database | projects/ores.qt/api/src/CMakeLists.txt | Declined | Already linked PUBLIC in the same list since before the PR; premise false. |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_move_change_reason_constants_to_dq.org
+++ b/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_move_change_reason_constants_to_dq.org
@@ -68,7 +68,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1052][#1052]] | [dq,iam,qt,http,ore] Move change reason constants to ores.dq.api |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_move_change_reason_constants_to_dq.org
+++ b/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_move_change_reason_constants_to_dq.org
@@ -7,7 +7,7 @@
 #+level: s1
 #+filetags: :architecture:components:cpp:dq:investigate_api_core_split:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/move-change-reason-constants-to-dq
 #+pr:
 #+blocked_on:
 #+blocked_since:
@@ -34,6 +34,17 @@ header, fix every consumer, delete the =ores.database= copy.
 Deliberately deferred from the inventory task as a post-cleanup
 change — the precondition (light dq.api) had to land and be verified
 first.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:BD519FC9-6B29-4055-877F-861E46043A06][Investigate the API/core split in components]] |
+| Now          | Header moved, all 10 consumers fixed, links updated; full build verifying. |
+| Waiting on   | Nothing.                               |
+| Next         | Commit, push, raise PR.                |
+| Last touched | 2026-06-04                               |
 
 * Acceptance
 

--- a/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_split_eventing_into_api_core.org
+++ b/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_split_eventing_into_api_core.org
@@ -1,0 +1,92 @@
+:PROPERTIES:
+:ID: 9800051F-8F04-4F2E-A143-4BFE2617816D
+:END:
+#+title: Task: Split ores.eventing into api and core sub-components
+#+description: ores.eventing links ores.database.lib PUBLIC and is itself linked PUBLIC by almost every api, so the database layer leaks transitively into all 'light' apis. Split it: ores.eventing.api keeps the domain event types (and generators) that apis need; ores.eventing.core takes the service machinery with the database and telemetry dependencies. Update all 18 consumers.
+#+type: task
+#+level: s1
+#+filetags: :architecture:components:cpp:eventing:investigate_api_core_split:sprint_19:v0:
+#+owner: marco
+#+branch:
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-04
+#+updated: 2026-06-04
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:BD519FC9-6B29-4055-877F-861E46043A06][Investigate the API/core split in components]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+=ores.eventing= links =ores.database.lib= PUBLIC and is itself linked
+PUBLIC by almost every api in the standard profile — so the database
+layer still leaks transitively into every "light" api, undoing what
+the dq.api cleanup achieved directly. The leak comes from exactly one
+header: =service/postgres_event_source.hpp=. Its consumers are all
+service-layer applications (http, compute, reporting, analytics,
+trading, workspace, refdata, ...) — precisely the layer where
+database dependencies belong.
+
+Split the component following the established api/core pattern:
+
+- =ores.eventing.api= — =domain= (entity change events, channel
+  info, event traits), =generators=, and the interface-level
+  =event_bus= / =event_channel_registry=. Links platform/utility
+  only.
+- =ores.eventing.core= — =postgres_event_source= (and registrar),
+  carrying the =ores.database= and telemetry dependencies.
+
+Mechanical but wide: 18 CMakeLists link =ores.eventing.lib= today;
+each repoints to =.api= or =.core= according to what it actually
+uses. This completes what the dq.api fix started: apis linking
+=eventing.api= become genuinely lightweight.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | BACKLOG                              |
+| Parent story | [[id:BD519FC9-6B29-4055-877F-861E46043A06][Investigate the API/core split in components]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Pick up after the constants move (PR #1052) lands. |
+| Last touched | 2026-06-04                               |
+
+* Acceptance
+
+- =ores.eventing= has api/core sub-components in the standard layout
+  (=api/include/ores.eventing.api/=, =core/...=), with the group
+  parent owning the root CMakeLists.
+- =ores.eventing.api= links only platform/utility (plus the rfl pch);
+  no database, no telemetry.
+- =postgres_event_source= and the registrar live in
+  =ores.eventing.core= with the database/telemetry links.
+- All 18 consumers repointed to =.api= or =.core= per actual usage;
+  no component links =.core= unless it uses the postgres source.
+- Domain-component apis that link =eventing.api= carry no transitive
+  =ores.database= in their public interface (spot-check dq.api,
+  trading.api).
+- Full build and tests green.
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -1483,6 +1483,7 @@ _STATIC_PARENT = {
     "skill": "doc/llm/skills",
     "manual": "doc/manual/user_guide",
     "memory": "doc/llm/memory",
+    "capture": "doc/agile/product_backlog/inbox",
 }
 
 def _default_parent_dir(doc_type):
@@ -1723,8 +1724,9 @@ def cmd_add(argv):
               "         diagram entity_org dataset_overview\n"
               "  --parent-dir defaults to the current sprint (story) or\n"
               "  version (sprint), doc/llm/skills (skill),\n"
-              "  doc/manual/user_guide (manual), or doc/llm/memory (memory);\n"
-              "  required otherwise.\n"
+              "  doc/manual/user_guide (manual), doc/llm/memory (memory),\n"
+              "  or doc/agile/product_backlog/inbox (capture); required\n"
+              "  otherwise.\n"
               "  diagram: scaffolds a .puml file with the standard licence header.\n"
               "  entity_org: scaffolds projects/ores.<component>/modeling/\n"
               "    ores.<component>.<slug>.org; requires --component, --slug,\n"

--- a/projects/ores.dq/api/include/ores.dq.api/domain/change_reason_constants.hpp
+++ b/projects/ores.dq/api/include/ores.dq.api/domain/change_reason_constants.hpp
@@ -18,19 +18,19 @@
  *
  */
 
-#ifndef ORES_DATABASE_DOMAIN_CHANGE_REASON_CONSTANTS_HPP
-#define ORES_DATABASE_DOMAIN_CHANGE_REASON_CONSTANTS_HPP
+#ifndef ORES_DQ_API_DOMAIN_CHANGE_REASON_CONSTANTS_HPP
+#define ORES_DQ_API_DOMAIN_CHANGE_REASON_CONSTANTS_HPP
 
 #include <string_view>
 
-namespace ores::database::domain::change_reason_constants {
+namespace ores::dq::domain::change_reason_constants {
 
 /**
  * @brief Change reason codes used throughout the system.
  *
  * These codes must match entries in the change_reasons database table.
- * Placed in ores.database as they define database field values used
- * across multiple domain components (IAM, DQ, etc.).
+ * They live in ores.dq.api — change reasons are a data quality domain
+ * concept — and are consumed across components (IAM, refdata, etc.).
  */
 namespace codes {
 
@@ -79,6 +79,6 @@ constexpr std::string_view system = "system";
 
 } // namespace categories
 
-} // namespace ores::database::domain::change_reason_constants
+} // namespace ores::dq::domain::change_reason_constants
 
 #endif

--- a/projects/ores.http/core/src/CMakeLists.txt
+++ b/projects/ores.http/core/src/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(${lib_target_name}
     PRIVATE
         ores.utility.lib
         ores.security.lib
-        ores.database.lib)
+        ores.database.lib
+        ores.dq.api.lib)
 
 install(TARGETS ${lib_target_name} LIBRARY DESTINATION lib)

--- a/projects/ores.http/core/src/routes/iam_routes.cpp
+++ b/projects/ores.http/core/src/routes/iam_routes.cpp
@@ -25,7 +25,7 @@
 #include "ores.security/jwt/jwt_claims.hpp"
 #include "ores.utility/rfl/reflectors.hpp" // IWYU pragma: keep.
 #include "ores.iam.api/domain/account_json.hpp"
-#include "ores.database/domain/change_reason_constants.hpp"
+#include "ores.dq.api/domain/change_reason_constants.hpp"
 #include "ores.iam.api/domain/role_json.hpp"
 #include "ores.iam.api/domain/permission_json.hpp"
 #include "ores.iam.api/domain/permission.hpp"
@@ -81,7 +81,7 @@ parsed_principal parse_principal(const std::string& principal) {
 }
 
 }  // anonymous namespace
-namespace reason = database::domain::change_reason_constants;
+namespace reason = ores::dq::domain::change_reason_constants;
 
 iam_routes::iam_routes(database::context ctx,
     std::shared_ptr<variability::service::system_settings_service> system_flags,

--- a/projects/ores.iam/core/include/ores.iam.core/messaging/tenant_handler.hpp
+++ b/projects/ores.iam/core/include/ores.iam.core/messaging/tenant_handler.hpp
@@ -35,7 +35,7 @@
 #include "ores.service/service/request_context.hpp"
 #include "ores.iam.api/messaging/tenant_protocol.hpp"
 #include "ores.iam.core/repository/tenant_repository.hpp"
-#include "ores.database/domain/change_reason_constants.hpp"
+#include "ores.dq.api/domain/change_reason_constants.hpp"
 #include "ores.variability.core/service/system_settings_service.hpp"
 
 namespace ores::iam::messaging {
@@ -213,7 +213,7 @@ public:
                 variability::service::system_settings_service vss(
                     *ctx_expected, ids.front());
                 vss.set_bootstrap_mode(false, ctx_expected->service_account(),
-                    std::string(database::domain::change_reason_constants::codes::new_record),
+                    std::string(ores::dq::domain::change_reason_constants::codes::new_record),
                     "Bootstrap mode cleared on tenant activation");
                 BOOST_LOG_SEV(tenant_handler_lg(), info)
                     << "Bootstrap mode cleared for tenant: " << ids.front();

--- a/projects/ores.iam/core/src/CMakeLists.txt
+++ b/projects/ores.iam/core/src/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${lib_target_name}
         ores.iam.api.lib
         ores.variability.core.lib
         ores.database.lib
+        ores.dq.api.lib
         ores.eventing.lib
         ores.geo.lib
         ores.platform.lib

--- a/projects/ores.iam/core/src/service/account_service.cpp
+++ b/projects/ores.iam/core/src/service/account_service.cpp
@@ -22,7 +22,7 @@
 #include <stdexcept>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/uuid_generators.hpp>
-#include "ores.database/domain/change_reason_constants.hpp"
+#include "ores.dq.api/domain/change_reason_constants.hpp"
 #include "ores.security/crypto/password_hasher.hpp"
 #include "ores.security/validation/password_validator.hpp"
 #include "ores.security/validation/email_validator.hpp"
@@ -30,7 +30,7 @@
 namespace ores::iam::service {
 
 using namespace ores::logging;
-namespace reason = database::domain::change_reason_constants;
+namespace reason = ores::dq::domain::change_reason_constants;
 namespace crypto = ores::security::crypto;
 namespace validation = ores::security::validation;
 

--- a/projects/ores.iam/core/src/service/authorization_service.cpp
+++ b/projects/ores.iam/core/src/service/authorization_service.cpp
@@ -23,7 +23,7 @@
 #include <stdexcept>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/lexical_cast.hpp>
-#include "ores.database/domain/change_reason_constants.hpp"
+#include "ores.dq.api/domain/change_reason_constants.hpp"
 #include "ores.iam.api/domain/permission.hpp"
 #include "ores.iam.api/eventing/role_assigned_event.hpp"
 #include "ores.iam.api/eventing/role_revoked_event.hpp"
@@ -32,7 +32,7 @@
 namespace ores::iam::service {
 
 using namespace ores::logging;
-namespace reason = database::domain::change_reason_constants;
+namespace reason = ores::dq::domain::change_reason_constants;
 
 authorization_service::authorization_service(context ctx, event_bus* event_bus)
     : permission_repo_(ctx),

--- a/projects/ores.iam/core/src/service/bootstrap_mode_service.cpp
+++ b/projects/ores.iam/core/src/service/bootstrap_mode_service.cpp
@@ -21,12 +21,12 @@
 #include "ores.iam.core/service/bootstrap_mode_service.hpp"
 
 #include <algorithm>
-#include "ores.database/domain/change_reason_constants.hpp"
+#include "ores.dq.api/domain/change_reason_constants.hpp"
 
 namespace ores::iam::service {
 
 using namespace ores::logging;
-namespace reason = database::domain::change_reason_constants;
+namespace reason = ores::dq::domain::change_reason_constants;
 
 bootstrap_mode_service::bootstrap_mode_service(database::context ctx,
     std::string tenant_id,

--- a/projects/ores.ore/core/src/CMakeLists.txt
+++ b/projects/ores.ore/core/src/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(${lib_target_name}
         ores.refdata.api.lib
         ores.trading.api.lib
     PRIVATE
+        ores.dq.api.lib
         ores.logging.lib
         ores.platform.lib
         ores.utility.lib

--- a/projects/ores.ore/core/src/planner/ore_import_planner.cpp
+++ b/projects/ores.ore/core/src/planner/ore_import_planner.cpp
@@ -24,13 +24,13 @@
 #include <unordered_set>
 #include "ores.ore.core/xml/importer.hpp"
 #include "ores.ore.core/hierarchy/ore_hierarchy_builder.hpp"
-#include "ores.database/domain/change_reason_constants.hpp"
+#include "ores.dq.api/domain/change_reason_constants.hpp"
 #include "ores.trading.api/domain/trade_instrument.hpp"
 
 namespace ores::ore::planner {
 
 using namespace ores::logging;
-namespace reason = ores::database::domain::change_reason_constants;
+namespace reason = ores::dq::domain::change_reason_constants;
 
 ore_import_planner::ore_import_planner(
     scanner::scan_result scan_result,

--- a/projects/ores.qt/api/src/CMakeLists.txt
+++ b/projects/ores.qt/api/src/CMakeLists.txt
@@ -68,7 +68,6 @@ target_link_libraries(${lib_target_name}
         ores.assets.api.lib
         ores.trading.api.lib
         ores.workspace.api.lib
-        ores.database.lib
         ores.logging.lib
         ores.utility.lib
         ores.platform.lib

--- a/projects/ores.qt/api/src/ChangeReasonDialog.cpp
+++ b/projects/ores.qt/api/src/ChangeReasonDialog.cpp
@@ -25,11 +25,11 @@
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QStandardItemModel>
-#include "ores.database/domain/change_reason_constants.hpp"
+#include "ores.dq.api/domain/change_reason_constants.hpp"
 
 namespace ores::qt {
 
-namespace reason = ores::database::domain::change_reason_constants;
+namespace reason = ores::dq::domain::change_reason_constants;
 
 ChangeReasonDialog::ChangeReasonDialog(
     const std::vector<dq::domain::change_reason>& reasons,

--- a/projects/ores.qt/application/src/PartyProvisioningWizard.cpp
+++ b/projects/ores.qt/application/src/PartyProvisioningWizard.cpp
@@ -33,7 +33,7 @@
 #include <QFutureWatcher>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
-#include "ores.database/domain/change_reason_constants.hpp"
+#include "ores.dq.api/domain/change_reason_constants.hpp"
 #include "ores.dq.api/messaging/publish_bundle_protocol.hpp"
 #include "ores.refdata.api/messaging/party_protocol.hpp"
 #include "ores.dq.api/messaging/report_definition_template_protocol.hpp"
@@ -43,7 +43,7 @@
 namespace ores::qt {
 
 using namespace ores::logging;
-namespace reason = ores::database::domain::change_reason_constants;
+namespace reason = ores::dq::domain::change_reason_constants;
 
 // ============================================================================
 // PartyProvisioningWizard

--- a/projects/ores.qt/application/src/TenantProvisioningWizard.cpp
+++ b/projects/ores.qt/application/src/TenantProvisioningWizard.cpp
@@ -35,7 +35,7 @@
 #include <QVBoxLayout>
 #include <QtConcurrent>
 #include <QFutureWatcher>
-#include "ores.database/domain/change_reason_constants.hpp"
+#include "ores.dq.api/domain/change_reason_constants.hpp"
 #include "ores.dq.api/messaging/publish_bundle_protocol.hpp"
 #include "ores.iam.api/domain/account_party.hpp"
 #include "ores.iam.api/messaging/account_party_protocol.hpp"
@@ -48,7 +48,7 @@
 namespace ores::qt {
 
 using namespace ores::logging;
-namespace reason = ores::database::domain::change_reason_constants;
+namespace reason = ores::dq::domain::change_reason_constants;
 
 // ============================================================================
 // TenantProvisioningWizard

--- a/projects/ores.qt/trading/src/CMakeLists.txt
+++ b/projects/ores.qt/trading/src/CMakeLists.txt
@@ -68,6 +68,7 @@ target_link_libraries(${lib_target_name}
         ores.marketdata.api.lib
         ores.storage.lib
     PRIVATE
+        ores.dq.api.lib
         # Transient: many dialogs/controllers still live in ores.qt. Remove when files move.
         ores.qt.lib
         ores.qt.workflow.lib)

--- a/projects/ores.qt/trading/src/OreImporter.cpp
+++ b/projects/ores.qt/trading/src/OreImporter.cpp
@@ -29,7 +29,7 @@
 #include "ores.refdata.api/messaging/book_protocol.hpp"
 #include "ores.trading.api/messaging/trade_protocol.hpp"
 #include "ores.trading.api/messaging/instrument_protocol.hpp"
-#include "ores.database/domain/change_reason_constants.hpp"
+#include "ores.dq.api/domain/change_reason_constants.hpp"
 
 namespace ores::qt {
 
@@ -336,7 +336,7 @@ ore_import_result OreImporter::execute(
             << num_batches << " batch(es) of up to " << trade_batch_size << " each";
         for (int offset = 0; offset < total_trades; offset += trade_batch_size) {
             const int end = std::min(offset + trade_batch_size, total_trades);
-            namespace reason = ores::database::domain::change_reason_constants;
+            namespace reason = ores::dq::domain::change_reason_constants;
             std::vector<trading::domain::trade> batch;
             batch.reserve(static_cast<std::size_t>(end - offset));
             for (int i = offset; i < end; ++i) {


### PR DESCRIPTION
## Summary

Completes the api/core split story: returns the change reason
constants to their semantic home. They are a data-quality domain
concept (the `change_reason` entity lives in `dq.api/domain`) but were
parked in `ores.database` to break a historical dq↔iam circular
dependency — and `ores.database` itself never uses them. With
`dq.api` now light (#1048), the move back is cycle-safe:
`iam.core → dq.api` cannot loop. Per project direction there are no
compatibility aliases; every consumer is fixed properly. Full
linux-clang-debug build green.

## Changes

- **Header moved**: `ores.database/domain/change_reason_constants.hpp`
  → `ores.dq.api/domain/change_reason_constants.hpp`; namespace
  `ores::dq::domain::change_reason_constants`; guard and doc comment
  updated.
- **Ten consumers updated** to the new include and fully-qualified
  namespace: http `iam_routes`, iam `tenant_handler.hpp` +
  account/authorization/bootstrap services, ore import planner, qt
  ChangeReasonDialog / provisioning wizards / OreImporter.
- **Links**: `ores.dq.api.lib` added to `iam.core` (PUBLIC — public
  header use), `http.core`, `ore.core`, `qt.trading` (PRIVATE);
  `ores.database.lib` dropped from `qt.api` (constants were its only
  database use).
- **Compass**: `add capture` now defaults `--parent-dir` to the
  product backlog inbox (same `_STATIC_PARENT` mechanism as memory).
- **Backlog**: capture filed — add `compass task finish` to clock off
  tasks (symmetric to `task start`).
- **Agile**: inventory task closed DONE (#1045, #1048 merged);
  constants-move task STARTED.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Investigate the API/core split in components](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/investigate_api_core_split/story.html) | BD519FC9-6B29-4055-877F-861E46043A06 |
| Task | [Move change reason constants from ores.database to ores.dq.api](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/investigate_api_core_split/task_move_change_reason_constants_to_dq.html) | 9409F936-C45C-4BF8-9507-D796907D1E45 |