### PR TITLE
[doc,ores.compass] Add user-facing roadmap page; compass Build pillar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,7 +348,7 @@ add_custom_target(deploy_site
     COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-site.el
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-add_custom_target(sync_org_roam
+add_custom_target(org_roam_db_sync
     COMMENT "Syncing org-roam database (.org-roam.db)" VERBATIM
     COMMAND emacs -Q --script projects/ores.lisp/src/ores-sync-org-roam.el
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,11 @@ add_custom_target(deploy_site
     COMMAND emacs -Q --script projects/ores.lisp/src/ores-build-site.el
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+add_custom_target(sync_org_roam
+    COMMENT "Syncing org-roam database (.org-roam.db)" VERBATIM
+    COMMAND emacs -Q --script projects/ores.lisp/src/ores-sync-org-roam.el
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
 set(ORES_MANUAL_PDF "doc/manual/user_guide/user_manual.pdf")
 add_custom_target(deploy_manual
     COMMENT "Building ORE Studio User Manual PDF to ${ORES_MANUAL_PDF}" VERBATIM

--- a/doc/agile/milestones/milestones.org
+++ b/doc/agile/milestones/milestones.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :milestones:index:agile:
 #+created: 2026-06-02
-#+updated: 2026-06-02
+#+updated: 2026-06-05
 
 * Summary
 
@@ -41,5 +41,6 @@ is met, the version closes and the software cuts the milestone release
 
 * See also
 
+- [[id:C4246E9D-D0AD-495C-943D-4200CFC17676][Roadmap]] — the user-facing narrative of where the product is going.
 - [[id:37C10313-E6E9-4D42-B82D-B6758D0A3AD9][Versions]] — the version series that do the work.
 - [[id:E5635EAC-CCE9-C0A4-A00B-C1780FF4A88E][Agile]] — entry point to the agile information architecture.

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/story.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/story.org
@@ -7,7 +7,7 @@
 #+level: s2
 #+filetags: :tooling:compass:scripts:refactor:documentation:sprint_19:v0:
 #+created: 2026-06-02
-#+updated: 2026-06-02
+#+updated: 2026-06-05
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -34,10 +34,10 @@ within this larger effort.
 |---------------+--------------------------------------------------|
 | State         | STARTED                                          |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]                               |
-| Now           | compass test results, sprint charts, branch staleness, bearings all shipped. rat now generates XML for compass test results. Windows env init bug scaffolded. |
+| Now           | compass test results, sprint charts, branch staleness, bearings all shipped. rat now generates XML for compass test results. Windows env init bug scaffolded. compass build (Build pillar first slice) landed. |
 | Waiting on    | Nothing.                                         |
 | Next          | Fix Windows venv activation path; document the compass env commands; then db/nats/Operate/Build/Generate migrations. |
-| Last touched  | 2026-06-03                                       |
+| Last touched  | 2026-06-05                                       |
 
 * Background: script inventory (2026-06-02)
 
@@ -126,7 +126,7 @@ migrate; the single service registry's home (=projects/services.json=).
 | [[id:AE2BCC66-983C-49E0-BC05-79100D388E8E][Add a command to record an env-version bump]] | BACKLOG | | | compass env bump: canonical version as data + changelog; init/validate read it. |
 | [[id:BAEB661D-2AB4-4796-B415-43B49BDCD3A6][Migrate db and nats setup into the Provision pillar]] | BACKLOG | | | compass db / compass nats verbs; delete scripts, update callers. |
 | [[id:333104A0-FFFE-4C20-9390-FA2ED732C2D5][Migrate the Operate pillar (services, client, logs)]] | BACKLOG | | | compass services {start,stop,status,clear-logs} + --delete-logs, compass client. |
-| [[id:D38238C9-702F-47AC-BE64-91D84A8EE716][Migrate the Build pillar (build, site)]] | BACKLOG | | | compass build, compass site serve. |
+| [[id:D38238C9-702F-47AC-BE64-91D84A8EE716][Migrate the Build pillar (build, site)]] | STARTED | 2026-06-05 | | compass build (preset from .env; site/manual aliases) landed; compass site serve outstanding. |
 | [[id:32DB538C-E2A6-493C-8CBA-6C73A7A10EC4][Add the Generate pillar (delegating gen verbs)]] | BACKLOG | | | compass gen verbs delegating to ores.codegen (keeps its own CLI). |
 | [[id:E65F42A6-0762-4F75-866F-25A428B3973F][Surface branch staleness vs main in compass Orient]] | STARTED | 2026-06-02 | | Compact ↑ahead/↓behind-origin/main indicator (no fetch) on where/status/fleet, escalating to a warning when too stale. |
 | [[id:81DE1DC9-FB73-46DB-A8AB-E4BE8F78C591][Port sprint_metrics.py to compass sprint charts]] | BACKLOG | | | compass sprint charts; auto-detects current sprint; deletes standalone script; updates recipes. |

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_migrate_build_pillar.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_migrate_build_pillar.org
@@ -43,8 +43,16 @@ build directory is configured automatically on first use. Fold
 - =compass build [TARGET...]= builds via the preset from =ORES_PRESET=
   in =.env=, with =--preset= override and auto-configure when the
   build directory is missing.
-- Friendly target aliases exist for =site= (=deploy_site=) and
-  =manual= (=deploy_manual=), extensible for future products.
+- Friendly target aliases exist for =site= (=deploy_site=), =manual=
+  (=deploy_manual=) and =org-roam= (=sync_org_roam=), extensible for
+  future products.
+- A standalone =sync_org_roam= CMake target regenerates =.org-roam.db=
+  (=ores-sync-org-roam.el=), previously only a side effect of
+  =deploy_site=; =compass index --sync-org-roam-db= runs it (directly,
+  no cmake) before indexing.
+- =compass search= (pretty format) reports freshness of =.compass.db=
+  and =.org-roam.db=: green/info under 1h, yellow/warning over 5h,
+  red/critical over 24h, with the refresh command to run.
 - The deploy-site recipe uses =compass build site= and links to the
   raw CMake build recipe instead of hardcoding a preset.
 - =serve-site.sh= is folded in as =compass site serve= and =build.sh=
@@ -59,8 +67,11 @@ task closes. Plans do not outlive their task.)
 * Notes
 
 2026-06-05: first slice landed — =compass build= with site/manual
-aliases plus recipe update. Remaining: =compass site serve=, retiring
-=build.sh= / =serve-site.sh= and updating their callers.
+aliases plus recipe update. Second slice: =sync_org_roam= target +
+=ores-sync-org-roam.el=, =org-roam= build alias, =compass index
+--sync-org-roam-db=, and db-freshness reporting on =compass search=.
+Remaining: =compass site serve=, retiring =build.sh= / =serve-site.sh=
+and updating their callers.
 
 * PRs
 

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_migrate_build_pillar.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_migrate_build_pillar.org
@@ -83,6 +83,6 @@ and updating their callers.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | cmake --target only accepts one target; repeat the flag | compass.py | Declined | Multi-target valid since CMake 3.15; project requires >= 3.28; verified on 4.3.3 (PR #1076) |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_migrate_build_pillar.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_migrate_build_pillar.org
@@ -44,11 +44,11 @@ build directory is configured automatically on first use. Fold
   in =.env=, with =--preset= override and auto-configure when the
   build directory is missing.
 - Friendly target aliases exist for =site= (=deploy_site=), =manual=
-  (=deploy_manual=) and =org-roam= (=sync_org_roam=), extensible for
+  (=deploy_manual=) and =org-roam-db-sync= (=org_roam_db_sync=), extensible for
   future products.
-- A standalone =sync_org_roam= CMake target regenerates =.org-roam.db=
+- A standalone =org_roam_db_sync= CMake target regenerates =.org-roam.db=
   (=ores-sync-org-roam.el=), previously only a side effect of
-  =deploy_site=; =compass index --sync-org-roam-db= runs it (directly,
+  =deploy_site=; =compass index --org-roam-db-sync= runs it (directly,
   no cmake) before indexing.
 - =compass search= (pretty format) reports freshness of =.compass.db=
   and =.org-roam.db=: green/info under 1h, yellow/warning over 5h,
@@ -67,9 +67,9 @@ task closes. Plans do not outlive their task.)
 * Notes
 
 2026-06-05: first slice landed — =compass build= with site/manual
-aliases plus recipe update. Second slice: =sync_org_roam= target +
-=ores-sync-org-roam.el=, =org-roam= build alias, =compass index
---sync-org-roam-db=, and db-freshness reporting on =compass search=.
+aliases plus recipe update. Second slice: =org_roam_db_sync= target +
+=ores-sync-org-roam.el=, =org-roam-db-sync= build alias, =compass index
+--org-roam-db-sync=, and db-freshness reporting on =compass search=.
 Remaining: =compass site serve=, retiring =build.sh= / =serve-site.sh=
 and updating their callers.
 

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_migrate_build_pillar.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_migrate_build_pillar.org
@@ -8,7 +8,7 @@
 #+filetags: :consolidate_scripts_into_compass:sprint_19:v0:
 #+owner: marco
 #+branch: feature/create-user-facing-roadmap
-#+pr:
+#+pr: 1076
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-02
@@ -77,7 +77,7 @@ and updating their callers.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1076][#1076]] | [doc,ores.compass] Add user-facing roadmap page; compass Build pillar |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_migrate_build_pillar.org
+++ b/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_migrate_build_pillar.org
@@ -7,34 +7,48 @@
 #+level: s1
 #+filetags: :consolidate_scripts_into_compass:sprint_19:v0:
 #+owner: marco
-#+branch:
+#+branch: feature/create-user-facing-roadmap
 #+pr:
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-02
-#+updated: 2026-06-02
+#+updated: 2026-06-05
 #+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
 
 This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]] story. It captures the goal, current status, acceptance, and any notes or results.
 
 * Goal
 
-(Describe what user-visible-or-internal change this task produces.)
+Give compass a Build pillar so day-to-day builds use the checkout's
+prevailing configuration instead of hardcoded preset names: =compass
+build= runs =cmake --build= with the preset read from =ORES_PRESET= in
+=.env=, =compass build site= / =compass build manual= map friendly
+aliases onto the =deploy_site= / =deploy_manual= targets, and the
+build directory is configured automatically on first use. Fold
+=build.sh= and =serve-site.sh= in behind compass and update callers.
 
 * Status
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | BACKLOG                              |
+| State        | STARTED                              |
 | Parent story | [[id:6695E245-E789-40EC-8AC6-EB10276CA241][Consolidate standalone scripts into compass]] |
-| Now          | Not yet started.                       |
+| Now          | compass build landed; serve migration outstanding. |
 | Waiting on   | Nothing.                               |
 | Next         | Begin implementation.                  |
-| Last touched | 2026-06-02                               |
+| Last touched | 2026-06-05                               |
 
 * Acceptance
 
--
+- =compass build [TARGET...]= builds via the preset from =ORES_PRESET=
+  in =.env=, with =--preset= override and auto-configure when the
+  build directory is missing.
+- Friendly target aliases exist for =site= (=deploy_site=) and
+  =manual= (=deploy_manual=), extensible for future products.
+- The deploy-site recipe uses =compass build site= and links to the
+  raw CMake build recipe instead of hardcoding a preset.
+- =serve-site.sh= is folded in as =compass site serve= and =build.sh=
+  callers are updated (remaining scope).
 
 * Plan
 
@@ -43,6 +57,10 @@ distilled into the parent story's =* Decisions= and cleared when the
 task closes. Plans do not outlive their task.)
 
 * Notes
+
+2026-06-05: first slice landed — =compass build= with site/manual
+aliases plus recipe update. Remaining: =compass site serve=, retiring
+=build.sh= / =serve-site.sh= and updating their callers.
 
 * PRs
 

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/story.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/story.org
@@ -7,7 +7,7 @@
 #+level: s2
 #+filetags: :documentation:agile:meta:sprint_19:v0:
 #+created: 2026-06-04
-#+updated: 2026-06-04
+#+updated: 2026-06-05
 #+todo: BACKLOG STARTED | DONE ABANDONED
 
 This page documents a [[id:699A8D45-B67E-4D3E-9206-24FA17C51ADA][story]] in [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]]. It captures the goal, current status, acceptance criteria, and the tasks that compose it.
@@ -34,12 +34,12 @@ and inventory that links them, and the smaller additions woven in.
 
 | Field         | Value                                  |
 |---------------+----------------------------------------|
-| State         | BACKLOG                              |
+| State         | STARTED                              |
 | Parent sprint | [[id:76AE36A4-A3ED-4F48-BDA0-977B362F2238][Sprint 19]] |
-| Now           | Not yet started; tasks scaffolded.     |
+| Now           | Creating the user-facing product roadmap page. |
 | Waiting on    | Nothing.                               |
 | Next          | Pick up the restructure task first — it shapes where the smaller additions land. |
-| Last touched  | 2026-06-04                               |
+| Last touched  | 2026-06-05                               |
 
 * Acceptance
 
@@ -72,6 +72,7 @@ and inventory that links them, and the smaller additions woven in.
 | [[id:3E8C142C-EFE3-432B-88F5-12CAFFCBDDD4][Add outreach step to the agile process]] | BACKLOG | | | LinkedIn post, Twitter/X post, Discord announcement. |
 | [[id:ACBB8643-CA16-4523-885C-E87943164378][Add a definition-of-done document]] | BACKLOG | | | What a DoD is, why task/story/sprint/version must have one; org-roam links from those docs. |
 | [[id:FAFFCE73-0AD3-4801-A613-4E6C9BDEF1D5][Split document types into one page per type]] | BACKLOG | | | One document_type_<type>.org per type; document_types.org becomes the index. |
+| [[id:DBA9185D-B2D9-4484-A7FA-49D861FCA910][Create a user-facing product roadmap page]] | STARTED | 2026-06-05 | | User-facing roadmap.org telling the product story; delegates to versions/milestones/product identity via links; site nav repointed. |
 
 Note: the "Link product identity to the user manual" task moved to the
 [[id:6111FDF8-96E6-4C40-88BD-C756B6841F85][Create a user guide for ores.qt]] story, which gathers all manual-content

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_create_user_facing_roadmap.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_create_user_facing_roadmap.org
@@ -8,7 +8,7 @@
 #+filetags: :documentation_review_followups:sprint_19:v0:
 #+owner: marco
 #+branch: feature/create-user-facing-roadmap
-#+pr:
+#+pr: 1076
 #+blocked_on:
 #+blocked_since:
 #+created: 2026-06-05
@@ -65,7 +65,7 @@ task closes. Plans do not outlive their task.)
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1076][#1076]] | [doc,ores.compass] Add user-facing roadmap page; compass Build pillar |
 
 * Review
 

--- a/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_create_user_facing_roadmap.org
+++ b/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_create_user_facing_roadmap.org
@@ -1,0 +1,76 @@
+:PROPERTIES:
+:ID: DBA9185D-B2D9-4484-A7FA-49D861FCA910
+:END:
+#+title: Task: Create a user-facing product roadmap page
+#+description: Replace the site's Roadmap nav target (currently versions.org, an internal agile index) with a proper user-facing roadmap.org: where the product is, where it is going, milestones and product identity in plain terms — delegating detail to versions, milestones and product identity pages via links rather than repeating content.
+#+type: task
+#+level: s1
+#+filetags: :documentation_review_followups:sprint_19:v0:
+#+owner: marco
+#+branch: feature/create-user-facing-roadmap
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-05
+#+updated: 2026-06-05
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+The site's "Roadmap" nav entry points at =versions.org= — an internal
+agile index (a one-row table of version series) that means little to a
+user or evaluator. Produce a proper user-facing =roadmap.org= that
+tells the product story in plain terms: what ORE Studio is for, where
+it is today, and where it is going — versions, milestones, and product
+identity woven into a narrative. The page must not repeat content: it
+delegates detail to [[id:37C10313-E6E9-4D42-B82D-B6758D0A3AD9][Versions]], [[id:C540506E-7129-4CF2-AE3E-6C8BB9C9417F][Milestones]], and the product identity
+pages via links. Repoint the site nav (=ores-build-site.el= and
+=site.org=) at the new page.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:305E3A3B-8A72-49D3-9972-FAF06FEB4552][Documentation review follow-ups]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-05                               |
+
+* Acceptance
+
+- A =roadmap.org= page exists, written for users/evaluators: current
+  state of the product, direction of travel, and milestone narrative
+  in plain language.
+- The page delegates to versions, milestones, and product identity
+  pages via org-roam links instead of duplicating their content.
+- The site nav "Roadmap" entry points at the new page (both
+  =projects/ores.lisp/src/ores-build-site.el= and
+  =projects/ores.lisp/modeling/site.org=).
+- The new page is reachable from the product identity documentation
+  (and vice versa where appropriate).
+
+* Plan
+
+(Transient implementation strategy. Written when work starts;
+distilled into the parent story's =* Decisions= and cleared when the
+task closes. Plans do not outlive their task.)
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/versions.org
+++ b/doc/agile/versions/versions.org
@@ -7,7 +7,7 @@
 #+level: cross
 #+filetags: :versions:index:knowledge:
 #+created: 2026-05-21
