### PR TITLE
[trading,qt,ore] Decompose FX instruments into nested structs; fix main CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
 # -*- mode: yaml; yaml-tab-width: 4; indent-tabs-mode: nil -*-
-# Generated from doc/knowledge/architecture/clang_format_config.org.
+# This file is generated from doc/knowledge/architecture/clang_format_config.org.
 # Do not edit directly — run: cmake --build --preset <preset> --target tangle_clang_format
 ---
 Language: Cpp
@@ -8,100 +8,68 @@ Language: Cpp
 # The string "c++23" is not yet a valid enum value in clang-format 21.
 Standard: Latest
 
-# ORE Studio clang-format configuration.
-# Tuned to match the project's actual code conventions.
-# Run `cmake --build --preset <preset> --target format` to reformat in-place.
-# Run `cmake --build --preset <preset> --target check-format` to check for drift.
-
+# ── Baseline ─────────────────────────────────────────────────────────────────
 BasedOnStyle: LLVM
 
 # ── Indentation ───────────────────────────────────────────────────────────────
-
 IndentWidth: 4
 TabWidth: 4
 UseTab: Never
-
-# Namespace body is NOT indented (content starts at column 0).
 NamespaceIndentation: None
-
-# public:/private:/protected: at class indent level, not indented further.
 AccessModifierOffset: -4
-
 IndentCaseLabels: true
 IndentPPDirectives: AfterHash
 
 # ── Line length ───────────────────────────────────────────────────────────────
-
 ColumnLimit: 100
 
 # ── Pointer / reference alignment ────────────────────────────────────────────
-# T* x and T& x (attached to type, not variable).
-
 DerivePointerAlignment: false
 PointerAlignment: Left
 ReferenceAlignment: Left
 
 # ── Constructor initialiser lists ─────────────────────────────────────────────
-# One initialiser per line, leading comma:
-#
-#   Foo::Foo(int a, int b)
-#       : a_(a)
-#       , b_(b) {}
-#
-
 BreakConstructorInitializers: BeforeComma
 ConstructorInitializerIndentWidth: 4
 PackConstructorInitializers: Never
 
 # ── Function parameters / arguments ──────────────────────────────────────────
-
 BinPackParameters: false
 BinPackArguments: false
 
 # ── Templates ─────────────────────────────────────────────────────────────────
-# Template declaration always on its own line.
-
 AlwaysBreakTemplateDeclarations: Yes
 
 # ── Short constructs ──────────────────────────────────────────────────────────
-
-# Empty function bodies on one line: Foo::Foo() {}
 AllowShortFunctionsOnASingleLine: Empty
-
-# Short lambdas inline: [this](auto x) { return f(x); }
 AllowShortLambdasOnASingleLine: Inline
-
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 
 # ── Includes ──────────────────────────────────────────────────────────────────
-# Group order (separated by blank lines):
-#   1. Local project headers ("ores.*", "ui_*", other quoted)
-#   2. Qt headers (<Q...>)
-#   3. Boost headers (<boost/...>)
-#   4. All other angle-bracket headers (std, rfl, openssl, ...)
-
+# Sorted into one merged block (no blank line separators), ordered:
+#   local "ores.*" / "ui_*" → Qt → Boost → std / other angle-bracket
+#   → order-dependent Windows SDK headers
+# Local-first ensures each header is self-sufficient: a missing transitive
+# include cannot be silently satisfied by a preceding std/Boost header.
+# The trailing Windows SDK category exists because those headers require
+# windows.h first but do not include it themselves (a Microsoft defect);
+# sorting them last guarantees windows.h precedes them.
 SortIncludes: CaseSensitive
 IncludeBlocks: Merge
 IncludeCategories:
-  # Local project headers first (quoted: ores.*, ui_*, etc.)
-  # Rationale: including local headers first ensures each header is
-  # self-sufficient — missing transitive includes are caught immediately
-  # rather than being silently satisfied by a preceding std/Boost header.
   - Regex: '^"'
     Priority: 1
-  # Qt headers
   - Regex: '^<Q[A-Z]'
     Priority: 2
-  # Boost headers
   - Regex: '^<boost/'
     Priority: 3
-  # Standard library and other angle-bracket headers last
+  - Regex: '^<(iphlpapi|ws2tcpip|psapi|tlhelp32|dbghelp|shellapi)\.h>'
+    Priority: 5
   - Regex: '^<'
     Priority: 4
 
-# ── Misc ──────────────────────────────────────────────────────────────────────
-
+# ── Miscellaneous ─────────────────────────────────────────────────────────────
 MaxEmptyLinesToKeep: 2
 FixNamespaceComments: false
 SortUsingDeclarations: false

--- a/doc/agile/product_backlog/inbox/separate_trade_instrument_detail_dialogs.org
+++ b/doc/agile/product_backlog/inbox/separate_trade_instrument_detail_dialogs.org
@@ -1,0 +1,56 @@
+:PROPERTIES:
+:ID: 671860F1-0671-4DB1-8F5D-320C54F4F660
+:END:
+#+title: Separate trade and instrument detail dialogs
+#+description: Trade and instrument are currently displayed in one details dialog. Consider separate dialogs with idiomatic navigation between them; needs a brainstorm on trading-system UX patterns.
+#+type: capture
+#+level: cross
+#+filetags: 
+#+created: 2026-06-05
+#+updated: 2026-06-05
+
+This page is a [[id:671F18E4-E09C-4B3B-BD24-D33DF8AE38A6][capture]] in the *inbox* bucket of the product backlog — a pre-sprint idea, not yet pulled into a sprint as a story.
+
+* What
+
+Split the current combined trade-plus-instrument details dialog into
+two separate detail dialogs — one for the trade, one for the
+instrument — and work out how a user navigates from one to the
+other. The navigation mechanism is the open design question and
+deserves a brainstorm session on idiomatic patterns in trading
+systems before committing to a design. Candidate patterns to seed
+the brainstorm:
+
+- A button/link in trade details that opens the linked instrument
+  details (the simplest option).
+- Hyperlinked entity references: any field that is a soft FK
+  (instrument_id, book_id, portfolio_id, party_id) renders as a
+  navigable link — the pattern generalises beyond trade/instrument.
+- Master-detail drill-down: instrument opens as a nested tab or
+  panel inside the trade window rather than a separate top-level
+  window.
+- Blotter-style navigation: trade blotter row → trade details →
+  "View Instrument" action, with breadcrumbs to step back.
+- A shared "related entities" sidebar listing all linked entities
+  of the focused record (what OMS/EMS front-ends often do).
+
+* Why
+
+The combined dialog tries to display two distinct aggregates in one
+window, which crowds the UI and couples the dialogs' lifecycles.
+Now that instruments are first-class (own tables, own NATS
+messages, own forms per type — see the C1202 nested-structs work),
+a dedicated instrument details dialog is natural, and the
+trade dialog gets simpler. The trade→instrument soft FK
+(=classification.instrument_id= / =identity.trade_id=) already
+provides the navigation key in both directions.
+
+* References
+
+- [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Story: Fix rfl complexity failure (Windows + macOS CI)]] —
+  instrument decomposition that makes instruments first-class.
+
+* See also
+
+- [[id:037B474D-84ED-4888-9054-D58AB1FB10D2][Story: Consolidate history dialogs onto HistoryDialogBase]] —
+  parallel effort to rationalise dialog architecture.

--- a/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/story.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/story.org
@@ -1,0 +1,76 @@
+:PROPERTIES:
+:ID: 037B474D-84ED-4888-9054-D58AB1FB10D2
+:END:
+#+title: Story: Consolidate history dialogs onto HistoryDialogBase
+#+description: All 67 entity history dialogs duplicate the version-list/load/stale pipeline and 6 hand-roll field diffs with four different idioms. Adopt HistoryDialogBase everywhere; move DiffResult and an abstract calculateDiff template method into the base.
+#+type: story
+#+level: s2
+#+filetags: :sprint_19:v0:
+#+created: 2026-06-05
+#+updated: 2026-06-05
+#+todo: BACKLOG STARTED | DONE ABANDONED
+
+This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
+
+* Goal
+
+Every entity history dialog derives from =HistoryDialogBase= and shares
+one implementation of the common machinery, so that fixes and UX
+changes land once instead of 67 times, and the per-dialog code shrinks
+to what is genuinely entity-specific (field comparisons and labels).
+
+Survey (2026-06-05, the day the CI broke on exactly this duplication):
+
+- 67 =*HistoryDialog= classes across ores.qt sub-libraries.
+- =HistoryDialogBase= already exists in ores.qt.api (signals,
+  =markAsStale()=, =code()=) but has exactly one adopter
+  (=WorkspaceHistoryDialog=).
+- 64 dialogs duplicate the version-list/load pipeline
+  (=onVersionSelected=, =loadHistory=, =QFutureWatcher= plumbing).
+- 6 dialogs (Account, SystemSetting, ChangeReason,
+  ChangeReasonCategory, Country, Currency) hand-roll a changes tab
+  with field-level diffs using four different idioms: a free
+  function, per-call lambdas, a =CHECK_DIFF_STRING= macro, and inline
+  if-blocks. The Account variant named a class-private alias from an
+  anonymous-namespace function, breaking GCC/AppleClang builds
+  (fixed tactically; this story is the proper fix).
+
+Design direction:
+
+- =DiffResult= (=QVector<QPair<QString, QPair<QString, QString>>>=)
+  is defined once in =HistoryDialogBase=.
+- The base owns the changes-tab rendering flow and calls an abstract
+  =calculateDiff(current, previous)= template method; derived
+  dialogs implement only the per-entity field comparisons.
+- Shared =checkString= / =checkInt= / =checkBool= helpers live with
+  the base so all dialogs format values identically.
+- Version-list population, async load, stale handling and toolbar
+  wiring migrate into the base (or an intermediate templated CRTP
+  helper if the version types resist a common interface).
+
+* Status
+
+| Field         | Value                                  |
+|---------------+----------------------------------------|
+| State         | BACKLOG                              |
+| Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
+| Now           | Not yet started.                       |
+| Waiting on    | Nothing.                               |
+| Next          | Break the story into tasks.            |
+| Last touched  | 2026-06-05                               |
+
+* Acceptance
+
+-
+
+* Tasks
+
+| Task | State | Start | End | Description |
+|------+-------+-------+-----+-------------|
+|      |       |       |     |             |
+
+* Decisions
+
+* Out of scope
+
+-

--- a/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/story.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_history_dialogs/story.org
@@ -2,7 +2,7 @@
 :ID: 037B474D-84ED-4888-9054-D58AB1FB10D2
 :END:
 #+title: Story: Consolidate history dialogs onto HistoryDialogBase
-#+description: All 67 entity history dialogs duplicate the version-list/load/stale pipeline and 6 hand-roll field diffs with four different idioms. Adopt HistoryDialogBase everywhere; move DiffResult and an abstract calculateDiff template method into the base.
+#+description: All 67 entity history dialogs duplicate the version-list/load/stale pipeline and 6 hand-roll field diffs with four different idioms. Compute diffs server-side via a domain-to-field-strings mapper and a generic NATS history message; adopt HistoryDialogBase everywhere with DiffResult and a calculateDiff template method in the base.
 #+type: story
 #+level: s2
 #+filetags: :sprint_19:v0:
@@ -35,18 +35,37 @@ Survey (2026-06-05, the day the CI broke on exactly this duplication):
   anonymous-namespace function, breaking GCC/AppleClang builds
   (fixed tactically; this story is the proper fix).
 
-Design direction:
+Design direction — two layers:
 
