### PR TITLE
[ores.http,ores.qt] Fix PR #1066 review: negative stoul wrapping; unused helper

### DIFF
--- a/projects/ores.http/core/src/routes/iam_routes.cpp
+++ b/projects/ores.http/core/src/routes/iam_routes.cpp
@@ -768,12 +768,12 @@ asio::awaitable<http_response> iam_routes::handle_list_accounts(const http_reque
 
         try {
             if (!offset_str.empty()) {
-                if (offset_str.front() == '-')
+                if (offset_str.find('-') != std::string::npos)
                     co_return http_response::bad_request("Invalid offset or limit query parameter");
                 offset = std::stoul(offset_str);
             }
             if (!limit_str.empty()) {
-                if (limit_str.front() == '-')
+                if (limit_str.find('-') != std::string::npos)
                     co_return http_response::bad_request("Invalid offset or limit query parameter");
                 limit = std::stoul(limit_str);
             }
@@ -1300,12 +1300,12 @@ asio::awaitable<http_response> iam_routes::handle_list_sessions(const http_reque
 
         try {
             if (!offset_str.empty()) {
-                if (offset_str.front() == '-')
+                if (offset_str.find('-') != std::string::npos)
                     co_return http_response::bad_request("Invalid offset or limit query parameter");
                 offset = std::stoul(offset_str);
             }
             if (!limit_str.empty()) {
-                if (limit_str.front() == '-')
+                if (limit_str.find('-') != std::string::npos)
                     co_return http_response::bad_request("Invalid offset or limit query parameter");
                 limit = std::stoul(limit_str);
             }

--- a/projects/ores.http/core/src/routes/iam_routes.cpp
+++ b/projects/ores.http/core/src/routes/iam_routes.cpp
@@ -767,10 +767,16 @@ asio::awaitable<http_response> iam_routes::handle_list_accounts(const http_reque
         auto limit_str = req.get_query_param("limit");
 
         try {
-            if (!offset_str.empty())
+            if (!offset_str.empty()) {
+                if (offset_str.front() == '-')
+                    co_return http_response::bad_request("Invalid offset or limit query parameter");
                 offset = std::stoul(offset_str);
-            if (!limit_str.empty())
+            }
+            if (!limit_str.empty()) {
+                if (limit_str.front() == '-')
+                    co_return http_response::bad_request("Invalid offset or limit query parameter");
                 limit = std::stoul(limit_str);
+            }
         } catch (const std::exception&) {
             co_return http_response::bad_request("Invalid offset or limit query parameter");
         }
@@ -1293,10 +1299,16 @@ asio::awaitable<http_response> iam_routes::handle_list_sessions(const http_reque
         auto limit_str = req.get_query_param("limit");
 
         try {
-            if (!offset_str.empty())
+            if (!offset_str.empty()) {
+                if (offset_str.front() == '-')
+                    co_return http_response::bad_request("Invalid offset or limit query parameter");
                 offset = std::stoul(offset_str);
-            if (!limit_str.empty())
+            }
+            if (!limit_str.empty()) {
+                if (limit_str.front() == '-')
+                    co_return http_response::bad_request("Invalid offset or limit query parameter");
                 limit = std::stoul(limit_str);
+            }
         } catch (const std::exception&) {
             co_return http_response::bad_request("Invalid offset or limit query parameter");
         }

--- a/projects/ores.qt/admin/src/AccountHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/AccountHistoryDialog.cpp
@@ -267,14 +267,6 @@ void check_diff_string(AccountHistoryDialog::DiffResult& diffs,
                       {QString::fromStdString(previous_val), QString::fromStdString(current_val)}});
 }
 
-void check_diff_bool(AccountHistoryDialog::DiffResult& diffs,
-                     const QString& field_name,
-                     bool current_val,
-                     bool previous_val) {
-    if (current_val != previous_val)
-        diffs.append({field_name, {previous_val ? "Yes" : "No", current_val ? "Yes" : "No"}});
-}
-
 }
 
 AccountHistoryDialog::DiffResult


### PR DESCRIPTION
## Summary

Follow-up fixes from the Gemini review of PR #1066.

## Changes

- **`iam_routes.cpp`**: reject negative `offset`/`limit` strings before passing to `std::stoul` — negative inputs silently wrap to huge unsigned values; now returns 400 Bad Request. Applied to both pagination call sites.
- **`AccountHistoryDialog.cpp`**: remove unused `check_diff_bool` helper from the anonymous namespace to prevent `-Wunused-function` compiler warning.

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Set up clang-format with CMake targets and CI integration](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/clang_format_setup/story.html) | 78D292E4-EA18-4FDE-9B23-E0F446A1B526 |