-#+updated: 2026-06-02
+#+updated: 2026-06-05
 
 This is the index of ORE Studio /versions/. A [[id:CA4D4BDE-2EAB-4F0A-BC8B-7C0BCB17BC82][version]] is a release
 series — a coherent group of [[id:0820B7FD-147C-4832-AC25-C043D38D5B61][sprints]] producing incremental builds
@@ -28,5 +28,6 @@ active version; the rest are released.
 
 * See also
 
+- [[id:C4246E9D-D0AD-495C-943D-4200CFC17676][Roadmap]] — the user-facing narrative of where the product is going.
 - [[id:C540506E-7129-4CF2-AE3E-6C8BB9C9417F][Milestones]] — the named release targets each version series works towards.
 - [[id:E5635EAC-CCE9-C0A4-A00B-C1780FF4A88E][Agile]] — entry point to the agile information architecture.

--- a/doc/identity/product_identity.org
+++ b/doc/identity/product_identity.org
@@ -7,7 +7,7 @@
 #+level: s5
 #+filetags: :identity:vision:
 #+created: 2026-05-21
-#+updated: 2026-05-21
+#+updated: 2026-06-05
 
 This is the [[id:436FB40C-422A-465B-B949-E9F0760820C1][product identity]] of ORE Studio — the [[id:6DF00A64-7CC3-40A7-950B-55D2B05A31C7][System 5]] document in our
 [[id:926B916E-A57E-498E-99AB-720B583C0362][cybernetic information architecture]], where identity is the durable policy layer