-- =DiffResult= (=QVector<QPair<QString, QPair<QString, QString>>>=)
-  is defined once in =HistoryDialogBase=.
-- The base owns the changes-tab rendering flow and calls an abstract
-  =calculateDiff(current, previous)= template method; derived
-  dialogs implement only the per-entity field comparisons.
-- Shared =checkString= / =checkInt= / =checkBool= helpers live with
-  the base so all dialogs format values identically.
-- Version-list population, async load, stale handling and toolbar
-  wiring migrate into the base (or an intermediate templated CRTP
-  helper if the version types resist a common interface).
+1. /Server-side diffs (the deeper fix)./ Computing field-level diffs
+   in the UI is the wrong place: when history views are added to the
+   shell, Wt and HTTP frontends the same comparison code would be
+   repeated in each. Instead:
+   - A per-entity mapper converts a domain type to an ordered list of
+     (field name, value) strings — one definition per entity, server
+     side, reusable by every frontend and candidate for codegen from
+     the entity models.
+   - A generic NATS history message returns the computed diffs
+     between consecutive versions (field, old value, new value),
+     rather than shipping two full versions for the client to
+     compare. Frontends only render.
+
+2. /Qt consolidation onto the base./
+   - =DiffResult= (list of (field, (old, new)) rows) is defined once
+     in =HistoryDialogBase=.
+   - The base owns the changes-tab rendering flow and calls an
+     abstract =calculateDiff(current, previous)= template method;
+     derived dialogs implement only the per-entity field
+     comparisons. Once the server-side diff message lands,
+     =calculateDiff= implementations collapse into rendering the
+     server-provided rows, and the template method may disappear
+     entirely.
+   - Shared =checkString= / =checkInt= / =checkBool= helpers live
+     with the base so all dialogs format values identically in the
+     interim.
+   - Version-list population, async load, stale handling and toolbar
+     wiring migrate into the base (or an intermediate templated CRTP
+     helper if the version types resist a common interface).
 
 * Status
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_fx_instrument_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_fx_instrument_c1202_nested_structs.org
@@ -51,6 +51,14 @@ audit_record move to dq.api (PR #1070):
 
 * Notes
 
+- FX entities lacked =workspace_id= even though all FX tables have the
+  column (DB default fills it). Added to all 7 entities + mappers for
+  symmetry with rates, per decision: all trade/instrument tables carry
+  workspace_id.
+- Follow-up candidate: FX repository where-clauses do not filter on
+  =workspace_id= (rates repositories do). Pre-existing gap, not
+  addressed here.
+
 * PRs
 
 | PR | Title |

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_fx_instrument_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_fx_instrument_c1202_nested_structs.org
@@ -63,7 +63,7 @@ audit_record move to dq.api (PR #1070):
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1071][#1071]] | [trading,qt,ore] Decompose FX instruments into nested structs; fix main CI |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_fx_instrument_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_fx_instrument_c1202_nested_structs.org
@@ -25,12 +25,12 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
-| Now          | Not yet started.                       |
+| Now          | Decomposing the 7 FX instrument types. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-04                               |
+| Next         | Apply identity/audit/type-specific pattern to all 7 headers and callers. |
+| Last touched | 2026-06-05                               |
 
 * Acceptance
 
@@ -38,9 +38,16 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+Follow the rates-instrument pattern from PR #1047, updated for the
+audit_record move to dq.api (PR #1070):
+
+1. Each of the 7 FX headers gains =instrument_identity identity= +
+   =dq::domain::audit_record audit= + type-specific flat fields;
+   parent Literal stays well below the C1202 threshold.
+2. Update all callers per type: mapper, generator, service,
+   repository, trade_handler, plus Qt parse/form/import paths.
+3. Wire format changes to nested JSON (internal-only).
+4. Round-trip tests updated.
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_rates_instrument_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_rates_instrument_c1202_nested_structs.org
@@ -105,5 +105,7 @@ See [[id:D75F4921-B431-4E78-99AB-62A47F761D1D][Investigation: MSVC C1202 and rfl
 | # | Comment summary                                                               | File              | Decision | Notes          |
 |---+-------------------------------------------------------------------------------+-------------------+----------+----------------|
 | 1 | Gemini: task doc missing Plan, PRs, Review, Result sections                   | task_fix_rates*.org | Accept  | Fixed this commit |
+| 2 | Gemini (#1070): same-target includes before external-component includes       | 10 rates headers  | Reject   | Considered at the clang-format level and rejected on merits: IncludeCategories regexes cannot express "current target" repo-wide (would need per-component configs); self-sufficiency is already enforced by main-header-first in each header's own TU; LLVM/Chromium sort project includes purely alphabetically |
+| 3 | Gemini (#1070): fully qualify ores::dq::domain::audit_record                  | 10 rates headers  | Accept   | Applied on PR #1071 branch (1070 merged early); also applied to the 7 FX headers for consistency |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_rates_instrument_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_rates_instrument_c1202_nested_structs.org
@@ -98,6 +98,7 @@ See [[id:D75F4921-B431-4E78-99AB-62A47F761D1D][Investigation: MSVC C1202 and rfl
 | PR                                                                         | Title                                                                                         |
 |----------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------|
 | [[https://github.com/OreStudio/OreStudio/pull/1047][#1047]] | [trading] Decompose all 9 rates instruments + extract shared audit_record / instrument_identity |
+| [[https://github.com/OreStudio/OreStudio/pull/1070][#1070]] | [dq,trading] Move audit_record from ores.utility to ores.dq.api |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/sprint.org
+++ b/doc/agile/versions/v0/sprint_19/sprint.org
@@ -78,6 +78,7 @@ while dogfooding the product.
 | [[id:F8E2AB1E-344B-4B04-BD0B-6EC96CDA5298][PnL tracking improvements]] | DONE | 2026-06-03 | 2026-06-03 | Capture: FX locking, timeframe-scoped PnL, dual charts, two-phase sell P&L, FIFO/WAVG. See [[id:42F22269-B875-489D-A3D7-7FEC456C69EA][Lightyear knowledge doc]]. |
 | [[id:814D4E79-8EB9-4B2B-8A87-DB72F145044D][Account type badge in Qt]] | DONE | 2026-06-04 | 2026-06-04 | Wire account_type as DB-driven badge in AccountItemDelegate; SQL population; badge setup recipe. PR [[https://github.com/OreStudio/OreStudio/pull/1038][#1038]]. |
 | [[id:72E7A7D0-A268-410F-B137-942DC5F16934][Badge colour semantics]] | DONE | 2026-06-04 | 2026-06-04 | Gray = inactive only; recolour service/unlocked/done; orange missing-definition fallback; detail dialog badges; UX language doc. PR [[https://github.com/OreStudio/OreStudio/pull/1044][#1044]]. |
+| [[id:037B474D-84ED-4888-9054-D58AB1FB10D2][Consolidate history dialogs]] | BACKLOG | | | Adopt HistoryDialogBase across all 67 history dialogs; DiffResult + abstract calculateDiff template method in the base. |
 
 ** Tooling
 

--- a/doc/knowledge/architecture/clang_format_config.org
+++ b/doc/knowledge/architecture/clang_format_config.org
@@ -280,13 +280,32 @@ parsed.
 #include <string>
 #+end_example
 
+One genuine external constraint is carved out: a handful of Windows
+SDK headers (=iphlpapi.h=, =ws2tcpip.h=, =psapi.h=, =tlhelp32.h=,
+=dbghelp.h=, =shellapi.h=) are not self-sufficient — they require the
+types from =windows.h= to have been declared first, but do not
+include it themselves. That is Microsoft's defect, not ours, and no
+amount of code hygiene on our side can fix their headers. Pure
+alphabetical sorting puts =iphlpapi.h= before =windows.h= and breaks
+every Windows build (see the post-format CI failures in
+=network_info.cpp=). These headers therefore get a dedicated trailing
+category so they always sort after =windows.h=, which stays in the
+ordinary system group. Encoding the constraint here — rather than
+with =clang-format off= pragmas at the include sites — means the
+formatter itself produces the correct order and can never silently
+re-break it.
+
 #+begin_src yaml
 
 # ── Includes ──────────────────────────────────────────────────────────────────
 # Sorted into one merged block (no blank line separators), ordered:
 #   local "ores.*" / "ui_*" → Qt → Boost → std / other angle-bracket
+#   → order-dependent Windows SDK headers
 # Local-first ensures each header is self-sufficient: a missing transitive
 # include cannot be silently satisfied by a preceding std/Boost header.
+# The trailing Windows SDK category exists because those headers require
+# windows.h first but do not include it themselves (a Microsoft defect);
+# sorting them last guarantees windows.h precedes them.
 SortIncludes: CaseSensitive
 IncludeBlocks: Merge
 IncludeCategories:
@@ -296,6 +315,8 @@ IncludeCategories:
     Priority: 2
   - Regex: '^<boost/'
     Priority: 3
+  - Regex: '^<(iphlpapi|ws2tcpip|psapi|tlhelp32|dbghelp|shellapi)\.h>'
+    Priority: 5
   - Regex: '^<'
     Priority: 4
 #+end_src

--- a/doc/llm/memory/include_order_owned_by_clang_format.org
+++ b/doc/llm/memory/include_order_owned_by_clang_format.org
@@ -1,0 +1,36 @@
+:PROPERTIES:
+:ID: E8C3B46F-D375-4CFA-853F-D6C36804E4E6
+:END:
+#+title: Include order is owned by clang-format
+#+description: Reject review suggestions to hand-tune C++ include order; the formatter is the single source of truth and will revert manual deviations.
+#+type: memory
+#+memory_subtype: feedback
+#+level: cross
+#+filetags: :memory:feedback:
+#+created: 2026-06-05
+#+updated: 2026-06-05
+
+C++ include order is owned by clang-format: the tangled =.clang-format=
+(generated from =doc/knowledge/architecture/clang_format_config.org=)
+is the single source of truth. Never hand-tune include order in source
+files, and reject review suggestions that ask for it. If an ordering
+suggestion sounds sensible, the change is made at the clang-format
+level — edit the literate org config, retangle, and let the formatter
+apply it everywhere.
+
+*Why:* Marco, 2026-06-05, while triaging Gemini review comments on PR
+#1070 that suggested same-target includes before external-component
+includes: "in terms of includes order, remember we go via clang
+format... any changes must be done at the clang format level, if they
+sound sensible." Manual deviations are reverted by the next format run
+or the nightly format bot. Precedent: the Windows SDK ordering
+constraint (iphlpapi.h after windows.h) was encoded as an
+IncludeCategories entry rather than per-file pragmas.
+
+*How to apply:* When a review comment, lint suggestion, or instinct
+says to reorder =#include= lines: do not edit the source file ordering
+by hand. Either reject (if it fights the alphabetical-within-category
+policy) or, if the rule is genuinely sensible, add it to the
+IncludeCategories in =clang_format_config.org=, run the
+=tangle_clang_format= target, and reformat. Always run =clang-format -i=
+on touched files so order matches the config.

--- a/projects/ores.hpp
+++ b/projects/ores.hpp
@@ -72,6 +72,6 @@
  * @note This project has no affiliation with Acadia, Open Source Risk Engine,
  * or QuantLib. See Doxygen documentation for full context.
  */
-namespace ores { }
+namespace ores {}
 
 #endif

--- a/projects/ores.http/core/src/routes/storage_routes.cpp
+++ b/projects/ores.http/core/src/routes/storage_routes.cpp
@@ -87,8 +87,8 @@ std::string storage_routes::resolve_path(const std::string& bucket, const std::s
     const fs::path full_path = (bucket_path / key).lexically_normal();
 
     // Ensure the resolved path stays within the bucket directory.
-    auto [it1, it2] = std::mismatch(
-        bucket_path.begin(), bucket_path.end(), full_path.begin(), full_path.end());
+    auto [it1, it2] =
+        std::mismatch(bucket_path.begin(), bucket_path.end(), full_path.begin(), full_path.end());
     if (it1 != bucket_path.end()) {
         BOOST_LOG_SEV(lg(), warn) << "Path traversal attempt: bucket=" << bucket << " key=" << key;
         return {};

--- a/projects/ores.ore/core/src/domain/fx_instrument_mapper.cpp
+++ b/projects/ores.ore/core/src/domain/fx_instrument_mapper.cpp
@@ -240,8 +240,8 @@ barrierData fx_instrument_mapper::make_barrier(const std::string& type, double l
 trading::domain::fx_instrument_variant fx_instrument_mapper::forward_fx_forward(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxForward: " << std::string(t.id);
     fx_forward_instrument r;
-    r.trade_type_code = "FxForward";
-    set_audit(r);
+    r.identity.trade_type_code = "FxForward";
+    set_audit(r.audit);
     if (!t.FxForwardData)
         return r;
     const auto& fwd = *t.FxForwardData;
@@ -264,8 +264,8 @@ trading::domain::fx_instrument_variant fx_instrument_mapper::forward_fx_forward(
 trading::domain::fx_instrument_variant fx_instrument_mapper::forward_fx_swap(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxSwap: " << std::string(t.id);
     fx_forward_instrument r;
-    r.trade_type_code = "FxSwap";
-    set_audit(r);
+    r.identity.trade_type_code = "FxSwap";
+    set_audit(r.audit);
     if (!t.FxSwapData)
         return r;
     const auto& sw = *t.FxSwapData;
@@ -289,8 +289,8 @@ trading::domain::fx_instrument_variant fx_instrument_mapper::forward_fx_swap(con
 trading::domain::fx_instrument_variant fx_instrument_mapper::forward_fx_option(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxOption: " << std::string(t.id);
     fx_vanilla_option_instrument r;
-    r.trade_type_code = "FxOption";
-    set_audit(r);
+    r.identity.trade_type_code = "FxOption";
+    set_audit(r.audit);
     if (!t.FxOptionData)
         return r;
     const auto& opt = *t.FxOptionData;
@@ -320,8 +320,8 @@ trading::domain::fx_instrument_variant
 fx_instrument_mapper::forward_fx_barrier_option(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxBarrierOption: " << std::string(t.id);
     fx_barrier_option_instrument r;
-    r.trade_type_code = "FxBarrierOption";
-    set_audit(r);
+    r.identity.trade_type_code = "FxBarrierOption";
+    set_audit(r.audit);
     if (!t.FxBarrierOptionData)
         return r;
     const auto& d = *t.FxBarrierOptionData;
@@ -351,8 +351,8 @@ trading::domain::fx_instrument_variant
 fx_instrument_mapper::forward_fx_double_barrier_option(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxDoubleBarrierOption: " << std::string(t.id);
     fx_barrier_option_instrument r;
-    r.trade_type_code = "FxDoubleBarrierOption";
-    set_audit(r);
+    r.identity.trade_type_code = "FxDoubleBarrierOption";
+    set_audit(r.audit);
     if (!t.FxDoubleBarrierOptionData)
         return r;
     const auto& d = *t.FxDoubleBarrierOptionData;
@@ -382,8 +382,8 @@ trading::domain::fx_instrument_variant
 fx_instrument_mapper::forward_fx_european_barrier_option(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxEuropeanBarrierOption: " << std::string(t.id);
     fx_barrier_option_instrument r;
-    r.trade_type_code = "FxEuropeanBarrierOption";
-    set_audit(r);
+    r.identity.trade_type_code = "FxEuropeanBarrierOption";
+    set_audit(r.audit);
     if (!t.FxEuropeanBarrierOptionData)
         return r;
     const auto& d = *t.FxEuropeanBarrierOptionData;
@@ -413,8 +413,8 @@ trading::domain::fx_instrument_variant
 fx_instrument_mapper::forward_fx_kiko_barrier_option(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxKIKOBarrierOption: " << std::string(t.id);
     fx_barrier_option_instrument r;
-    r.trade_type_code = "FxKIKOBarrierOption";
-    set_audit(r);
+    r.identity.trade_type_code = "FxKIKOBarrierOption";
+    set_audit(r.audit);
     if (!t.FxKIKOBarrierOptionData)
         return r;
     const auto& d = *t.FxKIKOBarrierOptionData;
@@ -446,8 +446,8 @@ trading::domain::fx_instrument_variant
 fx_instrument_mapper::forward_fx_generic_barrier_option(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxGenericBarrierOption: " << std::string(t.id);
     fx_barrier_option_instrument r;
-    r.trade_type_code = "FxGenericBarrierOption";
-    set_audit(r);
+    r.identity.trade_type_code = "FxGenericBarrierOption";
+    set_audit(r.audit);
     if (!t.FxGenericBarrierOptionData)
         return r;
     const auto& d = *t.FxGenericBarrierOptionData;
@@ -481,9 +481,9 @@ trading::domain::fx_instrument_variant
 fx_instrument_mapper::forward_fx_digital_option(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxDigitalOption: " << std::string(t.id);
     fx_digital_option_instrument r;
-    r.trade_type_code = "FxDigitalOption";
+    r.identity.trade_type_code = "FxDigitalOption";
     r.long_short = "Long";
-    set_audit(r);
+    set_audit(r.audit);
     if (!t.FxDigitalOptionData)
         return r;
     const auto& d = *t.FxDigitalOptionData;
@@ -506,9 +506,9 @@ trading::domain::fx_instrument_variant
 fx_instrument_mapper::forward_fx_digital_barrier_option(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxDigitalBarrierOption: " << std::string(t.id);
     fx_digital_option_instrument r;
-    r.trade_type_code = "FxDigitalBarrierOption";
+    r.identity.trade_type_code = "FxDigitalBarrierOption";
     r.long_short = "Long";
-    set_audit(r);
+    set_audit(r.audit);
     if (!t.FxDigitalBarrierOptionData)
         return r;
     const auto& d = *t.FxDigitalBarrierOptionData;
@@ -538,9 +538,9 @@ fx_instrument_mapper::forward_fx_touch_option(const trade& t) {
     const std::string type_str = to_string(t.TradeType);
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping " << type_str << ": " << std::string(t.id);
     fx_digital_option_instrument r;
-    r.trade_type_code = type_str;
+    r.identity.trade_type_code = type_str;
     r.long_short = "Long";
-    set_audit(r);
+    set_audit(r.audit);
 
     const fxTouchOptionData* dp = nullptr;
     if (t.FxTouchOptionData)
@@ -575,9 +575,9 @@ trading::domain::fx_instrument_variant
 fx_instrument_mapper::forward_fx_variance_swap(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxVarianceSwap: " << std::string(t.id);
     fx_variance_swap_instrument r;
-    r.trade_type_code = "FxVarianceSwap";
+    r.identity.trade_type_code = "FxVarianceSwap";
     r.long_short = "Long";
-    set_audit(r);
+    set_audit(r.audit);
     if (!t.FxVarianceSwapData)
         return r;
     const auto& d = *t.FxVarianceSwapData;
@@ -604,8 +604,8 @@ trading::domain::fx_instrument_variant
 fx_instrument_mapper::forward_fx_average_forward(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxAverageForward: " << std::string(t.id);
     fx_asian_forward_instrument r;
-    r.trade_type_code = "FxAverageForward";
-    set_audit(r);
+    r.identity.trade_type_code = "FxAverageForward";
+    set_audit(r.audit);
     if (!t.FxAverageForwardData)
         return r;
     const auto& d = *t.FxAverageForwardData;
@@ -628,9 +628,9 @@ trading::domain::fx_instrument_variant
 fx_instrument_mapper::forward_fx_accumulator(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxAccumulator: " << std::string(t.id);
     fx_accumulator_instrument r;
-    r.trade_type_code = "FxAccumulator";
+    r.identity.trade_type_code = "FxAccumulator";
     r.long_short = "Long";
-    set_audit(r);
+    set_audit(r.audit);
     if (!t.FxAccumulatorData)
         return r;
     const auto& d = *t.FxAccumulatorData;
@@ -662,8 +662,8 @@ fx_instrument_mapper::forward_fx_accumulator(const trade& t) {
 trading::domain::fx_instrument_variant fx_instrument_mapper::forward_fx_tarf(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping FxTaRF: " << std::string(t.id);
     fx_asian_forward_instrument r;
-    r.trade_type_code = "FxTaRF";
-    set_audit(r);
+    r.identity.trade_type_code = "FxTaRF";
+    set_audit(r.audit);
     if (!t.FxTaRFData)
         return r;
     const auto& d = *t.FxTaRFData;
@@ -930,9 +930,9 @@ trade fx_instrument_mapper::reverse_fx_digital_barrier_option(
 // ===========================================================================
 
 trade fx_instrument_mapper::reverse_fx_touch_option(const fx_digital_option_instrument& instr) {
-    BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping " << instr.trade_type_code;
+    BOOST_LOG_SEV(lg(), debug) << "Reverse-mapping " << instr.identity.trade_type_code;
     trade t;
-    t.TradeType = (instr.trade_type_code == "FxDoubleTouchOption") ?
+    t.TradeType = (instr.identity.trade_type_code == "FxDoubleTouchOption") ?
                       oreTradeType::FxDoubleTouchOption :
                       oreTradeType::FxTouchOption;
 
@@ -951,7 +951,7 @@ trade fx_instrument_mapper::reverse_fx_touch_option(const fx_digital_option_inst
     if (instr.upper_barrier.has_value())
         d.BarrierData.push_back(make_barrier(instr.barrier_type, *instr.upper_barrier));
 
-    if (instr.trade_type_code == "FxDoubleTouchOption")
+    if (instr.identity.trade_type_code == "FxDoubleTouchOption")
         t.FxDoubleTouchOptionData = std::move(d);
     else
         t.FxTouchOptionData = std::move(d);

--- a/projects/ores.ore/core/tests/planner_import_planner_tests.cpp
+++ b/projects/ores.ore/core/tests/planner_import_planner_tests.cpp
@@ -318,8 +318,16 @@ TEST_CASE("plan_instrument_trade_id_matches_minted_trade_id", tags) {
                             ++checked;
                         },
                         r.instrument);
-                } else if constexpr (std::is_same_v<T, fx_instrument_variant> ||
-                                     std::is_same_v<T, equity_instrument_variant>) {
+                } else if constexpr (std::is_same_v<T, fx_instrument_variant>) {
+                    std::visit(
+                        [&](const auto& instr) {
+                            INFO("Instrument variant index checked");
+                            REQUIRE(instr.identity.trade_id.has_value());
+                            CHECK(*instr.identity.trade_id == item.trade.identity.id);
+                            ++checked;
+                        },
+                        r);
+                } else if constexpr (std::is_same_v<T, equity_instrument_variant>) {
                     std::visit(
                         [&](const auto& instr) {
                             INFO("Instrument variant index checked");

--- a/projects/ores.ore/core/tests/xml_fx_exotic_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/core/tests/xml_fx_exotic_mapper_roundtrip_tests.cpp
@@ -76,7 +76,7 @@ TEST_CASE("fx_exotic_mapper_roundtrip_barrier_option", tags) {
     const auto r = load_and_map("FX_Barrier_Option.xml");
     const auto& instr = std::get<fx_barrier_option_instrument>(r);
 
-    CHECK(instr.trade_type_code == "FxBarrierOption");
+    CHECK(instr.identity.trade_type_code == "FxBarrierOption");
     CHECK(!instr.bought_currency.empty());
     CHECK(!instr.sold_currency.empty());
     CHECK(instr.bought_amount > 0.0);
@@ -95,7 +95,7 @@ TEST_CASE("fx_exotic_mapper_roundtrip_digital_option", tags) {
     const auto r = load_and_map("FX_Digital_Option.xml");
     const auto& instr = std::get<fx_digital_option_instrument>(r);
 
-    CHECK(instr.trade_type_code == "FxDigitalOption");
+    CHECK(instr.identity.trade_type_code == "FxDigitalOption");
     CHECK(!instr.foreign_currency.empty());
     CHECK(!instr.domestic_currency.empty());
     REQUIRE(instr.strike.has_value());
@@ -115,7 +115,7 @@ TEST_CASE("fx_exotic_mapper_roundtrip_digital_barrier_option", tags) {
     const auto r = load_and_map("FX_Digital_Barrier_Option.xml");
     const auto& instr = std::get<fx_digital_option_instrument>(r);
 
-    CHECK(instr.trade_type_code == "FxDigitalBarrierOption");
+    CHECK(instr.identity.trade_type_code == "FxDigitalBarrierOption");
     CHECK(!instr.foreign_currency.empty());
     CHECK(!instr.domestic_currency.empty());
     REQUIRE(instr.strike.has_value());
@@ -137,7 +137,7 @@ TEST_CASE("fx_exotic_mapper_roundtrip_touch_option", tags) {
     const auto r = load_and_map("FX_OneTouch_option.xml");
     const auto& instr = std::get<fx_digital_option_instrument>(r);
 
-    CHECK(instr.trade_type_code == "FxTouchOption");
+    CHECK(instr.identity.trade_type_code == "FxTouchOption");
     CHECK(!instr.foreign_currency.empty());
     CHECK(instr.payoff_amount > 0.0);
     CHECK(!instr.barrier_type.empty());
@@ -156,7 +156,7 @@ TEST_CASE("fx_exotic_mapper_roundtrip_double_touch_option", tags) {
     const auto r = load_and_map("FX_DoubleTouch_Option.xml");
     const auto& instr = std::get<fx_digital_option_instrument>(r);
 
-    CHECK(instr.trade_type_code == "FxDoubleTouchOption");
+    CHECK(instr.identity.trade_type_code == "FxDoubleTouchOption");
     CHECK(!instr.foreign_currency.empty());
     CHECK(instr.payoff_amount > 0.0);
     CHECK(!instr.barrier_type.empty());
@@ -173,7 +173,7 @@ TEST_CASE("fx_exotic_mapper_roundtrip_variance_swap", tags) {
     const auto r = load_and_map("FX_Variance_Swap.xml");
     const auto& instr = std::get<fx_variance_swap_instrument>(r);
 
-    CHECK(instr.trade_type_code == "FxVarianceSwap");
+    CHECK(instr.identity.trade_type_code == "FxVarianceSwap");
     CHECK(!instr.underlying_code.empty());
     CHECK(instr.strike > 0.0);
     CHECK(instr.notional > 0.0);
@@ -192,7 +192,7 @@ TEST_CASE("fx_exotic_mapper_roundtrip_average_forward", tags) {
     const auto r = load_and_map("FX_Average_Forward.xml");
     const auto& instr = std::get<fx_asian_forward_instrument>(r);
 
-    CHECK(instr.trade_type_code == "FxAverageForward");
+    CHECK(instr.identity.trade_type_code == "FxAverageForward");
     CHECK(!instr.payment_date.empty());
     CHECK(!instr.reference_currency.empty());
     CHECK(!instr.settlement_currency.empty());
@@ -211,7 +211,7 @@ TEST_CASE("fx_exotic_mapper_roundtrip_accumulator", tags) {
     const auto r = load_and_map("Exotic_FxAccumulator.xml");
     const auto& instr = std::get<fx_accumulator_instrument>(r);
 
-    CHECK(instr.trade_type_code == "FxAccumulator");
+    CHECK(instr.identity.trade_type_code == "FxAccumulator");
     CHECK(!instr.underlying_code.empty());
     CHECK(!instr.currency.empty());
     CHECK(instr.fixing_amount > 0.0);
@@ -228,7 +228,7 @@ TEST_CASE("fx_exotic_mapper_roundtrip_tarf", tags) {
     const auto r = load_and_map("Exotic_FxTaRF.xml");
     const auto& instr = std::get<fx_asian_forward_instrument>(r);
 
-    CHECK(instr.trade_type_code == "FxTaRF");
+    CHECK(instr.identity.trade_type_code == "FxTaRF");
     CHECK(!instr.fx_index.empty());
     CHECK(!instr.currency.empty());
     CHECK(!instr.long_short.empty());
@@ -251,7 +251,7 @@ TEST_CASE("fx_exotic_mapper_roundtrip_generic_barrier_option", tags) {
     const auto r = load_and_map("Exotic_FxGenericBarrierOption.xml");
     const auto& instr = std::get<fx_barrier_option_instrument>(r);
 
-    CHECK(instr.trade_type_code == "FxGenericBarrierOption");
+    CHECK(instr.identity.trade_type_code == "FxGenericBarrierOption");
     CHECK(!instr.underlying_code.empty());
     CHECK(!instr.bought_currency.empty());
 

--- a/projects/ores.ore/core/tests/xml_fx_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/core/tests/xml_fx_mapper_roundtrip_tests.cpp
@@ -78,7 +78,7 @@ TEST_CASE("mapper_roundtrip_fx_forward_forward", tags) {
     const auto result = fx_instrument_mapper::forward_fx_forward(t);
     const auto& instr = std::get<fx_forward_instrument>(result);
 
-    CHECK(instr.trade_type_code == "FxForward");
+    CHECK(instr.identity.trade_type_code == "FxForward");
     CHECK(!instr.value_date.empty());
     CHECK(instr.value_date == "2033-02-20");
     CHECK(instr.bought_currency == "EUR");
@@ -118,7 +118,7 @@ TEST_CASE("mapper_roundtrip_fx_swap_forward", tags) {
     const auto result = fx_instrument_mapper::forward_fx_swap(t);
     const auto& instr = std::get<fx_forward_instrument>(result);
 
-    CHECK(instr.trade_type_code == "FxSwap");
+    CHECK(instr.identity.trade_type_code == "FxSwap");
     CHECK(!instr.value_date.empty());
     CHECK(instr.value_date == "2025-08-23");
     CHECK(instr.bought_currency == "EUR");
@@ -156,7 +156,7 @@ TEST_CASE("mapper_roundtrip_fx_option_forward", tags) {
     const auto result = fx_instrument_mapper::forward_fx_option(t);
     const auto& instr = std::get<fx_vanilla_option_instrument>(result);
 
-    CHECK(instr.trade_type_code == "FxOption");
+    CHECK(instr.identity.trade_type_code == "FxOption");
     CHECK(instr.bought_currency == "EUR");
     CHECK(instr.bought_amount == Approx(1000000.0).epsilon(0.001));
     CHECK(instr.sold_currency == "USD");

--- a/projects/ores.ore/core/tests/xml_remaining_phases_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/core/tests/xml_remaining_phases_mapper_roundtrip_tests.cpp
@@ -131,7 +131,7 @@ TEST_CASE("fx_double_barrier_option_forward", tags) {
     const auto r = load_and_map_fx("FX_DoubleBarrierOption.xml");
     const auto& instr = std::get<fx_barrier_option_instrument>(r);
 
-    CHECK(instr.trade_type_code == "FxDoubleBarrierOption");
+    CHECK(instr.identity.trade_type_code == "FxDoubleBarrierOption");
     CHECK(!instr.bought_currency.empty());
     CHECK(!instr.sold_currency.empty());
     CHECK(!instr.option_type.empty());
@@ -159,7 +159,7 @@ TEST_CASE("fx_european_barrier_option_forward", tags) {
     const auto r = load_and_map_fx("FX_FxEuropeanBarrierOption.xml");
     const auto& instr = std::get<fx_barrier_option_instrument>(r);
 
-    CHECK(instr.trade_type_code == "FxEuropeanBarrierOption");
+    CHECK(instr.identity.trade_type_code == "FxEuropeanBarrierOption");
     CHECK(!instr.bought_currency.empty());
     CHECK(!instr.sold_currency.empty());
 
@@ -186,7 +186,7 @@ TEST_CASE("fx_kiko_barrier_option_forward", tags) {
     const auto r = load_and_map_fx("FX_KIKO_Barrier_Option.xml");
     const auto& instr = std::get<fx_barrier_option_instrument>(r);
 
-    CHECK(instr.trade_type_code == "FxKIKOBarrierOption");
+    CHECK(instr.identity.trade_type_code == "FxKIKOBarrierOption");
     CHECK(!instr.option_type.empty());
 
     BOOST_LOG_SEV(lg, info) << "FxKIKOBarrierOption forward test passed";

--- a/projects/ores.ore/core/tests/xml_trade_import_tests.cpp
+++ b/projects/ores.ore/core/tests/xml_trade_import_tests.cpp
@@ -305,10 +305,10 @@ TEST_CASE("import_portfolio_with_context_fx_forward_has_instrument", tags) {
 
     const auto& r = std::get<fx_instrument_variant>(item.instrument);
     const auto& instr = std::get<fx_forward_instrument>(r);
-    CHECK(instr.instrument_id != item.trade.identity.id);
-    REQUIRE(instr.trade_id.has_value());
-    CHECK(*instr.trade_id == item.trade.identity.id);
-    CHECK(item.trade.classification.instrument_id == instr.instrument_id);
+    CHECK(instr.identity.instrument_id != item.trade.identity.id);
+    REQUIRE(instr.identity.trade_id.has_value());
+    CHECK(*instr.identity.trade_id == item.trade.identity.id);
+    CHECK(item.trade.classification.instrument_id == instr.identity.instrument_id);
     CHECK(item.trade.classification.product_type == ores::trading::domain::product_type::fx);
     CHECK(!instr.bought_currency.empty());
     CHECK(!instr.sold_currency.empty());

--- a/projects/ores.platform/src/net/network_info.cpp
+++ b/projects/ores.platform/src/net/network_info.cpp
@@ -41,8 +41,8 @@
 #    include <sys/types.h>
 #    include <unistd.h>
 #elif defined(_WIN32)
-#    include <iphlpapi.h>
 #    include <windows.h>
+#    include <iphlpapi.h>
 #    pragma comment(lib, "iphlpapi.lib")
 #endif
 

--- a/projects/ores.qt/admin/include/ores.qt/AccountHistoryDialog.hpp
+++ b/projects/ores.qt/admin/include/ores.qt/AccountHistoryDialog.hpp
@@ -26,10 +26,8 @@
 #include "ores.qt/ClientManager.hpp"
 #include "ui_AccountHistoryDialog.h"
 #include <QAction>
-#include <QPair>
 #include <QString>
 #include <QToolBar>
-#include <QVector>
 #include <QWidget>
 #include <memory>
 
@@ -109,15 +107,6 @@ private slots:
 private:
     void displayChangesTab(int version_index);
     void displayFullDetailsTab(int version_index);
-
-    /**
-     * @brief Calculate differences between two versions.
-     *
-     * @return Vector of (field_name, (old_value, new_value)) pairs.
-     */
-    using DiffResult = QVector<QPair<QString, QPair<QString, QString>>>;
-    DiffResult calculateDiff(const iam::domain::account_version& current,
-                             const iam::domain::account_version& previous);
 
     void setupToolbar();
     void updateButtonStates();

--- a/projects/ores.qt/admin/src/AccountHistoryDialog.cpp
+++ b/projects/ores.qt/admin/src/AccountHistoryDialog.cpp
@@ -26,8 +26,10 @@
 #include <QDateTime>
 #include <QFutureWatcher>
 #include <QIcon>
+#include <QPair>
 #include <QScrollBar>
 #include <QVBoxLayout>
+#include <QVector>
 #include <QtConcurrent>
 
 namespace ores::qt {
@@ -206,6 +208,39 @@ void AccountHistoryDialog::onVersionSelected(int index) {
     displayFullDetailsTab(index);
 }
 
+namespace {
+
+/**
+ * @brief Vector of (field_name, (old_value, new_value)) pairs.
+ *
+ * Local to this translation unit; the planned HistoryDialogBase
+ * consolidation will move DiffResult and the calculateDiff template
+ * method into the base class.
+ */
+using DiffResult = QVector<QPair<QString, QPair<QString, QString>>>;
+
+void check_diff_string(DiffResult& diffs,
+                       const QString& field_name,
+                       const std::string& current_val,
+                       const std::string& previous_val) {
+    if (current_val != previous_val)
+        diffs.append({field_name,
+                      {QString::fromStdString(previous_val), QString::fromStdString(current_val)}});
+}
+
+DiffResult calculateDiff(const iam::domain::account_version& current,
+                         const iam::domain::account_version& previous) {
+
+    DiffResult diffs;
+
+    check_diff_string(diffs, "Username", current.data.username, previous.data.username);
+    check_diff_string(diffs, "Email", current.data.email, previous.data.email);
+
+    return diffs;
+}
+
+}
+
 void AccountHistoryDialog::displayChangesTab(int version_index) {
     ui_->changesTableWidget->setRowCount(0);
 
@@ -254,31 +289,6 @@ void AccountHistoryDialog::displayFullDetailsTab(int version_index) {
     ui_->versionNumberValue->setText(QString::number(version.version_number));
     ui_->modifiedByValue->setText(QString::fromStdString(version.modified_by));
     ui_->recordedAtValue->setText(relative_time_helper::format(version.recorded_at));
-}
-
-namespace {
-
-void check_diff_string(AccountHistoryDialog::DiffResult& diffs,
-                       const QString& field_name,
-                       const std::string& current_val,
-                       const std::string& previous_val) {
-    if (current_val != previous_val)
-        diffs.append({field_name,
-                      {QString::fromStdString(previous_val), QString::fromStdString(current_val)}});
-}
-
-}
-
-AccountHistoryDialog::DiffResult
-AccountHistoryDialog::calculateDiff(const iam::domain::account_version& current,
-                                    const iam::domain::account_version& previous) {
-
-    DiffResult diffs;
-
-    check_diff_string(diffs, "Username", current.data.username, previous.data.username);
-    check_diff_string(diffs, "Email", current.data.email, previous.data.email);
-
-    return diffs;
 }
 
 void AccountHistoryDialog::setupToolbar() {

--- a/projects/ores.qt/admin/src/AccountPartiesWidget.cpp
+++ b/projects/ores.qt/admin/src/AccountPartiesWidget.cpp
@@ -162,55 +162,56 @@ void AccountPartiesWidget::load() {
     });
 
     auto* clientManager = clientManager_;
-    QFuture<LoadResult> future = QtConcurrent::run([self, clientManager, accountId, has_account]() -> LoadResult {
-        if (!self)
-            return {.success = false};
+    QFuture<LoadResult> future =
+        QtConcurrent::run([self, clientManager, accountId, has_account]() -> LoadResult {
+            if (!self)
+                return {.success = false};
 
-        std::vector<iam::domain::account_party> assigned;
-        if (has_account) {
-            auto assignedFuture = std::async(std::launch::async, [clientManager, accountId]() {
-                iam::messaging::get_account_parties_by_account_request request;
-                request.account_id = boost::uuids::to_string(accountId);
-                return clientManager->process_authenticated_request(std::move(request));
-            });
+            std::vector<iam::domain::account_party> assigned;
+            if (has_account) {
+                auto assignedFuture = std::async(std::launch::async, [clientManager, accountId]() {
+                    iam::messaging::get_account_parties_by_account_request request;
+                    request.account_id = boost::uuids::to_string(accountId);
+                    return clientManager->process_authenticated_request(std::move(request));
+                });
 
-            auto allPartiesFuture = std::async(std::launch::async, [clientManager]() {
-                refdata::messaging::get_parties_request request;
-                request.offset = 0;
-                request.limit = 1000;
-                return clientManager->process_authenticated_request(std::move(request));
-            });
+                auto allPartiesFuture = std::async(std::launch::async, [clientManager]() {
+                    refdata::messaging::get_parties_request request;
+                    request.offset = 0;
+                    request.limit = 1000;
+                    return clientManager->process_authenticated_request(std::move(request));
+                });
 
-            auto assignedResult = assignedFuture.get();
-            auto allPartiesResult = allPartiesFuture.get();
+                auto assignedResult = assignedFuture.get();
+                auto allPartiesResult = allPartiesFuture.get();
 
-            if (!assignedResult) {
-                BOOST_LOG_SEV(lg(), error)
-                    << "Failed to fetch assigned parties: " << assignedResult.error();
+                if (!assignedResult) {
+                    BOOST_LOG_SEV(lg(), error)
+                        << "Failed to fetch assigned parties: " << assignedResult.error();
+                    return {.success = false};
+                }
+                if (!allPartiesResult) {
+                    BOOST_LOG_SEV(lg(), error)
+                        << "Failed to fetch all parties: " << allPartiesResult.error();
+                    return {.success = false};
+                }
+                return {.success = true,
+                        .assignedParties = std::move(assignedResult->account_parties),
+                        .allParties = std::move(allPartiesResult->parties)};
+            }
+
+            // Create mode: only fetch all parties
+            refdata::messaging::get_parties_request request;
+            request.offset = 0;
+            request.limit = 1000;
+            auto result = clientManager->process_authenticated_request(std::move(request));
+
+            if (!result) {
+                BOOST_LOG_SEV(lg(), error) << "Failed to fetch parties: " << result.error();
                 return {.success = false};
             }
-            if (!allPartiesResult) {
-                BOOST_LOG_SEV(lg(), error)
-                    << "Failed to fetch all parties: " << allPartiesResult.error();
-                return {.success = false};
-            }
-            return {.success = true,
-                    .assignedParties = std::move(assignedResult->account_parties),
-                    .allParties = std::move(allPartiesResult->parties)};
-        }
-
-        // Create mode: only fetch all parties
-        refdata::messaging::get_parties_request request;
-        request.offset = 0;
-        request.limit = 1000;
-        auto result = clientManager->process_authenticated_request(std::move(request));
-
-        if (!result) {
-            BOOST_LOG_SEV(lg(), error) << "Failed to fetch parties: " << result.error();
-            return {.success = false};
-        }
-        return {.success = true, .allParties = std::move(result->parties)};
-    });
+            return {.success = true, .allParties = std::move(result->parties)};
+        });
 
     watcher->setFuture(future);
 }

--- a/projects/ores.qt/admin/src/AccountRolesWidget.cpp
+++ b/projects/ores.qt/admin/src/AccountRolesWidget.cpp
@@ -151,50 +151,52 @@ void AccountRolesWidget::load() {
     });
 
     auto* clientManager = clientManager_;
-    QFuture<LoadResult> future = QtConcurrent::run([self, clientManager, accountId, has_account]() -> LoadResult {
-        if (!self)
-            return {.success = false};
+    QFuture<LoadResult> future =
+        QtConcurrent::run([self, clientManager, accountId, has_account]() -> LoadResult {
+            if (!self)
+                return {.success = false};
 
-        if (has_account) {
-            auto accountRolesFuture = std::async(std::launch::async, [clientManager, accountId]() {
-                iam::messaging::get_account_roles_request request;
-                request.account_id = boost::uuids::to_string(accountId);
-                return clientManager->process_authenticated_request(std::move(request));
-            });
+            if (has_account) {
+                auto accountRolesFuture =
+                    std::async(std::launch::async, [clientManager, accountId]() {
+                        iam::messaging::get_account_roles_request request;
+                        request.account_id = boost::uuids::to_string(accountId);
+                        return clientManager->process_authenticated_request(std::move(request));
+                    });
 
-            auto allRolesFuture = std::async(std::launch::async, [clientManager]() {
-                iam::messaging::list_roles_request request;
-                return clientManager->process_authenticated_request(std::move(request));
-            });
+                auto allRolesFuture = std::async(std::launch::async, [clientManager]() {
+                    iam::messaging::list_roles_request request;
+                    return clientManager->process_authenticated_request(std::move(request));
+                });
 
-            auto accountRolesResult = accountRolesFuture.get();
-            auto allRolesResult = allRolesFuture.get();
+                auto accountRolesResult = accountRolesFuture.get();
+                auto allRolesResult = allRolesFuture.get();
 
-            if (!accountRolesResult) {
-                BOOST_LOG_SEV(lg(), error)
-                    << "Failed to fetch account roles: " << accountRolesResult.error();
+                if (!accountRolesResult) {
+                    BOOST_LOG_SEV(lg(), error)
+                        << "Failed to fetch account roles: " << accountRolesResult.error();
+                    return {.success = false};
+                }
+                if (!allRolesResult) {
+                    BOOST_LOG_SEV(lg(), error)
+                        << "Failed to fetch all roles: " << allRolesResult.error();
+                    return {.success = false};
+                }
+                return {.success = true,
+                        .assignedRoles = std::move(accountRolesResult->roles),
+                        .allRoles = std::move(allRolesResult->roles)};
+            }
+
+            // Create mode: only fetch all roles
+            iam::messaging::list_roles_request request;
+            auto result = clientManager->process_authenticated_request(std::move(request));
+
+            if (!result) {
+                BOOST_LOG_SEV(lg(), error) << "Failed to fetch roles: " << result.error();
                 return {.success = false};
             }
-            if (!allRolesResult) {
-                BOOST_LOG_SEV(lg(), error)
-                    << "Failed to fetch all roles: " << allRolesResult.error();
-                return {.success = false};
-            }
-            return {.success = true,
-                    .assignedRoles = std::move(accountRolesResult->roles),
-                    .allRoles = std::move(allRolesResult->roles)};
-        }
-
-        // Create mode: only fetch all roles
-        iam::messaging::list_roles_request request;
-        auto result = clientManager->process_authenticated_request(std::move(request));
-
-        if (!result) {
-            BOOST_LOG_SEV(lg(), error) << "Failed to fetch roles: " << result.error();
-            return {.success = false};
-        }
-        return {.success = true, .allRoles = std::move(result->roles)};
-    });
+            return {.success = true, .allRoles = std::move(result->roles)};
+        });
 
     watcher->setFuture(future);
 }

--- a/projects/ores.qt/api/tests/instrument_parse_dispatch_tests.cpp
+++ b/projects/ores.qt/api/tests/instrument_parse_dispatch_tests.cpp
@@ -252,8 +252,8 @@ TEST_CASE("parse_trade_instrument_dispatches_scripted", tags) {
 
 TEST_CASE("parse_trade_instrument_dispatches_fx_forward", tags) {
     fx_forward_instrument instr;
-    instr.instrument_id = boost::uuids::random_generator()();
-    instr.trade_type_code = "FxForward";
+    instr.identity.instrument_id = boost::uuids::random_generator()();
+    instr.identity.trade_type_code = "FxForward";
     instr.bought_currency = "EUR";
     instr.sold_currency = "USD";
     instr.bought_amount = 1'000'000.0;
@@ -269,7 +269,7 @@ TEST_CASE("parse_trade_instrument_dispatches_fx_forward", tags) {
     REQUIRE(result.has_value());
     CHECK(result->classification.product_type == product_type::fx);
     REQUIRE(pop.called);
-    CHECK(pop.got.instrument_id == instr.instrument_id);
+    CHECK(pop.got.identity.instrument_id == instr.identity.instrument_id);
     CHECK(pop.got.bought_currency == "EUR");
     CHECK(pop.got.sold_currency == "USD");
     CHECK(pop.got.value_date == "2026-06-30");
@@ -281,8 +281,8 @@ TEST_CASE("parse_trade_instrument_dispatches_fx_forward", tags) {
 
 TEST_CASE("parse_trade_instrument_dispatches_fx_vanilla_option", tags) {
     fx_vanilla_option_instrument instr;
-    instr.instrument_id = boost::uuids::random_generator()();
-    instr.trade_type_code = "FxOption";
+    instr.identity.instrument_id = boost::uuids::random_generator()();
+    instr.identity.trade_type_code = "FxOption";
 
     auto json = make_response_json(make_test_trade(product_type::fx, "FxOption"),
                                    trade_instrument{fx_instrument_variant{instr}});
@@ -293,7 +293,7 @@ TEST_CASE("parse_trade_instrument_dispatches_fx_vanilla_option", tags) {
     REQUIRE(result.has_value());
     CHECK(result->classification.product_type == product_type::fx);
     REQUIRE(pop.called);
-    CHECK(pop.got.instrument_id == instr.instrument_id);
+    CHECK(pop.got.identity.instrument_id == instr.identity.instrument_id);
 }
 
 // =============================================================================

--- a/projects/ores.qt/trading/src/FxAccumulatorInstrumentForm.cpp
+++ b/projects/ores.qt/trading/src/FxAccumulatorInstrumentForm.cpp
@@ -116,9 +116,9 @@ void FxAccumulatorInstrumentForm::setUsername(const std::string& username) {
 }
 
 void FxAccumulatorInstrumentForm::clear() {
-    const std::string ttc = instrument_.trade_type_code;
+    const std::string ttc = instrument_.identity.trade_type_code;
     instrument_ = trading::domain::fx_accumulator_instrument{};
-    instrument_.trade_type_code = ttc;
+    instrument_.identity.trade_type_code = ttc;
     loaded_ = true;
     dirty_ = false;
     populateFromInstrument();
@@ -127,7 +127,7 @@ void FxAccumulatorInstrumentForm::clear() {
 void FxAccumulatorInstrumentForm::setTradeType(const QString& code,
                                                bool /*has_options*/,
                                                bool /*has_extension*/) {
-    instrument_.trade_type_code = code.trimmed().toStdString();
+    instrument_.identity.trade_type_code = code.trimmed().toStdString();
     ui_->tradeTypeCodeEdit->setText(code.trimmed());
 }
 
@@ -151,8 +151,8 @@ bool FxAccumulatorInstrumentForm::isLoaded() const {
 
 void FxAccumulatorInstrumentForm::setChangeReason(const std::string& code,
                                                   const std::string& commentary) {
-    instrument_.change_reason_code = code;
-    instrument_.change_commentary = commentary;
+    instrument_.audit.change_reason_code = code;
+    instrument_.audit.change_commentary = commentary;
 }
 
 void FxAccumulatorInstrumentForm::writeUiToInstrument() {
@@ -167,8 +167,8 @@ void FxAccumulatorInstrumentForm::writeUiToInstrument() {
         instrument_.knock_out_barrier = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
     }
     instrument_.description = ui_->descriptionEdit->toPlainText().trimmed().toStdString();
-    instrument_.modified_by = username_;
-    instrument_.performed_by = username_;
+    instrument_.audit.modified_by = username_;
+    instrument_.audit.performed_by = username_;
 }
 
 void FxAccumulatorInstrumentForm::populate(
@@ -194,7 +194,7 @@ void FxAccumulatorInstrumentForm::populateFromInstrument() {
     };
 
     block(true);
-    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.trade_type_code));
+    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.identity.trade_type_code));
     InstrumentFormUtils::setComboValue(ui_->currencyCombo, instrument_.currency);
     ui_->fixingAmountSpinBox->setValue(instrument_.fixing_amount);
     ui_->strikeSpinBox->setValue(instrument_.strike);
@@ -208,12 +208,12 @@ void FxAccumulatorInstrumentForm::populateFromInstrument() {
 
 void FxAccumulatorInstrumentForm::emitProvenance() {
     InstrumentProvenance p;
-    p.version = instrument_.version;
-    p.modified_by = instrument_.modified_by;
-    p.performed_by = instrument_.performed_by;
-    p.recorded_at = instrument_.recorded_at;
-    p.change_reason_code = instrument_.change_reason_code;
-    p.change_commentary = instrument_.change_commentary;
+    p.version = instrument_.identity.version;
+    p.modified_by = instrument_.audit.modified_by;
+    p.performed_by = instrument_.audit.performed_by;
+    p.recorded_at = instrument_.audit.recorded_at;
+    p.change_reason_code = instrument_.audit.change_reason_code;
+    p.change_commentary = instrument_.audit.change_commentary;
     emit provenanceChanged(p);
 }
 
@@ -258,7 +258,7 @@ void FxAccumulatorInstrumentForm::saveInstrument(std::function<void(const std::s
             BOOST_LOG_SEV(lg(), info) << "FX accumulator instrument saved";
             self->dirty_ = false;
             self->emitProvenance();
-            on_success(boost::uuids::to_string(self->instrument_.instrument_id));
+            on_success(boost::uuids::to_string(self->instrument_.identity.instrument_id));
         });
 
     auto* cm = clientManager_;

--- a/projects/ores.qt/trading/src/FxAsianForwardInstrumentForm.cpp
+++ b/projects/ores.qt/trading/src/FxAsianForwardInstrumentForm.cpp
@@ -139,9 +139,9 @@ void FxAsianForwardInstrumentForm::setUsername(const std::string& username) {
 }
 
 void FxAsianForwardInstrumentForm::clear() {
-    const std::string ttc = instrument_.trade_type_code;
+    const std::string ttc = instrument_.identity.trade_type_code;
     instrument_ = trading::domain::fx_asian_forward_instrument{};
-    instrument_.trade_type_code = ttc;
+    instrument_.identity.trade_type_code = ttc;
     loaded_ = true;
     dirty_ = false;
     populateFromInstrument();
@@ -150,7 +150,7 @@ void FxAsianForwardInstrumentForm::clear() {
 void FxAsianForwardInstrumentForm::setTradeType(const QString& code,
                                                 bool /*has_options*/,
                                                 bool /*has_extension*/) {
-    instrument_.trade_type_code = code.trimmed().toStdString();
+    instrument_.identity.trade_type_code = code.trimmed().toStdString();
     ui_->tradeTypeCodeEdit->setText(code.trimmed());
 }
 
@@ -178,8 +178,8 @@ bool FxAsianForwardInstrumentForm::isLoaded() const {
 
 void FxAsianForwardInstrumentForm::setChangeReason(const std::string& code,
                                                    const std::string& commentary) {
-    instrument_.change_reason_code = code;
-    instrument_.change_commentary = commentary;
+    instrument_.audit.change_reason_code = code;
+    instrument_.audit.change_commentary = commentary;
 }
 
 void FxAsianForwardInstrumentForm::writeUiToInstrument() {
@@ -212,8 +212,8 @@ void FxAsianForwardInstrumentForm::writeUiToInstrument() {
         instrument_.strike = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
     }
     instrument_.description = ui_->descriptionEdit->toPlainText().trimmed().toStdString();
-    instrument_.modified_by = username_;
-    instrument_.performed_by = username_;
+    instrument_.audit.modified_by = username_;
+    instrument_.audit.performed_by = username_;
 }
 
 void FxAsianForwardInstrumentForm::populate(
@@ -243,7 +243,7 @@ void FxAsianForwardInstrumentForm::populateFromInstrument() {
     };
 
     block(true);
-    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.trade_type_code));
+    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.identity.trade_type_code));
     ui_->fxIndexEdit->setText(QString::fromStdString(instrument_.fx_index));
     InstrumentFormUtils::setComboValue(ui_->referenceCurrencyCombo, instrument_.reference_currency);
     ui_->referenceNotionalSpinBox->setValue(instrument_.reference_notional.value_or(0.0));
@@ -262,12 +262,12 @@ void FxAsianForwardInstrumentForm::populateFromInstrument() {
 
 void FxAsianForwardInstrumentForm::emitProvenance() {
     InstrumentProvenance p;
-    p.version = instrument_.version;
-    p.modified_by = instrument_.modified_by;
-    p.performed_by = instrument_.performed_by;
-    p.recorded_at = instrument_.recorded_at;
-    p.change_reason_code = instrument_.change_reason_code;
-    p.change_commentary = instrument_.change_commentary;
+    p.version = instrument_.identity.version;
+    p.modified_by = instrument_.audit.modified_by;
+    p.performed_by = instrument_.audit.performed_by;
+    p.recorded_at = instrument_.audit.recorded_at;
+    p.change_reason_code = instrument_.audit.change_reason_code;
+    p.change_commentary = instrument_.audit.change_commentary;
     emit provenanceChanged(p);
 }
 
@@ -313,7 +313,7 @@ void FxAsianForwardInstrumentForm::saveInstrument(
             BOOST_LOG_SEV(lg(), info) << "FX asian forward instrument saved";
             self->dirty_ = false;
             self->emitProvenance();
-            on_success(boost::uuids::to_string(self->instrument_.instrument_id));
+            on_success(boost::uuids::to_string(self->instrument_.identity.instrument_id));
         });
 
     auto* cm = clientManager_;

--- a/projects/ores.qt/trading/src/FxBarrierOptionInstrumentForm.cpp
+++ b/projects/ores.qt/trading/src/FxBarrierOptionInstrumentForm.cpp
@@ -134,9 +134,9 @@ void FxBarrierOptionInstrumentForm::setUsername(const std::string& username) {
 }
 
 void FxBarrierOptionInstrumentForm::clear() {
-    const std::string ttc = instrument_.trade_type_code;
+    const std::string ttc = instrument_.identity.trade_type_code;
     instrument_ = trading::domain::fx_barrier_option_instrument{};
-    instrument_.trade_type_code = ttc;
+    instrument_.identity.trade_type_code = ttc;
     loaded_ = true;
     dirty_ = false;
     populateFromInstrument();
@@ -145,7 +145,7 @@ void FxBarrierOptionInstrumentForm::clear() {
 void FxBarrierOptionInstrumentForm::setTradeType(const QString& code,
                                                  bool /*has_options*/,
                                                  bool /*has_extension*/) {
-    instrument_.trade_type_code = code.trimmed().toStdString();
+    instrument_.identity.trade_type_code = code.trimmed().toStdString();
     ui_->tradeTypeCodeEdit->setText(code.trimmed());
 }
 
@@ -173,8 +173,8 @@ bool FxBarrierOptionInstrumentForm::isLoaded() const {
 
 void FxBarrierOptionInstrumentForm::setChangeReason(const std::string& code,
                                                     const std::string& commentary) {
-    instrument_.change_reason_code = code;
-    instrument_.change_commentary = commentary;
+    instrument_.audit.change_reason_code = code;
+    instrument_.audit.change_commentary = commentary;
 }
 
 void FxBarrierOptionInstrumentForm::writeUiToInstrument() {
@@ -193,8 +193,8 @@ void FxBarrierOptionInstrumentForm::writeUiToInstrument() {
     }
     instrument_.underlying_code = ui_->underlyingCodeEdit->text().trimmed().toStdString();
     instrument_.description = ui_->descriptionEdit->toPlainText().trimmed().toStdString();
-    instrument_.modified_by = username_;
-    instrument_.performed_by = username_;
+    instrument_.audit.modified_by = username_;
+    instrument_.audit.performed_by = username_;
 }
 
 void FxBarrierOptionInstrumentForm::populate(
@@ -224,7 +224,7 @@ void FxBarrierOptionInstrumentForm::populateFromInstrument() {
     };
 
     block(true);
-    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.trade_type_code));
+    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.identity.trade_type_code));
     InstrumentFormUtils::setComboValue(ui_->boughtCurrencyCombo, instrument_.bought_currency);
     ui_->boughtAmountSpinBox->setValue(instrument_.bought_amount);
     InstrumentFormUtils::setComboValue(ui_->soldCurrencyCombo, instrument_.sold_currency);
@@ -242,12 +242,12 @@ void FxBarrierOptionInstrumentForm::populateFromInstrument() {
 
 void FxBarrierOptionInstrumentForm::emitProvenance() {
     InstrumentProvenance p;
-    p.version = instrument_.version;
-    p.modified_by = instrument_.modified_by;
-    p.performed_by = instrument_.performed_by;
-    p.recorded_at = instrument_.recorded_at;
-    p.change_reason_code = instrument_.change_reason_code;
-    p.change_commentary = instrument_.change_commentary;
+    p.version = instrument_.identity.version;
+    p.modified_by = instrument_.audit.modified_by;
+    p.performed_by = instrument_.audit.performed_by;
+    p.recorded_at = instrument_.audit.recorded_at;
+    p.change_reason_code = instrument_.audit.change_reason_code;
+    p.change_commentary = instrument_.audit.change_commentary;
     emit provenanceChanged(p);
 }
 
@@ -293,7 +293,7 @@ void FxBarrierOptionInstrumentForm::saveInstrument(
             BOOST_LOG_SEV(lg(), info) << "FX barrier option instrument saved";
             self->dirty_ = false;
             self->emitProvenance();
-            on_success(boost::uuids::to_string(self->instrument_.instrument_id));
+            on_success(boost::uuids::to_string(self->instrument_.identity.instrument_id));
         });
 
     auto* cm = clientManager_;

--- a/projects/ores.qt/trading/src/FxDigitalOptionInstrumentForm.cpp
+++ b/projects/ores.qt/trading/src/FxDigitalOptionInstrumentForm.cpp
@@ -139,9 +139,9 @@ void FxDigitalOptionInstrumentForm::setUsername(const std::string& username) {
 }
 
 void FxDigitalOptionInstrumentForm::clear() {
-    const std::string ttc = instrument_.trade_type_code;
+    const std::string ttc = instrument_.identity.trade_type_code;
     instrument_ = trading::domain::fx_digital_option_instrument{};
-    instrument_.trade_type_code = ttc;
+    instrument_.identity.trade_type_code = ttc;
     loaded_ = true;
     dirty_ = false;
     populateFromInstrument();
@@ -150,7 +150,7 @@ void FxDigitalOptionInstrumentForm::clear() {
 void FxDigitalOptionInstrumentForm::setTradeType(const QString& code,
                                                  bool /*has_options*/,
                                                  bool /*has_extension*/) {
-    instrument_.trade_type_code = code.trimmed().toStdString();
+    instrument_.identity.trade_type_code = code.trimmed().toStdString();
     ui_->tradeTypeCodeEdit->setText(code.trimmed());
 }
 
@@ -178,8 +178,8 @@ bool FxDigitalOptionInstrumentForm::isLoaded() const {
 
 void FxDigitalOptionInstrumentForm::setChangeReason(const std::string& code,
                                                     const std::string& commentary) {
-    instrument_.change_reason_code = code;
-    instrument_.change_commentary = commentary;
+    instrument_.audit.change_reason_code = code;
+    instrument_.audit.change_commentary = commentary;
 }
 
 void FxDigitalOptionInstrumentForm::writeUiToInstrument() {
@@ -204,8 +204,8 @@ void FxDigitalOptionInstrumentForm::writeUiToInstrument() {
         instrument_.upper_barrier = (v > 0.0) ? std::optional<double>(v) : std::nullopt;
     }
     instrument_.description = ui_->descriptionEdit->toPlainText().trimmed().toStdString();
-    instrument_.modified_by = username_;
-    instrument_.performed_by = username_;
+    instrument_.audit.modified_by = username_;
+    instrument_.audit.performed_by = username_;
 }
 
 void FxDigitalOptionInstrumentForm::populate(
@@ -235,7 +235,7 @@ void FxDigitalOptionInstrumentForm::populateFromInstrument() {
     };
 
     block(true);
-    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.trade_type_code));
+    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.identity.trade_type_code));
     InstrumentFormUtils::setComboValue(ui_->foreignCurrencyCombo, instrument_.foreign_currency);
     InstrumentFormUtils::setComboValue(ui_->domesticCurrencyCombo, instrument_.domestic_currency);
     InstrumentFormUtils::setComboValue(ui_->payoffCurrencyCombo, instrument_.payoff_currency);
@@ -253,12 +253,12 @@ void FxDigitalOptionInstrumentForm::populateFromInstrument() {
 
 void FxDigitalOptionInstrumentForm::emitProvenance() {
     InstrumentProvenance p;
-    p.version = instrument_.version;
-    p.modified_by = instrument_.modified_by;
-    p.performed_by = instrument_.performed_by;
-    p.recorded_at = instrument_.recorded_at;
-    p.change_reason_code = instrument_.change_reason_code;
-    p.change_commentary = instrument_.change_commentary;
+    p.version = instrument_.identity.version;
+    p.modified_by = instrument_.audit.modified_by;
+    p.performed_by = instrument_.audit.performed_by;
+    p.recorded_at = instrument_.audit.recorded_at;
+    p.change_reason_code = instrument_.audit.change_reason_code;
+    p.change_commentary = instrument_.audit.change_commentary;
     emit provenanceChanged(p);
 }
 
@@ -304,7 +304,7 @@ void FxDigitalOptionInstrumentForm::saveInstrument(
             BOOST_LOG_SEV(lg(), info) << "FX digital option instrument saved";
             self->dirty_ = false;
             self->emitProvenance();
-            on_success(boost::uuids::to_string(self->instrument_.instrument_id));
+            on_success(boost::uuids::to_string(self->instrument_.identity.instrument_id));
         });
 
     auto* cm = clientManager_;

--- a/projects/ores.qt/trading/src/FxInstrumentForm.cpp
+++ b/projects/ores.qt/trading/src/FxInstrumentForm.cpp
@@ -132,7 +132,7 @@ void FxInstrumentForm::clear() {
 }
 
 void FxInstrumentForm::setTradeType(const QString& code, bool has_options, bool /*has_extension*/) {
-    instrument_.trade_type_code = code.trimmed().toStdString();
+    instrument_.identity.trade_type_code = code.trimmed().toStdString();
     ui_->tradeTypeCodeEdit->setText(code.trimmed());
     // FX has only an options sub-section; the extension flag is unused.
     ui_->subTabWidget->setTabVisible(ui_->subTabWidget->indexOf(ui_->optionsTab), has_options);
@@ -158,8 +158,8 @@ bool FxInstrumentForm::isLoaded() const {
 }
 
 void FxInstrumentForm::setChangeReason(const std::string& code, const std::string& commentary) {
-    instrument_.change_reason_code = code;
-    instrument_.change_commentary = commentary;
+    instrument_.audit.change_reason_code = code;
+    instrument_.audit.change_commentary = commentary;
 }
 
 void FxInstrumentForm::writeUiToInstrument() {
@@ -170,8 +170,8 @@ void FxInstrumentForm::writeUiToInstrument() {
     instrument_.value_date = ui_->valueDateEdit->isoDate();
     instrument_.settlement = InstrumentFormUtils::getComboValue(ui_->settlementCombo);
     instrument_.description = ui_->descriptionEdit->toPlainText().trimmed().toStdString();
-    instrument_.modified_by = username_;
-    instrument_.performed_by = username_;
+    instrument_.audit.modified_by = username_;
+    instrument_.audit.performed_by = username_;
 }
 
 void FxInstrumentForm::populate(const trading::domain::fx_forward_instrument& instr) {
@@ -181,7 +181,7 @@ void FxInstrumentForm::populate(const trading::domain::fx_forward_instrument& in
     populateFromInstrument();
     emitProvenance();
     BOOST_LOG_SEV(lg(), debug) << "FxInstrumentForm: instrument loaded trade_type_code="
-                               << instrument_.trade_type_code;
+                               << instrument_.identity.trade_type_code;
     emit instrumentLoaded();
 }
 
@@ -199,7 +199,7 @@ void FxInstrumentForm::populateFromInstrument() {
     };
 
     block(true);
-    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.trade_type_code));
+    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.identity.trade_type_code));
     InstrumentFormUtils::setComboValue(ui_->boughtCurrencyCombo, instrument_.bought_currency);
     ui_->boughtAmountSpinBox->setValue(instrument_.bought_amount);
     InstrumentFormUtils::setComboValue(ui_->soldCurrencyCombo, instrument_.sold_currency);
@@ -212,12 +212,12 @@ void FxInstrumentForm::populateFromInstrument() {
 
 void FxInstrumentForm::emitProvenance() {
     InstrumentProvenance p;
-    p.version = instrument_.version;
-    p.modified_by = instrument_.modified_by;
-    p.performed_by = instrument_.performed_by;
-    p.recorded_at = instrument_.recorded_at;
-    p.change_reason_code = instrument_.change_reason_code;
-    p.change_commentary = instrument_.change_commentary;
+    p.version = instrument_.identity.version;
+    p.modified_by = instrument_.audit.modified_by;
+    p.performed_by = instrument_.audit.performed_by;
+    p.recorded_at = instrument_.audit.recorded_at;
+    p.change_reason_code = instrument_.audit.change_reason_code;
+    p.change_commentary = instrument_.audit.change_commentary;
     emit provenanceChanged(p);
 }
 
@@ -262,7 +262,7 @@ void FxInstrumentForm::saveInstrument(std::function<void(const std::string&)> on
             BOOST_LOG_SEV(lg(), info) << "FX instrument saved";
             self->dirty_ = false;
             self->emitProvenance();
-            on_success(boost::uuids::to_string(self->instrument_.instrument_id));
+            on_success(boost::uuids::to_string(self->instrument_.identity.instrument_id));
         });
 
     auto* cm = clientManager_;

--- a/projects/ores.qt/trading/src/FxVanillaOptionInstrumentForm.cpp
+++ b/projects/ores.qt/trading/src/FxVanillaOptionInstrumentForm.cpp
@@ -125,9 +125,9 @@ void FxVanillaOptionInstrumentForm::setUsername(const std::string& username) {
 }
 
 void FxVanillaOptionInstrumentForm::clear() {
-    const std::string ttc = instrument_.trade_type_code;
+    const std::string ttc = instrument_.identity.trade_type_code;
     instrument_ = trading::domain::fx_vanilla_option_instrument{};
-    instrument_.trade_type_code = ttc;
+    instrument_.identity.trade_type_code = ttc;
     loaded_ = true;
     dirty_ = false;
     populateFromInstrument();
@@ -136,7 +136,7 @@ void FxVanillaOptionInstrumentForm::clear() {
 void FxVanillaOptionInstrumentForm::setTradeType(const QString& code,
                                                  bool /*has_options*/,
                                                  bool /*has_extension*/) {
-    instrument_.trade_type_code = code.trimmed().toStdString();
+    instrument_.identity.trade_type_code = code.trimmed().toStdString();
     ui_->tradeTypeCodeEdit->setText(code.trimmed());
 }
 
@@ -161,8 +161,8 @@ bool FxVanillaOptionInstrumentForm::isLoaded() const {
 
 void FxVanillaOptionInstrumentForm::setChangeReason(const std::string& code,
                                                     const std::string& commentary) {
-    instrument_.change_reason_code = code;
-    instrument_.change_commentary = commentary;
+    instrument_.audit.change_reason_code = code;
+    instrument_.audit.change_commentary = commentary;
 }
 
 void FxVanillaOptionInstrumentForm::writeUiToInstrument() {
@@ -175,8 +175,8 @@ void FxVanillaOptionInstrumentForm::writeUiToInstrument() {
     instrument_.exercise_style = InstrumentFormUtils::getComboValue(ui_->exerciseStyleCombo);
     instrument_.settlement = InstrumentFormUtils::getComboValue(ui_->settlementCombo);
     instrument_.description = ui_->descriptionEdit->toPlainText().trimmed().toStdString();
-    instrument_.modified_by = username_;
-    instrument_.performed_by = username_;
+    instrument_.audit.modified_by = username_;
+    instrument_.audit.performed_by = username_;
 }
 
 void FxVanillaOptionInstrumentForm::populate(
@@ -203,7 +203,7 @@ void FxVanillaOptionInstrumentForm::populateFromInstrument() {
     };
 
     block(true);
-    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.trade_type_code));
+    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.identity.trade_type_code));
     InstrumentFormUtils::setComboValue(ui_->boughtCurrencyCombo, instrument_.bought_currency);
     ui_->boughtAmountSpinBox->setValue(instrument_.bought_amount);
     InstrumentFormUtils::setComboValue(ui_->soldCurrencyCombo, instrument_.sold_currency);
@@ -218,12 +218,12 @@ void FxVanillaOptionInstrumentForm::populateFromInstrument() {
 
 void FxVanillaOptionInstrumentForm::emitProvenance() {
     InstrumentProvenance p;
-    p.version = instrument_.version;
-    p.modified_by = instrument_.modified_by;
-    p.performed_by = instrument_.performed_by;
-    p.recorded_at = instrument_.recorded_at;
-    p.change_reason_code = instrument_.change_reason_code;
-    p.change_commentary = instrument_.change_commentary;
+    p.version = instrument_.identity.version;
+    p.modified_by = instrument_.audit.modified_by;
+    p.performed_by = instrument_.audit.performed_by;
+    p.recorded_at = instrument_.audit.recorded_at;
+    p.change_reason_code = instrument_.audit.change_reason_code;
+    p.change_commentary = instrument_.audit.change_commentary;
     emit provenanceChanged(p);
 }
 
@@ -269,7 +269,7 @@ void FxVanillaOptionInstrumentForm::saveInstrument(
             BOOST_LOG_SEV(lg(), info) << "FX vanilla option instrument saved";
             self->dirty_ = false;
             self->emitProvenance();
-            on_success(boost::uuids::to_string(self->instrument_.instrument_id));
+            on_success(boost::uuids::to_string(self->instrument_.identity.instrument_id));
         });
 
     auto* cm = clientManager_;

--- a/projects/ores.qt/trading/src/FxVarianceSwapInstrumentForm.cpp
+++ b/projects/ores.qt/trading/src/FxVarianceSwapInstrumentForm.cpp
@@ -115,9 +115,9 @@ void FxVarianceSwapInstrumentForm::setUsername(const std::string& username) {
 }
 
 void FxVarianceSwapInstrumentForm::clear() {
-    const std::string ttc = instrument_.trade_type_code;
+    const std::string ttc = instrument_.identity.trade_type_code;
     instrument_ = trading::domain::fx_variance_swap_instrument{};
-    instrument_.trade_type_code = ttc;
+    instrument_.identity.trade_type_code = ttc;
     loaded_ = true;
     dirty_ = false;
     populateFromInstrument();
@@ -126,7 +126,7 @@ void FxVarianceSwapInstrumentForm::clear() {
 void FxVarianceSwapInstrumentForm::setTradeType(const QString& code,
                                                 bool /*has_options*/,
                                                 bool /*has_extension*/) {
-    instrument_.trade_type_code = code.trimmed().toStdString();
+    instrument_.identity.trade_type_code = code.trimmed().toStdString();
     ui_->tradeTypeCodeEdit->setText(code.trimmed());
 }
 
@@ -151,8 +151,8 @@ bool FxVarianceSwapInstrumentForm::isLoaded() const {
 
 void FxVarianceSwapInstrumentForm::setChangeReason(const std::string& code,
                                                    const std::string& commentary) {
-    instrument_.change_reason_code = code;
-    instrument_.change_commentary = commentary;
+    instrument_.audit.change_reason_code = code;
+    instrument_.audit.change_commentary = commentary;
 }
 
 void FxVarianceSwapInstrumentForm::writeUiToInstrument() {
@@ -165,8 +165,8 @@ void FxVarianceSwapInstrumentForm::writeUiToInstrument() {
     instrument_.notional = ui_->notionalSpinBox->value();
     instrument_.moment_type = InstrumentFormUtils::getComboValue(ui_->momentTypeCombo);
     instrument_.description = ui_->descriptionEdit->toPlainText().trimmed().toStdString();
-    instrument_.modified_by = username_;
-    instrument_.performed_by = username_;
+    instrument_.audit.modified_by = username_;
+    instrument_.audit.performed_by = username_;
 }
 
 void FxVarianceSwapInstrumentForm::populate(
@@ -193,7 +193,7 @@ void FxVarianceSwapInstrumentForm::populateFromInstrument() {
     };
 
     block(true);
-    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.trade_type_code));
+    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.identity.trade_type_code));
     ui_->startDateEdit->setIsoDate(instrument_.start_date);
     ui_->endDateEdit->setIsoDate(instrument_.end_date);
     InstrumentFormUtils::setComboValue(ui_->currencyCombo, instrument_.currency);
@@ -208,12 +208,12 @@ void FxVarianceSwapInstrumentForm::populateFromInstrument() {
 
 void FxVarianceSwapInstrumentForm::emitProvenance() {
     InstrumentProvenance p;
-    p.version = instrument_.version;
-    p.modified_by = instrument_.modified_by;
-    p.performed_by = instrument_.performed_by;
-    p.recorded_at = instrument_.recorded_at;
-    p.change_reason_code = instrument_.change_reason_code;
-    p.change_commentary = instrument_.change_commentary;
+    p.version = instrument_.identity.version;
+    p.modified_by = instrument_.audit.modified_by;
+    p.performed_by = instrument_.audit.performed_by;
+    p.recorded_at = instrument_.audit.recorded_at;
+    p.change_reason_code = instrument_.audit.change_reason_code;
+    p.change_commentary = instrument_.audit.change_commentary;
     emit provenanceChanged(p);
 }
 
@@ -259,7 +259,7 @@ void FxVarianceSwapInstrumentForm::saveInstrument(
             BOOST_LOG_SEV(lg(), info) << "FX variance swap instrument saved";
             self->dirty_ = false;
             self->emitProvenance();
-            on_success(boost::uuids::to_string(self->instrument_.instrument_id));
+            on_success(boost::uuids::to_string(self->instrument_.identity.instrument_id));
         });
 
     auto* cm = clientManager_;

--- a/projects/ores.qt/trading/src/ImportTradeDialog.cpp
+++ b/projects/ores.qt/trading/src/ImportTradeDialog.cpp
@@ -602,8 +602,14 @@ void ImportTradeDialog::onImportClicked() {
                             r.instrument);
                         for (auto& leg : r.legs)
                             leg.identity.instrument_id = instr_id;
-                    } else if constexpr (std::is_same_v<T, fx_instrument_variant> ||
-                                         std::is_same_v<T, equity_instrument_variant>) {
+                    } else if constexpr (std::is_same_v<T, fx_instrument_variant>) {
+                        std::visit(
+                            [&](auto& instr) {
+                                instr.identity.instrument_id = instr_id;
+                                instr.identity.trade_id = tti.trade.identity.id;
+                            },
+                            r);
+                    } else if constexpr (std::is_same_v<T, equity_instrument_variant>) {
                         std::visit(
                             [&](auto& instr) {
                                 instr.instrument_id = instr_id;

--- a/projects/ores.trading/api/include/ores.trading.api/domain/balance_guaranteed_swap_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/balance_guaranteed_swap_instrument.hpp
@@ -64,7 +64,7 @@ struct balance_guaranteed_swap_instrument final {
      */
     std::string description;
 
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/callable_swap_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/callable_swap_instrument.hpp
@@ -71,7 +71,7 @@ struct callable_swap_instrument final {
      */
     std::string description;
 
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/cap_floor_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/cap_floor_instrument.hpp
@@ -57,7 +57,7 @@ struct cap_floor_instrument final {
      */
     std::string description;
 
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/fra_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/fra_instrument.hpp
@@ -92,7 +92,7 @@ struct fra_instrument final {
      */
     std::string description;
 
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/fx_accumulator_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/fx_accumulator_instrument.hpp
@@ -74,7 +74,7 @@ struct fx_accumulator_instrument final {
 
     std::string description;
 
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/fx_accumulator_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/fx_accumulator_instrument.hpp
@@ -20,9 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_FX_ACCUMULATOR_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_FX_ACCUMULATOR_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <optional>
 #include <string>
 
@@ -36,21 +35,7 @@ namespace ores::trading::domain {
  * Multiple barriers and complex fixing schedules are a Phase 2 coverage gap.
  */
 struct fx_accumulator_instrument final {
-    int version = 0;
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this FX accumulator instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    boost::uuids::uuid party_id;
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code: FxAccumulator.
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     /**
      * @brief Settlement currency (domestic side).
@@ -88,11 +73,8 @@ struct fx_accumulator_instrument final {
     std::optional<double> knock_out_barrier;
 
     std::string description;
-    std::string modified_by;
-    std::string performed_by;
-    std::string change_reason_code;
-    std::string change_commentary;
-    std::chrono::system_clock::time_point recorded_at;
+
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/fx_asian_forward_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/fx_asian_forward_instrument.hpp
@@ -97,7 +97,7 @@ struct fx_asian_forward_instrument final {
 
     std::string description;
 
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/fx_asian_forward_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/fx_asian_forward_instrument.hpp
@@ -20,9 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_FX_ASIAN_FORWARD_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_FX_ASIAN_FORWARD_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <optional>
 #include <string>
 
@@ -37,21 +36,7 @@ namespace ores::trading::domain {
  * fx_index captures Underlying.Name for the FX fixing source.
  */
 struct fx_asian_forward_instrument final {
-    int version = 0;
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this FX asian forward instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    boost::uuids::uuid party_id;
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code: FxAverageForward or FxTaRF.
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     /**
      * @brief FX index / underlying name (e.g. FX-TR20H-EUR-USD).
@@ -111,11 +96,8 @@ struct fx_asian_forward_instrument final {
     std::optional<double> strike;
 
     std::string description;
-    std::string modified_by;
-    std::string performed_by;
-    std::string change_reason_code;
-    std::string change_commentary;
-    std::chrono::system_clock::time_point recorded_at;
+
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/fx_barrier_option_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/fx_barrier_option_instrument.hpp
@@ -20,9 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_FX_BARRIER_OPTION_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_FX_BARRIER_OPTION_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <optional>
 #include <string>
 
@@ -40,23 +39,7 @@ namespace ores::trading::domain {
  * underlying_code is used by KIKO and generic barrier products.
  */
 struct fx_barrier_option_instrument final {
-    int version = 0;
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this FX barrier option instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    boost::uuids::uuid party_id;
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code. One of: FxBarrierOption,
-     * FxDoubleBarrierOption, FxEuropeanBarrierOption,
-     * FxKIKOBarrierOption, FxGenericBarrierOption.
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     std::string bought_currency;
     double bought_amount = 0.0;
@@ -101,11 +84,8 @@ struct fx_barrier_option_instrument final {
     std::string underlying_code;
 
     std::string description;
-    std::string modified_by;
-    std::string performed_by;
-    std::string change_reason_code;
-    std::string change_commentary;
-    std::chrono::system_clock::time_point recorded_at;
+
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/fx_barrier_option_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/fx_barrier_option_instrument.hpp
@@ -85,7 +85,7 @@ struct fx_barrier_option_instrument final {
 
     std::string description;
 
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/fx_digital_option_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/fx_digital_option_instrument.hpp
@@ -99,7 +99,7 @@ struct fx_digital_option_instrument final {
 
     std::string description;
 
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/fx_digital_option_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/fx_digital_option_instrument.hpp
@@ -20,9 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_FX_DIGITAL_OPTION_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_FX_DIGITAL_OPTION_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <optional>
 #include <string>
 
@@ -40,22 +39,7 @@ namespace ores::trading::domain {
  * lower_barrier / upper_barrier capture single or double barrier levels.
  */
 struct fx_digital_option_instrument final {
-    int version = 0;
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this FX digital option instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    boost::uuids::uuid party_id;
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code. One of: FxDigitalOption,
-     * FxDigitalBarrierOption, FxTouchOption, FxDoubleTouchOption.
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     /**
      * @brief ForeignCurrency from ORE XML (source / underlying currency).
@@ -114,11 +98,8 @@ struct fx_digital_option_instrument final {
     std::optional<double> upper_barrier;
 
     std::string description;
-    std::string modified_by;
-    std::string performed_by;
-    std::string change_reason_code;
-    std::string change_commentary;
-    std::chrono::system_clock::time_point recorded_at;
+
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/fx_forward_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/fx_forward_instrument.hpp
@@ -20,10 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_FX_FORWARD_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_FX_FORWARD_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
-#include <optional>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <string>
 
 namespace ores::trading::domain {
@@ -35,21 +33,7 @@ namespace ores::trading::domain {
  * leg (FarDate, FarBoughtAmount, FarSoldAmount) is a documented coverage gap.
  */
 struct fx_forward_instrument final {
-    int version = 0;
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this FX forward instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    boost::uuids::uuid party_id;
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code: FxForward or FxSwap.
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     /**
      * @brief ISO 4217 currency code of the bought leg (e.g. EUR).
@@ -84,11 +68,8 @@ struct fx_forward_instrument final {
     std::string settlement;
 
     std::string description;
-    std::string modified_by;
-    std::string performed_by;
-    std::string change_reason_code;
-    std::string change_commentary;
-    std::chrono::system_clock::time_point recorded_at;
+
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/fx_forward_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/fx_forward_instrument.hpp
@@ -69,7 +69,7 @@ struct fx_forward_instrument final {
 
     std::string description;
 
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/fx_vanilla_option_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/fx_vanilla_option_instrument.hpp
@@ -20,10 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_FX_VANILLA_OPTION_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_FX_VANILLA_OPTION_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
-#include <optional>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <string>
 
 namespace ores::trading::domain {
@@ -35,21 +33,7 @@ namespace ores::trading::domain {
  * there is no separate strike field in ORE's FxOptionData.
  */
 struct fx_vanilla_option_instrument final {
-    int version = 0;
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this FX vanilla option instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    boost::uuids::uuid party_id;
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code: FxOption.
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     /**
      * @brief ISO 4217 currency code of the bought leg.
@@ -92,11 +76,8 @@ struct fx_vanilla_option_instrument final {
     std::string settlement;
 
     std::string description;
-    std::string modified_by;
-    std::string performed_by;
-    std::string change_reason_code;
-    std::string change_commentary;
-    std::chrono::system_clock::time_point recorded_at;
+
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/fx_vanilla_option_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/fx_vanilla_option_instrument.hpp
@@ -77,7 +77,7 @@ struct fx_vanilla_option_instrument final {
 
     std::string description;
 
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/fx_variance_swap_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/fx_variance_swap_instrument.hpp
@@ -79,7 +79,7 @@ struct fx_variance_swap_instrument final {
 
     std::string description;
 
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/fx_variance_swap_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/fx_variance_swap_instrument.hpp
@@ -20,10 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_FX_VARIANCE_SWAP_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_FX_VARIANCE_SWAP_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
-#include <optional>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <string>
 
 namespace ores::trading::domain {
@@ -35,21 +33,7 @@ namespace ores::trading::domain {
  * moment_type distinguishes Variance swaps from Volatility swaps.
  */
 struct fx_variance_swap_instrument final {
-    int version = 0;
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this FX variance swap instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    boost::uuids::uuid party_id;
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code: FxVarianceSwap.
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     /**
      * @brief Variance observation start date (ISO 8601 date string).
@@ -94,11 +78,8 @@ struct fx_variance_swap_instrument final {
     std::string moment_type;
 
     std::string description;
-    std::string modified_by;
-    std::string performed_by;
-    std::string change_reason_code;
-    std::string change_commentary;
-    std::chrono::system_clock::time_point recorded_at;
+
+    dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/inflation_swap_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/inflation_swap_instrument.hpp
@@ -78,7 +78,7 @@ struct inflation_swap_instrument final {
      */
     std::string description;
 
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/knock_out_swap_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/knock_out_swap_instrument.hpp
@@ -78,7 +78,7 @@ struct knock_out_swap_instrument final {
      */
     std::string description;
 
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/rpa_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/rpa_instrument.hpp
@@ -79,7 +79,7 @@ struct rpa_instrument final {
      */
     std::string description;
 
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/swap_leg.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/swap_leg.hpp
@@ -66,7 +66,7 @@ struct swap_leg_terms final {
 struct swap_leg final {
     swap_leg_identity identity;
     swap_leg_terms terms;
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/swaption_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/swaption_instrument.hpp
@@ -86,7 +86,7 @@ struct swaption_instrument final {
      */
     std::string description;
 
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/vanilla_swap_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/vanilla_swap_instrument.hpp
@@ -71,7 +71,7 @@ struct vanilla_swap_instrument final {
      */
     std::string description;
 
-    dq::domain::audit_record audit;
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/core/include/ores.trading.core/messaging/trade_handler.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/messaging/trade_handler.hpp
@@ -328,7 +328,7 @@ private:
         // FX types
         auto add_fx = [&](auto&& results) {
             for (auto& v : results)
-                imap[boost::uuids::to_string(v.instrument_id)] =
+                imap[boost::uuids::to_string(v.identity.instrument_id)] =
                     ores::trading::domain::fx_instrument_variant{std::move(v)};
         };
         if (!fxfwd_ids.empty()) {

--- a/projects/ores.trading/core/include/ores.trading.core/repository/fx_accumulator_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/fx_accumulator_instrument_entity.hpp
@@ -39,6 +39,7 @@ struct fx_accumulator_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> instrument_id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/fx_asian_forward_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/fx_asian_forward_instrument_entity.hpp
@@ -39,6 +39,7 @@ struct fx_asian_forward_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> instrument_id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/fx_barrier_option_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/fx_barrier_option_instrument_entity.hpp
@@ -40,6 +40,7 @@ struct fx_barrier_option_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> instrument_id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/fx_digital_option_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/fx_digital_option_instrument_entity.hpp
@@ -40,6 +40,7 @@ struct fx_digital_option_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> instrument_id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/fx_forward_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/fx_forward_instrument_entity.hpp
@@ -39,6 +39,7 @@ struct fx_forward_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> instrument_id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/fx_vanilla_option_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/fx_vanilla_option_instrument_entity.hpp
@@ -39,6 +39,7 @@ struct fx_vanilla_option_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> instrument_id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/fx_variance_swap_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/fx_variance_swap_instrument_entity.hpp
@@ -39,6 +39,7 @@ struct fx_variance_swap_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> instrument_id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/src/repository/fx_accumulator_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/fx_accumulator_instrument_mapper.cpp
@@ -33,14 +33,15 @@ fx_accumulator_instrument_mapper::map(const fx_accumulator_instrument_entity& v)
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::fx_accumulator_instrument r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.currency = v.currency;
     r.fixing_amount = v.fixing_amount;
     r.strike = v.strike;
@@ -49,11 +50,11 @@ fx_accumulator_instrument_mapper::map(const fx_accumulator_instrument_entity& v)
     r.start_date = v.start_date;
     r.knock_out_barrier = v.knock_out_barrier;
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -64,13 +65,15 @@ fx_accumulator_instrument_mapper::map(const domain::fx_accumulator_instrument& v
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     fx_accumulator_instrument_entity r;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.version = v.version;
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.version = v.identity.version;
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.currency = v.currency;
     r.fixing_amount = v.fixing_amount;
     r.strike = v.strike;
@@ -79,10 +82,10 @@ fx_accumulator_instrument_mapper::map(const domain::fx_accumulator_instrument& v
     r.start_date = v.start_date;
     r.knock_out_barrier = v.knock_out_barrier;
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/fx_accumulator_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/fx_accumulator_instrument_repository.cpp
@@ -38,7 +38,7 @@ std::string fx_accumulator_instrument_repository::sql() {
 
 void fx_accumulator_instrument_repository::write(context ctx,
                                                  const domain::fx_accumulator_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing FX accumulator instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX accumulator instrument: " << v.identity.instrument_id;
     execute_write_query(ctx,
                         fx_accumulator_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/repository/fx_asian_forward_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/fx_asian_forward_instrument_mapper.cpp
@@ -33,14 +33,15 @@ fx_asian_forward_instrument_mapper::map(const fx_asian_forward_instrument_entity
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::fx_asian_forward_instrument r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.fx_index = v.fx_index;
     r.reference_currency = v.reference_currency.value_or("");
     r.reference_notional = v.reference_notional;
@@ -53,11 +54,11 @@ fx_asian_forward_instrument_mapper::map(const fx_asian_forward_instrument_entity
     r.target_amount = v.target_amount;
     r.strike = v.strike;
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -68,13 +69,15 @@ fx_asian_forward_instrument_mapper::map(const domain::fx_asian_forward_instrumen
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     fx_asian_forward_instrument_entity r;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.version = v.version;
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.version = v.identity.version;
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.fx_index = v.fx_index;
     r.reference_currency =
         v.reference_currency.empty() ? std::nullopt : std::optional(v.reference_currency);
@@ -89,10 +92,10 @@ fx_asian_forward_instrument_mapper::map(const domain::fx_asian_forward_instrumen
     r.target_amount = v.target_amount;
     r.strike = v.strike;
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/fx_asian_forward_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/fx_asian_forward_instrument_repository.cpp
@@ -38,7 +38,8 @@ std::string fx_asian_forward_instrument_repository::sql() {
 
 void fx_asian_forward_instrument_repository::write(context ctx,
                                                    const domain::fx_asian_forward_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing FX asian forward instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX asian forward instrument: "
+                               << v.identity.instrument_id;
     execute_write_query(ctx,
                         fx_asian_forward_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/repository/fx_barrier_option_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/fx_barrier_option_instrument_mapper.cpp
@@ -33,14 +33,15 @@ fx_barrier_option_instrument_mapper::map(const fx_barrier_option_instrument_enti
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::fx_barrier_option_instrument r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.bought_currency = v.bought_currency;
     r.bought_amount = v.bought_amount;
     r.sold_currency = v.sold_currency;
@@ -53,11 +54,11 @@ fx_barrier_option_instrument_mapper::map(const fx_barrier_option_instrument_enti
     r.upper_barrier = v.upper_barrier;
     r.underlying_code = v.underlying_code.value_or("");
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -68,13 +69,15 @@ fx_barrier_option_instrument_mapper::map(const domain::fx_barrier_option_instrum
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     fx_barrier_option_instrument_entity r;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.version = v.version;
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.version = v.identity.version;
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.bought_currency = v.bought_currency;
     r.bought_amount = v.bought_amount;
     r.sold_currency = v.sold_currency;
@@ -87,10 +90,10 @@ fx_barrier_option_instrument_mapper::map(const domain::fx_barrier_option_instrum
     r.upper_barrier = v.upper_barrier;
     r.underlying_code = v.underlying_code.empty() ? std::nullopt : std::optional(v.underlying_code);
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/fx_barrier_option_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/fx_barrier_option_instrument_repository.cpp
@@ -38,7 +38,8 @@ std::string fx_barrier_option_instrument_repository::sql() {
 
 void fx_barrier_option_instrument_repository::write(context ctx,
                                                     const domain::fx_barrier_option_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing FX barrier option instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX barrier option instrument: "
+                               << v.identity.instrument_id;
     execute_write_query(ctx,
                         fx_barrier_option_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/repository/fx_digital_option_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/fx_digital_option_instrument_mapper.cpp
@@ -33,14 +33,15 @@ fx_digital_option_instrument_mapper::map(const fx_digital_option_instrument_enti
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::fx_digital_option_instrument r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.foreign_currency = v.foreign_currency;
     r.domestic_currency = v.domestic_currency;
     r.payoff_currency = v.payoff_currency;
@@ -53,11 +54,11 @@ fx_digital_option_instrument_mapper::map(const fx_digital_option_instrument_enti
     r.lower_barrier = v.lower_barrier;
     r.upper_barrier = v.upper_barrier;
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -68,13 +69,15 @@ fx_digital_option_instrument_mapper::map(const domain::fx_digital_option_instrum
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     fx_digital_option_instrument_entity r;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.version = v.version;
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.version = v.identity.version;
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.foreign_currency = v.foreign_currency;
     r.domestic_currency = v.domestic_currency;
     r.payoff_currency = v.payoff_currency;
@@ -87,10 +90,10 @@ fx_digital_option_instrument_mapper::map(const domain::fx_digital_option_instrum
     r.lower_barrier = v.lower_barrier;
     r.upper_barrier = v.upper_barrier;
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/fx_digital_option_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/fx_digital_option_instrument_repository.cpp
@@ -38,7 +38,8 @@ std::string fx_digital_option_instrument_repository::sql() {
 
 void fx_digital_option_instrument_repository::write(context ctx,
                                                     const domain::fx_digital_option_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing FX digital option instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX digital option instrument: "
+                               << v.identity.instrument_id;
     execute_write_query(ctx,
                         fx_digital_option_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/repository/fx_forward_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/fx_forward_instrument_mapper.cpp
@@ -33,14 +33,15 @@ fx_forward_instrument_mapper::map(const fx_forward_instrument_entity& v) {
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::fx_forward_instrument r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.bought_currency = v.bought_currency;
     r.bought_amount = v.bought_amount;
     r.sold_currency = v.sold_currency;
@@ -48,11 +49,11 @@ fx_forward_instrument_mapper::map(const fx_forward_instrument_entity& v) {
     r.value_date = v.value_date;
     r.settlement = v.settlement.value_or("");
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -63,13 +64,15 @@ fx_forward_instrument_mapper::map(const domain::fx_forward_instrument& v) {
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     fx_forward_instrument_entity r;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.version = v.version;
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.version = v.identity.version;
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.bought_currency = v.bought_currency;
     r.bought_amount = v.bought_amount;
     r.sold_currency = v.sold_currency;
@@ -77,10 +80,10 @@ fx_forward_instrument_mapper::map(const domain::fx_forward_instrument& v) {
     r.value_date = v.value_date;
     r.settlement = v.settlement.empty() ? std::nullopt : std::optional(v.settlement);
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/fx_forward_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/fx_forward_instrument_repository.cpp
@@ -37,7 +37,7 @@ std::string fx_forward_instrument_repository::sql() {
 }
 
 void fx_forward_instrument_repository::write(context ctx, const domain::fx_forward_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing FX forward instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX forward instrument: " << v.identity.instrument_id;
     execute_write_query(ctx,
                         fx_forward_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/repository/fx_vanilla_option_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/fx_vanilla_option_instrument_mapper.cpp
@@ -33,14 +33,15 @@ fx_vanilla_option_instrument_mapper::map(const fx_vanilla_option_instrument_enti
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::fx_vanilla_option_instrument r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.bought_currency = v.bought_currency;
     r.bought_amount = v.bought_amount;
     r.sold_currency = v.sold_currency;
@@ -50,11 +51,11 @@ fx_vanilla_option_instrument_mapper::map(const fx_vanilla_option_instrument_enti
     r.exercise_style = v.exercise_style;
     r.settlement = v.settlement.value_or("");
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -65,13 +66,15 @@ fx_vanilla_option_instrument_mapper::map(const domain::fx_vanilla_option_instrum
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     fx_vanilla_option_instrument_entity r;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.version = v.version;
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.version = v.identity.version;
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.bought_currency = v.bought_currency;
     r.bought_amount = v.bought_amount;
     r.sold_currency = v.sold_currency;
@@ -81,10 +84,10 @@ fx_vanilla_option_instrument_mapper::map(const domain::fx_vanilla_option_instrum
     r.exercise_style = v.exercise_style;
     r.settlement = v.settlement.empty() ? std::nullopt : std::optional(v.settlement);
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/fx_vanilla_option_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/fx_vanilla_option_instrument_repository.cpp
@@ -38,7 +38,8 @@ std::string fx_vanilla_option_instrument_repository::sql() {
 
 void fx_vanilla_option_instrument_repository::write(context ctx,
                                                     const domain::fx_vanilla_option_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing FX vanilla option instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX vanilla option instrument: "
+                               << v.identity.instrument_id;
     execute_write_query(ctx,
                         fx_vanilla_option_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/repository/fx_variance_swap_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/fx_variance_swap_instrument_mapper.cpp
@@ -33,14 +33,15 @@ fx_variance_swap_instrument_mapper::map(const fx_variance_swap_instrument_entity
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::fx_variance_swap_instrument r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.start_date = v.start_date;
     r.end_date = v.end_date;
     r.currency = v.currency;
@@ -50,11 +51,11 @@ fx_variance_swap_instrument_mapper::map(const fx_variance_swap_instrument_entity
     r.notional = v.notional;
     r.moment_type = v.moment_type;
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -65,13 +66,15 @@ fx_variance_swap_instrument_mapper::map(const domain::fx_variance_swap_instrumen
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     fx_variance_swap_instrument_entity r;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.version = v.version;
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.version = v.identity.version;
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.start_date = v.start_date;
     r.end_date = v.end_date;
     r.currency = v.currency;
@@ -81,10 +84,10 @@ fx_variance_swap_instrument_mapper::map(const domain::fx_variance_swap_instrumen
     r.notional = v.notional;
     r.moment_type = v.moment_type;
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/fx_variance_swap_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/fx_variance_swap_instrument_repository.cpp
@@ -38,7 +38,8 @@ std::string fx_variance_swap_instrument_repository::sql() {
 
 void fx_variance_swap_instrument_repository::write(context ctx,
                                                    const domain::fx_variance_swap_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing FX variance swap instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing FX variance swap instrument: "
+                               << v.identity.instrument_id;
     execute_write_query(ctx,
                         fx_variance_swap_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/service/fx_accumulator_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/fx_accumulator_instrument_service.cpp
@@ -41,13 +41,13 @@ fx_accumulator_instrument_service::get_fx_accumulator_instrument(const std::stri
 
 void fx_accumulator_instrument_service::save_fx_accumulator_instrument(
     const domain::fx_accumulator_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("FX accumulator instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving fx_accumulator_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving fx_accumulator_instrument: " << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved fx_accumulator_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved fx_accumulator_instrument: " << t.identity.instrument_id;
 }
 
 

--- a/projects/ores.trading/core/src/service/fx_asian_forward_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/fx_asian_forward_instrument_service.cpp
@@ -41,13 +41,14 @@ fx_asian_forward_instrument_service::get_fx_asian_forward_instrument(const std::
 
 void fx_asian_forward_instrument_service::save_fx_asian_forward_instrument(
     const domain::fx_asian_forward_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("FX Asian forward instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving fx_asian_forward_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving fx_asian_forward_instrument: "
+                               << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved fx_asian_forward_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved fx_asian_forward_instrument: " << t.identity.instrument_id;
 }
 
 

--- a/projects/ores.trading/core/src/service/fx_barrier_option_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/fx_barrier_option_instrument_service.cpp
@@ -41,13 +41,14 @@ fx_barrier_option_instrument_service::get_fx_barrier_option_instrument(const std
 
 void fx_barrier_option_instrument_service::save_fx_barrier_option_instrument(
     const domain::fx_barrier_option_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("FX barrier option instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving fx_barrier_option_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving fx_barrier_option_instrument: "
+                               << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved fx_barrier_option_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved fx_barrier_option_instrument: " << t.identity.instrument_id;
 }
 
 

--- a/projects/ores.trading/core/src/service/fx_digital_option_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/fx_digital_option_instrument_service.cpp
@@ -41,13 +41,14 @@ fx_digital_option_instrument_service::get_fx_digital_option_instrument(const std
 
 void fx_digital_option_instrument_service::save_fx_digital_option_instrument(
     const domain::fx_digital_option_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("FX digital option instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving fx_digital_option_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving fx_digital_option_instrument: "
+                               << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved fx_digital_option_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved fx_digital_option_instrument: " << t.identity.instrument_id;
 }
 
 

--- a/projects/ores.trading/core/src/service/fx_forward_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/fx_forward_instrument_service.cpp
@@ -41,13 +41,13 @@ fx_forward_instrument_service::get_fx_forward_instrument(const std::string& id) 
 
 void fx_forward_instrument_service::save_fx_forward_instrument(
     const domain::fx_forward_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("FX forward instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving fx_forward_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving fx_forward_instrument: " << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved fx_forward_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved fx_forward_instrument: " << t.identity.instrument_id;
 }
 
 

--- a/projects/ores.trading/core/src/service/fx_vanilla_option_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/fx_vanilla_option_instrument_service.cpp
@@ -41,13 +41,14 @@ fx_vanilla_option_instrument_service::get_fx_vanilla_option_instrument(const std
 
 void fx_vanilla_option_instrument_service::save_fx_vanilla_option_instrument(
     const domain::fx_vanilla_option_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("FX vanilla option instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving fx_vanilla_option_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving fx_vanilla_option_instrument: "
+                               << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved fx_vanilla_option_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved fx_vanilla_option_instrument: " << t.identity.instrument_id;
 }
 
 

--- a/projects/ores.trading/core/src/service/fx_variance_swap_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/fx_variance_swap_instrument_service.cpp
@@ -41,13 +41,14 @@ fx_variance_swap_instrument_service::get_fx_variance_swap_instrument(const std::
 
 void fx_variance_swap_instrument_service::save_fx_variance_swap_instrument(
     const domain::fx_variance_swap_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("FX variance swap instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving fx_variance_swap_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving fx_variance_swap_instrument: "
+                               << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved fx_variance_swap_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved fx_variance_swap_instrument: " << t.identity.instrument_id;
 }
 
 

--- a/projects/ores.trading/core/tests/repository_fx_accumulator_instrument_repository_tests.cpp
+++ b/projects/ores.trading/core/tests/repository_fx_accumulator_instrument_repository_tests.cpp
@@ -47,9 +47,9 @@ using namespace ores::logging;
  */
 fx_accumulator_instrument make_instrument(database_helper& h) {
     fx_accumulator_instrument r;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.tenant_id = h.tenant_id();
-    r.trade_type_code = "FxAccumulator";
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.tenant_id = h.tenant_id();
+    r.identity.trade_type_code = "FxAccumulator";
     r.currency = "JPY";
     r.fixing_amount = 350000.0;
     r.strike = 122.0;
@@ -57,10 +57,10 @@ fx_accumulator_instrument make_instrument(database_helper& h) {
     r.long_short = "Long";
     r.start_date = "2026-01-12";
     r.knock_out_barrier = 126.0;
-    r.modified_by = h.db_user();
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.audit.modified_by = h.db_user();
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -74,7 +74,7 @@ TEST_CASE("fx_accumulator_instrument_write_and_read_latest", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
     BOOST_LOG_SEV(lg, debug) << "Writing FX accumulator instrument: " << instr;
 
     fx_accumulator_instrument_repository repo;
@@ -82,7 +82,7 @@ TEST_CASE("fx_accumulator_instrument_write_and_read_latest", tags) {
 
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
-    CHECK(read[0].trade_type_code == "FxAccumulator");
+    CHECK(read[0].identity.trade_type_code == "FxAccumulator");
     CHECK(read[0].currency == "JPY");
     CHECK(read[0].fixing_amount == 350000.0);
     CHECK(read[0].strike == 122.0);
@@ -113,7 +113,7 @@ TEST_CASE("fx_accumulator_instrument_remove", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
 
     fx_accumulator_instrument_repository repo;
     repo.write(ctx, instr);

--- a/projects/ores.trading/core/tests/repository_fx_asian_forward_instrument_repository_tests.cpp
+++ b/projects/ores.trading/core/tests/repository_fx_asian_forward_instrument_repository_tests.cpp
@@ -46,9 +46,9 @@ using namespace ores::logging;
  */
 fx_asian_forward_instrument make_instrument(database_helper& h) {
     fx_asian_forward_instrument r;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.tenant_id = h.tenant_id();
-    r.trade_type_code = "FxAverageForward";
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.tenant_id = h.tenant_id();
+    r.identity.trade_type_code = "FxAverageForward";
     r.fx_index = "FX-TR20H-EUR-USD";
     r.reference_currency = "EUR";
     r.reference_notional = 8614.0;
@@ -56,10 +56,10 @@ fx_asian_forward_instrument make_instrument(database_helper& h) {
     r.settlement_notional = 10000.0;
     r.payment_date = "2025-09-30";
     r.long_short = "Long";
-    r.modified_by = h.db_user();
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.audit.modified_by = h.db_user();
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -73,7 +73,7 @@ TEST_CASE("fx_asian_forward_instrument_write_and_read_latest", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
     BOOST_LOG_SEV(lg, debug) << "Writing FX asian forward instrument: " << instr;
 
     fx_asian_forward_instrument_repository repo;
@@ -81,7 +81,7 @@ TEST_CASE("fx_asian_forward_instrument_write_and_read_latest", tags) {
 
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
-    CHECK(read[0].trade_type_code == "FxAverageForward");
+    CHECK(read[0].identity.trade_type_code == "FxAverageForward");
     CHECK(read[0].fx_index == "FX-TR20H-EUR-USD");
     CHECK(read[0].reference_currency == "EUR");
     REQUIRE(read[0].reference_notional.has_value());
@@ -113,7 +113,7 @@ TEST_CASE("fx_asian_forward_instrument_remove", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
 
     fx_asian_forward_instrument_repository repo;
     repo.write(ctx, instr);

--- a/projects/ores.trading/core/tests/repository_fx_barrier_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading/core/tests/repository_fx_barrier_option_instrument_repository_tests.cpp
@@ -45,9 +45,9 @@ using namespace ores::logging;
  */
 fx_barrier_option_instrument make_instrument(database_helper& h) {
     fx_barrier_option_instrument r;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.tenant_id = h.tenant_id();
-    r.trade_type_code = "FxBarrierOption";
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.tenant_id = h.tenant_id();
+    r.identity.trade_type_code = "FxBarrierOption";
     r.bought_currency = "EUR";
     r.bought_amount = 1000000.0;
     r.sold_currency = "USD";
@@ -56,10 +56,10 @@ fx_barrier_option_instrument make_instrument(database_helper& h) {
     r.expiry_date = "2033-02-20";
     r.barrier_type = "UpAndIn";
     r.lower_barrier = 1.2;
-    r.modified_by = h.db_user();
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.audit.modified_by = h.db_user();
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -73,7 +73,7 @@ TEST_CASE("fx_barrier_option_instrument_write_and_read_latest", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
     BOOST_LOG_SEV(lg, debug) << "Writing FX barrier option instrument: " << instr;
 
     fx_barrier_option_instrument_repository repo;
@@ -81,7 +81,7 @@ TEST_CASE("fx_barrier_option_instrument_write_and_read_latest", tags) {
 
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
-    CHECK(read[0].trade_type_code == "FxBarrierOption");
+    CHECK(read[0].identity.trade_type_code == "FxBarrierOption");
     CHECK(read[0].bought_currency == "EUR");
     CHECK(read[0].bought_amount == 1000000.0);
     CHECK(read[0].sold_currency == "USD");
@@ -113,7 +113,7 @@ TEST_CASE("fx_barrier_option_instrument_remove", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
 
     fx_barrier_option_instrument_repository repo;
     repo.write(ctx, instr);

--- a/projects/ores.trading/core/tests/repository_fx_digital_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading/core/tests/repository_fx_digital_option_instrument_repository_tests.cpp
@@ -47,9 +47,9 @@ using namespace ores::logging;
  */
 fx_digital_option_instrument make_instrument(database_helper& h) {
     fx_digital_option_instrument r;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.tenant_id = h.tenant_id();
-    r.trade_type_code = "FxDigitalOption";
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.tenant_id = h.tenant_id();
+    r.identity.trade_type_code = "FxDigitalOption";
     r.foreign_currency = "EUR";
     r.domestic_currency = "USD";
     r.payoff_currency = "EUR";
@@ -58,10 +58,10 @@ fx_digital_option_instrument make_instrument(database_helper& h) {
     r.expiry_date = "2033-02-20";
     r.long_short = "Long";
     r.strike = 1.1;
-    r.modified_by = h.db_user();
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.audit.modified_by = h.db_user();
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -75,7 +75,7 @@ TEST_CASE("fx_digital_option_instrument_write_and_read_latest", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
     BOOST_LOG_SEV(lg, debug) << "Writing FX digital option instrument: " << instr;
 
     fx_digital_option_instrument_repository repo;
@@ -83,7 +83,7 @@ TEST_CASE("fx_digital_option_instrument_write_and_read_latest", tags) {
 
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
-    CHECK(read[0].trade_type_code == "FxDigitalOption");
+    CHECK(read[0].identity.trade_type_code == "FxDigitalOption");
     CHECK(read[0].foreign_currency == "EUR");
     CHECK(read[0].domestic_currency == "USD");
     CHECK(read[0].payoff_currency == "EUR");
@@ -117,7 +117,7 @@ TEST_CASE("fx_digital_option_instrument_remove", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
 
     fx_digital_option_instrument_repository repo;
     repo.write(ctx, instr);

--- a/projects/ores.trading/core/tests/repository_fx_forward_instrument_repository_tests.cpp
+++ b/projects/ores.trading/core/tests/repository_fx_forward_instrument_repository_tests.cpp
@@ -43,19 +43,19 @@ using namespace ores::logging;
  */
 fx_forward_instrument make_instrument(database_helper& h) {
     fx_forward_instrument r;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.tenant_id = h.tenant_id();
-    r.trade_type_code = "FxForward";
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.tenant_id = h.tenant_id();
+    r.identity.trade_type_code = "FxForward";
     r.bought_currency = "EUR";
     r.bought_amount = 1000000.0;
     r.sold_currency = "USD";
     r.sold_amount = 1100000.0;
     r.value_date = "2033-02-20";
     r.settlement = "Cash";
-    r.modified_by = h.db_user();
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.audit.modified_by = h.db_user();
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -69,7 +69,7 @@ TEST_CASE("fx_forward_instrument_write_and_read_latest", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
     BOOST_LOG_SEV(lg, debug) << "Writing FX forward instrument: " << instr;
 
     fx_forward_instrument_repository repo;
@@ -77,7 +77,7 @@ TEST_CASE("fx_forward_instrument_write_and_read_latest", tags) {
 
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
-    CHECK(read[0].trade_type_code == "FxForward");
+    CHECK(read[0].identity.trade_type_code == "FxForward");
     CHECK(read[0].bought_currency == "EUR");
     CHECK(read[0].bought_amount == 1000000.0);
     CHECK(read[0].sold_currency == "USD");
@@ -106,7 +106,7 @@ TEST_CASE("fx_forward_instrument_remove", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
 
     fx_forward_instrument_repository repo;
     repo.write(ctx, instr);

--- a/projects/ores.trading/core/tests/repository_fx_vanilla_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading/core/tests/repository_fx_vanilla_option_instrument_repository_tests.cpp
@@ -43,9 +43,9 @@ using namespace ores::logging;
  */
 fx_vanilla_option_instrument make_instrument(database_helper& h) {
     fx_vanilla_option_instrument r;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.tenant_id = h.tenant_id();
-    r.trade_type_code = "FxOption";
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.tenant_id = h.tenant_id();
+    r.identity.trade_type_code = "FxOption";
     r.bought_currency = "EUR";
     r.bought_amount = 1000000.0;
     r.sold_currency = "USD";
@@ -54,10 +54,10 @@ fx_vanilla_option_instrument make_instrument(database_helper& h) {
     r.expiry_date = "2033-02-20";
     r.exercise_style = "European";
     r.settlement = "Cash";
-    r.modified_by = h.db_user();
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.audit.modified_by = h.db_user();
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -71,7 +71,7 @@ TEST_CASE("fx_vanilla_option_instrument_write_and_read_latest", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
     BOOST_LOG_SEV(lg, debug) << "Writing FX vanilla option instrument: " << instr;
 
     fx_vanilla_option_instrument_repository repo;
@@ -79,7 +79,7 @@ TEST_CASE("fx_vanilla_option_instrument_write_and_read_latest", tags) {
 
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
-    CHECK(read[0].trade_type_code == "FxOption");
+    CHECK(read[0].identity.trade_type_code == "FxOption");
     CHECK(read[0].bought_currency == "EUR");
     CHECK(read[0].bought_amount == 1000000.0);
     CHECK(read[0].sold_currency == "USD");
@@ -110,7 +110,7 @@ TEST_CASE("fx_vanilla_option_instrument_remove", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
 
     fx_vanilla_option_instrument_repository repo;
     repo.write(ctx, instr);

--- a/projects/ores.trading/core/tests/repository_fx_variance_swap_instrument_repository_tests.cpp
+++ b/projects/ores.trading/core/tests/repository_fx_variance_swap_instrument_repository_tests.cpp
@@ -47,9 +47,9 @@ using namespace ores::logging;
  */
 fx_variance_swap_instrument make_instrument(database_helper& h) {
     fx_variance_swap_instrument r;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.tenant_id = h.tenant_id();
-    r.trade_type_code = "FxVarianceSwap";
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.tenant_id = h.tenant_id();
+    r.identity.trade_type_code = "FxVarianceSwap";
     r.start_date = "2025-10-22";
     r.end_date = "2026-04-26";
     r.currency = "USD";
@@ -58,10 +58,10 @@ fx_variance_swap_instrument make_instrument(database_helper& h) {
     r.strike = 0.02;
     r.notional = 50000.0;
     r.moment_type = "Variance";
-    r.modified_by = h.db_user();
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.audit.modified_by = h.db_user();
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -75,7 +75,7 @@ TEST_CASE("fx_variance_swap_instrument_write_and_read_latest", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
     BOOST_LOG_SEV(lg, debug) << "Writing FX variance swap instrument: " << instr;
 
     fx_variance_swap_instrument_repository repo;
@@ -83,7 +83,7 @@ TEST_CASE("fx_variance_swap_instrument_write_and_read_latest", tags) {
 
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
-    CHECK(read[0].trade_type_code == "FxVarianceSwap");
+    CHECK(read[0].identity.trade_type_code == "FxVarianceSwap");
     CHECK(read[0].start_date == "2025-10-22");
     CHECK(read[0].end_date == "2026-04-26");
     CHECK(read[0].currency == "USD");
@@ -114,7 +114,7 @@ TEST_CASE("fx_variance_swap_instrument_remove", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
 
     fx_variance_swap_instrument_repository repo;
     repo.write(ctx, instr);

--- a/projects/ores.trading/core/tests/test_data/fx_accumulator_instrument.json
+++ b/projects/ores.trading/core/tests/test_data/fx_accumulator_instrument.json
@@ -9,7 +9,9 @@
     "observation dates are not captured (Phase 2 gap)"
   ],
   "instrument": {
-    "trade_type_code": "FxAccumulator",
+    "identity": {
+      "trade_type_code": "FxAccumulator"
+    },
     "currency": "JPY",
     "fixing_amount": 350000.0,
     "strike": 122.0,
@@ -18,9 +20,11 @@
     "start_date": "2026-01-12",
     "knock_out_barrier": 126.0,
     "description": "",
-    "modified_by": "ores",
-    "performed_by": "ores",
-    "change_reason_code": "system.external_data_import",
-    "change_commentary": "Imported from ORE XML"
+    "audit": {
+      "modified_by": "ores",
+      "performed_by": "ores",
+      "change_reason_code": "system.external_data_import",
+      "change_commentary": "Imported from ORE XML"
+    }
   }
 }

--- a/projects/ores.trading/core/tests/test_data/fx_asian_forward_instrument.json
+++ b/projects/ores.trading/core/tests/test_data/fx_asian_forward_instrument.json
@@ -4,11 +4,13 @@
   "mapper": "fx_instrument_mapper::forward_fx_average_forward (via trade_mapper::map_fx_instrument)",
   "notes": [
     "long_short is hardcoded to Long by mapper",
-    "currency, fixing_amount, target_amount, strike are FxTaRF-specific — empty/null for FxAverageForward",
+    "currency, fixing_amount, target_amount, strike are FxTaRF-specific \u2014 empty/null for FxAverageForward",
     "observation dates are not captured (Phase 2 gap)"
   ],
   "instrument": {
-    "trade_type_code": "FxAverageForward",
+    "identity": {
+      "trade_type_code": "FxAverageForward"
+    },
     "fx_index": "FX-TR20H-EUR-USD",
     "reference_currency": "EUR",
     "reference_notional": 8614.0,
@@ -21,9 +23,11 @@
     "target_amount": null,
     "strike": null,
     "description": "",
-    "modified_by": "ores",
-    "performed_by": "ores",
-    "change_reason_code": "system.external_data_import",
-    "change_commentary": "Imported from ORE XML"
+    "audit": {
+      "modified_by": "ores",
+      "performed_by": "ores",
+      "change_reason_code": "system.external_data_import",
+      "change_commentary": "Imported from ORE XML"
+    }
   }
 }

--- a/projects/ores.trading/core/tests/test_data/fx_barrier_option_instrument.json
+++ b/projects/ores.trading/core/tests/test_data/fx_barrier_option_instrument.json
@@ -3,12 +3,14 @@
   "trade_id_in_xml": "FX_UPIN_BARRIER_CALL_OPTION_EURUSD_10Y",
   "mapper": "fx_instrument_mapper::forward_fx_barrier_option (via trade_mapper::map_fx_instrument)",
   "notes": [
-    "settlement is not extracted by forward_fx_barrier_option — field is empty",
-    "underlying_code is not extracted by forward_fx_barrier_option for FxBarrierOption — field is empty",
+    "settlement is not extracted by forward_fx_barrier_option \u2014 field is empty",
+    "underlying_code is not extracted by forward_fx_barrier_option for FxBarrierOption \u2014 field is empty",
     "upper_barrier is absent: XML has a single-level BarrierData block"
   ],
   "instrument": {
-    "trade_type_code": "FxBarrierOption",
+    "identity": {
+      "trade_type_code": "FxBarrierOption"
+    },
     "bought_currency": "EUR",
     "bought_amount": 1000000.0,
     "sold_currency": "USD",
@@ -21,9 +23,11 @@
     "upper_barrier": null,
     "underlying_code": "",
     "description": "",
-    "modified_by": "ores",
-    "performed_by": "ores",
-    "change_reason_code": "system.external_data_import",
-    "change_commentary": "Imported from ORE XML"
+    "audit": {
+      "modified_by": "ores",
+      "performed_by": "ores",
+      "change_reason_code": "system.external_data_import",
+      "change_commentary": "Imported from ORE XML"
+    }
   }
 }

--- a/projects/ores.trading/core/tests/test_data/fx_digital_option_instrument.json
+++ b/projects/ores.trading/core/tests/test_data/fx_digital_option_instrument.json
@@ -8,7 +8,9 @@
     "barrier_type, lower_barrier, upper_barrier are absent for plain FxDigitalOption"
   ],
   "instrument": {
-    "trade_type_code": "FxDigitalOption",
+    "identity": {
+      "trade_type_code": "FxDigitalOption"
+    },
     "foreign_currency": "EUR",
     "domestic_currency": "USD",
     "payoff_currency": "EUR",
@@ -21,9 +23,11 @@
     "lower_barrier": null,
     "upper_barrier": null,
     "description": "",
-    "modified_by": "ores",
-    "performed_by": "ores",
-    "change_reason_code": "system.external_data_import",
-    "change_commentary": "Imported from ORE XML"
+    "audit": {
+      "modified_by": "ores",
+      "performed_by": "ores",
+      "change_reason_code": "system.external_data_import",
+      "change_commentary": "Imported from ORE XML"
+    }
   }
 }

--- a/projects/ores.trading/core/tests/test_data/fx_forward_instrument.json
+++ b/projects/ores.trading/core/tests/test_data/fx_forward_instrument.json
@@ -3,7 +3,9 @@
   "trade_id_in_xml": "FXFWD_EURUSD_10Y",
   "mapper": "fx_instrument_mapper::forward_fx_forward",
   "instrument": {
-    "trade_type_code": "FxForward",
+    "identity": {
+      "trade_type_code": "FxForward"
+    },
     "bought_currency": "EUR",
     "bought_amount": 1000000.0,
     "sold_currency": "USD",
@@ -11,9 +13,11 @@
     "value_date": "2033-02-20",
     "settlement": "Cash",
     "description": "",
-    "modified_by": "ores",
-    "performed_by": "ores",
-    "change_reason_code": "system.external_data_import",
-    "change_commentary": "Imported from ORE XML"
+    "audit": {
+      "modified_by": "ores",
+      "performed_by": "ores",
+      "change_reason_code": "system.external_data_import",
+      "change_commentary": "Imported from ORE XML"
+    }
   }
 }

--- a/projects/ores.trading/core/tests/test_data/fx_vanilla_option_instrument.json
+++ b/projects/ores.trading/core/tests/test_data/fx_vanilla_option_instrument.json
@@ -3,7 +3,9 @@
   "trade_id_in_xml": "FX_CALL_OPTION",
   "mapper": "fx_instrument_mapper::forward_fx_option",
   "instrument": {
-    "trade_type_code": "FxOption",
+    "identity": {
+      "trade_type_code": "FxOption"
+    },
     "bought_currency": "EUR",
     "bought_amount": 1000000.0,
     "sold_currency": "USD",
@@ -13,9 +15,11 @@
     "exercise_style": "European",
     "settlement": "Cash",
     "description": "",
-    "modified_by": "ores",
-    "performed_by": "ores",
-    "change_reason_code": "system.external_data_import",
-    "change_commentary": "Imported from ORE XML"
+    "audit": {
+      "modified_by": "ores",
+      "performed_by": "ores",
+      "change_reason_code": "system.external_data_import",
+      "change_commentary": "Imported from ORE XML"
+    }
   }
 }

--- a/projects/ores.trading/core/tests/test_data/fx_variance_swap_instrument.json
+++ b/projects/ores.trading/core/tests/test_data/fx_variance_swap_instrument.json
@@ -8,7 +8,9 @@
     "underlying_code comes from Underlying.Name (TR20H-EUR-USD), not the FX prefix version"
   ],
   "instrument": {
-    "trade_type_code": "FxVarianceSwap",
+    "identity": {
+      "trade_type_code": "FxVarianceSwap"
+    },
     "start_date": "2025-10-22",
     "end_date": "2026-04-26",
     "currency": "USD",
@@ -18,9 +20,11 @@
     "notional": 50000.0,
     "moment_type": "Variance",
     "description": "",
-    "modified_by": "ores",
-    "performed_by": "ores",
-    "change_reason_code": "system.external_data_import",
-    "change_commentary": "Imported from ORE XML"
+    "audit": {
+      "modified_by": "ores",
+      "performed_by": "ores",
+      "change_reason_code": "system.external_data_import",
+      "change_commentary": "Imported from ORE XML"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Two strands, both in service of green builds everywhere:

### 1. FX instrument decomposition (task 13 of the C1202 story)

Applies the `instrument_identity` + `audit_record` pattern from #1047 to all 7 FX types (`fx_forward`, `fx_vanilla_option`, `fx_barrier_option`, `fx_digital_option`, `fx_asian_forward`, `fx_accumulator`, `fx_variance_swap`):

- Each domain struct: `identity` + type-specific fields + `audit` — parent Literal well below the MSVC C1202 threshold
- FX entities gain `workspace_id` (column already existed in all FX tables; decision: all trade/instrument tables carry it); mappers map it both ways
- All callers updated: 7 mappers/repos/services, `trade_handler`, Qt forms + import dialog (fx/equity branch split — equity stays flat), ores.ore XML mapper + round-trip tests, 7 repository test files
- `test_data/fx_*.json` reference snapshots updated to the nested wire shape

### 2. Main CI fixes (all four platforms were red)

- **Windows (msvc + clang):** alphabetical include sorting put `iphlpapi.h` before `windows.h`. The constraint is Microsoft's (SDK headers are not self-sufficient), so it is encoded in the literate clang-format config: order-dependent SDK headers get a trailing include category. `.clang-format` retangled; `network_info.cpp` reformatted by the new config. Full-codebase format run confirms no churn beyond the intended fix.
- **macOS + Linux gcc:** `AccountHistoryDialog`'s anonymous-namespace helper named the class-private `DiffResult` alias. Tactical fix (local alias + free `calculateDiff`); the proper consolidation is scaffolded as the "Consolidate history dialogs onto HistoryDialogBase" story, including server-side diff computation via a generic NATS history message.

## Test plan

- Full local `linux-clang-debug-make` build green (0 errors, 100%)
- `format` target across the codebase: only pre-existing drift, committed separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)