### PR TITLE
[compass] Standardise list output: icons, two-line format, show hints

### DIFF
--- a/doc/agile/versions/v0/sprint_19/compass_orient_command/task_standardise-list-output.org
+++ b/doc/agile/versions/v0/sprint_19/compass_orient_command/task_standardise-list-output.org
@@ -1,0 +1,70 @@
+:PROPERTIES:
+:ID: AA66C482-630C-40E5-956C-EE7C96548FB0
+:END:
+#+title: Task: Standardise compass list output: icons, two-line format, show hints
+#+description: compass list prints raw pipe-separated lines while bearings has the polished UX. Make list use the standard two-line format: type icon + title + description on line one, yellow 'compass show UUID' on line two. Introduce a shared type-to-icon map and colour helpers for all commands.
+#+type: task
+#+level: s1
+#+filetags: :compass_orient_command:sprint_19:v0:
+#+owner: marco
+#+branch: feature/standardise-list-output
+#+pr:
+#+blocked_on:
+#+blocked_since:
+#+created: 2026-06-05
+#+updated: 2026-06-05
+#+todo: DISCOVERED BACKLOG STARTED BLOCKED | DONE ABANDONED
+
+This page documents a [[id:31C868B9-306E-4282-BA8C-07E647021B34][task]] in the [[id:2E5F5DB5-7417-45B8-8D0B-C71650127D32][Add compass bearings command for LLM on-boarding]] story. It captures the goal, current status, acceptance, and any notes or results.
+
+* Goal
+
+=compass list= renders in the standard compass UX instead of raw
+pipe-separated lines: each doc as a two-line block — type icon, type,
+bold-cyan title and description on the first line; a yellow
+=compass show UUID= hint on the second — matching bearings/show.
+A shared =ui.py= module becomes the single source of truth for the
+colour palette, =header()=/=ycmd()= helpers and the per-type icon map,
+so every compass command renders documents identically.
+
+* Status
+
+| Field        | Value                                  |
+|--------------+----------------------------------------|
+| State        | STARTED                              |
+| Parent story | [[id:2E5F5DB5-7417-45B8-8D0B-C71650127D32][Add compass bearings command for LLM on-boarding]] |
+| Now          | Not yet started.                       |
+| Waiting on   | Nothing.                               |
+| Next         | Begin implementation.                  |
+| Last touched | 2026-06-05                               |
+
+* Acceptance
+
+-
+
+* Plan
+
+1. New =src/ui.py=: colour palette, =header()=, =ycmd()=, TYPE_ICONS
+   map (15 doc types) + =icon_for()= with 📄 fallback.
+2. =doc_list.py=: default output becomes the two-line standard format
+   with a 🧭 count header; =--oneline= preserves the old
+   machine-friendly format; =--paths= / =--count= unchanged.
+3. =doc_show.py=: header icon comes from =icon_for()=; colour
+   constants re-exported from =ui=.
+4. Component overview command table updated.
+
+* Notes
+
+* PRs
+
+| PR | Title |
+|----+-------|
+|    |       |
+
+* Review
+
+| # | Comment summary | File | Decision | Notes |
+|---+-----------------+------+----------+-------|
+|   |                 |      |          |       |
+
+* Result

--- a/doc/agile/versions/v0/sprint_19/compass_orient_command/task_standardise-list-output.org
+++ b/doc/agile/versions/v0/sprint_19/compass_orient_command/task_standardise-list-output.org
@@ -65,6 +65,7 @@ so every compass command renders documents identically.
 
 | # | Comment summary | File | Decision | Notes |
 |---+-----------------+------+----------+-------|
-|   |                 |      |          |       |
+| 1 | Gemini: None-guard d.title/d.description in list (2 sites) | doc_list.py | Decline | doc_index.py:179-180 coalesces missing fields to ""; Doc declares title/description as str — None is unreachable via load_all() |
+| 2 | Gemini: None-guard doc.title in show header | doc_show.py | Decline | Same contract; guards would imply None is a valid state |
 
 * Result

--- a/doc/agile/versions/v0/sprint_19/compass_orient_command/task_standardise-list-output.org
+++ b/doc/agile/versions/v0/sprint_19/compass_orient_command/task_standardise-list-output.org
@@ -31,11 +31,11 @@ so every compass command renders documents identically.
 
 | Field        | Value                                  |
 |--------------+----------------------------------------|
-| State        | STARTED                              |
+| State        | DONE                              |
 | Parent story | [[id:2E5F5DB5-7417-45B8-8D0B-C71650127D32][Add compass bearings command for LLM on-boarding]] |
-| Now          | Not yet started.                       |
+| Now          | Complete: PR #1077 ready to merge.     |
 | Waiting on   | Nothing.                               |
