### PR TITLE
[dq,trading] Move audit_record from ores.utility to ores.dq.api

### DIFF
--- a/projects/ores.dq/api/include/ores.dq.api/domain/audit_record.hpp
+++ b/projects/ores.dq/api/include/ores.dq.api/domain/audit_record.hpp
@@ -17,16 +17,19 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
-#ifndef ORES_UTILITY_DOMAIN_AUDIT_RECORD_HPP
-#define ORES_UTILITY_DOMAIN_AUDIT_RECORD_HPP
+#ifndef ORES_DQ_API_DOMAIN_AUDIT_RECORD_HPP
+#define ORES_DQ_API_DOMAIN_AUDIT_RECORD_HPP
 
 #include <chrono>
 #include <string>
 
-namespace ores::utility::domain {
+namespace ores::dq::domain {
 
 /**
  * @brief Provenance and audit trail shared by all temporal domain entities.
+ *
+ * Lives in data quality alongside change_reason, which governs the
+ * vocabulary for change_reason_code.
  *
  * Extracted as a plain nested sub-struct so that rfl::internal::no_duplicate_field_names
  * never instantiates a Literal wider than 5 fields for this block.

--- a/projects/ores.trading/api/include/ores.trading.api/domain/balance_guaranteed_swap_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/balance_guaranteed_swap_instrument.hpp
@@ -20,8 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_BALANCE_GUARANTEED_SWAP_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_BALANCE_GUARANTEED_SWAP_INSTRUMENT_HPP
 
+#include "ores.dq.api/domain/audit_record.hpp"
 #include "ores.trading.api/domain/instrument_identity.hpp"
-#include "ores.utility/domain/audit_record.hpp"
 #include <chrono>
 #include <string>
 
@@ -64,7 +64,7 @@ struct balance_guaranteed_swap_instrument final {
      */
     std::string description;
 
-    utility::domain::audit_record audit;
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/callable_swap_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/callable_swap_instrument.hpp
@@ -20,8 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_CALLABLE_SWAP_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_CALLABLE_SWAP_INSTRUMENT_HPP
 
+#include "ores.dq.api/domain/audit_record.hpp"
 #include "ores.trading.api/domain/instrument_identity.hpp"
-#include "ores.utility/domain/audit_record.hpp"
 #include <chrono>
 #include <string>
 
@@ -71,7 +71,7 @@ struct callable_swap_instrument final {
      */
     std::string description;
 
-    utility::domain::audit_record audit;
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/cap_floor_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/cap_floor_instrument.hpp
@@ -20,8 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_CAP_FLOOR_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_CAP_FLOOR_INSTRUMENT_HPP
 
+#include "ores.dq.api/domain/audit_record.hpp"
 #include "ores.trading.api/domain/instrument_identity.hpp"
-#include "ores.utility/domain/audit_record.hpp"
 #include <chrono>
 #include <string>
 
@@ -57,7 +57,7 @@ struct cap_floor_instrument final {
      */
     std::string description;
 
-    utility::domain::audit_record audit;
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/fra_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/fra_instrument.hpp
@@ -20,8 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_FRA_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_FRA_INSTRUMENT_HPP
 
+#include "ores.dq.api/domain/audit_record.hpp"
 #include "ores.trading.api/domain/instrument_identity.hpp"
-#include "ores.utility/domain/audit_record.hpp"
 #include <chrono>
 #include <string>
 
@@ -92,7 +92,7 @@ struct fra_instrument final {
      */
     std::string description;
 
-    utility::domain::audit_record audit;
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/inflation_swap_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/inflation_swap_instrument.hpp
@@ -20,8 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_INFLATION_SWAP_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_INFLATION_SWAP_INSTRUMENT_HPP
 
+#include "ores.dq.api/domain/audit_record.hpp"
 #include "ores.trading.api/domain/instrument_identity.hpp"
-#include "ores.utility/domain/audit_record.hpp"
 #include <chrono>
 #include <string>
 
@@ -78,7 +78,7 @@ struct inflation_swap_instrument final {
      */
     std::string description;
 
-    utility::domain::audit_record audit;
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/knock_out_swap_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/knock_out_swap_instrument.hpp
@@ -20,8 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_KNOCK_OUT_SWAP_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_KNOCK_OUT_SWAP_INSTRUMENT_HPP
 
+#include "ores.dq.api/domain/audit_record.hpp"
 #include "ores.trading.api/domain/instrument_identity.hpp"
-#include "ores.utility/domain/audit_record.hpp"
 #include <chrono>
 #include <string>
 
@@ -78,7 +78,7 @@ struct knock_out_swap_instrument final {
      */
     std::string description;
 
-    utility::domain::audit_record audit;
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/rpa_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/rpa_instrument.hpp
@@ -20,8 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_RPA_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_RPA_INSTRUMENT_HPP
 
+#include "ores.dq.api/domain/audit_record.hpp"
 #include "ores.trading.api/domain/instrument_identity.hpp"
-#include "ores.utility/domain/audit_record.hpp"
 #include <chrono>
 #include <string>
 
@@ -79,7 +79,7 @@ struct rpa_instrument final {
      */
     std::string description;
 
-    utility::domain::audit_record audit;
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/swap_leg.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/swap_leg.hpp
@@ -20,7 +20,7 @@
 #ifndef ORES_TRADING_DOMAIN_SWAP_LEG_HPP
 #define ORES_TRADING_DOMAIN_SWAP_LEG_HPP
 
-#include "ores.utility/domain/audit_record.hpp"
+#include "ores.dq.api/domain/audit_record.hpp"
 #include "ores.utility/uuid/tenant_id.hpp"
 #include <boost/uuid/uuid.hpp>
 #include <string>
@@ -66,7 +66,7 @@ struct swap_leg_terms final {
 struct swap_leg final {
     swap_leg_identity identity;
     swap_leg_terms terms;
-    utility::domain::audit_record audit;
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/swaption_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/swaption_instrument.hpp
@@ -20,8 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_SWAPTION_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_SWAPTION_INSTRUMENT_HPP
 
+#include "ores.dq.api/domain/audit_record.hpp"
 #include "ores.trading.api/domain/instrument_identity.hpp"
-#include "ores.utility/domain/audit_record.hpp"
 #include <chrono>
 #include <string>
 
@@ -86,7 +86,7 @@ struct swaption_instrument final {
      */
     std::string description;
 
-    utility::domain::audit_record audit;
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/vanilla_swap_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/vanilla_swap_instrument.hpp
@@ -20,8 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_VANILLA_SWAP_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_VANILLA_SWAP_INSTRUMENT_HPP
 
+#include "ores.dq.api/domain/audit_record.hpp"
 #include "ores.trading.api/domain/instrument_identity.hpp"
-#include "ores.utility/domain/audit_record.hpp"
 #include <chrono>
 #include <string>
 
@@ -71,7 +71,7 @@ struct vanilla_swap_instrument final {
      */
     std::string description;
 
-    utility::domain::audit_record audit;
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/src/CMakeLists.txt
+++ b/projects/ores.trading/api/src/CMakeLists.txt
@@ -41,6 +41,7 @@ target_include_directories(${lib_target_name} PUBLIC
 
 target_link_libraries(${lib_target_name}
     PUBLIC
+        ores.dq.api.lib
         ores.eventing.api.lib
         ores.platform.lib
     PRIVATE


### PR DESCRIPTION
## Summary

Relocates the shared `audit_record` provenance struct from `ores.utility/domain` (where it was introduced by the rates-instrument decomposition, #1047) to its agreed home in `ores.dq.api/domain`.

Data quality is the right place for audit provenance: it sits alongside `change_reason` and `change_reason_constants`, which govern the vocabulary for `change_reason_code`. This became viable once dq.api was made lightweight (#1048) and eventing was split into api/core (#1068) — dq.api now publicly links only `eventing.api` + `platform`, so trading.api gains no heavy transitive dependencies.

## Changes

- `ores.dq.api/domain/audit_record.hpp`: new home, namespace `ores::dq::domain`
- `ores.utility/domain/` removed entirely — `audit_record.hpp` was its only occupant
- 10 trading headers (9 rates instruments + `swap_leg`) repointed to `dq::domain::audit_record`
- `ores.trading.api` now links `ores.dq.api.lib` PUBLIC (no cycle: dq has no trading dependency)
- clang-format clean; include order follows the local-first convention

Story-ID: 7763DOEE… → `Fix rfl complexity failure (Windows + macOS CI)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)