### PR TITLE
[trading,qt,ore] Decompose all 9 equity instruments into nested structs

### DIFF
--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_equity_instrument_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_equity_instrument_c1202_nested_structs.org
@@ -25,12 +25,12 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
-| Now          | Not yet started.                       |
+| Now          | Decomposing the 9 equity instrument types. |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
-| Last touched | 2026-06-04                               |
+| Next         | Apply the FX playbook: headers, entities (+workspace_id), mappers, repos, services, Qt, ores.ore, tests. |
+| Last touched | 2026-06-05                               |
 
 * Acceptance
 
@@ -38,9 +38,19 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 * Plan
 
-(Transient implementation strategy. Written when work starts;
-distilled into the parent story's =* Decisions= and cleared when the
-task closes. Plans do not outlive their task.)
+Replay the FX playbook from PR #1071 for the 9 equity types:
+
+1. Headers: identity (instrument_identity) + type-specific +
+   ores::dq::domain::audit_record audit (fully qualified, per the
+   #1070 review decision).
+2. Entities gain workspace_id; mappers map it both directions.
+3. Repositories/services: domain accesses via identity.
+4. trade_handler add_eq keys on identity.instrument_id.
+5. Qt: equity forms' provenance via identity/audit; ImportTradeDialog
+   and planner test equity branches switch to identity (they were
+   deliberately left flat in #1071); parse dispatch test equity cases.
+6. ores.ore: equity XML mapper + round-trip tests.
+7. 9 equity repository test files + JSON snapshots.
 
 * Notes
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_equity_instrument_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_equity_instrument_c1202_nested_structs.org
@@ -64,6 +64,6 @@ Replay the FX playbook from PR #1071 for the 9 equity types:
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Gemini round 1: no inline comments ("no feedback to provide") | — | n/a | Clean round; branch rebased onto main (#1076) and re-pushed |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_equity_instrument_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_equity_instrument_c1202_nested_structs.org
@@ -58,7 +58,7 @@ Replay the FX playbook from PR #1071 for the 9 equity types:
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1075][#1075]] | [trading,qt,ore] Decompose all 9 equity instruments into nested structs |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_fx_instrument_c1202_nested_structs.org
+++ b/doc/agile/versions/v0/sprint_19/fix_rfl_complexity/task_fix_fx_instrument_c1202_nested_structs.org
@@ -25,11 +25,11 @@ This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:7763D0EE-A500-4497-9B2D-973C02ADC739][Fix rfl complexity failure (Windows + macOS CI)]] |
-| Now          | Decomposing the 7 FX instrument types. |
+| Now          | Complete: PR #1071 merged.             |
 | Waiting on   | Nothing.                               |
-| Next         | Apply identity/audit/type-specific pattern to all 7 headers and callers. |
+| Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |
 
 * Acceptance
@@ -72,3 +72,11 @@ audit_record move to dq.api (PR #1070):
 |   |                 |      |          |       |
 
 * Result
+
+All 7 FX instrument types decomposed into identity + type-specific +
+audit nested structs; FX entities gained workspace_id; all callers
+updated (mappers, repositories, services, trade_handler, Qt forms and
+import dialog, ores.ore XML layer, 13 test files, JSON snapshots).
+PR #1071 also carried the main CI fixes (Windows SDK include category
+in clang-format; AccountHistoryDialog DiffResult access) and the
+PR #1070 review round. CI green on all four platforms; merged.

--- a/projects/ores.ore/core/src/domain/equity_instrument_mapper.cpp
+++ b/projects/ores.ore/core/src/domain/equity_instrument_mapper.cpp
@@ -256,11 +256,11 @@ equity_instrument_mapper::forward_equity_option(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityOption: " << std::string(t.id);
     trading::domain::equity_instrument_variant result;
     auto& inst = result.emplace<ores::trading::domain::equity_option_instrument>();
-    inst.trade_type_code = "EquityOption";
-    inst.modified_by = "ores";
-    inst.performed_by = "ores";
-    inst.change_reason_code = "system.external_data_import";
-    inst.change_commentary = "Imported from ORE XML";
+    inst.identity.trade_type_code = "EquityOption";
+    inst.audit.modified_by = "ores";
+    inst.audit.performed_by = "ores";
+    inst.audit.change_reason_code = "system.external_data_import";
+    inst.audit.change_commentary = "Imported from ORE XML";
     if (!t.EquityOptionData)
         return result;
     const auto& d = *t.EquityOptionData;
@@ -284,11 +284,11 @@ equity_instrument_mapper::forward_equity_forward(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityForward: " << std::string(t.id);
     trading::domain::equity_instrument_variant result;
     auto& inst = result.emplace<ores::trading::domain::equity_forward_instrument>();
-    inst.trade_type_code = "EquityForward";
-    inst.modified_by = "ores";
-    inst.performed_by = "ores";
-    inst.change_reason_code = "system.external_data_import";
-    inst.change_commentary = "Imported from ORE XML";
+    inst.identity.trade_type_code = "EquityForward";
+    inst.audit.modified_by = "ores";
+    inst.audit.performed_by = "ores";
+    inst.audit.change_reason_code = "system.external_data_import";
+    inst.audit.change_commentary = "Imported from ORE XML";
     if (!t.EquityForwardData)
         return result;
     const auto& d = *t.EquityForwardData;
@@ -310,11 +310,11 @@ equity_instrument_mapper::forward_equity_swap(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquitySwap: " << std::string(t.id);
     trading::domain::equity_instrument_variant result;
     auto& inst = result.emplace<ores::trading::domain::equity_swap_instrument>();
-    inst.trade_type_code = "EquitySwap";
-    inst.modified_by = "ores";
-    inst.performed_by = "ores";
-    inst.change_reason_code = "system.external_data_import";
-    inst.change_commentary = "Imported from ORE XML";
+    inst.identity.trade_type_code = "EquitySwap";
+    inst.audit.modified_by = "ores";
+    inst.audit.performed_by = "ores";
+    inst.audit.change_reason_code = "system.external_data_import";
+    inst.audit.change_commentary = "Imported from ORE XML";
     if (!t.EquitySwapData)
         return result;
     const auto& d = *t.EquitySwapData;
@@ -359,11 +359,11 @@ equity_instrument_mapper::forward_equity_variance_swap(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityVarianceSwap: " << std::string(t.id);
     trading::domain::equity_instrument_variant result;
     auto& inst = result.emplace<ores::trading::domain::equity_variance_swap_instrument>();
-    inst.trade_type_code = "EquityVarianceSwap";
-    inst.modified_by = "ores";
-    inst.performed_by = "ores";
-    inst.change_reason_code = "system.external_data_import";
-    inst.change_commentary = "Imported from ORE XML";
+    inst.identity.trade_type_code = "EquityVarianceSwap";
+    inst.audit.modified_by = "ores";
+    inst.audit.performed_by = "ores";
+    inst.audit.change_reason_code = "system.external_data_import";
+    inst.audit.change_commentary = "Imported from ORE XML";
     if (!t.EquityVarianceSwapData)
         return result;
     const auto& d = *t.EquityVarianceSwapData;
@@ -386,11 +386,11 @@ equity_instrument_mapper::forward_equity_barrier_option(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityBarrierOption: " << std::string(t.id);
     trading::domain::equity_instrument_variant result;
     auto& inst = result.emplace<ores::trading::domain::equity_barrier_option_instrument>();
-    inst.trade_type_code = "EquityBarrierOption";
-    inst.modified_by = "ores";
-    inst.performed_by = "ores";
-    inst.change_reason_code = "system.external_data_import";
-    inst.change_commentary = "Imported from ORE XML";
+    inst.identity.trade_type_code = "EquityBarrierOption";
+    inst.audit.modified_by = "ores";
+    inst.audit.performed_by = "ores";
+    inst.audit.change_reason_code = "system.external_data_import";
+    inst.audit.change_commentary = "Imported from ORE XML";
     if (!t.EquityBarrierOptionData)
         return result;
     const auto& d = *t.EquityBarrierOptionData;
@@ -419,11 +419,11 @@ equity_instrument_mapper::forward_equity_asian_option(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityAsianOption: " << std::string(t.id);
     trading::domain::equity_instrument_variant result;
     auto& inst = result.emplace<ores::trading::domain::equity_asian_option_instrument>();
-    inst.trade_type_code = "EquityAsianOption";
-    inst.modified_by = "ores";
-    inst.performed_by = "ores";
-    inst.change_reason_code = "system.external_data_import";
-    inst.change_commentary = "Imported from ORE XML";
+    inst.identity.trade_type_code = "EquityAsianOption";
+    inst.audit.modified_by = "ores";
+    inst.audit.performed_by = "ores";
+    inst.audit.change_reason_code = "system.external_data_import";
+    inst.audit.change_commentary = "Imported from ORE XML";
     if (!t.EquityAsianOptionData)
         return result;
     const auto& d = *t.EquityAsianOptionData;
@@ -449,11 +449,11 @@ equity_instrument_mapper::forward_equity_digital_option(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityDigitalOption: " << std::string(t.id);
     trading::domain::equity_instrument_variant result;
     auto& inst = result.emplace<ores::trading::domain::equity_digital_option_instrument>();
-    inst.trade_type_code = "EquityDigitalOption";
-    inst.modified_by = "ores";
-    inst.performed_by = "ores";
-    inst.change_reason_code = "system.external_data_import";
-    inst.change_commentary = "Imported from ORE XML";
+    inst.identity.trade_type_code = "EquityDigitalOption";
+    inst.audit.modified_by = "ores";
+    inst.audit.performed_by = "ores";
+    inst.audit.change_reason_code = "system.external_data_import";
+    inst.audit.change_commentary = "Imported from ORE XML";
     if (!t.EquityDigitalOptionData)
         return result;
     const auto& d = *t.EquityDigitalOptionData;
@@ -477,11 +477,11 @@ equity_instrument_mapper::forward_equity_touch_option(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityTouchOption: " << std::string(t.id);
     trading::domain::equity_instrument_variant result;
     auto& inst = result.emplace<ores::trading::domain::equity_digital_option_instrument>();
-    inst.trade_type_code = "EquityTouchOption";
-    inst.modified_by = "ores";
-    inst.performed_by = "ores";
-    inst.change_reason_code = "system.external_data_import";
-    inst.change_commentary = "Imported from ORE XML";
+    inst.identity.trade_type_code = "EquityTouchOption";
+    inst.audit.modified_by = "ores";
+    inst.audit.performed_by = "ores";
+    inst.audit.change_reason_code = "system.external_data_import";
+    inst.audit.change_commentary = "Imported from ORE XML";
     if (!t.EquityTouchOptionData)
         return result;
     const auto& d = *t.EquityTouchOptionData;
@@ -508,11 +508,11 @@ equity_instrument_mapper::forward_equity_outperformance_option(const trade& t) {
                                << std::string(t.id);
     trading::domain::equity_instrument_variant result;
     auto& inst = result.emplace<ores::trading::domain::equity_option_instrument>();
-    inst.trade_type_code = "EquityOutperformanceOption";
-    inst.modified_by = "ores";
-    inst.performed_by = "ores";
-    inst.change_reason_code = "system.external_data_import";
-    inst.change_commentary = "Imported from ORE XML";
+    inst.identity.trade_type_code = "EquityOutperformanceOption";
+    inst.audit.modified_by = "ores";
+    inst.audit.performed_by = "ores";
+    inst.audit.change_reason_code = "system.external_data_import";
+    inst.audit.change_commentary = "Imported from ORE XML";
     if (!t.EquityOutperformanceOptionData)
         return result;
     const auto& d = *t.EquityOutperformanceOptionData;
@@ -541,11 +541,11 @@ equity_instrument_mapper::forward_equity_accumulator(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityAccumulator: " << std::string(t.id);
     trading::domain::equity_instrument_variant result;
     auto& inst = result.emplace<ores::trading::domain::equity_accumulator_instrument>();
-    inst.trade_type_code = "EquityAccumulator";
-    inst.modified_by = "ores";
-    inst.performed_by = "ores";
-    inst.change_reason_code = "system.external_data_import";
-    inst.change_commentary = "Imported from ORE XML";
+    inst.identity.trade_type_code = "EquityAccumulator";
+    inst.audit.modified_by = "ores";
+    inst.audit.performed_by = "ores";
+    inst.audit.change_reason_code = "system.external_data_import";
+    inst.audit.change_commentary = "Imported from ORE XML";
     if (!t.EquityAccumulatorData)
         return result;
     const auto& d = *t.EquityAccumulatorData;
@@ -580,11 +580,11 @@ equity_instrument_mapper::forward_equity_tarf(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityTaRF: " << std::string(t.id);
     trading::domain::equity_instrument_variant result;
     auto& inst = result.emplace<ores::trading::domain::equity_accumulator_instrument>();
-    inst.trade_type_code = "EquityTaRF";
-    inst.modified_by = "ores";
-    inst.performed_by = "ores";
-    inst.change_reason_code = "system.external_data_import";
-    inst.change_commentary = "Imported from ORE XML";
+    inst.identity.trade_type_code = "EquityTaRF";
+    inst.audit.modified_by = "ores";
+    inst.audit.performed_by = "ores";
+    inst.audit.change_reason_code = "system.external_data_import";
+    inst.audit.change_commentary = "Imported from ORE XML";
     if (!t.EquityTaRFData)
         return result;
     const auto& d = *t.EquityTaRFData;
@@ -614,11 +614,11 @@ equity_instrument_mapper::forward_equity_cliquet_option(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityCliquetOption: " << std::string(t.id);
     trading::domain::equity_instrument_variant result;
     auto& inst = result.emplace<ores::trading::domain::equity_option_instrument>();
-    inst.trade_type_code = "EquityCliquetOption";
-    inst.modified_by = "ores";
-    inst.performed_by = "ores";
-    inst.change_reason_code = "system.external_data_import";
-    inst.change_commentary = "Imported from ORE XML";
+    inst.identity.trade_type_code = "EquityCliquetOption";
+    inst.audit.modified_by = "ores";
+    inst.audit.performed_by = "ores";
+    inst.audit.change_reason_code = "system.external_data_import";
+    inst.audit.change_commentary = "Imported from ORE XML";
     if (!t.EquityCliquetOptionData)
         return result;
     const auto& d = *t.EquityCliquetOptionData;
@@ -647,11 +647,11 @@ equity_instrument_mapper::forward_equity_worst_of_basket_swap(const trade& t) {
     BOOST_LOG_SEV(lg(), debug) << "Forward-mapping EquityWorstOfBasketSwap: " << std::string(t.id);
     trading::domain::equity_instrument_variant result;
     auto& inst = result.emplace<ores::trading::domain::equity_swap_instrument>();
-    inst.trade_type_code = "EquityWorstOfBasketSwap";
-    inst.modified_by = "ores";
-    inst.performed_by = "ores";
-    inst.change_reason_code = "system.external_data_import";
-    inst.change_commentary = "Imported from ORE XML";
+    inst.identity.trade_type_code = "EquityWorstOfBasketSwap";
+    inst.audit.modified_by = "ores";
+    inst.audit.performed_by = "ores";
+    inst.audit.change_reason_code = "system.external_data_import";
+    inst.audit.change_commentary = "Imported from ORE XML";
     if (!t.EquityWorstOfBasketSwapData)
         return result;
     const auto& d = *t.EquityWorstOfBasketSwapData;
@@ -1065,11 +1065,11 @@ equity_instrument_mapper::forward_equity_double_barrier_option(const trade& t) {
                                << std::string(t.id);
     trading::domain::equity_instrument_variant result;
     auto& inst = result.emplace<ores::trading::domain::equity_barrier_option_instrument>();
-    inst.trade_type_code = "EquityDoubleBarrierOption";
-    inst.modified_by = "ores";
-    inst.performed_by = "ores";
-    inst.change_reason_code = "system.external_data_import";
-    inst.change_commentary = "Imported from ORE XML";
+    inst.identity.trade_type_code = "EquityDoubleBarrierOption";
+    inst.audit.modified_by = "ores";
+    inst.audit.performed_by = "ores";
+    inst.audit.change_reason_code = "system.external_data_import";
+    inst.audit.change_commentary = "Imported from ORE XML";
     if (!t.EquityDoubleBarrierOptionData)
         return result;
     const auto& d = *t.EquityDoubleBarrierOptionData;
@@ -1098,11 +1098,11 @@ equity_instrument_mapper::forward_equity_european_barrier_option(const trade& t)
                                << std::string(t.id);
     trading::domain::equity_instrument_variant result;
     auto& inst = result.emplace<ores::trading::domain::equity_barrier_option_instrument>();
-    inst.trade_type_code = "EquityEuropeanBarrierOption";
-    inst.modified_by = "ores";
-    inst.performed_by = "ores";
-    inst.change_reason_code = "system.external_data_import";
-    inst.change_commentary = "Imported from ORE XML";
+    inst.identity.trade_type_code = "EquityEuropeanBarrierOption";
+    inst.audit.modified_by = "ores";
+    inst.audit.performed_by = "ores";
+    inst.audit.change_reason_code = "system.external_data_import";
+    inst.audit.change_commentary = "Imported from ORE XML";
     if (!t.EquityEuropeanBarrierOptionData)
         return result;
     const auto& d = *t.EquityEuropeanBarrierOptionData;

--- a/projects/ores.ore/core/tests/planner_import_planner_tests.cpp
+++ b/projects/ores.ore/core/tests/planner_import_planner_tests.cpp
@@ -318,21 +318,13 @@ TEST_CASE("plan_instrument_trade_id_matches_minted_trade_id", tags) {
                             ++checked;
                         },
                         r.instrument);
-                } else if constexpr (std::is_same_v<T, fx_instrument_variant>) {
+                } else if constexpr (std::is_same_v<T, fx_instrument_variant> ||
+                                     std::is_same_v<T, equity_instrument_variant>) {
                     std::visit(
                         [&](const auto& instr) {
                             INFO("Instrument variant index checked");
                             REQUIRE(instr.identity.trade_id.has_value());
                             CHECK(*instr.identity.trade_id == item.trade.identity.id);
-                            ++checked;
-                        },
-                        r);
-                } else if constexpr (std::is_same_v<T, equity_instrument_variant>) {
-                    std::visit(
-                        [&](const auto& instr) {
-                            INFO("Instrument variant index checked");
-                            REQUIRE(instr.trade_id.has_value());
-                            CHECK(*instr.trade_id == item.trade.identity.id);
                             ++checked;
                         },
                         r);

--- a/projects/ores.ore/core/tests/xml_equity_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/core/tests/xml_equity_mapper_roundtrip_tests.cpp
@@ -75,7 +75,7 @@ TEST_CASE("equity_mapper_roundtrip_option", tags) {
     const auto r = load_and_map("Equity_Option_European.xml");
     const auto& inst = std::get<ores::trading::domain::equity_option_instrument>(r);
 
-    CHECK(inst.trade_type_code == "EquityOption");
+    CHECK(inst.identity.trade_type_code == "EquityOption");
     CHECK(!inst.underlying_name.empty());
     CHECK(!inst.currency.empty());
     CHECK(inst.notional > 0.0);
@@ -94,7 +94,7 @@ TEST_CASE("equity_mapper_roundtrip_forward", tags) {
     const auto r = load_and_map("Equity_Forward.xml");
     const auto& inst = std::get<ores::trading::domain::equity_forward_instrument>(r);
 
-    CHECK(inst.trade_type_code == "EquityForward");
+    CHECK(inst.identity.trade_type_code == "EquityForward");
     CHECK(!inst.underlying_name.empty());
     CHECK(!inst.currency.empty());
     CHECK(inst.quantity > 0.0);
@@ -111,7 +111,7 @@ TEST_CASE("equity_mapper_roundtrip_swap", tags) {
     const auto r = load_and_map("Equity_Swap.xml");
     const auto& inst = std::get<ores::trading::domain::equity_swap_instrument>(r);
 
-    CHECK(inst.trade_type_code == "EquitySwap");
+    CHECK(inst.identity.trade_type_code == "EquitySwap");
     CHECK(!inst.underlying_name.empty());
     CHECK(!inst.currency.empty());
     CHECK(!inst.return_type.empty());
@@ -129,7 +129,7 @@ TEST_CASE("equity_mapper_roundtrip_variance_swap", tags) {
     const auto r = load_and_map("Equity_Variance_Swap.xml");
     const auto& inst = std::get<ores::trading::domain::equity_variance_swap_instrument>(r);
 
-    CHECK(inst.trade_type_code == "EquityVarianceSwap");
+    CHECK(inst.identity.trade_type_code == "EquityVarianceSwap");
     CHECK(!inst.underlying_name.empty());
     CHECK(inst.variance_strike > 0.0);
     CHECK(!inst.start_date.empty());
@@ -147,7 +147,7 @@ TEST_CASE("equity_mapper_roundtrip_barrier_option", tags) {
     const auto r = load_and_map("Equity_Barrier_Option.xml");
     const auto& inst = std::get<ores::trading::domain::equity_barrier_option_instrument>(r);
 
-    CHECK(inst.trade_type_code == "EquityBarrierOption");
+    CHECK(inst.identity.trade_type_code == "EquityBarrierOption");
     CHECK(!inst.underlying_name.empty());
     CHECK(!inst.lower_barrier_type.empty());
     CHECK(inst.lower_barrier > 0.0);
@@ -164,7 +164,7 @@ TEST_CASE("equity_mapper_roundtrip_asian_option", tags) {
     const auto r = load_and_map("Equity_Asian_Option.xml");
     const auto& inst = std::get<ores::trading::domain::equity_asian_option_instrument>(r);
 
-    CHECK(inst.trade_type_code == "EquityAsianOption");
+    CHECK(inst.identity.trade_type_code == "EquityAsianOption");
     CHECK(!inst.underlying_name.empty());
     CHECK(inst.strike > 0.0);
     CHECK(!inst.averaging_start_date.empty());
@@ -181,7 +181,7 @@ TEST_CASE("equity_mapper_roundtrip_digital_option", tags) {
     const auto r = load_and_map("Equity_Digital_Option.xml");
     const auto& inst = std::get<ores::trading::domain::equity_digital_option_instrument>(r);
 
-    CHECK(inst.trade_type_code == "EquityDigitalOption");
+    CHECK(inst.identity.trade_type_code == "EquityDigitalOption");
     CHECK(!inst.underlying_name.empty());
     CHECK(inst.strike.value_or(0.0) > 0.0);
     CHECK(!inst.option_type.empty());
@@ -198,7 +198,7 @@ TEST_CASE("equity_mapper_roundtrip_touch_option", tags) {
     const auto r = load_and_map("Equity_OneTouch_Option.xml");
     const auto& inst = std::get<ores::trading::domain::equity_digital_option_instrument>(r);
 
-    CHECK(inst.trade_type_code == "EquityTouchOption");
+    CHECK(inst.identity.trade_type_code == "EquityTouchOption");
     CHECK(!inst.barrier_type.empty());
     CHECK(inst.barrier_level.value_or(0.0) > 0.0);
 
@@ -214,7 +214,7 @@ TEST_CASE("equity_mapper_roundtrip_outperformance_option", tags) {
     const auto r = load_and_map("Equity_OutperformanceOption.xml");
     const auto& inst = std::get<ores::trading::domain::equity_option_instrument>(r);
 
-    CHECK(inst.trade_type_code == "EquityOutperformanceOption");
+    CHECK(inst.identity.trade_type_code == "EquityOutperformanceOption");
     CHECK(!inst.currency.empty());
     CHECK(inst.notional > 0.0);
     // Outperformance joins two underlyings as "n1/n2" in underlying_name
@@ -237,7 +237,7 @@ TEST_CASE("equity_mapper_roundtrip_accumulator", tags) {
     const auto r = load_and_map("Exotic_EquityAccumulator_single_name.xml");
     const auto& inst = std::get<ores::trading::domain::equity_accumulator_instrument>(r);
 
-    CHECK(inst.trade_type_code == "EquityAccumulator");
+    CHECK(inst.identity.trade_type_code == "EquityAccumulator");
     CHECK(!inst.underlying_name.empty());
     CHECK(inst.fixing_amount > 0.0);
     CHECK(inst.knock_out_level.value_or(0.0) > 0.0);
@@ -253,7 +253,7 @@ TEST_CASE("equity_mapper_roundtrip_tarf", tags) {
     const auto r = load_and_map("Exotic_EquityTaRF.xml");
     const auto& inst = std::get<ores::trading::domain::equity_accumulator_instrument>(r);
 
-    CHECK(inst.trade_type_code == "EquityTaRF");
+    CHECK(inst.identity.trade_type_code == "EquityTaRF");
     CHECK(!inst.underlying_name.empty());
     CHECK(inst.fixing_amount > 0.0);
 
@@ -268,7 +268,7 @@ TEST_CASE("equity_mapper_roundtrip_cliquet_option", tags) {
     const auto r = load_and_map("Exotic_Equity_Cliquet_Option.xml");
     const auto& inst = std::get<ores::trading::domain::equity_option_instrument>(r);
 
-    CHECK(inst.trade_type_code == "EquityCliquetOption");
+    CHECK(inst.identity.trade_type_code == "EquityCliquetOption");
     CHECK(!inst.underlying_name.empty());
     CHECK(inst.notional > 0.0);
 
@@ -283,7 +283,7 @@ TEST_CASE("equity_mapper_roundtrip_worst_of_basket_swap", tags) {
     const auto r = load_and_map("Exotic_EquityWorstOfBasketSwap.xml");
     const auto& inst = std::get<ores::trading::domain::equity_swap_instrument>(r);
 
-    CHECK(inst.trade_type_code == "EquityWorstOfBasketSwap");
+    CHECK(inst.identity.trade_type_code == "EquityWorstOfBasketSwap");
     CHECK(!inst.currency.empty());
     CHECK(inst.notional > 0.0);
     CHECK(!inst.basket_json.empty());

--- a/projects/ores.ore/core/tests/xml_remaining_phases_mapper_roundtrip_tests.cpp
+++ b/projects/ores.ore/core/tests/xml_remaining_phases_mapper_roundtrip_tests.cpp
@@ -212,7 +212,7 @@ TEST_CASE("equity_double_barrier_option_forward", tags) {
     const auto r = load_and_map_equity("Equity_Double_Barrier_Option.xml");
     const auto& instr = std::get<ores::trading::domain::equity_barrier_option_instrument>(r);
 
-    CHECK(instr.trade_type_code == "EquityDoubleBarrierOption");
+    CHECK(instr.identity.trade_type_code == "EquityDoubleBarrierOption");
     CHECK(!instr.option_type.empty());
     CHECK(!instr.underlying_name.empty());
 
@@ -240,7 +240,7 @@ TEST_CASE("equity_european_barrier_option_forward", tags) {
     const auto r = load_and_map_equity("Equity_European_Barrier_Option.xml");
     const auto& instr = std::get<ores::trading::domain::equity_barrier_option_instrument>(r);
 
-    CHECK(instr.trade_type_code == "EquityEuropeanBarrierOption");
+    CHECK(instr.identity.trade_type_code == "EquityEuropeanBarrierOption");
     CHECK(!instr.option_type.empty());
 
     BOOST_LOG_SEV(lg, info) << "EquityEuropeanBarrierOption forward test passed";

--- a/projects/ores.qt/api/tests/instrument_parse_dispatch_tests.cpp
+++ b/projects/ores.qt/api/tests/instrument_parse_dispatch_tests.cpp
@@ -361,8 +361,8 @@ TEST_CASE("parse_trade_instrument_dispatches_vanilla_swap", tags) {
 
 TEST_CASE("parse_trade_instrument_dispatches_equity_option", tags) {
     equity_option_instrument instr;
-    instr.instrument_id = boost::uuids::random_generator()();
-    instr.trade_type_code = "EquityOption";
+    instr.identity.instrument_id = boost::uuids::random_generator()();
+    instr.identity.trade_type_code = "EquityOption";
     instr.underlying_name = "AAPL";
     instr.currency = "USD";
     instr.option_type = "Call";
@@ -376,7 +376,7 @@ TEST_CASE("parse_trade_instrument_dispatches_equity_option", tags) {
     REQUIRE(result.has_value());
     CHECK(result->classification.product_type == product_type::equity);
     REQUIRE(pop.called);
-    CHECK(pop.got.instrument_id == instr.instrument_id);
+    CHECK(pop.got.identity.instrument_id == instr.identity.instrument_id);
     CHECK(pop.got.underlying_name == "AAPL");
     CHECK(pop.got.option_type == "Call");
 }
@@ -387,8 +387,8 @@ TEST_CASE("parse_trade_instrument_dispatches_equity_option", tags) {
 
 TEST_CASE("parse_trade_instrument_dispatches_equity_forward", tags) {
     equity_forward_instrument instr;
-    instr.instrument_id = boost::uuids::random_generator()();
-    instr.trade_type_code = "EquityForward";
+    instr.identity.instrument_id = boost::uuids::random_generator()();
+    instr.identity.trade_type_code = "EquityForward";
 
     auto json = make_response_json(make_test_trade(product_type::equity, "EquityForward"),
                                    trade_instrument{equity_instrument_variant{instr}});
@@ -399,7 +399,7 @@ TEST_CASE("parse_trade_instrument_dispatches_equity_forward", tags) {
     REQUIRE(result.has_value());
     CHECK(result->classification.product_type == product_type::equity);
     REQUIRE(pop.called);
-    CHECK(pop.got.instrument_id == instr.instrument_id);
+    CHECK(pop.got.identity.instrument_id == instr.identity.instrument_id);
 }
 
 // =============================================================================

--- a/projects/ores.qt/trading/src/EquityInstrumentForm.cpp
+++ b/projects/ores.qt/trading/src/EquityInstrumentForm.cpp
@@ -163,7 +163,7 @@ void EquityInstrumentForm::clear() {
 }
 
 void EquityInstrumentForm::setTradeType(const QString& code, bool has_options, bool has_extension) {
-    instrument_.trade_type_code = code.trimmed().toStdString();
+    instrument_.identity.trade_type_code = code.trimmed().toStdString();
     ui_->tradeTypeCodeEdit->setText(code.trimmed());
     ui_->subTabWidget->setTabVisible(ui_->subTabWidget->indexOf(ui_->optionsTab), has_options);
     ui_->subTabWidget->setTabVisible(ui_->subTabWidget->indexOf(ui_->extensionsTab), has_extension);
@@ -203,8 +203,8 @@ bool EquityInstrumentForm::isLoaded() const {
 }
 
 void EquityInstrumentForm::setChangeReason(const std::string& code, const std::string& commentary) {
-    instrument_.change_reason_code = code;
-    instrument_.change_commentary = commentary;
+    instrument_.audit.change_reason_code = code;
+    instrument_.audit.change_commentary = commentary;
 }
 
 void EquityInstrumentForm::writeUiToInstrument() {
@@ -217,8 +217,8 @@ void EquityInstrumentForm::writeUiToInstrument() {
     instrument_.exercise_type = InstrumentFormUtils::getComboValue(ui_->exerciseTypeCombo);
     instrument_.strike = ui_->strikePriceSpinBox->value();
     instrument_.cliquet_frequency = InstrumentFormUtils::getComboValue(ui_->cliquetFrequencyCombo);
-    instrument_.modified_by = username_;
-    instrument_.performed_by = username_;
+    instrument_.audit.modified_by = username_;
+    instrument_.audit.performed_by = username_;
 }
 
 void EquityInstrumentForm::populate(const trading::domain::equity_option_instrument& instr) {
@@ -258,7 +258,7 @@ void EquityInstrumentForm::populateFromInstrument() {
     };
 
     block(true);
-    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.trade_type_code));
+    ui_->tradeTypeCodeEdit->setText(QString::fromStdString(instrument_.identity.trade_type_code));
     ui_->underlyingCodeEdit->setText(QString::fromStdString(instrument_.underlying_name));
     InstrumentFormUtils::setComboValue(ui_->currencyCombo, instrument_.currency);
     ui_->notionalSpinBox->setValue(instrument_.notional);
@@ -287,12 +287,12 @@ void EquityInstrumentForm::populateFromInstrument() {
 
 void EquityInstrumentForm::emitProvenance() {
     InstrumentProvenance p;
-    p.version = instrument_.version;
-    p.modified_by = instrument_.modified_by;
-    p.performed_by = instrument_.performed_by;
-    p.recorded_at = instrument_.recorded_at;
-    p.change_reason_code = instrument_.change_reason_code;
-    p.change_commentary = instrument_.change_commentary;
+    p.version = instrument_.identity.version;
+    p.modified_by = instrument_.audit.modified_by;
+    p.performed_by = instrument_.audit.performed_by;
+    p.recorded_at = instrument_.audit.recorded_at;
+    p.change_reason_code = instrument_.audit.change_reason_code;
+    p.change_commentary = instrument_.audit.change_commentary;
     emit provenanceChanged(p);
 }
 
@@ -337,7 +337,7 @@ void EquityInstrumentForm::saveInstrument(std::function<void(const std::string&)
             BOOST_LOG_SEV(lg(), info) << "Equity instrument saved";
             self->dirty_ = false;
             self->emitProvenance();
-            on_success(boost::uuids::to_string(self->instrument_.instrument_id));
+            on_success(boost::uuids::to_string(self->instrument_.identity.instrument_id));
         });
 
     auto* cm = clientManager_;

--- a/projects/ores.qt/trading/src/ImportTradeDialog.cpp
+++ b/projects/ores.qt/trading/src/ImportTradeDialog.cpp
@@ -602,18 +602,12 @@ void ImportTradeDialog::onImportClicked() {
                             r.instrument);
                         for (auto& leg : r.legs)
                             leg.identity.instrument_id = instr_id;
-                    } else if constexpr (std::is_same_v<T, fx_instrument_variant>) {
+                    } else if constexpr (std::is_same_v<T, fx_instrument_variant> ||
+                                         std::is_same_v<T, equity_instrument_variant>) {
                         std::visit(
                             [&](auto& instr) {
                                 instr.identity.instrument_id = instr_id;
                                 instr.identity.trade_id = tti.trade.identity.id;
-                            },
-                            r);
-                    } else if constexpr (std::is_same_v<T, equity_instrument_variant>) {
-                        std::visit(
-                            [&](auto& instr) {
-                                instr.instrument_id = instr_id;
-                                instr.trade_id = tti.trade.identity.id;
                             },
                             r);
                     } else if constexpr (std::is_same_v<T, composite_instrument_data>) {

--- a/projects/ores.trading/api/include/ores.trading.api/domain/equity_accumulator_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/equity_accumulator_instrument.hpp
@@ -20,9 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_EQUITY_ACCUMULATOR_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_EQUITY_ACCUMULATOR_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <optional>
 #include <string>
 
@@ -34,21 +33,7 @@ namespace ores::trading::domain {
  * Represents EquityAccumulator and EquityTaRF trades.
  */
 struct equity_accumulator_instrument final {
-    int version = 0;
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this equity accumulator instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    boost::uuids::uuid party_id;
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code: EquityAccumulator or EquityTaRF.
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     std::string underlying_name;
     std::string currency;
@@ -104,11 +89,8 @@ struct equity_accumulator_instrument final {
     std::string payoff_type;
 
     std::string description;
-    std::string modified_by;
-    std::string performed_by;
-    std::string change_reason_code;
-    std::string change_commentary;
-    std::chrono::system_clock::time_point recorded_at;
+
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/equity_asian_option_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/equity_asian_option_instrument.hpp
@@ -20,10 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_EQUITY_ASIAN_OPTION_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_EQUITY_ASIAN_OPTION_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
-#include <optional>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <string>
 
 namespace ores::trading::domain {
@@ -34,21 +32,7 @@ namespace ores::trading::domain {
  * Represents EquityAsianOption trades.
  */
 struct equity_asian_option_instrument final {
-    int version = 0;
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this equity asian option instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    boost::uuids::uuid party_id;
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code: EquityAsianOption.
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     /**
      * @brief ORE equity Name identifier.
@@ -106,11 +90,8 @@ struct equity_asian_option_instrument final {
     std::string averaging_end_date;
 
     std::string description;
-    std::string modified_by;
-    std::string performed_by;
-    std::string change_reason_code;
-    std::string change_commentary;
-    std::chrono::system_clock::time_point recorded_at;
+
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/equity_barrier_option_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/equity_barrier_option_instrument.hpp
@@ -20,9 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_EQUITY_BARRIER_OPTION_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_EQUITY_BARRIER_OPTION_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <optional>
 #include <string>
 
@@ -35,22 +34,7 @@ namespace ores::trading::domain {
  * EquityEuropeanBarrierOption trades.
  */
 struct equity_barrier_option_instrument final {
-    int version = 0;
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this equity barrier option instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    boost::uuids::uuid party_id;
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code: EquityBarrierOption, EquityDoubleBarrierOption,
-     * or EquityEuropeanBarrierOption.
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     /**
      * @brief ORE equity Name identifier.
@@ -115,11 +99,8 @@ struct equity_barrier_option_instrument final {
     std::optional<double> rebate;
 
     std::string description;
-    std::string modified_by;
-    std::string performed_by;
-    std::string change_reason_code;
-    std::string change_commentary;
-    std::chrono::system_clock::time_point recorded_at;
+
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/equity_digital_option_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/equity_digital_option_instrument.hpp
@@ -20,9 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_EQUITY_DIGITAL_OPTION_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_EQUITY_DIGITAL_OPTION_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <optional>
 #include <string>
 
@@ -34,21 +33,7 @@ namespace ores::trading::domain {
  * Represents EquityDigitalOption and EquityTouchOption trades.
  */
 struct equity_digital_option_instrument final {
-    int version = 0;
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this equity digital option instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    boost::uuids::uuid party_id;
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code: EquityDigitalOption or EquityTouchOption.
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     /**
      * @brief ORE equity Name identifier.
@@ -98,11 +83,8 @@ struct equity_digital_option_instrument final {
     std::optional<double> payout_amount;
 
     std::string description;
-    std::string modified_by;
-    std::string performed_by;
-    std::string change_reason_code;
-    std::string change_commentary;
-    std::chrono::system_clock::time_point recorded_at;
+
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/equity_forward_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/equity_forward_instrument.hpp
@@ -20,9 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_EQUITY_FORWARD_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_EQUITY_FORWARD_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <optional>
 #include <string>
 
@@ -34,21 +33,7 @@ namespace ores::trading::domain {
  * Represents EquityForward trades.
  */
 struct equity_forward_instrument final {
-    int version = 0;
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this equity forward instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    boost::uuids::uuid party_id;
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code: EquityForward.
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     /**
      * @brief ORE equity Name identifier.
@@ -86,11 +71,8 @@ struct equity_forward_instrument final {
     std::string settlement_type;
 
     std::string description;
-    std::string modified_by;
-    std::string performed_by;
-    std::string change_reason_code;
-    std::string change_commentary;
-    std::chrono::system_clock::time_point recorded_at;
+
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/equity_option_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/equity_option_instrument.hpp
@@ -20,10 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_EQUITY_OPTION_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_EQUITY_OPTION_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
-#include <optional>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <string>
 
 namespace ores::trading::domain {
@@ -34,21 +32,7 @@ namespace ores::trading::domain {
  * Represents EquityOption and EquityCliquetOption trades.
  */
 struct equity_option_instrument final {
-    int version = 0;
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this equity option instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    boost::uuids::uuid party_id;
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code: EquityOption or EquityCliquetOption.
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     /**
      * @brief ORE equity Name identifier.
@@ -101,11 +85,8 @@ struct equity_option_instrument final {
     std::string cliquet_frequency;
 
     std::string description;
-    std::string modified_by;
-    std::string performed_by;
-    std::string change_reason_code;
-    std::string change_commentary;
-    std::chrono::system_clock::time_point recorded_at;
+
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/equity_position_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/equity_position_instrument.hpp
@@ -20,9 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_EQUITY_POSITION_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_EQUITY_POSITION_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <optional>
 #include <string>
 
@@ -34,21 +33,7 @@ namespace ores::trading::domain {
  * Represents EquityPosition and EquityOptionPosition trades.
  */
 struct equity_position_instrument final {
-    int version = 0;
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this equity position instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    boost::uuids::uuid party_id;
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code: EquityPosition or EquityOptionPosition.
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     std::string underlying_name;
     std::string currency;
@@ -69,11 +54,8 @@ struct equity_position_instrument final {
     std::string option_data_json;
 
     std::string description;
-    std::string modified_by;
-    std::string performed_by;
-    std::string change_reason_code;
-    std::string change_commentary;
-    std::chrono::system_clock::time_point recorded_at;
+
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/equity_swap_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/equity_swap_instrument.hpp
@@ -20,10 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_EQUITY_SWAP_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_EQUITY_SWAP_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
-#include <optional>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <string>
 
 namespace ores::trading::domain {
@@ -34,21 +32,7 @@ namespace ores::trading::domain {
  * Represents EquitySwap and EquityWorstOfBasketSwap trades.
  */
 struct equity_swap_instrument final {
-    int version = 0;
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this equity swap instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    boost::uuids::uuid party_id;
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code: EquitySwap or EquityWorstOfBasketSwap.
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     /**
      * @brief Single underlying; empty for basket swaps.
@@ -93,11 +77,8 @@ struct equity_swap_instrument final {
     std::string payment_frequency;
 
     std::string description;
-    std::string modified_by;
-    std::string performed_by;
-    std::string change_reason_code;
-    std::string change_commentary;
-    std::chrono::system_clock::time_point recorded_at;
+
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/api/include/ores.trading.api/domain/equity_variance_swap_instrument.hpp
+++ b/projects/ores.trading/api/include/ores.trading.api/domain/equity_variance_swap_instrument.hpp
@@ -20,10 +20,8 @@
 #ifndef ORES_TRADING_DOMAIN_EQUITY_VARIANCE_SWAP_INSTRUMENT_HPP
 #define ORES_TRADING_DOMAIN_EQUITY_VARIANCE_SWAP_INSTRUMENT_HPP
 
-#include "ores.utility/uuid/tenant_id.hpp"
-#include <boost/uuid/uuid.hpp>
-#include <chrono>
-#include <optional>
+#include "ores.dq.api/domain/audit_record.hpp"
+#include "ores.trading.api/domain/instrument_identity.hpp"
 #include <string>
 
 namespace ores::trading::domain {
@@ -34,21 +32,7 @@ namespace ores::trading::domain {
  * Represents EquityVarianceSwap trades.
  */
 struct equity_variance_swap_instrument final {
-    int version = 0;
-    utility::uuid::tenant_id tenant_id = utility::uuid::tenant_id::system();
-
-    /**
-     * @brief UUID uniquely identifying this equity variance swap instrument.
-     */
-    boost::uuids::uuid instrument_id;
-
-    boost::uuids::uuid party_id;
-    std::optional<boost::uuids::uuid> trade_id;
-
-    /**
-     * @brief ORE product type code: EquityVarianceSwap.
-     */
-    std::string trade_type_code;
+    instrument_identity identity;
 
     std::string underlying_name;
     std::string currency;
@@ -79,11 +63,8 @@ struct equity_variance_swap_instrument final {
     std::string long_short;
 
     std::string description;
-    std::string modified_by;
-    std::string performed_by;
-    std::string change_reason_code;
-    std::string change_commentary;
-    std::chrono::system_clock::time_point recorded_at;
+
+    ores::dq::domain::audit_record audit;
 };
 
 }

--- a/projects/ores.trading/core/include/ores.trading.core/messaging/trade_handler.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/messaging/trade_handler.hpp
@@ -363,7 +363,7 @@ private:
         // Equity types
         auto add_eq = [&](auto&& results) {
             for (auto& v : results)
-                imap[boost::uuids::to_string(v.instrument_id)] =
+                imap[boost::uuids::to_string(v.identity.instrument_id)] =
                     ores::trading::domain::equity_instrument_variant{std::move(v)};
         };
         if (!eq_opt_ids.empty()) {

--- a/projects/ores.trading/core/include/ores.trading.core/repository/equity_accumulator_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/equity_accumulator_instrument_entity.hpp
@@ -39,6 +39,7 @@ struct equity_accumulator_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> instrument_id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/equity_asian_option_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/equity_asian_option_instrument_entity.hpp
@@ -34,6 +34,7 @@ struct equity_asian_option_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> instrument_id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/equity_barrier_option_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/equity_barrier_option_instrument_entity.hpp
@@ -34,6 +34,7 @@ struct equity_barrier_option_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> instrument_id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/equity_digital_option_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/equity_digital_option_instrument_entity.hpp
@@ -34,6 +34,7 @@ struct equity_digital_option_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> instrument_id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/equity_forward_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/equity_forward_instrument_entity.hpp
@@ -34,6 +34,7 @@ struct equity_forward_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> instrument_id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/equity_option_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/equity_option_instrument_entity.hpp
@@ -34,6 +34,7 @@ struct equity_option_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> instrument_id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/equity_position_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/equity_position_instrument_entity.hpp
@@ -39,6 +39,7 @@ struct equity_position_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> instrument_id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/equity_swap_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/equity_swap_instrument_entity.hpp
@@ -39,6 +39,7 @@ struct equity_swap_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> instrument_id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/include/ores.trading.core/repository/equity_variance_swap_instrument_entity.hpp
+++ b/projects/ores.trading/core/include/ores.trading.core/repository/equity_variance_swap_instrument_entity.hpp
@@ -39,6 +39,7 @@ struct equity_variance_swap_instrument_entity {
 
     sqlgen::PrimaryKey<std::string> instrument_id;
     std::string tenant_id;
+    std::string workspace_id;
     int version = 0;
     std::string party_id;
     std::optional<std::string> trade_id;

--- a/projects/ores.trading/core/src/repository/equity_accumulator_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/equity_accumulator_instrument_mapper.cpp
@@ -33,14 +33,15 @@ equity_accumulator_instrument_mapper::map(const equity_accumulator_instrument_en
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::equity_accumulator_instrument r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.underlying_name = v.underlying_name;
     r.currency = v.currency;
     r.strike = v.strike;
@@ -54,11 +55,11 @@ equity_accumulator_instrument_mapper::map(const equity_accumulator_instrument_en
     r.target_type = v.target_type.value_or("");
     r.payoff_type = v.payoff_type;
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -69,13 +70,15 @@ equity_accumulator_instrument_mapper::map(const domain::equity_accumulator_instr
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     equity_accumulator_instrument_entity r;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.version = v.version;
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.version = v.identity.version;
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.underlying_name = v.underlying_name;
     r.currency = v.currency;
     r.strike = v.strike;
@@ -89,10 +92,10 @@ equity_accumulator_instrument_mapper::map(const domain::equity_accumulator_instr
     r.target_type = v.target_type.empty() ? std::nullopt : std::optional(v.target_type);
     r.payoff_type = v.payoff_type;
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/equity_accumulator_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/equity_accumulator_instrument_repository.cpp
@@ -38,7 +38,8 @@ std::string equity_accumulator_instrument_repository::sql() {
 
 void equity_accumulator_instrument_repository::write(
     context ctx, const domain::equity_accumulator_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing equity accumulator instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity accumulator instrument: "
+                               << v.identity.instrument_id;
     execute_write_query(ctx,
                         equity_accumulator_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/repository/equity_asian_option_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/equity_asian_option_instrument_mapper.cpp
@@ -33,14 +33,15 @@ equity_asian_option_instrument_mapper::map(const equity_asian_option_instrument_
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::equity_asian_option_instrument r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.underlying_name = v.underlying_name;
     r.currency = v.currency;
     r.notional = v.notional;
@@ -53,11 +54,11 @@ equity_asian_option_instrument_mapper::map(const equity_asian_option_instrument_
     r.averaging_start_date = v.averaging_start_date;
     r.averaging_end_date = v.averaging_end_date;
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -68,13 +69,15 @@ equity_asian_option_instrument_mapper::map(const domain::equity_asian_option_ins
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     equity_asian_option_instrument_entity r;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.version = v.version;
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.version = v.identity.version;
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.underlying_name = v.underlying_name;
     r.currency = v.currency;
     r.notional = v.notional;
@@ -87,10 +90,10 @@ equity_asian_option_instrument_mapper::map(const domain::equity_asian_option_ins
     r.averaging_start_date = v.averaging_start_date;
     r.averaging_end_date = v.averaging_end_date;
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/equity_asian_option_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/equity_asian_option_instrument_repository.cpp
@@ -38,7 +38,8 @@ std::string equity_asian_option_instrument_repository::sql() {
 
 void equity_asian_option_instrument_repository::write(
     context ctx, const domain::equity_asian_option_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing equity asian option instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity asian option instrument: "
+                               << v.identity.instrument_id;
     execute_write_query(ctx,
                         equity_asian_option_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/repository/equity_barrier_option_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/equity_barrier_option_instrument_mapper.cpp
@@ -33,14 +33,15 @@ equity_barrier_option_instrument_mapper::map(const equity_barrier_option_instrum
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::equity_barrier_option_instrument r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.underlying_name = v.underlying_name;
     r.currency = v.currency;
     r.notional = v.notional;
@@ -55,11 +56,11 @@ equity_barrier_option_instrument_mapper::map(const equity_barrier_option_instrum
     r.upper_barrier_type = v.upper_barrier_type.value_or("");
     r.rebate = v.rebate;
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -70,13 +71,15 @@ equity_barrier_option_instrument_mapper::map(const domain::equity_barrier_option
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     equity_barrier_option_instrument_entity r;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.version = v.version;
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.version = v.identity.version;
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.underlying_name = v.underlying_name;
     r.currency = v.currency;
     r.notional = v.notional;
@@ -92,10 +95,10 @@ equity_barrier_option_instrument_mapper::map(const domain::equity_barrier_option
         v.upper_barrier_type.empty() ? std::nullopt : std::optional(v.upper_barrier_type);
     r.rebate = v.rebate;
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/equity_barrier_option_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/equity_barrier_option_instrument_repository.cpp
@@ -38,7 +38,8 @@ std::string equity_barrier_option_instrument_repository::sql() {
 
 void equity_barrier_option_instrument_repository::write(
     context ctx, const domain::equity_barrier_option_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing equity barrier option instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity barrier option instrument: "
+                               << v.identity.instrument_id;
     execute_write_query(ctx,
                         equity_barrier_option_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/repository/equity_digital_option_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/equity_digital_option_instrument_mapper.cpp
@@ -33,14 +33,15 @@ equity_digital_option_instrument_mapper::map(const equity_digital_option_instrum
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::equity_digital_option_instrument r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.underlying_name = v.underlying_name;
     r.currency = v.currency;
     r.notional = v.notional;
@@ -52,11 +53,11 @@ equity_digital_option_instrument_mapper::map(const equity_digital_option_instrum
     r.long_short = v.long_short;
     r.payout_amount = v.payout_amount;
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -67,13 +68,15 @@ equity_digital_option_instrument_mapper::map(const domain::equity_digital_option
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     equity_digital_option_instrument_entity r;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.version = v.version;
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.version = v.identity.version;
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.underlying_name = v.underlying_name;
     r.currency = v.currency;
     r.notional = v.notional;
@@ -85,10 +88,10 @@ equity_digital_option_instrument_mapper::map(const domain::equity_digital_option
     r.long_short = v.long_short;
     r.payout_amount = v.payout_amount;
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/equity_digital_option_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/equity_digital_option_instrument_repository.cpp
@@ -38,7 +38,8 @@ std::string equity_digital_option_instrument_repository::sql() {
 
 void equity_digital_option_instrument_repository::write(
     context ctx, const domain::equity_digital_option_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing equity digital option instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity digital option instrument: "
+                               << v.identity.instrument_id;
     execute_write_query(ctx,
                         equity_digital_option_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/repository/equity_forward_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/equity_forward_instrument_mapper.cpp
@@ -33,14 +33,15 @@ equity_forward_instrument_mapper::map(const equity_forward_instrument_entity& v)
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::equity_forward_instrument r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.underlying_name = v.underlying_name;
     r.currency = v.currency;
     r.quantity = v.quantity;
@@ -49,11 +50,11 @@ equity_forward_instrument_mapper::map(const equity_forward_instrument_entity& v)
     r.long_short = v.long_short;
     r.settlement_type = v.settlement_type.value_or("");
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -64,13 +65,15 @@ equity_forward_instrument_mapper::map(const domain::equity_forward_instrument& v
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     equity_forward_instrument_entity r;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.version = v.version;
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.version = v.identity.version;
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.underlying_name = v.underlying_name;
     r.currency = v.currency;
     r.quantity = v.quantity;
@@ -79,10 +82,10 @@ equity_forward_instrument_mapper::map(const domain::equity_forward_instrument& v
     r.long_short = v.long_short;
     r.settlement_type = v.settlement_type.empty() ? std::nullopt : std::optional(v.settlement_type);
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/equity_forward_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/equity_forward_instrument_repository.cpp
@@ -38,7 +38,7 @@ std::string equity_forward_instrument_repository::sql() {
 
 void equity_forward_instrument_repository::write(context ctx,
                                                  const domain::equity_forward_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing equity forward instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity forward instrument: " << v.identity.instrument_id;
     execute_write_query(ctx,
                         equity_forward_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/repository/equity_option_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/equity_option_instrument_mapper.cpp
@@ -33,14 +33,15 @@ equity_option_instrument_mapper::map(const equity_option_instrument_entity& v) {
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::equity_option_instrument r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.underlying_name = v.underlying_name;
     r.currency = v.currency;
     r.notional = v.notional;
@@ -52,11 +53,11 @@ equity_option_instrument_mapper::map(const equity_option_instrument_entity& v) {
     r.settlement_type = v.settlement_type.value_or("");
     r.cliquet_frequency = v.cliquet_frequency.value_or("");
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -67,13 +68,15 @@ equity_option_instrument_mapper::map(const domain::equity_option_instrument& v) 
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     equity_option_instrument_entity r;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.version = v.version;
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.version = v.identity.version;
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.underlying_name = v.underlying_name;
     r.currency = v.currency;
     r.notional = v.notional;
@@ -86,10 +89,10 @@ equity_option_instrument_mapper::map(const domain::equity_option_instrument& v) 
     r.cliquet_frequency =
         v.cliquet_frequency.empty() ? std::nullopt : std::optional(v.cliquet_frequency);
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/equity_option_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/equity_option_instrument_repository.cpp
@@ -38,7 +38,7 @@ std::string equity_option_instrument_repository::sql() {
 
 void equity_option_instrument_repository::write(context ctx,
                                                 const domain::equity_option_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing equity option instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity option instrument: " << v.identity.instrument_id;
     execute_write_query(ctx,
                         equity_option_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/repository/equity_position_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/equity_position_instrument_mapper.cpp
@@ -33,25 +33,26 @@ equity_position_instrument_mapper::map(const equity_position_instrument_entity& 
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::equity_position_instrument r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.underlying_name = v.underlying_name;
     r.currency = v.currency;
     r.quantity = v.quantity;
     r.price = v.price;
     r.option_data_json = v.option_data_json.value_or("");
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -62,13 +63,15 @@ equity_position_instrument_mapper::map(const domain::equity_position_instrument&
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     equity_position_instrument_entity r;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.version = v.version;
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.version = v.identity.version;
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.underlying_name = v.underlying_name;
     r.currency = v.currency;
     r.quantity = v.quantity;
@@ -76,10 +79,10 @@ equity_position_instrument_mapper::map(const domain::equity_position_instrument&
     r.option_data_json =
         v.option_data_json.empty() ? std::nullopt : std::optional(v.option_data_json);
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/equity_position_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/equity_position_instrument_repository.cpp
@@ -38,7 +38,8 @@ std::string equity_position_instrument_repository::sql() {
 
 void equity_position_instrument_repository::write(context ctx,
                                                   const domain::equity_position_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing equity position instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity position instrument: "
+                               << v.identity.instrument_id;
     execute_write_query(ctx,
                         equity_position_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/repository/equity_swap_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/equity_swap_instrument_mapper.cpp
@@ -33,14 +33,15 @@ equity_swap_instrument_mapper::map(const equity_swap_instrument_entity& v) {
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::equity_swap_instrument r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.underlying_name = v.underlying_name.value_or("");
     r.basket_json = v.basket_json.value_or("");
     r.currency = v.currency;
@@ -51,11 +52,11 @@ equity_swap_instrument_mapper::map(const equity_swap_instrument_entity& v) {
     r.long_short = v.long_short;
     r.payment_frequency = v.payment_frequency;
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -66,13 +67,15 @@ equity_swap_instrument_mapper::map(const domain::equity_swap_instrument& v) {
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     equity_swap_instrument_entity r;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.version = v.version;
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.version = v.identity.version;
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.underlying_name = v.underlying_name.empty() ? std::nullopt : std::optional(v.underlying_name);
     r.basket_json = v.basket_json.empty() ? std::nullopt : std::optional(v.basket_json);
     r.currency = v.currency;
@@ -83,10 +86,10 @@ equity_swap_instrument_mapper::map(const domain::equity_swap_instrument& v) {
     r.long_short = v.long_short;
     r.payment_frequency = v.payment_frequency;
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/equity_swap_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/equity_swap_instrument_repository.cpp
@@ -38,7 +38,7 @@ std::string equity_swap_instrument_repository::sql() {
 
 void equity_swap_instrument_repository::write(context ctx,
                                               const domain::equity_swap_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing equity swap instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity swap instrument: " << v.identity.instrument_id;
     execute_write_query(ctx,
                         equity_swap_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/repository/equity_variance_swap_instrument_mapper.cpp
+++ b/projects/ores.trading/core/src/repository/equity_variance_swap_instrument_mapper.cpp
@@ -33,14 +33,15 @@ equity_variance_swap_instrument_mapper::map(const equity_variance_swap_instrumen
     BOOST_LOG_SEV(lg(), trace) << "Mapping db entity: " << v;
 
     domain::equity_variance_swap_instrument r;
-    r.version = v.version;
-    r.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
-    r.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
-    r.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
-    r.trade_id = v.trade_id.has_value() ?
-                     std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
-                     std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.identity.version = v.version;
+    r.identity.tenant_id = utility::uuid::tenant_id::from_string(v.tenant_id).value();
+    r.identity.workspace_id = boost::lexical_cast<boost::uuids::uuid>(v.workspace_id);
+    r.identity.instrument_id = boost::lexical_cast<boost::uuids::uuid>(v.instrument_id.value());
+    r.identity.party_id = boost::lexical_cast<boost::uuids::uuid>(v.party_id);
+    r.identity.trade_id = v.trade_id.has_value() ?
+                              std::optional(boost::lexical_cast<boost::uuids::uuid>(*v.trade_id)) :
+                              std::nullopt;
+    r.identity.trade_type_code = v.trade_type_code;
     r.underlying_name = v.underlying_name;
     r.currency = v.currency;
     r.notional = v.notional;
@@ -49,11 +50,11 @@ equity_variance_swap_instrument_mapper::map(const equity_variance_swap_instrumen
     r.maturity_date = v.maturity_date;
     r.long_short = v.long_short;
     r.description = v.description.value_or("");
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
-    r.recorded_at = timestamp_to_timepoint(v.valid_from);
+    r.audit.modified_by = v.modified_by;
+    r.audit.performed_by = v.performed_by;
+    r.audit.change_reason_code = v.change_reason_code;
+    r.audit.change_commentary = v.change_commentary;
+    r.audit.recorded_at = timestamp_to_timepoint(v.valid_from);
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped db entity. Result: " << r;
     return r;
@@ -64,13 +65,15 @@ equity_variance_swap_instrument_mapper::map(const domain::equity_variance_swap_i
     BOOST_LOG_SEV(lg(), trace) << "Mapping domain entity: " << v;
 
     equity_variance_swap_instrument_entity r;
-    r.instrument_id = boost::uuids::to_string(v.instrument_id);
-    r.tenant_id = v.tenant_id.to_string();
-    r.version = v.version;
-    r.party_id = boost::uuids::to_string(v.party_id);
-    r.trade_id =
-        v.trade_id.has_value() ? std::optional(boost::uuids::to_string(*v.trade_id)) : std::nullopt;
-    r.trade_type_code = v.trade_type_code;
+    r.instrument_id = boost::uuids::to_string(v.identity.instrument_id);
+    r.tenant_id = v.identity.tenant_id.to_string();
+    r.workspace_id = boost::uuids::to_string(v.identity.workspace_id);
+    r.version = v.identity.version;
+    r.party_id = boost::uuids::to_string(v.identity.party_id);
+    r.trade_id = v.identity.trade_id.has_value() ?
+                     std::optional(boost::uuids::to_string(*v.identity.trade_id)) :
+                     std::nullopt;
+    r.trade_type_code = v.identity.trade_type_code;
     r.underlying_name = v.underlying_name;
     r.currency = v.currency;
     r.notional = v.notional;
@@ -79,10 +82,10 @@ equity_variance_swap_instrument_mapper::map(const domain::equity_variance_swap_i
     r.maturity_date = v.maturity_date;
     r.long_short = v.long_short;
     r.description = v.description.empty() ? std::nullopt : std::optional(v.description);
-    r.modified_by = v.modified_by;
-    r.performed_by = v.performed_by;
-    r.change_reason_code = v.change_reason_code;
-    r.change_commentary = v.change_commentary;
+    r.modified_by = v.audit.modified_by;
+    r.performed_by = v.audit.performed_by;
+    r.change_reason_code = v.audit.change_reason_code;
+    r.change_commentary = v.audit.change_commentary;
 
     BOOST_LOG_SEV(lg(), trace) << "Mapped domain entity. Result: " << r;
     return r;

--- a/projects/ores.trading/core/src/repository/equity_variance_swap_instrument_repository.cpp
+++ b/projects/ores.trading/core/src/repository/equity_variance_swap_instrument_repository.cpp
@@ -38,7 +38,8 @@ std::string equity_variance_swap_instrument_repository::sql() {
 
 void equity_variance_swap_instrument_repository::write(
     context ctx, const domain::equity_variance_swap_instrument& v) {
-    BOOST_LOG_SEV(lg(), debug) << "Writing equity variance swap instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Writing equity variance swap instrument: "
+                               << v.identity.instrument_id;
     execute_write_query(ctx,
                         equity_variance_swap_instrument_mapper::map(v),
                         lg(),

--- a/projects/ores.trading/core/src/service/equity_accumulator_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/equity_accumulator_instrument_service.cpp
@@ -41,13 +41,15 @@ equity_accumulator_instrument_service::get_equity_accumulator_instrument(const s
 
 void equity_accumulator_instrument_service::save_equity_accumulator_instrument(
     const domain::equity_accumulator_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("Equity accumulator instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving equity_accumulator_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_accumulator_instrument: "
+                               << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved equity_accumulator_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_accumulator_instrument: "
+                              << t.identity.instrument_id;
 }
 
 

--- a/projects/ores.trading/core/src/service/equity_asian_option_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/equity_asian_option_instrument_service.cpp
@@ -41,13 +41,15 @@ equity_asian_option_instrument_service::get_equity_asian_option_instrument(const
 
 void equity_asian_option_instrument_service::save_equity_asian_option_instrument(
     const domain::equity_asian_option_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("Equity asian option instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving equity_asian_option_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_asian_option_instrument: "
+                               << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved equity_asian_option_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_asian_option_instrument: "
+                              << t.identity.instrument_id;
 }
 
 

--- a/projects/ores.trading/core/src/service/equity_barrier_option_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/equity_barrier_option_instrument_service.cpp
@@ -42,13 +42,15 @@ equity_barrier_option_instrument_service::get_equity_barrier_option_instrument(
 
 void equity_barrier_option_instrument_service::save_equity_barrier_option_instrument(
     const domain::equity_barrier_option_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("Equity barrier option instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving equity_barrier_option_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_barrier_option_instrument: "
+                               << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved equity_barrier_option_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_barrier_option_instrument: "
+                              << t.identity.instrument_id;
 }
 
 

--- a/projects/ores.trading/core/src/service/equity_digital_option_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/equity_digital_option_instrument_service.cpp
@@ -42,13 +42,15 @@ equity_digital_option_instrument_service::get_equity_digital_option_instrument(
 
 void equity_digital_option_instrument_service::save_equity_digital_option_instrument(
     const domain::equity_digital_option_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("Equity digital option instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving equity_digital_option_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_digital_option_instrument: "
+                               << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved equity_digital_option_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_digital_option_instrument: "
+                              << t.identity.instrument_id;
 }
 
 

--- a/projects/ores.trading/core/src/service/equity_forward_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/equity_forward_instrument_service.cpp
@@ -41,13 +41,13 @@ equity_forward_instrument_service::get_equity_forward_instrument(const std::stri
 
 void equity_forward_instrument_service::save_equity_forward_instrument(
     const domain::equity_forward_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("Equity forward instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving equity_forward_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_forward_instrument: " << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved equity_forward_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_forward_instrument: " << t.identity.instrument_id;
 }
 
 

--- a/projects/ores.trading/core/src/service/equity_option_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/equity_option_instrument_service.cpp
@@ -41,13 +41,13 @@ equity_option_instrument_service::get_equity_option_instrument(const std::string
 
 void equity_option_instrument_service::save_equity_option_instrument(
     const domain::equity_option_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("Equity option instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving equity_option_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_option_instrument: " << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved equity_option_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_option_instrument: " << t.identity.instrument_id;
 }
 
 

--- a/projects/ores.trading/core/src/service/equity_position_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/equity_position_instrument_service.cpp
@@ -41,13 +41,13 @@ equity_position_instrument_service::get_equity_position_instrument(const std::st
 
 void equity_position_instrument_service::save_equity_position_instrument(
     const domain::equity_position_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("Equity position instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving equity_position_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_position_instrument: " << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved equity_position_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_position_instrument: " << t.identity.instrument_id;
 }
 
 

--- a/projects/ores.trading/core/src/service/equity_swap_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/equity_swap_instrument_service.cpp
@@ -41,13 +41,13 @@ equity_swap_instrument_service::get_equity_swap_instrument(const std::string& id
 
 void equity_swap_instrument_service::save_equity_swap_instrument(
     const domain::equity_swap_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("Equity swap instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving equity_swap_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_swap_instrument: " << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved equity_swap_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_swap_instrument: " << t.identity.instrument_id;
 }
 
 

--- a/projects/ores.trading/core/src/service/equity_variance_swap_instrument_service.cpp
+++ b/projects/ores.trading/core/src/service/equity_variance_swap_instrument_service.cpp
@@ -42,13 +42,15 @@ equity_variance_swap_instrument_service::get_equity_variance_swap_instrument(
 
 void equity_variance_swap_instrument_service::save_equity_variance_swap_instrument(
     const domain::equity_variance_swap_instrument& v) {
-    if (v.instrument_id.is_nil())
+    if (v.identity.instrument_id.is_nil())
         throw std::invalid_argument("Equity variance swap instrument id cannot be empty.");
-    BOOST_LOG_SEV(lg(), debug) << "Saving equity_variance_swap_instrument: " << v.instrument_id;
+    BOOST_LOG_SEV(lg(), debug) << "Saving equity_variance_swap_instrument: "
+                               << v.identity.instrument_id;
     auto t = v;
     stamp(t, ctx_);
     repo_.write(ctx_, t);
-    BOOST_LOG_SEV(lg(), info) << "Saved equity_variance_swap_instrument: " << t.instrument_id;
+    BOOST_LOG_SEV(lg(), info) << "Saved equity_variance_swap_instrument: "
+                              << t.identity.instrument_id;
 }
 
 

--- a/projects/ores.trading/core/tests/repository_equity_accumulator_instrument_repository_tests.cpp
+++ b/projects/ores.trading/core/tests/repository_equity_accumulator_instrument_repository_tests.cpp
@@ -43,9 +43,9 @@ using namespace ores::logging;
  */
 equity_accumulator_instrument make_instrument(database_helper& h) {
     equity_accumulator_instrument r;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.tenant_id = h.tenant_id();
-    r.trade_type_code = "EquityAccumulator";
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.tenant_id = h.tenant_id();
+    r.identity.trade_type_code = "EquityAccumulator";
     r.underlying_name = ".STOXX50";
     r.currency = "EUR";
     r.strike = 4000.0;
@@ -57,10 +57,10 @@ equity_accumulator_instrument make_instrument(database_helper& h) {
     r.knock_out_level = 3500.0;
     r.target_type = "";
     r.payoff_type = "Decumulator";
-    r.modified_by = h.db_user();
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.audit.modified_by = h.db_user();
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -74,7 +74,7 @@ TEST_CASE("equity_accumulator_instrument_write_and_read_latest", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
     BOOST_LOG_SEV(lg, debug) << "Writing equity accumulator instrument: " << instr;
 
     equity_accumulator_instrument_repository repo;
@@ -82,7 +82,7 @@ TEST_CASE("equity_accumulator_instrument_write_and_read_latest", tags) {
 
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
-    CHECK(read[0].trade_type_code == "EquityAccumulator");
+    CHECK(read[0].identity.trade_type_code == "EquityAccumulator");
     CHECK(read[0].underlying_name == ".STOXX50");
     CHECK(read[0].currency == "EUR");
     CHECK(read[0].strike == 4000.0);
@@ -115,7 +115,7 @@ TEST_CASE("equity_accumulator_instrument_remove", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
 
     equity_accumulator_instrument_repository repo;
     repo.write(ctx, instr);

--- a/projects/ores.trading/core/tests/repository_equity_asian_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading/core/tests/repository_equity_asian_option_instrument_repository_tests.cpp
@@ -43,9 +43,9 @@ using namespace ores::logging;
  */
 equity_asian_option_instrument make_instrument(database_helper& h) {
     equity_asian_option_instrument r;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.tenant_id = h.tenant_id();
-    r.trade_type_code = "EquityAsianOption";
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.tenant_id = h.tenant_id();
+    r.identity.trade_type_code = "EquityAsianOption";
     r.underlying_name = "RIC:.SPX";
     r.currency = "USD";
     r.notional = 1.0;
@@ -57,10 +57,10 @@ equity_asian_option_instrument make_instrument(database_helper& h) {
     r.average_type = "Arithmetic";
     r.averaging_start_date = "2025-07-12";
     r.averaging_end_date = "2026-01-19";
-    r.modified_by = h.db_user();
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.audit.modified_by = h.db_user();
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -74,7 +74,7 @@ TEST_CASE("equity_asian_option_instrument_write_and_read_latest", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
     BOOST_LOG_SEV(lg, debug) << "Writing equity asian option instrument: " << instr;
 
     equity_asian_option_instrument_repository repo;
@@ -82,7 +82,7 @@ TEST_CASE("equity_asian_option_instrument_write_and_read_latest", tags) {
 
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
-    CHECK(read[0].trade_type_code == "EquityAsianOption");
+    CHECK(read[0].identity.trade_type_code == "EquityAsianOption");
     CHECK(read[0].underlying_name == "RIC:.SPX");
     CHECK(read[0].currency == "USD");
     CHECK(read[0].notional == 1.0);
@@ -116,7 +116,7 @@ TEST_CASE("equity_asian_option_instrument_remove", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
 
     equity_asian_option_instrument_repository repo;
     repo.write(ctx, instr);

--- a/projects/ores.trading/core/tests/repository_equity_barrier_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading/core/tests/repository_equity_barrier_option_instrument_repository_tests.cpp
@@ -43,9 +43,9 @@ using namespace ores::logging;
  */
 equity_barrier_option_instrument make_instrument(database_helper& h) {
     equity_barrier_option_instrument r;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.tenant_id = h.tenant_id();
-    r.trade_type_code = "EquityBarrierOption";
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.tenant_id = h.tenant_id();
+    r.identity.trade_type_code = "EquityBarrierOption";
     r.underlying_name = "RIC:.SPX";
     r.currency = "USD";
     r.notional = 1000.0;
@@ -57,10 +57,10 @@ equity_barrier_option_instrument make_instrument(database_helper& h) {
     r.lower_barrier = 3500.0;
     r.lower_barrier_type = "UpAndOut";
     r.upper_barrier_type = "";
-    r.modified_by = h.db_user();
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.audit.modified_by = h.db_user();
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -74,7 +74,7 @@ TEST_CASE("equity_barrier_option_instrument_write_and_read_latest", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
     BOOST_LOG_SEV(lg, debug) << "Writing equity barrier option instrument: " << instr;
 
     equity_barrier_option_instrument_repository repo;
@@ -82,7 +82,7 @@ TEST_CASE("equity_barrier_option_instrument_write_and_read_latest", tags) {
 
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
-    CHECK(read[0].trade_type_code == "EquityBarrierOption");
+    CHECK(read[0].identity.trade_type_code == "EquityBarrierOption");
     CHECK(read[0].underlying_name == "RIC:.SPX");
     CHECK(read[0].currency == "USD");
     CHECK(read[0].notional == 1000.0);
@@ -115,7 +115,7 @@ TEST_CASE("equity_barrier_option_instrument_remove", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
 
     equity_barrier_option_instrument_repository repo;
     repo.write(ctx, instr);

--- a/projects/ores.trading/core/tests/repository_equity_digital_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading/core/tests/repository_equity_digital_option_instrument_repository_tests.cpp
@@ -43,9 +43,9 @@ using namespace ores::logging;
  */
 equity_digital_option_instrument make_instrument(database_helper& h) {
     equity_digital_option_instrument r;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.tenant_id = h.tenant_id();
-    r.trade_type_code = "EquityDigitalOption";
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.tenant_id = h.tenant_id();
+    r.identity.trade_type_code = "EquityDigitalOption";
     r.underlying_name = "RIC:.SPX";
     r.currency = "USD";
     r.notional = 1000.0;
@@ -55,10 +55,10 @@ equity_digital_option_instrument make_instrument(database_helper& h) {
     r.expiry_date = "2026-07-17";
     r.long_short = "Long";
     r.payout_amount = 1000.0;
-    r.modified_by = h.db_user();
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.audit.modified_by = h.db_user();
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -72,7 +72,7 @@ TEST_CASE("equity_digital_option_instrument_write_and_read_latest", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
     BOOST_LOG_SEV(lg, debug) << "Writing equity digital option instrument: " << instr;
 
     equity_digital_option_instrument_repository repo;
@@ -80,7 +80,7 @@ TEST_CASE("equity_digital_option_instrument_write_and_read_latest", tags) {
 
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
-    CHECK(read[0].trade_type_code == "EquityDigitalOption");
+    CHECK(read[0].identity.trade_type_code == "EquityDigitalOption");
     CHECK(read[0].underlying_name == "RIC:.SPX");
     CHECK(read[0].currency == "USD");
     CHECK(read[0].notional == 1000.0);
@@ -111,7 +111,7 @@ TEST_CASE("equity_digital_option_instrument_remove", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
 
     equity_digital_option_instrument_repository repo;
     repo.write(ctx, instr);

--- a/projects/ores.trading/core/tests/repository_equity_forward_instrument_repository_tests.cpp
+++ b/projects/ores.trading/core/tests/repository_equity_forward_instrument_repository_tests.cpp
@@ -43,9 +43,9 @@ using namespace ores::logging;
  */
 equity_forward_instrument make_instrument(database_helper& h) {
     equity_forward_instrument r;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.tenant_id = h.tenant_id();
-    r.trade_type_code = "EquityForward";
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.tenant_id = h.tenant_id();
+    r.identity.trade_type_code = "EquityForward";
     r.underlying_name = "RIC:.SPX";
     r.currency = "USD";
     r.quantity = 775.0;
@@ -53,10 +53,10 @@ equity_forward_instrument make_instrument(database_helper& h) {
     r.expiry_date = "2025-02-20";
     r.long_short = "Long";
     r.settlement_type = "";
-    r.modified_by = h.db_user();
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.audit.modified_by = h.db_user();
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -70,7 +70,7 @@ TEST_CASE("equity_forward_instrument_write_and_read_latest", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
     BOOST_LOG_SEV(lg, debug) << "Writing equity forward instrument: " << instr;
 
     equity_forward_instrument_repository repo;
@@ -78,7 +78,7 @@ TEST_CASE("equity_forward_instrument_write_and_read_latest", tags) {
 
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
-    CHECK(read[0].trade_type_code == "EquityForward");
+    CHECK(read[0].identity.trade_type_code == "EquityForward");
     CHECK(read[0].underlying_name == "RIC:.SPX");
     CHECK(read[0].currency == "USD");
     CHECK(read[0].quantity == 775.0);
@@ -107,7 +107,7 @@ TEST_CASE("equity_forward_instrument_remove", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
 
     equity_forward_instrument_repository repo;
     repo.write(ctx, instr);

--- a/projects/ores.trading/core/tests/repository_equity_option_instrument_repository_tests.cpp
+++ b/projects/ores.trading/core/tests/repository_equity_option_instrument_repository_tests.cpp
@@ -43,9 +43,9 @@ using namespace ores::logging;
  */
 equity_option_instrument make_instrument(database_helper& h) {
     equity_option_instrument r;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.tenant_id = h.tenant_id();
-    r.trade_type_code = "EquityOption";
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.tenant_id = h.tenant_id();
+    r.identity.trade_type_code = "EquityOption";
     r.underlying_name = "RIC:.SPX";
     r.currency = "USD";
     r.notional = 775.0;
@@ -56,10 +56,10 @@ equity_option_instrument make_instrument(database_helper& h) {
     r.long_short = "Long";
     r.settlement_type = "Cash";
     r.cliquet_frequency = "";
-    r.modified_by = h.db_user();
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.audit.modified_by = h.db_user();
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -73,7 +73,7 @@ TEST_CASE("equity_option_instrument_write_and_read_latest", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
     BOOST_LOG_SEV(lg, debug) << "Writing equity option instrument: " << instr;
 
     equity_option_instrument_repository repo;
@@ -81,7 +81,7 @@ TEST_CASE("equity_option_instrument_write_and_read_latest", tags) {
 
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
-    CHECK(read[0].trade_type_code == "EquityOption");
+    CHECK(read[0].identity.trade_type_code == "EquityOption");
     CHECK(read[0].underlying_name == "RIC:.SPX");
     CHECK(read[0].currency == "USD");
     CHECK(read[0].notional == 775.0);
@@ -113,7 +113,7 @@ TEST_CASE("equity_option_instrument_remove", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
 
     equity_option_instrument_repository repo;
     repo.write(ctx, instr);

--- a/projects/ores.trading/core/tests/repository_equity_position_instrument_repository_tests.cpp
+++ b/projects/ores.trading/core/tests/repository_equity_position_instrument_repository_tests.cpp
@@ -43,18 +43,18 @@ using namespace ores::logging;
  */
 equity_position_instrument make_instrument(database_helper& h) {
     equity_position_instrument r;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.tenant_id = h.tenant_id();
-    r.trade_type_code = "EquityPosition";
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.tenant_id = h.tenant_id();
+    r.identity.trade_type_code = "EquityPosition";
     r.underlying_name = "BBG00R251JN8";
     r.currency = "USD";
     r.quantity = 18101.486;
     r.price = 6927.586;
     r.option_data_json = "";
-    r.modified_by = h.db_user();
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.audit.modified_by = h.db_user();
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -68,7 +68,7 @@ TEST_CASE("equity_position_instrument_write_and_read_latest", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
     BOOST_LOG_SEV(lg, debug) << "Writing equity position instrument: " << instr;
 
     equity_position_instrument_repository repo;
@@ -76,7 +76,7 @@ TEST_CASE("equity_position_instrument_write_and_read_latest", tags) {
 
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
-    CHECK(read[0].trade_type_code == "EquityPosition");
+    CHECK(read[0].identity.trade_type_code == "EquityPosition");
     CHECK(read[0].underlying_name == "BBG00R251JN8");
     CHECK(read[0].currency == "USD");
     CHECK(read[0].quantity == 18101.486);
@@ -103,7 +103,7 @@ TEST_CASE("equity_position_instrument_remove", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
 
     equity_position_instrument_repository repo;
     repo.write(ctx, instr);

--- a/projects/ores.trading/core/tests/repository_equity_swap_instrument_repository_tests.cpp
+++ b/projects/ores.trading/core/tests/repository_equity_swap_instrument_repository_tests.cpp
@@ -43,9 +43,9 @@ using namespace ores::logging;
  */
 equity_swap_instrument make_instrument(database_helper& h) {
     equity_swap_instrument r;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.tenant_id = h.tenant_id();
-    r.trade_type_code = "EquitySwap";
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.tenant_id = h.tenant_id();
+    r.identity.trade_type_code = "EquitySwap";
     r.underlying_name = ".SPX";
     r.basket_json = "";
     r.currency = "USD";
@@ -55,10 +55,10 @@ equity_swap_instrument make_instrument(database_helper& h) {
     r.maturity_date = "2025-12-31";
     r.long_short = "Long";
     r.payment_frequency = "1M";
-    r.modified_by = h.db_user();
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.audit.modified_by = h.db_user();
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -72,7 +72,7 @@ TEST_CASE("equity_swap_instrument_write_and_read_latest", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
     BOOST_LOG_SEV(lg, debug) << "Writing equity swap instrument: " << instr;
 
     equity_swap_instrument_repository repo;
@@ -80,7 +80,7 @@ TEST_CASE("equity_swap_instrument_write_and_read_latest", tags) {
 
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
-    CHECK(read[0].trade_type_code == "EquitySwap");
+    CHECK(read[0].identity.trade_type_code == "EquitySwap");
     CHECK(read[0].underlying_name == ".SPX");
     CHECK(read[0].currency == "USD");
     CHECK(read[0].notional == 2000000.0);
@@ -111,7 +111,7 @@ TEST_CASE("equity_swap_instrument_remove", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
 
     equity_swap_instrument_repository repo;
     repo.write(ctx, instr);

--- a/projects/ores.trading/core/tests/repository_equity_variance_swap_instrument_repository_tests.cpp
+++ b/projects/ores.trading/core/tests/repository_equity_variance_swap_instrument_repository_tests.cpp
@@ -43,9 +43,9 @@ using namespace ores::logging;
  */
 equity_variance_swap_instrument make_instrument(database_helper& h) {
     equity_variance_swap_instrument r;
-    r.instrument_id = boost::uuids::random_generator()();
-    r.tenant_id = h.tenant_id();
-    r.trade_type_code = "EquityVarianceSwap";
+    r.identity.instrument_id = boost::uuids::random_generator()();
+    r.identity.tenant_id = h.tenant_id();
+    r.identity.trade_type_code = "EquityVarianceSwap";
     r.underlying_name = ".SPX";
     r.currency = "USD";
     r.notional = 50000.0;
@@ -53,10 +53,10 @@ equity_variance_swap_instrument make_instrument(database_helper& h) {
     r.start_date = "2025-02-20";
     r.maturity_date = "2025-05-20";
     r.long_short = "Long";
-    r.modified_by = h.db_user();
-    r.performed_by = "ores";
-    r.change_reason_code = "system.external_data_import";
-    r.change_commentary = "Imported from ORE XML";
+    r.audit.modified_by = h.db_user();
+    r.audit.performed_by = "ores";
+    r.audit.change_reason_code = "system.external_data_import";
+    r.audit.change_commentary = "Imported from ORE XML";
     return r;
 }
 
@@ -70,7 +70,7 @@ TEST_CASE("equity_variance_swap_instrument_write_and_read_latest", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
     BOOST_LOG_SEV(lg, debug) << "Writing equity variance swap instrument: " << instr;
 
     equity_variance_swap_instrument_repository repo;
@@ -78,7 +78,7 @@ TEST_CASE("equity_variance_swap_instrument_write_and_read_latest", tags) {
 
     const auto read = repo.read_latest(ctx, id_str);
     REQUIRE(read.size() == 1);
-    CHECK(read[0].trade_type_code == "EquityVarianceSwap");
+    CHECK(read[0].identity.trade_type_code == "EquityVarianceSwap");
     CHECK(read[0].underlying_name == ".SPX");
     CHECK(read[0].currency == "USD");
     CHECK(read[0].notional == 50000.0);
@@ -108,7 +108,7 @@ TEST_CASE("equity_variance_swap_instrument_remove", tags) {
     auto ctx = h.context().with_party(h.tenant_id(), party_id, {party_id}, h.db_user());
 
     auto instr = make_instrument(h);
-    const auto id_str = boost::uuids::to_string(instr.instrument_id);
+    const auto id_str = boost::uuids::to_string(instr.identity.instrument_id);
 
     equity_variance_swap_instrument_repository repo;
     repo.write(ctx, instr);

--- a/projects/ores.trading/core/tests/test_data/equity_accumulator_instrument.json
+++ b/projects/ores.trading/core/tests/test_data/equity_accumulator_instrument.json
@@ -12,7 +12,9 @@
     "target_amount is absent for Decumulator"
   ],
   "instrument": {
-    "trade_type_code": "EquityAccumulator",
+    "identity": {
+      "trade_type_code": "EquityAccumulator"
+    },
     "underlying_name": ".STOXX50",
     "currency": "EUR",
     "strike": 4000.0,
@@ -26,9 +28,11 @@
     "target_type": "",
     "payoff_type": "Decumulator",
     "description": "",
-    "modified_by": "ores",
-    "performed_by": "ores",
-    "change_reason_code": "system.external_data_import",
-    "change_commentary": "Imported from ORE XML"
+    "audit": {
+      "modified_by": "ores",
+      "performed_by": "ores",
+      "change_reason_code": "system.external_data_import",
+      "change_commentary": "Imported from ORE XML"
+    }
   }
 }

--- a/projects/ores.trading/core/tests/test_data/equity_asian_option_instrument.json
+++ b/projects/ores.trading/core/tests/test_data/equity_asian_option_instrument.json
@@ -12,7 +12,9 @@
     "averaging_end_date maps from ObservationDates.Rules.EndDate (2026-01-19)"
   ],
   "instrument": {
-    "trade_type_code": "EquityAsianOption",
+    "identity": {
+      "trade_type_code": "EquityAsianOption"
+    },
     "underlying_name": "RIC:.SPX",
     "currency": "USD",
     "notional": 1.0,
@@ -25,9 +27,11 @@
     "averaging_start_date": "2025-07-12",
     "averaging_end_date": "2026-01-19",
     "description": "",
-    "modified_by": "ores",
-    "performed_by": "ores",
-    "change_reason_code": "system.external_data_import",
-    "change_commentary": "Imported from ORE XML"
+    "audit": {
+      "modified_by": "ores",
+      "performed_by": "ores",
+      "change_reason_code": "system.external_data_import",
+      "change_commentary": "Imported from ORE XML"
+    }
   }
 }

--- a/projects/ores.trading/core/tests/test_data/equity_barrier_option_instrument.json
+++ b/projects/ores.trading/core/tests/test_data/equity_barrier_option_instrument.json
@@ -9,7 +9,9 @@
     "upper_barrier is absent: XML has a single-level BarrierData block"
   ],
   "instrument": {
-    "trade_type_code": "EquityBarrierOption",
+    "identity": {
+      "trade_type_code": "EquityBarrierOption"
+    },
     "underlying_name": "RIC:.SPX",
     "currency": "USD",
     "notional": 1000.0,
@@ -24,9 +26,11 @@
     "upper_barrier_type": "",
     "rebate": null,
     "description": "",
-    "modified_by": "ores",
-    "performed_by": "ores",
-    "change_reason_code": "system.external_data_import",
-    "change_commentary": "Imported from ORE XML"
+    "audit": {
+      "modified_by": "ores",
+      "performed_by": "ores",
+      "change_reason_code": "system.external_data_import",
+      "change_commentary": "Imported from ORE XML"
+    }
   }
 }

--- a/projects/ores.trading/core/tests/test_data/equity_digital_option_instrument.json
+++ b/projects/ores.trading/core/tests/test_data/equity_digital_option_instrument.json
@@ -8,7 +8,9 @@
     "barrier_level is absent for digital options (present only for touch options)"
   ],
   "instrument": {
-    "trade_type_code": "EquityDigitalOption",
+    "identity": {
+      "trade_type_code": "EquityDigitalOption"
+    },
     "underlying_name": "RIC:.SPX",
     "currency": "USD",
     "notional": 1000.0,
@@ -20,9 +22,11 @@
     "long_short": "Long",
     "payout_amount": 1000.0,
     "description": "",
-    "modified_by": "ores",
-    "performed_by": "ores",
-    "change_reason_code": "system.external_data_import",
-    "change_commentary": "Imported from ORE XML"
+    "audit": {
+      "modified_by": "ores",
+      "performed_by": "ores",
+      "change_reason_code": "system.external_data_import",
+      "change_commentary": "Imported from ORE XML"
+    }
   }
 }

--- a/projects/ores.trading/core/tests/test_data/equity_forward_instrument.json
+++ b/projects/ores.trading/core/tests/test_data/equity_forward_instrument.json
@@ -6,10 +6,12 @@
     "quantity maps from Quantity (775)",
     "forward_price maps from Strike (2800)",
     "expiry_date maps from Maturity (2025-02-20)",
-    "settlement_type is not present in XML — field is empty"
+    "settlement_type is not present in XML \u2014 field is empty"
   ],
   "instrument": {
-    "trade_type_code": "EquityForward",
+    "identity": {
+      "trade_type_code": "EquityForward"
+    },
     "underlying_name": "RIC:.SPX",
     "currency": "USD",
     "quantity": 775.0,
@@ -18,9 +20,11 @@
     "long_short": "Long",
     "settlement_type": "",
     "description": "",
-    "modified_by": "ores",
-    "performed_by": "ores",
-    "change_reason_code": "system.external_data_import",
-    "change_commentary": "Imported from ORE XML"
+    "audit": {
+      "modified_by": "ores",
+      "performed_by": "ores",
+      "change_reason_code": "system.external_data_import",
+      "change_commentary": "Imported from ORE XML"
+    }
   }
 }

--- a/projects/ores.trading/core/tests/test_data/equity_option_instrument.json
+++ b/projects/ores.trading/core/tests/test_data/equity_option_instrument.json
@@ -3,7 +3,9 @@
   "trade_id_in_xml": "EquityOption",
   "mapper": "equity_instrument_mapper::forward_equity_option (planned Phase 3 mapper)",
   "instrument": {
-    "trade_type_code": "EquityOption",
+    "identity": {
+      "trade_type_code": "EquityOption"
+    },
     "underlying_name": "RIC:.SPX",
     "currency": "USD",
     "notional": 775.0,
@@ -15,9 +17,11 @@
     "settlement_type": "Cash",
     "cliquet_frequency": "",
     "description": "",
-    "modified_by": "ores",
-    "performed_by": "ores",
-    "change_reason_code": "system.external_data_import",
-    "change_commentary": "Imported from ORE XML"
+    "audit": {
+      "modified_by": "ores",
+      "performed_by": "ores",
+      "change_reason_code": "system.external_data_import",
+      "change_commentary": "Imported from ORE XML"
+    }
   }
 }

--- a/projects/ores.trading/core/tests/test_data/equity_position_instrument.json
+++ b/projects/ores.trading/core/tests/test_data/equity_position_instrument.json
@@ -10,16 +10,20 @@
     "currency maps from ReturnData.Currency (USD)"
   ],
   "instrument": {
-    "trade_type_code": "EquityPosition",
+    "identity": {
+      "trade_type_code": "EquityPosition"
+    },
     "underlying_name": "BBG00R251JN8",
     "currency": "USD",
     "quantity": 18101.486,
     "price": 6927.586,
     "option_data_json": "",
     "description": "",
-    "modified_by": "ores",
-    "performed_by": "ores",
-    "change_reason_code": "system.external_data_import",
-    "change_commentary": "Imported from ORE XML"
+    "audit": {
+      "modified_by": "ores",
+      "performed_by": "ores",
+      "change_reason_code": "system.external_data_import",
+      "change_commentary": "Imported from ORE XML"
+    }
   }
 }

--- a/projects/ores.trading/core/tests/test_data/equity_swap_instrument.json
+++ b/projects/ores.trading/core/tests/test_data/equity_swap_instrument.json
@@ -12,7 +12,9 @@
     "basket_json is empty for single-underlying swaps"
   ],
   "instrument": {
-    "trade_type_code": "EquitySwap",
+    "identity": {
+      "trade_type_code": "EquitySwap"
+    },
     "underlying_name": ".SPX",
     "basket_json": "",
     "currency": "USD",
@@ -23,9 +25,11 @@
     "long_short": "Long",
     "payment_frequency": "1M",
     "description": "",
-    "modified_by": "ores",
-    "performed_by": "ores",
-    "change_reason_code": "system.external_data_import",
-    "change_commentary": "Imported from ORE XML"
+    "audit": {
+      "modified_by": "ores",
+      "performed_by": "ores",
+      "change_reason_code": "system.external_data_import",
+      "change_commentary": "Imported from ORE XML"
+    }
   }
 }

--- a/projects/ores.trading/core/tests/test_data/equity_variance_swap_instrument.json
+++ b/projects/ores.trading/core/tests/test_data/equity_variance_swap_instrument.json
@@ -6,21 +6,25 @@
     "long_short is hardcoded to Long by mapper",
     "variance_strike maps from Strike (0.20)",
     "maturity_date maps from EndDate (2025-05-20)",
-    "MomentType (Variance) is implicit in the trade type — not stored separately"
+    "MomentType (Variance) is implicit in the trade type \u2014 not stored separately"
   ],
   "instrument": {
-    "trade_type_code": "EquityVarianceSwap",
+    "identity": {
+      "trade_type_code": "EquityVarianceSwap"
+    },
     "underlying_name": ".SPX",
     "currency": "USD",
     "notional": 50000.0,
-    "variance_strike": 0.20,
+    "variance_strike": 0.2,
     "start_date": "2025-02-20",
     "maturity_date": "2025-05-20",
     "long_short": "Long",
     "description": "",
-    "modified_by": "ores",
-    "performed_by": "ores",
-    "change_reason_code": "system.external_data_import",
-    "change_commentary": "Imported from ORE XML"
+    "audit": {
+      "modified_by": "ores",
+      "performed_by": "ores",
+      "change_reason_code": "system.external_data_import",
+      "change_commentary": "Imported from ORE XML"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Task 14 of the C1202 story: applies the `instrument_identity` + `audit_record` pattern (#1047 rates, #1071 FX) to all 9 equity instrument types (`equity_option`, `equity_forward`, `equity_digital_option`, `equity_asian_option`, `equity_barrier_option`, `equity_accumulator`, `equity_variance_swap`, `equity_swap`, `equity_position`).

- Each domain struct: `identity` + type-specific fields + `ores::dq::domain::audit_record audit` (fully qualified, per the #1070 review decision) — parent Literals well below the MSVC C1202 threshold
- Equity entities gain `workspace_id` (columns already exist; all trade/instrument tables carry it); mappers map it both directions
- `trade_handler` `add_eq` keys on `identity.instrument_id`
- Qt: `EquityInstrumentForm` provenance via identity/audit; the fx/equity branches in `ImportTradeDialog` and the planner test — split in #1071 while equity was still flat — merge back into a single nested branch; equity parse-dispatch test cases nested
- ores.ore: `equity_instrument_mapper` forward mappers (15 sites), 2 XML round-trip test files
- 9 equity repository test files + 9 JSON reference snapshots updated

Remaining flat by design: bond, credit, commodity, composite, scripted — that's task 15.

## Test plan

- Full local `linux-clang-debug-make` build green (0 errors)
- Repo-wide sweep confirms no flat identity/audit access on equity types; non-migrated families untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)