@@ -89,6 +89,7 @@ The product identity is durable. [[id:37C10313-E6E9-4D42-B82D-B6758D0A3AD9][Vers
 establishes the shape; =v1.0= and beyond will extend it. When something in this
 document changes, that is a re-identification — not a version bump.
 
-See [[id:37C10313-E6E9-4D42-B82D-B6758D0A3AD9][Versions]] for the running list of versions that have implemented this
-identity, and [[id:C540506E-7129-4CF2-AE3E-6C8BB9C9417F][Milestones]] for the major release targets bounding each version
-series.
+See the [[id:C4246E9D-D0AD-495C-943D-4200CFC17676][Roadmap]] for the user-facing narrative of where the product is and
+where it is going, [[id:37C10313-E6E9-4D42-B82D-B6758D0A3AD9][Versions]] for the running list of versions that have
+implemented this identity, and [[id:C540506E-7129-4CF2-AE3E-6C8BB9C9417F][Milestones]] for the major release targets
+bounding each version series.

--- a/doc/recipes/cmake/how_do_i_deploy_the_site.org
+++ b/doc/recipes/cmake/how_do_i_deploy_the_site.org
@@ -2,12 +2,12 @@
 :ID: 6930472B-222C-4621-AB37-CFEE3070A8BD
 :END:
 #+title: How do I deploy the site?
-#+description: Build the ORE Studio website locally with the `deploy_site` CMake target.
+#+description: Build the ORE Studio website locally with `compass build site`.
 #+type: recipe
 #+level: cross
-#+filetags: :cmake:build:site:website:emacs:recipe:
+#+filetags: :cmake:build:site:website:emacs:compass:recipe:
 #+created: 2026-05-18
-#+updated: 2026-05-18
+#+updated: 2026-06-05
 
 For the build script that does the work (=projects/ores.lisp/src/ores-build-site.el=) and the
 output location, see [[id:5AAE6900-8488-4E22-9F31-A1B9D5320EFB][CMake setup]].
@@ -18,15 +18,22 @@ How do I build the ORE Studio website locally?
 
 * Answer
 
-The =deploy_site= CMake target invokes Emacs in batch mode against
-=projects/ores.lisp/src/ores-build-site.el=, which publishes every =.org= file in the repository
-(excluding =.packages=, =vcpkg=, =build=) to HTML:
+Build the site with compass, which resolves the checkout's CMake
+preset from =ORES_PRESET= in =.env= and configures the build directory
+first if it does not exist yet:
 
 #+begin_src sh :results verbatim
-cmake --build --preset linux-clang-debug-ninja --target deploy_site
+./compass.sh build site
 #+end_src
 
-Output lands at =build/output/site/=.
+Under the hood this drives the =deploy_site= CMake target, which
+invokes Emacs in batch mode against
+=projects/ores.lisp/src/ores-build-site.el=, publishing every =.org=
+file in the repository (excluding =.packages=, =vcpkg=, =build=) to
+HTML. Output lands at =build/output/site/=.
+
+For instructions on how to run the raw CMake build (presets, targets,
+=cmake --build= directly), see [[id:F176FCA1-68D5-420D-B076-75A65FEE5EBB][How do I build the system?]].
 
 ** Previewing locally
 
@@ -52,8 +59,9 @@ Use =--port= to override the default port 8000, or set the =PORT= env var.
 
 - Emacs on PATH. The script uses =org-publish=, =org-id=, and =oc-bibtex=
   from a default Emacs install with =org-mode= shipped.
-- The project must be configured (=cmake --preset ...=); the target
-  lives in the preset's build directory.
+- A =.env= with =ORES_PRESET= set (run =compass env init= if missing).
+  =compass build= configures the preset's build directory automatically
+  when it does not exist.
 
 ** When to re-run
 

--- a/doc/roadmap.org
+++ b/doc/roadmap.org
@@ -1,0 +1,92 @@
+:PROPERTIES:
+:ID: C4246E9D-D0AD-495C-943D-4200CFC17676
+:END:
+#+title: Roadmap
+#+description: Where ORE Studio is and where it is going: the product direction in plain terms, with links to versions, milestones, and product identity for the detail.
+#+type: knowledge
+#+level: cross
+#+filetags: :roadmap:product:knowledge:
+#+created: 2026-06-05
+#+updated: 2026-06-05
+
+* Summary
+
+ORE Studio is built in public, milestone by milestone. Today the
+project is in its first release series, working towards *v1.0 — Static
+World*: a release that can reproduce every ORE sample perfectly, end
+to end, from a standing start. After that comes *v2.0 — Dynamic
+World*, where time starts to move — ticking market data, live
+pricing, and trade lifecycles. This page explains that journey in
+plain terms; the linked pages carry the detail.
+
+* Where we are going
+
+The destination is fixed by the [[id:2F71292F-CDB0-4E2E-B50F-4F02E10597C4][product identity]]: a learning
+environment for quantitative finance, built on [[id:1CBDEA40-5FAE-4F04-BD21-2BB29172B5AA][ORE]] and [[id:0412444A-0A4C-4611-887C-09353A3CB253][QuantLib]],
+that gives developers a database, a GUI, and an orchestration layer
+through which to explore how computational finance actually works.
+The identity page is the durable statement of what the product /is/
+and /is not/ — the roadmap below is how we get there in stages.
+
+Each stage is a [[id:65B2F1A0-3C4D-4E7A-9B8D-1F2A3C4D5E6F][milestone]]: a named major release with its own theme,
+mission, and definition of done. The full catalogue lives on the
+[[id:C540506E-7129-4CF2-AE3E-6C8BB9C9417F][Milestones]] page; the journey so far and next is:
+
+** v1.0 — Static World /(in progress)/
+
+Time stands still. The world is a snapshot, and the goal is to
+reproduce it perfectly: ingest any ORE sample, persist every input
+and output in the database, execute the full pipeline inside ORE
+Studio, and produce results bit-for-bit identical to the ORE
+reference outputs — with GUI coverage for every data operation. The
+correctness bar is the ORE reference implementation itself.
+
+See [[id:DDA02748-7054-463B-9238-CC196601403D][Milestone v1.0 — Static World]] for the mission and definition of
+done.
+
+** v2.0 — Dynamic World /(planned)/
+
+Time starts to move. Market data ticks, trades transition through
+their lifecycle, curves bootstrap live, and pricing screens update as
+data arrives. Where v1.0 proves correctness against a static
+snapshot, v2.0 proves it in a live environment.
+
+See [[id:1651993D-F3E8-4A73-861C-0A0B03F12CF0][Milestone v2.0 — Dynamic World]] for the mission and definition of
+done.
+
+* Where we are now
+
+We are in [[id:E6FD30ED-963E-4705-B414-91BF471C23D0][Version 0]] — the =0.x.x= release series working towards
+v1.0. Every sprint cuts an incremental build (=0.0.18= is the latest
+at the time of writing; see [[id:37C10313-E6E9-4D42-B82D-B6758D0A3AD9][Versions]] for the running series and
+[[https://github.com/OreStudio/OreStudio/releases][GitHub releases]] for downloads). The architectural tiers are standing
+— Postgres persistence, a service layer, a Qt GUI, CLI and shell
+front-ends — and reference data is being commissioned through them
+type by type, with ORE sample round-trips as the proof of
+correctness.
+
+When v1.0's definition of done is met — every ORE sample loads,
+executes, and round-trips with zero diff — Version 0 closes, =1.0.0=
+is cut, and work moves to the next series.
+
+* How to read the plan
+
+Two documents structure all forward-looking work, and this page
+deliberately repeats neither:
+
+- [[id:C540506E-7129-4CF2-AE3E-6C8BB9C9417F][Milestones]] own the /what and why/ — identity, theme, mission, and
+  definition of done for each major release target.
+- [[id:37C10313-E6E9-4D42-B82D-B6758D0A3AD9][Versions]] own the /how and when/ — the release series, the sprints
+  within them, and the incremental builds they produce.
+
+Timelines are deliberately coarse — v1.0 carries a horizon of months,
+v2.0 of years — because ORE Studio is a learning-driven project, not
+a delivery commitment. The day-to-day truth of what is being worked
+on right now is always in the current sprint under [[id:E5635EAC-CCE9-C0A4-A00B-C1780FF4A88E][Agile]].
+
+* See also
+
+- [[id:2F71292F-CDB0-4E2E-B50F-4F02E10597C4][Product identity]] — what ORE Studio is and is not.
+- [[id:C540506E-7129-4CF2-AE3E-6C8BB9C9417F][Milestones]] — the major release targets in full.
+- [[id:37C10313-E6E9-4D42-B82D-B6758D0A3AD9][Versions]] — the release series and their sprints.
+- [[id:E5635EAC-CCE9-C0A4-A00B-C1780FF4A88E][Agile]] — how the rolling work is organised.

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -156,6 +156,20 @@ def cmd_index(args):
     print(f"📂 Using org-roam.db: {ORG_ROAM_DB}")
     print(f"🌳 Project root:      {PROJECT_ROOT}")
 
+    if getattr(args, "sync_org_roam_db", False):
+        script = (PROJECT_ROOT / "projects" / "ores.lisp" / "src"
+                  / "ores-sync-org-roam.el")
+        print(f"🔄 Syncing org-roam db first: emacs -Q --script "
+              f"{script.relative_to(PROJECT_ROOT)}")
+        rc = subprocess.run(
+            ["emacs", "-Q", "--script", str(script)],
+            cwd=PROJECT_ROOT).returncode
+        if rc != 0:
+            print(f"❌ org-roam db sync failed (exit code {rc}); "
+                  f"indexing aborted.", file=sys.stderr)
+            sys.exit(rc)
+        validate_paths("index")
+
     roam_conn = get_roam_conn()
     file_count = roam_conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
     print(f"📝 Found {file_count} files registered in org-roam.db")
@@ -400,6 +414,7 @@ def cmd_search(args):
             print(f'{r["roam_id"]} "{rel_path}" "{matched_text}"')
 
     else:  # Pretty format (default)
+        print_db_freshness()
         print(f"\nFound {len(results)} results for '{query}':\n" + "-"*50)
         for r in results:
             title = r['title'] or "Untitled"
@@ -688,6 +703,42 @@ _C_CYAN   = "\033[36m"
 _C_BOLD   = "\033[1m"
 _C_RESET  = "\033[0m"
 _C_SEV    = {"ok": _C_GREEN, "warn": _C_YELLOW, "stale": _C_RED}
+
+# Freshness bands for the search/index databases, in seconds.
+_FRESH_GREEN    = 3600       # < 1h: green, fresh
+_FRESH_WARNING  = 5 * 3600   # > 5h: yellow, warning
+_FRESH_CRITICAL = 24 * 3600  # > 24h: red, critical
+
+
+def db_freshness_line(label, path, refresh_hint):
+    """One-line freshness report for a database file.
+
+    < 1h green (info), 1h–5h plain (info), > 5h yellow (warning),
+    > 24h red (critical). Missing file is always critical.
+    """
+    if not os.path.exists(path):
+        return (f"{_C_RED}🛑 {label}: missing — "
+                f"run: {refresh_hint}{_C_RESET}")
+    age = time.time() - os.path.getmtime(path)
+    human = _age_human(age)
+    if age > _FRESH_CRITICAL:
+        return (f"{_C_RED}🛑 {label}: {human} old (critical) — "
+                f"run: {refresh_hint}{_C_RESET}")
+    if age > _FRESH_WARNING:
+        return (f"{_C_YELLOW}⚠  {label}: {human} old (stale) — "
+                f"consider: {refresh_hint}{_C_RESET}")
+    if age < _FRESH_GREEN:
+        return f"{_C_GREEN}✅ {label}: {human} old (fresh){_C_RESET}"
+    return f"ℹ️  {label}: {human} old"
+
+
+def print_db_freshness():
+    """Print freshness of the compass index and the org-roam db."""
+    print(db_freshness_line("index (.compass.db)", COMPASS_DB,
+                            "compass index"))
+    print(db_freshness_line("org-roam (.org-roam.db)", ORG_ROAM_DB,
+                            "compass index --sync-org-roam-db"))
+
 
 def staleness_lines(info):
     """Return (chip_line, warning_line_or_None) for a branch_staleness dict."""
@@ -2674,6 +2725,7 @@ def cmd_bearings(argv):
 BUILD_TARGET_ALIASES = {
     "site": "deploy_site",
     "manual": "deploy_manual",
+    "org-roam": "sync_org_roam",
 }
 
 
@@ -2818,6 +2870,8 @@ def main():
 
     index_parser = subparsers.add_parser("index", help="Index or update notes from org-roam.db")
     index_parser.add_argument("--rebuild", action="store_true", help="Rebuild the entire index from scratch")
+    index_parser.add_argument("--sync-org-roam-db", action="store_true",
+                              help="Sync .org-roam.db (emacs batch org-roam-db-sync) before indexing")
 
     search_parser = subparsers.add_parser("search", aliases=["find"], help="Search your notes")
     search_parser.add_argument("query", type=str, help="The search query")
@@ -2876,8 +2930,11 @@ def main():
     args = parser.parse_args()
 
     # Only the org-roam-backed commands need org-roam.db; the agile/doc-graph
-    # commands read the working tree directly.
-    if args.command in ("index", "search", "find", "debug"):
+    # commands read the working tree directly. index --sync-org-roam-db
+    # creates the db itself, so it validates after the sync (in cmd_index).
+    if args.command in ("index", "search", "find", "debug") and \
+            not (args.command == "index"
+                 and getattr(args, "sync_org_roam_db", False)):
         validate_paths(args.command)
 
     if args.command == "index":

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -156,7 +156,7 @@ def cmd_index(args):
     print(f"📂 Using org-roam.db: {ORG_ROAM_DB}")
     print(f"🌳 Project root:      {PROJECT_ROOT}")
 
-    if getattr(args, "sync_org_roam_db", False):
+    if getattr(args, "org_roam_db_sync", False):
         script = (PROJECT_ROOT / "projects" / "ores.lisp" / "src"
                   / "ores-sync-org-roam.el")
         print(f"🔄 Syncing org-roam db first: emacs -Q --script "
@@ -737,7 +737,7 @@ def print_db_freshness():
     print(db_freshness_line("index (.compass.db)", COMPASS_DB,
                             "compass index"))
     print(db_freshness_line("org-roam (.org-roam.db)", ORG_ROAM_DB,
-                            "compass index --sync-org-roam-db"))
+                            "compass index --org-roam-db-sync"))
 
 
 def staleness_lines(info):
@@ -2725,7 +2725,7 @@ def cmd_bearings(argv):
 BUILD_TARGET_ALIASES = {
     "site": "deploy_site",
     "manual": "deploy_manual",
-    "org-roam": "sync_org_roam",
+    "org-roam-db-sync": "org_roam_db_sync",
 }
 
 
@@ -2870,7 +2870,7 @@ def main():
 
     index_parser = subparsers.add_parser("index", help="Index or update notes from org-roam.db")
     index_parser.add_argument("--rebuild", action="store_true", help="Rebuild the entire index from scratch")
-    index_parser.add_argument("--sync-org-roam-db", action="store_true",
+    index_parser.add_argument("--org-roam-db-sync", action="store_true",
                               help="Sync .org-roam.db (emacs batch org-roam-db-sync) before indexing")
 
     search_parser = subparsers.add_parser("search", aliases=["find"], help="Search your notes")
@@ -2930,11 +2930,11 @@ def main():
     args = parser.parse_args()
 
     # Only the org-roam-backed commands need org-roam.db; the agile/doc-graph
-    # commands read the working tree directly. index --sync-org-roam-db
+    # commands read the working tree directly. index --org-roam-db-sync
     # creates the db itself, so it validates after the sync (in cmd_index).
     if args.command in ("index", "search", "find", "debug") and \
             not (args.command == "index"
-                 and getattr(args, "sync_org_roam_db", False)):
+                 and getattr(args, "org_roam_db_sync", False)):
         validate_paths(args.command)
 
     if args.command == "index":

--- a/projects/ores.compass/src/compass.py
+++ b/projects/ores.compass/src/compass.py
@@ -2667,6 +2667,78 @@ def cmd_bearings(argv):
     return 0
 
 
+# --- Build pillar ---
+
+# Friendly target aliases: compass-level names → cmake target names.
+# Add new entries here as more build products get compass-level names.
+BUILD_TARGET_ALIASES = {
+    "site": "deploy_site",
+    "manual": "deploy_manual",
+}
+
+
+def cmd_build(argv):
+    """compass build — Build pillar: cmake builds via the prevailing preset.
+
+    The preset comes from ORES_PRESET in .env (override with --preset), so
+    every checkout builds with its own configuration without recipes or
+    sessions hardcoding preset names. If the preset has never been
+    configured, the configure step (cmake --preset <preset>) runs first.
+    """
+    ap = argparse.ArgumentParser(
+        prog="compass build",
+        description="Build pillar: run cmake builds with the preset from "
+                    ".env (ORES_PRESET).")
+    aliases = ", ".join(f"'{k}' → {v}" for k, v in
+                        sorted(BUILD_TARGET_ALIASES.items()))
+    ap.add_argument("targets", nargs="*", metavar="TARGET",
+                    help="Build target(s): a friendly alias or any raw "
+                         f"cmake target. Aliases: {aliases}. "
+                         "Default: build everything.")
+    ap.add_argument("--preset", default="",
+                    help="CMake preset name (default: read ORES_PRESET "
+                         "from .env)")
+    ap.add_argument("-j", "--jobs", type=int, default=0,
+                    help="Parallel build jobs (default: cmake's default)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Print the cmake command(s) without running them")
+    args = ap.parse_args(argv)
+
+    preset = args.preset or _tr_read_preset()
+    if not preset:
+        print("❌ No preset supplied and ORES_PRESET not set in .env.\n"
+              "   Pass --preset <name> or run compass env init.",
+              file=sys.stderr)
+        return 1
+
+    targets = [BUILD_TARGET_ALIASES.get(t, t) for t in args.targets]
+
+    commands = []
+    build_dir = PROJECT_ROOT / "build" / "output" / preset
+    if not build_dir.is_dir():
+        print(f"ℹ️  {build_dir.relative_to(PROJECT_ROOT)} not found — "
+              f"configuring first: cmake --preset {preset}")
+        commands.append(["cmake", "--preset", preset])
+
+    build_cmd = ["cmake", "--build", "--preset", preset]
+    if targets:
+        build_cmd += ["--target", *targets]
+    if args.jobs:
+        build_cmd += ["-j", str(args.jobs)]
+    commands.append(build_cmd)
+
+    for cmd in commands:
+        print(f"🔨 {' '.join(cmd)}")
+        if args.dry_run:
+            continue
+        rc = subprocess.run(cmd, cwd=PROJECT_ROOT).returncode
+        if rc != 0:
+            print(f"❌ Command failed with exit code {rc}: {' '.join(cmd)}",
+                  file=sys.stderr)
+            return rc
+    return 0
+
+
 def main():
     # `list` and `show` pass every remaining argument straight through to the
     # bundled doc tools (full flag compatibility, including their own --help).
@@ -2694,6 +2766,8 @@ def main():
         sys.exit(cmd_nats(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] == "test":
         sys.exit(cmd_test(sys.argv[2:]))
+    if len(sys.argv) >= 2 and sys.argv[1] == "build":
+        sys.exit(cmd_build(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] in ("bearings", "orient"):
         sys.exit(cmd_bearings(sys.argv[2:]))
     if len(sys.argv) >= 2 and sys.argv[1] in ALL_BUCKETS:
@@ -2704,7 +2778,7 @@ def main():
         _KNOWN_COMMANDS = [
             "index", "search", "find", "debug", "where", "status", "fleet",
             "list", "show", "add", "sprint", "story", "task", "journal",
-            "env", "nats", "test", "bearings", "orient", "capture",
+            "env", "nats", "test", "build", "bearings", "orient", "capture",
             "inbox", "next", "deferred", "discarded", "backlog",
         ]
         cmd_given = sys.argv[1]
@@ -2726,6 +2800,7 @@ def main():
         "  Journal:   journal\n"
         "  Provision: env, nats\n"
         "  Test:      test\n"
+        "  Build:     build\n"
         "  Bearings:  bearings (alias: orient)\n"
         "\n"
         "Entity commands (sub-subcommands span pillars):\n"
@@ -2786,6 +2861,9 @@ def main():
     subparsers.add_parser("test",
                           help="Test: 'test results' shows last run overview; "
                                "'test logging on|off|status' toggles test logging; 'test --help'")
+    subparsers.add_parser("build",
+                          help="Build: run cmake with the preset from .env (ORES_PRESET); "
+                               "'build site' builds the website; 'build --help'")
     subparsers.add_parser("bearings",
                           help="Cold-start orientation: identity, where, last session, recipes, memories")
     subparsers.add_parser("orient",

--- a/projects/ores.lisp/modeling/site.org
+++ b/projects/ores.lisp/modeling/site.org
@@ -58,7 +58,7 @@ page via the =:html-preamble= key of the =site:pages= project:
     <a href='/OreStudio/doc/downloads.html'>Downloads</a>
     <a href='/OreStudio/doc/agile/agile.html'>Agile</a>
     <a href='/OreStudio/doc/developer.html'>Developer</a>
-    <a href='/OreStudio/doc/agile/versions/versions.html'>Roadmap</a>
+    <a href='/OreStudio/doc/roadmap.html'>Roadmap</a>
     <a href='/OreStudio/graph/index.html'>Knowledge Graph</a>
     <a href='https://github.com/OreStudio/OreStudio' ...><i class='fab fa-github'></i></a>
   </nav>

--- a/projects/ores.lisp/src/ores-build-site.el
+++ b/projects/ores.lisp/src/ores-build-site.el
@@ -138,7 +138,7 @@
     <a href='/OreStudio/projects/modeling/masd.html'>MASD</a>
     <a href='/OreStudio/doc/agile/agile.html'>Agile</a>
     <a href='/OreStudio/doc/developer.html'>Developer</a>
-    <a href='/OreStudio/doc/agile/versions/versions.html'>Roadmap</a>
+    <a href='/OreStudio/doc/roadmap.html'>Roadmap</a>
     <a href='/OreStudio/graph/index.html'>Knowledge Graph</a>
     <a href='https://github.com/OreStudio/OreStudio' aria-label='GitHub' title='GitHub'><i class='fab fa-github'></i></a>
   </nav>

--- a/projects/ores.lisp/src/ores-sync-org-roam.el
+++ b/projects/ores.lisp/src/ores-sync-org-roam.el
@@ -1,0 +1,65 @@
+;;; ores-sync-org-roam.el --- Sync the org-roam database. -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2026 Marco Craveiro
+;;
+;; Author: Marco Craveiro <marco.craveiro@gmail.com>
+;; Maintainer: Marco Craveiro <marco.craveiro@gmail.com>
+;; URL: https://github.com/OreStudio/OreStudio
+;;
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation, either version 3 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program. If not, see <https://www.gnu.org/licenses/>.
+;;
+;;; Commentary:
+;;
+;; Regenerates .org-roam.db from the repository's org files. This is the
+;; standalone counterpart of the sync that ores-build-site.el performs as a
+;; side effect of publishing the site; run it via the sync_org_roam CMake
+;; target, `compass build org-roam`, or `compass index --sync-org-roam-db`
+;; when only the database needs refreshing.
+;;
+;;; Code:
+(require 'package)
+
+(setq debug-on-error nil)
+(setq debug-on-quit nil)
+
+;; Same package bootstrap as ores-build-site.el: packages live in
+;; ./.packages so CI and local runs share the cache.
+(setq package-user-dir (expand-file-name "./.packages"))
+(setq package-archives '(("gnu" . "https://elpa.gnu.org/packages/")
+                         ("nongnu" . "https://elpa.nongnu.org/nongnu/")
+                         ("melpa" . "https://melpa.org/packages/")))
+(package-initialize)
+(unless (package-installed-p 'org-roam)
+  (condition-case err
+      (package-refresh-contents)
+    (error (message "Warning: could not refresh package archives (%s); using cached contents"
+                    (error-message-string err))))
+  (package-install 'org-roam))
+
+(condition-case err
+    (progn
+      (setq org-roam-directory (expand-file-name "./"))
+      (setq org-roam-db-location (expand-file-name "./.org-roam.db"))
+      (setq org-roam-file-exclude-regexp
+            "\\(^\\|/\\)\\(\\.packages\\|vcpkg\\|build\\|tmp\\)/\\|external/org-roam-ui")
+      (require 'org-roam)
+      (org-roam-db-sync)
+      (message "org-roam DB sync succeeded: %s" org-roam-db-location)
+      (kill-emacs 0))
+  (error
+   (message "org-roam DB sync failed: %s" (error-message-string err))
+   (kill-emacs 1)))
+
+(provide 'ores-sync-org-roam)
+;;; ores-sync-org-roam.el ends here

--- a/projects/ores.lisp/src/ores-sync-org-roam.el
+++ b/projects/ores.lisp/src/ores-sync-org-roam.el
@@ -23,9 +23,9 @@
 ;;
 ;; Regenerates .org-roam.db from the repository's org files. This is the
 ;; standalone counterpart of the sync that ores-build-site.el performs as a
-;; side effect of publishing the site; run it via the sync_org_roam CMake
-;; target, `compass build org-roam`, or `compass index --sync-org-roam-db`
-;; when only the database needs refreshing.
+;; side effect of publishing the site; run it via the org_roam_db_sync CMake
+;; target, `compass build org-roam-db-sync`, or `compass index
+;; --org-roam-db-sync` when only the database needs refreshing.
 ;;
 ;;; Code:
 (require 'package)


### PR DESCRIPTION
## Summary

Two strands of work, one per story: a user-facing product roadmap page for the site, and the first slice of the compass Build pillar (discovered when the deploy-site recipe's hardcoded preset failed in this checkout).

## Changes

### User-facing roadmap

- Add `doc/roadmap.org` — a user-facing narrative of where the product is and where it is going (v1.0 Static World → v2.0 Dynamic World), delegating detail to versions, milestones, and product identity via links rather than repeating content.
- Repoint the site nav Roadmap entry (previously `versions.org`, an internal agile index) in both `ores-build-site.el` and its `site.org` model.
- Cross-link the new page from product identity, Versions, and Milestones.

### compass Build pillar

- `compass build [TARGET...]`: cmake builds via the preset from `ORES_PRESET` in `.env` (no more hardcoded presets in recipes), with `--preset` override, auto-configure on first use, `--dry-run`, `-j`.
- Friendly target aliases: `site` → `deploy_site`, `manual` → `deploy_manual`, `org-roam-db-sync` → `org_roam_db_sync` (named after org-roam's own `M-x org-roam-db-sync`).
- New standalone `org_roam_db_sync` CMake target (`ores-sync-org-roam.el`) — db regeneration no longer only a side effect of `deploy_site`.
- `compass index --org-roam-db-sync`: sync the org-roam db before indexing.
- `compass search` now reports db freshness: green/info < 1h, yellow/warning > 5h, red/critical > 24h, with the refresh command to run.
- Deploy-site recipe updated to `compass build site`, linking to the raw-build recipe instead of hardcoding a ninja preset.

## Notes

- Verified end-to-end: `compass build site` builds the site (roadmap.html renders, nav repointed, all org-roam links resolve); `compass build org-roam-db-sync` and `compass index --org-roam-db-sync` run the sync; the freshness banner was exercised across fresh/stale states.
- The new cmake target requires a one-time reconfigure of existing build directories (picked up automatically on the next build of a known target).

## Traceability

| Artefact | Link | ID |
|----------|------|----|
| Story | [Documentation review follow-ups](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/documentation_review_followups/story.html) | 305E3A3B-8A72-49D3-9972-FAF06FEB4552 |
| Task | [Create a user-facing product roadmap page](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/documentation_review_followups/task_create_user_facing_roadmap.html) | DBA9185D-B2D9-4484-A7FA-49D861FCA910 |
| Story | [Consolidate standalone scripts into compass](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/story.html) | 6695E245-E789-40EC-8AC6-EB10276CA241 |
| Task | [Migrate the Build pillar (build, site)](https://orestudio.github.io/OreStudio/doc/agile/versions/v0/sprint_19/consolidate_scripts_into_compass/task_migrate_build_pillar.html) | D38238C9-702F-47AC-BE64-91D84A8EE716 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)