-| Next         | Begin implementation.                  |
+| Next         | Nothing.                               |
 | Last touched | 2026-06-05                               |
 
 * Acceptance
@@ -69,3 +69,11 @@ so every compass command renders documents identically.
 | 2 | Gemini: None-guard doc.title in show header | doc_show.py | Decline | Same contract; guards would imply None is a valid state |
 
 * Result
+
+compass list renders in the standard two-line UX: type icon + type +
+bold-cyan title + description, then a yellow 'compass show UUID' hint,
+with a count header. New src/ui.py centralises the colour palette,
+header()/ycmd() helpers and the per-type icon map (15 types, generic
+fallback); doc_show adopts it. --oneline preserves the legacy format;
+--paths/--count unchanged. Review round 1: 3 None-guard suggestions
+declined (type contract in doc_index). PR #1077.

--- a/doc/agile/versions/v0/sprint_19/compass_orient_command/task_standardise-list-output.org
+++ b/doc/agile/versions/v0/sprint_19/compass_orient_command/task_standardise-list-output.org
@@ -59,7 +59,7 @@ so every compass command renders documents identically.
 
 | PR | Title |
 |----+-------|
-|    |       |
+| [[https://github.com/OreStudio/OreStudio/pull/1077][#1077]] | [compass] Standardise list output: icons, two-line format, show hints |
 
 * Review
 

--- a/projects/ores.compass/modeling/component_overview.org
+++ b/projects/ores.compass/modeling/component_overview.org
@@ -149,7 +149,7 @@ requires =org-roam.db= or the FTS5 cache.
 
 | Form | Description |
 |------+-------------|
-| =compass list= | List every addressable doc (UUID, type, title, path). |
+| =compass list= | List every addressable doc in the standard two-line format: icon + type + title + description, then a =compass show UUID= hint. =--oneline= keeps the old machine-friendly format. |
 | =compass list --type recipe= | Filter by =#+type:=. |
 | =compass list --tag sprint_18= | Filter by filetag. |
 | =compass list --regex "sql"= | Filter by regex against title or description. |

--- a/projects/ores.compass/src/doc_list.py
+++ b/projects/ores.compass/src/doc_list.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """
-List every addressable doc in the repo as a single line per doc.
+List every addressable doc in the repo in the standard compass format.
 
-Each line:
-  <uuid> | <type> | <title> — <description>   (rel/path)
+Each doc renders as two lines (plus a separating blank):
+  <icon>  <type>: <title> — <description>
+      compass show <UUID>
 
 Filters:
   --regex PATTERN   Match (case-insensitive) against title OR description.
@@ -16,6 +17,8 @@ Filters:
   --count           Print only the match count.
   --paths           Print one path per line (no other fields). Useful for
                     piping into grep / xargs.
+  --oneline         Old machine-friendly single-line format:
+                    <uuid> | <ver> | <type> | <title> — <desc>  (rel/path)
 
 Examples:
   # All recipe docs mentioning "trade"
@@ -35,6 +38,7 @@ import argparse
 import re
 import sys
 
+import ui
 from doc_index import load_all, REPO_ROOT
 
 
@@ -51,6 +55,8 @@ def main(argv=None) -> int:
     ap.add_argument("--sort", choices=["title", "updated", "path"], default="path")
     ap.add_argument("--count", action="store_true", help="print match count only")
     ap.add_argument("--paths", action="store_true", help="print only paths, one per line")
+    ap.add_argument("--oneline", action="store_true",
+                    help="old machine-friendly single-line format")
     args = ap.parse_args(argv)
 
     pattern = re.compile(args.regex, re.IGNORECASE) if args.regex else None
@@ -88,16 +94,29 @@ def main(argv=None) -> int:
             print(d.rel_path)
         return 0
 
+    if args.oneline:
+        for d in results:
+            type_label = d.doctype or "?"
+            ver_label = f"v{d.version}" if d.version else "v?"
+            desc = d.description.replace("\n", " ").strip()
+            title = d.title.replace("\n", " ").strip()
+            line = f"{d.id} | {ver_label} | {type_label:<14} | {title}"
+            if desc:
+                line += f"  —  {desc}"
+            line += f"   ({d.rel_path})"
+            print(line)
+        return 0
+
+    print(f"🧭 ores.compass — list ({len(results)} docs)")
     for d in results:
-        type_label = d.doctype or "?"
-        ver_label  = f"v{d.version}" if d.version else "v?"
+        type_label = d.doctype or "doc"
         desc = d.description.replace("\n", " ").strip()
         title = d.title.replace("\n", " ").strip()
-        line = f"{d.id} | {ver_label} | {type_label:<14} | {title}"
+        line = f"{ui.icon_for(d.doctype)}  {type_label}: {ui.header(title)}"
         if desc:
-            line += f"  —  {desc}"
-        line += f"   ({d.rel_path})"
-        print(line)
+            line += f" — {desc}"
+        print(f"\n{line}")
+        print(f"    {ui.ycmd(f'compass show {d.id.upper()}')}")
     return 0
 
 

--- a/projects/ores.compass/src/doc_show.py
+++ b/projects/ores.compass/src/doc_show.py
@@ -26,19 +26,18 @@ one doc. Output sections:
 import argparse
 import sys
 
+import ui
 from doc_index import (
     load_all, load_anchors, build_inbound,
     resolve_id, resolve_anchor, find_ambiguous,
 )
 
-_C_BOLD   = "\033[1m"
-_C_CYAN   = "\033[36m"
-_C_YELLOW = "\033[33m"
-_C_RESET  = "\033[0m"
+_C_BOLD   = ui.BOLD
+_C_CYAN   = ui.CYAN
+_C_YELLOW = ui.YELLOW
+_C_RESET  = ui.RESET
 
-def _h(text):
-    """Wrap text in bold cyan for section headings."""
-    return f"{_C_BOLD}{_C_CYAN}{text}{_C_RESET}"
+_h = ui.header
 
 
 def show_link_row(uuid: str, docs, anchors) -> str:
@@ -105,7 +104,7 @@ def main(argv=None) -> int:
 
     anchors_all = load_anchors(docs)
 
-    print(f"{_h('📄  ' + doc.title)}")
+    print(f"{_h(ui.icon_for(doc.doctype) + '  ' + doc.title)}")
     print(f"    Type:    {doc.doctype or '(none)'}")
     print(f"    Path:    {doc.rel_path}")
     if doc.tags:

--- a/projects/ores.compass/src/ui.py
+++ b/projects/ores.compass/src/ui.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Shared terminal UX helpers for compass commands.
+
+Single source of truth for the compass colour palette, the standard
+per-doc-type icons, and the small formatting helpers used across
+subcommands (bearings, list, show, ...). Keep all new output styling
+here so every command renders documents the same way:
+
+  <icon>  <type>: <bold-cyan title> — <description>
+      <yellow compass show UUID>
+"""
+
+# ── Colour palette ────────────────────────────────────────────────────────────
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+RED = "\033[31m"
+CYAN = "\033[36m"
+BOLD = "\033[1m"
+RESET = "\033[0m"
+
+
+def header(text: str) -> str:
+    """Render a section header in the standard bold cyan."""
+    return f"{BOLD}{CYAN}{text}{RESET}"
+
+
+def ycmd(cmd: str) -> str:
+    """Render a compass command hint in the standard yellow."""
+    return f"{YELLOW}{cmd}{RESET}"
+
+
+# ── Standard doc-type icons ───────────────────────────────────────────────────
+# One icon per #+type:. Aligned with existing usage (🧠 memories and 🏢
+# product identity in bearings, 📓 journal). Fallback is the generic 📄
+# used by compass show.
+TYPE_ICONS = {
+    "version": "🏷️",
+    "sprint": "🏃",
+    "story": "📖",
+    "task": "☑️",
+    "recipe": "📜",
+    "runbook": "📋",
+    "knowledge": "📚",
+    "memory": "🧠",
+    "capture": "📥",
+    "investigation": "🔍",
+    "skill": "🧩",
+    "manual": "📕",
+    "component": "📦",
+    "diagram": "📐",
+    "product_identity": "🏢",
+}
+
+DEFAULT_ICON = "📄"
+
+
+def icon_for(doctype: str | None) -> str:
+    """Standard icon for a #+type:, falling back to the generic doc icon."""
+    return TYPE_ICONS.get((doctype or "").lower(), DEFAULT_ICON)


### PR DESCRIPTION
## Summary

`compass list` now renders each doc in the standard compass UX — the two-line format established by `bearings`/`show` — instead of raw pipe-separated lines:

```
🧭 ores.compass — list (13 docs)

📋  runbook: Handle a PR review round — Sync with main, read review comments, ...
    compass show 5373A4E5-172B-44FD-BAE0-07E25BBD3292
```

- First line: standard type icon, doc type, bold-cyan title, description
- Second line: yellow `compass show UUID` hint
- `--oneline` preserves the old machine-friendly single-line format; `--paths` and `--count` unchanged
- New `src/ui.py` is the single source of truth for the colour palette, `header()`/`ycmd()` helpers and the per-type icon map (15 types, 📄 fallback); `doc_show` adopts it (per-type header icon, shared constants); `compass.py` can migrate incrementally

## Test plan

- Manual: `compass list --type {runbook,memory,story,capture}`, `--oneline`, `--paths`, `--count`, `compass show <uuid>`, `compass bearings` — all verified working

🤖 Generated with [Claude Code](https://claude.com/claude-code)